### PR TITLE
feat(mcp): add list_endpoint_pools

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -279,6 +279,11 @@ assert.ok(
 );
 const gapsPage = await callOk("list_gaps", { limit: 3 });
 assert.ok(Array.isArray(gapsPage.gaps), "list_gaps must return gaps[]");
+const endpointPoolsPage = await callOk("list_endpoint_pools", { limit: 3 });
+assert.ok(
+  Array.isArray(endpointPoolsPage.pools),
+  "list_endpoint_pools must return pools[]",
+);
 await callOk("registry_summary", {});
 await callOk("get_coverage", {});
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/endpoint-pools-mcp.mjs
+++ b/src/endpoint-pools-mcp.mjs
@@ -1,0 +1,245 @@
+// Endpoint pool list loader for MCP parity on GET /api/v1/endpoint-pools.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/endpoint-pools.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+
+export const ENDPOINT_POOLS_ARTIFACT = "/metagraph/endpoint-pools.json";
+
+const POOL_SORT_FIELDS = API_QUERY_COLLECTIONS["endpoint-pools"].sort_fields;
+const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"];
+
+export function endpointPoolsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw endpointPoolsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw endpointPoolsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw endpointPoolsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function endpointPoolsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/endpoint-pools");
+  const id = optionalString(args, "id");
+  if (id) url.searchParams.set("id", id);
+  const kind = optionalEnum(args, "kind", POOL_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const sort = optionalEnum(args, "sort", POOL_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  const minEligible = optionalRangeBound(args, "min_eligible_count");
+  if (minEligible !== null) {
+    url.searchParams.set("min_eligible_count", String(minEligible));
+  }
+  const maxEligible = optionalRangeBound(args, "max_eligible_count");
+  if (maxEligible !== null) {
+    url.searchParams.set("max_eligible_count", String(maxEligible));
+  }
+  const minEndpoint = optionalRangeBound(args, "min_endpoint_count");
+  if (minEndpoint !== null) {
+    url.searchParams.set("min_endpoint_count", String(minEndpoint));
+  }
+  const maxEndpoint = optionalRangeBound(args, "max_endpoint_count");
+  if (maxEndpoint !== null) {
+    url.searchParams.set("max_endpoint_count", String(maxEndpoint));
+  }
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw endpointPoolsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadEndpointPoolsList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = endpointPoolsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, ENDPOINT_POOLS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw endpointPoolsMcpError(
+        "not_found",
+        "Endpoint pool snapshot unavailable.",
+      );
+    }
+    throw endpointPoolsMcpError(
+      code,
+      `Could not load ${ENDPOINT_POOLS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw endpointPoolsMcpError(
+      "not_found",
+      "Endpoint pool snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "endpoint-pools", []);
+  if (transformed.error) {
+    throw endpointPoolsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.pools) ? data.pools : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    pools: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_ENDPOINT_POOLS_INSTRUCTIONS =
+  "list_endpoint_pools generalized endpoint pool scores (eligible/endpoint counts; " +
+  "mirrors GET /api/v1/endpoint-pools), ";
+
+export const LIST_ENDPOINT_POOLS_MCP_TOOL = {
+  name: "list_endpoint_pools",
+  title: "List generalized endpoint pools",
+  description:
+    "Fetch generalized endpoint pool scores from the registry: each pool's kind, " +
+    "eligible endpoint count, total endpoint count, and probe-derived routing score. " +
+    "Filter by id or kind, threshold with min_/max_eligible_count and " +
+    "min_/max_endpoint_count, sort with sort + order, and page with limit (1-100) / " +
+    "cursor. Complements list_endpoints (individual resources) and list_rpc_pools " +
+    "(Bittensor RPC proxy pools). Mirrors GET /api/v1/endpoint-pools.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Filter to one pool id, e.g. 'finney-rpc'.",
+      },
+      kind: {
+        type: "string",
+        enum: POOL_KINDS,
+        description: "Filter by pool kind.",
+      },
+      min_eligible_count: {
+        type: "number",
+        description: "Keep pools with eligible_count >= this bound.",
+      },
+      max_eligible_count: {
+        type: "number",
+        description: "Keep pools with eligible_count <= this bound.",
+      },
+      min_endpoint_count: {
+        type: "number",
+        description: "Keep pools with endpoint_count >= this bound.",
+      },
+      max_endpoint_count: {
+        type: "number",
+        description: "Keep pools with endpoint_count <= this bound.",
+      },
+      sort: {
+        type: "string",
+        enum: POOL_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of pool row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["pools"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    pools: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -38,6 +38,12 @@ import {
   loadGapsList,
 } from "./gaps-mcp.mjs";
 import {
+  LIST_ENDPOINT_POOLS_INSTRUCTIONS,
+  LIST_ENDPOINT_POOLS_MCP_TOOL,
+  LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
+  loadEndpointPoolsList,
+} from "./endpoint-pools-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -389,7 +395,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.59.0";
+export const MCP_SERVER_VERSION = "1.60.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -624,7 +630,9 @@ export const MCP_INSTRUCTIONS =
   "provenance/verification evidence ledger, list_rpc_endpoints the monitored " +
   "Bittensor RPC endpoint catalog, list_source_snapshots the per-source " +
   "input-hash/record-count ledger, list_rpc_pools the load-balanced RPC pool " +
-  "scores, get_subnet_endpoints one subnet\u0027s endpoint resources, " +
+  "scores, " +
+  LIST_ENDPOINT_POOLS_INSTRUCTIONS +
+  "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
   "its provenance evidence claims, and list_fixtures " +
   "live request/response examples. All data is public and " +
@@ -6178,6 +6186,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_ENDPOINT_POOLS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadEndpointPoolsList(ctx, args);
+    },
+  },
+  {
     name: "get_lineage",
     title: "Get cross-network subnet lineage",
     description:
@@ -9725,6 +9739,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
+  list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   get_lineage: {
     type: "object",
     additionalProperties: true,

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -1,0 +1,377 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  ENDPOINT_POOLS_ARTIFACT,
+  LIST_ENDPOINT_POOLS_INSTRUCTIONS,
+  LIST_ENDPOINT_POOLS_MCP_TOOL,
+  LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
+  endpointPoolsMcpError,
+  endpointPoolsQueryUrl,
+  loadEndpointPoolsList,
+} from "../src/endpoint-pools-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  pools: [
+    {
+      id: "finney-rpc",
+      kind: "subtensor-rpc",
+      eligible_count: 2,
+      endpoint_count: 5,
+    },
+    {
+      id: "finney-wss",
+      kind: "subtensor-wss",
+      eligible_count: 8,
+      endpoint_count: 10,
+    },
+    {
+      id: "finney-archive",
+      kind: "archive",
+      eligible_count: 0,
+      endpoint_count: 3,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ENDPOINT_POOLS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("endpoint-pools-mcp", () => {
+  test("endpointPoolsMcpError is shaped for MCP toolError handling", () => {
+    const err = endpointPoolsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("endpointPoolsQueryUrl validates filters, range bounds, and cursor", () => {
+    const url = endpointPoolsQueryUrl({
+      id: "finney-rpc",
+      kind: "subtensor-rpc",
+      min_eligible_count: 2,
+      max_eligible_count: 8,
+      min_endpoint_count: 4,
+      max_endpoint_count: 10,
+      sort: "eligible_count",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("id"), "finney-rpc");
+    assert.equal(url.searchParams.get("kind"), "subtensor-rpc");
+    assert.equal(url.searchParams.get("min_eligible_count"), "2");
+    assert.equal(url.searchParams.get("max_eligible_count"), "8");
+    assert.equal(url.searchParams.get("min_endpoint_count"), "4");
+    assert.equal(url.searchParams.get("max_endpoint_count"), "10");
+    assert.equal(url.searchParams.get("sort"), "eligible_count");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("endpointPoolsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl rejects empty id", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ id: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl rejects non-string id", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ id: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl rejects non-numeric range bounds", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ min_eligible_count: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl trims and forwards a fields projection", () => {
+    const url = endpointPoolsQueryUrl({ fields: " id,kind " });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("endpointPoolsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = endpointPoolsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("endpointPoolsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = endpointPoolsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("endpointPoolsQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointPoolsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = endpointPoolsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadEndpointPoolsList returns filtered rows with pagination meta", async () => {
+    const out = await loadEndpointPoolsList(
+      { env: {}, readArtifact },
+      { id: "finney-rpc" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.pools[0].id, "finney-rpc");
+    assert.equal(out.pools[0].eligible_count, 2);
+  });
+
+  test("loadEndpointPoolsList applies range filters", async () => {
+    const out = await loadEndpointPoolsList(
+      { env: {}, readArtifact },
+      { min_eligible_count: 2 },
+    );
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.pools.map((p) => p.id),
+      ["finney-rpc", "finney-wss"],
+    );
+  });
+
+  test("loadEndpointPoolsList sorts and pages the collection", async () => {
+    const out = await loadEndpointPoolsList(
+      { env: {}, readArtifact },
+      { sort: "eligible_count", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.pools[0].id, "finney-wss");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadEndpointPoolsList uses an injected readArtifact dep", async () => {
+    const out = await loadEndpointPoolsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { pools: [{ id: "test" }] },
+        }),
+      },
+    );
+    assert.equal(out.pools[0].id, "test");
+  });
+
+  test("loadEndpointPoolsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointPoolsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /endpoint-pools\.json/.test(err.message),
+    );
+  });
+
+  test("loadEndpointPoolsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointPoolsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadEndpointPoolsList rejects contradictory range bounds", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointPoolsList(
+          { env: {}, readArtifact },
+          { min_eligible_count: 9, max_eligible_count: 2 },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadEndpointPoolsList projects row fields when requested", async () => {
+    const out = await loadEndpointPoolsList(
+      { env: {}, readArtifact },
+      { fields: "id,eligible_count", limit: 1 },
+    );
+    assert.deepEqual(out.pools[0], {
+      id: "finney-rpc",
+      eligible_count: 2,
+    });
+  });
+
+  test("loadEndpointPoolsList preserves array notes from the artifact", async () => {
+    const out = await loadEndpointPoolsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            notes: ["advisory only"],
+            pools: [{ id: "solo" }],
+          },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.notes, ["advisory only"]);
+  });
+
+  test("loadEndpointPoolsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadEndpointPoolsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { pools: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadEndpointPoolsList treats a non-array pools key as empty", async () => {
+    const out = await loadEndpointPoolsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { pools: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.pools, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadEndpointPoolsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { pools: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadEndpointPoolsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadEndpointPoolsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointPoolsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_ENDPOINT_POOLS_MCP_TOOL.name, "list_endpoint_pools");
+    assert.match(LIST_ENDPOINT_POOLS_INSTRUCTIONS, /list_endpoint_pools/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
+    assert.ok(tool);
+    assert.equal(tool.title, "List generalized endpoint pools");
+  });
+});

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -660,6 +660,23 @@ describe("list_gaps — branch coverage", () => {
   });
 });
 
+// ── list_endpoint_pools — endpoint pool artifact list ─────────────────────
+describe("list_endpoint_pools — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_endpoint_pools", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /endpoint-pools\.json/);
+  });
+});
+
 // ── get_agent_resources — AI-resources artifact ───────────────────────────
 describe("get_agent_resources — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1429,6 +1429,61 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_endpoint_pools returns filtered pool rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/endpoint-pools.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        pools: [
+          {
+            id: "finney-rpc",
+            kind: "subtensor-rpc",
+            eligible_count: 2,
+            endpoint_count: 5,
+          },
+          {
+            id: "finney-wss",
+            kind: "subtensor-wss",
+            eligible_count: 8,
+            endpoint_count: 10,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_endpoint_pools",
+      { kind: "subtensor-rpc" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.pools[0].id, "finney-rpc");
+  });
+
+  test("list_endpoint_pools reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_endpoint_pools", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Endpoint pool snapshot unavailable/,
+    );
+  });
+
+  test("list_endpoint_pools payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_endpoint_pools",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/endpoint-pools.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        notes: "ok",
+        pools: [{ id: "finney-rpc", eligible_count: 2 }],
+      },
+    });
+    const res = await callTool("list_endpoint_pools", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("registry_summary returns the summary artifact", async () => {
     const res = await callTool("registry_summary", {}, { deps });
     assert.equal(res.body.result.structuredContent.completeness, 0.42);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_endpoint_pools` MCP tool mirroring `GET /api/v1/endpoint-pools` (baked `/metagraph/endpoint-pools.json` artifact: generalized endpoint pool scores with eligible/endpoint counts).
- Extract loader to `src/endpoint-pools-mcp.mjs` with REST-parity list-query filters (id, kind, min_/max_eligible_count, min_/max_endpoint_count, sort, order, fields, limit, cursor) and full unit + integration tests (100% line/branch coverage on the new module).
- Bump MCP server SemVer **1.59.0 → 1.60.0** (`server.json`, `validate-mcp.mjs`).

## Test plan
- [x] `npm run lint` + `npm run format:check`
- [x] `npx vitest run tests/endpoint-pools-mcp.test.mjs` (100% coverage on new module)
- [x] `npx vitest run tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs` (list_endpoint_pools paths)
- [x] `npm run build` + `node scripts/validate-mcp.mjs` (129 tools)
- [x] SemVer asserts updated across MCP test suites


Made with [Cursor](https://cursor.com)