### PR TITLE
feat(mcp): add get_chain_deregistrations mirroring GET /api/v1/chain/deregistrations

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -461,6 +461,16 @@ assert.ok(
     chainAxonRemovals.network != null,
   "get_chain_axon_removals must return subnet_count + network + subnets[]",
 );
+const chainDeregistrations = await callOk("get_chain_deregistrations", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainDeregistrations.subnet_count) &&
+    Array.isArray(chainDeregistrations.subnets) &&
+    chainDeregistrations.network != null,
+  "get_chain_deregistrations must return subnet_count + network + subnets[]",
+);
 const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-deregistrations.mjs
+++ b/src/chain-deregistrations.mjs
@@ -15,6 +15,12 @@ export const DEREGISTRATION_EVENT_KIND = "NeuronDeregistered";
 export const CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT = 20;
 export const CHAIN_DEREGISTRATIONS_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_DEREGISTRATIONS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW = "7d";
+
 // Round a deregistrations-per-hotkey ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -168,6 +168,13 @@ import {
   CHAIN_AXON_REMOVALS_WINDOWS,
   DEFAULT_CHAIN_AXON_REMOVALS_WINDOW,
 } from "./chain-axon-removals.mjs";
+import {
+  loadChainDeregistrations,
+  CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+  CHAIN_DEREGISTRATIONS_WINDOWS,
+  DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW,
+} from "./chain-deregistrations.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -328,7 +335,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.48.0";
+export const MCP_SERVER_VERSION = "1.49.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -342,6 +349,9 @@ const CHAIN_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
 );
 const CHAIN_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
   CHAIN_AXON_REMOVALS_WINDOWS,
+);
+const CHAIN_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
+  CHAIN_DEREGISTRATIONS_WINDOWS,
 );
 const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
@@ -477,6 +487,9 @@ export const MCP_INSTRUCTIONS =
   "fee/tip market series plus top payers, get_chain_registrations the " +
   "network-wide neuron-registration leaderboard (per-subnet NeuronRegistered " +
   "activity and re-registration intensity) across all subnets, " +
+  "get_chain_deregistrations the network-wide neuron-deregistration leaderboard " +
+  "(per-subnet NeuronDeregistered activity, distinct deregistered hotkeys, and " +
+  "deregistrations-per-hotkey intensity) across all subnets, " +
   "get_chain_transfers network-wide " +
   "native-TAO transfer volume plus top senders/receivers, " +
   "get_chain_transfer_pairs the top sender->receiver transfer corridors " +
@@ -4874,6 +4887,58 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_deregistrations",
+    title: "Get network-wide neuron-deregistration activity",
+    description:
+      "Fetch the network-wide neuron-deregistration leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by " +
+      "NeuronDeregistered events with its distinct-deregistered-hotkey count and " +
+      "deregistrations-per-hotkey intensity, plus a network rollup (distinct " +
+      "deregistered hotkeys, total deregistrations, deregistrations per hotkey) " +
+      "and the count/mean/min/p25/median/p75/p90/max spread of per-subnet " +
+      "intensity, summed live from the account_events stream. Raw eviction " +
+      "activity — the exit-side companion to get_chain_registrations " +
+      "(NeuronRegistered demand) and get_subnet_deregistrations (one subnet). " +
+      "Mirrors GET /api/v1/chain/deregistrations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_DEREGISTRATIONS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the deregistration leaderboard (1-${CHAIN_DEREGISTRATIONS_LIMIT_MAX}, default ${CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
+      if (!Object.hasOwn(CHAIN_DEREGISTRATIONS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_DEREGISTRATIONS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+        CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+      );
+      return loadChainDeregistrations(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_DEREGISTRATIONS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
     name: "get_chain_transfers",
     title: "Get network-wide native-TAO transfer analytics",
     description:
@@ -8262,6 +8327,84 @@ const TOOL_OUTPUT_SCHEMAS = {
         registrations: NULLABLE_INT,
         registrations_per_registrant: { type: ["number", "null"] },
       }),
+    },
+  },
+  get_chain_deregistrations: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that saw a NeuronDeregistered event. A
+      // hotkey deregistered on several subnets counts once in
+      // distinct_deregistered_hotkeys. deregistrations_per_hotkey is null when
+      // the network-wide distinct-hotkey count is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "distinct_deregistered_hotkeys",
+          "deregistrations",
+          "deregistrations_per_hotkey",
+        ],
+        properties: {
+          distinct_deregistered_hotkeys: { type: "integer" },
+          deregistrations: { type: "integer" },
+          deregistrations_per_hotkey: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet re-deregistration intensity (NeuronDeregistered
+      // events per hotkey) over EVERY subnet that saw a deregistration; null when
+      // no subnet saw a deregistration in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet deregistration leaderboard, most NeuronDeregistered events
+      // first. Each listed subnet has at least one distinct deregistered hotkey,
+      // so deregistrations_per_hotkey is always a finite number here.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_deregistered_hotkeys",
+            "deregistrations",
+            "deregistrations_per_hotkey",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_deregistered_hotkeys: { type: "integer" },
+            deregistrations: { type: "integer" },
+            deregistrations_per_hotkey: { type: "number" },
+          },
+        },
+      },
     },
   },
   get_chain_transfers: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6259,6 +6259,8 @@ describe("MCP economics + metagraph data tools", () => {
     stakeTransfersSubnetRows = [],
     axonRemovalsNetworkRows = [],
     axonRemovalsSubnetRows = [],
+    chainDeregistrationsNetworkRows = [],
+    chainDeregistrationsSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
   } = {}) {
@@ -6276,6 +6278,12 @@ describe("MCP economics + metagraph data tools", () => {
                   // per-subnet GROUP BY (AS movements); get_chain_stake_transfers
                   // reads a network aggregate (newest_observed + distinct_senders)
                   // then a per-subnet GROUP BY (AS transfers);
+                  // get_chain_axon_removals reads a network aggregate
+                  // (newest_observed + distinct_removers) then a per-subnet
+                  // GROUP BY (AS removals); get_chain_deregistrations reads a
+                  // network aggregate (newest_observed +
+                  // distinct_deregistered_hotkeys) then a per-subnet GROUP BY
+                  // (AS deregistrations + distinct_deregistered_hotkeys);
                   // get_chain_transfer_pairs reads a totals CTE
                   // (top_pair_volume_tao) then per-corridor rows (AS from_address);
                   // everything else uses the flat account_events fixture.
@@ -6298,6 +6306,11 @@ describe("MCP economics + metagraph data tools", () => {
                         results: axonRemovalsNetworkRows,
                       });
                     }
+                    if (sql.includes("distinct_deregistered_hotkeys")) {
+                      return Promise.resolve({
+                        results: chainDeregistrationsNetworkRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
@@ -6313,6 +6326,14 @@ describe("MCP economics + metagraph data tools", () => {
                   }
                   if (sql.includes("AS removals")) {
                     return Promise.resolve({ results: axonRemovalsSubnetRows });
+                  }
+                  if (
+                    sql.includes("AS deregistrations") &&
+                    sql.includes("distinct_deregistered_hotkeys")
+                  ) {
+                    return Promise.resolve({
+                      results: chainDeregistrationsSubnetRows,
+                    });
                   }
                   if (sql.includes("top_pair_volume_tao")) {
                     return Promise.resolve({ results: transferPairTotals });
@@ -7725,6 +7746,118 @@ describe("MCP economics + metagraph data tools", () => {
       chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
         axonRemovalsRow(1, 20, 5),
         axonRemovalsRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainDeregistrations reads first (its
+  // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
+  // unlocks the per-subnet read.
+  function chainDeregistrationsNetwork(distinct_deregistered_hotkeys) {
+    return {
+      distinct_deregistered_hotkeys,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT deregistrations + distinct hotkeys).
+  function chainDeregistrationsRow(
+    netuid,
+    deregistrations,
+    distinct_deregistered_hotkeys,
+  ) {
+    return { netuid, deregistrations, distinct_deregistered_hotkeys };
+  }
+
+  function chainDeregistrationsEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          chainDeregistrationsNetworkRows: network ? [network] : [],
+          chainDeregistrationsSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_deregistrations returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_deregistrations", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.deregistrations, 0);
+    assert.equal(out.network.deregistrations_per_hotkey, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_deregistrations ranks subnets by deregistrations with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_deregistrations",
+      { window: "30d", limit: 10 },
+      chainDeregistrationsEnv(chainDeregistrationsNetwork(8), [
+        // netuid 2: fewer deregistrations -> ranks last despite higher intensity.
+        chainDeregistrationsRow(2, 10, 4),
+        // netuid 1: most NeuronDeregistered events -> ranks first.
+        chainDeregistrationsRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].deregistrations, 20);
+    assert.equal(out.subnets[0].deregistrations_per_hotkey, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].deregistrations_per_hotkey, 2.5); // 10 / 4
+    // Network rollup: total deregistrations 30 over 8 distinct hotkeys -> 3.75.
+    assert.equal(out.network.deregistrations, 30);
+    assert.equal(out.network.distinct_deregistered_hotkeys, 8);
+    assert.equal(out.network.deregistrations_per_hotkey, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_deregistrations rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_chain_deregistrations",
+      { window: "90d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_deregistrations caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_deregistrations",
+      { limit: 1 },
+      chainDeregistrationsEnv(chainDeregistrationsNetwork(8), [
+        chainDeregistrationsRow(1, 20, 5),
+        chainDeregistrationsRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_deregistrations payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_deregistrations",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_deregistrations",
+      {},
+      chainDeregistrationsEnv(chainDeregistrationsNetwork(8), [
+        chainDeregistrationsRow(1, 20, 5),
+        chainDeregistrationsRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.48.0");
+    assert.equal(MCP_SERVER_VERSION, "1.49.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_chain_deregistrations` MCP tool mirroring `GET /api/v1/chain/deregistrations`, wiring the existing `loadChainDeregistrations` loader with REST-parity `7d`/`30d` window and leaderboard limit validation.
- Export `CHAIN_DEREGISTRATIONS_WINDOWS` / `DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW` from the loader module and add a deeply-typed output schema (network rollup, intensity distribution, per-subnet leaderboard).
- Bump MCP server version to `1.49.0` (118 tools); extend validate-mcp cold path, D1 mock routing, and five integration tests (cold zeros, ranking + rollup, bad window, limit cap, output schema validation).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/mcp-server.test.mjs tests/chain-deregistrations.test.mjs` (+ version assertion suites)