### PR TITLE
feat(mcp): add get_subnet_weights mirroring GET /api/v1/subnets/{netuid}/weights

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -431,6 +431,20 @@ assert.ok(
     chainWeights.network != null,
   "get_chain_weights must return subnet_count + network + subnets[]",
 );
+const subnetWeights = await callOk("get_subnet_weights", {
+  netuid: 7,
+  window: "7d",
+});
+assert.equal(
+  subnetWeights.netuid,
+  7,
+  "get_subnet_weights must echo the netuid",
+);
+assert.ok(
+  Number.isInteger(subnetWeights.distinct_setters) &&
+    Number.isInteger(subnetWeights.weight_sets),
+  "get_subnet_weights must return distinct_setters + weight_sets",
+);
 const chainStakeMoves = await callOk("get_chain_stake_moves", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -248,6 +248,11 @@ import {
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
 } from "./subnet-weight-setters.mjs";
 import {
+  loadSubnetWeights,
+  SUBNET_WEIGHTS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHTS_WINDOW,
+} from "./subnet-weights.mjs";
+import {
   loadSubnetRegistrations,
   SUBNET_REGISTRATIONS_WINDOWS,
   DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
@@ -389,7 +394,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.59.0";
+export const MCP_SERVER_VERSION = "1.60.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -429,6 +434,7 @@ const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
 const SUBNET_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
   SUBNET_WEIGHT_SETTERS_WINDOWS,
 );
+const SUBNET_WEIGHTS_WINDOW_KEYS = Object.keys(SUBNET_WEIGHTS_WINDOWS);
 const SUBNET_AXON_REMOVALS_WINDOW_KEYS = Object.keys(
   SUBNET_AXON_REMOVALS_WINDOWS,
 );
@@ -519,8 +525,10 @@ export const MCP_INSTRUCTIONS =
   "boundary snapshots, get_subnet_stake_flow net capital in/out for one " +
   "subnet (StakeAdded vs StakeRemoved), get_subnet_event_summary the windowed " +
   "account-event summary for one subnet (per-kind counts plus a recent-events " +
-  "tail), get_subnet_weight_setters the per-subnet weight-setter leaderboard " +
-  "(the validators behind /weights ranked by activity), " +
+  "tail), get_subnet_weights the per-subnet weight-setting activity card " +
+  "(distinct setters, WeightsSet count, sets per setter — the per-subnet " +
+  "companion to get_chain_weights), get_subnet_weight_setters the per-subnet weight-setter leaderboard " +
+  "(the validators behind /weights ranked by activity — the setter-level drill-in of get_subnet_weights), " +
   "get_subnet_registrations the per-subnet neuron-registration activity, " +
   "get_subnet_stake_moves the per-subnet stake-relocation activity, " +
   "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
@@ -2982,6 +2990,45 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_weights",
+    title: "Get subnet weight-setting activity",
+    description:
+      "Fetch one subnet's validator weight-setting activity over a 7d or 30d " +
+      "window (default 7d): the distinct weight-setting validators, WeightsSet " +
+      "event count, and average updates per validator, computed live from the " +
+      "account_events WeightsSet stream. The per-subnet companion to " +
+      "get_chain_weights — use get_subnet_weight_setters for the setter-level " +
+      "leaderboard drill-in. Mirrors GET /api/v1/subnets/{netuid}/weights.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_WEIGHTS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_WEIGHTS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_WEIGHTS_WINDOW;
+      if (!Object.hasOwn(SUBNET_WEIGHTS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_WEIGHTS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      return await loadSubnetWeights(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_WEIGHTS_WINDOWS[window],
+      });
+    },
+  },
+  {
     name: "get_subnet_weight_setters",
     title: "Get subnet weight-setter leaderboard",
     description:
@@ -2989,8 +3036,8 @@ export const MCP_TOOLS = [
       "window (default 7d): the individual validators behind /weights ranked " +
       "by activity, each with its WeightsSet count, its share of the subnet's " +
       "total weight-setting, and its first/last set times, computed live from " +
-      "the account_events WeightsSet stream. The setter-level drill-in of the " +
-      "aggregate get_chain_weights / subnet weights. " +
+      "the account_events WeightsSet stream. The setter-level drill-in of " +
+      "get_subnet_weights / get_chain_weights. " +
       "Mirrors GET /api/v1/subnets/{netuid}/weights/setters.",
     inputSchema: {
       type: "object",
@@ -8268,6 +8315,26 @@ const TOOL_OUTPUT_SCHEMAS = {
       distinct_registrants: { type: "integer" },
       registrations: { type: "integer" },
       registrations_per_registrant: { type: ["number", "null"] },
+    },
+  },
+  get_subnet_weights: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "distinct_setters",
+      "weight_sets",
+      "sets_per_setter",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_setters: { type: "integer" },
+      weight_sets: { type: "integer" },
+      sets_per_setter: { type: ["number", "null"] },
     },
   },
   get_subnet_weight_setters: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4134,6 +4134,95 @@ describe("MCP get_subnet_registrations", () => {
   });
 });
 
+describe("MCP get_subnet_weights", () => {
+  function weightsD1(row = null, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("reports weight-setting activity for one subnet over the window", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_subnet_weights",
+      { netuid: 5, window: "7d" },
+      {
+        env: weightsD1(
+          {
+            distinct_setters: 2,
+            weight_sets: 20,
+            newest_observed: 1_750_000_000_000,
+          },
+          capture,
+        ),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 5);
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_setters, 2);
+    assert.equal(out.weight_sets, 20);
+    assert.equal(out.sets_per_setter, 10);
+    assert.equal(capture[0].params[0], 5);
+  });
+
+  test("defaults to the 7d window and degrades to a zeroed card on cold D1", async () => {
+    const res = await callTool("get_subnet_weights", { netuid: 5 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.distinct_setters, 0);
+    assert.equal(out.weight_sets, 0);
+    assert.equal(out.sets_per_setter, null);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_weights", {
+      netuid: 5,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_weights", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+
+  test("get_subnet_weights payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_subnet_weights",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_subnet_weights",
+      { netuid: 5 },
+      {
+        env: weightsD1({
+          distinct_setters: 1,
+          weight_sets: 3,
+          newest_observed: 1_750_000_000_000,
+        }),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+});
+
 describe("MCP get_subnet_weight_setters", () => {
   // The loader runs two reads: the per-setter leaderboard (GROUP BY the
   // hotkey-or-uid identity) and the subnet-wide totals row. Route by SQL shape.

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.59.0");
+    assert.equal(MCP_SERVER_VERSION, "1.60.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_subnet_weights` MCP tool mirroring `GET /api/v1/subnets/{netuid}/weights`, wiring the existing `loadSubnetWeights` loader with 7d/30d window support and a typed output schema.
- Bump MCP server version to **1.60.0** (129 tools) and extend validate-mcp cold-path coverage.
- Add integration tests: happy path, cold D1 zeros, invalid window, missing netuid, and outputSchema validation.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp` (129 tools)
- [x] `vitest run tests/mcp-server.test.mjs tests/subnet-weights.test.mjs` + version assertion suites


Made with [Cursor](https://cursor.com)