### PR TITLE
feat(api): add CSV export for subnet concentration/history endpoint

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1728,7 +1728,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). */
+        /** Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetConcentrationHistory"];
         put?: never;
         post?: never;
@@ -20981,6 +20981,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -20990,7 +20992,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -21041,6 +21043,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetConcentrationHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share
+                     *     2026-06-27,2,0.490099,1,0.990099,0.409091,1,0.909091
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4866,7 +4866,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "cache": "short",
-      "description": "Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup).",
+      "description": "Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). Pass ?format=csv to download the per-day series as CSV.",
       "id": "subnet-concentration-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/concentration/history",
@@ -4881,6 +4881,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -498,7 +498,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
+      "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history; pass ?format=csv to download the per-day series as CSV (no static file).",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationHistoryArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -40467,6 +40467,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -40525,9 +40538,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share\r\n2026-06-27,2,0.490099,1,0.990099,0.409091,1,0.909091",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -40584,7 +40603,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup).",
+        "summary": "Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). Pass ?format=csv to download the per-day series as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1728,7 +1728,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). */
+        /** Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetConcentrationHistory"];
         put?: never;
         post?: never;
@@ -20981,6 +20981,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -20990,7 +20992,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -21041,6 +21043,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetConcentrationHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share
+                     *     2026-06-27,2,0.490099,1,0.990099,0.409091,1,0.909091
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -950,7 +950,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-concentration-history",
     "/metagraph/subnets/{netuid}/concentration/history.json",
-    "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
+    "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history; pass ?format=csv to download the per-day series as CSV (no static file).",
     "SubnetConcentrationHistoryArtifact",
   ),
   artifact(
@@ -2033,15 +2033,15 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/concentration/history",
     "/metagraph/subnets/{netuid}/concentration/history.json",
-    "Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup).",
+    "Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily D1 rollup). Pass ?format=csv to download the per-day series as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
       },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -9,6 +9,10 @@ const EVENTS_CSV_EXAMPLE = [
 ].join("\r\n");
 
 export const ROUTE_CSV_EXAMPLES = {
+  "subnet-concentration-history": [
+    "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share",
+    "2026-06-27,2,0.490099,1,0.990099,0.409091,1,0.909091",
+  ].join("\r\n"),
   "subnet-yield": [
     "uid,hotkey,role,stake_tao,emission_tao,yield,vs_median",
     "0,hk_sample,validator,1000,22.1,0.0221,above",

--- a/tests/subnet-concentration-history-csv.test.mjs
+++ b/tests/subnet-concentration-history-csv.test.mjs
@@ -1,0 +1,275 @@
+// CSV export tests for GET /api/v1/subnets/{netuid}/concentration/history — kept in
+// a dedicated file so this PR does not contend with open entity-handler PRs on the
+// shared request-handlers-entities.test.mjs harness.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  canonicalSubnetConcentrationHistoryCachePath,
+  handleSubnetConcentrationHistory,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+function neuronDailyEnv(rows) {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(..._params) {
+            return {
+              all: async () => {
+                if (/FROM neuron_daily WHERE netuid = \?/.test(sql)) {
+                  return { results: rows };
+                }
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("subnet concentration history OpenAPI CSV contract", () => {
+  test("documents the CSV header on the concentration/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/concentration/history"].get
+        .responses["200"].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(
+      csvContent.example.split("\r\n")[0],
+      "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share",
+    );
+  });
+});
+
+describe("handleSubnetConcentrationHistory CSV export", () => {
+  test("returns CSV response when ?format=csv is present", async () => {
+    const env = neuronDailyEnv([
+      { snapshot_date: "2026-06-27", stake_tao: 100, emission_tao: 10 },
+      { snapshot_date: "2026-06-27", stake_tao: 1, emission_tao: 1 },
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+    ]);
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(
+      res.headers
+        .get("content-disposition")
+        .includes('filename="subnet-7-concentration-history.csv"'),
+    );
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share",
+    );
+    assert.equal(lines[1], "2026-06-26,2,0,2,0.5,0,2,0.5");
+    assert.equal(
+      lines[2],
+      "2026-06-27,2,0.490099,1,0.990099,0.409091,1,0.909091",
+    );
+  });
+
+  test("returns CSV response when Accept: text/csv header is present", async () => {
+    const env = neuronDailyEnv([
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+    ]);
+    const request = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/concentration/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const res = await handleSubnetConcentrationHistory(
+      request,
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[1], "2026-06-26,2,0,2,0.5,0,2,0.5");
+  });
+
+  test("returns header-only CSV when D1 is cold", async () => {
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share",
+    );
+    assert.equal(lines.length, 1);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=30d&format=pdf`,
+      ),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/concentration/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("returns the JSON envelope when CSV is not requested", async () => {
+    const env = neuronDailyEnv([
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+    ]);
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.point_count, 1);
+    assert.equal(body.data.points[0].snapshot_date, "2026-06-26");
+  });
+
+  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
+    const env = neuronDailyEnv([
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+    ]);
+    const request = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/concentration/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const res = await handleSubnetConcentrationHistory(
+      request,
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=7d&format=json`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.data.point_count, 1);
+  });
+});
+
+describe("canonicalSubnetConcentrationHistoryCachePath", () => {
+  test("default window stays canonical for JSON", () => {
+    assert.equal(
+      canonicalSubnetConcentrationHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/concentration/history`),
+      ),
+      `/api/v1/subnets/${NETUID}/concentration/history?window=30d`,
+    );
+  });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalSubnetConcentrationHistoryCachePath(
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=7d&format=csv`,
+      ),
+    );
+    assert.equal(
+      csv,
+      `/api/v1/subnets/${NETUID}/concentration/history?window=7d&format=csv`,
+    );
+
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/concentration/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const json = canonicalSubnetConcentrationHistoryCachePath(
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=7d&format=json`,
+      ),
+      csvAccept,
+    );
+    assert.equal(
+      json,
+      `/api/v1/subnets/${NETUID}/concentration/history?window=7d`,
+    );
+  });
+
+  test("adds format=csv when only Accept: text/csv is present", () => {
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/concentration/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    assert.equal(
+      canonicalSubnetConcentrationHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/concentration/history?window=90d`),
+        csvAccept,
+      ),
+      `/api/v1/subnets/${NETUID}/concentration/history?window=90d&format=csv`,
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = `/api/v1/subnets/${NETUID}/concentration/history?bogus=1`;
+    assert.equal(canonicalSubnetConcentrationHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid format", () => {
+    const raw = `/api/v1/subnets/${NETUID}/concentration/history?format=pdf`;
+    assert.equal(canonicalSubnetConcentrationHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window", () => {
+    const raw = `/api/v1/subnets/${NETUID}/concentration/history?window=1y`;
+    assert.equal(canonicalSubnetConcentrationHistoryCachePath(url(raw)), raw);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1432,7 +1432,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(concentrationHistoryMatch[1]),
             resolved.url,
           ),
-        canonicalSubnetConcentrationHistoryCachePath(resolved.url),
+        canonicalSubnetConcentrationHistoryCachePath(resolved.url, request),
       );
     }
     const performanceHistoryMatch =

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -299,6 +299,16 @@ const SUBNET_YIELD_CSV_COLUMNS = [
   "yield",
   "vs_median",
 ];
+const SUBNET_CONCENTRATION_HISTORY_CSV_COLUMNS = [
+  "snapshot_date",
+  "neuron_count",
+  "stake_gini",
+  "stake_nakamoto_coefficient",
+  "stake_top_10pct_share",
+  "emission_gini",
+  "emission_nakamoto_coefficient",
+  "emission_top_10pct_share",
+];
 
 // CSV projection for the recent-block feed (#2528). The block rows are already
 // flat (formatBlock), so the feed's own fields are the columns in read order.
@@ -916,8 +926,20 @@ export function canonicalSubnetHistoryCachePath(url) {
   return canonicalWindowedCachePath(url, parseHistoryWindow);
 }
 
-export function canonicalSubnetConcentrationHistoryCachePath(url) {
-  return canonicalWindowedCachePath(url, parseConcentrationHistoryWindow);
+export function canonicalSubnetConcentrationHistoryCachePath(url, request = null) {
+  const validationError = validateQueryParams(url, ["window", "format"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateResponseFormat(url);
+  if (formatError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseConcentrationHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return `${url.pathname}${url.search}`;
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 export function canonicalSubnetPerformanceHistoryCachePath(url) {
@@ -1123,8 +1145,10 @@ export async function handleSubnetConcentrationHistory(
   netuid,
   url,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateResponseFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { label, days, error } = parseConcentrationHistoryWindow(
     url.searchParams.get("window"),
   );
@@ -1141,6 +1165,18 @@ export async function handleSubnetConcentrationHistory(
     window: label,
     capped: rows.length >= CONCENTRATION_HISTORY_ROW_CAP,
   });
+  if (csvRequested(url, request)) {
+    const points = [...data.points].sort((a, b) =>
+      String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
+    );
+    return csvResponse(
+      points,
+      `subnet-${netuid}-concentration-history`,
+      "short",
+      request,
+      SUBNET_CONCENTRATION_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -926,7 +926,10 @@ export function canonicalSubnetHistoryCachePath(url) {
   return canonicalWindowedCachePath(url, parseHistoryWindow);
 }
 
-export function canonicalSubnetConcentrationHistoryCachePath(url, request = null) {
+export function canonicalSubnetConcentrationHistoryCachePath(
+  url,
+  request = null,
+) {
   const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return `${url.pathname}${url.search}`;
   const formatError = validateResponseFormat(url);


### PR DESCRIPTION
## Summary

Adds `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/subnets/{netuid}/concentration/history` so the per-day stake and emission decentralization series (Gini, Nakamoto coefficient, top-10% share) can be downloaded as CSV.

Implementation follows the same pattern as the existing subnet yield and trajectory CSV exports:
- handler + edge-cache changes in `workers/request-handlers/entities.mjs`
- OpenAPI/contract artifacts regenerated via `npm run build`
- CSV example isolated in `csv-route-examples.mjs`
- dedicated test file `tests/subnet-concentration-history-csv.test.mjs` (avoids contending with open entity-handler PRs on shared harness files)

**10 files changed, 1 commit** — no bundled work from other open PRs.

## Test plan

- [x] `npm run build`
- [x] `npm run validate`
- [x] `tests/subnet-concentration-history-csv.test.mjs` — CSV body, Accept header, cold export, JSON envelope, format validation, cache-key variants, OpenAPI CSV example
