### PR TITLE
feat(mcp): add get_chain_axon_removals mirroring GET /api/v1/chain/axon-removals

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -451,6 +451,16 @@ assert.ok(
     chainStakeTransfers.network != null,
   "get_chain_stake_transfers must return subnet_count + network + subnets[]",
 );
+const chainAxonRemovals = await callOk("get_chain_axon_removals", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainAxonRemovals.subnet_count) &&
+    Array.isArray(chainAxonRemovals.subnets) &&
+    chainAxonRemovals.network != null,
+  "get_chain_axon_removals must return subnet_count + network + subnets[]",
+);
 const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-axon-removals.mjs
+++ b/src/chain-axon-removals.mjs
@@ -15,6 +15,12 @@ export const AXON_REMOVAL_EVENT_KIND = "AxonInfoRemoved";
 export const CHAIN_AXON_REMOVALS_LIMIT_DEFAULT = 20;
 export const CHAIN_AXON_REMOVALS_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_AXON_REMOVALS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_AXON_REMOVALS_WINDOW = "7d";
+
 // Round a removals-per-remover ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -161,6 +161,13 @@ import {
   CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
   CHAIN_REGISTRATIONS_LIMIT_MAX,
 } from "./chain-registrations.mjs";
+import {
+  loadChainAxonRemovals,
+  CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+  CHAIN_AXON_REMOVALS_LIMIT_MAX,
+  CHAIN_AXON_REMOVALS_WINDOWS,
+  DEFAULT_CHAIN_AXON_REMOVALS_WINDOW,
+} from "./chain-axon-removals.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -321,7 +328,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.47.0";
+export const MCP_SERVER_VERSION = "1.48.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -332,6 +339,9 @@ const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
 const CHAIN_STAKE_MOVES_WINDOW_KEYS = Object.keys(CHAIN_STAKE_MOVES_WINDOWS);
 const CHAIN_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
   CHAIN_STAKE_TRANSFERS_WINDOWS,
+);
+const CHAIN_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
+  CHAIN_AXON_REMOVALS_WINDOWS,
 );
 const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
@@ -491,6 +501,9 @@ export const MCP_INSTRUCTIONS =
   "get_chain_stake_transfers the network-wide stake-transfer (between-coldkeys) " +
   "leaderboard (per-subnet StakeTransferred activity, distinct senders, and " +
   "transfers-per-sender intensity) across all subnets, " +
+  "get_chain_axon_removals the network-wide axon-teardown leaderboard " +
+  "(per-subnet AxonInfoRemoved activity, distinct removers, and " +
+  "removals-per-remover intensity) across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2477,6 +2490,58 @@ export const MCP_TOOLS = [
       return loadChainStakeTransfers(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_STAKE_TRANSFERS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_axon_removals",
+    title: "Get network-wide axon-removal activity",
+    description:
+      "Fetch the network-wide axon-teardown leaderboard over the requested " +
+      "window (7d or 30d; default 7d): each subnet ranked by AxonInfoRemoved " +
+      "events with its distinct-remover (hotkey) count and removals-per-remover " +
+      "intensity, plus a network rollup (distinct removers, total removals, " +
+      "removals per remover) and the count/mean/min/p25/median/p75/p90/max spread " +
+      "of per-subnet intensity, summed live from the account_events stream. " +
+      "AxonInfoRemoved is emitted when a neuron's announced axon endpoint is " +
+      "removed — the teardown-side companion to get_chain_serving (axon " +
+      "announcements) and get_subnet_axon_removals (one subnet). Mirrors GET " +
+      "/api/v1/chain/axon-removals.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_AXON_REMOVALS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_AXON_REMOVALS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the axon-removal leaderboard (1-${CHAIN_AXON_REMOVALS_LIMIT_MAX}, default ${CHAIN_AXON_REMOVALS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_AXON_REMOVALS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
+      if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_AXON_REMOVALS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+        CHAIN_AXON_REMOVALS_LIMIT_MAX,
+      );
+      return loadChainAxonRemovals(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_AXON_REMOVALS_WINDOWS[window],
         limit,
       });
     },
@@ -7182,6 +7247,80 @@ const TOOL_OUTPUT_SCHEMAS = {
             distinct_senders: { type: "integer" },
             transfers: { type: "integer" },
             transfers_per_sender: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_axon_removals: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that saw an AxonInfoRemoved event. A
+      // hotkey removing an axon on several subnets counts once in distinct_removers.
+      // removals_per_remover is null when the network-wide distinct-remover count
+      // is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: ["distinct_removers", "removals", "removals_per_remover"],
+        properties: {
+          distinct_removers: { type: "integer" },
+          removals: { type: "integer" },
+          removals_per_remover: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet re-teardown intensity (AxonInfoRemoved events per
+      // remover) over EVERY subnet that saw a removal; null when no subnet saw
+      // a removal in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet axon-removal leaderboard, most AxonInfoRemoved events first.
+      // Each listed subnet has at least one distinct remover, so removals_per_remover
+      // is always a finite number here (never divide-by-zero).
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_removers",
+            "removals",
+            "removals_per_remover",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_removers: { type: "integer" },
+            removals: { type: "integer" },
+            removals_per_remover: { type: "number" },
           },
         },
       },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6257,6 +6257,8 @@ describe("MCP economics + metagraph data tools", () => {
     stakeMovesSubnetRows = [],
     stakeTransfersNetworkRows = [],
     stakeTransfersSubnetRows = [],
+    axonRemovalsNetworkRows = [],
+    axonRemovalsSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
   } = {}) {
@@ -6291,6 +6293,11 @@ describe("MCP economics + metagraph data tools", () => {
                         results: stakeTransfersNetworkRows,
                       });
                     }
+                    if (sql.includes("distinct_removers")) {
+                      return Promise.resolve({
+                        results: axonRemovalsNetworkRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
@@ -6303,6 +6310,9 @@ describe("MCP economics + metagraph data tools", () => {
                     return Promise.resolve({
                       results: stakeTransfersSubnetRows,
                     });
+                  }
+                  if (sql.includes("AS removals")) {
+                    return Promise.resolve({ results: axonRemovalsSubnetRows });
                   }
                   if (sql.includes("top_pair_volume_tao")) {
                     return Promise.resolve({ results: transferPairTotals });
@@ -7607,6 +7617,114 @@ describe("MCP economics + metagraph data tools", () => {
       chainStakeTransfersEnv(stakeTransfersNetwork(8), [
         stakeTransfersRow(1, 20, 5),
         stakeTransfersRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainAxonRemovals reads first (its
+  // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
+  // unlocks the per-subnet read.
+  function axonRemovalsNetwork(distinct_removers) {
+    return {
+      distinct_removers,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT removals + distinct removers).
+  function axonRemovalsRow(netuid, removals, distinct_removers) {
+    return { netuid, removals, distinct_removers };
+  }
+
+  function chainAxonRemovalsEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          axonRemovalsNetworkRows: network ? [network] : [],
+          axonRemovalsSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_axon_removals returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_axon_removals", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.removals, 0);
+    assert.equal(out.network.removals_per_remover, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_axon_removals ranks subnets by removals with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_axon_removals",
+      { window: "30d", limit: 10 },
+      chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
+        // netuid 2: fewer removals -> ranks last despite higher intensity.
+        axonRemovalsRow(2, 10, 4),
+        // netuid 1: most AxonInfoRemoved events -> ranks first.
+        axonRemovalsRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].removals, 20);
+    assert.equal(out.subnets[0].removals_per_remover, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].removals_per_remover, 2.5); // 10 / 4
+    // Network rollup: total removals 30 over 8 distinct removers -> 3.75.
+    assert.equal(out.network.removals, 30);
+    assert.equal(out.network.distinct_removers, 8);
+    assert.equal(out.network.removals_per_remover, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_axon_removals rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_chain_axon_removals",
+      { window: "90d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_axon_removals caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_axon_removals",
+      { limit: 1 },
+      chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
+        axonRemovalsRow(1, 20, 5),
+        axonRemovalsRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_axon_removals payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_axon_removals",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_axon_removals",
+      {},
+      chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
+        axonRemovalsRow(1, 20, 5),
+        axonRemovalsRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.47.0");
+    assert.equal(MCP_SERVER_VERSION, "1.48.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds a new MCP tool `get_chain_axon_removals` that exposes the network-wide **axon-teardown leaderboard** — the network-wide companion to `get_subnet_axon_removals` (one subnet) and the teardown-side counterpart to `get_chain_serving` (axon announcements).

Each subnet is ranked by `AxonInfoRemoved` events with its distinct-remover (hotkey) count and `removals_per_remover` intensity, plus:
- a **network rollup** (distinct removers, total removals, removals per remover), and
- the `count/mean/min/p25/median/p75/p90/max` **spread of per-subnet intensity**,

summed live from the `account_events` stream over a `7d`/`30d` window (default `7d`).

The tool delegates to the existing `loadChainAxonRemovals` loader that already backs `GET /api/v1/chain/axon-removals`, so the MCP surface stays in lockstep with the REST endpoint (same window set, same `limit` bounds 1–100, default 20, same cold-store zeros).

## Changes
- `src/chain-axon-removals.mjs`: export `CHAIN_AXON_REMOVALS_WINDOWS` / `DEFAULT_CHAIN_AXON_REMOVALS_WINDOW` (co-located with the loader so the tool schema cannot drift from the route).
- `src/mcp-server.mjs`: register `get_chain_axon_removals` (import, window keys, instructions, handler with window/limit validation, deeply-typed output schema); bump `MCP_SERVER_VERSION` to `1.48.0` (additive — new tool).
- `server.json`: version → `1.48.0`.
- `scripts/validate-mcp.mjs`: cold-path assertion for the new tool.
- Tests: cold-store zeros, ranking + network rollup, unsupported-window rejection, limit cap, and output-schema validation; version-assertion updates.

## Test plan
- [x] `npm run validate:mcp` (117 tools, lifecycle + all tools/call)
- [x] `npx vitest run` for `mcp-server` + `chain-axon-removals` + all version-assertion suites (694 passed)
- [x] `eslint` + `prettier` clean
- [x] No conflict with open PRs (#3194 streamer fix, #3153 enrich chore)
