### PR TITLE
fix(feeds): omit invalid RSS pubDate instead of emitting Invalid Date

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -119,7 +119,10 @@ function toIso(value) {
 }
 
 function toRfc822(iso) {
-  return new Date(iso).toUTCString();
+  if (iso == null) return null;
+  const ms = Date.parse(String(iso));
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toUTCString();
 }
 
 // ── item builders (from existing served artifacts) ──────────────────────────
@@ -394,21 +397,26 @@ function jsonFeed(meta, items) {
 
 function rssFeed(meta, items) {
   const body = items
-    .map((it) =>
-      [
+    .map((it) => {
+      const pubDate = toRfc822(it.timestamp);
+      return [
         "    <item>",
         `      <guid isPermaLink="false">${escapeXml(it.id)}</guid>`,
         `      <link>${escapeXml(it.url)}</link>`,
         `      <title>${escapeXml(it.title)}</title>`,
         `      <description>${escapeXml(it.summary)}</description>`,
-        `      <pubDate>${toRfc822(it.timestamp)}</pubDate>`,
+        ...(pubDate ? [`      <pubDate>${escapeXml(pubDate)}</pubDate>`] : []),
         ...(it.tags || []).map(
           (t) => `      <category>${escapeXml(t)}</category>`,
         ),
         "    </item>",
-      ].join("\n"),
-    )
+      ].join("\n");
+    })
     .join("\n");
+  const lastBuildDate = toRfc822(meta.updated);
+  const lastBuildDateLine = lastBuildDate
+    ? `    <lastBuildDate>${escapeXml(lastBuildDate)}</lastBuildDate>`
+    : null;
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
@@ -417,7 +425,7 @@ function rssFeed(meta, items) {
     `    <link>${escapeXml(meta.homeUrl)}</link>`,
     `    <atom:link href="${escapeXml(meta.feedUrl)}" rel="self" type="application/rss+xml"/>`,
     `    <description>${escapeXml(meta.description)}</description>`,
-    `    <lastBuildDate>${toRfc822(meta.updated)}</lastBuildDate>`,
+    ...(lastBuildDateLine ? [lastBuildDateLine] : []),
     body,
     "  </channel>",
     "</rss>",
@@ -753,6 +761,7 @@ export function feedLinkHeader(originUrl, netuid) {
 // Exported for unit tests.
 export const __test = {
   toIso,
+  toRfc822,
   registryItems,
   incidentItems,
   gapsItems,

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -40,6 +40,7 @@ function installMockCache() {
 
 const {
   toIso,
+  toRfc822,
   registryItems,
   incidentItems,
   gapsItems,
@@ -809,6 +810,42 @@ describe("feeds — serializers", () => {
     assert.match(xml, /<channel>[\s\S]*<\/channel>/);
     assert.ok((xml.match(/<item>/g) || []).length === items.length);
     assert.match(xml, /<pubDate>.*GMT<\/pubDate>/);
+  });
+
+  test("toRfc822 returns null for corrupt timestamps", () => {
+    assert.equal(toRfc822("not-a-date"), null);
+    assert.equal(toRfc822(null), null);
+    assert.equal(
+      toRfc822("2026-06-15T00:00:00.000Z"),
+      "Mon, 15 Jun 2026 00:00:00 GMT",
+    );
+  });
+
+  test("rssFeed omits pubDate for corrupt item timestamps instead of Invalid Date", () => {
+    const xml = rssFeed(meta, [
+      {
+        id: "bad-ts",
+        url: "https://example.com/x",
+        title: "bad",
+        summary: "bad",
+        timestamp: "not-a-date",
+        tags: [],
+      },
+    ]);
+    assert.doesNotMatch(xml, /Invalid Date/);
+    assert.match(xml, /<item>/);
+    assert.doesNotMatch(xml, /<pubDate>/);
+  });
+
+  test("rssFeed omits lastBuildDate when meta.updated is corrupt", () => {
+    const xml = rssFeed({ ...meta, updated: "not-a-date" }, items.slice(0, 1));
+    assert.doesNotMatch(xml, /Invalid Date/);
+    assert.doesNotMatch(xml, /<lastBuildDate>/);
+  });
+
+  test("rssFeed includes lastBuildDate when meta.updated is valid", () => {
+    const xml = rssFeed(meta, items.slice(0, 1));
+    assert.match(xml, /<lastBuildDate>.*GMT<\/lastBuildDate>/);
   });
 
   test("atomFeed has the required feed + entry structure", () => {


### PR DESCRIPTION
## Summary

- Harden `toRfc822()` so corrupt feed timestamps return `null` instead of `"Invalid Date"` or throwing.
- Omit RSS `<pubDate>` and `<lastBuildDate>` when serialization fails, keeping the rest of the feed valid.

## What changed

- `src/feeds.mjs` — guard `toRfc822`; conditionally emit RSS date elements; export helper for tests.
- `tests/feeds.test.mjs` — regression tests for corrupt item/channel timestamps.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/feeds.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`
