### PR TITLE
feat(mcp): add get_subnet_weight_setters mirroring GET /api/v1/subnets/{netuid}/weights/setters

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -202,6 +202,11 @@ import {
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "./account-events.mjs";
+import {
+  loadSubnetWeightSetters,
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+} from "./subnet-weight-setters.mjs";
 import { loadAccountPortfolio } from "./account-portfolio.mjs";
 import {
   buildNeuronHistory,
@@ -280,7 +285,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.34.0";
+export const MCP_SERVER_VERSION = "1.35.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -295,6 +300,9 @@ const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
   SUBNET_EVENT_SUMMARY_WINDOWS,
+);
+const SUBNET_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
 );
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -378,7 +386,9 @@ export const MCP_INSTRUCTIONS =
   "boundary snapshots, get_subnet_stake_flow net capital in/out for one " +
   "subnet (StakeAdded vs StakeRemoved), get_subnet_event_summary the windowed " +
   "account-event summary for one subnet (per-kind counts plus a recent-events " +
-  "tail), get_subnet_movers the cross-subnet " +
+  "tail), get_subnet_weight_setters the per-subnet weight-setter leaderboard " +
+  "(the validators behind /weights ranked by activity), " +
+  "get_subnet_movers the cross-subnet " +
   "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
   "rates plus distribution percentiles over the current metagraph snapshot, " +
   "get_registry_leaderboards the live " +
@@ -2518,6 +2528,46 @@ export const MCP_TOOLS = [
       return await loadSubnetEventSummary(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
         limit,
+      });
+    },
+  },
+  {
+    name: "get_subnet_weight_setters",
+    title: "Get subnet weight-setter leaderboard",
+    description:
+      "Fetch the per-subnet weight-setter leaderboard over a 7d or 30d " +
+      "window (default 7d): the individual validators behind /weights ranked " +
+      "by activity, each with its WeightsSet count, its share of the subnet's " +
+      "total weight-setting, and its first/last set times, computed live from " +
+      "the account_events WeightsSet stream. The setter-level drill-in of the " +
+      "aggregate get_chain_weights / subnet weights. " +
+      "Mirrors GET /api/v1/subnets/{netuid}/weights/setters.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_WEIGHT_SETTERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW;
+      if (!Object.hasOwn(SUBNET_WEIGHT_SETTERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      return await loadSubnetWeightSetters(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window],
       });
     },
   },
@@ -6460,6 +6510,35 @@ const TOOL_OUTPUT_SCHEMAS = {
         last_observed_at: NULLABLE_STRING,
       }),
       recent_events: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_subnet_weight_setters: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "distinct_setters",
+      "weight_sets",
+      "setter_count",
+      "setters",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_setters: { type: "integer" },
+      weight_sets: { type: "integer" },
+      setter_count: { type: "integer" },
+      setters: objectItems({
+        hotkey: NULLABLE_STRING,
+        uid: NULLABLE_INT,
+        weight_sets: { type: "integer" },
+        share: ANY,
+        first_set_at: NULLABLE_STRING,
+        last_set_at: NULLABLE_STRING,
+      }),
     },
   },
   get_subnet_movers: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3164,6 +3164,114 @@ describe("MCP get_subnet_event_summary", () => {
   });
 });
 
+describe("MCP get_subnet_weight_setters", () => {
+  // The loader runs two reads: the per-setter leaderboard (GROUP BY the
+  // hotkey-or-uid identity) and the subnet-wide totals row. Route by SQL shape.
+  function weightSettersD1(
+    { leaderboardRows = [], totalsRow = null } = {},
+    capture = [],
+  ) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (/GROUP BY/.test(sql)) {
+                    return { results: leaderboardRows };
+                  }
+                  return { results: totalsRow ? [totalsRow] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("ranks setters with per-setter shares and set-time bounds", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_subnet_weight_setters",
+      { netuid: 5, window: "7d" },
+      {
+        env: weightSettersD1(
+          {
+            leaderboardRows: [
+              {
+                hotkey: "5Val1",
+                uid: 3,
+                weight_sets: 6,
+                first_set: 1_717_000_000_000,
+                last_set: 1_717_500_000_000,
+              },
+              {
+                hotkey: "5Val2",
+                uid: 7,
+                weight_sets: 4,
+                first_set: 1_717_100_000_000,
+                last_set: 1_717_400_000_000,
+              },
+            ],
+            totalsRow: {
+              weight_sets: 10,
+              distinct_setters: 2,
+              newest_observed: 1_717_500_000_000,
+            },
+          },
+          capture,
+        ),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 5);
+    assert.equal(out.window, "7d");
+    assert.equal(out.weight_sets, 10);
+    assert.equal(out.distinct_setters, 2);
+    assert.equal(out.setter_count, 2);
+    assert.equal(out.setters[0].hotkey, "5Val1");
+    assert.equal(out.setters[0].uid, 3);
+    assert.equal(out.setters[0].weight_sets, 6);
+    assert.equal(out.setters[0].share, 0.6);
+    assert.equal(
+      out.setters[0].last_set_at,
+      new Date(1_717_500_000_000).toISOString(),
+    );
+    assert.equal(out.setters[1].hotkey, "5Val2");
+    assert.equal(out.setters[1].share, 0.4);
+    // netuid is bound first on both reads.
+    assert.equal(capture[0].params[0], 5);
+  });
+
+  test("defaults to the 7d window and degrades to an empty leaderboard on cold D1", async () => {
+    const res = await callTool("get_subnet_weight_setters", { netuid: 5 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.weight_sets, 0);
+    assert.equal(out.distinct_setters, 0);
+    assert.equal(out.setter_count, 0);
+    assert.deepEqual(out.setters, []);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_weight_setters", {
+      netuid: 5,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_weight_setters", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+});
+
 describe("MCP get_network_activity", () => {
   test("merges extrinsics + blocks tiers from D1", async () => {
     const env = {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.34.0");
+    assert.equal(MCP_SERVER_VERSION, "1.35.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## What

Adds a new MCP tool **`get_subnet_weight_setters`** that mirrors the existing
`GET /api/v1/subnets/{netuid}/weights/setters` REST endpoint — the per-subnet
weight-setter leaderboard.

It returns, for one subnet over a 7d or 30d window (default 7d), the individual
validators behind `/weights` ranked by activity — each with its WeightsSet
count, its share of the subnet's total weight-setting, and its first/last set
times, computed live from the `account_events` WeightsSet stream. It's the
**setter-level drill-in** of the aggregate weights view (which never names the
setters). Modeled on the existing `get_subnet_event_summary` tool; reads the
same `loadSubnetWeightSetters` loader the REST route serves.

## Why

Every other per-subnet analytic (`get_subnet_stake_flow`, `get_subnet_event_summary`,
`get_subnet_movers`, …) is exposed over MCP, but the weight-setter leaderboard —
the only setter-level view of who actually sets a subnet's weights — had no MCP
counterpart. This closes that gap with no new data surface.

## Notes

- Pure MCP wiring over an existing loader — no REST contract change, so no
  OpenAPI/type regeneration.
- Bumps the MCP server version to 1.35.0 (`server.json` + the per-tool SemVer
  assertions updated to match, per `validate:mcp`).
- Tests cover the happy path (per-setter leaderboard + shares), cold-DB default
  window, invalid `window`, and missing `netuid`. `validate:mcp` reports the new
  tool (101 total); `validate:contract-drift`, lint, and prettier pass.