### PR TITLE
fix(webhooks): reject invalid Content-Length before reading the body

### DIFF
--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -500,6 +500,47 @@ describe("webhook route edge cases", () => {
     assert.equal((await res.json()).error.code, "payload_too_large");
   });
 
+  test("400 when Content-Length is invalid before reading the body", async () => {
+    for (const contentLength of ["-1", "not-a-number"]) {
+      const res = await handleRequest(
+        req("/api/v1/webhooks/subscriptions", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "content-length": contentLength,
+            "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+          },
+          body: JSON.stringify({ url: "https://hooks.example.com/mg" }),
+        }),
+        envWith(makeKv()),
+        {},
+      );
+      assert.equal(res.status, 400);
+      assert.equal((await res.json()).error.code, "invalid_content_length");
+    }
+  });
+
+  test("accepts a finite Content-Length within the cap before reading the body", async () => {
+    const payload = { url: "https://hooks.example.com/mg" };
+    const body = JSON.stringify(payload);
+    const kv = makeKv();
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(new TextEncoder().encode(body).byteLength),
+          "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+        },
+        body,
+      }),
+      envWith(kv),
+      {},
+    );
+    assert.equal(res.status, 201);
+    assert.equal((await res.json()).ok, true);
+  });
+
   test("413 when the decoded body byte length exceeds the limit", async () => {
     // content-length omitted, but the JSON payload itself is oversized.
     const body = JSON.stringify({

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3457,14 +3457,23 @@ async function createWebhookSubscription(request, env) {
     return authorized.response;
   }
 
-  if (
-    Number(request.headers.get("content-length") || 0) > MAX_WEBHOOK_BODY_BYTES
-  ) {
-    return errorResponse(
-      "payload_too_large",
-      "Subscription body exceeds the size limit.",
-      413,
-    );
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const contentLength = Number(declaredLength);
+    if (!Number.isFinite(contentLength) || contentLength < 0) {
+      return errorResponse(
+        "invalid_content_length",
+        "Invalid Content-Length header.",
+        400,
+      );
+    }
+    if (contentLength > MAX_WEBHOOK_BODY_BYTES) {
+      return errorResponse(
+        "payload_too_large",
+        "Subscription body exceeds the size limit.",
+        413,
+      );
+    }
   }
   let body;
   try {


### PR DESCRIPTION
## Summary

- Validate `Content-Length` on `POST /api/v1/webhooks/subscriptions` when the header is present.
- Non-numeric and negative values return 400 `invalid_content_length` instead of skipping the early guard.

## What changed

- `workers/api.mjs` — mirror GraphQL/RPC Content-Length validation in `createWebhookSubscription`.
- `tests/webhooks-worker.test.mjs` — regression tests for negative and non-numeric headers.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/webhooks-worker.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`