### PR TITLE
feat(registry): add SN33 ReadyAI organic-query-results dataset

### DIFF
--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -172,6 +172,25 @@
       },
       "source_urls": ["https://api.readyai.ai/openapi.json"],
       "url": "https://api.readyai.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-33-readyai-organic-query-results",
+      "kind": "data-artifact",
+      "name": "ReadyAI organic query results dataset",
+      "notes": "Public ReadyAI (SN33) HuggingFace text-classification corpus of organic query results (text plus classification labels and token counts); not gated. Published by the ReadyAi HF org whose podcast dataset the SN33 README already links, and the README declares the subnet (--netuid 33). Distinct from the already-registered podcast-conversations dataset.",
+      "provider": "readyai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md",
+        "https://huggingface.co/ReadyAi"
+      ],
+      "url": "https://huggingface.co/datasets/ReadyAi/organic_query_results_dataset"
     }
   ],
   "website_url": "https://readyai.ai/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN33 (ReadyAI): the public **`organic_query_results_dataset`** HuggingFace text-classification corpus — distinct from the podcast-conversations dataset already registered on this subnet. Exactly one file changed: `registry/subnets/readyai.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/ReadyAi/organic_query_results_dataset` |
| `source_urls` | SN33 README (`afterpartyai/bittensor-conversation-genome-project`) · `https://huggingface.co/ReadyAi` |
| `provider` | `readyai` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, `private:false`, `gated:false`, ~60k downloads): a text-classification corpus — `data` (text), `result` (classification labels), `totalTokens`. Plain text corpus (no credential/validator columns).
- **`source_url` (README)** — the SN33 repo README declares the subnet (*"you can specify `--netuid 33` which is our mainnet subnet uid"*) and links the `ReadyAi` HuggingFace org (via the org's podcast dataset), establishing `ReadyAi` as the SN33 operator's HF org.
- **`source_url` (org)** — `https://huggingface.co/ReadyAi`, the operator's HF org that owns this dataset.

Non-duplicate: the file's existing HF `data-artifact` is a different ReadyAi dataset (`5000-podcast-conversations-…`); this is a distinct dataset under the same org.

## Registry Safety

- [x] Exactly one `registry/subnets/readyai.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s proving SN33 publishes it; provider `readyai` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/readyai.json` — passed (8 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1267 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
