### PR TITLE
fix(performance): reject whitespace-only score cells in both subnet and network scoreDistribution

### DIFF
--- a/src/chain-performance.mjs
+++ b/src/chain-performance.mjs
@@ -59,7 +59,9 @@ function captureStamp(value) {
 function finiteValues(values) {
   const out = [];
   for (const raw of values) {
-    if (raw == null || raw === "") continue;
+    // trim() catches whitespace-only cells too, not just the exact empty string
+    // (Number(" ") === 0, which would count an absent score as a real 0).
+    if (raw == null || (typeof raw === "string" && raw.trim() === "")) continue;
     const n = typeof raw === "number" ? raw : Number(raw);
     if (Number.isFinite(n)) out.push(n);
   }

--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -61,9 +61,10 @@ function captureStamp(value) {
 function finiteValues(values) {
   const out = [];
   for (const raw of values) {
-    // Guard null/undefined/blank BEFORE Number(): Number(null) / Number("") are 0,
+    // Guard null/undefined/blank BEFORE Number(): Number(null) / Number(" ") are 0,
     // which would count an absent score as a real 0 and pollute the distribution.
-    if (raw == null || raw === "") continue;
+    // trim() catches whitespace-only cells too, not just the exact empty string.
+    if (raw == null || (typeof raw === "string" && raw.trim() === "")) continue;
     const n = typeof raw === "number" ? raw : Number(raw);
     if (Number.isFinite(n)) out.push(n);
   }

--- a/tests/chain-performance.test.mjs
+++ b/tests/chain-performance.test.mjs
@@ -76,6 +76,13 @@ describe("scoreDistribution", () => {
     assert.equal(d.max, 0.5);
   });
 
+  test("drops a whitespace-only cell instead of reading it as a real 0", () => {
+    const d = scoreDistribution([0.5, " "]);
+    assert.equal(d.count, 1); // the blank cell carries no real score
+    assert.equal(d.mean, 0.5);
+    assert.equal(d.min, 0.5);
+  });
+
   test("empty / all-null column → null (schema-stable)", () => {
     assert.equal(scoreDistribution([]), null);
     assert.equal(scoreDistribution([null, undefined, "x"]), null);

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -76,6 +76,13 @@ describe("scoreDistribution", () => {
     assert.equal(d.max, 0.5);
   });
 
+  test("drops a whitespace-only cell instead of reading it as a real 0", () => {
+    const d = scoreDistribution([0.5, " "]);
+    assert.equal(d.count, 1); // the blank cell carries no real score
+    assert.equal(d.mean, 0.5);
+    assert.equal(d.min, 0.5);
+  });
+
   test("empty / all-null column → null (schema-stable)", () => {
     assert.equal(scoreDistribution([]), null);
     assert.equal(scoreDistribution([null, undefined, "x"]), null);


### PR DESCRIPTION
## Summary
- `finiteValues` in both `src/subnet-performance.mjs` and `src/chain-performance.mjs` guarded `raw === ""` before `Number()`, but a whitespace-only D1 cell (e.g. `" "`) is not `=== ""` and still coerces to `0` via `Number(" ")`, so a blank `trust`/`consensus`/`validator_trust` cell was counted as a real `0` observation instead of being excluded.
- Both files duplicate the same helper - fixing only one leaves the sibling endpoint with the same reachable data bug, so this PR fixes both together: `GET /api/v1/subnets/{netuid}/performance` and `GET /api/v1/chain/performance`. Neither route has any query-param validation that touches D1 row content, so nothing upstream blocks this input on either endpoint.
- Skews `count`, `mean`, `min`, and every percentile (p10/p25/p50/p75/p90) in the response body for whichever score field has the blank cell.
- Sibling modules from the same batch (`counterparties.mjs`, `movers.mjs`, `subnet-yield.mjs`) already guard with `typeof value === "string" && value.trim() === ""`; both performance files had regressed to the partial `=== ""` check.

## Test plan
- [x] New unit test in both `tests/subnet-performance.test.mjs` and `tests/chain-performance.test.mjs`: `scoreDistribution([0.5, " "])` returns `count: 1, mean: 0.5, min: 0.5` (the blank cell excluded, not read as `0`)
- [x] `npm run lint` + `npm run format:check` (scoped to changed files)
- [x] `npm run validate`
- [x] `npx vitest run tests/subnet-performance.test.mjs tests/chain-performance.test.mjs` - 41 passed; `chain-performance.mjs` 100% covered, the changed line in `subnet-performance.mjs` fully covered (checked against exact diff line ranges)
