### PR TITLE
fix(build): raise openapi-typescript spawn buffer above the 1 MiB default

### DIFF
--- a/scripts/generate-types.mjs
+++ b/scripts/generate-types.mjs
@@ -19,6 +19,10 @@ const result = spawnSync(
     cwd: repoRoot,
     encoding: "utf8",
     stdio: "pipe",
+    // The generated .d.ts is ~1 MiB and growing with every new route; the default
+    // 1 MiB stdout cap would SIGTERM the child (ENOBUFS) mid-stream. Match the
+    // 32 MiB buffer the other build scripts already use so type-gen keeps working.
+    maxBuffer: 32 * 1024 * 1024,
   },
 );
 

--- a/scripts/validate-contract-drift.mjs
+++ b/scripts/validate-contract-drift.mjs
@@ -43,6 +43,10 @@ const typegen = spawnSync(
   {
     cwd: repoRoot,
     encoding: "utf8",
+    // The generated .d.ts is ~1 MiB and grows with every route; the default 1 MiB
+    // stdout cap would SIGTERM the child (ENOBUFS) and misreport it as a drift
+    // failure. Match the 32 MiB buffer the build's generate-types.mjs uses.
+    maxBuffer: 32 * 1024 * 1024,
   },
 );
 if (typegen.status !== 0) {

--- a/scripts/validate-types.mjs
+++ b/scripts/validate-types.mjs
@@ -16,6 +16,10 @@ const result = spawnSync(
   {
     cwd: repoRoot,
     encoding: "utf8",
+    // The generated .d.ts is ~1 MiB and grows with every route; the default 1 MiB
+    // stdout cap would SIGTERM the child (ENOBUFS). Match the 32 MiB buffer the
+    // build's generate-types.mjs uses so the type check keeps working.
+    maxBuffer: 32 * 1024 * 1024,
   },
 );
 


### PR DESCRIPTION
## Summary

`generate-types.mjs`, `validate-contract-drift.mjs`, and `validate-types.mjs` each run `openapi-typescript` via `spawnSync` with the **default 1 MiB `stdout` buffer**. The generated API `.d.ts` is already **~1 MiB and grows with every new `/api/v1` route**, so the first route to push it over 1 MiB makes `spawnSync` SIGTERM the child (`status: null`, `error: ENOBUFS`) — and the scripts misreport it as `"openapi-typescript failed."` / a stale-contract drift, **failing the build and the `contract-drift` gate even though the contract is correct**.

This raises `maxBuffer` to **32 MiB** in all three call sites, matching the buffer the sibling build scripts (`build-changelog.mjs`, `build-surface-aliases.mjs`, `r2-upload.mjs`) already use. It's a **latent-bug fix with no behavior change below 1 MiB** — no generated files change on the current tree; it simply keeps type generation and the drift check working as the contract keeps growing.

## Why now

Measured on `main`: the generated TypeScript is **1,040,995 bytes** — only ~7.5 KB under the 1,048,576-byte (1 MiB) default. The repo is effectively **at the ceiling**: the next new route trips it, and the failure is deterministic (output size is a pure function of `openapi.json`), so it fails on CI, not just locally.

Reproduction:

```js
const { spawnSync } = require("node:child_process");
const r = spawnSync(process.execPath,
  ["node_modules/openapi-typescript/bin/cli.js", "public/metagraph/openapi.json"],
  { encoding: "utf8" });          // default 1 MiB maxBuffer
// once the output exceeds 1 MiB:
//   r.status === null, r.signal === "SIGTERM", r.error.code === "ENOBUFS"
```

## Changes

- `scripts/generate-types.mjs` — add `maxBuffer: 32 * 1024 * 1024` to the `openapi-typescript` `spawnSync`.
- `scripts/validate-contract-drift.mjs` — same.
- `scripts/validate-types.mjs` — same.

12 lines across 3 files; no other files touched.

## Validation

```
npm run build                    # type-gen succeeds
npm run validate:contract-drift  # passed
npm run validate:types           # Generated API types are current
npm run lint                     # clean
```

No generated artifacts change (no-op below 1 MiB), so there is no contract drift to commit.
