### PR TITLE
feat(registry): add SN52 Dojo Human Feedback DPO dataset data-artifact

### DIFF
--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -144,6 +144,25 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Public Tensorplex Dojo (SN52) HuggingFace dataset of 12.5k synthetic HTML/CSS/JS interface-generation Q&A pairs (id + messages columns), used to train the subnet's DOJO-INTERFACE-CODER model; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset."
+    },
+    {
+      "id": "sn-52-dojo-humanfeedback-dpo",
+      "name": "Dojo Human Feedback DPO dataset",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/datasets/tensorplex-labs/Dojo-HumanFeedback-DPO",
+      "provider": "tensorplex",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo",
+        "https://huggingface.co/tensorplex-labs"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "notes": "Public Tensorplex Dojo (SN52) HuggingFace DPO dataset of human-feedback preference pairs collected through the subnet's Dojo human-feedback-loop platform; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset. Distinct from the subnet's registered Dojo-Synthetic-SFT dataset."
     }
   ],
   "contact": "jarvis@tensorplex.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/dojo.json` (SN52 Dojo). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds Dojo's human-feedback DPO dataset on Hugging Face (`tensorplex-labs/Dojo-HumanFeedback-DPO`) — preference pairs collected through the subnet's Dojo human-feedback-loop platform. First-party: the `tensorplex-labs` HF org matches the subnet operator, and the `tensorplex-labs/dojo` repo README declares the Bittensor subnet (`--netuid 52`).

This is a distinct dataset from the subnet's already-registered `tensorplex-labs/Dojo-Synthetic-SFT` data-artifact.

## Surface

- Netuid: 52
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/tensorplex-labs/Dojo-HumanFeedback-DPO
- Source URLs: https://github.com/tensorplex-labs/dojo , https://huggingface.co/tensorplex-labs
- Provider slug: tensorplex

Same first-party provenance as the sibling `Dojo-Synthetic-SFT` dataset already in the registry.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this dataset, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public dataset plus the first-party dojo repo/org sources establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/dojo.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
