### PR TITLE
fix(subnet-performance): report history *_median as the conventional median, not lower-middle p50

### DIFF
--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -79,6 +79,25 @@ function percentile(ascending, p) {
   return ascending[rank - 1];
 }
 
+// Conventional median of a 0..1 score column: the middle value for an odd count,
+// the average of the two middle values for an even count — NOT the nearest-rank
+// p50, which returns the lower-middle for an even count (e.g. [0.2, 0.8] -> 0.2).
+// This matches the median() the sibling subnet-yield.mjs uses for median_yield
+// (its test asserts "averages the two middle values ... not lower-middle"), so a
+// field literally named *_median reports the same statistic across both modules.
+// Returns null when no neuron carries a finite value.
+function scoreMedian(values) {
+  const ascending = finiteValues(Array.isArray(values) ? values : []).sort(
+    (a, b) => a - b,
+  );
+  const n = ascending.length;
+  if (n === 0) return null;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 1
+    ? round(ascending[mid])
+    : round((ascending[mid - 1] + ascending[mid]) / 2);
+}
+
 // Distribution summary for one 0..1 score column, or `null` when no neuron carries
 // a finite value (cold store / empty subnet / all-null column). count/mean plus the
 // SCORE_PERCENTILES spread and the min/max, all rounded to a stable precision.
@@ -233,11 +252,13 @@ function performanceHistoryPoint(date, dayRows) {
     dividends_nakamoto_coefficient: dividends?.nakamoto_coefficient ?? null,
     dividends_top_10pct_share: dividends?.top_10pct_share ?? null,
     trust_mean: trust?.mean ?? null,
-    trust_median: trust?.p50 ?? null,
+    trust_median: scoreMedian(dayRows.map((row) => row?.trust)),
     consensus_mean: consensus?.mean ?? null,
-    consensus_median: consensus?.p50 ?? null,
+    consensus_median: scoreMedian(dayRows.map((row) => row?.consensus)),
     validator_trust_mean: validatorTrust?.mean ?? null,
-    validator_trust_median: validatorTrust?.p50 ?? null,
+    validator_trust_median: scoreMedian(
+      validatorRows.map((row) => row?.validator_trust),
+    ),
   };
 }
 

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -337,6 +337,46 @@ describe("buildSubnetPerformanceHistory", () => {
   test("an omitted window is emitted as null", () => {
     assert.equal(buildSubnetPerformanceHistory([], 5).window, null);
   });
+
+  test("the *_median fields are the conventional median, not the lower-middle p50", () => {
+    // An even neuron count: nearest-rank p50 would return the lower-middle value
+    // (e.g. trust [0.2, 0.8] -> 0.2), but a field named *_median must be the
+    // conventional median = average of the two middle values, matching the
+    // median subnet-yield.mjs reports for median_yield.
+    const day = (over) => ({
+      snapshot_date: "2026-06-20",
+      incentive: 0.1,
+      dividends: 0.1,
+      trust: 0.2,
+      consensus: 0.1,
+      validator_trust: 0.4,
+      validator_permit: 1,
+      active: 1,
+      ...over,
+    });
+    const even = buildSubnetPerformanceHistory(
+      [
+        day({ trust: 0.2, consensus: 0.1, validator_trust: 0.4 }),
+        day({ trust: 0.8, consensus: 0.9, validator_trust: 0.6 }),
+      ],
+      7,
+    );
+    const p = even.points[0];
+    assert.equal(p.trust_median, 0.5); // (0.2 + 0.8) / 2, not the lower-middle 0.2
+    assert.equal(p.consensus_median, 0.5); // (0.1 + 0.9) / 2
+    assert.equal(p.validator_trust_median, 0.5); // (0.4 + 0.6) / 2, validators only
+
+    // An odd count still returns the true middle value.
+    const odd = buildSubnetPerformanceHistory(
+      [day({ trust: 0.1 }), day({ trust: 0.4 }), day({ trust: 0.9 })],
+      7,
+    );
+    assert.equal(odd.points[0].trust_median, 0.4);
+
+    // A day with no finite scores keeps the field null (schema-stable).
+    const none = buildSubnetPerformanceHistory([day({ trust: null })], 7);
+    assert.equal(none.points[0].trust_median, null);
+  });
 });
 
 describe("loadSubnetPerformanceHistory", () => {


### PR DESCRIPTION
## Summary

`GET /api/v1/subnets/{netuid}/performance/history` reports `trust_median`, `consensus_median`, and `validator_trust_median` per day, but for an **even** neuron count these returned the **lower-middle** value (nearest-rank `p50`) instead of the conventional median. `performanceHistoryPoint` set each from `scoreDistribution(...).p50`, whose `percentile` is nearest-rank (`rank = ceil(p/100 · n)`), so for `n = 2` it returns `ascending[0]`.

### Repro

A day with two neurons whose `trust` scores are `[0.2, 0.8]`:
- **Before:** `trust_median: 0.2` (the minimum / lower-middle)
- **After:** `trust_median: 0.5` — the median of `[0.2, 0.8]`

## Why this is the correct behavior

- The field is named `*_median`, and the schema documents it only as `["number","null"]` — no "p50 / nearest-rank" qualifier.
- The sibling `src/subnet-yield.mjs` already computes `median_yield` as a **conventional** median (average of the two middle values) and carries a regression test — *"median averages the two middle values for an even count (not lower-middle)"* — establishing the intended semantics for a `*median*` field over these 0..1 scores.
- So the same statistic was computed two different ways across sibling modules; this aligns `subnet-performance`'s history medians with that established convention.

`scoreDistribution.p50` is intentionally nearest-rank (and unit-tested as such at `subnet-performance.test.mjs`) — correct for a field named `p50` — and is **left unchanged**. The main `/performance` snapshot route, which exposes the full distribution object (`p50` honestly named), is unaffected.

## What Changed

- **`src/subnet-performance.mjs`** — add a `scoreMedian()` helper (odd → middle value; even → average of the two middle; empty → null; mirrors `subnet-yield.mjs`'s `median()`), and compute the three history `*_median` fields with it instead of `scoreDistribution().p50`.
- **`tests/subnet-performance.test.mjs`** — regression test asserting the even-count average (`0.5`, not the lower-middle `0.2`), the odd-count middle (`0.4`), and the empty-column `null`.

No schema/contract/artifact change — the field types stay `["number","null"]`, so no `public/**` regeneration.

## Registry / Safety

- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched (pure runtime logic; live-computed route).
- [x] Public API shape unchanged — a mislabeled statistic is corrected to match the field name + the sibling convention.

## Validation

Run locally (Windows; Node 22):

- [x] `vitest run tests/subnet-performance.test.mjs --coverage` — 24 passing; **100%** coverage of the changed lines (verified via v8; the one uncovered line, 54, is a pre-existing `captured_at` branch outside this diff)
- [x] `eslint` + `prettier --check` on the changed files (clean, LF)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
