### PR TITLE
feat(mcp): netuid filter on get_account_events

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -314,7 +314,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.45.0";
+export const MCP_SERVER_VERSION = "1.46.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -3465,10 +3465,11 @@ export const MCP_TOOLS = [
       "Fetch the paginated first-party chain-event history for one account by its " +
       "SS58 address (hotkey OR coldkey), newest first: each event's kind, block, " +
       "Subnet, UID, amount, and timestamp. Optionally filter by event kind (e.g. " +
-      "StakeAdded, StakeRemoved, NeuronRegistered, AxonServed, WeightsSet). " +
-      "Optionally constrain block height with block_start/block_end (inclusive). " +
-      "Page with limit (1-1000, default 100) / offset, or follow next_cursor for stable " +
-      "keyset pagination. Mirrors GET /api/v1/accounts/{ss58}/events.",
+      "StakeAdded, StakeRemoved, NeuronRegistered, AxonServed, WeightsSet) or scope " +
+      "to one subnet with netuid. Optionally constrain block height with " +
+      "block_start/block_end (inclusive). Page with limit (1-1000, default 100) / " +
+      "offset, or follow next_cursor for stable keyset pagination. Mirrors " +
+      "GET /api/v1/accounts/{ss58}/events.",
     inputSchema: {
       type: "object",
       properties: {
@@ -3483,6 +3484,13 @@ export const MCP_TOOLS = [
           description:
             "Optional event-kind filter, e.g. 'StakeAdded' or 'NeuronRegistered'. " +
             "Omit for all kinds; unsupported kinds are rejected.",
+        },
+        netuid: {
+          type: "integer",
+          description:
+            "Optional subnet scope: only events tied to this netuid. Omit for " +
+            "events across every subnet.",
+          minimum: 0,
         },
         block_start: {
           type: "integer",
@@ -3523,6 +3531,7 @@ export const MCP_TOOLS = [
       requireKnownEventKind(kind);
       const cursor = optionalString(args, "cursor");
       return loadAccountEvents(mcpD1Runner(ctx), ss58, {
+        netuid: optionalNonNegativeInt(args, "netuid"),
         blockStart: optionalNonNegativeInt(args, "block_start"),
         blockEnd: optionalNonNegativeInt(args, "block_end"),
         limit: args?.limit,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8744,6 +8744,59 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     assert.ok(eventsQuery.params.includes("StakeRemoved"));
   });
 
+  test("get_account_events scopes to one subnet with netuid (#2585 parity)", async () => {
+    const capture = [];
+    const env = accountD1(
+      {
+        events: [
+          {
+            block_number: 210,
+            event_index: 0,
+            event_kind: "StakeAdded",
+            hotkey: SS58,
+            coldkey: null,
+            netuid: 74,
+            uid: 5,
+            amount_tao: 1.0,
+            observed_at: 1750009100000,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_account_events",
+      { ss58: SS58, netuid: 74 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.events[0].netuid, 74);
+    // The netuid filter must reach the SQL as a bound param inside each indexed
+    // branch of the hotkey/coldkey union (never interpolated).
+    const eventsQuery = capture.find((q) => /FROM account_events/.test(q.sql));
+    assert.equal((eventsQuery.sql.match(/AND netuid = \?/g) || []).length, 2);
+    assert.ok(eventsQuery.params.includes(74));
+  });
+
+  test("get_account_events without netuid is unscoped (no netuid predicate)", async () => {
+    const capture = [];
+    const env = accountD1({ events: [] }, capture);
+    await callTool("get_account_events", { ss58: SS58 }, { env });
+    const eventsQuery = capture.find((q) => /FROM account_events/.test(q.sql));
+    assert.doesNotMatch(eventsQuery.sql, /AND netuid = \?/);
+  });
+
+  test("get_account_events rejects a malformed netuid", async () => {
+    const env = accountD1({ events: [] });
+    const res = await callTool(
+      "get_account_events",
+      { ss58: SS58, netuid: -1 },
+      { env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
   test("get_account_events clamps an over-range limit the same way the REST route does", async () => {
     const capture = [];
     const env = accountD1({ events: [] }, capture);


### PR DESCRIPTION
## Summary

The `account_events` D1 rows carry a `netuid` column (added in #2774, which powers the REST route's `?netuid=` filter — `loadAccountEvents` already accepts a `netuid` option), but the MCP `get_account_events` tool never exposed it, unlike its REST sibling.

Adds a validated `netuid` arg that scopes the returned event history to one subnet, threaded through as a bound `AND netuid = ?` predicate inside **both** the hotkey and coldkey branches of the underlying indexed union — mirroring exactly how the REST route already does it, so both index seeks stay scoped.

Additive tool input, so `MCP_SERVER_VERSION` (src/mcp-server.mjs) and `server.json` both move 1.45.0 -> 1.46.0 per the file-local SemVer bump policy (#393).

## Changes
- `src/mcp-server.mjs`: `netuid` arg on `get_account_events`'s inputSchema; threaded into `loadAccountEvents({ netuid, ... })`; version bump.
- `server.json`: version bump to match.
- `tests/mcp-server.test.mjs`: netuid scoping (SQL + bound param in both union branches), unscoped-shape pin, malformed-netuid rejection.

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed (worker-computed).

## Validation
- `node scripts/validate-mcp.mjs` (114 tools, version consistency) — green
- `npx vitest run tests/mcp-server.test.mjs` — 525 passed; new lines fully covered
- `npm run lint`, `npm run format:check` — clean