### PR TITLE
feat(mcp): add get_chain_weight_setters mirroring GET /api/v1/chain/weights/setters

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -450,6 +450,16 @@ assert.ok(
     Number.isInteger(subnetWeights.weight_sets),
   "get_subnet_weights must return distinct_setters + weight_sets",
 );
+const chainWeightSetters = await callOk("get_chain_weight_setters", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainWeightSetters.distinct_setters) &&
+    Number.isInteger(chainWeightSetters.weight_sets) &&
+    Array.isArray(chainWeightSetters.setters),
+  "get_chain_weight_setters must return distinct_setters + weight_sets + setters[]",
+);
 const chainStakeMoves = await callOk("get_chain_stake_moves", {
   window: "7d",
   limit: 5,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -117,6 +117,13 @@ import {
   DEFAULT_CHAIN_WEIGHTS_WINDOW,
 } from "./chain-weights.mjs";
 import {
+  loadChainWeightSetters,
+  CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+  CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+  CHAIN_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW,
+} from "./chain-weight-setters.mjs";
+import {
   loadChainStakeMoves,
   CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
   CHAIN_STAKE_MOVES_LIMIT_MAX,
@@ -400,7 +407,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.60.0";
+export const MCP_SERVER_VERSION = "1.61.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -408,6 +415,9 @@ const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
+const CHAIN_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
+  CHAIN_WEIGHT_SETTERS_WINDOWS,
+);
 const CHAIN_STAKE_MOVES_WINDOW_KEYS = Object.keys(CHAIN_STAKE_MOVES_WINDOWS);
 const CHAIN_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
   CHAIN_STAKE_TRANSFERS_WINDOWS,
@@ -607,6 +617,9 @@ export const MCP_INSTRUCTIONS =
   "get_chain_weights the network-wide validator weight-setting leaderboard " +
   "(per-subnet WeightsSet activity, distinct setters, and update intensity) " +
   "across all subnets, " +
+  "get_chain_weight_setters the network-wide weight-setter leaderboard " +
+  "(the individual validators behind /weights ranked by activity across every " +
+  "subnet) — the setter-level drill-in of get_chain_weights, " +
   "get_chain_stake_moves the network-wide stake-movement (re-delegation) " +
   "leaderboard (per-subnet StakeMoved activity, distinct movers, and " +
   "movements-per-mover intensity) across all subnets, " +
@@ -2506,6 +2519,56 @@ export const MCP_TOOLS = [
       return loadChainWeights(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_WEIGHTS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_weight_setters",
+    title: "Get network-wide weight-setter leaderboard",
+    description:
+      "Fetch the network-wide weight-setter leaderboard over the requested " +
+      "window (7d or 30d; default 7d): the individual validators driving " +
+      "consensus across every subnet, each with its total WeightsSet count " +
+      "(summed across every subnet it operates on), its share of the network " +
+      "total, and its first/last set times, ranked by activity. The " +
+      "setter-level drill-in of get_chain_weights / get_subnet_weight_setters " +
+      "— use get_subnet_weight_setters for one subnet's setter board. Mirrors " +
+      "GET /api/v1/chain/weights/setters.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_WEIGHT_SETTERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max setters in the leaderboard (1-${CHAIN_WEIGHT_SETTERS_LIMIT_MAX}, default ${CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
+      if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+        CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+      );
+      return loadChainWeightSetters(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_WEIGHT_SETTERS_WINDOWS[window],
         limit,
       });
     },
@@ -7788,6 +7851,32 @@ const TOOL_OUTPUT_SCHEMAS = {
           },
         },
       },
+    },
+  },
+  get_chain_weight_setters: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "distinct_setters",
+      "weight_sets",
+      "setter_count",
+      "setters",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_setters: { type: "integer" },
+      weight_sets: { type: "integer" },
+      setter_count: { type: "integer" },
+      setters: objectItems({
+        hotkey: NULLABLE_STRING,
+        uid: NULLABLE_INT,
+        weight_sets: { type: "integer" },
+        share: ANY,
+        first_set_at: NULLABLE_STRING,
+        last_set_at: NULLABLE_STRING,
+      }),
     },
   },
   get_chain_stake_moves: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7338,6 +7338,8 @@ describe("MCP economics + metagraph data tools", () => {
     accountEvents = [],
     weightsNetworkRows = [],
     weightsSubnetRows = [],
+    chainWeightSettersLeaderRows = [],
+    chainWeightSettersTotalsRows = [],
     stakeMovesNetworkRows = [],
     stakeMovesSubnetRows = [],
     stakeTransfersNetworkRows = [],
@@ -7384,7 +7386,12 @@ describe("MCP economics + metagraph data tools", () => {
                   // everything else uses the flat account_events fixture.
                   if (sql.includes("newest_observed")) {
                     if (sql.includes("weight_sets")) {
-                      return Promise.resolve({ results: weightsNetworkRows });
+                      return Promise.resolve({
+                        results:
+                          chainWeightSettersTotalsRows.length > 0
+                            ? chainWeightSettersTotalsRows
+                            : weightsNetworkRows,
+                      });
                     }
                     if (sql.includes("distinct_movers")) {
                       return Promise.resolve({
@@ -7419,6 +7426,11 @@ describe("MCP economics + metagraph data tools", () => {
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
+                    if (sql.includes("first_set")) {
+                      return Promise.resolve({
+                        results: chainWeightSettersLeaderRows,
+                      });
+                    }
                     return Promise.resolve({ results: weightsSubnetRows });
                   }
                   if (sql.includes("AS movements")) {
@@ -8547,6 +8559,140 @@ describe("MCP economics + metagraph data tools", () => {
       chainWeightsEnv(weightsNetwork(30, 8), [
         weightsRow(1, 20, 5),
         weightsRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  function weightSettersTotals(weight_sets, distinct_setters) {
+    return {
+      weight_sets,
+      distinct_setters,
+      newest_observed: 1_750_600_000_000,
+    };
+  }
+
+  function weightSettersLeaderRow(
+    hotkey,
+    uid,
+    weight_sets,
+    first_set,
+    last_set,
+  ) {
+    return { hotkey, uid, weight_sets, first_set, last_set };
+  }
+
+  function chainWeightSettersEnv(totals, leaders) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          chainWeightSettersTotalsRows: totals ? [totals] : [],
+          chainWeightSettersLeaderRows: leaders,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_weight_setters returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_weight_setters", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d");
+    assert.equal(out.setter_count, 0);
+    assert.deepEqual(out.setters, []);
+    assert.equal(out.weight_sets, 0);
+    assert.equal(out.distinct_setters, 0);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_weight_setters ranks setters with network totals", async () => {
+    const res = await callTool(
+      "get_chain_weight_setters",
+      { window: "30d", limit: 10 },
+      chainWeightSettersEnv(weightSettersTotals(40, 2), [
+        weightSettersLeaderRow(
+          "5Grw...alice",
+          3,
+          30,
+          1_750_000_000_000,
+          1_750_600_000_000,
+        ),
+        weightSettersLeaderRow(
+          null,
+          8,
+          10,
+          1_750_100_000_000,
+          1_750_200_000_000,
+        ),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.setter_count, 2);
+    assert.equal(out.weight_sets, 40);
+    assert.equal(out.distinct_setters, 2);
+    assert.equal(out.setters[0].weight_sets, 30);
+    assert.equal(out.setters[0].share, 0.75);
+    assert.equal(out.setters[1].weight_sets, 10);
+    assert.equal(out.setters[1].share, 0.25);
+    assert.equal(
+      out.observed_at,
+      new Date(1_750_600_000_000).toISOString(),
+    );
+  });
+
+  test("get_chain_weight_setters rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_chain_weight_setters",
+      { window: "90d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_weight_setters caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_weight_setters",
+      { limit: 1 },
+      chainWeightSettersEnv(weightSettersTotals(40, 2), [
+        weightSettersLeaderRow(
+          "5Grw...alice",
+          3,
+          30,
+          1_750_000_000_000,
+          1_750_600_000_000,
+        ),
+        weightSettersLeaderRow(
+          null,
+          8,
+          10,
+          1_750_100_000_000,
+          1_750_200_000_000,
+        ),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.distinct_setters, 2);
+    assert.equal(out.setters.length, 1);
+  });
+
+  test("get_chain_weight_setters payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_weight_setters",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_weight_setters",
+      {},
+      chainWeightSettersEnv(weightSettersTotals(40, 2), [
+        weightSettersLeaderRow(
+          "5Grw...alice",
+          3,
+          30,
+          1_750_000_000_000,
+          1_750_600_000_000,
+        ),
       ]),
     );
     const validate = new Ajv2020().compile(schema);


### PR DESCRIPTION
## Summary

Add `get_chain_weight_setters` MCP tool mirroring `GET /api/v1/chain/weights/setters`.

## What Changed

- Register `get_chain_weight_setters` in `src/mcp-server.mjs`, delegating to the existing `loadChainWeightSetters` loader with `window` and `limit` parameters.
- Declare the tool output schema and bump MCP server version to 1.61.0.
- Extend MCP validation and unit tests for cold D1, ranked results, window rejection, limit capping, and outputSchema conformance.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

Tests added for the new tool in `tests/mcp-server.test.mjs`; full suite not run locally (Node unavailable in this environment).

## Template Used

- backend-code.md
