### PR TITLE
fix(health-prober): fail closed on DoH errors for Worker probe SSRF guard

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -260,12 +260,7 @@ export function createWorkerPinnedFetch({
       throw error;
     }
 
-    let parsed;
-    try {
-      parsed = new URL(url);
-    } catch (error) {
-      throw error;
-    }
+    const parsed = new URL(url);
 
     const host = normalizedHostname(parsed.hostname);
     const isLiteral = ipv4Octets(host) || host.includes(":");

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -98,14 +98,13 @@ function sanitizeRpcLatestBlocks(rows) {
   }
 }
 
-// --- DNS-aware SSRF guard for the Worker prober (codex #255) -------------------
+// --- DNS-aware SSRF guard + pinned fetch for the Worker prober (codex #255) ----
 // The literal `isUnsafePublicUrl` guard can't see DNS rebinding (a public-looking
 // hostname that resolves to a private IP). Workers have no node:dns, so we verify
-// answers via Cloudflare DNS-over-HTTPS immediately before the probe. Policy:
-// block on a DETECTED private answer (real rebinding), but fail OPEN on a DoH
-// timeout/error/no-answer — operational surfaces are a curated, public_safe,
-// PR-reviewed allowlist that already passed the literal guard, so a DoH blip must
-// never falsely mark all health unsafe.
+// answers via Cloudflare DNS-over-HTTPS immediately before the probe, then connect
+// to the vetted address with a Host header (mirroring scripts/lib.mjs safeFetch).
+// Policy: block on a DETECTED private answer (real rebinding) and FAIL CLOSED on a
+// DoH timeout/error/no-answer — an unverified hostname must never be probed.
 function normalizedHostname(value) {
   return String(value || "")
     .trim()
@@ -188,34 +187,119 @@ async function resolveDnsJson(host, recordType, fetchImpl, endpoint) {
   return dnsAddressAnswers(await response.json());
 }
 
-export function workerResolvedUrlSafetyGuard({
+function dnsAnswerFamily(address) {
+  return ipv4Octets(address) ? 4 : 6;
+}
+
+function buildPinnedUrl(parsed, { address, family }) {
+  const pinned = new URL(parsed.toString());
+  pinned.hostname =
+    family === 6 || address.includes(":") ? `[${address}]` : address;
+  return pinned.toString();
+}
+
+// Resolve a probe URL to one or more vetted public addresses via DoH. Returns
+// [] when the URL is unsafe, unresolvable, or DoH failed (fail-closed).
+export async function resolveWorkerPublicUrlAddresses(
+  value,
+  { fetchImpl = fetch, dnsJsonEndpoint = DNS_JSON_ENDPOINT } = {},
+) {
+  if (isUnsafePublicUrl(value)) {
+    return [];
+  }
+  let host;
+  try {
+    host = normalizedHostname(new URL(value).hostname);
+  } catch {
+    return [];
+  }
+  if (ipv4Octets(host) || host.includes(":")) {
+    return isUnsafeIpAddress(host)
+      ? []
+      : [{ address: host, family: dnsAnswerFamily(host) }];
+  }
+  const lookups = await Promise.allSettled(
+    DNS_RECORD_TYPES.map((type) =>
+      resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
+    ),
+  );
+  const answers = lookups.flatMap((lookup) =>
+    lookup.status === "fulfilled" ? lookup.value : [],
+  );
+  if (answers.some(isUnsafeIpAddress) || answers.length === 0) {
+    return [];
+  }
+  return answers.map((address) => ({
+    address,
+    family: dnsAnswerFamily(address),
+  }));
+}
+
+export function workerResolvedUrlSafetyGuard(options = {}) {
+  return async function isUnsafeWorkerResolvedUrl(value) {
+    const addresses = await resolveWorkerPublicUrlAddresses(value, options);
+    return addresses.length === 0;
+  };
+}
+
+// SSRF-safe outbound fetch for the Worker prober: resolves via DoH, pins the
+// vetted address into the request URL, and sets Host so TLS/SNI stay correct.
+export function createWorkerPinnedFetch({
   fetchImpl = fetch,
+  dohFetchImpl = fetch,
   dnsJsonEndpoint = DNS_JSON_ENDPOINT,
 } = {}) {
-  return async function isUnsafeWorkerResolvedUrl(value) {
-    if (isUnsafePublicUrl(value)) {
-      return true;
+  return async function workerPinnedFetch(url, init = {}) {
+    const addresses = await resolveWorkerPublicUrlAddresses(url, {
+      fetchImpl: dohFetchImpl,
+      dnsJsonEndpoint,
+    });
+    if (addresses.length === 0) {
+      const error = new Error("unsafe or unresolvable URL");
+      error.name = "WorkerPinnedFetchError";
+      throw error;
     }
-    let host;
+
+    let parsed;
     try {
-      host = normalizedHostname(new URL(value).hostname);
-    } catch {
-      return true;
+      parsed = new URL(url);
+    } catch (error) {
+      throw error;
     }
-    if (ipv4Octets(host) || host.includes(":")) {
-      return isUnsafeIpAddress(host);
+
+    const host = normalizedHostname(parsed.hostname);
+    const isLiteral = ipv4Octets(host) || host.includes(":");
+    if (isLiteral) {
+      return fetchImpl(url, init);
     }
-    const lookups = await Promise.allSettled(
-      DNS_RECORD_TYPES.map((type) =>
-        resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
-      ),
-    );
-    const answers = lookups.flatMap((lookup) =>
-      lookup.status === "fulfilled" ? lookup.value : [],
-    );
-    // Block on any confirmed private answer (rebinding), even if another RR
-    // lookup failed. No confirmed private answer / DoH failure → fail open.
-    return answers.some(isUnsafeIpAddress);
+
+    const headers = new Headers(init.headers);
+    headers.set("Host", parsed.host);
+    return fetchImpl(buildPinnedUrl(parsed, addresses[0]), {
+      ...init,
+      headers,
+    });
+  };
+}
+
+export function createWorkerProbeOptions(overrides = {}) {
+  const dohFetch = overrides.safetyFetch ?? overrides.dohFetchImpl ?? fetch;
+  const pinnedFetch =
+    overrides.pinnedFetch ??
+    createWorkerPinnedFetch({
+      fetchImpl: overrides.fetchImpl ?? dohFetch,
+      dohFetchImpl: dohFetch,
+      dnsJsonEndpoint: overrides.dnsJsonEndpoint,
+    });
+  return {
+    isUnsafeUrl:
+      overrides.isUnsafeUrl ||
+      workerResolvedUrlSafetyGuard({
+        fetchImpl: dohFetch,
+        dnsJsonEndpoint: overrides.dnsJsonEndpoint,
+      }),
+    fetchImpl: pinnedFetch,
+    connect: overrides.connect || workerWebSocketConnector(pinnedFetch),
   };
 }
 
@@ -385,14 +469,16 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   const loadSurfaces =
     overrides.loadSurfaces || (() => loadOperationalSurfaces(env));
   const probe = overrides.probeSurface || coreProbeSurface;
-  const probeOptions = overrides.probeOptions || {
-    // DNS-aware SSRF guard (resolves via DoH; fail-open on DoH error). Falls back
-    // to the isomorphic literal guard when an override is supplied (tests).
-    isUnsafeUrl:
-      overrides.isUnsafeUrl ||
-      workerResolvedUrlSafetyGuard({ fetchImpl: overrides.safetyFetch }),
-    connect: overrides.connect || workerWebSocketConnector(),
-  };
+  const probeOptions =
+    overrides.probeOptions ||
+    createWorkerProbeOptions({
+      isUnsafeUrl: overrides.isUnsafeUrl,
+      safetyFetch: overrides.safetyFetch,
+      fetchImpl: overrides.fetchImpl,
+      pinnedFetch: overrides.pinnedFetch,
+      connect: overrides.connect,
+      dnsJsonEndpoint: overrides.dnsJsonEndpoint,
+    });
   const concurrency = overrides.concurrency || PROBE_CONCURRENCY;
 
   const runAt = now();

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -98,13 +98,18 @@ function sanitizeRpcLatestBlocks(rows) {
   }
 }
 
-// --- DNS-aware SSRF guard + pinned fetch for the Worker prober (codex #255) ----
+// --- DNS-aware SSRF guard for the Worker prober (codex #255) -------------------
 // The literal `isUnsafePublicUrl` guard can't see DNS rebinding (a public-looking
 // hostname that resolves to a private IP). Workers have no node:dns, so we verify
-// answers via Cloudflare DNS-over-HTTPS immediately before the probe, then connect
-// to the vetted address with a Host header (mirroring scripts/lib.mjs safeFetch).
-// Policy: block on a DETECTED private answer (real rebinding) and FAIL CLOSED on a
-// DoH timeout/error/no-answer — an unverified hostname must never be probed.
+// answers via Cloudflare DNS-over-HTTPS immediately before the probe. Policy:
+// block on a DETECTED private answer (real rebinding) and FAIL CLOSED on a DoH
+// timeout/error/no-answer — an unverified hostname must never be probed.
+//
+// Unlike scripts/lib.mjs safeFetch (Node undici pinned lookup), Workers fetch()
+// cannot pin connect-time DNS to a vetted address while preserving the original
+// hostname for TLS SNI on arbitrary third-party targets. Probes therefore fetch
+// the original URL after DoH verification; a narrow DNS-rebinding TOCTOU window
+// remains between the check and connect.
 function normalizedHostname(value) {
   return String(value || "")
     .trim()
@@ -191,13 +196,6 @@ function dnsAnswerFamily(address) {
   return ipv4Octets(address) ? 4 : 6;
 }
 
-function buildPinnedUrl(parsed, { address, family }) {
-  const pinned = new URL(parsed.toString());
-  pinned.hostname =
-    family === 6 || address.includes(":") ? `[${address}]` : address;
-  return pinned.toString();
-}
-
 // Resolve a probe URL to one or more vetted public addresses via DoH. Returns
 // [] when the URL is unsafe, unresolvable, or DoH failed (fail-closed).
 export async function resolveWorkerPublicUrlAddresses(
@@ -207,12 +205,7 @@ export async function resolveWorkerPublicUrlAddresses(
   if (isUnsafePublicUrl(value)) {
     return [];
   }
-  let host;
-  try {
-    host = normalizedHostname(new URL(value).hostname);
-  } catch {
-    return [];
-  }
+  const host = normalizedHostname(new URL(value).hostname);
   if (ipv4Octets(host) || host.includes(":")) {
     return isUnsafeIpAddress(host)
       ? []
@@ -242,50 +235,9 @@ export function workerResolvedUrlSafetyGuard(options = {}) {
   };
 }
 
-// SSRF-safe outbound fetch for the Worker prober: resolves via DoH, pins the
-// vetted address into the request URL, and sets Host so TLS/SNI stay correct.
-export function createWorkerPinnedFetch({
-  fetchImpl = fetch,
-  dohFetchImpl = fetch,
-  dnsJsonEndpoint = DNS_JSON_ENDPOINT,
-} = {}) {
-  return async function workerPinnedFetch(url, init = {}) {
-    const addresses = await resolveWorkerPublicUrlAddresses(url, {
-      fetchImpl: dohFetchImpl,
-      dnsJsonEndpoint,
-    });
-    if (addresses.length === 0) {
-      const error = new Error("unsafe or unresolvable URL");
-      error.name = "WorkerPinnedFetchError";
-      throw error;
-    }
-
-    const parsed = new URL(url);
-
-    const host = normalizedHostname(parsed.hostname);
-    const isLiteral = ipv4Octets(host) || host.includes(":");
-    if (isLiteral) {
-      return fetchImpl(url, init);
-    }
-
-    const headers = new Headers(init.headers);
-    headers.set("Host", parsed.host);
-    return fetchImpl(buildPinnedUrl(parsed, addresses[0]), {
-      ...init,
-      headers,
-    });
-  };
-}
-
 export function createWorkerProbeOptions(overrides = {}) {
-  const dohFetch = overrides.safetyFetch ?? overrides.dohFetchImpl ?? fetch;
-  const pinnedFetch =
-    overrides.pinnedFetch ??
-    createWorkerPinnedFetch({
-      fetchImpl: overrides.fetchImpl ?? dohFetch,
-      dohFetchImpl: dohFetch,
-      dnsJsonEndpoint: overrides.dnsJsonEndpoint,
-    });
+  const dohFetch = overrides.dohFetchImpl ?? overrides.safetyFetch ?? fetch;
+  const probeFetch = overrides.fetchImpl ?? fetch;
   return {
     isUnsafeUrl:
       overrides.isUnsafeUrl ||
@@ -293,8 +245,8 @@ export function createWorkerProbeOptions(overrides = {}) {
         fetchImpl: dohFetch,
         dnsJsonEndpoint: overrides.dnsJsonEndpoint,
       }),
-    fetchImpl: pinnedFetch,
-    connect: overrides.connect || workerWebSocketConnector(pinnedFetch),
+    fetchImpl: probeFetch,
+    connect: overrides.connect || workerWebSocketConnector(probeFetch),
   };
 }
 
@@ -469,8 +421,8 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     createWorkerProbeOptions({
       isUnsafeUrl: overrides.isUnsafeUrl,
       safetyFetch: overrides.safetyFetch,
+      dohFetchImpl: overrides.dohFetchImpl,
       fetchImpl: overrides.fetchImpl,
-      pinnedFetch: overrides.pinnedFetch,
       connect: overrides.connect,
       dnsJsonEndpoint: overrides.dnsJsonEndpoint,
     });

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -145,8 +145,7 @@ import {
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
-  workerResolvedUrlSafetyGuard,
-  workerWebSocketConnector,
+  createWorkerProbeOptions,
 } from "./health-prober.mjs";
 import {
   findSurface,
@@ -5323,12 +5322,7 @@ export const MCP_TOOLS = [
           "Provide either surface_id or netuid.",
         );
       }
-      return await verifySurfaceWithCache(surface, {
-        isUnsafeUrl: workerResolvedUrlSafetyGuard({
-          fetchImpl: globalThis.fetch,
-        }),
-        connect: workerWebSocketConnector(globalThis.fetch),
-      });
+      return await verifySurfaceWithCache(surface, createWorkerProbeOptions());
     },
   },
 ];

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -4,9 +4,11 @@ import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
+  createWorkerPinnedFetch,
   loadOperationalSurfaces,
   OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
+  resolveWorkerPublicUrlAddresses,
   rollupDailyUptime,
   runD1StatementBatches,
   D1_STATEMENTS_PER_BATCH,
@@ -126,16 +128,16 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
     assert.equal(await guard("https://ok.example.com/x"), false);
   });
 
-  test("fails OPEN on a DoH error (does not block all health)", async () => {
+  test("fails CLOSED on a DoH error (does not probe unverified hostnames)", async () => {
     const guard = workerResolvedUrlSafetyGuard({
       fetchImpl: async () => {
         throw new Error("DoH unreachable");
       },
     });
-    assert.equal(await guard("https://ok.example.com/x"), false);
+    assert.equal(await guard("https://ok.example.com/x"), true);
   });
 
-  test("fails OPEN on no DNS answer / non-ok DoH", async () => {
+  test("fails CLOSED on no DNS answer / non-ok DoH", async () => {
     const guard = workerResolvedUrlSafetyGuard({
       fetchImpl: async () => ({
         ok: false,
@@ -144,7 +146,107 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
         },
       }),
     });
-    assert.equal(await guard("https://unknown.example.com/x"), false);
+    assert.equal(await guard("https://unknown.example.com/x"), true);
+  });
+});
+
+describe("resolveWorkerPublicUrlAddresses", () => {
+  const dohFetch = (records) => async (url) => {
+    const u = new URL(url);
+    const name = u.searchParams.get("name");
+    const type = u.searchParams.get("type");
+    const data = records[name]?.[type] || [];
+    return {
+      ok: true,
+      async json() {
+        return { Answer: data.map((d) => ({ data: d })) };
+      },
+    };
+  };
+
+  test("returns vetted public addresses for a hostname", async () => {
+    const addresses = await resolveWorkerPublicUrlAddresses(
+      "https://ok.example.com/x",
+      { fetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }) },
+    );
+    assert.deepEqual(addresses, [{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  test("returns [] on DoH failure (fail-closed)", async () => {
+    const addresses = await resolveWorkerPublicUrlAddresses(
+      "https://unknown.example.com/x",
+      {
+        fetchImpl: async () => {
+          throw new Error("DoH unreachable");
+        },
+      },
+    );
+    assert.deepEqual(addresses, []);
+  });
+});
+
+describe("createWorkerPinnedFetch", () => {
+  const dohFetch = (records) => async (url) => {
+    const u = new URL(url);
+    const name = u.searchParams.get("name");
+    const type = u.searchParams.get("type");
+    const data = records[name]?.[type] || [];
+    return {
+      ok: true,
+      async json() {
+        return { Answer: data.map((d) => ({ data: d })) };
+      },
+    };
+  };
+
+  test("pins hostname probes to the vetted address and sets Host", async () => {
+    let capturedUrl = null;
+    let capturedInit = null;
+    const pinned = createWorkerPinnedFetch({
+      dohFetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }),
+      fetchImpl: async (url, init) => {
+        capturedUrl = url;
+        capturedInit = init;
+        return new Response("ok", { status: 200 });
+      },
+    });
+    await pinned("https://ok.example.com/path?q=1", {
+      headers: { accept: "text/plain" },
+    });
+    assert.equal(capturedUrl, "https://93.184.216.34/path?q=1");
+    assert.equal(capturedInit.headers.get("Host"), "ok.example.com");
+    assert.equal(capturedInit.headers.get("accept"), "text/plain");
+  });
+
+  test("throws WorkerPinnedFetchError when resolution fails", async () => {
+    const pinned = createWorkerPinnedFetch({
+      dohFetchImpl: async () => {
+        throw new Error("DoH unreachable");
+      },
+      fetchImpl: async () => new Response("ok"),
+    });
+    await assert.rejects(
+      () => pinned("https://unknown.example.com/x"),
+      (error) => {
+        assert.equal(error.name, "WorkerPinnedFetchError");
+        return true;
+      },
+    );
+  });
+
+  test("passes IP-literal URLs through without rewriting", async () => {
+    let capturedUrl = null;
+    const pinned = createWorkerPinnedFetch({
+      dohFetchImpl: async () => {
+        throw new Error("DoH should not run for IP literals");
+      },
+      fetchImpl: async (url) => {
+        capturedUrl = url;
+        return new Response("ok");
+      },
+    });
+    await pinned("https://8.8.8.8/x");
+    assert.equal(capturedUrl, "https://8.8.8.8/x");
   });
 });
 

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -4,7 +4,7 @@ import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
-  createWorkerPinnedFetch,
+  createWorkerProbeOptions,
   loadOperationalSurfaces,
   OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
@@ -183,9 +183,76 @@ describe("resolveWorkerPublicUrlAddresses", () => {
     );
     assert.deepEqual(addresses, []);
   });
+
+  test("returns [] for unsafe schemes and private literals blocked by the guard", async () => {
+    const dohFetch = async () => {
+      throw new Error("DoH should not run");
+    };
+    assert.deepEqual(
+      await resolveWorkerPublicUrlAddresses("not a url", {
+        fetchImpl: dohFetch,
+      }),
+      [],
+    );
+    assert.deepEqual(
+      await resolveWorkerPublicUrlAddresses("http://10.0.0.1/x", {
+        fetchImpl: dohFetch,
+      }),
+      [],
+    );
+    assert.deepEqual(
+      await resolveWorkerPublicUrlAddresses("https://127.0.0.1/x", {
+        fetchImpl: dohFetch,
+      }),
+      [],
+    );
+  });
+
+  test("returns [] for unsafe IP literals that pass the public URL guard", async () => {
+    const dohFetch = async () => {
+      throw new Error("DoH should not run");
+    };
+    // 100::/64 CGNAT IPv6 is blocked by isUnsafeIpAddress but not isUnsafeIpv6Literal.
+    assert.deepEqual(
+      await resolveWorkerPublicUrlAddresses("https://[100::1]/x", {
+        fetchImpl: dohFetch,
+      }),
+      [],
+    );
+  });
+
+  test("returns [] when DNS answers are private or empty", async () => {
+    const privateDoh = dohFetch({ "evil.example.com": { A: ["10.1.2.3"] } });
+    assert.deepEqual(
+      await resolveWorkerPublicUrlAddresses("https://evil.example.com/x", {
+        fetchImpl: privateDoh,
+      }),
+      [],
+    );
+    assert.deepEqual(
+      await resolveWorkerPublicUrlAddresses("https://empty.example.com/x", {
+        fetchImpl: dohFetch({}),
+      }),
+      [],
+    );
+  });
+
+  test("returns vetted IPv6 addresses from AAAA records", async () => {
+    const addresses = await resolveWorkerPublicUrlAddresses(
+      "https://v6.example.com/x",
+      {
+        fetchImpl: dohFetch({
+          "v6.example.com": { AAAA: ["2001:4860:4860::8888"] },
+        }),
+      },
+    );
+    assert.deepEqual(addresses, [
+      { address: "2001:4860:4860::8888", family: 6 },
+    ]);
+  });
 });
 
-describe("createWorkerPinnedFetch", () => {
+describe("createWorkerProbeOptions", () => {
   const dohFetch = (records) => async (url) => {
     const u = new URL(url);
     const name = u.searchParams.get("name");
@@ -199,54 +266,63 @@ describe("createWorkerPinnedFetch", () => {
     };
   };
 
-  test("pins hostname probes to the vetted address and sets Host", async () => {
+  test("builds default guard + fetch + connector wiring", () => {
+    const options = createWorkerProbeOptions();
+    assert.equal(typeof options.isUnsafeUrl, "function");
+    assert.equal(typeof options.fetchImpl, "function");
+    assert.equal(typeof options.connect, "function");
+  });
+
+  test("fetch keeps the original hostname so TLS SNI stays valid", async () => {
     let capturedUrl = null;
-    let capturedInit = null;
-    const pinned = createWorkerPinnedFetch({
+    const options = createWorkerProbeOptions({
       dohFetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }),
-      fetchImpl: async (url, init) => {
-        capturedUrl = url;
-        capturedInit = init;
-        return new Response("ok", { status: 200 });
-      },
-    });
-    await pinned("https://ok.example.com/path?q=1", {
-      headers: { accept: "text/plain" },
-    });
-    assert.equal(capturedUrl, "https://93.184.216.34/path?q=1");
-    assert.equal(capturedInit.headers.get("Host"), "ok.example.com");
-    assert.equal(capturedInit.headers.get("accept"), "text/plain");
-  });
-
-  test("throws WorkerPinnedFetchError when resolution fails", async () => {
-    const pinned = createWorkerPinnedFetch({
-      dohFetchImpl: async () => {
-        throw new Error("DoH unreachable");
-      },
-      fetchImpl: async () => new Response("ok"),
-    });
-    await assert.rejects(
-      () => pinned("https://unknown.example.com/x"),
-      (error) => {
-        assert.equal(error.name, "WorkerPinnedFetchError");
-        return true;
-      },
-    );
-  });
-
-  test("passes IP-literal URLs through without rewriting", async () => {
-    let capturedUrl = null;
-    const pinned = createWorkerPinnedFetch({
-      dohFetchImpl: async () => {
-        throw new Error("DoH should not run for IP literals");
-      },
       fetchImpl: async (url) => {
         capturedUrl = url;
         return new Response("ok");
       },
     });
-    await pinned("https://8.8.8.8/x");
-    assert.equal(capturedUrl, "https://8.8.8.8/x");
+    assert.equal(await options.isUnsafeUrl("https://ok.example.com/x"), false);
+    await options.fetchImpl("https://ok.example.com/path?q=1");
+    assert.equal(capturedUrl, "https://ok.example.com/path?q=1");
+  });
+
+  test("DoH fetch and probe fetch are wired independently", async () => {
+    const calls = [];
+    const options = createWorkerProbeOptions({
+      dohFetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }),
+      fetchImpl: async (url) => {
+        calls.push(["probe", url]);
+        return new Response("ok");
+      },
+    });
+    assert.equal(await options.isUnsafeUrl("https://ok.example.com/x"), false);
+    await options.fetchImpl("https://ok.example.com/x");
+    assert.ok(
+      calls.some(
+        ([kind, url]) => kind === "probe" && url.includes("ok.example.com"),
+      ),
+    );
+    assert.ok(
+      !calls.some(
+        ([kind, url]) => kind === "probe" && url.includes("cloudflare-dns.com"),
+      ),
+    );
+  });
+
+  test("honors explicit overrides for fetch, guard, connect, and DoH", () => {
+    const isUnsafeUrl = async () => false;
+    const probeFetch = async () => new Response("ok");
+    const connect = () => {};
+    const options = createWorkerProbeOptions({
+      isUnsafeUrl,
+      fetchImpl: probeFetch,
+      connect,
+      dohFetchImpl: async () => new Response("{}"),
+    });
+    assert.equal(options.isUnsafeUrl, isUnsafeUrl);
+    assert.equal(options.fetchImpl, probeFetch);
+    assert.equal(options.connect, connect);
   });
 });
 

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -46,8 +46,7 @@ import {
 import { SURFACE_ALIASES_PATH } from "../../src/surface-aliases.mjs";
 import {
   KV_HEALTH_RPC_POOL,
-  workerResolvedUrlSafetyGuard,
-  workerWebSocketConnector,
+  createWorkerProbeOptions,
 } from "../../src/health-prober.mjs";
 import { ipv6EmbeddedIpv4 } from "../../src/ip-safety.mjs";
 import { overlayRpcPoolEligibility } from "../../src/health-serving.mjs";
@@ -226,12 +225,7 @@ export async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
 
   const result = await verifySurfaceWithCache(
     surface,
-    {
-      isUnsafeUrl: workerResolvedUrlSafetyGuard({
-        fetchImpl: globalThis.fetch,
-      }),
-      connect: workerWebSocketConnector(globalThis.fetch),
-    },
+    createWorkerProbeOptions(),
     {
       waitUntil: (promise) => ctx?.waitUntil?.(promise),
     },


### PR DESCRIPTION
## Summary

- Close the fail-open SSRF gap in Worker outbound health probes by verifying hostnames via DoH before probing and blocking when DoH is unavailable or returns private/unresolved answers.
- Centralize Worker probe wiring in `createWorkerProbeOptions()` for the cron prober, surface verify API, and MCP verify tool.
- Workers `fetch()` cannot pin connect-time DNS to a vetted address while preserving TLS SNI on arbitrary third-party hostnames (unlike Node `safeFetch`); probes therefore use the original URL after DoH verification, leaving a narrow rebinding TOCTOU window.

## What Changed

- `src/health-prober.mjs` — add `resolveWorkerPublicUrlAddresses` and `createWorkerProbeOptions`; switch the guard from fail-open to fail-closed; wire DoH guard into default probe options.
- `workers/request-handlers/rpc-proxy.mjs` — use `createWorkerProbeOptions()` for on-demand surface verify.
- `src/mcp-server.mjs` — same for the MCP verify tool.
- `tests/health-prober.test.mjs` — update guard expectations; add probe-options and resolution tests.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/health-prober.test.mjs`
- [x] `npm test -- tests/surface-verify.test.mjs tests/health-probe-core.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run worker:test`
- [x] `git diff --check`
