### PR TITLE
fix(api): clamp a near-monopoly weight-setter share below a flat 1

### DIFF
--- a/src/subnet-weight-setters.mjs
+++ b/src/subnet-weight-setters.mjs
@@ -28,11 +28,15 @@ const SETTER_IDENTITY =
   "WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid " +
   "ELSE NULL END";
 
-// Round a share to a stable 4dp precision. Always finite here (a per-setter count over a
-// positive total, with the divisor guarded below).
+// Round a share to a stable 4dp precision WITHOUT letting a sub-1 share round up to an
+// exact 1 -- a setter that drove < 100% of the subnet's weight-setting must not read as a
+// flat 1 while another setter still holds activity (e.g. 49999/50000 = 0.99998 -> 1.0000).
+// The same anti-overstatement guard the sibling share/ratio rounders apply. A genuine sole
+// setter (its count == the subnet total) keeps a true 1.
 function round(value, dp = 4) {
   const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
 }
 
 // A non-negative whole count from a D1 COUNT() cell (number, numeric string, or null),

--- a/tests/subnet-weight-setters.test.mjs
+++ b/tests/subnet-weight-setters.test.mjs
@@ -61,6 +61,33 @@ describe("buildSubnetWeightSetters", () => {
     assert.equal(buildSubnetWeightSetters([], {}, NETUID).window, null);
   });
 
+  test("a near-monopoly setter's share does not round up to a flat 1 while others set weights", () => {
+    // One setter drove 49999 of the subnet's 50000 WeightsSet events (99.998%);
+    // a second setter drove the last 1. A bare 4dp round lifts 0.99998 to exactly
+    // 1, reading as if the top setter did ALL the weight-setting. Clamp holds it
+    // below 1 while the true sole-setter case (below) still reports 1.
+    const d = buildSubnetWeightSetters(
+      [
+        { hotkey: "5Grw...alice", uid: 3, weight_sets: 49999 },
+        { hotkey: "5Frw...bob", uid: 4, weight_sets: 1 },
+      ],
+      { weight_sets: 50000, distinct_setters: 2 },
+      NETUID,
+    );
+    assert.ok(d.setters[0].share < 1, "near-monopoly share must stay below 1");
+    assert.equal(d.setters[0].share, 0.9999);
+    assert.equal(d.setters[1].share, 0); // 1/50000 rounds to 0.0000 at 4dp
+  });
+
+  test("a genuine sole setter keeps an exact share of 1", () => {
+    const d = buildSubnetWeightSetters(
+      [{ hotkey: "5Grw...alice", uid: 3, weight_sets: 100 }],
+      { weight_sets: 100, distinct_setters: 1 },
+      NETUID,
+    );
+    assert.equal(d.setters[0].share, 1);
+  });
+
   test("shapes the leaderboard: counts, shares, first/last, nullable hotkey/uid", () => {
     const d = buildSubnetWeightSetters(LEADER_ROWS, TOTALS, NETUID, {
       window: "30d",


### PR DESCRIPTION
## What

`buildSubnetWeightSetters` (the new `GET /api/v1/subnets/{netuid}/weight-setters` leaderboard, #3098) computes each setter's `share` — its `WeightsSet` count over the subnet total — and rounds to 4 dp with a bare `Math.round`:

```js
share: totalSets > 0 ? round(weightSets / totalSets) : null,
// round(v) = Math.round(v * 10000) / 10000
```

A setter that drove just under 100% of the subnet's weight-setting rounds up to an exact `1`, reading as if it did **all** of it — while another setter still held activity.

## Concrete case

Two setters: A drove 49999 of the subnet's 50000 `WeightsSet` events (99.998%), B drove the last 1.

- **Before:** `A.share = 1` (0.99998 → `1.0000`) — reads as a sole setter
- **After:** `A.share = 0.9999`
- B's `1/50000 = 0.00002` rounds to `0` at 4 dp either way.

## Fix

Clamp a sub-1 share so it never rounds up to an exact `1` — the same anti-overstatement guard the sibling share/ratio rounders already apply (`roundShare` in `chain-transfer-pairs` #2971, `roundConcentration` in `account-stake-flow` #2997, `pctShare` in `movers` #2985). A genuine sole setter (its count equals the subnet total) still reports a true `1`.

`round` is used only for `share` (a 0..1 ratio), so the clamp is added there directly — no new helper.

## Tests

- New: a near-monopoly setter (99.998%) with a second setter present clamps to `0.9999`; a genuine sole setter keeps `1`. Fails on the old bare round, passes with the fix.
- Existing leaderboard tests still pass (17/17).

Source + tests only — no schema/contract/generated-artifact changes (`share` stays `number | null`). `eslint` clean, `prettier` clean, 100% patch coverage.
