### PR TITLE
feat(registry): add SN17 404—GEN 404mini data-artifact surface

### DIFF
--- a/registry/subnets/sn-17.json
+++ b/registry/subnets/sn-17.json
@@ -33,6 +33,22 @@
         "https://www.404.xyz/plugin"
       ],
       "url": "https://github.com/404-Repo/404-gen-blender-add-on"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-17-404-gen-data-artifact",
+      "kind": "data-artifact",
+      "name": "404—GEN Mini 3D dataset",
+      "notes": "Official 404-Gen HuggingFace dataset of 20k+ text-to-3D assets generated on SN17 (MIT-licensed, public); the 404-Gen org profile used as the source declares it operates Subnet 17 and links the on-chain 404.xyz website.",
+      "provider": "404-gen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://huggingface.co/404-Gen"],
+      "url": "https://huggingface.co/datasets/404-Gen/404mini"
     }
   ],
   "website_url": "https://www.404.xyz/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN17 (404—GEN): the public **404mini** HuggingFace dataset — 20k+ text-to-3D assets generated on Bittensor Subnet 17. The subnet's registry file previously held only the Blender SDK add-on, so this fills its `missing-data-artifact` gap with a high-value callable surface. Exactly one file changed: `registry/subnets/sn-17.json`.

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/404-Gen/404mini` |
| `source_url` | `https://huggingface.co/404-Gen` |
| `provider` | `404-gen` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-matched, live, public)

- **`url`** — fetched live (HTTP 200, MIT-licensed, no auth). Dataset card: *"3D assets generated from text prompts on **Bittensor Subnet 17**, providing mid- and high-quality 3D assets for text-to-3D generation models."*
- **`source_url`** — the `404-Gen` HuggingFace org profile (fetched live): *"We operate **Subnet 17** on the Bittensor network…"*, lists `404-Gen/404mini` among its datasets, and links the official website `404.xyz`. That website is exactly the subnet's on-chain `website_url` on record (`https://www.404.xyz/`) and the `404-gen` provider's `website_url` — closing the owner-match chain (HF org → declares SN17 + owns the dataset namespace + links the on-chain site).

Non-duplicate: the subnet file's only existing surface is the `sdk` Blender add-on (a different kind and URL); a full `registry/` grep for the dataset returns no prior entry.

## Registry Safety

- [x] Exactly one `registry/subnets/<slug>.json` changed; appends one community surface, nothing else (no generated artifacts, no other subnet).
- [x] Real public `url` + a `source_url` that independently proves SN17 publishes it; owner-matched via the on-chain website.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/verification/secrets set by hand.
- [x] Not a duplicate of an existing surface or an open PR; correct `kind` for the surface.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/sn-17.json` — passed (2 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1262 surfaces); generated artifacts reverted so the diff is only the one subnet file
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
