### PR TITLE
feat(mcp): add get_chain_stake_moves mirroring GET /api/v1/chain/stake-moves

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -431,6 +431,16 @@ assert.ok(
     chainWeights.network != null,
   "get_chain_weights must return subnet_count + network + subnets[]",
 );
+const chainStakeMoves = await callOk("get_chain_stake_moves", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainStakeMoves.subnet_count) &&
+    Array.isArray(chainStakeMoves.subnets) &&
+    chainStakeMoves.network != null,
+  "get_chain_stake_moves must return subnet_count + network + subnets[]",
+);
 const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-stake-moves.mjs
+++ b/src/chain-stake-moves.mjs
@@ -15,6 +15,12 @@ export const STAKE_MOVED_EVENT_KIND = "StakeMoved";
 export const CHAIN_STAKE_MOVES_LIMIT_DEFAULT = 20;
 export const CHAIN_STAKE_MOVES_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_STAKE_MOVES_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_STAKE_MOVES_WINDOW = "7d";
+
 // Round a movements-per-mover ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct coldkeys, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -111,6 +111,13 @@ import {
   DEFAULT_CHAIN_WEIGHTS_WINDOW,
 } from "./chain-weights.mjs";
 import {
+  loadChainStakeMoves,
+  CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+  CHAIN_STAKE_MOVES_LIMIT_MAX,
+  CHAIN_STAKE_MOVES_WINDOWS,
+  DEFAULT_CHAIN_STAKE_MOVES_WINDOW,
+} from "./chain-stake-moves.mjs";
+import {
   loadChainTransferPairs,
   CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
   CHAIN_TRANSFER_PAIR_LIMIT_MAX,
@@ -273,7 +280,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.33.0";
+export const MCP_SERVER_VERSION = "1.34.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -281,6 +288,7 @@ const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
+const CHAIN_STAKE_MOVES_WINDOW_KEYS = Object.keys(CHAIN_STAKE_MOVES_WINDOWS);
 const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
 );
@@ -413,6 +421,9 @@ export const MCP_INSTRUCTIONS =
   "get_chain_weights the network-wide validator weight-setting leaderboard " +
   "(per-subnet WeightsSet activity, distinct setters, and update intensity) " +
   "across all subnets, " +
+  "get_chain_stake_moves the network-wide stake-movement (re-delegation) " +
+  "leaderboard (per-subnet StakeMoved activity, distinct movers, and " +
+  "movements-per-mover intensity) across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2229,6 +2240,58 @@ export const MCP_TOOLS = [
       return loadChainWeights(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_WEIGHTS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_stake_moves",
+    title: "Get network-wide stake-movement (re-delegation) activity",
+    description:
+      "Fetch the network-wide stake-movement (re-delegation) leaderboard over " +
+      "the requested window (7d or 30d; default 7d): each subnet ranked by " +
+      "StakeMoved events with its distinct-mover (coldkey) count and " +
+      "movements-per-mover intensity, plus a network rollup (distinct movers, " +
+      "total movements, movements per mover) and the count/mean/min/p25/median/" +
+      "p75/p90/max spread of per-subnet intensity, summed live from the " +
+      "account_events stream. StakeMoved is a coldkey relocating stake between " +
+      "hotkeys/subnets without unstaking — it measures re-delegation churn, not " +
+      "net capital flow (that is get_chain_stake_flow). Mirrors GET " +
+      "/api/v1/chain/stake-moves.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_STAKE_MOVES_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_STAKE_MOVES_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the stake-movement leaderboard (1-${CHAIN_STAKE_MOVES_LIMIT_MAX}, default ${CHAIN_STAKE_MOVES_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_STAKE_MOVES_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
+      if (!Object.hasOwn(CHAIN_STAKE_MOVES_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_STAKE_MOVES_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+        CHAIN_STAKE_MOVES_LIMIT_MAX,
+      );
+      return loadChainStakeMoves(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_STAKE_MOVES_WINDOWS[window],
         limit,
       });
     },
@@ -6185,6 +6248,79 @@ const TOOL_OUTPUT_SCHEMAS = {
             distinct_setters: { type: "integer" },
             weight_sets: { type: "integer" },
             sets_per_setter: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_stake_moves: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that saw a StakeMoved event. A coldkey
+      // moving stake out of several subnets counts once in distinct_movers.
+      // movements_per_mover is null when the network-wide distinct-mover count
+      // is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: ["distinct_movers", "movements", "movements_per_mover"],
+        properties: {
+          distinct_movers: { type: "integer" },
+          movements: { type: "integer" },
+          movements_per_mover: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet re-move intensity (StakeMoved events per mover) over
+      // EVERY subnet that saw a move; null when no subnet saw a move in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet stake-movement leaderboard, most StakeMoved events first. Each
+      // listed subnet has at least one distinct mover, so movements_per_mover is
+      // always a finite number here (never divide-by-zero).
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_movers",
+            "movements",
+            "movements_per_mover",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_movers: { type: "integer" },
+            movements: { type: "integer" },
+            movements_per_mover: { type: "number" },
           },
         },
       },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5733,6 +5733,8 @@ describe("MCP economics + metagraph data tools", () => {
     accountEvents = [],
     weightsNetworkRows = [],
     weightsSubnetRows = [],
+    stakeMovesNetworkRows = [],
+    stakeMovesSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
   } = {}) {
@@ -5743,18 +5745,30 @@ describe("MCP economics + metagraph data tools", () => {
             return {
               all() {
                 if (sql.includes("FROM account_events")) {
-                  // get_chain_weights reads a network aggregate (carries
-                  // newest_observed) then a per-subnet GROUP BY (carries
-                  // weight_sets); get_chain_transfer_pairs reads a totals CTE
-                  // (carries top_pair_volume_tao) then the per-corridor rows
-                  // (aliased AS from_address); everything else uses the flat
-                  // account_events fixture (e.g. get_chain_stake_flow's single
-                  // grouped read).
+                  // get_chain_weights reads a network aggregate (newest_observed
+                  // + weight_sets) then a per-subnet GROUP BY (weight_sets);
+                  // get_chain_stake_moves reads a network aggregate
+                  // (newest_observed + distinct_movers, no weight_sets) then a
+                  // per-subnet GROUP BY (AS movements); get_chain_transfer_pairs
+                  // reads a totals CTE (top_pair_volume_tao) then per-corridor
+                  // rows (AS from_address); everything else uses the flat
+                  // account_events fixture (e.g. get_chain_stake_flow).
                   if (sql.includes("newest_observed")) {
+                    if (sql.includes("weight_sets")) {
+                      return Promise.resolve({ results: weightsNetworkRows });
+                    }
+                    if (sql.includes("distinct_movers")) {
+                      return Promise.resolve({
+                        results: stakeMovesNetworkRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
                     return Promise.resolve({ results: weightsSubnetRows });
+                  }
+                  if (sql.includes("AS movements")) {
+                    return Promise.resolve({ results: stakeMovesSubnetRows });
                   }
                   if (sql.includes("top_pair_volume_tao")) {
                     return Promise.resolve({ results: transferPairTotals });
@@ -6731,6 +6745,110 @@ describe("MCP economics + metagraph data tools", () => {
       chainWeightsEnv(weightsNetwork(30, 8), [
         weightsRow(1, 20, 5),
         weightsRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainStakeMoves reads first (its
+  // COUNT(DISTINCT coldkey)/MAX(observed_at) probe); a non-null newest_observed
+  // unlocks the per-subnet read.
+  function stakeMovesNetwork(distinct_movers) {
+    return {
+      distinct_movers,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT movements + distinct movers).
+  function stakeMovesRow(netuid, movements, distinct_movers) {
+    return { netuid, movements, distinct_movers };
+  }
+
+  function chainStakeMovesEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          stakeMovesNetworkRows: network ? [network] : [],
+          stakeMovesSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_stake_moves returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_stake_moves", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.movements, 0);
+    assert.equal(out.network.movements_per_mover, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_stake_moves ranks subnets by movements with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_stake_moves",
+      { window: "30d", limit: 10 },
+      chainStakeMovesEnv(stakeMovesNetwork(8), [
+        // netuid 2: fewer movements -> ranks last despite higher intensity.
+        stakeMovesRow(2, 10, 4),
+        // netuid 1: most StakeMoved events -> ranks first.
+        stakeMovesRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].movements, 20);
+    assert.equal(out.subnets[0].movements_per_mover, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].movements_per_mover, 2.5); // 10 / 4
+    // Network rollup: total movements 30 over 8 distinct movers -> 3.75.
+    assert.equal(out.network.movements, 30);
+    assert.equal(out.network.distinct_movers, 8);
+    assert.equal(out.network.movements_per_mover, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_stake_moves rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_stake_moves", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_stake_moves caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_stake_moves",
+      { limit: 1 },
+      chainStakeMovesEnv(stakeMovesNetwork(8), [
+        stakeMovesRow(1, 20, 5),
+        stakeMovesRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_stake_moves payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_stake_moves",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_stake_moves",
+      {},
+      chainStakeMovesEnv(stakeMovesNetwork(8), [
+        stakeMovesRow(1, 20, 5),
+        stakeMovesRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.33.0");
+    assert.equal(MCP_SERVER_VERSION, "1.34.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds a new MCP tool `get_chain_stake_moves` that exposes the network-wide **stake-movement (re-delegation) leaderboard** — the re-delegation-churn companion to `get_chain_stake_flow` (net capital flow).

Each subnet is ranked by `StakeMoved` events with its distinct-mover (coldkey) count and `movements_per_mover` intensity, plus:
- a **network rollup** (distinct movers, total movements, movements per mover), and
- the `count/mean/min/p25/median/p75/p90/max` **spread of per-subnet intensity**,

summed live from the `account_events` stream over a `7d`/`30d` window (default `7d`).

`StakeMoved` is a coldkey relocating stake between hotkeys/subnets without unstaking — it measures re-delegation churn, not net capital flow.

The tool delegates to the existing `loadChainStakeMoves` loader that already backs `GET /api/v1/chain/stake-moves` (#3117), so the MCP surface stays in lockstep with the REST endpoint (same window set, same `limit` bounds 1–100, default 20, same cold-store zeros).

## Changes
- `src/chain-stake-moves.mjs`: export `CHAIN_STAKE_MOVES_WINDOWS` / `DEFAULT_CHAIN_STAKE_MOVES_WINDOW` (co-located with the loader so the tool schema cannot drift from the route).
- `src/mcp-server.mjs`: register `get_chain_stake_moves` (import, window keys, instructions, handler with window/limit validation, deeply-typed output schema); bump `MCP_SERVER_VERSION` to `1.34.0` (additive — new tool).
- `server.json`: version → `1.34.0`.
- `scripts/validate-mcp.mjs`: cold-path assertion for the new tool.
- Tests: cold-store zeros, ranking + network rollup, unsupported-window rejection, limit cap, and output-schema validation; version-assertion updates.

## Test plan
- [x] `npm run validate:mcp` (100 tools, lifecycle + all tools/call)
- [x] `npx vitest run` for `mcp-server` + `chain-stake-moves` + all version-assertion suites (622 passed)
- [x] `eslint` + `prettier` clean
- [x] No open PRs to conflict with (additive MCP tool only)
