### PR TITLE
feat(registry): add SN64 Chutes diffusion invocation stats data-artifact

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -488,6 +488,22 @@
       },
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/nodes/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-diffusion-stats",
+      "kind": "data-artifact",
+      "name": "Chutes per-chute diffusion invocation stats",
+      "notes": "Public no-auth JSON of per-chute diffusion (image-generation) invocation statistics on the Chutes platform (chute_id, name, invocation counts); GET /invocations/stats/diffusion in the OpenAPI spec. The diffusion-model counterpart to the subnet's registered /invocations/usage feed, distinct from the subnet's other data-artifacts.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/invocations/stats/diffusion"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chutes.json` (SN64 Chutes). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds the Chutes per-chute diffusion-invocation statistics feed (`GET /invocations/stats/diffusion`) — a public, no-auth JSON of image-generation (diffusion) usage per deployed chute (chute_id, name, invocation counts). The diffusion-model counterpart to the subnet's registered `/invocations/usage` feed, sourced from the official Chutes OpenAPI contract.

This is a distinct endpoint from the subnet's other registered data-artifacts.

## Surface

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/invocations/stats/diffusion
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

The endpoint is defined in the official Chutes OpenAPI spec as `Get Diffusion Stats` with no security requirement — the same source used by the subnet's existing data-artifact surfaces.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
