### PR TITLE
fix(health-prober): pin Worker probe DNS and fail closed on DoH errors

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -260,12 +260,7 @@ export function createWorkerPinnedFetch({
       throw error;
     }
 
-    let parsed;
-    try {
-      parsed = new URL(url);
-    } catch (error) {
-      throw error;
-    }
+    const parsed = new URL(url);
 
     const host = normalizedHostname(parsed.hostname);
     const isLiteral = ipv4Octets(host) || host.includes(":");

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -98,14 +98,13 @@ function sanitizeRpcLatestBlocks(rows) {
   }
 }
 
-// --- DNS-aware SSRF guard for the Worker prober (codex #255) -------------------
+// --- DNS-aware SSRF guard + pinned fetch for the Worker prober (codex #255) ----
 // The literal `isUnsafePublicUrl` guard can't see DNS rebinding (a public-looking
 // hostname that resolves to a private IP). Workers have no node:dns, so we verify
-// answers via Cloudflare DNS-over-HTTPS immediately before the probe. Policy:
-// block on a DETECTED private answer (real rebinding), but fail OPEN on a DoH
-// timeout/error/no-answer — operational surfaces are a curated, public_safe,
-// PR-reviewed allowlist that already passed the literal guard, so a DoH blip must
-// never falsely mark all health unsafe.
+// answers via Cloudflare DNS-over-HTTPS immediately before the probe, then connect
+// to the vetted address with a Host header (mirroring scripts/lib.mjs safeFetch).
+// Policy: block on a DETECTED private answer (real rebinding) and FAIL CLOSED on a
+// DoH timeout/error/no-answer — an unverified hostname must never be probed.
 function normalizedHostname(value) {
   return String(value || "")
     .trim()
@@ -188,34 +187,119 @@ async function resolveDnsJson(host, recordType, fetchImpl, endpoint) {
   return dnsAddressAnswers(await response.json());
 }
 
-export function workerResolvedUrlSafetyGuard({
+function dnsAnswerFamily(address) {
+  return ipv4Octets(address) ? 4 : 6;
+}
+
+function buildPinnedUrl(parsed, { address, family }) {
+  const pinned = new URL(parsed.toString());
+  pinned.hostname =
+    family === 6 || address.includes(":") ? `[${address}]` : address;
+  return pinned.toString();
+}
+
+// Resolve a probe URL to one or more vetted public addresses via DoH. Returns
+// [] when the URL is unsafe, unresolvable, or DoH failed (fail-closed).
+export async function resolveWorkerPublicUrlAddresses(
+  value,
+  { fetchImpl = fetch, dnsJsonEndpoint = DNS_JSON_ENDPOINT } = {},
+) {
+  if (isUnsafePublicUrl(value)) {
+    return [];
+  }
+  let host;
+  try {
+    host = normalizedHostname(new URL(value).hostname);
+  } catch {
+    return [];
+  }
+  if (ipv4Octets(host) || host.includes(":")) {
+    return isUnsafeIpAddress(host)
+      ? []
+      : [{ address: host, family: dnsAnswerFamily(host) }];
+  }
+  const lookups = await Promise.allSettled(
+    DNS_RECORD_TYPES.map((type) =>
+      resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
+    ),
+  );
+  const answers = lookups.flatMap((lookup) =>
+    lookup.status === "fulfilled" ? lookup.value : [],
+  );
+  if (answers.some(isUnsafeIpAddress) || answers.length === 0) {
+    return [];
+  }
+  return answers.map((address) => ({
+    address,
+    family: dnsAnswerFamily(address),
+  }));
+}
+
+export function workerResolvedUrlSafetyGuard(options = {}) {
+  return async function isUnsafeWorkerResolvedUrl(value) {
+    const addresses = await resolveWorkerPublicUrlAddresses(value, options);
+    return addresses.length === 0;
+  };
+}
+
+// SSRF-safe outbound fetch for the Worker prober: resolves via DoH, pins the
+// vetted address into the request URL, and sets Host so TLS/SNI stay correct.
+export function createWorkerPinnedFetch({
   fetchImpl = fetch,
+  dohFetchImpl = fetch,
   dnsJsonEndpoint = DNS_JSON_ENDPOINT,
 } = {}) {
-  return async function isUnsafeWorkerResolvedUrl(value) {
-    if (isUnsafePublicUrl(value)) {
-      return true;
+  return async function workerPinnedFetch(url, init = {}) {
+    const addresses = await resolveWorkerPublicUrlAddresses(url, {
+      fetchImpl: dohFetchImpl,
+      dnsJsonEndpoint,
+    });
+    if (addresses.length === 0) {
+      const error = new Error("unsafe or unresolvable URL");
+      error.name = "WorkerPinnedFetchError";
+      throw error;
     }
-    let host;
+
+    let parsed;
     try {
-      host = normalizedHostname(new URL(value).hostname);
-    } catch {
-      return true;
+      parsed = new URL(url);
+    } catch (error) {
+      throw error;
     }
-    if (ipv4Octets(host) || host.includes(":")) {
-      return isUnsafeIpAddress(host);
+
+    const host = normalizedHostname(parsed.hostname);
+    const isLiteral = ipv4Octets(host) || host.includes(":");
+    if (isLiteral) {
+      return fetchImpl(url, init);
     }
-    const lookups = await Promise.allSettled(
-      DNS_RECORD_TYPES.map((type) =>
-        resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
-      ),
-    );
-    const answers = lookups.flatMap((lookup) =>
-      lookup.status === "fulfilled" ? lookup.value : [],
-    );
-    // Block on any confirmed private answer (rebinding), even if another RR
-    // lookup failed. No confirmed private answer / DoH failure → fail open.
-    return answers.some(isUnsafeIpAddress);
+
+    const headers = new Headers(init.headers);
+    headers.set("Host", parsed.host);
+    return fetchImpl(buildPinnedUrl(parsed, addresses[0]), {
+      ...init,
+      headers,
+    });
+  };
+}
+
+export function createWorkerProbeOptions(overrides = {}) {
+  const dohFetch = overrides.safetyFetch ?? overrides.dohFetchImpl ?? fetch;
+  const pinnedFetch =
+    overrides.pinnedFetch ??
+    createWorkerPinnedFetch({
+      fetchImpl: overrides.fetchImpl ?? dohFetch,
+      dohFetchImpl: dohFetch,
+      dnsJsonEndpoint: overrides.dnsJsonEndpoint,
+    });
+  return {
+    isUnsafeUrl:
+      overrides.isUnsafeUrl ||
+      workerResolvedUrlSafetyGuard({
+        fetchImpl: dohFetch,
+        dnsJsonEndpoint: overrides.dnsJsonEndpoint,
+      }),
+    fetchImpl: pinnedFetch,
+    connect: overrides.connect || workerWebSocketConnector(pinnedFetch),
   };
 }
 
@@ -385,14 +469,16 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   const loadSurfaces =
     overrides.loadSurfaces || (() => loadOperationalSurfaces(env));
   const probe = overrides.probeSurface || coreProbeSurface;
-  const probeOptions = overrides.probeOptions || {
-    // DNS-aware SSRF guard (resolves via DoH; fail-open on DoH error). Falls back
-    // to the isomorphic literal guard when an override is supplied (tests).
-    isUnsafeUrl:
-      overrides.isUnsafeUrl ||
-      workerResolvedUrlSafetyGuard({ fetchImpl: overrides.safetyFetch }),
-    connect: overrides.connect || workerWebSocketConnector(),
-  };
+  const probeOptions =
+    overrides.probeOptions ||
+    createWorkerProbeOptions({
+      isUnsafeUrl: overrides.isUnsafeUrl,
+      safetyFetch: overrides.safetyFetch,
+      fetchImpl: overrides.fetchImpl,
+      pinnedFetch: overrides.pinnedFetch,
+      connect: overrides.connect,
+      dnsJsonEndpoint: overrides.dnsJsonEndpoint,
+    });
   const concurrency = overrides.concurrency || PROBE_CONCURRENCY;
 
   const runAt = now();

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -145,8 +145,7 @@ import {
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
-  workerResolvedUrlSafetyGuard,
-  workerWebSocketConnector,
+  createWorkerProbeOptions,
 } from "./health-prober.mjs";
 import {
   findSurface,
@@ -5323,12 +5322,7 @@ export const MCP_TOOLS = [
           "Provide either surface_id or netuid.",
         );
       }
-      return await verifySurfaceWithCache(surface, {
-        isUnsafeUrl: workerResolvedUrlSafetyGuard({
-          fetchImpl: globalThis.fetch,
-        }),
-        connect: workerWebSocketConnector(globalThis.fetch),
-      });
+      return await verifySurfaceWithCache(surface, createWorkerProbeOptions());
     },
   },
 ];

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -4,9 +4,11 @@ import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
+  createWorkerPinnedFetch,
   loadOperationalSurfaces,
   OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
+  resolveWorkerPublicUrlAddresses,
   rollupDailyUptime,
   runD1StatementBatches,
   D1_STATEMENTS_PER_BATCH,
@@ -126,16 +128,16 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
     assert.equal(await guard("https://ok.example.com/x"), false);
   });
 
-  test("fails OPEN on a DoH error (does not block all health)", async () => {
+  test("fails CLOSED on a DoH error (does not probe unverified hostnames)", async () => {
     const guard = workerResolvedUrlSafetyGuard({
       fetchImpl: async () => {
         throw new Error("DoH unreachable");
       },
     });
-    assert.equal(await guard("https://ok.example.com/x"), false);
+    assert.equal(await guard("https://ok.example.com/x"), true);
   });
 
-  test("fails OPEN on no DNS answer / non-ok DoH", async () => {
+  test("fails CLOSED on no DNS answer / non-ok DoH", async () => {
     const guard = workerResolvedUrlSafetyGuard({
       fetchImpl: async () => ({
         ok: false,
@@ -144,7 +146,107 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
         },
       }),
     });
-    assert.equal(await guard("https://unknown.example.com/x"), false);
+    assert.equal(await guard("https://unknown.example.com/x"), true);
+  });
+});
+
+describe("resolveWorkerPublicUrlAddresses", () => {
+  const dohFetch = (records) => async (url) => {
+    const u = new URL(url);
+    const name = u.searchParams.get("name");
+    const type = u.searchParams.get("type");
+    const data = records[name]?.[type] || [];
+    return {
+      ok: true,
+      async json() {
+        return { Answer: data.map((d) => ({ data: d })) };
+      },
+    };
+  };
+
+  test("returns vetted public addresses for a hostname", async () => {
+    const addresses = await resolveWorkerPublicUrlAddresses(
+      "https://ok.example.com/x",
+      { fetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }) },
+    );
+    assert.deepEqual(addresses, [{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  test("returns [] on DoH failure (fail-closed)", async () => {
+    const addresses = await resolveWorkerPublicUrlAddresses(
+      "https://unknown.example.com/x",
+      {
+        fetchImpl: async () => {
+          throw new Error("DoH unreachable");
+        },
+      },
+    );
+    assert.deepEqual(addresses, []);
+  });
+});
+
+describe("createWorkerPinnedFetch", () => {
+  const dohFetch = (records) => async (url) => {
+    const u = new URL(url);
+    const name = u.searchParams.get("name");
+    const type = u.searchParams.get("type");
+    const data = records[name]?.[type] || [];
+    return {
+      ok: true,
+      async json() {
+        return { Answer: data.map((d) => ({ data: d })) };
+      },
+    };
+  };
+
+  test("pins hostname probes to the vetted address and sets Host", async () => {
+    let capturedUrl = null;
+    let capturedInit = null;
+    const pinned = createWorkerPinnedFetch({
+      dohFetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }),
+      fetchImpl: async (url, init) => {
+        capturedUrl = url;
+        capturedInit = init;
+        return new Response("ok", { status: 200 });
+      },
+    });
+    await pinned("https://ok.example.com/path?q=1", {
+      headers: { accept: "text/plain" },
+    });
+    assert.equal(capturedUrl, "https://93.184.216.34/path?q=1");
+    assert.equal(capturedInit.headers.get("Host"), "ok.example.com");
+    assert.equal(capturedInit.headers.get("accept"), "text/plain");
+  });
+
+  test("throws WorkerPinnedFetchError when resolution fails", async () => {
+    const pinned = createWorkerPinnedFetch({
+      dohFetchImpl: async () => {
+        throw new Error("DoH unreachable");
+      },
+      fetchImpl: async () => new Response("ok"),
+    });
+    await assert.rejects(
+      () => pinned("https://unknown.example.com/x"),
+      (error) => {
+        assert.equal(error.name, "WorkerPinnedFetchError");
+        return true;
+      },
+    );
+  });
+
+  test("passes IP-literal URLs through without rewriting", async () => {
+    let capturedUrl = null;
+    const pinned = createWorkerPinnedFetch({
+      dohFetchImpl: async () => {
+        throw new Error("DoH should not run for IP literals");
+      },
+      fetchImpl: async (url) => {
+        capturedUrl = url;
+        return new Response("ok");
+      },
+    });
+    await pinned("https://8.8.8.8/x");
+    assert.equal(capturedUrl, "https://8.8.8.8/x");
   });
 });
 

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -46,8 +46,7 @@ import {
 import { SURFACE_ALIASES_PATH } from "../../src/surface-aliases.mjs";
 import {
   KV_HEALTH_RPC_POOL,
-  workerResolvedUrlSafetyGuard,
-  workerWebSocketConnector,
+  createWorkerProbeOptions,
 } from "../../src/health-prober.mjs";
 import { ipv6EmbeddedIpv4 } from "../../src/ip-safety.mjs";
 import { overlayRpcPoolEligibility } from "../../src/health-serving.mjs";
@@ -226,12 +225,7 @@ export async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
 
   const result = await verifySurfaceWithCache(
     surface,
-    {
-      isUnsafeUrl: workerResolvedUrlSafetyGuard({
-        fetchImpl: globalThis.fetch,
-      }),
-      connect: workerWebSocketConnector(globalThis.fetch),
-    },
+    createWorkerProbeOptions(),
     {
       waitUntil: (promise) => ctx?.waitUntil?.(promise),
     },


### PR DESCRIPTION
## Summary

- Close the DNS-rebinding SSRF gap in Worker outbound health probes by pinning connect-time requests to DoH-vetted addresses (IP literal + `Host` header), matching the build pipeline's `safeFetch` model.
- Fail closed when DoH is unavailable or returns no public answers — unverified hostnames are no longer probed.
- Centralize Worker probe wiring in `createWorkerProbeOptions()` for the cron prober, surface verify API, and MCP verify tool.

## What Changed

- `src/health-prober.mjs` — add `resolveWorkerPublicUrlAddresses`, `createWorkerPinnedFetch`, and `createWorkerProbeOptions`; switch the guard from fail-open to fail-closed; wire pinned fetch into default probe options.
- `workers/request-handlers/rpc-proxy.mjs` — use `createWorkerProbeOptions()` for on-demand surface verify.
- `src/mcp-server.mjs` — same for the MCP verify tool.
- `tests/health-prober.test.mjs` — update guard expectations; add pinned-fetch and resolution tests.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/health-prober.test.mjs`
- [x] `npm test -- tests/surface-verify.test.mjs tests/health-probe-core.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run worker:test`
- [x] `git diff --check`
