### PR TITLE
feat(mcp): add get_chain_prometheus mirroring GET /api/v1/chain/prometheus

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -471,6 +471,16 @@ assert.ok(
     chainDeregistrations.network != null,
   "get_chain_deregistrations must return subnet_count + network + subnets[]",
 );
+const chainPrometheus = await callOk("get_chain_prometheus", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainPrometheus.subnet_count) &&
+    Array.isArray(chainPrometheus.subnets) &&
+    chainPrometheus.network != null,
+  "get_chain_prometheus must return subnet_count + network + subnets[]",
+);
 const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-prometheus.mjs
+++ b/src/chain-prometheus.mjs
@@ -14,6 +14,12 @@ export const PROMETHEUS_EVENT_KIND = "PrometheusServed";
 export const CHAIN_PROMETHEUS_LIMIT_DEFAULT = 20;
 export const CHAIN_PROMETHEUS_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_PROMETHEUS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_PROMETHEUS_WINDOW = "7d";
+
 // Round an announcements-per-exporter ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -175,6 +175,13 @@ import {
   CHAIN_DEREGISTRATIONS_WINDOWS,
   DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW,
 } from "./chain-deregistrations.mjs";
+import {
+  loadChainPrometheus,
+  CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+  CHAIN_PROMETHEUS_LIMIT_MAX,
+  CHAIN_PROMETHEUS_WINDOWS,
+  DEFAULT_CHAIN_PROMETHEUS_WINDOW,
+} from "./chain-prometheus.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -335,7 +342,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.49.0";
+export const MCP_SERVER_VERSION = "1.50.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -353,6 +360,7 @@ const CHAIN_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
 const CHAIN_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   CHAIN_DEREGISTRATIONS_WINDOWS,
 );
+const CHAIN_PROMETHEUS_WINDOW_KEYS = Object.keys(CHAIN_PROMETHEUS_WINDOWS);
 const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
 );
@@ -517,6 +525,9 @@ export const MCP_INSTRUCTIONS =
   "get_chain_axon_removals the network-wide axon-teardown leaderboard " +
   "(per-subnet AxonInfoRemoved activity, distinct removers, and " +
   "removals-per-remover intensity) across all subnets, " +
+  "get_chain_prometheus the network-wide Prometheus-endpoint serving " +
+  "leaderboard (per-subnet PrometheusServed activity, distinct exporters, and " +
+  "announcements-per-exporter intensity) across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2555,6 +2566,59 @@ export const MCP_TOOLS = [
       return loadChainAxonRemovals(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_AXON_REMOVALS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_prometheus",
+    title: "Get network-wide Prometheus-endpoint serving activity",
+    description:
+      "Fetch the network-wide Prometheus-endpoint serving leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by " +
+      "PrometheusServed events with its distinct-exporter (hotkey) count and " +
+      "announcements-per-exporter intensity, plus a network rollup (distinct " +
+      "exporters, total announcements, announcements per exporter) and the " +
+      "count/mean/min/p25/median/p75/p90/max spread of per-subnet intensity, " +
+      "summed live from the account_events stream. PrometheusServed is emitted " +
+      "when a neuron announces its Prometheus telemetry endpoint — the " +
+      "telemetry-endpoint companion to get_chain_serving (axon announcements) " +
+      "and get_subnet_prometheus (one subnet). Mirrors GET " +
+      "/api/v1/chain/prometheus.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_PROMETHEUS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_PROMETHEUS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the Prometheus serving leaderboard (1-${CHAIN_PROMETHEUS_LIMIT_MAX}, default ${CHAIN_PROMETHEUS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_PROMETHEUS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_PROMETHEUS_WINDOW;
+      if (!Object.hasOwn(CHAIN_PROMETHEUS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_PROMETHEUS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+        CHAIN_PROMETHEUS_LIMIT_MAX,
+      );
+      return loadChainPrometheus(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_PROMETHEUS_WINDOWS[window],
         limit,
       });
     },
@@ -7386,6 +7450,84 @@ const TOOL_OUTPUT_SCHEMAS = {
             distinct_removers: { type: "integer" },
             removals: { type: "integer" },
             removals_per_remover: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_prometheus: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that saw a PrometheusServed event. A
+      // hotkey announcing on several subnets counts once in distinct_exporters.
+      // announcements_per_exporter is null when the network-wide distinct-exporter
+      // count is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "distinct_exporters",
+          "announcements",
+          "announcements_per_exporter",
+        ],
+        properties: {
+          distinct_exporters: { type: "integer" },
+          announcements: { type: "integer" },
+          announcements_per_exporter: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet re-announcement intensity (PrometheusServed events
+      // per exporter) over EVERY subnet that saw an announcement; null when no
+      // subnet saw Prometheus activity in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet Prometheus serving leaderboard, most PrometheusServed events
+      // first. Each listed subnet has at least one distinct exporter, so
+      // announcements_per_exporter is always a finite number here.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_exporters",
+            "announcements",
+            "announcements_per_exporter",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_exporters: { type: "integer" },
+            announcements: { type: "integer" },
+            announcements_per_exporter: { type: "number" },
           },
         },
       },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6261,6 +6261,8 @@ describe("MCP economics + metagraph data tools", () => {
     axonRemovalsSubnetRows = [],
     chainDeregistrationsNetworkRows = [],
     chainDeregistrationsSubnetRows = [],
+    chainPrometheusNetworkRows = [],
+    chainPrometheusSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
   } = {}) {
@@ -6284,6 +6286,9 @@ describe("MCP economics + metagraph data tools", () => {
                   // network aggregate (newest_observed +
                   // distinct_deregistered_hotkeys) then a per-subnet GROUP BY
                   // (AS deregistrations + distinct_deregistered_hotkeys);
+                  // get_chain_prometheus reads a network aggregate
+                  // (newest_observed + distinct_exporters) then a per-subnet GROUP BY
+                  // (AS announcements + distinct_exporters);
                   // get_chain_transfer_pairs reads a totals CTE
                   // (top_pair_volume_tao) then per-corridor rows (AS from_address);
                   // everything else uses the flat account_events fixture.
@@ -6311,6 +6316,11 @@ describe("MCP economics + metagraph data tools", () => {
                         results: chainDeregistrationsNetworkRows,
                       });
                     }
+                    if (sql.includes("distinct_exporters")) {
+                      return Promise.resolve({
+                        results: chainPrometheusNetworkRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
@@ -6333,6 +6343,14 @@ describe("MCP economics + metagraph data tools", () => {
                   ) {
                     return Promise.resolve({
                       results: chainDeregistrationsSubnetRows,
+                    });
+                  }
+                  if (
+                    sql.includes("AS announcements") &&
+                    sql.includes("distinct_exporters")
+                  ) {
+                    return Promise.resolve({
+                      results: chainPrometheusSubnetRows,
                     });
                   }
                   if (sql.includes("top_pair_volume_tao")) {
@@ -7858,6 +7876,110 @@ describe("MCP economics + metagraph data tools", () => {
       chainDeregistrationsEnv(chainDeregistrationsNetwork(8), [
         chainDeregistrationsRow(1, 20, 5),
         chainDeregistrationsRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainPrometheus reads first (its
+  // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
+  // unlocks the per-subnet read.
+  function chainPrometheusNetwork(distinct_exporters) {
+    return {
+      distinct_exporters,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT announcements + distinct exporters).
+  function chainPrometheusRow(netuid, announcements, distinct_exporters) {
+    return { netuid, announcements, distinct_exporters };
+  }
+
+  function chainPrometheusEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          chainPrometheusNetworkRows: network ? [network] : [],
+          chainPrometheusSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_prometheus returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_prometheus", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.announcements, 0);
+    assert.equal(out.network.announcements_per_exporter, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_prometheus ranks subnets by announcements with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_prometheus",
+      { window: "30d", limit: 10 },
+      chainPrometheusEnv(chainPrometheusNetwork(8), [
+        // netuid 2: fewer announcements -> ranks last despite higher intensity.
+        chainPrometheusRow(2, 10, 4),
+        // netuid 1: most PrometheusServed events -> ranks first.
+        chainPrometheusRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].announcements, 20);
+    assert.equal(out.subnets[0].announcements_per_exporter, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].announcements_per_exporter, 2.5); // 10 / 4
+    // Network rollup: total announcements 30 over 8 distinct exporters -> 3.75.
+    assert.equal(out.network.announcements, 30);
+    assert.equal(out.network.distinct_exporters, 8);
+    assert.equal(out.network.announcements_per_exporter, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_prometheus rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_prometheus", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_prometheus caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_prometheus",
+      { limit: 1 },
+      chainPrometheusEnv(chainPrometheusNetwork(8), [
+        chainPrometheusRow(1, 20, 5),
+        chainPrometheusRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_prometheus payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_prometheus",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_prometheus",
+      {},
+      chainPrometheusEnv(chainPrometheusNetwork(8), [
+        chainPrometheusRow(1, 20, 5),
+        chainPrometheusRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.49.0");
+    assert.equal(MCP_SERVER_VERSION, "1.50.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_chain_prometheus` MCP tool mirroring `GET /api/v1/chain/prometheus`, wiring the existing `loadChainPrometheus` loader with REST-parity `7d`/`30d` window and leaderboard limit validation.
- Export `CHAIN_PROMETHEUS_WINDOWS` / `DEFAULT_CHAIN_PROMETHEUS_WINDOW` from the loader module and add a deeply-typed output schema (network rollup, intensity distribution, per-subnet leaderboard).
- Bump MCP server version to `1.50.0` (119 tools); extend validate-mcp cold path, D1 mock routing, and five integration tests (cold zeros, ranking + rollup, bad window, limit cap, output schema validation).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/mcp-server.test.mjs tests/chain-prometheus.test.mjs` (+ version assertion suites)