### PR TITLE
feat(registry): add SN64 Chutes supported GPU catalog data-artifact

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -456,6 +456,22 @@
       },
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/invocations/usage"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-supported-gpus",
+      "kind": "data-artifact",
+      "name": "Chutes supported GPU catalog",
+      "notes": "Public no-auth JSON catalog of the GPU models the Chutes platform supports, with per-model hardware specs (display name, memory, compute capability, tensor cores, ECC/SXM flags); GET /nodes/supported in the OpenAPI spec. Distinct endpoint from the subnet's existing /chutes/*, /users/growth, /daily_revenue_summary, and /invocations/usage data-artifacts.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/nodes/supported"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chutes.json` (SN64 Chutes). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds the Chutes supported-GPU catalog (`GET /nodes/supported`) — a public, no-auth JSON of every GPU model the platform supports with its hardware specs (display name, memory, compute capability, tensor cores, ECC/SXM flags). A stable reference artifact for the subnet's compute layer, sourced from the official Chutes OpenAPI contract.

This is a distinct endpoint from the subnet's already-registered `/chutes/*`, `/users/growth`, `/daily_revenue_summary`, and `/invocations/usage` data-artifacts.

## Surface

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/nodes/supported
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

The endpoint is defined in the official Chutes OpenAPI spec as `List Supported Gpus` with no security requirement — the same source used by the subnet's existing data-artifact surfaces.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
