### PR TITLE
feat(mcp): netuid filter on get_account_events

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -314,7 +314,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.45.0";
+export const MCP_SERVER_VERSION = "1.46.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -3465,10 +3465,11 @@ export const MCP_TOOLS = [
       "Fetch the paginated first-party chain-event history for one account by its " +
       "SS58 address (hotkey OR coldkey), newest first: each event's kind, block, " +
       "Subnet, UID, amount, and timestamp. Optionally filter by event kind (e.g. " +
-      "StakeAdded, StakeRemoved, NeuronRegistered, AxonServed, WeightsSet). " +
-      "Optionally constrain block height with block_start/block_end (inclusive). " +
-      "Page with limit (1-1000, default 100) / offset, or follow next_cursor for stable " +
-      "keyset pagination. Mirrors GET /api/v1/accounts/{ss58}/events.",
+      "StakeAdded, StakeRemoved, NeuronRegistered, AxonServed, WeightsSet) or scope " +
+      "to one subnet with netuid. Optionally constrain block height with " +
+      "block_start/block_end (inclusive). Page with limit (1-1000, default 100) / " +
+      "offset, or follow next_cursor for stable keyset pagination. Mirrors " +
+      "GET /api/v1/accounts/{ss58}/events.",
     inputSchema: {
       type: "object",
       properties: {
@@ -3483,6 +3484,13 @@ export const MCP_TOOLS = [
           description:
             "Optional event-kind filter, e.g. 'StakeAdded' or 'NeuronRegistered'. " +
             "Omit for all kinds; unsupported kinds are rejected.",
+        },
+        netuid: {
+          type: "integer",
+          description:
+            "Optional subnet scope: only events tied to this netuid. Omit for " +
+            "events across every subnet.",
+          minimum: 0,
         },
         block_start: {
           type: "integer",
@@ -3523,6 +3531,7 @@ export const MCP_TOOLS = [
       requireKnownEventKind(kind);
       const cursor = optionalString(args, "cursor");
       return loadAccountEvents(mcpD1Runner(ctx), ss58, {
+        netuid: optionalNonNegativeInt(args, "netuid"),
         blockStart: optionalNonNegativeInt(args, "block_start"),
         blockEnd: optionalNonNegativeInt(args, "block_end"),
         limit: args?.limit,

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8744,6 +8744,59 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     assert.ok(eventsQuery.params.includes("StakeRemoved"));
   });
 
+  test("get_account_events scopes to one subnet with netuid (#2585 parity)", async () => {
+    const capture = [];
+    const env = accountD1(
+      {
+        events: [
+          {
+            block_number: 210,
+            event_index: 0,
+            event_kind: "StakeAdded",
+            hotkey: SS58,
+            coldkey: null,
+            netuid: 74,
+            uid: 5,
+            amount_tao: 1.0,
+            observed_at: 1750009100000,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_account_events",
+      { ss58: SS58, netuid: 74 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.events[0].netuid, 74);
+    // The netuid filter must reach the SQL as a bound param inside each indexed
+    // branch of the hotkey/coldkey union (never interpolated).
+    const eventsQuery = capture.find((q) => /FROM account_events/.test(q.sql));
+    assert.equal((eventsQuery.sql.match(/AND netuid = \?/g) || []).length, 2);
+    assert.ok(eventsQuery.params.includes(74));
+  });
+
+  test("get_account_events without netuid is unscoped (no netuid predicate)", async () => {
+    const capture = [];
+    const env = accountD1({ events: [] }, capture);
+    await callTool("get_account_events", { ss58: SS58 }, { env });
+    const eventsQuery = capture.find((q) => /FROM account_events/.test(q.sql));
+    assert.doesNotMatch(eventsQuery.sql, /AND netuid = \?/);
+  });
+
+  test("get_account_events rejects a malformed netuid", async () => {
+    const env = accountD1({ events: [] });
+    const res = await callTool(
+      "get_account_events",
+      { ss58: SS58, netuid: -1 },
+      { env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
   test("get_account_events clamps an over-range limit the same way the REST route does", async () => {
     const capture = [];
     const env = accountD1({ events: [] }, capture);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Resubmits #3193, closed by the automated gate for a CI failure unrelated to this PR's own code: bumping `MCP_SERVER_VERSION` broke 7 other test files' hardcoded `assert.equal(MCP_SERVER_VERSION, "1.45.0")` regression checks (each written when its own tool was added, asserting the version *at that time* — a structural landmine any version-bump PR trips). Fixed by updating all 7 to the new version; verified green locally before this resubmit.

---

The `account_events` D1 rows carry a `netuid` column (added in #2774, which powers the REST route's `?netuid=` filter — `loadAccountEvents` already accepts a `netuid` option), but the MCP `get_account_events` tool never exposed it, unlike its REST sibling.

Adds a validated `netuid` arg that scopes the returned event history to one subnet, threaded through as a bound `AND netuid = ?` predicate inside **both** the hotkey and coldkey branches of the underlying indexed union — mirroring exactly how the REST route already does it, so both index seeks stay scoped.

Additive tool input, so `MCP_SERVER_VERSION` (src/mcp-server.mjs) and `server.json` both move 1.45.0 -> 1.46.0 per the file-local SemVer bump policy (#393).

## Changes
- `src/mcp-server.mjs`: `netuid` arg on `get_account_events`'s inputSchema; threaded into `loadAccountEvents({ netuid, ... })`; version bump.
- `server.json`: version bump to match.
- `tests/mcp-server.test.mjs`: netuid scoping (SQL + bound param in both union branches), unscoped-shape pin, malformed-netuid rejection.
- `tests/{agent-resources,curation,gaps,global-operational-health,health-history,profiles,registry-coverage}-mcp.test.mjs`: hardcoded version-literal fix (see above).

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed (worker-computed).

## Validation
- `node scripts/validate-mcp.mjs` (114 tools, version consistency) — green
- Full relevant suite (`mcp-server.test.mjs` + the 7 version-literal files) — 642 passed
- `npm run lint`, `npm run format:check` — clean