### PR TITLE
feat(mcp): add get_chain_weight_setters mirroring GET /api/v1/chain/weights/setters

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -450,6 +450,15 @@ assert.ok(
     Number.isInteger(subnetWeights.weight_sets),
   "get_subnet_weights must return distinct_setters + weight_sets",
 );
+const chainWeightSetters = await callOk("get_chain_weight_setters", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainWeightSetters.distinct_setters) &&
+    Array.isArray(chainWeightSetters.setters),
+  "get_chain_weight_setters must return distinct_setters + setters[]",
+);
 const chainStakeMoves = await callOk("get_chain_stake_moves", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -117,6 +117,13 @@ import {
   DEFAULT_CHAIN_WEIGHTS_WINDOW,
 } from "./chain-weights.mjs";
 import {
+  loadChainWeightSetters,
+  CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+  CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+  CHAIN_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW,
+} from "./chain-weight-setters.mjs";
+import {
   loadChainStakeMoves,
   CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
   CHAIN_STAKE_MOVES_LIMIT_MAX,
@@ -400,7 +407,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.60.0";
+export const MCP_SERVER_VERSION = "1.61.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -408,6 +415,9 @@ const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
+const CHAIN_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
+  CHAIN_WEIGHT_SETTERS_WINDOWS,
+);
 const CHAIN_STAKE_MOVES_WINDOW_KEYS = Object.keys(CHAIN_STAKE_MOVES_WINDOWS);
 const CHAIN_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
   CHAIN_STAKE_TRANSFERS_WINDOWS,
@@ -606,7 +616,9 @@ export const MCP_INSTRUCTIONS =
   "(per-subnet net TAO staked/unstaked and direction) across all subnets, " +
   "get_chain_weights the network-wide validator weight-setting leaderboard " +
   "(per-subnet WeightsSet activity, distinct setters, and update intensity) " +
-  "across all subnets, " +
+  "across all subnets, get_chain_weight_setters the network-wide weight-setter " +
+  "leaderboard (individual validators ranked by activity — the setter-level drill-in " +
+  "of get_chain_weights), " +
   "get_chain_stake_moves the network-wide stake-movement (re-delegation) " +
   "leaderboard (per-subnet StakeMoved activity, distinct movers, and " +
   "movements-per-mover intensity) across all subnets, " +
@@ -2471,7 +2483,8 @@ export const MCP_TOOLS = [
       "sets per setter) and the count/mean/min/p25/median/p75/p90/max spread of " +
       "per-subnet intensity, summed live from the account_events stream. The " +
       "consensus-maintenance companion to get_chain_stake_flow (capital) and " +
-      "get_chain_turnover (validator churn). Mirrors GET /api/v1/chain/weights.",
+      "get_chain_turnover (validator churn). Use get_chain_weight_setters for the " +
+      "setter-level leaderboard drill-in. Mirrors GET /api/v1/chain/weights.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2506,6 +2519,56 @@ export const MCP_TOOLS = [
       return loadChainWeights(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_WEIGHTS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_weight_setters",
+    title: "Get network-wide weight-setter leaderboard",
+    description:
+      "Fetch the network-wide weight-setter leaderboard over a 7d or 30d " +
+      "window (default 7d): the individual validators driving consensus across " +
+      "every subnet, each with its total WeightsSet count (summed across every " +
+      "subnet it operates on), its share of the network total, and its first/last " +
+      "set times, ranked by activity and capped by limit (1-100, default 20). " +
+      "The network-wide drill-in behind get_chain_weights — use " +
+      "get_subnet_weight_setters for one subnet's setter leaderboard. Mirrors GET " +
+      "/api/v1/chain/weights/setters.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_WEIGHT_SETTERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max setters in the leaderboard (1-${CHAIN_WEIGHT_SETTERS_LIMIT_MAX}, default ${CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
+      if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+        CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+      );
+      return loadChainWeightSetters(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_WEIGHT_SETTERS_WINDOWS[window],
         limit,
       });
     },
@@ -7788,6 +7851,33 @@ const TOOL_OUTPUT_SCHEMAS = {
           },
         },
       },
+    },
+  },
+  get_chain_weight_setters: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "window",
+      "distinct_setters",
+      "weight_sets",
+      "setter_count",
+      "setters",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_setters: { type: "integer" },
+      weight_sets: { type: "integer" },
+      setter_count: { type: "integer" },
+      setters: objectItems({
+        hotkey: NULLABLE_STRING,
+        uid: NULLABLE_INT,
+        weight_sets: { type: "integer" },
+        share: ANY,
+        first_set_at: NULLABLE_STRING,
+        last_set_at: NULLABLE_STRING,
+      }),
     },
   },
   get_chain_stake_moves: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8553,6 +8553,128 @@ describe("MCP economics + metagraph data tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  function chainWeightSettersD1(
+    { leaderboardRows = [], totalsRow = null } = {},
+    capture = [],
+  ) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: {
+          prepare(sql) {
+            return {
+              bind(...params) {
+                capture.push({ sql, params });
+                return {
+                  async all() {
+                    if (/GROUP BY/.test(sql)) {
+                      return { results: leaderboardRows };
+                    }
+                    return { results: totalsRow ? [totalsRow] : [] };
+                  },
+                };
+              },
+            };
+          },
+        },
+      },
+    };
+  }
+
+  test("get_chain_weight_setters ranks setters with network-wide shares", async () => {
+    const res = await callTool(
+      "get_chain_weight_setters",
+      { window: "7d", limit: 10 },
+      chainWeightSettersD1({
+        leaderboardRows: [
+          {
+            hotkey: "5Val1",
+            uid: 3,
+            weight_sets: 6,
+            first_set: 1_717_000_000_000,
+            last_set: 1_717_500_000_000,
+          },
+          {
+            hotkey: "5Val2",
+            uid: 7,
+            weight_sets: 4,
+            first_set: 1_717_100_000_000,
+            last_set: 1_717_400_000_000,
+          },
+        ],
+        totalsRow: {
+          weight_sets: 10,
+          distinct_setters: 2,
+          newest_observed: 1_717_500_000_000,
+        },
+      }),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.weight_sets, 10);
+    assert.equal(out.distinct_setters, 2);
+    assert.equal(out.setter_count, 2);
+    assert.equal(out.setters[0].hotkey, "5Val1");
+    assert.equal(out.setters[0].share, 0.6);
+  });
+
+  test("get_chain_weight_setters returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_weight_setters", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.weight_sets, 0);
+    assert.equal(out.distinct_setters, 0);
+    assert.equal(out.setter_count, 0);
+    assert.deepEqual(out.setters, []);
+  });
+
+  test("get_chain_weight_setters rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_weight_setters", { window: "90d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_chain_weight_setters caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_weight_setters",
+      { limit: 1 },
+      chainWeightSettersD1({
+        leaderboardRows: [
+          { hotkey: "5Val1", uid: 3, weight_sets: 6 },
+          { hotkey: "5Val2", uid: 7, weight_sets: 4 },
+        ],
+        totalsRow: {
+          weight_sets: 10,
+          distinct_setters: 2,
+          newest_observed: 1_717_500_000_000,
+        },
+      }),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.distinct_setters, 2);
+    assert.equal(out.setter_count, 1);
+    assert.equal(out.setters.length, 1);
+  });
+
+  test("get_chain_weight_setters payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_weight_setters",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_weight_setters",
+      {},
+      chainWeightSettersD1({
+        leaderboardRows: [{ hotkey: "5Val1", uid: 3, weight_sets: 6 }],
+        totalsRow: {
+          weight_sets: 6,
+          distinct_setters: 1,
+          newest_observed: 1_717_500_000_000,
+        },
+      }),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   // The network-wide aggregate row loadChainStakeMoves reads first (its
   // COUNT(DISTINCT coldkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.61.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_chain_weight_setters` MCP tool mirroring `GET /api/v1/chain/weights/setters`, wiring the existing `loadChainWeightSetters` loader with 7d/30d window support, limit (1-100), and a typed output schema.
- Bump MCP server version to **1.61.0** (131 tools) and extend validate-mcp cold-path coverage.
- Add integration tests: happy path, cold D1 zeros, invalid window, limit cap, and outputSchema validation.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp` (131 tools)
- [x] `vitest run tests/mcp-server.test.mjs tests/chain-weight-setters.test.mjs` + version assertion suites


Made with [Cursor](https://cursor.com)