### PR TITLE
feat(registry): add SN15 ORO ShoppingBench traces dataset data-artifact

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -165,6 +165,25 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/v1/public/suites"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-shoppingbench-traces",
+      "kind": "data-artifact",
+      "name": "ORO SN15 ShoppingBench traces dataset",
+      "notes": "Public ORO (SN15) HuggingFace dataset of 18,043 multi-turn agentic shopping trajectories (messages/tools/task_name columns) harvested from the subnet's ShoppingBench agentic-commerce benchmark; CC BY 4.0, not gated. The dataset card names \"ORO Subnet 15 (SN15), the Bittensor deployment\" and the ORO repo README (source) declares the subnet; the oro-ai HF org matches the operator's ORO-AI GitHub org.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/ORO-AI/oro",
+        "https://huggingface.co/oro-ai"
+      ],
+      "url": "https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-traces-18k"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN15 (ORO): the public **`sn15-shoppingbench-traces-18k`** HuggingFace dataset — 18,043 multi-turn agentic shopping trajectories from the subnet's ShoppingBench benchmark. The subnet file previously had no HuggingFace surface. Exactly one file changed: `registry/subnets/oro.json` (a minimal 19-line append).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-traces-18k` |
| `source_urls` | `https://github.com/ORO-AI/oro` · `https://huggingface.co/oro-ai` |
| `provider` | `oro` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, CC BY 4.0, not gated): **18,043 rows**, columns `messages` (list), `tools` (list), `task_name`, `trac_export_version`. Card: *"Multi-turn agentic shopping trajectories harvested from **ORO Subnet 15 (SN15), the Bittensor deployment** of the ShoppingBench agentic-commerce benchmark."* Plain trajectory corpus — no credential/validator columns.
- **`source_url` (README)** — the `ORO-AI/oro` repo README declares the subnet (*"ORO is a Bittensor subnet (SN15)…"*); the `oro-ai` HuggingFace org matches the `ORO-AI` GitHub org (oroagents.com), the SN15 operator.
- **`source_url` (org)** — `https://huggingface.co/oro-ai`, the operator's HF org.

Non-duplicate: the subnet file had zero `huggingface.co` surfaces before this. Strong owner-match — the dataset slug is literally `sn15-…` and the card names "ORO Subnet 15 (SN15)".

## Registry Safety

- [x] Exactly one `registry/subnets/oro.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s proving SN15 publishes it; provider `oro` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/oro.json` — passed (8 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1275 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
