### PR TITLE
feat(registry): add SN64 Chutes daily revenue summary data-artifact

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -424,6 +424,22 @@
       },
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/users/growth"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-daily-revenue-summary",
+      "kind": "data-artifact",
+      "name": "Chutes daily revenue summary",
+      "notes": "Public no-auth JSON daily revenue summary for the Chutes platform (date, new subscriber count, subscription and pay-as-you-go revenue per day); GET /daily_revenue_summary in the OpenAPI spec. Distinct endpoint from the subnet's existing /chutes/* and /users/growth data-artifacts.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/daily_revenue_summary"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chutes.json` (SN64 Chutes). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds the Chutes platform daily-revenue-summary feed (`GET /daily_revenue_summary`) — a public, no-auth JSON time series of per-day platform revenue (date, new subscriber count, subscription and pay-as-you-go revenue). It is live and current (latest point is today), consistent with the subnet's other registered operational data-artifacts, all sourced from the same official Chutes OpenAPI contract.

This is a distinct endpoint from the subnet's already-registered `/chutes/*` and `/users/growth` data-artifacts.

## Surface

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/daily_revenue_summary
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

The endpoint is defined in the official Chutes OpenAPI spec as `Get Daily Revenue Summary` with no security requirement — the same source used by the subnet's existing data-artifact surfaces.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
