### PR TITLE
feat(mcp): add get_account_prometheus mirroring GET /api/v1/accounts/{ss58}/prometheus

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -654,6 +654,19 @@ assert.equal(
   SS58,
   "get_account_axon_removals must echo the address",
 );
+const accountPrometheus = await callOk("get_account_prometheus", {
+  ss58: SS58,
+  window: "30d",
+});
+assert.ok(
+  Array.isArray(accountPrometheus.subnets),
+  "get_account_prometheus must return subnets[]",
+);
+assert.equal(
+  accountPrometheus.address,
+  SS58,
+  "get_account_prometheus must echo the address",
+);
 const accountBalance = await callOk("get_account_balance", { ss58: SS58 });
 assert.ok(
   "balance_tao" in accountBalance && accountBalance.ss58 === SS58,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -310,6 +310,11 @@ import {
   DEFAULT_AXON_REMOVAL_WINDOW,
 } from "./account-axon-removals.mjs";
 import {
+  loadAccountPrometheus,
+  PROMETHEUS_WINDOWS,
+  DEFAULT_PROMETHEUS_WINDOW,
+} from "./account-prometheus.mjs";
+import {
   loadSubnetMovers,
   MOVERS_WINDOWS,
   MOVERS_SORTS,
@@ -359,7 +364,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.53.0";
+export const MCP_SERVER_VERSION = "1.54.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -387,6 +392,7 @@ const ACCOUNT_STAKE_MOVES_WINDOW_KEYS = Object.keys(
   ACCOUNT_STAKE_MOVES_WINDOWS,
 );
 const ACCOUNT_AXON_REMOVALS_WINDOW_KEYS = Object.keys(AXON_REMOVAL_WINDOWS);
+const ACCOUNT_PROMETHEUS_WINDOW_KEYS = Object.keys(PROMETHEUS_WINDOWS);
 const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
   SUBNET_EVENT_SUMMARY_WINDOWS,
 );
@@ -515,7 +521,9 @@ export const MCP_INSTRUCTIONS =
   "get_account_stake_moves its per-subnet StakeMoved re-delegation footprint " +
   "with movement counts, first/last timestamps, and concentration labels, " +
   "get_account_axon_removals its per-subnet AxonInfoRemoved teardown footprint " +
-  "with removal counts, first/last timestamps, and concentration labels. For chain-wide " +
+  "with removal counts, first/last timestamps, and concentration labels, " +
+  "get_account_prometheus its per-subnet PrometheusServed telemetry footprint " +
+  "with announcement counts, first/last timestamps, and concentration labels. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_registrations the " +
@@ -4103,6 +4111,53 @@ export const MCP_TOOLS = [
         );
       }
       const { data } = await loadAccountAxonRemovals(mcpD1Runner(ctx), ss58, {
+        windowLabel: window,
+      });
+      return data;
+    },
+  },
+  {
+    name: "get_account_prometheus",
+    title: "Get an account's Prometheus-endpoint serving footprint",
+    description:
+      "Fetch one account's PrometheusServed (telemetry endpoint) footprint per " +
+      "subnet over the requested window (7d, 30d, or 90d; default 30d): each " +
+      "subnet's announcement count with the first and last PrometheusServed " +
+      "timestamps, plus account totals, an HHI concentration of where its telemetry " +
+      "activity is focused, and the dominant subnet. PrometheusServed is emitted when " +
+      "a neuron announces its Prometheus telemetry endpoint — the telemetry-endpoint " +
+      "companion to get_account_serving (axon announcements) and the account-level " +
+      "companion to get_chain_prometheus and get_subnet_prometheus. Mirrors GET " +
+      "/api/v1/accounts/{ss58}/prometheus.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 hotkey address, base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+        window: {
+          type: "string",
+          enum: ACCOUNT_PROMETHEUS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_PROMETHEUS_WINDOW}).`,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_PROMETHEUS_WINDOW;
+      if (!Object.hasOwn(PROMETHEUS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${ACCOUNT_PROMETHEUS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const { data } = await loadAccountPrometheus(mcpD1Runner(ctx), ss58, {
         windowLabel: window,
       });
       return data;
@@ -8474,6 +8529,47 @@ const TOOL_OUTPUT_SCHEMAS = {
             removals: { type: "integer" },
             first_removed_at: NULLABLE_STRING,
             last_removed_at: NULLABLE_STRING,
+          },
+        },
+      },
+    },
+  },
+  get_account_prometheus: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "address",
+      "window",
+      "total_announcements",
+      "subnet_count",
+      "subnets",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      address: { type: "string" },
+      window: NULLABLE_STRING,
+      total_announcements: { type: "integer" },
+      subnet_count: { type: "integer" },
+      // Herfindahl-Hirschman index of PrometheusServed events across subnets: 1
+      // means all announcements on one subnet; null when the account has none.
+      concentration: { type: ["number", "null"] },
+      dominant_netuid: NULLABLE_INT,
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "announcements",
+            "first_announced_at",
+            "last_announced_at",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            announcements: { type: "integer" },
+            first_announced_at: NULLABLE_STRING,
+            last_announced_at: NULLABLE_STRING,
           },
         },
       },

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3189,6 +3189,123 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  function accountPrometheusD1(rows = [], capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (
+                    /idx_account_events_hotkey/.test(sql) &&
+                    /AS announcements/.test(sql) &&
+                    /first_observed/.test(sql)
+                  ) {
+                    return { results: rows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("get_account_prometheus shapes per-subnet announcement counts and concentration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const res = await callTool(
+        "get_account_prometheus",
+        { ss58: SS58, window: "7d" },
+        {
+          env: accountPrometheusD1([
+            {
+              netuid: 7,
+              announcements: 3,
+              first_observed: 1_717_000_000_000,
+              last_observed: 1_717_500_000_000,
+            },
+            {
+              netuid: 9,
+              announcements: 1,
+              first_observed: 1_717_100_000_000,
+              last_observed: 1_717_100_000_000,
+            },
+          ]),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.address, SS58);
+      assert.equal(out.window, "7d");
+      assert.equal(out.total_announcements, 4);
+      assert.equal(out.subnet_count, 2);
+      assert.equal(out.subnets[0].netuid, 7);
+      assert.equal(out.dominant_netuid, 7);
+      assert.equal(out.subnets[0].announcements, 3);
+      assert.equal(
+        out.subnets[0].first_announced_at,
+        new Date(1_717_000_000_000).toISOString(),
+      );
+      assert.ok(out.concentration > 0.5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("get_account_prometheus rejects a missing ss58", async () => {
+    const res = await callTool("get_account_prometheus", {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /ss58/i);
+  });
+
+  test("get_account_prometheus rejects an unsupported window", async () => {
+    const res = await callTool("get_account_prometheus", {
+      ss58: SS58,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_account_prometheus degrades to zeros on cold D1", async () => {
+    const res = await callTool("get_account_prometheus", { ss58: SS58 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.address, SS58);
+    assert.equal(out.window, "30d");
+    assert.equal(out.total_announcements, 0);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.concentration, null);
+    assert.equal(out.dominant_netuid, null);
+    assert.deepEqual(out.subnets, []);
+  });
+
+  test("get_account_prometheus payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_account_prometheus",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_account_prometheus",
+      { ss58: SS58 },
+      {
+        env: accountPrometheusD1([
+          {
+            netuid: 7,
+            announcements: 2,
+            first_observed: 1_717_000_000_000,
+            last_observed: 1_717_500_000_000,
+          },
+        ]),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_subnet_movers ranks subnets by stake delta", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
@@ -3345,6 +3462,16 @@ describe("MCP stake-flow and movers economics tools", () => {
       assert.ok(
         validatorFor("get_account_axon_removals")(
           accountAxonRemovals.body.result.structuredContent,
+        ),
+      );
+      const accountPrometheus = await callTool(
+        "get_account_prometheus",
+        { ss58: SS58 },
+        { env: accountPrometheusD1([]) },
+      );
+      assert.ok(
+        validatorFor("get_account_prometheus")(
+          accountPrometheus.body.result.structuredContent,
         ),
       );
       const movers = await callTool(

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.53.0");
+    assert.equal(MCP_SERVER_VERSION, "1.54.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_account_prometheus` MCP tool mirroring `GET /api/v1/accounts/{ss58}/prometheus`, wiring the existing `loadAccountPrometheus` loader with REST-parity `7d`/`30d`/`90d` window validation.
- Add a deeply-typed output schema (per-subnet announcement counts, first/last timestamps, HHI concentration, dominant subnet) matching the account footprint card shape.
- Bump MCP server version to `1.54.0` (123 tools); extend validate-mcp cold path and five integration tests (cold zeros, ranking + concentration, missing ss58, bad window, output schema validation).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/mcp-server.test.mjs tests/account-prometheus.test.mjs` (+ version assertion suites)

Made with [Cursor](https://cursor.com)