### PR TITLE
feat(mcp): add get_subnet_yield_history mirroring GET /api/v1/subnets/{netuid}/yield/history

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -601,6 +601,20 @@ assert.ok(
   "get_subnet_yield must return neurons[]",
 );
 assert.equal(yieldCard.netuid, 7, "get_subnet_yield must echo the netuid");
+const yieldHistory = await callOk("get_subnet_yield_history", {
+  netuid: 7,
+  window: "7d",
+});
+assert.equal(
+  yieldHistory.netuid,
+  7,
+  "get_subnet_yield_history must echo the netuid",
+);
+assert.ok(
+  Number.isInteger(yieldHistory.point_count) &&
+    Array.isArray(yieldHistory.points),
+  "get_subnet_yield_history must return point_count + points[]",
+);
 const uptimeFiltered = await callOk("get_subnet_uptime", {
   netuid: 7,
   min_samples: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -305,7 +305,11 @@ import {
 } from "./neuron-history.mjs";
 import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
-import { loadSubnetYield } from "./subnet-yield.mjs";
+import {
+  loadSubnetYield,
+  loadSubnetYieldHistory,
+  parseSubnetYieldHistoryWindow,
+} from "./subnet-yield.mjs";
 import {
   loadSubnetPerformance,
   loadSubnetPerformanceHistory,
@@ -407,7 +411,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.61.0";
+export const MCP_SERVER_VERSION = "1.62.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -559,6 +563,8 @@ export const MCP_INSTRUCTIONS =
   "per-day reward-flow and trust trend for one subnet, get_subnet_movers the cross-subnet " +
   "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
   "rates plus distribution percentiles over the current metagraph snapshot, " +
+  "get_subnet_yield_history the per-day emission-yield distribution trend for one " +
+  "subnet (subnet-wide return plus mean/median/p25/p75/p90 of per-UID yields), " +
   "get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, " +
   LIST_PROFILES_INSTRUCTIONS +
@@ -2950,6 +2956,42 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetYield(mcpD1Runner(ctx), netuid);
+    },
+  },
+  {
+    name: "get_subnet_yield_history",
+    title: "Get subnet yield history",
+    description:
+      "Fetch the per-day emission-yield distribution trend for one subnet " +
+      "over a 7d, 30d, or 90d window (default 30d): each day's subnet-wide " +
+      "return (total emission over total stake) plus the mean, median, p25, " +
+      "p75, and p90 of the per-UID emission-per-stake yields from the " +
+      "neuron_daily rollup. The time-series companion to get_subnet_yield. " +
+      "Mirrors GET /api/v1/subnets/{netuid}/yield/history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d"],
+          description: "Lookback window (default 30d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const parsed = parseSubnetYieldHistoryWindow(args?.window);
+      if (args?.window !== undefined && parsed.error) {
+        throw toolError("invalid_params", parsed.error.message);
+      }
+      const { label, days } = parsed;
+      return await loadSubnetYieldHistory(mcpD1Runner(ctx), netuid, {
+        windowLabel: label,
+        windowDays: days,
+      });
     },
   },
   {
@@ -8318,6 +8360,18 @@ const TOOL_OUTPUT_SCHEMAS = {
       p75_yield: { type: ["number", "null"] },
       p90_yield: { type: ["number", "null"] },
       neurons: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_subnet_yield_history: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "window", "point_count", "points"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      point_count: { type: "integer" },
+      points: { type: "array", items: { type: "object" } },
     },
   },
   get_subnet_stake_flow: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4769,6 +4769,101 @@ describe("MCP get_subnet_performance_history", () => {
   });
 });
 
+describe("MCP get_subnet_yield_history", () => {
+  function yieldHistoryD1(rows = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(_sql) {
+          return {
+            bind(..._params) {
+              return {
+                async all() {
+                  return { results: rows };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("returns the per-day yield series", async () => {
+    const res = await callTool(
+      "get_subnet_yield_history",
+      { netuid: 7, window: "7d" },
+      {
+        env: yieldHistoryD1([
+          {
+            snapshot_date: "2026-06-27",
+            stake_tao: 100,
+            emission_tao: 10,
+            validator_permit: 1,
+          },
+          {
+            snapshot_date: "2026-06-27",
+            stake_tao: 100,
+            emission_tao: 5,
+            validator_permit: 0,
+          },
+        ]),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "7d");
+    assert.equal(out.point_count, 1);
+    assert.equal(out.points[0].snapshot_date, "2026-06-27");
+    assert.equal(out.points[0].yield_count, 2);
+    assert.equal(out.points[0].subnet_yield, 0.075);
+  });
+
+  test("defaults to the 30d window on cold D1", async () => {
+    const res = await callTool("get_subnet_yield_history", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.point_count, 0);
+    assert.deepEqual(out.points, []);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_subnet_yield_history", {
+      netuid: 7,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_yield_history", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+
+  test("get_subnet_yield_history payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_subnet_yield_history",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_subnet_yield_history",
+      { netuid: 7 },
+      {
+        env: yieldHistoryD1([
+          {
+            snapshot_date: "2026-06-27",
+            stake_tao: 100,
+            emission_tao: 10,
+            validator_permit: 1,
+          },
+        ]),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+});
+
 describe("MCP get_network_activity", () => {
   test("merges extrinsics + blocks tiers from D1", async () => {
     const env = {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.61.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_subnet_yield_history` MCP tool mirroring `GET /api/v1/subnets/{netuid}/yield/history`, wiring the existing `loadSubnetYieldHistory` loader with 7d/30d/90d window support and a typed output schema.
- Bump MCP server version to **1.60.0** (129 tools) and extend validate-mcp cold-path coverage.
- Add integration tests: happy path, cold D1 zeros, invalid window, missing netuid, and outputSchema validation.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp` (129 tools)
- [x] `vitest run tests/mcp-server.test.mjs tests/subnet-yield.test.mjs` + version assertion suites


Made with [Cursor](https://cursor.com)