### PR TITLE
test(api): cover profiles CSV export (#2525)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1270,6 +1270,21 @@ describe("review enrichment list CSV export", () => {
 
 // --- registry list CSV export (#2521-#2526) -----------------------------------
 describe("registry list CSV export", () => {
+  const parseCsv = async (res) => {
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    const text = await res.text();
+    const lines = text.split("\r\n").filter(Boolean);
+    const header = lines[0].split(",");
+    const rows = lines.slice(1).map((line) => {
+      const values = line.split(",");
+      return Object.fromEntries(
+        header.map((name, index) => [name, values[index]]),
+      );
+    });
+    return { header, rows, lines };
+  };
+
   const CSV_ROUTES = [
     "economics",
     "surfaces",
@@ -1331,6 +1346,38 @@ describe("registry list CSV export", () => {
       assert.ok(header.includes(","), "header should list multiple columns");
     });
   }
+
+  test("profiles CSV export projects completeness columns and preserves descending score order (#2525)", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/profiles?format=csv&fields=netuid,completeness_score,curation_level,profile_level&sort=completeness_score&order=desc&limit=5",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="profiles.csv"',
+    );
+
+    const { header, rows } = await parseCsv(res);
+    assert.equal(
+      header.join(","),
+      "netuid,completeness_score,curation_level,profile_level",
+    );
+    assert.ok(rows.length > 1);
+    const scores = rows.map((row) => Number(row.completeness_score));
+    assert.ok(scores.every(Number.isFinite));
+    assert.deepEqual(
+      scores,
+      [...scores].sort((a, b) => b - a),
+    );
+    assert.ok(rows.every((row) => /^\d+$/.test(row.netuid)));
+    assert.ok(rows.every((row) => row.curation_level !== ""));
+    assert.ok(rows.every((row) => row.profile_level !== ""));
+  });
 
   test("subnet-scoped surfaces export CSV for one netuid", async () => {
     const res = await handleRequest(


### PR DESCRIPTION
## Summary

- Adds focused coverage for the profiles CSV export requested in #2525.
- Verifies projected completeness fields and descending `completeness_score` ordering for `/api/v1/profiles?format=csv`.

## What Changed

- Extended `tests/api-coverage.test.mjs` with a registry-list CSV assertion for the profiles route.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npm test -- tests/api-coverage.test.mjs`

Fixes #2525