### PR TITLE
fix(rpc-proxy): reject invalid Content-Length before reading the body

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1892,6 +1892,20 @@ describe("RPC proxy edges", () => {
     assert.equal((await res.json()).error.code, "rpc_body_too_large");
   });
 
+  test("400 when Content-Length is invalid before reading the body", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney", {
+        method: "POST",
+        headers: { "content-length": "-1" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "system_health" }),
+      }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "rpc_invalid_content_length");
+  });
+
   test("413 when the decoded body byte length exceeds the limit", async () => {
     // content-length header omitted/0, but the actual body is oversized.
     const big = "x".repeat(70000);

--- a/tests/request-handlers-rpc-proxy.test.mjs
+++ b/tests/request-handlers-rpc-proxy.test.mjs
@@ -370,6 +370,70 @@ describe("handleRpcProxyRequest", () => {
     assert.equal(body.error.code, "rpc_invalid_json");
   });
 
+  test("400 rpc_invalid_content_length for a negative Content-Length", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost(
+        { jsonrpc: "2.0", id: 1, method: "system_health" },
+        {
+          "content-length": "-1",
+        },
+      ),
+      rpcEnv(),
+      finneyUrl,
+    );
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_content_length");
+  });
+
+  test("400 rpc_invalid_content_length for a non-numeric Content-Length", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost(
+        { jsonrpc: "2.0", id: 1, method: "system_health" },
+        {
+          "content-length": "not-a-number",
+        },
+      ),
+      rpcEnv(),
+      finneyUrl,
+    );
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_content_length");
+  });
+
+  test("413 rpc_body_too_large when Content-Length exceeds the cap", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost(
+        { jsonrpc: "2.0", id: 1, method: "system_health" },
+        {
+          "content-length": "70000",
+        },
+      ),
+      rpcEnv(),
+      finneyUrl,
+    );
+    const body = await errorJson(res, 413);
+    assert.equal(body.error.code, "rpc_body_too_large");
+  });
+
+  test("passes a finite Content-Length within the cap before reading the body", async () => {
+    const payload = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "author_submitExtrinsic",
+    };
+    const res = await handleRpcProxyRequest(
+      rpcPost(payload, {
+        "content-length": String(
+          new TextEncoder().encode(JSON.stringify(payload)).byteLength,
+        ),
+      }),
+      rpcEnv(),
+      finneyUrl,
+    );
+    const body = await errorJson(res, 403);
+    assert.equal(body.error.code, "rpc_method_blocked");
+  });
+
   test("403 rpc_method_blocked for a denied method", async () => {
     const res = await handleRpcProxyRequest(
       rpcPost({ jsonrpc: "2.0", id: 1, method: "author_submitExtrinsic" }),

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -286,13 +286,23 @@ export async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     }
   }
 
-  const contentLength = Number(request.headers.get("content-length") || 0);
-  if (contentLength > MAX_RPC_BODY_BYTES) {
-    return errorResponse(
-      "rpc_body_too_large",
-      "RPC request body is too large for the read-only proxy.",
-      413,
-    );
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const contentLength = Number(declaredLength);
+    if (!Number.isFinite(contentLength) || contentLength < 0) {
+      return errorResponse(
+        "rpc_invalid_content_length",
+        "Invalid Content-Length header.",
+        400,
+      );
+    }
+    if (contentLength > MAX_RPC_BODY_BYTES) {
+      return errorResponse(
+        "rpc_body_too_large",
+        "RPC request body is too large for the read-only proxy.",
+        413,
+      );
+    }
   }
 
   let bodyText;


### PR DESCRIPTION
## Summary

- Validate the RPC proxy `Content-Length` header when present so non-numeric and negative values return 400 instead of skipping the pre-read guard.
- Keep the existing 413 path for finite lengths above `MAX_RPC_BODY_BYTES`.

## What changed

- `workers/request-handlers/rpc-proxy.mjs` — mirror GraphQL's Content-Length validation before `request.text()`.
- `tests/request-handlers-rpc-proxy.test.mjs` — direct-handler regression tests.
- `tests/api-coverage.test.mjs` — integration-route regression test.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/request-handlers-rpc-proxy.test.mjs tests/api-coverage.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`