### PR TITLE
feat(registry): add SN68 NOVA Mol-Rxn-DB molecule database data-artifact

### DIFF
--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -46,6 +46,24 @@
         "https://huggingface.co/Metanova"
       ],
       "url": "https://huggingface.co/datasets/Metanova/SAVI-2020"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-68-nova-mol-rxn-db",
+      "kind": "data-artifact",
+      "name": "NOVA Mol-Rxn-DB combinatorial molecule database",
+      "notes": "Public Metanova (NOVA, SN68) Hugging Face dataset — the combinatorial molecule/reaction database (molecules.sqlite) the subnet's drug-discovery validators screen candidate compounds against. The official metanova-labs/nova install script downloads it directly (install_deps.sh line 57), establishing first-party ownership.",
+      "provider": "nova",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/install_deps.sh#L57"
+      ],
+      "url": "https://huggingface.co/datasets/Metanova/Mol-Rxn-DB"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/nova.json` (SN68 NOVA). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds NOVA's combinatorial molecule/reaction database on Hugging Face (`Metanova/Mol-Rxn-DB`) — the `molecules.sqlite` candidate-compound library the subnet's drug-discovery validators screen against. It is first-party: the official `metanova-labs/nova` install script downloads this exact dataset (`install_deps.sh` line 57).

This is a distinct dataset from the subnet's already-registered `Metanova/Submission-Archive` and `Metanova/SAVI-2020` data-artifacts.

## Surface

- Netuid: 68
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/Metanova/Mol-Rxn-DB
- Source URL (proves the claim): https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/install_deps.sh#L57
- Provider slug: nova

The commit-pinned source line shows the subnet's own install script fetching `molecules.sqlite` from this dataset, establishing first-party ownership.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this dataset, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public dataset plus the first-party install-script source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/nova.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
