### PR TITLE
feat(mcp): add get_subnet_prometheus mirroring GET /api/v1/subnets/{netuid}/prometheus

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -481,6 +481,20 @@ assert.ok(
     chainPrometheus.network != null,
   "get_chain_prometheus must return subnet_count + network + subnets[]",
 );
+const subnetPrometheus = await callOk("get_subnet_prometheus", {
+  netuid: 7,
+  window: "7d",
+});
+assert.equal(
+  subnetPrometheus.netuid,
+  7,
+  "get_subnet_prometheus must echo the netuid",
+);
+assert.ok(
+  Number.isInteger(subnetPrometheus.distinct_exporters) &&
+    Number.isInteger(subnetPrometheus.announcements),
+  "get_subnet_prometheus must return distinct_exporters + announcements",
+);
 const chainServing = await callOk("get_chain_serving", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -263,6 +263,11 @@ import {
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
 } from "./subnet-axon-removals.mjs";
 import {
+  loadSubnetPrometheus,
+  SUBNET_PROMETHEUS_WINDOWS,
+  DEFAULT_SUBNET_PROMETHEUS_WINDOW,
+} from "./subnet-prometheus.mjs";
+import {
   loadSubnetDeregistrations,
   SUBNET_DEREGISTRATIONS_WINDOWS,
   DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
@@ -379,7 +384,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.57.0";
+export const MCP_SERVER_VERSION = "1.58.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -422,6 +427,7 @@ const SUBNET_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
 const SUBNET_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
   SUBNET_AXON_REMOVALS_WINDOWS,
 );
+const SUBNET_PROMETHEUS_WINDOW_KEYS = Object.keys(SUBNET_PROMETHEUS_WINDOWS);
 const SUBNET_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   SUBNET_DEREGISTRATIONS_WINDOWS,
 );
@@ -513,7 +519,10 @@ export const MCP_INSTRUCTIONS =
   "get_subnet_stake_moves the per-subnet stake-relocation activity, " +
   "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
   "(distinct removers, event count, removals per remover — the removal-side " +
-  "companion to /serving), get_subnet_deregistrations the per-subnet " +
+  "companion to /serving), get_subnet_prometheus the per-subnet PrometheusServed " +
+  "telemetry-endpoint activity card (distinct exporters, event count, announcements " +
+  "per exporter — the telemetry-endpoint companion to get_chain_prometheus), " +
+  "get_subnet_deregistrations the per-subnet " +
   "neuron-deregistration activity card, get_subnet_performance_history the " +
   "per-day reward-flow and trust trend for one subnet, get_subnet_movers the cross-subnet " +
   "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
@@ -3119,6 +3128,47 @@ export const MCP_TOOLS = [
       return await loadSubnetAxonRemovals(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
         windowDays: SUBNET_AXON_REMOVALS_WINDOWS[window],
+      });
+    },
+  },
+  {
+    name: "get_subnet_prometheus",
+    title: "Get subnet Prometheus-endpoint serving activity",
+    description:
+      "Fetch one subnet's Prometheus-endpoint serving activity over a 7d or " +
+      "30d window (default 7d): the distinct exporters (hotkeys), " +
+      "PrometheusServed event count, and average announcements per exporter, " +
+      "computed live from the account_events PrometheusServed stream. " +
+      "PrometheusServed is emitted when a neuron announces its Prometheus " +
+      "telemetry endpoint — the telemetry-endpoint companion to get_subnet_serving " +
+      "(axon announcements) and the per-subnet companion to get_chain_prometheus. " +
+      "Mirrors GET /api/v1/subnets/{netuid}/prometheus.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_PROMETHEUS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_PROMETHEUS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_PROMETHEUS_WINDOW;
+      if (!Object.hasOwn(SUBNET_PROMETHEUS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_PROMETHEUS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      return await loadSubnetPrometheus(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_PROMETHEUS_WINDOWS[window],
       });
     },
   },
@@ -8218,6 +8268,26 @@ const TOOL_OUTPUT_SCHEMAS = {
       distinct_removers: { type: "integer" },
       removals: { type: "integer" },
       removals_per_remover: { type: ["number", "null"] },
+    },
+  },
+  get_subnet_prometheus: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "distinct_exporters",
+      "announcements",
+      "announcements_per_exporter",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_exporters: { type: "integer" },
+      announcements: { type: "integer" },
+      announcements_per_exporter: { type: ["number", "null"] },
     },
   },
   get_subnet_deregistrations: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4312,6 +4312,95 @@ describe("MCP get_subnet_axon_removals", () => {
   });
 });
 
+describe("MCP get_subnet_prometheus", () => {
+  function prometheusD1(row = null, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("reports Prometheus serving activity for one subnet over the window", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_subnet_prometheus",
+      { netuid: 7, window: "7d" },
+      {
+        env: prometheusD1(
+          {
+            distinct_exporters: 2,
+            announcements: 20,
+            newest_observed: 1_750_000_000_000,
+          },
+          capture,
+        ),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_exporters, 2);
+    assert.equal(out.announcements, 20);
+    assert.equal(out.announcements_per_exporter, 10);
+    assert.equal(capture[0].params[0], 7);
+  });
+
+  test("defaults to the 7d window and degrades to a zeroed card on cold D1", async () => {
+    const res = await callTool("get_subnet_prometheus", { netuid: 9 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_exporters, 0);
+    assert.equal(out.announcements, 0);
+    assert.equal(out.announcements_per_exporter, null);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_prometheus", {
+      netuid: 7,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_prometheus", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+
+  test("get_subnet_prometheus payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_subnet_prometheus",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_subnet_prometheus",
+      { netuid: 7 },
+      {
+        env: prometheusD1({
+          distinct_exporters: 1,
+          announcements: 3,
+          newest_observed: 1_750_000_000_000,
+        }),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+});
+
 describe("MCP get_subnet_deregistrations", () => {
   function deregistrationsD1(row = null) {
     return {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.57.0");
+    assert.equal(MCP_SERVER_VERSION, "1.58.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_subnet_prometheus` MCP tool mirroring `GET /api/v1/subnets/{netuid}/prometheus`, wiring the existing `loadSubnetPrometheus` loader with 7d/30d window support and a typed output schema.
- Bump MCP server version to **1.58.0** (127 tools) and extend validate-mcp cold-path coverage.
- Add integration tests: happy path, cold D1 zeros, invalid window, missing netuid, and outputSchema validation.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp` (127 tools)
- [x] `vitest run tests/mcp-server.test.mjs tests/subnet-prometheus.test.mjs` + version assertion suites


Made with [Cursor](https://cursor.com)