### PR TITLE
feat(mcp): add list_endpoint_incidents

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -284,6 +284,13 @@ assert.ok(
   Array.isArray(endpointPoolsPage.pools),
   "list_endpoint_pools must return pools[]",
 );
+const endpointIncidentsPage = await callOk("list_endpoint_incidents", {
+  limit: 3,
+});
+assert.ok(
+  Array.isArray(endpointIncidentsPage.incidents),
+  "list_endpoint_incidents must return incidents[]",
+);
 await callOk("registry_summary", {});
 await callOk("get_coverage", {});
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/endpoint-incidents-mcp.mjs
+++ b/src/endpoint-incidents-mcp.mjs
@@ -1,0 +1,255 @@
+// Endpoint incident list loader for MCP parity on GET /api/v1/endpoint-incidents.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/endpoint-incidents.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const ENDPOINT_INCIDENTS_ARTIFACT = "/metagraph/endpoint-incidents.json";
+
+const INCIDENT_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["endpoint-incidents"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const INCIDENT_SEVERITIES = QUERY_ENUMS.endpointIncidentSeverity;
+const INCIDENT_STATES = QUERY_ENUMS.endpointIncidentState;
+
+export function endpointIncidentsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw endpointIncidentsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw endpointIncidentsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function endpointIncidentsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/endpoint-incidents");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw endpointIncidentsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const severity = optionalEnum(args, "severity", INCIDENT_SEVERITIES);
+  if (severity) url.searchParams.set("severity", severity);
+  const state = optionalEnum(args, "state", INCIDENT_STATES);
+  if (state) url.searchParams.set("state", state);
+  const sort = optionalEnum(args, "sort", INCIDENT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw endpointIncidentsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadEndpointIncidentsList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = endpointIncidentsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, ENDPOINT_INCIDENTS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw endpointIncidentsMcpError(
+        "not_found",
+        "Endpoint incident snapshot unavailable.",
+      );
+    }
+    throw endpointIncidentsMcpError(
+      code,
+      `Could not load ${ENDPOINT_INCIDENTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw endpointIncidentsMcpError(
+      "not_found",
+      "Endpoint incident snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "endpoint-incidents",
+    [],
+  );
+  if (transformed.error) {
+    throw endpointIncidentsMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.incidents) ? data.incidents : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    summary: data.summary ?? null,
+    incidents: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS =
+  "list_endpoint_incidents probe-derived endpoint incident feed (severity, state; " +
+  "mirrors GET /api/v1/endpoint-incidents), ";
+
+export const LIST_ENDPOINT_INCIDENTS_MCP_TOOL = {
+  name: "list_endpoint_incidents",
+  title: "List endpoint incidents",
+  description:
+    "Fetch probe-derived endpoint incidents from the registry: active endpoint " +
+    "failures and degradations with severity, state, provider, subnet, and probe " +
+    "metadata. Filter by netuid, kind, provider, status, severity, or state; sort " +
+    "with sort + order; and page with limit (1-100) / cursor. Complements " +
+    "list_endpoints (the full catalog) and get_global_incidents (registry-wide " +
+    "operational incidents). Mirrors GET /api/v1/endpoint-incidents.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      severity: {
+        type: "string",
+        enum: INCIDENT_SEVERITIES,
+        description: "Filter by incident severity.",
+      },
+      state: {
+        type: "string",
+        enum: INCIDENT_STATES,
+        description: "Filter by incident state.",
+      },
+      sort: {
+        type: "string",
+        enum: INCIDENT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of incident row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["incidents"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    summary: { type: ["object", "null"] },
+    incidents: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -44,6 +44,12 @@ import {
   loadEndpointPoolsList,
 } from "./endpoint-pools-mcp.mjs";
 import {
+  LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
+  LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
+  LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
+  loadEndpointIncidentsList,
+} from "./endpoint-incidents-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -400,7 +406,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.60.0";
+export const MCP_SERVER_VERSION = "1.61.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -640,6 +646,7 @@ export const MCP_INSTRUCTIONS =
   "input-hash/record-count ledger, list_rpc_pools the load-balanced RPC pool " +
   "scores, " +
   LIST_ENDPOINT_POOLS_INSTRUCTIONS +
+  LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
   "its provenance evidence claims, and list_fixtures " +
@@ -6239,6 +6246,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadEndpointIncidentsList(ctx, args);
+    },
+  },
+  {
     name: "get_lineage",
     title: "Get cross-network subnet lineage",
     description:
@@ -9807,6 +9820,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
+  list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   get_lineage: {
     type: "object",
     additionalProperties: true,

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  ENDPOINT_INCIDENTS_ARTIFACT,
+  LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
+  LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
+  LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
+  endpointIncidentsMcpError,
+  endpointIncidentsQueryUrl,
+  loadEndpointIncidentsList,
+} from "../src/endpoint-incidents-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["probe-derived only"],
+  summary: { incident_count: 2, active_count: 2 },
+  incidents: [
+    {
+      id: "incident-a",
+      endpoint_id: "a",
+      netuid: 7,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "failed",
+      severity: "critical",
+      state: "active",
+    },
+    {
+      id: "incident-b",
+      endpoint_id: "b",
+      netuid: 31,
+      kind: "openapi",
+      provider: "candles",
+      status: "degraded",
+      severity: "warning",
+      state: "active",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ENDPOINT_INCIDENTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("endpoint-incidents-mcp", () => {
+  test("endpointIncidentsMcpError is shaped for MCP toolError handling", () => {
+    const err = endpointIncidentsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("endpointIncidentsQueryUrl validates filters and cursor", () => {
+    const url = endpointIncidentsQueryUrl({
+      netuid: 7,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "failed",
+      severity: "critical",
+      state: "active",
+      sort: "severity",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("status"), "failed");
+    assert.equal(url.searchParams.get("severity"), "critical");
+    assert.equal(url.searchParams.get("state"), "active");
+    assert.equal(url.searchParams.get("sort"), "severity");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("endpointIncidentsQueryUrl rejects invalid severity", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ severity: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects invalid state", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ state: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects empty provider", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects non-string provider", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointIncidentsQueryUrl trims and forwards a fields projection", () => {
+    const url = endpointIncidentsQueryUrl({ fields: " netuid,severity " });
+    assert.equal(url.searchParams.get("fields"), "netuid,severity");
+  });
+
+  test("endpointIncidentsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = endpointIncidentsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("endpointIncidentsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = endpointIncidentsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("endpointIncidentsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = endpointIncidentsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadEndpointIncidentsList returns filtered rows with pagination meta", async () => {
+    const out = await loadEndpointIncidentsList(
+      { env: {}, readArtifact },
+      { netuid: 7 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.incidents[0].netuid, 7);
+    assert.equal(out.incidents[0].severity, "critical");
+  });
+
+  test("loadEndpointIncidentsList sorts and pages the collection", async () => {
+    const out = await loadEndpointIncidentsList(
+      { env: {}, readArtifact },
+      { sort: "netuid", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.incidents[0].netuid, 31);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadEndpointIncidentsList uses an injected readArtifact dep", async () => {
+    const out = await loadEndpointIncidentsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { incidents: [{ id: "solo" }] },
+        }),
+      },
+    );
+    assert.equal(out.incidents[0].id, "solo");
+  });
+
+  test("loadEndpointIncidentsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointIncidentsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointIncidentsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointIncidentsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /endpoint-incidents\.json/.test(err.message),
+    );
+  });
+
+  test("loadEndpointIncidentsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointIncidentsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadEndpointIncidentsList projects row fields when requested", async () => {
+    const out = await loadEndpointIncidentsList(
+      { env: {}, readArtifact },
+      { fields: "netuid,severity", limit: 1 },
+    );
+    assert.deepEqual(out.incidents[0], { netuid: 7, severity: "critical" });
+  });
+
+  test("loadEndpointIncidentsList preserves array notes and summary from the artifact", async () => {
+    const out = await loadEndpointIncidentsList(
+      { env: {}, readArtifact },
+      { limit: 1 },
+    );
+    assert.deepEqual(out.notes, ["probe-derived only"]);
+    assert.equal(out.summary.incident_count, 2);
+  });
+
+  test("loadEndpointIncidentsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadEndpointIncidentsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { incidents: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadEndpointIncidentsList treats a non-array incidents key as empty", async () => {
+    const out = await loadEndpointIncidentsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { incidents: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.incidents, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadEndpointIncidentsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { incidents: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadEndpointIncidentsList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadEndpointIncidentsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointIncidentsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointIncidentsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointIncidentsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_ENDPOINT_INCIDENTS_MCP_TOOL.name,
+      "list_endpoint_incidents",
+    );
+    assert.match(
+      LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
+      /list_endpoint_incidents/,
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
+    assert.ok(tool);
+    assert.equal(tool.title, "List endpoint incidents");
+  });
+});

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -677,6 +677,23 @@ describe("list_endpoint_pools — branch coverage", () => {
   });
 });
 
+// ── list_endpoint_incidents — endpoint incident artifact list ─────────────
+describe("list_endpoint_incidents — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_endpoint_incidents", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /endpoint-incidents\.json/);
+  });
+});
+
 // ── get_agent_resources — AI-resources artifact ───────────────────────────
 describe("get_agent_resources — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1484,6 +1484,73 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_endpoint_incidents returns filtered incident rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/endpoint-incidents.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        summary: { incident_count: 2 },
+        incidents: [
+          {
+            id: "incident-a",
+            netuid: 7,
+            severity: "critical",
+            state: "active",
+            status: "failed",
+          },
+          {
+            id: "incident-b",
+            netuid: 31,
+            severity: "warning",
+            state: "active",
+            status: "degraded",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_endpoint_incidents",
+      { severity: "critical" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.incidents[0].id, "incident-a");
+  });
+
+  test("list_endpoint_incidents reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_endpoint_incidents",
+      {},
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Endpoint incident snapshot unavailable/,
+    );
+  });
+
+  test("list_endpoint_incidents payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_endpoint_incidents",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/endpoint-incidents.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        notes: ["ok"],
+        summary: { incident_count: 1 },
+        incidents: [{ id: "incident-a", severity: "critical" }],
+      },
+    });
+    const res = await callTool(
+      "list_endpoint_incidents",
+      { limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("registry_summary returns the summary artifact", async () => {
     const res = await callTool("registry_summary", {}, { deps });
     assert.equal(res.body.result.structuredContent.completeness, 0.42);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_endpoint_incidents` MCP tool mirroring `GET /api/v1/endpoint-incidents` (baked `/metagraph/endpoint-incidents.json` artifact: probe-derived endpoint failures/degradations with severity, state, provider, and subnet metadata).
- Extract loader to `src/endpoint-incidents-mcp.mjs` with REST-parity list-query filters (netuid, kind, provider, status, severity, state, sort, order, fields, limit, cursor) and full unit + integration tests (100% line/branch coverage on the new module).
- Bump MCP server SemVer **1.60.0 → 1.61.0** (`server.json`, `validate-mcp.mjs`).

## Test plan
- [x] `npm run lint` + `npm run format:check`
- [x] `npx vitest run tests/endpoint-incidents-mcp.test.mjs` (100% coverage on new module)
- [x] `npx vitest run tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs` (list_endpoint_incidents paths)
- [x] `npm run build` + `node scripts/validate-mcp.mjs` (131 tools)
- [x] SemVer asserts updated across MCP test suites


