### PR TITLE
feat(registry): add SN68 NOVA SAVI-2020 molecule library data-artifact

### DIFF
--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -27,6 +27,25 @@
         "https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/docs/nanobody_stragegy_guide.md#L197"
       ],
       "url": "https://huggingface.co/datasets/Metanova/Submission-Archive"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-68-nova-savi-2020-dataset",
+      "kind": "data-artifact",
+      "name": "NOVA SAVI-2020 molecule library",
+      "notes": "Public Metanova (NOVA, SN68) HuggingFace SAVI-2020 dataset — ~1.5B computationally generated, synthetically-accessible organic compounds (SMILES, drug-likeness scores, single-step routes), the candidate-molecule library NOVA's drug-discovery miners screen against; not gated, chemistry columns only. The metanova-labs/nova README (source) declares the Bittensor subnet and the Metanova HF org owns the dataset.",
+      "provider": "nova",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/metanova-labs/nova",
+        "https://huggingface.co/Metanova"
+      ],
+      "url": "https://huggingface.co/datasets/Metanova/SAVI-2020"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN68 (NOVA, by Metanova Labs): the public **`SAVI-2020`** HuggingFace molecule library — NOVA's target screening dataset for its drug-discovery task. The subnet file previously registered only the Metanova submission-archive dataset. Exactly one file changed: `registry/subnets/nova.json` (a minimal 19-line append).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/Metanova/SAVI-2020` |
| `source_urls` | `https://github.com/metanova-labs/nova` · `https://huggingface.co/Metanova` |
| `provider` | `nova` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, not gated): *"The Synthetically Accessible Virtual Inventory (SAVI) 2020 dataset is a comprehensive collection of over 1.5 billion computationally generated organic compounds…"* Columns are chemistry-only — `product_smiles`, `product_qed_score`, `r1_smiles`/`r2_smiles`, `weight`, `h_donors`, etc. No credential/validator columns.
- **`source_url` (README)** — the `metanova-labs/nova` repo README declares the subnet (*"NOVA — SN68 … powered by Bittensor"*); the `Metanova` HuggingFace org (= the Metanova Labs GitHub org) owns the dataset, and SAVI-2020 is the candidate-molecule library NOVA's miners screen.
- **`source_url` (org)** — `https://huggingface.co/Metanova`, the operator's HF org.

Non-duplicate: the file's existing `data-artifact` is `Metanova/Submission-Archive` (a different dataset).

## Registry Safety

- [x] Exactly one `registry/subnets/nova.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s proving SN68 publishes it; provider `nova` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/nova.json` — passed (2 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1273 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
