### PR TITLE
feat(mcp): filter and paginate list_endpoints

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -18,7 +18,7 @@ import {
 import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
-import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,
@@ -314,7 +314,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.46.0";
+export const MCP_SERVER_VERSION = "1.47.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -1089,6 +1089,19 @@ function requireNetuid(args) {
 function optionalBoolean(args, key) {
   const value = args?.[key];
   if (value === undefined || value === null) return false;
+  if (typeof value !== "boolean") {
+    throw toolError("invalid_params", `Argument \`${key}\` must be a boolean.`);
+  }
+  return value;
+}
+
+// Unlike optionalBoolean (which defaults an absent flag to false), a tri-state
+// filter arg must distinguish "not provided, don't filter" (null) from an
+// explicit true/false, or an absent filter would wrongly narrow to only the
+// false-valued rows.
+function optionalNullableBoolean(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null) return null;
   if (typeof value !== "boolean") {
     throw toolError("invalid_params", `Argument \`${key}\` must be a boolean.`);
   }
@@ -5086,15 +5099,93 @@ export const MCP_TOOLS = [
       "monitored public endpoint/surface across providers and subnets, each " +
       "with its kind, layer, provider, subnet (netuid), publication state, and " +
       "probe-derived status/latency/score. Use it to discover live endpoints " +
-      "network-wide (filter client-side by kind, status, or latency). Mirrors " +
-      "GET /api/v1/endpoints.",
+      "network-wide. Optionally filter by kind/layer/netuid/provider/" +
+      "publication_state/status/pool_eligible and page with limit/offset — the " +
+      "full catalog can be large. Mirrors GET /api/v1/endpoints.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        kind: {
+          type: "string",
+          enum: QUERY_ENUMS.surfaceKind,
+          description: "Surface kind, e.g. 'subnet-api' or 'openapi'.",
+        },
+        layer: {
+          type: "string",
+          enum: QUERY_ENUMS.endpointLayer,
+          description: "Endpoint layer, e.g. 'subnet-app' or 'bittensor-base'.",
+        },
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        provider: {
+          type: "string",
+          description: "Provider slug, e.g. 'datura'.",
+        },
+        publication_state: {
+          type: "string",
+          enum: QUERY_ENUMS.endpointPublicationState,
+          description:
+            "Publication state, e.g. 'monitored' or 'pool-eligible'.",
+        },
+        status: {
+          type: "string",
+          enum: QUERY_ENUMS.healthStatus,
+          description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
+        },
+        pool_eligible: {
+          type: "boolean",
+          description: "Only endpoints eligible (or not) for RPC pooling.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max endpoints to return. Omit for the full list.",
+          minimum: 1,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset into the (filtered) list. Default 0.",
+          minimum: 0,
+        },
+      },
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/endpoints.json");
+    async handler(args, ctx) {
+      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
+      const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
+      const netuid = optionalNonNegativeInt(args, "netuid");
+      const provider = optionalString(args, "provider");
+      const publicationState = optionalEnum(
+        args,
+        "publication_state",
+        QUERY_ENUMS.endpointPublicationState,
+      );
+      const status = optionalEnum(args, "status", QUERY_ENUMS.healthStatus);
+      const poolEligible = optionalNullableBoolean(args, "pool_eligible");
+      const limit = optionalPositiveInt(args, "limit");
+      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
+      const all = Array.isArray(data.endpoints) ? data.endpoints : [];
+      const filtered = all.filter(
+        (e) =>
+          (kind === null || e.kind === kind) &&
+          (layer === null || e.layer === layer) &&
+          (netuid === null || e.netuid === netuid) &&
+          (provider === null || e.provider === provider) &&
+          (publicationState === null ||
+            e.publication_state === publicationState) &&
+          (status === null || e.status === status) &&
+          (poolEligible === null || e.pool_eligible === poolEligible),
+      );
+      const page =
+        limit === null
+          ? filtered.slice(offset)
+          : filtered.slice(offset, offset + limit);
+      return {
+        ...data,
+        endpoints: page,
+        total: filtered.length,
+        returned: page.length,
+        offset,
+      };
     },
   },
   {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -11018,9 +11018,170 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
         endpoints: [{ netuid: 7, kind: "rest", provider: "datura" }],
       },
     });
-    const res = await callTool("list_endpoints", { netuid: 7 }, { deps });
+    const res = await callTool("list_endpoints", { bogus: 1 }, { deps });
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
+  function endpointsDeps() {
+    return makeDeps({
+      "/metagraph/endpoints.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        endpoints: [
+          {
+            netuid: 7,
+            kind: "subnet-api",
+            layer: "subnet-app",
+            provider: "datura",
+            publication_state: "monitored",
+            status: "ok",
+            pool_eligible: false,
+          },
+          {
+            netuid: 7,
+            kind: "openapi",
+            layer: "docs-provider",
+            provider: "chutes",
+            publication_state: "verified",
+            status: "degraded",
+            pool_eligible: false,
+          },
+          {
+            netuid: 12,
+            kind: "subtensor-rpc",
+            layer: "bittensor-base",
+            provider: "datura",
+            publication_state: "pool-eligible",
+            status: "ok",
+            pool_eligible: true,
+          },
+        ],
+      },
+    });
+  }
+
+  test("list_endpoints filters by kind, layer, netuid, provider, publication_state, status, pool_eligible", async () => {
+    const deps = endpointsDeps();
+    const byKind = (
+      await callTool("list_endpoints", { kind: "openapi" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byKind.total, 1);
+    assert.equal(byKind.endpoints[0].provider, "chutes");
+
+    const byLayer = (
+      await callTool("list_endpoints", { layer: "bittensor-base" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byLayer.total, 1);
+    assert.equal(byLayer.endpoints[0].netuid, 12);
+
+    const byNetuid = (await callTool("list_endpoints", { netuid: 7 }, { deps }))
+      .body.result.structuredContent;
+    assert.equal(byNetuid.total, 2);
+
+    const byProvider = (
+      await callTool("list_endpoints", { provider: "datura" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byProvider.total, 2);
+
+    const byPubState = (
+      await callTool(
+        "list_endpoints",
+        { publication_state: "verified" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byPubState.total, 1);
+    assert.equal(byPubState.endpoints[0].kind, "openapi");
+
+    const byStatus = (
+      await callTool("list_endpoints", { status: "degraded" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byStatus.total, 1);
+
+    const byPoolEligible = (
+      await callTool("list_endpoints", { pool_eligible: true }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byPoolEligible.total, 1);
+    assert.equal(byPoolEligible.endpoints[0].netuid, 12);
+  });
+
+  test("list_endpoints combines filters (AND) and reports total vs returned", async () => {
+    const deps = endpointsDeps();
+    const res = await callTool(
+      "list_endpoints",
+      { netuid: 7, status: "ok" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].provider, "datura");
+  });
+
+  test("list_endpoints paginates the filtered list with limit/offset", async () => {
+    const deps = endpointsDeps();
+    const res = await callTool(
+      "list_endpoints",
+      { limit: 1, offset: 1 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 1);
+    assert.equal(out.offset, 1);
+    assert.equal(out.endpoints[0].provider, "chutes");
+  });
+
+  test("list_endpoints rejects an unknown kind/layer/publication_state/status enum value", async () => {
+    const deps = endpointsDeps();
+    const badKind = await callTool(
+      "list_endpoints",
+      { kind: "not-a-kind" },
+      { deps },
+    );
+    assert.equal(badKind.body.result.isError, true);
+
+    const badLayer = await callTool(
+      "list_endpoints",
+      { layer: "not-a-layer" },
+      { deps },
+    );
+    assert.equal(badLayer.body.result.isError, true);
+
+    const badPubState = await callTool(
+      "list_endpoints",
+      { publication_state: "not-a-state" },
+      { deps },
+    );
+    assert.equal(badPubState.body.result.isError, true);
+
+    const badStatus = await callTool(
+      "list_endpoints",
+      { status: "not-a-status" },
+      { deps },
+    );
+    assert.equal(badStatus.body.result.isError, true);
+  });
+
+  test("list_endpoints rejects a non-boolean pool_eligible", async () => {
+    const deps = endpointsDeps();
+    const res = await callTool(
+      "list_endpoints",
+      { pool_eligible: "yes" },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("list_endpoints is schema-stable when the artifact has no endpoints array", async () => {
+    const deps = makeDeps({
+      "/metagraph/endpoints.json": { generated_at: "2026-01-01T00:00:00Z" },
+    });
+    const res = await callTool("list_endpoints", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
   });
 
   test("list_evidence returns the evidence ledger artifact", async () => {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

`list_endpoints` returns the entire network-wide endpoint catalog with no way to narrow or page it — unlike most other `list_*` MCP tools. Its own description conceded the gap: "discover live endpoints network-wide (filter client-side by kind, status, or latency)".

Adds optional `kind` / `layer` / `netuid` / `provider` / `publication_state` / `status` / `pool_eligible` filters (the enum-valued ones validated against the same `QUERY_ENUMS` the REST contract uses) plus `limit`/`offset` pagination over the filtered result.

**Omitting every arg keeps the response backward compatible** — `endpoints` is unchanged; `total`/`returned`/`offset` are simply added.

`pool_eligible` needed its own tri-state boolean parser (`optionalNullableBoolean`): the existing `optionalBoolean` helper defaults an *absent* flag to `false` (right for a simple flag like `include_endpoints`), which here would have wrongly narrowed an unfiltered call to only `pool_eligible=false` rows. Caught by the "omitting every arg is unchanged" test before this PR — a companion fixture with a `pool_eligible: true` row failed until the fix.

Additive tool input, so `MCP_SERVER_VERSION` and `server.json` both move 1.46.0 -> 1.47.0 per the bump policy (#393); the 7 other test files that hardcode the prior version literal are updated in the same commit.

## Changes
- `src/mcp-server.mjs`: imports `QUERY_ENUMS`; `optionalNullableBoolean` helper; filter + pagination logic on `list_endpoints`'s handler; inputSchema gains the 9 new optional args; version bump.
- `server.json`: version bump to match.
- `tests/mcp-server.test.mjs`: per-field filters (incl. the boolean tri-state case), combined (AND) filtering, limit/offset pagination, invalid enum/boolean rejection; the old "rejects an unexpected argument" test now uses a genuinely unsupported key since `netuid` is valid now.
- The 7 version-literal files: bumped to match.

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed. Independent of #3199 (list_candidates) — different tool, no file overlap beyond the same 9 version-bump files (identical target value, so no conflict expected).

## Validation
- `node scripts/validate-mcp.mjs` (115 tools, version consistency) — green
- Full relevant suite (`mcp-server.test.mjs` + the 7 version-literal files) — 652 passed; new lines fully covered
- `npm run lint`, `npm run format:check` — clean