### PR TITLE
feat(mcp): add get_subnet_registrations mirroring GET /api/v1/subnets/{netuid}/registrations

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -213,6 +213,11 @@ import {
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
 } from "./subnet-weight-setters.mjs";
 import {
+  loadSubnetRegistrations,
+  SUBNET_REGISTRATIONS_WINDOWS,
+  DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
+} from "./subnet-registrations.mjs";
+import {
   loadSubnetAxonRemovals,
   SUBNET_AXON_REMOVALS_WINDOWS,
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
@@ -295,7 +300,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.38.0";
+export const MCP_SERVER_VERSION = "1.39.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -401,6 +406,7 @@ export const MCP_INSTRUCTIONS =
   "account-event summary for one subnet (per-kind counts plus a recent-events " +
   "tail), get_subnet_weight_setters the per-subnet weight-setter leaderboard " +
   "(the validators behind /weights ranked by activity), " +
+  "get_subnet_registrations the per-subnet neuron-registration activity, " +
   "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
   "(distinct removers, event count, removals per remover — the removal-side " +
   "companion to /serving), get_subnet_movers the cross-subnet " +
@@ -2588,6 +2594,45 @@ export const MCP_TOOLS = [
       return await loadSubnetWeightSetters(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
         windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window],
+      });
+    },
+  },
+  {
+    name: "get_subnet_registrations",
+    title: "Get subnet registration activity",
+    description:
+      "Fetch neuron-registration activity for one subnet over a 7d or 30d " +
+      "window (default 7d): the NeuronRegistered count, the number of distinct " +
+      "registrant hotkeys, and the registrations-per-registrant intensity, " +
+      "computed live from the account_events NeuronRegistered stream. The " +
+      "per-subnet companion to get_chain_registrations. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/registrations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: Object.keys(SUBNET_REGISTRATIONS_WINDOWS),
+          description: `Lookback window (default ${DEFAULT_SUBNET_REGISTRATIONS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
+      if (!Object.hasOwn(SUBNET_REGISTRATIONS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${Object.keys(SUBNET_REGISTRATIONS_WINDOWS).join(", ")}.`,
+        );
+      }
+      return await loadSubnetRegistrations(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_REGISTRATIONS_WINDOWS[window],
       });
     },
   },
@@ -6651,6 +6696,20 @@ const TOOL_OUTPUT_SCHEMAS = {
         last_observed_at: NULLABLE_STRING,
       }),
       recent_events: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_subnet_registrations: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "window", "distinct_registrants", "registrations"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_registrants: { type: "integer" },
+      registrations: { type: "integer" },
+      registrations_per_registrant: { type: ["number", "null"] },
     },
   },
   get_subnet_weight_setters: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3245,6 +3245,69 @@ describe("MCP get_subnet_event_summary", () => {
   });
 });
 
+describe("MCP get_subnet_registrations", () => {
+  function registrationsSubnetD1(row = null, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("summarizes per-subnet registration activity", async () => {
+    const res = await callTool(
+      "get_subnet_registrations",
+      { netuid: 5, window: "7d" },
+      {
+        env: registrationsSubnetD1({
+          registrations: 12,
+          distinct_registrants: 4,
+          newest_observed: 1_717_500_000_000,
+        }),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 5);
+    assert.equal(out.registrations, 12);
+    assert.equal(out.distinct_registrants, 4);
+  });
+
+  test("cold subnet degrades to a schema-stable empty summary", async () => {
+    const res = await callTool(
+      "get_subnet_registrations",
+      { netuid: 5 },
+      { env: registrationsSubnetD1(null) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.registrations, 0);
+    assert.equal(out.distinct_registrants, 0);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_registrations", {
+      netuid: 5,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_registrations", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+  });
+});
+
 describe("MCP get_subnet_weight_setters", () => {
   // The loader runs two reads: the per-setter leaderboard (GROUP BY the
   // hotkey-or-uid identity) and the subnet-wide totals row. Route by SQL shape.

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.38.0");
+    assert.equal(MCP_SERVER_VERSION, "1.39.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## What

Adds a new MCP tool **`get_subnet_registrations`** that mirrors the existing
`GET /api/v1/subnets/{netuid}/registrations` REST endpoint — per-subnet
neuron-registration analytics.

For one subnet over a 7d or 30d window (default 7d) it returns the
`NeuronRegistered` count, the number of distinct registrant hotkeys, and the
registrations-per-registrant intensity — computed live from the `account_events`
stream. It's the per-subnet companion to the network-wide `get_chain_registrations`.
Modeled on the existing `get_subnet_weight_setters` / `get_subnet_event_summary`
tools; reads the same `loadSubnetRegistrations` loader the REST route serves.

## Why

The per-subnet registration feed rounds out the subnet analytics family already
exposed over MCP (`get_subnet_stake_flow`, `get_subnet_event_summary`,
`get_subnet_weight_setters`, …) — the only per-subnet view of registration
churn had no MCP counterpart. This closes that gap with no new data surface.

## Notes

- Pure MCP wiring over an existing loader — no REST contract change, so no
  OpenAPI/type regeneration.
- Bumps the MCP server version to 1.39.0 (`server.json` + the per-tool SemVer
  assertions updated to match, per `validate:mcp`).
- Tests cover the happy path, a cold-store empty summary, invalid `window`, and
  missing `netuid`. `validate:mcp` reports the new tool;
  `validate:contract-drift`, lint, and prettier pass.