### PR TITLE
fix(api): key subnet uptime edge cache on min_samples to avoid a stale-row collision

### DIFF
--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -813,6 +813,40 @@ describe("canonicalUptimeCachePath", () => {
     const raw = "/api/v1/subnets/7/uptime?window=7d";
     assert.equal(canonicalUptimeCachePath(url(raw)), raw);
   });
+
+  test("keys on min_samples so distinct thresholds do not share a cache entry", () => {
+    // min_samples is a HAVING row-filter: two thresholds return different rows and
+    // must NOT collapse to the same cache key (the bug this guards against).
+    const strict = canonicalUptimeCachePath(
+      url("/api/v1/subnets/7/uptime?min_samples=100"),
+    );
+    const loose = canonicalUptimeCachePath(
+      url("/api/v1/subnets/7/uptime?min_samples=0"),
+    );
+    assert.equal(strict, "/api/v1/subnets/7/uptime?window=90d&min_samples=100");
+    assert.equal(loose, "/api/v1/subnets/7/uptime?window=90d&min_samples=0");
+    assert.notEqual(strict, loose);
+  });
+
+  test("omits min_samples from the key when the param is absent", () => {
+    // A bare request (no filter) keeps the window-only key, distinct from any
+    // explicit ?min_samples= request.
+    assert.equal(
+      canonicalUptimeCachePath(url("/api/v1/subnets/7/uptime?window=1y")),
+      "/api/v1/subnets/7/uptime?window=1y",
+    );
+    assert.notEqual(
+      canonicalUptimeCachePath(url("/api/v1/subnets/7/uptime?window=1y")),
+      canonicalUptimeCachePath(
+        url("/api/v1/subnets/7/uptime?window=1y&min_samples=5"),
+      ),
+    );
+  });
+
+  test("falls back to raw search on an invalid min_samples value", () => {
+    const raw = "/api/v1/subnets/7/uptime?min_samples=-1";
+    assert.equal(canonicalUptimeCachePath(url(raw)), raw);
+  });
 });
 
 describe("canonicalEconomicsTrendsCachePath", () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -279,12 +279,23 @@ export async function handleUptime(request, env, netuid, url) {
 // ?window=90d request both resolve to the same edge-cache entry — mirrors
 // canonicalSubnetConcentrationHistoryCachePath in entities.mjs.
 export function canonicalUptimeCachePath(url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "min_samples"]);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam))
     return `${url.pathname}${url.search}`;
-  return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
+  // min_samples is a HAVING row-filter that changes the response (handleUptime
+  // drops day rows below the threshold), so it MUST be part of the cache key.
+  // Omitting it collides ?min_samples=100 (few rows) with ?min_samples=0 (all
+  // rows) on one edge-cache entry, serving whichever was cached first for both.
+  const minSamples = parseNonNegativeIntParam(
+    url.searchParams.get("min_samples"),
+    "min_samples",
+  );
+  if (minSamples.error) return `${url.pathname}${url.search}`;
+  const params = [`window=${encodeURIComponent(windowParam)}`];
+  if (minSamples.value !== null) params.push(`min_samples=${minSamples.value}`);
+  return `${url.pathname}?${params.join("&")}`;
 }
 
 // Normalises the economics-trends URL so that a bare ?-free request and an explicit


### PR DESCRIPTION
## Summary

Key the `GET /api/v1/subnets/{netuid}/uptime` edge cache on `min_samples` so two requests with different thresholds no longer collide on one cache entry and serve each other's row set.

`handleUptime` accepts `?min_samples=` — a real HAVING row-filter that drops day rows whose aggregated probe count is below the threshold, so it changes the response body. But `canonicalUptimeCachePath` (the cache key used by `withEdgeCache` at `workers/api.mjs`) keyed **only on `window`**, dropping `min_samples` entirely. So:

- `GET /api/v1/subnets/7/uptime?min_samples=100` (strict — few days) is cached under key `…/uptime?window=90d`.
- A following `GET /api/v1/subnets/7/uptime?min_samples=0` (all days) hits that same cached entry and is served the **min_samples=100** row set — the wrong, over-filtered data (and vice-versa, depending on which populated the cache first).

## What Changed

- `workers/request-handlers/analytics-routes.mjs` (`canonicalUptimeCachePath`): add `min_samples` to the accepted params and include its normalized value in the cache key (`?window=X&min_samples=Y`) when present, using the same `parseNonNegativeIntParam` the handler uses. A bare request (no filter) keeps the window-only key, and an invalid `min_samples` falls back to the raw search (the handler will 400 it), matching the function's existing window handling. No response-shape or OpenAPI change — cache-key correctness only.
- Regression tests: distinct `min_samples` thresholds produce distinct cache keys (never collide); an absent `min_samples` keeps the window-only key and differs from an explicit one; an invalid `min_samples` falls back to raw.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None — cache-key logic only.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npx vitest run tests/request-handlers-analytics-routes.test.mjs tests/analytics-edge-cache.test.mjs`
- [x] `npx vitest run` (full suite)
- [x] `npm run lint` · `npm run format:check` · `npm run pipeline:check` · `git diff --check`
