### PR TITLE
feat(registry): add SN34 BitMind bm-real image dataset

### DIFF
--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -214,6 +214,25 @@
         "https://github.com/BitMind-AI/bitmind-subnet/blob/bdbdb75c0828125ed1891aa1f0bb5e133aa42ab9/README.md#L13"
       ],
       "url": "https://huggingface.co/gasstation"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-34-bitmind-bm-real-dataset",
+      "kind": "data-artifact",
+      "name": "BitMind bm-real image dataset",
+      "notes": "Public BitMind (SN34) HuggingFace corpus of ~28k real (non-generated) images in Parquet, a reference set for the subnet's synthetic-vs-real image detection task; not gated, image column only. The bitmind-subnet README (source) declares Bittensor SN34 and the bitmind HF org owns the dataset.",
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/BitMind-AI/bitmind-subnet",
+        "https://bitmind.ai/"
+      ],
+      "url": "https://huggingface.co/datasets/bitmind/bm-real"
     }
   ],
   "website_url": "https://bitmind.ai/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN34 (BitMind): the public **`bm-real`** HuggingFace image corpus — a reference set of ~28k real (non-generated) images for the subnet's synthetic-vs-real image-detection task. The subnet file previously registered only the `gasstation` HF org root, not this dataset. Exactly one file changed: `registry/subnets/bitmind.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/bitmind/bm-real` |
| `source_urls` | `https://github.com/BitMind-AI/bitmind-subnet` · `https://bitmind.ai/` |
| `provider` | `bitmind` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, `private:false`, `gated:false`): 28,393-row Parquet corpus, single `image` feature column (real/non-generated images). Plain image corpus — no credential/validator columns.
- **`source_url` (README)** — the `bitmind-subnet` repo README declares the subnet (*"Bittensor SN34"*); the `bitmind` HuggingFace org owns the dataset.
- **`source_url` (site)** — `https://bitmind.ai/`, the operator's official website.

Non-duplicate: the file's existing HF `data-artifact` points at the `gasstation` org root; this is a distinct specific dataset under the `bitmind` org. (Note: I deliberately avoided the `gasstation/gs-*` datasets — they carry `validator_hotkey`/`generator_hotkey` columns; `bm-real` is image-only and clean.)

## Registry Safety

- [x] Exactly one `registry/subnets/bitmind.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s proving SN34 publishes it; provider `bitmind` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/bitmind.json` — passed (10 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1269 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
