### PR TITLE
test(api): cover surfaces CSV filters (#2522)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1346,6 +1346,50 @@ describe("registry list CSV export", () => {
     );
   });
 
+  test("surfaces CSV export projects kind/provider/name and honors kind filters (#2522)", async () => {
+    const parseCsv = async (res) => {
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type"), /^text\/csv/);
+      const lines = (await res.text()).split("\r\n").filter(Boolean);
+      const header = lines[0].split(",");
+      const rows = lines.slice(1).map((line) => {
+        const values = line.split(",");
+        return Object.fromEntries(
+          header.map((name, index) => [name, values[index]]),
+        );
+      });
+      return { header, rows };
+    };
+
+    const all = await handleRequest(
+      req(
+        "/api/v1/surfaces?format=csv&fields=kind,provider,name&kind=openapi&limit=5",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const allCsv = await parseCsv(all);
+    assert.equal(allCsv.header.join(","), "kind,provider,name");
+    assert.ok(allCsv.rows.length > 0);
+    assert.ok(allCsv.rows.every((row) => row.kind === "openapi"));
+    assert.ok(allCsv.rows.every((row) => row.provider !== ""));
+    assert.ok(allCsv.rows.every((row) => row.name !== ""));
+
+    const subnet = await handleRequest(
+      req(
+        "/api/v1/subnets/6/surfaces?format=csv&fields=kind,provider,name&kind=openapi",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const subnetCsv = await parseCsv(subnet);
+    assert.equal(subnetCsv.header.join(","), "kind,provider,name");
+    assert.ok(subnetCsv.rows.length > 0);
+    assert.ok(subnetCsv.rows.every((row) => row.kind === "openapi"));
+    assert.ok(subnetCsv.rows.every((row) => row.provider !== ""));
+    assert.ok(subnetCsv.rows.every((row) => row.name !== ""));
+  });
+
   test("endpoints CSV export filters, projects, and streams the large route path (#2523)", async () => {
     const res = await handleRequest(
       req(


### PR DESCRIPTION
## Summary

- Adds focused coverage for the curated surfaces CSV export requested in #2522.
- Verifies all-subnet and subnet-scoped surface CSV exports project `kind`, `provider`, and `name`, and honor `kind=openapi` filtering.

## What Changed

- Extended `tests/api-coverage.test.mjs` with registry-list CSV assertions for `/api/v1/surfaces` and `/api/v1/subnets/6/surfaces`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npm test -- tests/api-coverage.test.mjs`

Fixes #2522