### PR TITLE
feat(mcp): filter and paginate list_candidates

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -18,7 +18,7 @@ import {
 import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
-import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,
@@ -314,7 +314,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.46.0";
+export const MCP_SERVER_VERSION = "1.47.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -5064,18 +5064,71 @@ export const MCP_TOOLS = [
     name: "list_candidates",
     title: "List unpromoted candidate surfaces",
     description:
-      "Fetch the full catalog of unpromoted candidate surfaces across all " +
-      "subnets: surfaces that have been discovered or proposed but not yet " +
-      "curated/promoted, each with its subnet (netuid), kind, provider, and " +
-      "review state. Use it to see what enrichment is still pending, versus the " +
-      "promoted catalog in list_surfaces. Mirrors GET /api/v1/candidates.",
+      "Fetch unpromoted candidate surfaces across all subnets: surfaces that " +
+      "have been discovered or proposed but not yet curated/promoted, each " +
+      "with its subnet (netuid), kind, provider, and review state. Use it to " +
+      "see what enrichment is still pending, versus the promoted catalog in " +
+      "list_surfaces. Optionally filter by netuid/kind/provider/state and page " +
+      "with limit/offset — the full catalog can be large. Mirrors " +
+      "GET /api/v1/candidates.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        kind: {
+          type: "string",
+          enum: QUERY_ENUMS.surfaceKind,
+          description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
+        },
+        provider: {
+          type: "string",
+          description: "Provider slug, e.g. 'datura'.",
+        },
+        state: {
+          type: "string",
+          enum: QUERY_ENUMS.candidateState,
+          description: "Review state, e.g. 'schema-valid' or 'verified'.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max candidates to return. Omit for the full list.",
+          minimum: 1,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset into the (filtered) list. Default 0.",
+          minimum: 0,
+        },
+      },
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/candidates.json");
+    async handler(args, ctx) {
+      const netuid = optionalNonNegativeInt(args, "netuid");
+      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
+      const provider = optionalString(args, "provider");
+      const state = optionalEnum(args, "state", QUERY_ENUMS.candidateState);
+      const limit = optionalPositiveInt(args, "limit");
+      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const data = await loadArtifactData(ctx, "/metagraph/candidates.json");
+      const all = Array.isArray(data.candidates) ? data.candidates : [];
+      const filtered = all.filter(
+        (c) =>
+          (netuid === null || c.netuid === netuid) &&
+          (kind === null || c.kind === kind) &&
+          (provider === null || c.provider === provider) &&
+          (state === null || c.state === state),
+      );
+      const page =
+        limit === null
+          ? filtered.slice(offset)
+          : filtered.slice(offset, offset + limit);
+      return {
+        ...data,
+        candidates: page,
+        total: filtered.length,
+        returned: page.length,
+        offset,
+      };
     },
   },
   {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -10994,8 +10994,118 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_candidates rejects an unexpected argument", async () => {
-    const res = await callTool("list_candidates", { netuid: 7 });
+    const res = await callTool("list_candidates", { bogus: 1 });
     assert.equal(res.body.result.isError, true);
+  });
+
+  function candidatesDeps() {
+    return makeDeps({
+      "/metagraph/candidates.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        candidates: [
+          {
+            netuid: 7,
+            kind: "openapi",
+            provider: "datura",
+            state: "verified",
+          },
+          {
+            netuid: 7,
+            kind: "subnet-api",
+            provider: "chutes",
+            state: "schema-valid",
+          },
+          {
+            netuid: 12,
+            kind: "openapi",
+            provider: "datura",
+            state: "stale",
+          },
+        ],
+      },
+    });
+  }
+
+  test("list_candidates filters by netuid, kind, provider, and state", async () => {
+    const deps = candidatesDeps();
+    const byNetuid = (
+      await callTool("list_candidates", { netuid: 12 }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byNetuid.total, 1);
+    assert.equal(byNetuid.candidates[0].provider, "datura");
+
+    const byKind = (
+      await callTool("list_candidates", { kind: "subnet-api" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byKind.total, 1);
+    assert.equal(byKind.candidates[0].provider, "chutes");
+
+    const byProvider = (
+      await callTool("list_candidates", { provider: "datura" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byProvider.total, 2);
+
+    const byState = (
+      await callTool("list_candidates", { state: "stale" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byState.total, 1);
+    assert.equal(byState.candidates[0].netuid, 12);
+  });
+
+  test("list_candidates combines filters (AND) and reports total vs returned", async () => {
+    const deps = candidatesDeps();
+    const res = await callTool(
+      "list_candidates",
+      { netuid: 7, provider: "datura" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].kind, "openapi");
+  });
+
+  test("list_candidates paginates the filtered list with limit/offset", async () => {
+    const deps = candidatesDeps();
+    const res = await callTool(
+      "list_candidates",
+      { limit: 1, offset: 1 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 1);
+    assert.equal(out.offset, 1);
+    assert.equal(out.candidates[0].provider, "chutes");
+  });
+
+  test("list_candidates rejects an unknown kind/state enum value", async () => {
+    const deps = candidatesDeps();
+    const badKind = await callTool(
+      "list_candidates",
+      { kind: "not-a-kind" },
+      { deps },
+    );
+    assert.equal(badKind.body.result.isError, true);
+    assert.match(badKind.body.result.content[0].text, /invalid_params/);
+
+    const badState = await callTool(
+      "list_candidates",
+      { state: "not-a-state" },
+      { deps },
+    );
+    assert.equal(badState.body.result.isError, true);
+  });
+
+  test("list_candidates is schema-stable when the artifact has no candidates array", async () => {
+    const deps = makeDeps({
+      "/metagraph/candidates.json": { generated_at: "2026-01-01T00:00:00Z" },
+    });
+    const res = await callTool("list_candidates", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.candidates, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
   });
 
   test("list_endpoints returns the endpoints catalog artifact", async () => {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.46.0");
+    assert.equal(MCP_SERVER_VERSION, "1.47.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Resubmits #3199, closed by the automated gate for a codecov/patch failure on the initial push (a genuine partial-branch coverage gap this commit already fixes): `Array.isArray(data.candidates) ? data.candidates : []` had its false-branch (missing/malformed `candidates` array) untested. Added a "schema-stable when the artifact has no candidates array" test; verified locally (no partial branches remain in the touched region) before this resubmit.

---

`list_candidates` returns the entire unpromoted-candidate catalog (thousands of rows across all subnets) with no way to narrow or page it — unlike most other `list_*` MCP tools. For an agent that only wants one subnet's candidates, or one kind/provider/state, this forces pulling and filtering the full dump client-side (the tool's own description previously said as much for the sibling `list_endpoints`).

Adds optional `netuid` / `kind` / `provider` / `state` filters plus `limit`/`offset` pagination over the filtered result. `kind` and `state` are validated against the same `QUERY_ENUMS.surfaceKind` / `QUERY_ENUMS.candidateState` the REST contract uses (imported from `contracts.mjs`), so the MCP and REST enums can't drift apart.

**Omitting every arg keeps the response backward compatible** — `candidates` is unchanged; `total`/`returned`/`offset` are simply added for callers that do filter or page.

Additive tool input, so `MCP_SERVER_VERSION` and `server.json` both move 1.46.0 -> 1.47.0 per the bump policy (#393); the 7 other test files that hardcode the prior version literal are updated in the same commit.

## Changes
- `src/mcp-server.mjs`: imports `QUERY_ENUMS`; filter + pagination logic on `list_candidates`'s handler; inputSchema gains the 6 new optional args; version bump.
- `server.json`: version bump to match.
- `tests/mcp-server.test.mjs`: per-field filters, combined (AND) filtering, limit/offset pagination, invalid enum rejection, missing-array schema-stability; the old "rejects an unexpected argument" test now uses a genuinely unsupported key since `netuid` is valid now.
- The 7 version-literal files: bumped to match.

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed.

## Validation
- `node scripts/validate-mcp.mjs` (115 tools, version consistency) — green
- Full relevant suite (`mcp-server.test.mjs` + the 7 version-literal files) — green; new lines fully covered (no partial branches)
- `npm run lint`, `npm run format:check` — clean