### PR TITLE
feat(registry): add SN24 Quasar training corpus dataset data-artifact

### DIFF
--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -199,6 +199,25 @@
       "public_safe": true,
       "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/24"],
       "url": "https://taomarketcap.com/subnets/24"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-24-quasar-training-corpus",
+      "kind": "data-artifact",
+      "name": "Quasar training corpus dataset",
+      "notes": "Public SILX Labs HuggingFace tokenized training corpus for Quasar (SN24) — ~1.05M rows (tokens/loss/shard/bucket scoring columns) fitting the subnet's continued-pretraining task; parquet, not gated. Published by silx-ai, whose SILX-LABS/QUASAR-SUBNET README (source) declares Mainnet netuid 24. The -SN3 suffix is a model/series version label, not a subnet-3 reference.",
+      "provider": "silx-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/SILX-LABS/QUASAR-SUBNET",
+        "https://huggingface.co/silx-ai"
+      ],
+      "url": "https://huggingface.co/datasets/silx-ai/Quasar-SN3"
     }
   ],
   "website_url": "https://silxinc.com/",


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN24 (Quasar, by SILX Labs): the operator's public **`Quasar-SN3`** tokenized training corpus (~1.05M rows). The subnet file registered the Quasar model + a base model, but no training dataset. Exactly one file changed: `registry/subnets/quasar.json` (a minimal 19-line append).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/silx-ai/Quasar-SN3` |
| `source_urls` | `https://github.com/SILX-LABS/QUASAR-SUBNET` · `https://huggingface.co/silx-ai` |
| `provider` | `silx-labs` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, not gated): ~**1,054,843 rows** (6.1 GB Parquet). Columns are a tokenized training corpus with scoring metrics — `shard`, `idx`, `loss`, `unique_r`, `rep_r`, `rep_ng4`, `tokens` (token-id array), `bucket`. No credential/validator columns.
- **`source_url` (README)** — the `SILX-LABS/QUASAR-SUBNET` repo README declares *"Mainnet subnet: `netuid 24`"* and references the `silx-ai` HuggingFace org, which owns this dataset. SILX Labs (silxinc.com) is the **current** SN24 operator.
- **`source_url` (org)** — `https://huggingface.co/silx-ai`, the same org the subnet's already-registered Quasar model `data-artifact` points to.

Non-duplicate: the file's existing `data-artifact`s are the Quasar *model* (`silx-ai/Quasar-3B-A1B-Preview`) and a base model (`Qwen/Qwen3.5-4B`); this is the distinct training **dataset**.

**Reviewer notes:** the dataset currently has no HF card, so the owner-match rests on the definitive org↔operator link (silx-ai = the SILX-LABS/QUASAR-SUBNET operator declaring netuid 24) plus the "Quasar" project name. The `-SN3` suffix is a model/series version label, **not** a subnet-3 claim.

## Registry Safety

- [x] Exactly one `registry/subnets/quasar.json` changed; a single appended community surface, nothing else (manual append — normalized diff is 19 insertions, 0 deletions; existing content and top-level fields untouched).
- [x] Real public `url` + `source_url`s; owner-matched to the current SN24 operator; provider `silx-labs` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/quasar.json` — passed (9 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1276 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
