### PR TITLE
fix(data-api): reject blank bigint cells instead of coercing to zero

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -77,6 +77,26 @@ test("chain-events coerces blank bigint cells to null, not zero", async () => {
   expect(body.next_cursor).toBeNull();
 });
 
+test("chain-events coerces null and non-numeric bigint cells to null", async () => {
+  mockRows.current = [
+    {
+      block_number: null,
+      event_index: 0,
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+      args: { x: 1 },
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 2,
+      observed_at: "not-a-number",
+    },
+  ];
+  const res = await req("/api/v1/blocks/123/chain-events");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.events[0].block_number).toBeNull();
+  expect(body.events[0].observed_at).toBeNull();
+});
+
 test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () => {
   const res = await req("/api/v1/blocks/123/chain-events");
   expect(res.status).toBe(200);

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4,26 +4,28 @@
 import { beforeEach, test, expect, vi } from "vitest";
 
 const sqlCalls = vi.hoisted(() => []);
+const mockRows = vi.hoisted(() => ({
+  current: [
+    {
+      block_number: "123",
+      event_index: 0,
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+      args: { x: 1 },
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 2,
+      observed_at: "100",
+    },
+  ],
+}));
 
 vi.mock("postgres", () => ({
   default: () => {
-    const rows = [
-      {
-        block_number: "123",
-        event_index: 0,
-        pallet: "System",
-        method: "ExtrinsicSuccess",
-        args: { x: 1 },
-        phase: "ApplyExtrinsic",
-        extrinsic_index: 2,
-        observed_at: "100",
-      },
-    ];
     // Every tagged-template call (top-level query OR nested fragment) resolves to rows;
     // the handler awaits the outer query and ignores interpolated fragment values.
     const sql = (strings, ...values) => {
       sqlCalls.push({ text: Array.from(strings).join("?"), values });
-      return Promise.resolve(rows);
+      return Promise.resolve(mockRows.current);
     };
     sql.end = () => Promise.resolve();
     return sql;
@@ -39,6 +41,40 @@ const queryText = () => sqlCalls.map((call) => call.text).join("\n");
 
 beforeEach(() => {
   sqlCalls.length = 0;
+  mockRows.current = [
+    {
+      block_number: "123",
+      event_index: 0,
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+      args: { x: 1 },
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 2,
+      observed_at: "100",
+    },
+  ];
+});
+
+test("chain-events coerces blank bigint cells to null, not zero", async () => {
+  mockRows.current = [
+    {
+      block_number: "",
+      event_index: "   ",
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+      args: { x: 1 },
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 2,
+      observed_at: "",
+    },
+  ];
+  const res = await req("/api/v1/chain-events?limit=1");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.events[0].block_number).toBeNull();
+  expect(body.events[0].observed_at).toBeNull();
+  // Blank seek keys must not produce a lossless cursor token.
+  expect(body.next_cursor).toBeNull();
 });
 
 test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -49,7 +49,13 @@ function clampStatsBlocks(raw) {
 // as numbers. block_number and observed_at are both < 2^53, so Number(...) is
 // lossless — coerce them per event row for a consistent numeric API shape.
 function numberOrNull(v) {
-  return v == null ? null : Number(v);
+  if (v == null) return null;
+  // Blank Hyperdrive/Postgres cells coerce via Number("") → 0; trim rejects "" /
+  // whitespace-only so absent indices/timestamps stay null (mirrors toBlockNumber
+  // in src/account-events.mjs and src/blocks.mjs).
+  if (typeof v === "string" && v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
 }
 
 function nonNegativeIntegerParam(params, key) {


### PR DESCRIPTION
## Summary

- Guard `numberOrNull` in the Hyperdrive data Worker so blank Postgres cells for `block_number`, `event_index`, and `observed_at` return `null` instead of `0`.
- Prevents corrupt chain-events API payloads and invalid lossless pagination cursors when a bigint column is empty.

## What changed

- `workers/data-api.mjs` — trim-check blank strings before `Number()` in `numberOrNull`.
- `tests/data-api.test.mjs` — regression test for blank bigint cells and null `next_cursor`.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/data-api.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `git diff --check`
