### PR TITLE
feat(registry): add SN38 ChronoLLM ChronoInstruct-SFT dataset data-artifact

### DIFF
--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -41,6 +41,25 @@
       },
       "source_urls": ["https://github.com/chronollm/sn38/blob/main/README.md"],
       "url": "https://huggingface.co/collections/manelalab/chronogpt-67c878a02139875341ca9d3b"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-38-chronoinstruct-sft-dataset",
+      "kind": "data-artifact",
+      "name": "ChronoInstruct SFT dataset",
+      "notes": "Public ManelaLab (WashU) HuggingFace ChronoInstruct-SFT dataset — 647,944 chronologically-consistent instruction-response pairs (conversation/label/source columns; label marks pre-2000 vs post-1999) built to remove lookahead bias, the SFT corpus for the ChronoGPT architecture the ChronoLLM (SN38) subnet mandates; ODC-BY-1.0, not gated. The chronollm/sn38 repo README (source) declares Subnet 38 and links the manelalab HF org (already the subnet's registered ChronoGPT model-collection org).",
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/chronollm/sn38",
+        "https://huggingface.co/manelalab"
+      ],
+      "url": "https://huggingface.co/datasets/manelalab/ChronoInstruct-SFT-v1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN38 (ChronoLLM): the public **`ChronoInstruct-SFT-v1`** HuggingFace dataset — 647,944 chronologically-consistent instruction pairs, the SFT corpus for the ChronoGPT architecture this subnet mandates. The subnet file previously registered only the ChronoGPT model *collection* (same `manelalab` org). Exactly one file changed: `registry/subnets/chronollm.json` (a minimal 19-line append).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/manelalab/ChronoInstruct-SFT-v1` |
| `source_urls` | `https://github.com/chronollm/sn38` · `https://huggingface.co/manelalab` |
| `provider` | `tao-colosseum` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, ODC-BY-1.0, not gated): **647,944 rows**, columns `conversation`, `label` (0 = pre-2000 / 1 = post-1999), `source`. Card: *"ChronoInstruct-SFT is the first chronologically consistent instruction-following dataset designed to remove lookahead bias in large language models."* Plain instruction corpus — no credential/validator columns.
- **`source_url` (README)** — the `chronollm/sn38` repo README declares **Subnet 38**, links the ChronoGPT models to `huggingface.co/manelalab`, and mandates the ChronoGPT architecture — the architecture this dataset trains.
- **`source_url` (org)** — `https://huggingface.co/manelalab`, the same HF org the subnet's already-registered ChronoGPT model-collection `data-artifact` points to.

Non-duplicate: the file's existing `data-artifact` is the ChronoGPT **models** collection (`collections/manelalab/…`); this is the distinct **dataset** under the same org.

## Registry Safety

- [x] Exactly one `registry/subnets/chronollm.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s; owner-matched via the `manelalab` org the subnet's README declares (and already accepted in this file); provider `tao-colosseum` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/chronollm.json` — passed (3 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1276 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
