### PR TITLE
feat(registry): add SN15 ORO ShoppingBench SFT dataset data-artifact

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -184,6 +184,25 @@
         "https://huggingface.co/oro-ai"
       ],
       "url": "https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-traces-18k"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-shoppingbench-sft",
+      "kind": "data-artifact",
+      "name": "ORO SN15 ShoppingBench SFT dataset",
+      "notes": "Public ORO (SN15) Hugging Face supervised-fine-tuning dataset of ~15k agentic-commerce instruction/response pairs distilled from the subnet's ShoppingBench benchmark; CC BY 4.0, not gated. The dataset card names ORO Subnet 15 and the oro-ai HF org matches the operator's ORO-AI GitHub org (the ORO repo README declares the subnet). Distinct from the subnet's registered ShoppingBench traces dataset.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/ORO-AI/oro",
+        "https://huggingface.co/oro-ai"
+      ],
+      "url": "https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-sft-15k"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/oro.json` (SN15 ORO). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds ORO's ShoppingBench SFT dataset on Hugging Face (`oro-ai/sn15-shoppingbench-sft-15k`) — a ~15k-example supervised-fine-tuning set of agentic-commerce instruction/response pairs distilled from the subnet's ShoppingBench benchmark. First-party: the dataset card names ORO Subnet 15, and the `oro-ai` HF org matches the operator's `ORO-AI` GitHub org (whose repo README declares the subnet).

This is a distinct dataset from the subnet's already-registered `oro-ai/sn15-shoppingbench-traces-18k` data-artifact.

## Surface

- Netuid: 15
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-sft-15k
- Source URLs: https://github.com/ORO-AI/oro , https://huggingface.co/oro-ai
- Provider slug: oro

Same first-party provenance as the sibling ShoppingBench traces dataset already in the registry: the `oro-ai` HF org (self-named `sn15-…`) is the SN15 operator's dataset org.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this dataset, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public dataset plus the first-party ORO repo/org sources establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/oro.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
