### PR TITLE
feat(mcp): add get_changelog

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -286,6 +286,15 @@ assert.ok(
 );
 await callOk("registry_summary", {});
 await callOk("get_coverage", {});
+const changelog = await callOk("get_changelog", {});
+assert.equal(
+  changelog.source,
+  "generated-artifact-diff",
+  "get_changelog must return the publish-time diff payload",
+);
+assert.ok(changelog.summary && typeof changelog.summary === "object");
+assert.ok(changelog.artifacts && typeof changelog.artifacts === "object");
+assert.ok(changelog.subnets && typeof changelog.subnets === "object");
 
 // Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold
 // env has them only after `npm run build` stages dist/. Exercise the happy path

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.60.0",
+  "version": "1.62.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/changelog-mcp.mjs
+++ b/src/changelog-mcp.mjs
@@ -1,0 +1,71 @@
+// Changelog loader for MCP parity on GET /api/v1/changelog.
+// Serves the baked /metagraph/changelog.json artifact (publish-time artifact,
+// subnet, and coverage diffs).
+
+export const CHANGELOG_ARTIFACT = "/metagraph/changelog.json";
+
+export function changelogToolError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export async function loadChangelog(ctx, { readArtifact } = {}) {
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, CHANGELOG_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw changelogToolError(
+        "not_found",
+        "The registry changelog is unavailable in this environment.",
+      );
+    }
+    throw changelogToolError(
+      code,
+      `Could not load ${CHANGELOG_ARTIFACT} (${code}).`,
+    );
+  }
+  return result.data;
+}
+
+export const GET_CHANGELOG_INSTRUCTIONS =
+  "get_changelog the latest publish-time registry change summary (artifact, " +
+  "subnet, and coverage diffs; mirrors GET /api/v1/changelog), ";
+
+export const GET_CHANGELOG_MCP_TOOL = {
+  name: "get_changelog",
+  title: "Get registry changelog",
+  description:
+    "Fetch the latest generated registry changelog: artifact added/modified/removed " +
+    "rows, subnet added/removed/renamed events, and coverage deltas since the " +
+    "previous publish. Use it to see what changed between registry publishes " +
+    "before drilling into registry_summary or list_enrichment_targets. Mirrors " +
+    "GET /api/v1/changelog.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+
+export const GET_CHANGELOG_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["source", "summary", "artifacts", "subnets"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    source: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    summary: { type: "object" },
+    artifacts: { type: "object" },
+    subnets: { type: "object" },
+    coverage_delta: { type: ["object", "null"] },
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -56,6 +56,12 @@ import {
   loadRegistryCoverage,
 } from "./registry-coverage.mjs";
 import {
+  GET_CHANGELOG_INSTRUCTIONS,
+  GET_CHANGELOG_MCP_TOOL,
+  GET_CHANGELOG_OUTPUT_SCHEMA,
+  loadChangelog,
+} from "./changelog-mcp.mjs";
+import {
   GET_AGENT_RESOURCES_INSTRUCTIONS,
   GET_AGENT_RESOURCES_MCP_TOOL,
   GET_AGENT_RESOURCES_OUTPUT_SCHEMA,
@@ -400,7 +406,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.60.0";
+export const MCP_SERVER_VERSION = "1.62.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -498,6 +504,7 @@ export const MCP_INSTRUCTIONS =
   "list_subnet_apis + get_api_schema to integrate a subnet's API, and " +
   "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
   GET_COVERAGE_INSTRUCTIONS +
+  GET_CHANGELOG_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
@@ -6293,6 +6300,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...GET_CHANGELOG_MCP_TOOL,
+    async handler(_args, ctx) {
+      return loadChangelog(ctx);
+    },
+  },
+  {
     name: "get_agent_catalog",
     title: "Get the agent capability catalog",
     description:
@@ -9840,6 +9853,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       generated_at: NULLABLE_STRING,
     },
   },
+  get_changelog: GET_CHANGELOG_OUTPUT_SCHEMA,
   get_agent_catalog: {
     // Two shapes: the global index (no netuid) and a single-subnet catalog
     // (with a netuid). They share few keys, so nothing is required; the

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  CHANGELOG_ARTIFACT,
+  GET_CHANGELOG_INSTRUCTIONS,
+  GET_CHANGELOG_MCP_TOOL,
+  GET_CHANGELOG_OUTPUT_SCHEMA,
+  changelogToolError,
+  loadChangelog,
+} from "../src/changelog-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_CHANGELOG = {
+  source: "generated-artifact-diff",
+  summary: {
+    artifact_added_count: 1,
+    artifact_modified_count: 2,
+    artifact_removed_count: 0,
+  },
+  artifacts: { added: [], modified: [], removed: [] },
+  subnets: { added: [], removed: [], renamed: [] },
+  notes: ["publish-time diff"],
+};
+
+describe("changelog-mcp", () => {
+  test("changelogToolError is shaped for MCP toolError handling", () => {
+    const err = changelogToolError("not_found", "missing");
+    assert.equal(err.code, "not_found");
+    assert.equal(err.toolError, true);
+    assert.equal(err.message, "missing");
+  });
+
+  test("loadChangelog returns the baked artifact payload", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async (_env, path) => ({
+        ok: true,
+        data: path === CHANGELOG_ARTIFACT ? SAMPLE_CHANGELOG : null,
+      }),
+    };
+    const out = await loadChangelog(ctx);
+    assert.equal(out.source, "generated-artifact-diff");
+    assert.equal(out.summary.artifact_added_count, 1);
+    assert.deepEqual(out.notes, ["publish-time diff"]);
+  });
+
+  test("loadChangelog uses an injected readArtifact dep", async () => {
+    const out = await loadChangelog(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            source: "test",
+            summary: {},
+            artifacts: {},
+            subnets: {},
+          },
+        }),
+      },
+    );
+    assert.equal(out.source, "test");
+  });
+
+  test("loadChangelog maps artifact_not_found to not_found", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_not_found",
+      }),
+    };
+    await assert.rejects(
+      () => loadChangelog(ctx),
+      (err) =>
+        err.code === "not_found" &&
+        err.toolError === true &&
+        /unavailable in this environment/.test(err.message),
+    );
+  });
+
+  test("loadChangelog surfaces other artifact failures with the path", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+    };
+    await assert.rejects(
+      () => loadChangelog(ctx),
+      (err) =>
+        err.code === "artifact_timeout" && /changelog\.json/.test(err.message),
+    );
+  });
+
+  test("loadChangelog defaults code when the read result is bare", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({ ok: false }),
+    };
+    await assert.rejects(
+      () => loadChangelog(ctx),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(GET_CHANGELOG_MCP_TOOL.name, "get_changelog");
+    assert.match(GET_CHANGELOG_INSTRUCTIONS, /get_changelog/);
+    assert.deepEqual(
+      Object.keys(GET_CHANGELOG_MCP_TOOL.inputSchema.properties),
+      [],
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(GET_CHANGELOG_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire get_changelog at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
+    assert.match(MCP_INSTRUCTIONS, /get_changelog/);
+    const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
+    assert.ok(tool);
+    assert.equal(tool.title, "Get registry changelog");
+  });
+});

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -677,6 +677,23 @@ describe("list_endpoint_pools — branch coverage", () => {
   });
 });
 
+// ── get_changelog — changelog artifact ────────────────────────────────────
+describe("get_changelog — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("get_changelog", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /changelog\.json/);
+  });
+});
+
 // ── get_agent_resources — AI-resources artifact ───────────────────────────
 describe("get_agent_resources — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1511,6 +1511,53 @@ describe("MCP tools (injected deps)", () => {
     );
   });
 
+  test("get_changelog returns the changelog artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/changelog.json": {
+        source: "generated-artifact-diff",
+        summary: { artifact_added_count: 3 },
+        artifacts: {
+          added: [{ path: "/metagraph/foo.json" }],
+          modified: [],
+          removed: [],
+        },
+        subnets: { added: [], removed: [], renamed: [] },
+        notes: ["publish-time diff"],
+      },
+    });
+    const res = await callTool("get_changelog", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "generated-artifact-diff");
+    assert.equal(out.summary.artifact_added_count, 3);
+    assert.equal(out.artifacts.added.length, 1);
+  });
+
+  test("get_changelog reports not_found when the artifact is absent", async () => {
+    const res = await callTool("get_changelog", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /unavailable in this environment/,
+    );
+  });
+
+  test("get_changelog payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_changelog",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/changelog.json": {
+        source: "generated-artifact-diff",
+        summary: { artifact_added_count: 0 },
+        artifacts: { added: [], modified: [], removed: [] },
+        subnets: { added: [], removed: [], renamed: [] },
+      },
+    });
+    const res = await callTool("get_changelog", {}, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_enrichment_targets returns ranked coverage-depth targets", async () => {
     const res = await callTool(
       "list_enrichment_targets",

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.60.0");
+    assert.equal(MCP_SERVER_VERSION, "1.62.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_changelog` MCP tool mirroring `GET /api/v1/changelog` (baked `/metagraph/changelog.json` artifact: publish-time artifact, subnet, and coverage diffs).
- Extract loader to `src/changelog-mcp.mjs` with full unit + integration tests (100% line/branch coverage on the new module).
- Bump MCP server SemVer **1.60.0 → 1.62.0** (`server.json`, `validate-mcp.mjs`). Skips 1.61.0 while #3235 (`list_endpoint_incidents`) is open.

## Test plan
- [x] `npm run lint` + `npm run format:check`
- [x] `npx vitest run tests/changelog-mcp.test.mjs` (100% coverage on new module)
- [x] `npx vitest run tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs` (get_changelog paths)
- [x] `npm run build` + `node scripts/validate-mcp.mjs` (131 tools)
- [x] SemVer asserts updated across MCP test suites


Made with [Cursor](https://cursor.com)