### PR TITLE
feat(registry): add SN56 Gradients latest-tournament-details subnet-api

### DIFF
--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -236,6 +236,25 @@
         "https://www.gradients.io/"
       ],
       "url": "https://api.gradients.io/v1/network/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-tournament-details",
+      "kind": "subnet-api",
+      "name": "Gradients latest tournament details API",
+      "notes": "Public no-auth Gradients tournament results endpoint (winner/base-winner hotkeys, per-round participant eliminations) for the latest text/image/environment tournaments; distinct from the registered performance/weights and network-status APIs. Declared in the operator's own OpenAPI spec (source).",
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://api.gradients.io/openapi.json",
+        "https://www.gradients.io/"
+      ],
+      "url": "https://api.gradients.io/tournament/latest/details"
     }
   ],
   "website_url": "https://www.gradients.io/"


### PR DESCRIPTION
## Summary

Adds one **community `subnet-api` surface** to SN56 (Gradients): the public, no-auth **latest-tournament-details** endpoint. It's a genuinely distinct capability from the surfaces already registered on the subnet (performance/weights + network-status) — it returns tournament *results*. Exactly one file changed: `registry/subnets/gradients.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `subnet-api` |
| `url` | `https://api.gradients.io/tournament/latest/details` |
| `source_urls` | `https://api.gradients.io/openapi.json` · `https://www.gradients.io/` |
| `provider` | `gradients` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, no auth): returns the latest text/image/environment tournament objects — `tournament_id`, `status`, `winner_hotkey`, `base_winner_hotkey`, and per-round `participants` with `eliminated_in_round_id`.
- **`source_url` (OpenAPI)** — the operator's own machine-readable spec at `api.gradients.io/openapi.json` defines `GET /tournament/latest/details` (summary "Get Latest Tournaments Details", `security: none`). This is the same first-party proof host the file's other `subnet-api` surfaces use.
- **`source_url` (site)** — `https://www.gradients.io/`, the operator's official website (cross-host).

Non-duplicate: the four registered `subnet-api` URLs are `/v1/performance/latest-tournament-weights`, `/v1/performance/weight-projection-static`, `/v1/performance/last-boss-battle`, and `/v1/network/status` — this `/tournament/latest/details` path is not among them and is a distinct capability (tournament results, not weight/performance metrics).

## Registry Safety

- [x] Exactly one `registry/subnets/gradients.json` changed; a single appended community surface, nothing else (no generated artifacts, no reformatting, no other subnet).
- [x] Real public `url` + first-party `source_url`s (the operator's OpenAPI spec + site) that prove SN56 publishes it; provider `gradients` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets (endpoint `security: none`); no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/gradients.json` — passed (11 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1264 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
