### PR TITLE
feat(mcp): mirror subnet deregistrations and performance/history REST routes

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -217,6 +217,11 @@ import {
   SUBNET_AXON_REMOVALS_WINDOWS,
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
 } from "./subnet-axon-removals.mjs";
+import {
+  loadSubnetDeregistrations,
+  SUBNET_DEREGISTRATIONS_WINDOWS,
+  DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
+} from "./subnet-deregistrations.mjs";
 import { loadAccountPortfolio } from "./account-portfolio.mjs";
 import {
   buildNeuronHistory,
@@ -228,7 +233,11 @@ import {
 import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
 import { loadSubnetYield } from "./subnet-yield.mjs";
-import { loadSubnetPerformance } from "./subnet-performance.mjs";
+import {
+  loadSubnetPerformance,
+  loadSubnetPerformanceHistory,
+  parseSubnetPerformanceHistoryWindow,
+} from "./subnet-performance.mjs";
 import { loadChainPerformance } from "./chain-performance.mjs";
 import { loadChainYield } from "./chain-yield.mjs";
 import { loadBlocksSummary } from "./blocks-summary.mjs";
@@ -295,7 +304,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.38.0";
+export const MCP_SERVER_VERSION = "1.39.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -316,6 +325,9 @@ const SUBNET_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
 );
 const SUBNET_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
   SUBNET_AXON_REMOVALS_WINDOWS,
+);
+const SUBNET_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
+  SUBNET_DEREGISTRATIONS_WINDOWS,
 );
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -403,7 +415,9 @@ export const MCP_INSTRUCTIONS =
   "(the validators behind /weights ranked by activity), " +
   "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
   "(distinct removers, event count, removals per remover — the removal-side " +
-  "companion to /serving), get_subnet_movers the cross-subnet " +
+  "companion to /serving), get_subnet_deregistrations the per-subnet " +
+  "neuron-deregistration activity card, get_subnet_performance_history the " +
+  "per-day reward-flow and trust trend for one subnet, get_subnet_movers the cross-subnet " +
   "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
   "rates plus distribution percentiles over the current metagraph snapshot, " +
   "get_registry_leaderboards the live " +
@@ -2628,6 +2642,80 @@ export const MCP_TOOLS = [
       return await loadSubnetAxonRemovals(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
         windowDays: SUBNET_AXON_REMOVALS_WINDOWS[window],
+      });
+    },
+  },
+  {
+    name: "get_subnet_deregistrations",
+    title: "Get subnet deregistration activity",
+    description:
+      "Fetch neuron-deregistration activity for one subnet over a 7d or 30d " +
+      "window (default 7d): the distinct deregistered hotkeys, the " +
+      "NeuronDeregistered event count, and the average deregistrations per " +
+      "hotkey, computed live from the account_events NeuronDeregistered stream. " +
+      "Raw deregistration/eviction activity — the exit-side companion to " +
+      "NeuronRegistered demand. Mirrors GET /api/v1/subnets/{netuid}/deregistrations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_DEREGISTRATIONS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
+      if (!Object.hasOwn(SUBNET_DEREGISTRATIONS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_DEREGISTRATIONS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      return await loadSubnetDeregistrations(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_DEREGISTRATIONS_WINDOWS[window],
+      });
+    },
+  },
+  {
+    name: "get_subnet_performance_history",
+    title: "Get subnet performance history",
+    description:
+      "Fetch the per-day reward-flow and trust trend for one subnet over a " +
+      "7d, 30d, or 90d window (default 30d): daily incentive/dividends Gini, " +
+      "Nakamoto coefficient, top-10% share, plus mean/median trust, consensus, " +
+      "and validator_trust scores from the neuron_daily rollup. Mirrors GET " +
+      "/api/v1/subnets/{netuid}/performance/history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d"],
+          description: "Lookback window (default 30d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const parsed = parseSubnetPerformanceHistoryWindow(args?.window);
+      if (args?.window !== undefined && parsed.error) {
+        throw toolError("invalid_params", parsed.error.message);
+      }
+      const { label, days } = parsed;
+      return await loadSubnetPerformanceHistory(mcpD1Runner(ctx), netuid, {
+        windowLabel: label,
+        windowDays: days,
       });
     },
   },
@@ -6700,6 +6788,38 @@ const TOOL_OUTPUT_SCHEMAS = {
       distinct_removers: { type: "integer" },
       removals: { type: "integer" },
       removals_per_remover: { type: ["number", "null"] },
+    },
+  },
+  get_subnet_deregistrations: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "distinct_deregistered_hotkeys",
+      "deregistrations",
+      "deregistrations_per_hotkey",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_deregistered_hotkeys: { type: "integer" },
+      deregistrations: { type: "integer" },
+      deregistrations_per_hotkey: { type: ["number", "null"] },
+    },
+  },
+  get_subnet_performance_history: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "window", "point_count", "points"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      point_count: { type: "integer" },
+      points: { type: "array", items: { type: "object" } },
     },
   },
   get_subnet_movers: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3427,9 +3427,9 @@ describe("MCP get_subnet_deregistrations", () => {
   function deregistrationsD1(row = null) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(_sql) {
           return {
-            bind(...params) {
+            bind(..._params) {
               return {
                 async all() {
                   return { results: row ? [row] : [] };
@@ -3462,6 +3462,24 @@ describe("MCP get_subnet_deregistrations", () => {
     assert.equal(out.deregistrations_per_hotkey, 4);
   });
 
+  test("defaults to the 7d window and degrades to a zeroed card on cold D1", async () => {
+    const res = await callTool("get_subnet_deregistrations", { netuid: 9 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_deregistered_hotkeys, 0);
+    assert.equal(out.deregistrations, 0);
+    assert.equal(out.deregistrations_per_hotkey, null);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_deregistrations", {
+      netuid: 9,
+      window: "90d",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
   test("rejects a missing netuid", async () => {
     const res = await callTool("get_subnet_deregistrations", { window: "30d" });
     assert.equal(res.body.result.isError, true);
@@ -3473,9 +3491,9 @@ describe("MCP get_subnet_performance_history", () => {
   function performanceHistoryD1(rows = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(_sql) {
           return {
-            bind(...params) {
+            bind(..._params) {
               return {
                 async all() {
                   return { results: rows };
@@ -3514,6 +3532,14 @@ describe("MCP get_subnet_performance_history", () => {
     assert.equal(out.points[0].snapshot_date, "2026-06-25");
   });
 
+  test("defaults to the 30d window on cold D1", async () => {
+    const res = await callTool("get_subnet_performance_history", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.point_count, 0);
+    assert.deepEqual(out.points, []);
+  });
+
   test("rejects an invalid window", async () => {
     const res = await callTool("get_subnet_performance_history", {
       netuid: 7,
@@ -3521,6 +3547,14 @@ describe("MCP get_subnet_performance_history", () => {
     });
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_performance_history", {
+      window: "7d",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
   });
 });
 

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3423,6 +3423,107 @@ describe("MCP get_subnet_axon_removals", () => {
   });
 });
 
+describe("MCP get_subnet_deregistrations", () => {
+  function deregistrationsD1(row = null) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("returns the deregistration scorecard", async () => {
+    const res = await callTool(
+      "get_subnet_deregistrations",
+      { netuid: 9 },
+      {
+        env: deregistrationsD1({
+          deregistrations: 8,
+          distinct_deregistered_hotkeys: 2,
+          newest_observed: 1_717_400_000_000,
+        }),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 9);
+    assert.equal(out.window, "7d");
+    assert.equal(out.deregistrations, 8);
+    assert.equal(out.distinct_deregistered_hotkeys, 2);
+    assert.equal(out.deregistrations_per_hotkey, 4);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_deregistrations", { window: "30d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+});
+
+describe("MCP get_subnet_performance_history", () => {
+  function performanceHistoryD1(rows = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              return {
+                async all() {
+                  return { results: rows };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("returns the per-day performance series", async () => {
+    const res = await callTool(
+      "get_subnet_performance_history",
+      { netuid: 7, window: "7d" },
+      {
+        env: performanceHistoryD1([
+          {
+            snapshot_date: "2026-06-25",
+            incentive: 0.1,
+            dividends: 0.2,
+            trust: 0.5,
+            consensus: 0.6,
+            validator_trust: 0.7,
+            validator_permit: 1,
+            active: 1,
+          },
+        ]),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "7d");
+    assert.equal(out.point_count, 1);
+    assert.equal(out.points[0].snapshot_date, "2026-06-25");
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_subnet_performance_history", {
+      netuid: 7,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+});
+
 describe("MCP get_network_activity", () => {
   test("merges extrinsics + blocks tiers from D1", async () => {
     const env = {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds two MCP tools that mirror recently shipped subnet analytics REST routes so agents can fetch the same datapoints without raw HTTP:

- `get_subnet_deregistrations` → `GET /api/v1/subnets/{netuid}/deregistrations`
- `get_subnet_performance_history` → `GET /api/v1/subnets/{netuid}/performance/history`

(`get_subnet_axon_removals` landed separately in #3138.)

## What Changed

- Wire existing loaders (`loadSubnetDeregistrations`, `loadSubnetPerformanceHistory`) into MCP tool handlers with the same window validation as the REST routes.
- Add structured output schemas and unit tests for happy path + invalid window/netuid.
- Bump MCP server version to **1.39.0** (`server.json` + SemVer assertions).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No REST contract change — pure MCP wiring over existing loaders (no OpenAPI/type regeneration).
- [x] Public-safe read-only analytics only.

## Validation

- [x] `npm test -- tests/mcp-server.test.mjs -t "get_subnet_deregistrations|get_subnet_performance_history"`
- [x] `npm test -- tests/mcp-server.test.mjs -t "tools/list returns all registered tools"`

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed (pull-only access). MCP parity follow-up to the REST routes already on main; modeled on merged #3138.
