### PR TITLE
feat(registry): add SN64 Chutes GPU node availability data-artifact

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -472,6 +472,22 @@
       },
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/nodes/supported"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-node-availability",
+      "kind": "data-artifact",
+      "name": "Chutes GPU node availability",
+      "notes": "Public no-auth JSON of live GPU node availability on the Chutes platform — provisioned vs idle node counts per GPU model (3090, 4090, 5090, a100, h100, ...); GET /nodes/ in the OpenAPI spec. A live operational feed, distinct from the static /nodes/supported hardware catalog and the subnet's other data-artifacts.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/nodes/"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chutes.json` (SN64 Chutes). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds the Chutes live GPU node-availability feed (`GET /nodes/`) — a public, no-auth JSON of provisioned vs idle node counts per GPU model (3090, 4090, 5090, a100, h100, …). A live operational feed for the subnet's compute layer, sourced from the official Chutes OpenAPI contract.

This is a distinct endpoint from the static `/nodes/supported` hardware catalog and the subnet's other registered data-artifacts.

## Surface

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/nodes/
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

The endpoint is defined in the official Chutes OpenAPI spec as `List Nodes` with no security requirement — the same source used by the subnet's existing data-artifact surfaces.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
