### PR TITLE
feat(registry): add SN42 Gopher web-scrape example dataset

### DIFF
--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -146,6 +146,25 @@
         "submitted_by": "claytonlin1110"
       },
       "notes": "Official SN42 Gopher Data API live search (POST data.gopher-ai.com/api/v1/search/live). gopher-client defines jobEndpoint /v1/search/live on default base https://data.gopher-ai.com/api; gopher-mcp-server posts to /search/live on https://data.gopher-ai.com/api/v1."
+    },
+    {
+      "id": "sn-42-gopher-webscrape-example",
+      "name": "Gopher web-scrape example dataset",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/datasets/Gopher-Lab/Bittensor_Whitepaper_Webscrape_Example",
+      "provider": "gopher-ai",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/gopher-lab/subnet-42",
+        "https://huggingface.co/Gopher-Lab"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public Gopher-Lab HuggingFace example of the SN42 web-scraper output (title/url/description/content columns of cleaned, structured page text; tagged Bittensor / Subnet / Masa), MIT-licensed and not gated. The subnet-42 repo (source) and developer portal declare the Bittensor subnet, and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN42 (Gopher, by Gopher AI): the public **`Bittensor_Whitepaper_Webscrape_Example`** HuggingFace dataset — an official Gopher-Lab demo of the subnet's web-scraper output (cleaned, structured page text). The subnet file previously had no HuggingFace surface. Exactly one file changed: `registry/subnets/gopher.json` (a minimal 19-line append).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/Gopher-Lab/Bittensor_Whitepaper_Webscrape_Example` |
| `source_urls` | `https://github.com/gopher-lab/subnet-42` · `https://huggingface.co/Gopher-Lab` |
| `provider` | `gopher-ai` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, MIT, not gated): columns `title`, `url`, `description`, `content` — cleaned, structured web-page text (the subnet's scraper output format). Tagged **Bittensor, Subnet, Masa, Webscrape**. No credential/validator columns.
- **`source_url` (repo)** — `gopher-lab/subnet-42`, the operator's subnet repo, and the developer portal (`developers.gopher-ai.com/docs/subnet/intro`) identify the mainnet subnet (netuid 42). The `Gopher-Lab` HuggingFace org matches the `gopher-lab` GitHub org (Gopher AI, gopher-ai.com), the SN42 operator.
- **`source_url` (org)** — `https://huggingface.co/Gopher-Lab`, the operator's HF org.

Non-duplicate: the subnet file had zero `huggingface.co` surfaces before this. (This is a small first-party *example* dataset demonstrating the scraper's structured output; the subnet's live data is served via the already-registered `data.gopher-ai.com` API.)

## Registry Safety

- [x] Exactly one `registry/subnets/gopher.json` changed; a single appended community surface, nothing else (normalized diff is a 19-line append; existing content untouched).
- [x] Real public `url` + `source_url`s; owner-matched via the Gopher-Lab org; provider `gopher-ai` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/gopher.json` — passed (6 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1273 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
