### PR TITLE
feat(registry): add SN72 StreetVision NATIX roadwork image dataset

### DIFF
--- a/registry/subnets/streetvision-natix.json
+++ b/registry/subnets/streetvision-natix.json
@@ -150,6 +150,25 @@
         "timeout_ms": 10000
       },
       "notes": "Public NATIX Hugging Face organization linked from the StreetVision README."
+    },
+    {
+      "id": "sn-72-natix-roadwork-dataset",
+      "name": "StreetVision roadwork image dataset",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/datasets/natix-network-org/roadwork",
+      "provider": "natix",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/natixnetwork/streetvision-subnet",
+        "https://huggingface.co/natix-network-org"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public NATIX StreetVision HuggingFace image+text dataset (~8.5k road/roadwork scenes with structured scene/weather/lighting metadata) backing the SN72 roadwork image-classification task; not gated. The StreetVision README (source) declares the Bittensor subnet and links the natix-network-org HF org that owns it."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN72 (StreetVision by NATIX): the public **`roadwork`** HuggingFace image dataset. The subnet file previously registered only the NATIX HF *org* page — not this specific dataset. Exactly one file changed: `registry/subnets/streetvision-natix.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/natix-network-org/roadwork` |
| `source_urls` | `https://github.com/natixnetwork/streetvision-subnet` · `https://huggingface.co/natix-network-org` |
| `provider` | `natix` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, `private:false`, `gated:false`): ~8,550 rows (6,250 train / 2,300 test), image+text modality — road/roadwork scenes paired with structured scene/weather/lighting metadata. Plain image corpus (no credential/validator columns).
- **`source_url` (README)** — the StreetVision repo README declares *"StreetVision - Bittensor Subnet for Image Classification and Object Detection"* (© NATIX Network) and links the `natix-network-org` HuggingFace org, tying this dataset to the subnet's roadwork-classification task.
- **`source_url` (org)** — `https://huggingface.co/natix-network-org`, the operator's HF org that owns the dataset.

Non-duplicate: the file's only existing `data-artifact` points at the org page `huggingface.co/natix-network-org`; this is a distinct specific dataset URL under that org.

## Registry Safety

- [x] Exactly one `registry/subnets/streetvision-natix.json` changed; a single appended community surface, nothing else (no generated artifacts, no reformatting, no other subnet).
- [x] Real public `url` + `source_url`s proving SN72 publishes it; provider `natix` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/streetvision-natix.json` — passed (7 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1267 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
