### PR TITLE
feat(mcp): limit and min_stake_tao filters on list_subnet_validators

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -314,7 +314,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.45.0";
+export const MCP_SERVER_VERSION = "1.46.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -1048,6 +1048,34 @@ function optionalNonNegativeInt(args, key) {
     throw toolError(
       "invalid_params",
       `Argument \`${key}\` must be a non-negative integer.`,
+    );
+  }
+  return value;
+}
+
+// Like optionalNonNegativeInt but for a decimal quantity (e.g. a TAO amount),
+// where a fractional value is valid.
+function optionalNonNegativeNumber(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-negative number.`,
+    );
+  }
+  return value;
+}
+
+// Like optionalNonNegativeInt, but 0 is invalid (a "cap the list to zero rows"
+// argument reads as a misuse, not a legitimate empty-result request).
+function optionalPositiveInt(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null) return null;
+  if (!Number.isInteger(value) || value < 1) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a positive integer.`,
     );
   }
   return value;
@@ -3127,18 +3155,49 @@ export const MCP_TOOLS = [
       "List one subnet's permit-holding validators, ranked by stake " +
       "(descending): hot and cold keys, stake, validator trust, consensus, " +
       "dividends, emission, and axon. Use it to pick which validators to " +
-      "target, delegate to, or weight against.",
+      "target, delegate to, or weight against. Optionally cap the list with " +
+      "limit (keeps the highest-stake rows, since the list is already " +
+      "stake-ranked) or drop small-stake rows with min_stake_tao.",
     inputSchema: {
       type: "object",
       properties: {
         netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        limit: {
+          type: "integer",
+          description:
+            "Max validators to return, keeping the highest-stake rows. Omit " +
+            "for the full list.",
+          minimum: 1,
+        },
+        min_stake_tao: {
+          type: "number",
+          description:
+            "Only validators whose stake is >= this many TAO. Omit for no floor.",
+          minimum: 0,
+        },
       },
       required: ["netuid"],
       additionalProperties: false,
     },
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return loadSubnetValidators(mcpD1Runner(ctx), netuid);
+      const limit = optionalPositiveInt(args, "limit");
+      const minStakeTao = optionalNonNegativeNumber(args, "min_stake_tao");
+      const data = await loadSubnetValidators(mcpD1Runner(ctx), netuid);
+      if (limit === null && minStakeTao === null) {
+        return data;
+      }
+      // The loader already ranks by stake_tao DESC, so a limit after the
+      // min_stake_tao floor keeps the highest-stake survivors — no re-sort.
+      const filtered =
+        minStakeTao === null
+          ? data.validators
+          : data.validators.filter(
+              (v) =>
+                typeof v.stake_tao === "number" && v.stake_tao >= minStakeTao,
+            );
+      const validators = limit === null ? filtered : filtered.slice(0, limit);
+      return { ...data, validator_count: validators.length, validators };
     },
   },
   {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6442,6 +6442,122 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.validators[0].validator_permit, true);
   });
 
+  function threeValidatorsD1() {
+    return {
+      METAGRAPH_HEALTH_DB: metagraphD1({
+        neurons: [
+          {
+            netuid: 7,
+            uid: 0,
+            hotkey: "5Hk-a",
+            coldkey: "5Co-a",
+            validator_permit: 1,
+            stake_tao: 100,
+            emission_tao: 1,
+            validator_trust: 0.9,
+            captured_at: 1750000000000,
+            block_number: 100,
+          },
+          {
+            netuid: 7,
+            uid: 1,
+            hotkey: "5Hk-b",
+            coldkey: "5Co-b",
+            validator_permit: 1,
+            stake_tao: 50,
+            emission_tao: 1,
+            validator_trust: 0.8,
+            captured_at: 1750000000000,
+            block_number: 100,
+          },
+          {
+            netuid: 7,
+            uid: 2,
+            hotkey: "5Hk-c",
+            coldkey: "5Co-c",
+            validator_permit: 1,
+            stake_tao: 5,
+            emission_tao: 1,
+            validator_trust: 0.5,
+            captured_at: 1750000000000,
+            block_number: 100,
+          },
+        ],
+      }),
+    };
+  }
+
+  test("list_subnet_validators limit keeps the highest-stake rows (already stake-ranked)", async () => {
+    const res = await callTool(
+      "list_subnet_validators",
+      { netuid: 7, limit: 2 },
+      { env: threeValidatorsD1() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.validator_count, 2);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["5Hk-a", "5Hk-b"],
+    );
+  });
+
+  test("list_subnet_validators min_stake_tao drops small-stake validators", async () => {
+    const res = await callTool(
+      "list_subnet_validators",
+      { netuid: 7, min_stake_tao: 50 },
+      { env: threeValidatorsD1() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.validator_count, 2);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["5Hk-a", "5Hk-b"],
+    );
+  });
+
+  test("list_subnet_validators combines min_stake_tao and limit", async () => {
+    const res = await callTool(
+      "list_subnet_validators",
+      { netuid: 7, min_stake_tao: 6, limit: 1 },
+      { env: threeValidatorsD1() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.validator_count, 1);
+    assert.equal(out.validators[0].hotkey, "5Hk-a");
+  });
+
+  test("list_subnet_validators without limit/min_stake_tao is unchanged (full ranked list)", async () => {
+    const res = await callTool(
+      "list_subnet_validators",
+      { netuid: 7 },
+      { env: threeValidatorsD1() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.validator_count, 3);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["5Hk-a", "5Hk-b", "5Hk-c"],
+    );
+  });
+
+  test("list_subnet_validators rejects limit=0 and a negative min_stake_tao", async () => {
+    const zeroLimit = await callTool(
+      "list_subnet_validators",
+      { netuid: 7, limit: 0 },
+      { env: threeValidatorsD1() },
+    );
+    assert.equal(zeroLimit.body.result.isError, true);
+    assert.match(zeroLimit.body.result.content[0].text, /invalid_params/);
+
+    const negStake = await callTool(
+      "list_subnet_validators",
+      { netuid: 7, min_stake_tao: -1 },
+      { env: threeValidatorsD1() },
+    );
+    assert.equal(negStake.body.result.isError, true);
+    assert.match(negStake.body.result.content[0].text, /invalid_params/);
+  });
+
   test("list_global_validators returns schema-stable empty list on cold D1", async () => {
     const res = await callTool("list_global_validators", {});
     const out = res.body.result.structuredContent;

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.45.0");
+    assert.equal(MCP_SERVER_VERSION, "1.46.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Resubmits #3195, closed by the automated gate for a CI failure unrelated to this PR's own code: bumping `MCP_SERVER_VERSION` broke 7 other test files' hardcoded `assert.equal(MCP_SERVER_VERSION, "1.45.0")` regression checks (each written when its own tool was added, asserting the version *at that time* — a structural landmine any version-bump PR trips). Fixed by updating all 7 to the new version; verified green locally before this resubmit.

---

`list_subnet_validators` returns every permit-holding validator for a subnet with no way to cap the list or drop small-stake rows — unlike most other `list_*`/`get_registry_leaderboards` MCP tools, which all take a `limit`. For a large subnet this can be a lot of rows to hand an agent.

Adds two opt-in filters:
- `limit` — keeps the highest-stake rows. The loader already ranks by `stake_tao DESC`, so this is a plain `slice(0, limit)`, no re-sort.
- `min_stake_tao` — drops validators whose stake is below the floor.

Both are post-filters over the existing loader output (`loadSubnetValidators` / SQL untouched). **Omitting both keeps the response byte-identical to today** — this is purely additive.

Additive tool input, so `MCP_SERVER_VERSION` (src/mcp-server.mjs) and `server.json` both move 1.45.0 -> 1.46.0 per the file-local SemVer bump policy (#393).

## Changes
- `src/mcp-server.mjs`: `optionalPositiveInt` / `optionalNonNegativeNumber` helpers; `limit` + `min_stake_tao` on `list_subnet_validators`'s inputSchema and handler; version bump.
- `server.json`: version bump to match.
- `tests/mcp-server.test.mjs`: limit keeps highest-stake rows, min_stake_tao floor, both combined, unchanged behaviour when neither is passed, and rejection of `limit=0` / a negative `min_stake_tao`.
- `tests/{agent-resources,curation,gaps,global-operational-health,health-history,profiles,registry-coverage}-mcp.test.mjs`: hardcoded version-literal fix (see above).

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed (worker-computed).

## Validation
- `node scripts/validate-mcp.mjs` (114 tools, version consistency) — green
- Full relevant suite (`mcp-server.test.mjs` + the 7 version-literal files) — 642 passed
- `npm run lint`, `npm run format:check` — clean