### PR TITLE
feat(registry): add SN64 Chutes per-chute invocation usage data-artifact

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -440,6 +440,22 @@
       },
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/daily_revenue_summary"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-invocations-usage",
+      "kind": "data-artifact",
+      "name": "Chutes per-chute invocation usage",
+      "notes": "Public no-auth JSON of per-chute invocation usage on the Chutes platform (chute_id, date, usd_amount, invocation_count); GET /invocations/usage in the OpenAPI spec. Distinct endpoint from the subnet's existing /chutes/*, /users/growth, and /daily_revenue_summary data-artifacts.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/invocations/usage"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chutes.json` (SN64 Chutes). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds the Chutes per-chute invocation usage feed (`GET /invocations/usage`) — a public, no-auth JSON of usage per deployed chute (chute_id, date, usd_amount, invocation_count). It is live and current, consistent with the subnet's other registered operational data-artifacts, all sourced from the same official Chutes OpenAPI contract.

This is a distinct endpoint from the subnet's already-registered `/chutes/*`, `/users/growth`, and `/daily_revenue_summary` data-artifacts.

## Surface

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/invocations/usage
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

The endpoint is defined in the official Chutes OpenAPI spec as `Get Usage` with no security requirement — the same source used by the subnet's existing data-artifact surfaces.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
