### PR TITLE
feat(mcp): add get_chain_registrations mirroring GET /api/v1/chain/registrations

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -149,6 +149,11 @@ import {
   parseCompareNetuidList,
   parseUptimeWindow,
 } from "./analytics-live.mjs";
+import {
+  loadChainRegistrations,
+  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_REGISTRATIONS_LIMIT_MAX,
+} from "./chain-registrations.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -285,7 +290,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.36.0";
+export const MCP_SERVER_VERSION = "1.37.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -413,7 +418,10 @@ export const MCP_INSTRUCTIONS =
   "its per-subnet staking flow with direction and concentration labels. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
-  "fee/tip market series plus top payers, get_chain_transfers network-wide " +
+  "fee/tip market series plus top payers, get_chain_registrations the " +
+  "network-wide neuron-registration leaderboard (per-subnet NeuronRegistered " +
+  "activity and re-registration intensity) across all subnets, " +
+  "get_chain_transfers network-wide " +
   "native-TAO transfer volume plus top senders/receivers, " +
   "get_chain_transfer_pairs the top sender->receiver transfer corridors " +
   "(directed pairs ranked by volume or count) with a network volume rollup, " +
@@ -4358,6 +4366,51 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_registrations",
+    title: "Get chain registration activity",
+    description:
+      "Fetch network-wide neuron-registration activity over the requested " +
+      "window (7d or 30d; default 7d) across every subnet with observed " +
+      "registration activity: a per-subnet registration leaderboard (ranked by " +
+      "NeuronRegistered count) plus the network rollup, computed live from the " +
+      "account_events NeuronRegistered stream. limit caps the leaderboard " +
+      "(1-100, default 20). Mirrors GET /api/v1/chain/registrations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max leaderboard subnets to return (1-100, default 20).",
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parsed;
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+        CHAIN_REGISTRATIONS_LIMIT_MAX,
+      );
+      return await loadChainRegistrations(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+        limit,
+      });
+    },
+  },
+  {
     name: "get_chain_transfers",
     title: "Get network-wide native-TAO transfer analytics",
     description:
@@ -7225,6 +7278,32 @@ const TOOL_OUTPUT_SCHEMAS = {
         total_fee_tao: { type: ["number", "null"] },
         total_tip_tao: { type: ["number", "null"] },
         extrinsic_count: NULLABLE_INT,
+      }),
+    },
+  },
+  get_chain_registrations: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      network: {
+        type: "object",
+        properties: {
+          distinct_registrants: NULLABLE_INT,
+          registrations: NULLABLE_INT,
+          registrations_per_registrant: { type: ["number", "null"] },
+        },
+      },
+      intensity_distribution: { type: ["object", "null"] },
+      subnets: objectItems({
+        netuid: NULLABLE_INT,
+        distinct_registrants: NULLABLE_INT,
+        registrations: NULLABLE_INT,
+        registrations_per_registrant: { type: ["number", "null"] },
       }),
     },
   },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2532,6 +2532,87 @@ describe("MCP get_chain_fees", () => {
   });
 });
 
+describe("MCP get_chain_registrations", () => {
+  // Route the two loadChainRegistrations reads by SQL: the network aggregate
+  // (distinct_registrants + newest_observed, single row) vs the per-subnet
+  // GROUP BY netuid leaderboard. The network aggregate's newest_observed must
+  // be non-null or the loader short-circuits the per-subnet read.
+  function registrationsD1(
+    {
+      network = { distinct_registrants: 7, newest_observed: 1_700_000_000_000 },
+      subnets = [
+        { netuid: 5, registrations: 12, distinct_registrants: 10 },
+        { netuid: 2, registrations: 4, distinct_registrants: 4 },
+      ],
+    } = {},
+    capture = [],
+  ) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (/GROUP BY netuid/.test(sql)) {
+                    return { results: subnets };
+                  }
+                  return { results: network ? [network] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("returns the per-subnet leaderboard and network rollup from D1", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_chain_registrations",
+      { window: "7d", limit: 20 },
+      { env: registrationsD1({}, capture) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.subnet_count, 2);
+    // Leaderboard ranked by registrations DESC.
+    assert.equal(out.subnets[0].netuid, 5);
+    assert.equal(out.subnets[0].registrations, 12);
+    assert.equal(out.subnets[0].registrations_per_registrant, 1.2);
+    assert.equal(out.subnets[1].netuid, 2);
+    // Network rollup: distinct_registrants from the aggregate row, registrations
+    // summed across subnets (12 + 4).
+    assert.equal(out.network.distinct_registrants, 7);
+    assert.equal(out.network.registrations, 16);
+    // The aggregate read runs before the GROUP BY leaderboard read.
+    assert.ok(!/GROUP BY netuid/.test(capture[0].sql));
+    assert.match(capture[1].sql, /GROUP BY netuid/);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool(
+      "get_chain_registrations",
+      { window: "99d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/i);
+  });
+
+  test("returns a schema-stable empty block on a cold D1 store", async () => {
+    const res = await callTool("get_chain_registrations", {}, {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.network.registrations, 0);
+    assert.equal(out.network.registrations_per_registrant, null);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+  });
+});
+
 describe("MCP get_chain_transfers", () => {
   function chainTransfersD1(
     {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## What

Adds a new MCP tool **`get_chain_registrations`** that mirrors the existing
`GET /api/v1/chain/registrations` REST endpoint — network-wide neuron-registration
analytics.

For a 7d or 30d window (default 7d) it returns, across every subnet with observed
`NeuronRegistered` activity, a per-subnet registration leaderboard (ranked by
registration count) plus the network rollup — computed live from the
`account_events` stream. `limit` caps the leaderboard (1-100, default 20).
Modeled on the existing `get_chain_fees` tool; reads the same
`loadChainRegistrations` loader the REST route serves.

## Why

The chain analytics family is broadly exposed over MCP (`get_chain_fees`,
`get_chain_stake_flow`, `get_chain_turnover`, `get_chain_activity`, …), but
network-wide registration activity — a core signal of where miners/validators
are entering the network — had no MCP counterpart. This closes that gap with no
new data surface.

## Notes

- Pure MCP wiring over an existing loader — no REST contract change, so no
  OpenAPI/type regeneration.
- Bumps the MCP server version to 1.37.0 (`server.json` + the per-tool SemVer
  assertions updated to match, per `validate:mcp`).
- Tests cover the happy path (leaderboard + rollup), invalid `window`, and a
  cold-store empty result. `validate:mcp` reports the new tool (103 total);
  `validate:contract-drift`, lint, and prettier pass.