### PR TITLE
feat(api): add GET /api/v1/chain/event-summary

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -480,6 +480,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/chain/event-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier; schema-stable empty block when cold. Companion to GET /api/v1/subnets/{netuid}/event-summary. */
+        get: operations["chainEventSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/chain/fees": {
         parameters: {
             query?: never;
@@ -2858,6 +2875,24 @@ export interface components {
             method: string | null;
             pallet: string | null;
         };
+        /** @description One event-kind aggregate in a network-wide windowed account_events summary. */
+        ChainEventKindSummary: {
+            alpha_amount: number;
+            amount_tao: number;
+            /** @enum {string} */
+            category: "registration" | "stake" | "serving" | "consensus" | "delegation" | "identity" | "governance" | "transfer" | "other";
+            coldkey_count: number;
+            event_count: number;
+            event_kind: string;
+            first_block: number | null;
+            /** Format: date-time */
+            first_observed_at: string | null;
+            hotkey_count: number;
+            last_block: number | null;
+            /** Format: date-time */
+            last_observed_at: string | null;
+            subnet_count: number;
+        };
         /** @description Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs. */
         ChainEventsFeedArtifact: {
             count: number;
@@ -2874,6 +2909,25 @@ export interface components {
             activity: components["schemas"]["ChainEventEntry"][];
             groups: number;
             window_blocks: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route. */
+        ChainEventSummaryArtifact: {
+            categories: components["schemas"]["SubnetEventCategorySummary"][];
+            category_count: number;
+            event_kinds: components["schemas"]["ChainEventKindSummary"][];
+            kind_count: number;
+            limit: number;
+            /** Format: date-time */
+            observed_at: string | null;
+            recent_event_count: number;
+            recent_events: components["schemas"]["AccountEvent"][];
+            schema_version: number;
+            subnet_count: number;
+            total_events: number;
+            /** @enum {string} */
+            window: "7d" | "30d" | "90d";
         } & {
             [key: string]: unknown;
         };
@@ -9866,6 +9920,151 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainConcentrationArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    chainEventSummary: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d" | "90d";
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "categories": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "event_count": 1,
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "kind_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z"
+                     *           }
+                     *         ],
+                     *         "category_count": 1,
+                     *         "event_kinds": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "coldkey_count": 1,
+                     *             "event_count": 1,
+                     *             "event_kind": "example",
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "hotkey_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "subnet_count": 1
+                     *           }
+                     *         ],
+                     *         "kind_count": 1,
+                     *         "limit": 1,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "recent_event_count": 1,
+                     *         "recent_events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "event_kind": "example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "total_events": 1,
+                     *         "window": "7d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["ChainEventSummaryArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -702,6 +702,13 @@
     },
     {
       "contract_version": "2026-07-03.2",
+      "id": "chain-event-summary",
+      "path": "/metagraph/chain/event-summary.json",
+      "schema_ref": "#/components/schemas/ChainEventSummaryArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-07-03.2",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "schema_ref": "#/components/schemas/ChainFeesArtifact",
@@ -6399,6 +6406,38 @@
           "name": "limit",
           "schema": {
             "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/chain/event-summary.json",
+      "cache": "short",
+      "description": "Fetch a network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier; schema-stable empty block when cold. Companion to GET /api/v1/subnets/{netuid}/event-summary.",
+      "id": "chain-event-summary",
+      "method": "GET",
+      "path": "/api/v1/chain/event-summary",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "enum": [
+              "7d",
+              "30d",
+              "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 50,
             "minimum": 1,
             "type": "integer"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -903,6 +903,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
+      "description": "Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice, served live from D1 at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route.",
+      "id": "chain-event-summary",
+      "path": "/metagraph/chain/event-summary.json",
+      "schema_ref": "#/components/schemas/ChainEventSummaryArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-07-03.2",
       "description": "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3210,6 +3210,96 @@
         ],
         "type": "object"
       },
+      "ChainEventKindSummary": {
+        "additionalProperties": false,
+        "description": "One event-kind aggregate in a network-wide windowed account_events summary.",
+        "properties": {
+          "alpha_amount": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "amount_tao": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "category": {
+            "enum": [
+              "registration",
+              "stake",
+              "serving",
+              "consensus",
+              "delegation",
+              "identity",
+              "governance",
+              "transfer",
+              "other"
+            ],
+            "type": "string"
+          },
+          "coldkey_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kind": {
+            "type": "string"
+          },
+          "first_block": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "first_observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "hotkey_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "last_block": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "last_observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subnet_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_kind",
+          "category",
+          "event_count",
+          "subnet_count",
+          "hotkey_count",
+          "coldkey_count",
+          "amount_tao",
+          "alpha_amount",
+          "first_block",
+          "last_block",
+          "first_observed_at",
+          "last_observed_at"
+        ],
+        "type": "object"
+      },
       "ChainEventsFeedArtifact": {
         "additionalProperties": true,
         "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
@@ -3270,6 +3360,88 @@
           "window_blocks",
           "groups",
           "activity"
+        ],
+        "type": "object"
+      },
+      "ChainEventSummaryArtifact": {
+        "additionalProperties": true,
+        "description": "Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route.",
+        "properties": {
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventCategorySummary"
+            },
+            "type": "array"
+          },
+          "category_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/ChainEventKindSummary"
+            },
+            "type": "array"
+          },
+          "kind_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "limit": {
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recent_event_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "recent_events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "subnet_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_events": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "window": {
+            "enum": [
+              "7d",
+              "30d",
+              "90d"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "window",
+          "observed_at",
+          "subnet_count",
+          "total_events",
+          "kind_count",
+          "category_count",
+          "recent_event_count",
+          "limit",
+          "categories",
+          "event_kinds",
+          "recent_events"
         ],
         "type": "object"
       },
@@ -22683,6 +22855,191 @@
           }
         },
         "summary": "Fetch network-wide stake and emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) aggregated across all subnets' neurons over three lenses (per-UID, per-entity with coldkeys collapsed across subnets into the network control distribution, and validator-only consensus power), computed live from the neurons D1 tier; schema-stable nulls when cold.",
+        "tags": [
+          "chain",
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/chain/event-summary": {
+      "get": {
+        "operationId": "chainEventSummary",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "enum": [
+                "7d",
+                "30d",
+                "90d"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "categories": [
+                      {
+                        "alpha_amount": 0.5,
+                        "amount_tao": 0.5,
+                        "category": "registration",
+                        "event_count": 1,
+                        "first_block": 5000000,
+                        "first_observed_at": "2026-06-01T00:00:00.000Z",
+                        "kind_count": 1,
+                        "last_block": 5000000,
+                        "last_observed_at": "2026-06-01T00:00:00.000Z"
+                      }
+                    ],
+                    "category_count": 1,
+                    "event_kinds": [
+                      {
+                        "alpha_amount": 0.5,
+                        "amount_tao": 0.5,
+                        "category": "registration",
+                        "coldkey_count": 1,
+                        "event_count": 1,
+                        "event_kind": "example",
+                        "first_block": 5000000,
+                        "first_observed_at": "2026-06-01T00:00:00.000Z",
+                        "hotkey_count": 1,
+                        "last_block": 5000000,
+                        "last_observed_at": "2026-06-01T00:00:00.000Z",
+                        "subnet_count": 1
+                      }
+                    ],
+                    "kind_count": 1,
+                    "limit": 1,
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "recent_event_count": 1,
+                    "recent_events": [
+                      {
+                        "block_number": 5000000,
+                        "event_kind": "example"
+                      }
+                    ],
+                    "schema_version": 1,
+                    "subnet_count": 1,
+                    "total_events": 1,
+                    "window": "7d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-29.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/ChainEventSummaryArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch a network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier; schema-stable empty block when cold. Companion to GET /api/v1/subnets/{netuid}/event-summary.",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -480,6 +480,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/chain/event-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier; schema-stable empty block when cold. Companion to GET /api/v1/subnets/{netuid}/event-summary. */
+        get: operations["chainEventSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/chain/fees": {
         parameters: {
             query?: never;
@@ -2858,6 +2875,24 @@ export interface components {
             method: string | null;
             pallet: string | null;
         };
+        /** @description One event-kind aggregate in a network-wide windowed account_events summary. */
+        ChainEventKindSummary: {
+            alpha_amount: number;
+            amount_tao: number;
+            /** @enum {string} */
+            category: "registration" | "stake" | "serving" | "consensus" | "delegation" | "identity" | "governance" | "transfer" | "other";
+            coldkey_count: number;
+            event_count: number;
+            event_kind: string;
+            first_block: number | null;
+            /** Format: date-time */
+            first_observed_at: string | null;
+            hotkey_count: number;
+            last_block: number | null;
+            /** Format: date-time */
+            last_observed_at: string | null;
+            subnet_count: number;
+        };
         /** @description Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs. */
         ChainEventsFeedArtifact: {
             count: number;
@@ -2874,6 +2909,25 @@ export interface components {
             activity: components["schemas"]["ChainEventEntry"][];
             groups: number;
             window_blocks: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route. */
+        ChainEventSummaryArtifact: {
+            categories: components["schemas"]["SubnetEventCategorySummary"][];
+            category_count: number;
+            event_kinds: components["schemas"]["ChainEventKindSummary"][];
+            kind_count: number;
+            limit: number;
+            /** Format: date-time */
+            observed_at: string | null;
+            recent_event_count: number;
+            recent_events: components["schemas"]["AccountEvent"][];
+            schema_version: number;
+            subnet_count: number;
+            total_events: number;
+            /** @enum {string} */
+            window: "7d" | "30d" | "90d";
         } & {
             [key: string]: unknown;
         };
@@ -9866,6 +9920,151 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainConcentrationArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    chainEventSummary: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d" | "90d";
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "categories": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "event_count": 1,
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "kind_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z"
+                     *           }
+                     *         ],
+                     *         "category_count": 1,
+                     *         "event_kinds": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "coldkey_count": 1,
+                     *             "event_count": 1,
+                     *             "event_kind": "example",
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "hotkey_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "subnet_count": 1
+                     *           }
+                     *         ],
+                     *         "kind_count": 1,
+                     *         "limit": 1,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "recent_event_count": 1,
+                     *         "recent_events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "event_kind": "example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "total_events": 1,
+                     *         "window": "7d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["ChainEventSummaryArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3196,6 +3196,96 @@
         ],
         "type": "object"
       },
+      "ChainEventKindSummary": {
+        "additionalProperties": false,
+        "description": "One event-kind aggregate in a network-wide windowed account_events summary.",
+        "properties": {
+          "alpha_amount": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "amount_tao": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "category": {
+            "enum": [
+              "registration",
+              "stake",
+              "serving",
+              "consensus",
+              "delegation",
+              "identity",
+              "governance",
+              "transfer",
+              "other"
+            ],
+            "type": "string"
+          },
+          "coldkey_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kind": {
+            "type": "string"
+          },
+          "first_block": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "first_observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "hotkey_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "last_block": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "last_observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subnet_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_kind",
+          "category",
+          "event_count",
+          "subnet_count",
+          "hotkey_count",
+          "coldkey_count",
+          "amount_tao",
+          "alpha_amount",
+          "first_block",
+          "last_block",
+          "first_observed_at",
+          "last_observed_at"
+        ],
+        "type": "object"
+      },
       "ChainEventsFeedArtifact": {
         "additionalProperties": true,
         "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
@@ -3256,6 +3346,88 @@
           "window_blocks",
           "groups",
           "activity"
+        ],
+        "type": "object"
+      },
+      "ChainEventSummaryArtifact": {
+        "additionalProperties": true,
+        "description": "Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route.",
+        "properties": {
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventCategorySummary"
+            },
+            "type": "array"
+          },
+          "category_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/ChainEventKindSummary"
+            },
+            "type": "array"
+          },
+          "kind_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "limit": {
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recent_event_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "recent_events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "subnet_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_events": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "window": {
+            "enum": [
+              "7d",
+              "30d",
+              "90d"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "window",
+          "observed_at",
+          "subnet_count",
+          "total_events",
+          "kind_count",
+          "category_count",
+          "recent_event_count",
+          "limit",
+          "categories",
+          "event_kinds",
+          "recent_events"
         ],
         "type": "object"
       },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -2162,6 +2162,102 @@
           }
         }
       },
+      "ChainEventKindSummary": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "One event-kind aggregate in a network-wide windowed account_events summary.",
+        "required": [
+          "event_kind",
+          "category",
+          "event_count",
+          "subnet_count",
+          "hotkey_count",
+          "coldkey_count",
+          "amount_tao",
+          "alpha_amount",
+          "first_block",
+          "last_block",
+          "first_observed_at",
+          "last_observed_at"
+        ],
+        "properties": {
+          "event_kind": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": [
+              "registration",
+              "stake",
+              "serving",
+              "consensus",
+              "delegation",
+              "identity",
+              "governance",
+              "transfer",
+              "other"
+            ]
+          },
+          "event_count": { "type": "integer", "minimum": 0 },
+          "subnet_count": { "type": "integer", "minimum": 0 },
+          "hotkey_count": { "type": "integer", "minimum": 0 },
+          "coldkey_count": { "type": "integer", "minimum": 0 },
+          "amount_tao": { "type": "number", "minimum": 0 },
+          "alpha_amount": { "type": "number", "minimum": 0 },
+          "first_block": { "type": ["integer", "null"], "minimum": 0 },
+          "last_block": { "type": ["integer", "null"], "minimum": 0 },
+          "first_observed_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "last_observed_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          }
+        }
+      },
+      "ChainEventSummaryArtifact": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route.",
+        "required": [
+          "schema_version",
+          "window",
+          "observed_at",
+          "subnet_count",
+          "total_events",
+          "kind_count",
+          "category_count",
+          "recent_event_count",
+          "limit",
+          "categories",
+          "event_kinds",
+          "recent_events"
+        ],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "window": { "type": "string", "enum": ["7d", "30d", "90d"] },
+          "observed_at": { "type": ["string", "null"], "format": "date-time" },
+          "subnet_count": { "type": "integer", "minimum": 0 },
+          "total_events": { "type": "integer", "minimum": 0 },
+          "kind_count": { "type": "integer", "minimum": 0 },
+          "category_count": { "type": "integer", "minimum": 0 },
+          "recent_event_count": { "type": "integer", "minimum": 0 },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 50 },
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventCategorySummary"
+            }
+          },
+          "event_kinds": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ChainEventKindSummary" }
+          },
+          "recent_events": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AccountEvent" }
+          }
+        }
+      },
       "AccountExtrinsicsArtifact": {
         "type": "object",
         "additionalProperties": true,

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -653,6 +653,17 @@ const checks = [
     },
   ],
   [
+    "/api/v1/chain/event-summary",
+    (body) => {
+      assert.equal(body.data.schema_version, 1);
+      assert.equal(typeof body.data.subnet_count, "number");
+      assert.equal(Array.isArray(body.data.categories), true);
+      assert.equal(Array.isArray(body.data.event_kinds), true);
+      assert.equal(Array.isArray(body.data.recent_events), true);
+      assert.equal(typeof body.data.total_events, "number");
+    },
+  ],
+  [
     "/api/v1/chain/performance",
     (body) => {
       assert.equal(body.data.schema_version, 1);

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -74,6 +74,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "chain-weights",
   "chain-serving",
   "chain-registrations",
+  "chain-event-summary",
   "chain-concentration",
   "chain-performance",
   "chain-identity-history",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -126,6 +126,9 @@ export const R2_ONLY_PATTERNS = [
   // Network-wide neuron-registration activity across every subnet, computed live from
   // the account_events NeuronRegistered stream at /api/v1/chain/registrations — never a file.
   /^chain\/registrations\.json$/,
+  // Network-wide windowed account_events summary across every subnet, computed live
+  // from the account_events D1 tier at /api/v1/chain/event-summary — never a file.
+  /^chain\/event-summary\.json$/,
   // Network-wide concentration aggregated across every subnet's neurons, computed
   // live from the neurons D1 tier at /api/v1/chain/concentration — never a file.
   /^chain\/concentration\.json$/,

--- a/src/chain-event-summary.mjs
+++ b/src/chain-event-summary.mjs
@@ -1,0 +1,287 @@
+// Network-wide windowed account_events summary: compact kind/category counts plus a
+// small newest-first evidence slice across every subnet. Pure shaping
+// (buildChainEventSummary) + a thin D1 loader (loadChainEventSummary); the field
+// semantics live in schemas/components/05-subnets.schema.json
+// (ChainEventSummaryArtifact). Companion to the per-subnet /subnets/{netuid}/event-summary
+// route and GET /api/v1/chain/event-summary.
+
+import { clampLimit } from "../workers/request-params.mjs";
+import {
+  ACCOUNT_EVENT_COLUMNS,
+  DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+  formatAccountEvent,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+} from "./account-events.mjs";
+
+export {
+  DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW as DEFAULT_CHAIN_EVENT_SUMMARY_WINDOW,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT as CHAIN_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX as CHAIN_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  SUBNET_EVENT_SUMMARY_WINDOWS as CHAIN_EVENT_SUMMARY_WINDOWS,
+};
+
+function toIso(ms) {
+  if (ms == null) return null;
+  const n = Number(ms);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+}
+
+function toBlockNumber(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
+function toTaoOrNull(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+function toTaoOrZero(value) {
+  return toTaoOrNull(value) ?? 0;
+}
+
+function toCount(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0;
+}
+
+const EVENT_KIND_CATEGORIES = {
+  NeuronRegistered: "registration",
+  NeuronDeregistered: "registration",
+  NetworkAdded: "registration",
+  NetworkRemoved: "registration",
+  RegistrationAllowed: "registration",
+  PowRegistrationAllowed: "registration",
+  Faucet: "registration",
+  StakeAdded: "stake",
+  StakeRemoved: "stake",
+  StakeMoved: "stake",
+  StakeTransferred: "stake",
+  AxonServed: "serving",
+  PrometheusServed: "serving",
+  AxonInfoRemoved: "serving",
+  WeightsSet: "consensus",
+  RootClaimed: "consensus",
+  DelegateAdded: "delegation",
+  TakeDecreased: "delegation",
+  TakeIncreased: "delegation",
+  HotkeySwapped: "identity",
+  ColdkeySwapped: "identity",
+  ColdkeySwapScheduled: "identity",
+  SubnetOwnerHotkeySet: "governance",
+  BurnSet: "governance",
+  Transfer: "transfer",
+};
+
+function eventKindCategory(kind) {
+  return EVENT_KIND_CATEGORIES[kind] ?? "other";
+}
+
+function emptyCategory(category) {
+  return {
+    category,
+    event_count: 0,
+    kind_count: 0,
+    amount_tao: 0,
+    alpha_amount: 0,
+    first_block: null,
+    last_block: null,
+    first_observed_at: null,
+    last_observed_at: null,
+  };
+}
+
+function mergeObserved(existing, next, choose) {
+  const nextValue = Number(next);
+  if (!Number.isFinite(nextValue) || nextValue <= 0) return existing;
+  if (existing == null) return nextValue;
+  return choose(existing, nextValue);
+}
+
+// Windowed event summary across every subnet: compact kind/category counts plus a
+// small newest-first evidence slice. Mirrors buildSubnetEventSummary but omits
+// netuid, carries root subnet_count, and each event_kind row includes subnet_count.
+export function buildChainEventSummary(
+  kindRows,
+  recentRows,
+  { window, limit, subnetCount } = {},
+) {
+  const eventKinds = [];
+  const categories = new Map();
+  let latestObserved = null;
+  for (const row of Array.isArray(kindRows) ? kindRows : []) {
+    const kind =
+      typeof row?.event_kind === "string" && row.event_kind.length > 0
+        ? row.event_kind
+        : null;
+    if (!kind) continue;
+    const category = eventKindCategory(kind);
+    const eventCount = toCount(row.event_count);
+    const amountTao = toTaoOrZero(row.amount_tao);
+    const alphaAmount = toTaoOrZero(row.alpha_amount);
+    const firstObservedMs = mergeObserved(
+      null,
+      row.first_observed_at,
+      Math.min,
+    );
+    const lastObservedMs = mergeObserved(null, row.last_observed_at, Math.max);
+    const shaped = {
+      event_kind: kind,
+      category,
+      event_count: eventCount,
+      subnet_count: toCount(row.subnet_count),
+      hotkey_count: toCount(row.hotkey_count),
+      coldkey_count: toCount(row.coldkey_count),
+      amount_tao: amountTao,
+      alpha_amount: alphaAmount,
+      first_block: toBlockNumber(row.first_block),
+      last_block: toBlockNumber(row.last_block),
+      first_observed_at: toIso(firstObservedMs),
+      last_observed_at: toIso(lastObservedMs),
+    };
+    eventKinds.push(shaped);
+    const summary = categories.get(category) ?? emptyCategory(category);
+    summary.event_count += eventCount;
+    summary.kind_count += 1;
+    summary.amount_tao = toTaoOrZero(summary.amount_tao + amountTao);
+    summary.alpha_amount = toTaoOrZero(summary.alpha_amount + alphaAmount);
+    summary.first_block =
+      summary.first_block == null
+        ? shaped.first_block
+        : shaped.first_block == null
+          ? summary.first_block
+          : Math.min(summary.first_block, shaped.first_block);
+    summary.last_block =
+      summary.last_block == null
+        ? shaped.last_block
+        : shaped.last_block == null
+          ? summary.last_block
+          : Math.max(summary.last_block, shaped.last_block);
+    summary.first_observed_at = toIso(
+      mergeObserved(
+        summary.first_observed_at == null
+          ? null
+          : Date.parse(summary.first_observed_at),
+        firstObservedMs,
+        Math.min,
+      ),
+    );
+    summary.last_observed_at = toIso(
+      mergeObserved(
+        summary.last_observed_at == null
+          ? null
+          : Date.parse(summary.last_observed_at),
+        lastObservedMs,
+        Math.max,
+      ),
+    );
+    categories.set(category, summary);
+    latestObserved = mergeObserved(latestObserved, lastObservedMs, Math.max);
+  }
+  eventKinds.sort(
+    (a, b) =>
+      b.event_count - a.event_count ||
+      a.category.localeCompare(b.category) ||
+      a.event_kind.localeCompare(b.event_kind),
+  );
+  const categoryList = [...categories.values()].sort(
+    (a, b) =>
+      b.event_count - a.event_count || a.category.localeCompare(b.category),
+  );
+  const recentEvents = (Array.isArray(recentRows) ? recentRows : [])
+    .map(formatAccountEvent)
+    .filter(Boolean);
+  for (const event of recentEvents) {
+    latestObserved = mergeObserved(
+      latestObserved,
+      event.observed_at == null ? null : Date.parse(event.observed_at),
+      Math.max,
+    );
+  }
+  return {
+    schema_version: 1,
+    window: window ?? null,
+    observed_at: toIso(latestObserved),
+    subnet_count: toCount(subnetCount),
+    total_events: eventKinds.reduce((sum, row) => sum + row.event_count, 0),
+    kind_count: eventKinds.length,
+    category_count: categoryList.length,
+    recent_event_count: recentEvents.length,
+    limit: limit ?? null,
+    categories: categoryList,
+    event_kinds: eventKinds,
+    recent_events: recentEvents,
+  };
+}
+
+const ACTOR_IDENTITY =
+  "CASE " +
+  "WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey " +
+  "WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid " +
+  "ELSE NULL END";
+
+export async function loadChainEventSummary(
+  d1,
+  {
+    windowLabel = DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+    limit = SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  } = {},
+) {
+  const effectiveWindowLabel = Object.hasOwn(
+    SUBNET_EVENT_SUMMARY_WINDOWS,
+    windowLabel,
+  )
+    ? windowLabel
+    : DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+  const days = SUBNET_EVENT_SUMMARY_WINDOWS[effectiveWindowLabel];
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const lim = clampLimit(limit, {
+    defaultLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    maxLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  });
+  const probeRows = await d1(
+    "SELECT COUNT(DISTINCT netuid) AS subnet_count, MAX(observed_at) AS newest_observed " +
+      "FROM account_events WHERE observed_at >= ?",
+    [cutoff],
+  );
+  const probe = probeRows?.[0] ?? null;
+  const subnetCount = toCount(probe?.subnet_count);
+  let kindRows = [];
+  let recentRows = [];
+  if (probe?.newest_observed != null) {
+    kindRows = await d1(
+      "SELECT event_kind, COUNT(*) AS event_count, " +
+        "COUNT(DISTINCT netuid) AS subnet_count, " +
+        "COUNT(DISTINCT " +
+        ACTOR_IDENTITY +
+        ") AS hotkey_count, " +
+        "COUNT(DISTINCT coldkey) AS coldkey_count, " +
+        "COALESCE(SUM(amount_tao), 0) AS amount_tao, " +
+        "COALESCE(SUM(alpha_amount), 0) AS alpha_amount, " +
+        "MIN(block_number) AS first_block, MAX(block_number) AS last_block, " +
+        "MIN(observed_at) AS first_observed_at, MAX(observed_at) AS last_observed_at " +
+        "FROM account_events WHERE observed_at >= ? " +
+        "GROUP BY event_kind ORDER BY event_count DESC, event_kind ASC",
+      [cutoff],
+    );
+    recentRows = await d1(
+      `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events ` +
+        "WHERE observed_at >= ? " +
+        "ORDER BY block_number DESC, event_index DESC LIMIT ?",
+      [cutoff, lim],
+    );
+  }
+  const summary = buildChainEventSummary(kindRows, recentRows, {
+    window: effectiveWindowLabel,
+    limit: lim,
+    subnetCount,
+  });
+  if (summary.observed_at == null && probe?.newest_observed != null) {
+    summary.observed_at = toIso(probe.newest_observed);
+  }
+  return summary;
+}

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1218,6 +1218,12 @@ export const PUBLIC_ARTIFACTS = [
     "ChainRegistrationsArtifact",
   ),
   artifact(
+    "chain-event-summary",
+    "/metagraph/chain/event-summary.json",
+    "Network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, and a small newest-first evidence slice, served live from D1 at /api/v1/chain/event-summary (no static file). Companion to the per-subnet /subnets/{netuid}/event-summary route.",
+    "ChainEventSummaryArtifact",
+  ),
+  artifact(
     "chain-fees",
     "/metagraph/chain/fees.json",
     "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
@@ -2688,6 +2694,23 @@ export const API_ROUTES = [
     [
       { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
+    ],
+    [],
+  ),
+  route(
+    "chain-event-summary",
+    "GET",
+    "/api/v1/chain/event-summary",
+    "/metagraph/chain/event-summary.json",
+    "Fetch a network-wide windowed account_events summary across every subnet: counts by event kind and coarse category, distinct hotkey/coldkey counts, per-kind subnet reach, TAO/alpha sums where applicable, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier; schema-stable empty block when cold. Companion to GET /api/v1/subnets/{netuid}/event-summary.",
+    "short",
+    ["chain", "analytics"],
+    [
+      {
+        name: "window",
+        schema: { type: "string", enum: ["7d", "30d", "90d"] },
+      },
+      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 50 } },
     ],
     [],
   ),

--- a/tests/chain-event-summary.test.mjs
+++ b/tests/chain-event-summary.test.mjs
@@ -1,0 +1,458 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import {
+  buildChainEventSummary,
+  loadChainEventSummary,
+  CHAIN_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  CHAIN_EVENT_SUMMARY_WINDOWS,
+} from "../src/chain-event-summary.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const OBS = 1_750_000_000_000;
+
+function kindRow(
+  event_kind,
+  event_count,
+  {
+    subnet_count = 1,
+    hotkey_count = 1,
+    coldkey_count = 0,
+    amount_tao = null,
+    alpha_amount = null,
+    first_block = 100,
+    last_block = 120,
+    first_observed_at = OBS,
+    last_observed_at = OBS + 10_000,
+  } = {},
+) {
+  return {
+    event_kind,
+    event_count,
+    subnet_count,
+    hotkey_count,
+    coldkey_count,
+    amount_tao,
+    alpha_amount,
+    first_block,
+    last_block,
+    first_observed_at,
+    last_observed_at,
+  };
+}
+
+describe("buildChainEventSummary", () => {
+  test("groups event kinds into coarse categories with per-kind subnet reach", () => {
+    const out = buildChainEventSummary(
+      [
+        kindRow("StakeAdded", "3", {
+          subnet_count: 2,
+          hotkey_count: "2",
+          coldkey_count: "1",
+          amount_tao: 3.3,
+          alpha_amount: "0.4",
+        }),
+        kindRow("WeightsSet", 2, {
+          subnet_count: 3,
+          hotkey_count: 1,
+          first_block: 90,
+          last_block: 119,
+          first_observed_at: 1_749_999_000_000,
+          last_observed_at: 1_750_000_005_000,
+        }),
+        { event_kind: "", event_count: 99 },
+      ],
+      [
+        {
+          block_number: 120,
+          event_index: 2,
+          event_kind: "StakeAdded",
+          netuid: 7,
+          observed_at: 1_750_000_010_000,
+        },
+      ],
+      { window: "7d", limit: 5, subnetCount: 4 },
+    );
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.window, "7d");
+    assert.equal(out.subnet_count, 4);
+    assert.equal(out.total_events, 5);
+    assert.equal(out.kind_count, 2);
+    assert.equal(out.category_count, 2);
+    assert.equal(out.event_kinds[0].event_kind, "StakeAdded");
+    assert.equal(out.event_kinds[0].subnet_count, 2);
+    assert.equal(out.event_kinds[0].amount_tao, 3.3);
+    assert.equal(out.categories[0].category, "stake");
+    assert.equal(out.categories[0].event_count, 3);
+    assert.equal(out.recent_event_count, 1);
+    assert.equal(out.observed_at, "2025-06-15T15:06:50.000Z");
+  });
+
+  test("merges same-category bounds and tie-sorts deterministically", () => {
+    const out = buildChainEventSummary(
+      [
+        kindRow("StakeAdded", 2, {
+          amount_tao: 1,
+          alpha_amount: 0.1,
+          first_block: 200,
+          last_block: 210,
+          first_observed_at: 1_750_000_200_000,
+          last_observed_at: 1_750_000_210_000,
+        }),
+        kindRow("StakeRemoved", 2, {
+          amount_tao: 2,
+          alpha_amount: 0.2,
+          first_block: null,
+          last_block: null,
+          first_observed_at: null,
+          last_observed_at: null,
+        }),
+        kindRow("StakeMoved", 2, {
+          amount_tao: 3,
+          alpha_amount: 0.3,
+          first_block: 150,
+          last_block: 250,
+          first_observed_at: 1_750_000_150_000,
+          last_observed_at: 1_750_000_260_000,
+        }),
+        kindRow("WeightsSet", 2, { first_block: 180, last_block: 181 }),
+        kindRow("AxonServed", 2, { first_block: 190, last_block: 191 }),
+      ],
+      [{ block_number: 250, event_index: 0, event_kind: "StakeMoved" }],
+      { window: "30d", limit: 1, subnetCount: 5 },
+    );
+    assert.deepEqual(
+      out.event_kinds.map((row) => row.event_kind),
+      ["WeightsSet", "AxonServed", "StakeAdded", "StakeMoved", "StakeRemoved"],
+    );
+    assert.deepEqual(
+      out.categories.map((row) => row.category),
+      ["stake", "consensus", "serving"],
+    );
+    assert.deepEqual(
+      {
+        event_count: out.categories[0].event_count,
+        amount_tao: out.categories[0].amount_tao,
+        first_block: out.categories[0].first_block,
+        last_block: out.categories[0].last_block,
+      },
+      {
+        event_count: 6,
+        amount_tao: 6,
+        first_block: 150,
+        last_block: 250,
+      },
+    );
+  });
+
+  test("is schema-stable for malformed cold inputs", () => {
+    const out = buildChainEventSummary(null, null, { subnetCount: null });
+    assert.equal(out.window, null);
+    assert.equal(out.observed_at, null);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.total_events, 0);
+    assert.equal(out.limit, null);
+    assert.deepEqual(out.categories, []);
+    assert.deepEqual(out.event_kinds, []);
+    assert.deepEqual(out.recent_events, []);
+  });
+
+  test("keeps unknown future kinds in the other category", () => {
+    const out = buildChainEventSummary(
+      [kindRow("FutureRuntimeEvent", 1)],
+      [],
+      { subnetCount: 1 },
+    );
+    assert.equal(out.event_kinds[0].event_kind, "FutureRuntimeEvent");
+    assert.equal(out.event_kinds[0].category, "other");
+    assert.equal(out.categories[0].category, "other");
+  });
+
+  test("coerces non-numeric subnet_count cells to zero", () => {
+    const out = buildChainEventSummary(
+      [kindRow("StakeAdded", 1, { subnet_count: "bad" })],
+      [],
+      { subnetCount: "nope" },
+    );
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.event_kinds[0].subnet_count, 0);
+  });
+});
+
+describe("loadChainEventSummary", () => {
+  test("probes subnet reach then reads kind aggregates and recent evidence", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      if (/GROUP BY event_kind/.test(sql)) {
+        return [kindRow("StakeAdded", 2, { subnet_count: 3 })];
+      }
+      if (/MAX\(observed_at\) AS newest_observed/.test(sql)) {
+        return [{ subnet_count: 4, newest_observed: OBS }];
+      }
+      return [{ block_number: 10, event_index: 1, event_kind: "StakeAdded" }];
+    };
+    const out = await loadChainEventSummary(d1, {
+      windowLabel: "90d",
+      limit: 50,
+    });
+    assert.equal(calls.length, 3);
+    assert.match(calls[0].sql, /MAX\(observed_at\) AS newest_observed/);
+    assert.match(calls[1].sql, /COUNT\(DISTINCT netuid\) AS subnet_count/);
+    assert.match(calls[1].sql, /GROUP BY event_kind/);
+    assert.doesNotMatch(calls[1].sql, /WHERE netuid = \?/);
+    assert.match(calls[2].sql, /ORDER BY block_number DESC, event_index DESC/);
+    assert.doesNotMatch(calls[2].sql, /WHERE netuid = \?/);
+    assert.equal(calls[2].params.at(-1), 50);
+    assert.equal(out.window, "90d");
+    assert.equal(out.limit, 50);
+    assert.equal(out.subnet_count, 4);
+    assert.equal(out.total_events, 2);
+  });
+
+  test("falls back to the default direct-call window", async () => {
+    let cutoff;
+    const out = await loadChainEventSummary(async (sql, params) => {
+      if (/MAX\(observed_at\) AS newest_observed/.test(sql)) {
+        cutoff = params[0];
+        return [{ subnet_count: 0, newest_observed: null }];
+      }
+      return [];
+    }, { windowLabel: "bogus" });
+    const expectedCutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    assert.ok(Math.abs(cutoff - expectedCutoff) < 1000);
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 0);
+  });
+
+  test("counts distinct actors over hotkey-or-uid identity for WeightsSet", async () => {
+    let kindSql;
+    const out = await loadChainEventSummary(async (sql) => {
+      if (/GROUP BY event_kind/.test(sql)) {
+        kindSql = sql;
+        return [
+          kindRow("WeightsSet", 3, {
+            hotkey_count: 3,
+            subnet_count: 2,
+          }),
+        ];
+      }
+      if (/MAX\(observed_at\) AS newest_observed/.test(sql)) {
+        return [{ subnet_count: 2, newest_observed: OBS }];
+      }
+      return [];
+    }, { windowLabel: "7d" });
+    assert.match(kindSql, /WHEN uid IS NOT NULL THEN 'uid:' \|\| netuid/);
+    assert.equal(out.event_kinds[0].hotkey_count, 3);
+  });
+
+  test("skips kind/recent reads on a cold store", async () => {
+    const calls = [];
+    const out = await loadChainEventSummary(async (sql, params) => {
+      calls.push({ sql, params });
+      return [{ subnet_count: 0, newest_observed: null }];
+    }, { windowLabel: "7d" });
+    assert.equal(calls.length, 1);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.total_events, 0);
+    assert.deepEqual(out.event_kinds, []);
+    assert.deepEqual(out.recent_events, []);
+  });
+
+  test("exports the same window constants as the subnet summary route", () => {
+    assert.deepEqual(CHAIN_EVENT_SUMMARY_WINDOWS, { "7d": 7, "30d": 30, "90d": 90 });
+  });
+
+  test("clamps recent evidence limit to the configured max", async () => {
+    const d1 = async (sql) => {
+      if (/MAX\(observed_at\) AS newest_observed/.test(sql)) {
+        return [{ subnet_count: 1, newest_observed: OBS }];
+      }
+      if (/GROUP BY event_kind/.test(sql)) return [];
+      return [];
+    };
+    const out = await loadChainEventSummary(d1, {
+      windowLabel: "7d",
+      limit: CHAIN_EVENT_SUMMARY_RECENT_LIMIT_MAX + 100,
+    });
+    assert.equal(out.limit, CHAIN_EVENT_SUMMARY_RECENT_LIMIT_MAX);
+  });
+});
+
+describe("GET /api/v1/chain/event-summary", () => {
+  function eventSummaryEnv({ probeRow, kindRows, recentRows }) {
+    return {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind: () => ({
+              all: () =>
+                Promise.resolve({
+                  results: /GROUP BY event_kind/.test(sql)
+                    ? kindRows
+                    : /MAX\(observed_at\) AS newest_observed/.test(sql)
+                      ? probeRow
+                      : recentRows,
+                }),
+            }),
+          };
+        },
+      },
+    };
+  }
+
+  const req = (q = "") =>
+    new Request(`https://api.metagraph.sh/api/v1/chain/event-summary${q}`);
+  const cold = {
+    probeRow: [{ subnet_count: 0, newest_observed: null }],
+    kindRows: [],
+    recentRows: [],
+  };
+  const warm = {
+    probeRow: [{ subnet_count: 3, newest_observed: OBS }],
+    kindRows: [
+      kindRow("StakeAdded", 5, { subnet_count: 2 }),
+      kindRow("WeightsSet", 3, { subnet_count: 3 }),
+    ],
+    recentRows: [
+      {
+        block_number: 120,
+        event_index: 1,
+        event_kind: "StakeAdded",
+        netuid: 7,
+        observed_at: OBS,
+      },
+    ],
+  };
+
+  test("dispatches to the network-wide event summary", async () => {
+    const res = await handleRequest(
+      req("?window=7d&limit=5"),
+      eventSummaryEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+    assert.equal(body.data.subnet_count, 3);
+    assert.equal(body.data.event_kinds[0].event_kind, "StakeAdded");
+    assert.equal(body.data.event_kinds[0].subnet_count, 2);
+    assert.equal(body.meta.artifact_path, "/metagraph/chain/event-summary.json");
+  });
+
+  test("serves a HEAD probe through the GET cache key with no body", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/event-summary", {
+        method: "HEAD",
+      }),
+      eventSummaryEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "");
+  });
+
+  test("serves a schema-stable empty summary on a cold store", async () => {
+    const res = await handleRequest(req(), eventSummaryEnv(cold), {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 0);
+    assert.deepEqual(body.data.categories, []);
+    assert.deepEqual(body.data.event_kinds, []);
+    assert.deepEqual(body.data.recent_events, []);
+  });
+
+  test("rejects an unsupported window with 400", async () => {
+    const res = await handleRequest(req("?window=1y"), eventSummaryEnv(cold), {});
+    assert.equal(res.status, 400);
+  });
+
+  test("rejects an unknown query param with 400", async () => {
+    const res = await handleRequest(req("?bogus=1"), eventSummaryEnv(cold), {});
+    assert.equal(res.status, 400);
+  });
+
+  test("rejects an out-of-range limit with 400", async () => {
+    const res = await handleRequest(req("?limit=0"), eventSummaryEnv(cold), {});
+    assert.equal(res.status, 400);
+  });
+
+  test("rejects ?format=csv as an unknown param (JSON-only route)", async () => {
+    const res = await handleRequest(
+      req("?format=csv"),
+      eventSummaryEnv(cold),
+      {},
+    );
+    assert.equal(res.status, 400);
+  });
+
+  test("defaults to the 30d window when omitted", async () => {
+    const res = await handleRequest(req(), eventSummaryEnv(warm), {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.window, "30d");
+  });
+});
+
+describe("chain/event-summary edge cache", () => {
+  let originalCaches;
+  afterEach(() => {
+    globalThis.caches = originalCaches;
+  });
+
+  test("routes through the edge cache with caches enabled", async () => {
+    originalCaches = globalThis.caches;
+    const store = new Map();
+    globalThis.caches = {
+      default: {
+        async match(request) {
+          const cached = store.get(request.url);
+          return cached ? cached.clone() : undefined;
+        },
+        async put(request, response) {
+          store.set(request.url, response.clone());
+        },
+      },
+    };
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          return key === "health:meta"
+            ? { last_run_at: "2026-06-30T00:00:00.000Z" }
+            : null;
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind: () => ({
+              all: () =>
+                Promise.resolve({
+                  results: /GROUP BY event_kind/.test(sql)
+                    ? [kindRow("StakeAdded", 1, { subnet_count: 1 })]
+                    : /MAX\(observed_at\) AS newest_observed/.test(sql)
+                      ? [{ subnet_count: 2, newest_observed: OBS }]
+                      : [],
+                }),
+            }),
+          };
+        },
+      },
+    };
+    const waits = [];
+    const call = () =>
+      handleRequest(
+        new Request("https://api.metagraph.sh/api/v1/chain/event-summary"),
+        env,
+        { waitUntil: (promise) => waits.push(promise) },
+      );
+    const res = await call();
+    assert.equal(res.status, 200);
+    const cached = await call();
+    assert.equal(cached.status, 200);
+    assert.equal(store.size, 1);
+    await Promise.all(waits);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -56,6 +56,7 @@ import {
   handleChainWeights,
   handleChainServing,
   handleChainRegistrations,
+  handleChainEventSummary,
   handleGlobalIncidents,
   loadGlobalIncidentsLedger,
   handleHealthIncidents,
@@ -1858,6 +1859,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (resolved.url.pathname === "/api/v1/chain/registrations") {
       return handleChainRegistrations(request, env, resolved.url, ctx);
     }
+    if (resolved.url.pathname === "/api/v1/chain/event-summary") {
+      return handleChainEventSummary(request, env, resolved.url, ctx);
+    }
     // GET /api/v1/chain/concentration: network-wide neurons aggregate — edge-cache
     // busts on the newest neuron captured_at across ALL subnets, not the health
     // prober tick (like the per-subnet concentration route, but network-scoped).
@@ -1997,6 +2001,7 @@ function isMainnetOnlyApiPath(pathname) {
     pathname === "/api/v1/chain/weights" ||
     pathname === "/api/v1/chain/serving" ||
     pathname === "/api/v1/chain/registrations" ||
+    pathname === "/api/v1/chain/event-summary" ||
     pathname === "/api/v1/chain/concentration" ||
     pathname === "/api/v1/chain/performance" ||
     pathname === "/api/v1/chain/identity-history" ||

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -76,6 +76,13 @@ import {
   CHAIN_REGISTRATIONS_LIMIT_MAX,
 } from "../../src/chain-registrations.mjs";
 import {
+  loadChainEventSummary,
+  CHAIN_EVENT_SUMMARY_WINDOWS,
+  DEFAULT_CHAIN_EVENT_SUMMARY_WINDOW,
+  CHAIN_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  CHAIN_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+} from "../../src/chain-event-summary.mjs";
+import {
   loadChainWeights,
   CHAIN_WEIGHTS_LIMIT_DEFAULT,
   CHAIN_WEIGHTS_LIMIT_MAX,
@@ -1375,6 +1382,72 @@ export async function handleChainRegistrations(request, env, url, ctx = {}) {
       );
     },
     canonicalAnalyticsCacheRoute(url, ["limit"]),
+  );
+  return request.method === "HEAD"
+    ? new Response(null, { status: response.status, headers: response.headers })
+    : response;
+}
+
+function canonicalChainEventSummaryCacheRoute(url) {
+  const search = new URL("https://cache-key.invalid/").searchParams;
+  const windowValue = url.searchParams.get("window");
+  search.set("window", windowValue ?? DEFAULT_CHAIN_EVENT_SUMMARY_WINDOW);
+  const limitValue = url.searchParams.get("limit");
+  if (limitValue !== null) search.set("limit", limitValue);
+  const query = search.toString();
+  return `${url.pathname}${query ? `?${query}` : ""}`;
+}
+
+// GET /api/v1/chain/event-summary: network-wide windowed account_events summary
+// across every subnet — compact kind/category counts plus a small newest-first
+// evidence slice. Companion to /subnets/{netuid}/event-summary.
+export async function handleChainEventSummary(request, env, url, ctx = {}) {
+  const validationError = validateQueryParams(url, ["window", "limit"]);
+  if (validationError) return analyticsQueryError(validationError);
+  const windowLabel =
+    url.searchParams.get("window") ?? DEFAULT_CHAIN_EVENT_SUMMARY_WINDOW;
+  if (
+    !Object.prototype.hasOwnProperty.call(CHAIN_EVENT_SUMMARY_WINDOWS, windowLabel)
+  ) {
+    return analyticsQueryError({
+      parameter: "window",
+      message: `window must be one of ${Object.keys(CHAIN_EVENT_SUMMARY_WINDOWS).join(", ")}.`,
+    });
+  }
+  const { limit, error: limitError } = parseLimitParam(url, {
+    defaultLimit: CHAIN_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    maxLimit: CHAIN_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  });
+  if (limitError) return analyticsQueryError(limitError);
+
+  const cacheRequest =
+    request.method === "HEAD"
+      ? new Request(request, { method: "GET" })
+      : request;
+  const response = await withEdgeCache(
+    cacheRequest,
+    ctx,
+    env,
+    "chain-event-summary",
+    async () => {
+      const data = await loadChainEventSummary(d1Runner(env), {
+        windowLabel,
+        limit,
+      });
+      return envelopeResponse(
+        cacheRequest,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/event-summary.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+    },
+    canonicalChainEventSummaryCacheRoute(url),
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/chain/event-summary` — network-wide windowed `account_events` summary with kind/category aggregates, per-kind `subnet_count`, and a newest-first evidence slice (`?window=7d|30d|90d`, `?limit` ≤50).
- Introduce `buildChainEventSummary` / `loadChainEventSummary` in `src/chain-event-summary.mjs`, mirroring the per-subnet event-summary builder/loader with network-wide SQL (no `netuid` filter, probe for root `subnet_count`, hotkey-or-uid actor identity for WeightsSet).
- Wire handler (`handleChainEventSummary`), edge cache, contracts, OpenAPI schemas (`ChainEventSummaryArtifact`, `ChainEventKindSummary`), and comprehensive tests.

## Scope

- [x] Branch `feat/chain-event-summary` from `upstream/main` (includes #3092 chain/registrations, #3093 turnover fix)
- [x] No blank-cell nullableTao fixes or unrelated bug fixes

## Test plan

- [x] `npm test -- tests/chain-event-summary.test.mjs` — 20 tests pass (builder, loader SQL contract, cold store, handler, edge cache)
- [x] `npm run validate:schemas` — pass
- [x] `npm run schemas:bundle`, `npm run openapi:generate`, `npm run types:generate`, `npm run build:artifacts` — generated artifacts updated

## Companion routes

- Per-subnet: `GET /api/v1/subnets/{netuid}/event-summary` (#2837)
- MCP: `get_subnet_event_summary` (#3088)
