### PR TITLE
feat(mcp): add get_chain_serving mirroring GET /api/v1/chain/serving

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -481,6 +481,16 @@ assert.ok(
     chainPrometheus.network != null,
   "get_chain_prometheus must return subnet_count + network + subnets[]",
 );
+const chainServing = await callOk("get_chain_serving", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainServing.subnet_count) &&
+    Array.isArray(chainServing.subnets) &&
+    chainServing.network != null,
+  "get_chain_serving must return subnet_count + network + subnets[]",
+);
 const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-serving.mjs
+++ b/src/chain-serving.mjs
@@ -11,6 +11,12 @@ export const SERVING_EVENT_KIND = "AxonServed";
 export const CHAIN_SERVING_LIMIT_DEFAULT = 20;
 export const CHAIN_SERVING_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_SERVING_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_SERVING_WINDOW = "7d";
+
 // Round a announcements-per-hotkey ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -182,6 +182,13 @@ import {
   CHAIN_PROMETHEUS_WINDOWS,
   DEFAULT_CHAIN_PROMETHEUS_WINDOW,
 } from "./chain-prometheus.mjs";
+import {
+  loadChainServing,
+  CHAIN_SERVING_LIMIT_DEFAULT,
+  CHAIN_SERVING_LIMIT_MAX,
+  CHAIN_SERVING_WINDOWS,
+  DEFAULT_CHAIN_SERVING_WINDOW,
+} from "./chain-serving.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -342,7 +349,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.50.0";
+export const MCP_SERVER_VERSION = "1.51.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -361,6 +368,7 @@ const CHAIN_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   CHAIN_DEREGISTRATIONS_WINDOWS,
 );
 const CHAIN_PROMETHEUS_WINDOW_KEYS = Object.keys(CHAIN_PROMETHEUS_WINDOWS);
+const CHAIN_SERVING_WINDOW_KEYS = Object.keys(CHAIN_SERVING_WINDOWS);
 const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
 );
@@ -525,6 +533,9 @@ export const MCP_INSTRUCTIONS =
   "get_chain_axon_removals the network-wide axon-teardown leaderboard " +
   "(per-subnet AxonInfoRemoved activity, distinct removers, and " +
   "removals-per-remover intensity) across all subnets, " +
+  "get_chain_serving the network-wide axon-endpoint serving leaderboard " +
+  "(per-subnet AxonServed activity, distinct servers, and " +
+  "announcements-per-server intensity) across all subnets, " +
   "get_chain_prometheus the network-wide Prometheus-endpoint serving " +
   "leaderboard (per-subnet PrometheusServed activity, distinct exporters, and " +
   "announcements-per-exporter intensity) across all subnets, " +
@@ -2566,6 +2577,59 @@ export const MCP_TOOLS = [
       return loadChainAxonRemovals(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_AXON_REMOVALS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_serving",
+    title: "Get network-wide axon-endpoint serving activity",
+    description:
+      "Fetch the network-wide axon-endpoint serving leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by " +
+      "AxonServed events with its distinct-server (hotkey) count and " +
+      "announcements-per-server intensity, plus a network rollup (distinct " +
+      "servers, total announcements, announcements per server) and the " +
+      "count/mean/min/p25/median/p75/p90/max spread of per-subnet intensity, " +
+      "summed live from the account_events stream. AxonServed is emitted when " +
+      "a neuron announces its axon endpoint — the axon-endpoint companion to " +
+      "get_chain_prometheus (Prometheus telemetry announcements) and " +
+      "get_chain_axon_removals (AxonInfoRemoved teardown). Mirrors GET " +
+      "/api/v1/chain/serving.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_SERVING_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_SERVING_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the axon serving leaderboard (1-${CHAIN_SERVING_LIMIT_MAX}, default ${CHAIN_SERVING_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_SERVING_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_SERVING_WINDOW;
+      if (!Object.hasOwn(CHAIN_SERVING_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_SERVING_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_SERVING_LIMIT_DEFAULT,
+        CHAIN_SERVING_LIMIT_MAX,
+      );
+      return loadChainServing(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_SERVING_WINDOWS[window],
         limit,
       });
     },
@@ -7450,6 +7514,84 @@ const TOOL_OUTPUT_SCHEMAS = {
             distinct_removers: { type: "integer" },
             removals: { type: "integer" },
             removals_per_remover: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_serving: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that saw an AxonServed event. A hotkey
+      // announcing on several subnets counts once in distinct_servers.
+      // announcements_per_server is null when the network-wide distinct-server
+      // count is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "distinct_servers",
+          "announcements",
+          "announcements_per_server",
+        ],
+        properties: {
+          distinct_servers: { type: "integer" },
+          announcements: { type: "integer" },
+          announcements_per_server: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet re-announcement intensity (AxonServed events per
+      // server) over EVERY subnet that saw an announcement; null when no subnet
+      // saw serving activity in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet axon serving leaderboard, most AxonServed events first. Each
+      // listed subnet has at least one distinct server, so announcements_per_server
+      // is always a finite number here.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_servers",
+            "announcements",
+            "announcements_per_server",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_servers: { type: "integer" },
+            announcements: { type: "integer" },
+            announcements_per_server: { type: "number" },
           },
         },
       },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6263,6 +6263,8 @@ describe("MCP economics + metagraph data tools", () => {
     chainDeregistrationsSubnetRows = [],
     chainPrometheusNetworkRows = [],
     chainPrometheusSubnetRows = [],
+    chainServingNetworkRows = [],
+    chainServingSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
   } = {}) {
@@ -6289,6 +6291,9 @@ describe("MCP economics + metagraph data tools", () => {
                   // get_chain_prometheus reads a network aggregate
                   // (newest_observed + distinct_exporters) then a per-subnet GROUP BY
                   // (AS announcements + distinct_exporters);
+                  // get_chain_serving reads a network aggregate
+                  // (newest_observed + distinct_servers) then a per-subnet GROUP BY
+                  // (AS announcements + distinct_servers);
                   // get_chain_transfer_pairs reads a totals CTE
                   // (top_pair_volume_tao) then per-corridor rows (AS from_address);
                   // everything else uses the flat account_events fixture.
@@ -6321,6 +6326,11 @@ describe("MCP economics + metagraph data tools", () => {
                         results: chainPrometheusNetworkRows,
                       });
                     }
+                    if (sql.includes("distinct_servers")) {
+                      return Promise.resolve({
+                        results: chainServingNetworkRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
@@ -6351,6 +6361,14 @@ describe("MCP economics + metagraph data tools", () => {
                   ) {
                     return Promise.resolve({
                       results: chainPrometheusSubnetRows,
+                    });
+                  }
+                  if (
+                    sql.includes("AS announcements") &&
+                    sql.includes("distinct_servers")
+                  ) {
+                    return Promise.resolve({
+                      results: chainServingSubnetRows,
                     });
                   }
                   if (sql.includes("top_pair_volume_tao")) {
@@ -7876,6 +7894,110 @@ describe("MCP economics + metagraph data tools", () => {
       chainDeregistrationsEnv(chainDeregistrationsNetwork(8), [
         chainDeregistrationsRow(1, 20, 5),
         chainDeregistrationsRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainServing reads first (its
+  // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
+  // unlocks the per-subnet read.
+  function chainServingNetwork(distinct_servers) {
+    return {
+      distinct_servers,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT announcements + distinct servers).
+  function chainServingRow(netuid, announcements, distinct_servers) {
+    return { netuid, announcements, distinct_servers };
+  }
+
+  function chainServingEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          chainServingNetworkRows: network ? [network] : [],
+          chainServingSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_serving returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_serving", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.announcements, 0);
+    assert.equal(out.network.announcements_per_server, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_serving ranks subnets by announcements with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_serving",
+      { window: "30d", limit: 10 },
+      chainServingEnv(chainServingNetwork(8), [
+        // netuid 2: fewer announcements -> ranks last despite higher intensity.
+        chainServingRow(2, 10, 4),
+        // netuid 1: most AxonServed events -> ranks first.
+        chainServingRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].announcements, 20);
+    assert.equal(out.subnets[0].announcements_per_server, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].announcements_per_server, 2.5); // 10 / 4
+    // Network rollup: total announcements 30 over 8 distinct servers -> 3.75.
+    assert.equal(out.network.announcements, 30);
+    assert.equal(out.network.distinct_servers, 8);
+    assert.equal(out.network.announcements_per_server, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_serving rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_serving", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_serving caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_serving",
+      { limit: 1 },
+      chainServingEnv(chainServingNetwork(8), [
+        chainServingRow(1, 20, 5),
+        chainServingRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_serving payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_serving",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_serving",
+      {},
+      chainServingEnv(chainServingNetwork(8), [
+        chainServingRow(1, 20, 5),
+        chainServingRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.50.0");
+    assert.equal(MCP_SERVER_VERSION, "1.51.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_chain_serving` MCP tool mirroring `GET /api/v1/chain/serving`, wiring the existing `loadChainServing` loader with REST-parity `7d`/`30d` window and leaderboard limit validation.
- Export `CHAIN_SERVING_WINDOWS` / `DEFAULT_CHAIN_SERVING_WINDOW` from the loader module and add a deeply-typed output schema (network rollup, intensity distribution, per-subnet leaderboard).
- Bump MCP server version to `1.51.0` (120 tools); extend validate-mcp cold path, D1 mock routing, and five integration tests (cold zeros, ranking + rollup, bad window, limit cap, output schema validation).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/mcp-server.test.mjs tests/chain-serving.test.mjs` (+ version assertion suites)
