### PR TITLE
feat(registry): add SN36 Eirel evaluation environment windows data-artifact

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -139,6 +139,22 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public no-auth JSON catalog of Eirel's evaluation workflow specifications (workflow_spec_id, class, description, node graph); GET /v1/workflow-specs in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/* and /v1/metagraph/status routes."
+    },
+    {
+      "id": "sn-36-eirel-env-windows",
+      "name": "Eirel evaluation environment windows",
+      "kind": "data-artifact",
+      "url": "https://api.eirel.ai/v1/env-windows",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window membership version); GET /v1/env-windows in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/sn-36.json` (SN36 Eirel). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds Eirel's active evaluation environment-windows feed (`GET /v1/env-windows`) — a public, no-auth JSON of the per-capability evaluation windows (capability, family, enabled state, min-completeness, weight, evaluation split, window membership version). Sourced from the subnet's official OpenAPI contract and website.

This is a distinct endpoint from Eirel's already-registered routes (`/api/v1/dashboard/*`, `/v1/metagraph/status`, `/v1/workflow-specs`).

## Surface

- Netuid: 36
- Kind: data-artifact
- Public URL: https://api.eirel.ai/v1/env-windows
- Source URLs: https://api.eirel.ai/openapi.json , https://eirel.ai/
- Provider slug: eirel

The endpoint is defined in the official Eirel OpenAPI spec as `Env Windows` with no security requirement, and the `api.eirel.ai` host is the subnet's first-party API (already established by the existing Eirel OpenAPI and dashboard surfaces).

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/sn-36.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
