### PR TITLE
feat(registry): add SN68 NOVA Proteins target dataset data-artifact

### DIFF
--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -64,6 +64,24 @@
         "https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/install_deps.sh#L57"
       ],
       "url": "https://huggingface.co/datasets/Metanova/Mol-Rxn-DB"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-68-nova-proteins",
+      "kind": "data-artifact",
+      "name": "NOVA Proteins target dataset",
+      "notes": "Public Metanova (NOVA, SN68) Hugging Face dataset of protein targets the subnet's drug-discovery challenges are posed against. The official metanova-labs/nova challenge code loads it directly (utils/challenge.py line 37: load_dataset(\"Metanova/Proteins\")), establishing first-party ownership. Distinct from the subnet's registered Submission-Archive, SAVI-2020, and Mol-Rxn-DB datasets.",
+      "provider": "nova",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/utils/challenge.py#L37"
+      ],
+      "url": "https://huggingface.co/datasets/Metanova/Proteins"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/nova.json` (SN68 NOVA). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds NOVA's protein-target dataset on Hugging Face (`Metanova/Proteins`) — the protein targets the subnet's drug-discovery challenges are posed against. It is first-party: the official `metanova-labs/nova` challenge code loads it directly (`utils/challenge.py` line 37, `load_dataset("Metanova/Proteins")`).

This is a distinct dataset from the subnet's already-registered `Metanova/Submission-Archive`, `Metanova/SAVI-2020`, and `Metanova/Mol-Rxn-DB` data-artifacts.

## Surface

- Netuid: 68
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/Metanova/Proteins
- Source URL (proves the claim): https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/utils/challenge.py#L37
- Provider slug: nova

The commit-pinned source line shows the subnet's own challenge code loading this dataset, establishing first-party ownership.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this dataset, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public dataset plus the first-party challenge-code source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/nova.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
