### PR TITLE
fix(scripts): detect JSON testnet probes with case-insensitive Content-Type

### DIFF
--- a/scripts/discover-testnet-surfaces.mjs
+++ b/scripts/discover-testnet-surfaces.mjs
@@ -15,7 +15,9 @@
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
+  isJsonContentType,
   isUnsafeResolvedUrl,
   readJson,
   repoRoot,
@@ -89,7 +91,9 @@ async function safeFetch(url, redirectCount = 0) {
       return safeFetch(redirectTarget, redirectCount + 1);
     }
 
-    const contentType = (res.headers.get("content-type") || "").split(";")[0];
+    const contentType = (res.headers.get("content-type") || "")
+      .split(";")[0]
+      .trim();
     const body = await readBodySnippet(res);
     return { status: res.status, contentType, body };
   } catch (error) {
@@ -130,7 +134,7 @@ async function classify(subnet) {
   // Probe the common callable-API paths first — a hit is the high-value signal.
   for (const apiPath of API_PATHS) {
     const probe = await safeFetch(base + apiPath);
-    if (probe.status === 200 && probe.contentType.includes("json")) {
+    if (probe.status === 200 && isJsonContentType(probe.contentType)) {
       return {
         ...subnet,
         classification: looksLikeOpenApi(probe.body) ? "openapi" : "json-api",
@@ -150,7 +154,7 @@ async function classify(subnet) {
       error: root.contentType,
     };
   }
-  if (root.contentType.includes("json") && looksLikeOpenApi(root.body)) {
+  if (isJsonContentType(root.contentType) && looksLikeOpenApi(root.body)) {
     return {
       ...subnet,
       classification: "openapi",
@@ -159,7 +163,7 @@ async function classify(subnet) {
       discovered_url: base,
     };
   }
-  if (root.contentType.includes("json")) {
+  if (isJsonContentType(root.contentType)) {
     return {
       ...subnet,
       classification: "maybe-api",
@@ -255,7 +259,14 @@ async function main() {
   return report;
 }
 
-main().catch((error) => {
-  console.error(`testnet discovery failed: ${error?.message || error}`);
-  process.exit(1);
-});
+export { classify };
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(`testnet discovery failed: ${error?.message || error}`);
+    process.exit(1);
+  });
+}

--- a/tests/discover-testnet-surfaces.test.mjs
+++ b/tests/discover-testnet-surfaces.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test, vi } from "vitest";
+
+vi.mock("../scripts/lib.mjs", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    isUnsafeResolvedUrl: vi.fn(async () => false),
+  };
+});
+
+const { classify } = await import("../scripts/discover-testnet-surfaces.mjs");
+
+const subnet = {
+  netuid: 99,
+  name: "Testnet Example",
+  url: "https://api.example.test",
+};
+
+function jsonResponse(body, contentType = "application/json") {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("classify treats uppercase JSON Content-Type as a callable API hit", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url) => {
+      if (String(url).endsWith("/openapi.json")) {
+        return jsonResponse(
+          '{"openapi":"3.0.0","paths":{}}',
+          "Application/JSON",
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }),
+  );
+
+  const result = await classify(subnet);
+  assert.equal(result.callable, true);
+  assert.equal(result.classification, "openapi");
+  assert.equal(result.discovered_url, "https://api.example.test/openapi.json");
+});
+
+test("classify treats spaced mixed-case root JSON as maybe-api", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url) => {
+      const target = String(url);
+      if (target === "https://api.example.test") {
+        return jsonResponse(
+          '{"status":"ok"}',
+          " application/json; charset=utf-8 ",
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }),
+  );
+
+  const result = await classify(subnet);
+  assert.equal(result.callable, false);
+  assert.equal(result.classification, "maybe-api");
+});


### PR DESCRIPTION
## Summary

- Use shared `isJsonContentType()` in testnet surface discovery so uppercase or mixed-case `Content-Type` values (e.g. `Application/JSON`) classify callable APIs correctly.
- Trim the media type before classification and guard `main()` so the script is importable in unit tests.

## What changed

- `scripts/discover-testnet-surfaces.mjs` — replace raw `.includes("json")` checks; trim `content-type`; export `classify`; direct-run guard.
- `tests/discover-testnet-surfaces.test.mjs` — regression tests for uppercase and spaced JSON content types.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/discover-testnet-surfaces.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`
