### PR TITLE
feat(registry): add SN19 BlockMachine epochs catalog data-artifact

### DIFF
--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -164,6 +164,25 @@
         "https://api.blockmachine.io/openapi.json"
       ],
       "url": "https://api.blockmachine.io/epochs/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-19-blockmachine-epochs-catalog",
+      "kind": "data-artifact",
+      "name": "BlockMachine epochs catalog",
+      "notes": "Public no-auth BlockMachine epochs listing — every epoch's id/number, participating gateway_ids, and per-gateway manifest (request log files + finalized CU-allocation objects). The full-history catalog behind the already-registered latest-finalized/current single-epoch endpoints; declared as GET /epochs (\"List Epochs\") in the operator's OpenAPI (source).",
+      "provider": "blockmachine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://blockmachine.io/",
+        "https://api.blockmachine.io/openapi.json"
+      ],
+      "url": "https://api.blockmachine.io/epochs"
     }
   ],
   "website_url": "https://blockmachine.io/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN19 (BlockMachine): the public, no-auth **`/epochs`** listing — the full epochs catalog behind the two single-epoch endpoints already registered on this subnet (`/epochs/latest-finalized`, `/epochs/current`). Exactly one file changed: `registry/subnets/blockmachine.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://api.blockmachine.io/epochs` |
| `source_urls` | `https://blockmachine.io/` · `https://api.blockmachine.io/openapi.json` |
| `provider` | `blockmachine` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, no auth): returns `{"epochs":[{"epoch_id":…,"epoch_number":…,"gateway_ids":[…],"manifest":{…per-gateway request log files + finalized CU-allocation objects…}}, …]}`.
- **`source_url` (OpenAPI)** — the operator's own spec at `api.blockmachine.io/openapi.json` defines `GET /epochs` (summary "List Epochs", `security: none`). This is the same first-party proof host the file's other API surfaces already use.
- **`source_url` (site)** — `https://blockmachine.io/`, the operator's official website.

Non-duplicate & distinct: the registered epoch surfaces are `/epochs/latest-finalized` and `/epochs/current` (each a single-epoch snapshot — e.g. `/current` returns just `{epoch_id, current_block, observed_at}`). `/epochs` is the full-history **collection** with per-epoch gateway manifests — a distinct, higher-scope capability, not a param-variant of either.

## Registry Safety

- [x] Exactly one `registry/subnets/blockmachine.json` changed; a single appended community surface, nothing else (no generated artifacts, no reformatting, no other subnet).
- [x] Real public `url` + first-party `source_url`s (operator OpenAPI + site) proving SN19 publishes it; provider `blockmachine` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets (endpoint `security: none`); no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind` (matches the sibling epoch `data-artifact`s).

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/blockmachine.json` — passed (8 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1265 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
