### PR TITLE
fix(mcp): reject invalid Content-Length before reading the body

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -8897,9 +8897,18 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
   const rateLimitResponse = await enforceMcpRateLimit(request, env);
   if (rateLimitResponse) return rateLimitResponse;
 
-  const contentLength = Number(request.headers.get("content-length") || 0);
-  if (contentLength > MAX_MCP_BODY_BYTES) {
-    return bodyTooLargeResponse();
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const contentLength = Number(declaredLength);
+    if (!Number.isFinite(contentLength) || contentLength < 0) {
+      return jsonResponse(
+        rpcError(null, RPC_INVALID_REQUEST, "Invalid Content-Length header."),
+        400,
+      );
+    }
+    if (contentLength > MAX_MCP_BODY_BYTES) {
+      return bodyTooLargeResponse();
+    }
   }
 
   let body;

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1002,6 +1002,55 @@ describe("handleMcpRequest — rate limiter success + content-length guard", () 
     const body = await response.json();
     assert.equal(body.error.code, -32600);
   });
+
+  test("a request with a negative content-length is rejected with 400", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "-1",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error.code, -32600);
+    assert.match(body.error.message, /Content-Length/i);
+  });
+
+  test("a request with a non-numeric content-length is rejected with 400", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "not-a-number",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error.code, -32600);
+    assert.match(body.error.message, /Content-Length/i);
+  });
+
+  test("a request with a finite content-length within the cap proceeds normally", async () => {
+    const payload = { jsonrpc: "2.0", id: 1, method: "ping" };
+    const body = JSON.stringify(payload);
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(new TextEncoder().encode(body).byteLength),
+      },
+      body,
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 200);
+    const parsed = await response.json();
+    assert.deepEqual(parsed.result, {});
+  });
 });
 
 // ── resolveNetuid index fallback ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Validate the MCP `Content-Length` header when present so non-numeric and negative values return 400 instead of skipping the pre-read guard.
- Keep the existing 413 path for finite lengths above `MAX_MCP_BODY_BYTES`.

## What changed

- `src/mcp-server.mjs` — mirror GraphQL/RPC Content-Length validation before `request.text()`.
- `tests/mcp-server-branch-coverage.test.mjs` — regression tests for negative and non-numeric headers.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/mcp-server-branch-coverage.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`