### PR TITLE
fix(mcp): validate tool arguments before dispatch

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1011,6 +1011,24 @@ async function rankSubnetsForTask(ctx, task, poolSize, callableByNetuid) {
   return { mode: "keyword", ranked };
 }
 
+function validateToolArguments(tool, args) {
+  if (args === undefined || args === null) return {};
+  if (
+    typeof args !== "object" ||
+    Array.isArray(args) ||
+    (tool.inputSchema?.additionalProperties === false &&
+      Object.keys(args).some(
+        (key) => !Object.hasOwn(tool.inputSchema?.properties ?? {}, key),
+      ))
+  ) {
+    throw toolError(
+      "invalid_params",
+      `Invalid arguments for tool ${tool.name}.`,
+    );
+  }
+  return args;
+}
+
 function requireNonNegativeInt(args, key) {
   const value = args?.[key];
   if (!Number.isInteger(value) || value < 0) {
@@ -8557,7 +8575,8 @@ async function callTool(params, ctx) {
     };
   }
   try {
-    const data = await tool.handler(params?.arguments || {}, ctx);
+    const args = validateToolArguments(tool, params?.arguments);
+    const data = await tool.handler(args, ctx);
     return {
       content: [{ type: "text", text: JSON.stringify(data) }],
       structuredContent: data,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -10843,8 +10843,15 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_endpoints rejects an unexpected argument", async () => {
-    const res = await callTool("list_endpoints", { netuid: 7 });
+    const deps = makeDeps({
+      "/metagraph/endpoints.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        endpoints: [{ netuid: 7, kind: "rest", provider: "datura" }],
+      },
+    });
+    const res = await callTool("list_endpoints", { netuid: 7 }, { deps });
     assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
   });
 
   test("list_evidence returns the evidence ledger artifact", async () => {


### PR DESCRIPTION
### Motivation
- MCP tools declared `inputSchema` with `additionalProperties: false` but `callTool` dispatched `params.arguments` directly, allowing unexpected parameters to be ignored instead of rejected.
- The `list_endpoints` tool advertised an empty object schema but its handler ignored supplied args, which caused the new regression test to pass incorrectly when an artifact existed; the behavior should be an `invalid_params` tool error.

### Description
- Add `validateToolArguments(tool, args)` to enforce that arguments are a plain object, not an array, and to reject unknown properties when `tool.inputSchema.additionalProperties === false`.
- Call `validateToolArguments` from `callTool` prior to invoking `tool.handler` so tools that declare no extra properties reject unexpected arguments.
- Update the `list_endpoints` regression test in `tests/mcp-server.test.mjs` to inject the `/metagraph/endpoints.json` artifact and assert that sending an unexpected `{ netuid: 7 }` returns an `invalid_params` tool error.

### Testing
- Ran the focused test for the change with `npm test -- tests/mcp-server.test.mjs -t "list_endpoints"`, which passed.
- Ran `npm run lint` and `npm run format:check`, both of which passed on the modified files.
- Ran the full MCP test suite `npm test -- tests/mcp-server.test.mjs`, which showed one unrelated failing test (`POST /mcp tools/call resolves real artifacts from the local env` expected `service_count >= 1`), so the environment-specific assertion remains failing in this environment.
- Ran `npm run validate:mcp`, which failed due to local artifact availability (`search_subnets` returned `not_found`), so full validation could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4953c4fdc0832cbd97666adabef47a)