### PR TITLE
feat(registry): add SN52 Dojo synthetic SFT dataset

### DIFF
--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -125,6 +125,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Dojo worker API repository."
+    },
+    {
+      "id": "sn-52-dojo-synthetic-sft-dataset",
+      "name": "Dojo synthetic SFT dataset",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/datasets/tensorplex-labs/Dojo-Synthetic-SFT",
+      "provider": "tensorplex",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo",
+        "https://huggingface.co/tensorplex-labs"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public Tensorplex Dojo (SN52) HuggingFace dataset of 12.5k synthetic HTML/CSS/JS interface-generation Q&A pairs (id + messages columns), used to train the subnet's DOJO-INTERFACE-CODER model; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset."
     }
   ],
   "contact": "jarvis@tensorplex.ai"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN52 (Dojo, by Tensorplex Labs): the public **`Dojo-Synthetic-SFT`** HuggingFace dataset. The subnet file previously had no HuggingFace surface at all. Exactly one file changed: `registry/subnets/dojo.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/tensorplex-labs/Dojo-Synthetic-SFT` |
| `source_urls` | `https://github.com/tensorplex-labs/dojo` · `https://huggingface.co/tensorplex-labs` |
| `provider` | `tensorplex` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, not gated): 12,500 synthetic Q&A pairs for frontend interface generation (HTML/CSS/JS), columns `id` + `messages`. Card: *"a question-answering dataset designed to improve interface generation capabilities in large language models."* Plain text corpus — no credential/validator columns.
- **`source_url` (README)** — the `tensorplex-labs/dojo` repo README declares the subnet (mainnet registration `btcli s register --netuid 52`); the `tensorplex-labs` HuggingFace org (same name as the GitHub org) owns the dataset, and its `DOJO-INTERFACE-CODER` model is trained on this data.
- **`source_url` (org)** — `https://huggingface.co/tensorplex-labs`, the operator's HF org.

Non-duplicate: the subnet file had zero `huggingface.co` surfaces before this.

## Registry Safety

- [x] Exactly one `registry/subnets/dojo.json` changed; a single appended community surface, nothing else (no reformatting of existing content — verified the normalized diff is a 19-line append).
- [x] Real public `url` + `source_url`s proving SN52 publishes it; provider `tensorplex` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/dojo.json` — passed (6 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1271 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
