### PR TITLE
fix(subnet-performance): reject whitespace-only score cells, not just exact empty string

### DIFF
--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -61,9 +61,10 @@ function captureStamp(value) {
 function finiteValues(values) {
   const out = [];
   for (const raw of values) {
-    // Guard null/undefined/blank BEFORE Number(): Number(null) / Number("") are 0,
+    // Guard null/undefined/blank BEFORE Number(): Number(null) / Number(" ") are 0,
     // which would count an absent score as a real 0 and pollute the distribution.
-    if (raw == null || raw === "") continue;
+    // trim() catches whitespace-only cells too, not just the exact empty string.
+    if (raw == null || (typeof raw === "string" && raw.trim() === "")) continue;
     const n = typeof raw === "number" ? raw : Number(raw);
     if (Number.isFinite(n)) out.push(n);
   }

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -72,6 +72,13 @@ describe("scoreDistribution", () => {
     assert.equal(d.max, 0.5);
   });
 
+  test("drops a whitespace-only cell instead of reading it as a real 0", () => {
+    const d = scoreDistribution([0.5, " "]);
+    assert.equal(d.count, 1); // the blank cell carries no real score
+    assert.equal(d.mean, 0.5);
+    assert.equal(d.min, 0.5);
+  });
+
   test("empty / all-null column → null (schema-stable)", () => {
     assert.equal(scoreDistribution([]), null);
     assert.equal(scoreDistribution([null, undefined, "x"]), null);


### PR DESCRIPTION
## Summary
- `finiteValues` in `src/subnet-performance.mjs` guarded `raw === ""` before `Number()`, but a whitespace-only D1 cell (e.g. `" "`) is not `=== ""` and still coerces to `0` via `Number(" ")`, so a blank `trust`/`consensus`/`validator_trust` cell was counted as a real `0` observation instead of being excluded.
- Reachable end-to-end: `GET /api/v1/subnets/{netuid}/performance` -> `handleSubnetPerformance` -> a raw `SELECT trust, consensus, validator_trust, ... FROM neurons WHERE netuid = ?` (no query-param validation touches D1 row content) -> `buildSubnetPerformance` -> `scoreDistribution` -> `finiteValues`. This skews `count`, `mean`, `min`, and every percentile (p10/p25/p50/p75/p90) in the response body for whichever score field has the blank cell.
- Sibling modules from the same batch (`counterparties.mjs`, `movers.mjs`, `subnet-yield.mjs`) already guard with `typeof value === "string" && value.trim() === ""`; this file's copy had regressed to the partial `=== ""` check.

## Test plan
- [x] New unit test: `scoreDistribution([0.5, " "])` returns `count: 1, mean: 0.5, min: 0.5` (the blank cell excluded, not read as `0`)
- [x] `npm run lint` (scoped to changed files)
- [x] `npm run validate`
- [x] `npx vitest run tests/subnet-performance.test.mjs --coverage --coverage.include='src/subnet-performance.mjs'` - 14 passed, the changed line fully covered
