### PR TITLE
feat(registry): add SN2 DSperse Inference Labs TruthTensor dataset data-artifact

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -148,6 +148,25 @@
       },
       "source_urls": ["https://github.com/inference-labs-inc/subnet-2"],
       "url": "https://www.inferencelabs.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-truthtensor-benchmark-dataset",
+      "kind": "data-artifact",
+      "name": "Inference Labs TruthTensor benchmark dataset",
+      "notes": "Public Inference Labs HuggingFace TruthTensor benchmark — ~88k text/parquet rows of per-run LLM decision-execution logs (model, latency/duration, token counts, action, reasoning columns) measuring instruction divergence; not gated. Published by inferencelabs, the HF-verified org of Inference Labs, the DSperse (SN2) operator (its site subnet2.inferencelabs.com and X @inference_labs are the subnet's registered surfaces).",
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://www.inferencelabs.com/",
+        "https://huggingface.co/inferencelabs"
+      ],
+      "url": "https://huggingface.co/datasets/inferencelabs/TruthTensor"
     }
   ],
   "website_url": "https://subnet2.inferencelabs.com/"


### PR DESCRIPTION
## Summary

Adds one **community `data-artifact` surface** to SN2 (DSperse, by Inference Labs): the operator's public **`TruthTensor`** HuggingFace benchmark dataset (~88k rows). The subnet file previously had no HuggingFace surface. Exactly one file changed: `registry/subnets/dsperse.json` (a minimal 19-line append).

## Surface

| Field | Value |
|-------|-------|
| `kind` | `data-artifact` |
| `url` | `https://huggingface.co/datasets/inferencelabs/TruthTensor` |
| `source_urls` | `https://www.inferencelabs.com/` · `https://huggingface.co/inferencelabs` |
| `provider` | `inference-labs` (existing) |
| `authority` | `community` · `review.state: community-submitted` |

## Proof (owner-published, live, public)

- **`url`** — fetched live (HTTP 200, not gated): ~**88,000 rows** (text/Parquet). Columns are per-run LLM decision-execution logs — `type`, `timestamp`, `model`, `scheduling_latency_ms`, `execution_duration_ms`, `input_tokens`/`output_tokens`/`reasoning_tokens`, `cost_usd`, `action`, `reasoning`, etc. No credential/validator columns.
- **`source_url` (org + site)** — the HF-**verified** `inferencelabs` org (linking `inferencelabs.com` + `@inference_labs`) owns the dataset, and Inference Labs is the **current** SN2 operator — its site `subnet2.inferencelabs.com` and social `x.com/inference_labs` are the subnet's registered surfaces. Airtight org↔operator match.

Non-duplicate: the subnet file had zero `huggingface.co` surfaces before this.

**Reviewer note:** the dataset is Inference Labs' own research benchmark (measuring LLM instruction divergence); the card doesn't print "SN2/Bittensor", so the tie rests on the definitive verified-org ↔ current-operator match plus the operator's name on the card.

## Registry Safety

- [x] Exactly one `registry/subnets/dsperse.json` changed; a single appended community surface, nothing else.
- [x] Real public `url` + `source_url`s; owner-matched to the current SN2 operator (Inference Labs); provider `inference-labs` already registered.
- [x] `authority: community`, `review.state: community-submitted`, `public_safe: true`; no auth/secrets; no health/verification hand-set.
- [x] Not a duplicate of an existing surface or open PR; correct `kind`.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate:surface -- registry/subnets/dsperse.json` — passed (6 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1280 surfaces); generated artifacts reverted so the diff is only the one subnet file (19-line append)
- [x] `prettier --check` (LF) · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
