### PR TITLE
feat(registry): add SN9 IOTA Macrocosmos code pretraining dataset

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -86,6 +86,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official IOTA source repository."
+    },
+    {
+      "id": "sn-9-iota-codeparrot-dataset",
+      "name": "IOTA code pretraining dataset",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/datasets/macrocosm-os/code-parrot-github-code",
+      "provider": "macrocosmos",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/macrocosm-os/iota",
+        "https://huggingface.co/macrocosm-os"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training."
     }
   ],
   "contact": "support@macrocosmos.ai"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN9 (IOTA, Macrocosmos' LLM-pretraining subnet): the operator's public **`code-parrot-github-code`** HuggingFace corpus. The subnet file previously had no HuggingFace surface. Exactly one file changed: `registry/subnets/iota.json` (a minimal 19-line append; no existing content touched).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/macrocosm-os/code-parrot-github-code` |
| `source_urls` | `https://github.com/macrocosm-os/iota` · `https://huggingface.co/macrocosm-os` |
| `provider` | `macrocosmos` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, not gated): a GitHub source-code corpus across 32 languages, columns `repo_name`, `path`, `size`, `content`, `license`. Plain code corpus — no credential/validator columns.
- **`source_url` (README)** — the `macrocosm-os/iota` repo README identifies IOTA as Macrocosmos' *"framework for pretraining large language models"* and links `docs.macrocosmos.ai/subnets/subnet-9-pre-training`, establishing Macrocosmos as the SN9 operator. The dataset is published under Macrocosmos' own `macrocosm-os` HuggingFace org (same org as the IOTA GitHub repo) — a code corpus is the appropriate pretraining-data fit for this pretraining subnet.
- **`source_url` (org)** — `https://huggingface.co/macrocosm-os`, the operator's HF org.

Non-duplicate: the subnet file had zero `huggingface.co` surfaces before this.

## Registry Safety

- [x] Exactly one `registry/subnets/iota.json` changed; a single appended community surface, nothing else (normalized diff is a 19-line append; existing content untouched).
- [x] Real public `url` + `source_url`s; owner-matched via the Macrocosmos org that operates SN9; provider `macrocosmos` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/iota.json` — passed (4 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1271 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
