### PR TITLE
fix(feeds): guard Atom updated elements against corrupt timestamps

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -436,19 +436,21 @@ function rssFeed(meta, items) {
 }
 
 function atomFeed(meta, items) {
+  const feedUpdated = toIso(meta.updated);
   const body = items
-    .map((it) =>
-      [
+    .map((it) => {
+      const updated = toIso(it.timestamp);
+      return [
         "  <entry>",
         `    <id>urn:metagraphed:${escapeXml(it.id)}</id>`,
         `    <title>${escapeXml(it.title)}</title>`,
         `    <link href="${escapeXml(it.url)}"/>`,
-        `    <updated>${it.timestamp}</updated>`,
+        ...(updated ? [`    <updated>${escapeXml(updated)}</updated>`] : []),
         `    <summary>${escapeXml(it.summary)}</summary>`,
         ...(it.tags || []).map((t) => `    <category term="${escapeXml(t)}"/>`),
         "  </entry>",
-      ].join("\n"),
-    )
+      ].join("\n");
+    })
     .join("\n");
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
@@ -457,7 +459,7 @@ function atomFeed(meta, items) {
     `  <link href="${escapeXml(meta.homeUrl)}"/>`,
     `  <link href="${escapeXml(meta.feedUrl)}" rel="self" type="application/atom+xml"/>`,
     `  <id>${escapeXml(meta.feedUrl)}</id>`,
-    `  <updated>${meta.updated}</updated>`,
+    ...(feedUpdated ? [`  <updated>${escapeXml(feedUpdated)}</updated>`] : []),
     `  <subtitle>${escapeXml(meta.description)}</subtitle>`,
     body,
     "</feed>",

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -853,6 +853,33 @@ describe("feeds — serializers", () => {
     assert.match(xml, /<feed xmlns="http:\/\/www\.w3\.org\/2005\/Atom">/);
     assert.match(xml, /<id>https:\/\/api\.metagraph\.sh/);
     assert.ok((xml.match(/<entry>/g) || []).length === items.length);
+    assert.match(xml, /<updated>2026-06-15T00:00:00\.000Z<\/updated>/);
+  });
+
+  test("atomFeed omits updated for corrupt item timestamps", () => {
+    const xml = atomFeed(meta, [
+      {
+        id: "bad-ts",
+        url: "https://example.com/x",
+        title: "bad",
+        summary: "bad",
+        timestamp: "not-a-date",
+        tags: [],
+      },
+    ]);
+    assert.doesNotMatch(xml, /Invalid Date/);
+    assert.match(xml, /<entry>/);
+    assert.doesNotMatch(xml, /<entry>[\s\S]*<updated>/);
+  });
+
+  test("atomFeed omits feed updated when meta.updated is corrupt", () => {
+    const xml = atomFeed({ ...meta, updated: "not-a-date" }, items.slice(0, 1));
+    assert.doesNotMatch(xml, /Invalid Date/);
+    assert.doesNotMatch(xml.split("<entry>")[0], /<updated>/);
+    assert.match(
+      xml,
+      /<entry>[\s\S]*<updated>2026-06-15T00:00:00\.000Z<\/updated>/,
+    );
   });
 
   test("escapeXml neutralizes markup + strips control chars", () => {


### PR DESCRIPTION

## Summary

- Harden Atom feed serialization so corrupt item or channel timestamps do not produce invalid `<updated>` elements or 500 the feed.
- Mirror the RSS pubDate guard: normalize with `toIso()` and omit the element when invalid.

## What changed

- `src/feeds.mjs` — guard entry and feed `<updated>` in `atomFeed`.
- `tests/feeds.test.mjs` — regression tests for corrupt item/channel timestamps.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/feeds.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`
