### PR TITLE
feat(registry): add SN22 Desearch search benchmark dataset

### DIFF
--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -259,6 +259,25 @@
         "https://github.com/Desearch-ai/desearch-search-evals/blob/cfd3c83b553f6fa61e4fe71b08d46dcbb098b8d5/README.md#L56"
       ],
       "url": "https://huggingface.co/datasets/desearch/desearch-search-evals"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-benchmark-questions",
+      "kind": "data-artifact",
+      "name": "Desearch search benchmark dataset",
+      "notes": "Public Desearch (SN22) HuggingFace benchmark of ~196k fresh web + X search questions (id/question/difficulty/date-window columns), regenerated daily from recent news and posts; not gated, no answer keys. Distinct from the already-registered search-evals results dataset. The subnet-22 README (source) declares the Bittensor subnet and the desearch HF org owns it.",
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/Desearch-ai/subnet-22",
+        "https://huggingface.co/desearch"
+      ],
+      "url": "https://huggingface.co/datasets/desearch/dataset"
     }
   ],
   "website_url": "https://www.desearch.ai/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN22 (Desearch): the public **`desearch/dataset`** HuggingFace search-benchmark corpus — ~196k fresh web + X (Twitter) search questions, regenerated daily. Distinct from the search-*evals* (results) dataset already registered on this subnet. Exactly one file changed: `registry/subnets/desearch.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/desearch/dataset` |
| `source_urls` | `https://github.com/Desearch-ai/subnet-22` · `https://huggingface.co/desearch` |
| `provider` | `desearch` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, `private:false`, `gated:false`): 196,509 rows across web-news and X subsets — columns `id`, `question`, `difficulty`, date-window timestamps. Card: *"Fresh, self-contained benchmark questions for evaluating web and X (Twitter) search. Regenerated daily from recent news and tweets."* Plain text benchmark — no credential/validator columns.
- **`source_url` (README)** — the `subnet-22` repo README declares the subnet (*"SN22 is the Bittensor subnet behind Desearch's decentralized real-time intelligence layer"*, netuid 22); the `desearch` HuggingFace org owns the dataset.
- **`source_url` (org)** — `https://huggingface.co/desearch`, the operator's HF org.

Non-duplicate: the file's existing HF `data-artifact` is `desearch/desearch-search-evals` (search *result* gradings); this is the distinct upstream *benchmark questions* dataset.

## Registry Safety

- [x] Exactly one `registry/subnets/desearch.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s proving SN22 publishes it; provider `desearch` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/desearch.json` — passed (12 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1269 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
