### PR TITLE
feat(mcp): add get_chain_stake_transfers mirroring GET /api/v1/chain/stake-transfers

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -441,6 +441,16 @@ assert.ok(
     chainStakeMoves.network != null,
   "get_chain_stake_moves must return subnet_count + network + subnets[]",
 );
+const chainStakeTransfers = await callOk("get_chain_stake_transfers", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainStakeTransfers.subnet_count) &&
+    Array.isArray(chainStakeTransfers.subnets) &&
+    chainStakeTransfers.network != null,
+  "get_chain_stake_transfers must return subnet_count + network + subnets[]",
+);
 const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -118,6 +118,13 @@ import {
   DEFAULT_CHAIN_STAKE_MOVES_WINDOW,
 } from "./chain-stake-moves.mjs";
 import {
+  loadChainStakeTransfers,
+  CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+  CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
+  CHAIN_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW,
+} from "./chain-stake-transfers.mjs";
+import {
   loadChainTransferPairs,
   CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
   CHAIN_TRANSFER_PAIR_LIMIT_MAX,
@@ -314,7 +321,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.46.0";
+export const MCP_SERVER_VERSION = "1.47.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -323,6 +330,9 @@ const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
 const CHAIN_STAKE_MOVES_WINDOW_KEYS = Object.keys(CHAIN_STAKE_MOVES_WINDOWS);
+const CHAIN_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
+  CHAIN_STAKE_TRANSFERS_WINDOWS,
+);
 const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
 );
@@ -478,6 +488,9 @@ export const MCP_INSTRUCTIONS =
   "get_chain_stake_moves the network-wide stake-movement (re-delegation) " +
   "leaderboard (per-subnet StakeMoved activity, distinct movers, and " +
   "movements-per-mover intensity) across all subnets, " +
+  "get_chain_stake_transfers the network-wide stake-transfer (between-coldkeys) " +
+  "leaderboard (per-subnet StakeTransferred activity, distinct senders, and " +
+  "transfers-per-sender intensity) across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2399,6 +2412,58 @@ export const MCP_TOOLS = [
       return loadChainStakeMoves(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_STAKE_MOVES_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_stake_transfers",
+    title: "Get network-wide stake-transfer (between-coldkeys) activity",
+    description:
+      "Fetch the network-wide stake-transfer leaderboard over the requested " +
+      "window (7d or 30d; default 7d): each subnet ranked by StakeTransferred " +
+      "events with its distinct-sender (origin coldkey) count and " +
+      "transfers-per-sender intensity, plus a network rollup (distinct senders, " +
+      "total transfers, transfers per sender) and the count/mean/min/p25/median/" +
+      "p75/p90/max spread of per-subnet intensity, summed live from the " +
+      "account_events stream. StakeTransferred moves staked alpha from one " +
+      "coldkey to another on the same hotkey — it relocates ownership, not net " +
+      "capital (get_chain_stake_flow) or re-delegation churn (get_chain_stake_moves). " +
+      "Mirrors GET /api/v1/chain/stake-transfers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_STAKE_TRANSFERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the stake-transfer leaderboard (1-${CHAIN_STAKE_TRANSFERS_LIMIT_MAX}, default ${CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
+      if (!Object.hasOwn(CHAIN_STAKE_TRANSFERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_STAKE_TRANSFERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+        CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
+      );
+      return loadChainStakeTransfers(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_STAKE_TRANSFERS_WINDOWS[window],
         limit,
       });
     },
@@ -6899,6 +6964,80 @@ const TOOL_OUTPUT_SCHEMAS = {
             distinct_movers: { type: "integer" },
             movements: { type: "integer" },
             movements_per_mover: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_stake_transfers: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that saw a StakeTransferred event. A
+      // coldkey transferring stake out of several subnets counts once in
+      // distinct_senders. transfers_per_sender is null when the network-wide
+      // distinct-sender count is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: ["distinct_senders", "transfers", "transfers_per_sender"],
+        properties: {
+          distinct_senders: { type: "integer" },
+          transfers: { type: "integer" },
+          transfers_per_sender: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet transfer intensity (StakeTransferred events per
+      // sender) over EVERY subnet that saw a transfer; null when no subnet saw
+      // a transfer in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet stake-transfer leaderboard, most StakeTransferred events
+      // first. Each listed subnet has at least one distinct sender, so
+      // transfers_per_sender is always a finite number here (never divide-by-zero).
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_senders",
+            "transfers",
+            "transfers_per_sender",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_senders: { type: "integer" },
+            transfers: { type: "integer" },
+            transfers_per_sender: { type: "number" },
           },
         },
       },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6255,6 +6255,8 @@ describe("MCP economics + metagraph data tools", () => {
     weightsSubnetRows = [],
     stakeMovesNetworkRows = [],
     stakeMovesSubnetRows = [],
+    stakeTransfersNetworkRows = [],
+    stakeTransfersSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
   } = {}) {
@@ -6269,10 +6271,12 @@ describe("MCP economics + metagraph data tools", () => {
                   // + weight_sets) then a per-subnet GROUP BY (weight_sets);
                   // get_chain_stake_moves reads a network aggregate
                   // (newest_observed + distinct_movers, no weight_sets) then a
-                  // per-subnet GROUP BY (AS movements); get_chain_transfer_pairs
-                  // reads a totals CTE (top_pair_volume_tao) then per-corridor
-                  // rows (AS from_address); everything else uses the flat
-                  // account_events fixture (e.g. get_chain_stake_flow).
+                  // per-subnet GROUP BY (AS movements); get_chain_stake_transfers
+                  // reads a network aggregate (newest_observed + distinct_senders)
+                  // then a per-subnet GROUP BY (AS transfers);
+                  // get_chain_transfer_pairs reads a totals CTE
+                  // (top_pair_volume_tao) then per-corridor rows (AS from_address);
+                  // everything else uses the flat account_events fixture.
                   if (sql.includes("newest_observed")) {
                     if (sql.includes("weight_sets")) {
                       return Promise.resolve({ results: weightsNetworkRows });
@@ -6282,6 +6286,11 @@ describe("MCP economics + metagraph data tools", () => {
                         results: stakeMovesNetworkRows,
                       });
                     }
+                    if (sql.includes("distinct_senders")) {
+                      return Promise.resolve({
+                        results: stakeTransfersNetworkRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
@@ -6289,6 +6298,11 @@ describe("MCP economics + metagraph data tools", () => {
                   }
                   if (sql.includes("AS movements")) {
                     return Promise.resolve({ results: stakeMovesSubnetRows });
+                  }
+                  if (sql.includes("AS transfers")) {
+                    return Promise.resolve({
+                      results: stakeTransfersSubnetRows,
+                    });
                   }
                   if (sql.includes("top_pair_volume_tao")) {
                     return Promise.resolve({ results: transferPairTotals });
@@ -7485,6 +7499,114 @@ describe("MCP economics + metagraph data tools", () => {
       chainStakeMovesEnv(stakeMovesNetwork(8), [
         stakeMovesRow(1, 20, 5),
         stakeMovesRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainStakeTransfers reads first (its
+  // COUNT(DISTINCT coldkey)/MAX(observed_at) probe); a non-null newest_observed
+  // unlocks the per-subnet read.
+  function stakeTransfersNetwork(distinct_senders) {
+    return {
+      distinct_senders,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT transfers + distinct senders).
+  function stakeTransfersRow(netuid, transfers, distinct_senders) {
+    return { netuid, transfers, distinct_senders };
+  }
+
+  function chainStakeTransfersEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          stakeTransfersNetworkRows: network ? [network] : [],
+          stakeTransfersSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_stake_transfers returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_stake_transfers", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.transfers, 0);
+    assert.equal(out.network.transfers_per_sender, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_stake_transfers ranks subnets by transfers with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_stake_transfers",
+      { window: "30d", limit: 10 },
+      chainStakeTransfersEnv(stakeTransfersNetwork(8), [
+        // netuid 2: fewer transfers -> ranks last despite higher intensity.
+        stakeTransfersRow(2, 10, 4),
+        // netuid 1: most StakeTransferred events -> ranks first.
+        stakeTransfersRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].transfers, 20);
+    assert.equal(out.subnets[0].transfers_per_sender, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].transfers_per_sender, 2.5); // 10 / 4
+    // Network rollup: total transfers 30 over 8 distinct senders -> 3.75.
+    assert.equal(out.network.transfers, 30);
+    assert.equal(out.network.distinct_senders, 8);
+    assert.equal(out.network.transfers_per_sender, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_stake_transfers rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_chain_stake_transfers",
+      { window: "90d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_stake_transfers caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_stake_transfers",
+      { limit: 1 },
+      chainStakeTransfersEnv(stakeTransfersNetwork(8), [
+        stakeTransfersRow(1, 20, 5),
+        stakeTransfersRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_stake_transfers payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_stake_transfers",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_stake_transfers",
+      {},
+      chainStakeTransfersEnv(stakeTransfersNetwork(8), [
+        stakeTransfersRow(1, 20, 5),
+        stakeTransfersRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds a new MCP tool `get_chain_stake_transfers` that exposes the network-wide **stake-transfer (between-coldkeys) leaderboard** — the ownership-relocation companion to `get_chain_stake_moves` (re-delegation churn) and `get_chain_stake_flow` (net capital flow).

Each subnet is ranked by `StakeTransferred` events with its distinct-sender (origin coldkey) count and `transfers_per_sender` intensity, plus:
- a **network rollup** (distinct senders, total transfers, transfers per sender), and
- the `count/mean/min/p25/median/p75/p90/max` **spread of per-subnet intensity**,

summed live from the `account_events` stream over a `7d`/`30d` window (default `7d`).

`StakeTransferred` moves staked alpha from one coldkey to another on the same hotkey — it relocates ownership, not net capital or re-delegation churn.

The tool delegates to the existing `loadChainStakeTransfers` loader that already backs `GET /api/v1/chain/stake-transfers` (#3192), so the MCP surface stays in lockstep with the REST endpoint (same window set, same `limit` bounds 1–100, default 20, same cold-store zeros).

## Changes
- `src/mcp-server.mjs`: register `get_chain_stake_transfers` (import, window keys, instructions, handler with window/limit validation, deeply-typed output schema); bump `MCP_SERVER_VERSION` to `1.47.0` (additive — new tool).
- `server.json`: version → `1.47.0`.
- `scripts/validate-mcp.mjs`: cold-path assertion for the new tool.
- Tests: cold-store zeros, ranking + network rollup, unsupported-window rejection, limit cap, and output-schema validation; version-assertion updates.

No changes to `src/chain-stake-transfers.mjs` — the loader and its window/limit constants already exist (they back the REST route).

## Test plan
- [x] `npm run validate:mcp` (116 tools, lifecycle + all tools/call)
- [x] `npx vitest run` for `mcp-server` + `chain-stake-transfers` + all version-assertion suites (678 passed)
- [x] `eslint` + `prettier` clean
- [x] No conflict with open PRs (#3201 list_endpoints, #3200 chain median fix)

Made with [Cursor](https://cursor.com)