### PR TITLE
feat(mcp): add get_subnet_axon_removals mirroring GET /api/v1/subnets/{netuid}/axon-removals

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -207,6 +207,11 @@ import {
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
 } from "./subnet-weight-setters.mjs";
+import {
+  loadSubnetAxonRemovals,
+  SUBNET_AXON_REMOVALS_WINDOWS,
+  DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
+} from "./subnet-axon-removals.mjs";
 import { loadAccountPortfolio } from "./account-portfolio.mjs";
 import {
   buildNeuronHistory,
@@ -285,7 +290,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.36.0";
+export const MCP_SERVER_VERSION = "1.37.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -303,6 +308,9 @@ const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
 );
 const SUBNET_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
   SUBNET_WEIGHT_SETTERS_WINDOWS,
+);
+const SUBNET_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
+  SUBNET_AXON_REMOVALS_WINDOWS,
 );
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -388,7 +396,9 @@ export const MCP_INSTRUCTIONS =
   "account-event summary for one subnet (per-kind counts plus a recent-events " +
   "tail), get_subnet_weight_setters the per-subnet weight-setter leaderboard " +
   "(the validators behind /weights ranked by activity), " +
-  "get_subnet_movers the cross-subnet " +
+  "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
+  "(distinct removers, event count, removals per remover — the removal-side " +
+  "companion to /serving), get_subnet_movers the cross-subnet " +
   "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
   "rates plus distribution percentiles over the current metagraph snapshot, " +
   "get_registry_leaderboards the live " +
@@ -2569,6 +2579,46 @@ export const MCP_TOOLS = [
       return await loadSubnetWeightSetters(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
         windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window],
+      });
+    },
+  },
+  {
+    name: "get_subnet_axon_removals",
+    title: "Get subnet axon-removal activity",
+    description:
+      "Fetch one subnet's axon-removal activity over a 7d or 30d window " +
+      "(default 7d): the distinct removers (hotkeys), AxonInfoRemoved event " +
+      "count, and average removals per remover, computed live from the " +
+      "account_events AxonInfoRemoved stream. Raw axon-teardown activity — " +
+      "the removal-side companion to get_subnet_serving (which measures " +
+      "neurons announcing an axon, not tearing one down). " +
+      "Mirrors GET /api/v1/subnets/{netuid}/axon-removals.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_AXON_REMOVALS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_AXON_REMOVALS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
+      if (!Object.hasOwn(SUBNET_AXON_REMOVALS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_AXON_REMOVALS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      return await loadSubnetAxonRemovals(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_AXON_REMOVALS_WINDOWS[window],
       });
     },
   },
@@ -6559,6 +6609,26 @@ const TOOL_OUTPUT_SCHEMAS = {
         first_set_at: NULLABLE_STRING,
         last_set_at: NULLABLE_STRING,
       }),
+    },
+  },
+  get_subnet_axon_removals: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "distinct_removers",
+      "removals",
+      "removals_per_remover",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_removers: { type: "integer" },
+      removals: { type: "integer" },
+      removals_per_remover: { type: ["number", "null"] },
     },
   },
   get_subnet_movers: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3280,7 +3280,11 @@ describe("MCP get_subnet_axon_removals", () => {
           return {
             bind(...params) {
               capture.push({ sql, params });
-              return { async all() { return { results: row ? [row] : [] }; } };
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
             },
           };
         },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3272,6 +3272,72 @@ describe("MCP get_subnet_weight_setters", () => {
   });
 });
 
+describe("MCP get_subnet_axon_removals", () => {
+  function axonRemovalsD1(row = null, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return { async all() { return { results: row ? [row] : [] }; } };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("reports removal activity for one subnet over the window", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_subnet_axon_removals",
+      { netuid: 7, window: "7d" },
+      {
+        env: axonRemovalsD1(
+          {
+            distinct_removers: 2,
+            removals: 20,
+            newest_observed: 1_750_000_000_000,
+          },
+          capture,
+        ),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_removers, 2);
+    assert.equal(out.removals, 20);
+    assert.equal(out.removals_per_remover, 10);
+    assert.equal(capture[0].params[0], 7);
+  });
+
+  test("defaults to the 7d window and degrades to a zeroed card on cold D1", async () => {
+    const res = await callTool("get_subnet_axon_removals", { netuid: 9 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_removers, 0);
+    assert.equal(out.removals, 0);
+    assert.equal(out.removals_per_remover, null);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_axon_removals", {
+      netuid: 7,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_axon_removals", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+});
+
 describe("MCP get_network_activity", () => {
   test("merges extrinsics + blocks tiers from D1", async () => {
     const env = {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.36.0");
+    assert.equal(MCP_SERVER_VERSION, "1.37.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## What

Adds a new MCP tool **`get_subnet_axon_removals`** that mirrors the existing
`GET /api/v1/subnets/{netuid}/axon-removals` REST endpoint - one subnet's axon-removal activity.

It returns, for one subnet over a 7d or 30d window (default 7d): the distinct removers (hotkeys), the AxonInfoRemoved event count, and removals per remover, computed live from the `account_events` AxonInfoRemoved stream. It's the removal-side companion to `get_subnet_serving` (which measures neurons announcing an axon, not tearing one down) - the same way `/registrations` (raw demand) coexists with `/turnover` (net churn). Modeled directly on `get_subnet_weight_setters`; reads the same `loadSubnetAxonRemovals` loader the REST route serves.

## Why

The REST route `/subnets/{netuid}/axon-removals` and its network-wide analogues (`get_chain_stake_moves`, etc.) already have MCP coverage, but this specific per-subnet endpoint had no MCP counterpart yet. This closes that gap with no new data surface.

## Notes

- Pure MCP wiring over an existing loader - no REST contract change, so no OpenAPI/type regeneration.
- Bumps the MCP server version to 1.37.0 (`server.json` + the per-tool SemVer assertions in 7 sibling test files, per `validate:mcp`).
- Tests cover the happy path (removal activity + per-remover ratio), cold-DB default window, invalid `window`, and missing `netuid`.

## Test plan
- [x] `npm run lint` (scoped to changed files)
- [x] `npm run validate`
- [x] `npm run validate:mcp` - 103 tools, lifecycle + all tools/call
- [x] `npx vitest run tests/mcp-server.test.mjs` - 491 passed
- [x] `npx vitest run tests/agent-resources-mcp.test.mjs tests/curation-mcp.test.mjs tests/gaps-mcp.test.mjs tests/global-operational-health.test.mjs tests/health-history-mcp.test.mjs tests/profiles-mcp.test.mjs tests/registry-coverage.test.mjs` - 115 passed
- [x] `npx vitest run tests/mcp-server.test.mjs --coverage --coverage.include='src/mcp-server.mjs'` - all new lines covered (verified against `git diff` line ranges)
