### PR TITLE
feat(api): add CSV export for subnet yield/history endpoint

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2289,7 +2289,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history — the per-UID yield distribution is not reconstructable from the stake+emission totals in /history. */
+        /** Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetYieldHistory"];
         put?: never;
         post?: never;
@@ -25580,6 +25580,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -25589,7 +25591,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -25640,6 +25642,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetYieldHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield
+                     *     2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5339,7 +5339,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/yield/history.json",
       "cache": "short",
-      "description": "Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history — the per-UID yield distribution is not reconstructable from the stake+emission totals in /history.",
+      "description": "Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
       "id": "subnet-yield-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/yield/history",
@@ -5354,6 +5354,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -651,7 +651,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Per-day emission-yield distribution trend (subnet-wide return plus the mean/median/p25/p75/p90 of the per-UID emission-per-stake yields) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/yield/history (no static file). The time-series companion to /yield and the return-rate twin of /concentration/history.",
+      "description": "Per-day emission-yield distribution trend (subnet-wide return plus the mean/median/p25/p75/p90 of the per-UID emission-per-stake yields) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/yield/history; pass ?format=csv to download the per-day series as CSV (no static file). The time-series companion to /yield and the return-rate twin of /concentration/history.",
       "id": "subnet-yield-history",
       "path": "/metagraph/subnets/{netuid}/yield/history.json",
       "schema_ref": "#/components/schemas/SubnetYieldHistoryArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -46837,6 +46837,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -46895,9 +46908,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield\r\n2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -46954,7 +46973,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history — the per-UID yield distribution is not reconstructable from the stake+emission totals in /history.",
+        "summary": "Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2289,7 +2289,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history — the per-UID yield distribution is not reconstructable from the stake+emission totals in /history. */
+        /** Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetYieldHistory"];
         put?: never;
         post?: never;
@@ -25580,6 +25580,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -25589,7 +25591,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -25640,6 +25642,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetYieldHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield
+                     *     2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1052,7 +1052,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-yield-history",
     "/metagraph/subnets/{netuid}/yield/history.json",
-    "Per-day emission-yield distribution trend (subnet-wide return plus the mean/median/p25/p75/p90 of the per-UID emission-per-stake yields) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/yield/history (no static file). The time-series companion to /yield and the return-rate twin of /concentration/history.",
+    "Per-day emission-yield distribution trend (subnet-wide return plus the mean/median/p25/p75/p90 of the per-UID emission-per-stake yields) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/yield/history; pass ?format=csv to download the per-day series as CSV (no static file). The time-series companion to /yield and the return-rate twin of /concentration/history.",
     "SubnetYieldHistoryArtifact",
   ),
   artifact(
@@ -2281,15 +2281,15 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/yield/history",
     "/metagraph/subnets/{netuid}/yield/history.json",
-    "Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history — the per-UID yield distribution is not reconstructable from the stake+emission totals in /history.",
+    "Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily D1 rollup). The time-series companion to /yield and the return-rate twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
       },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -13,6 +13,10 @@ export const ROUTE_CSV_EXAMPLES = {
     "uid,hotkey,role,stake_tao,emission_tao,yield,vs_median",
     "0,hk_sample,validator,1000,22.1,0.0221,above",
   ].join("\r\n"),
+  "subnet-yield-history": [
+    "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
+    "2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1",
+  ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
   // The Postgres all-events feed: flat scalar columns of each raw pallet.method

--- a/tests/subnet-yield-history-csv.test.mjs
+++ b/tests/subnet-yield-history-csv.test.mjs
@@ -1,0 +1,284 @@
+// CSV export tests for GET /api/v1/subnets/{netuid}/yield/history — kept in a
+// dedicated file so this PR does not contend with open entity-handler PRs on the
+// shared request-handlers-entities.test.mjs harness.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  canonicalSubnetYieldHistoryCachePath,
+  handleSubnetYieldHistory,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+function neuronDailyEnv(rows) {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(..._params) {
+            return {
+              all: async () => {
+                if (/FROM neuron_daily WHERE netuid = \?/.test(sql)) {
+                  return { results: rows };
+                }
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("subnet yield history OpenAPI CSV contract", () => {
+  test("documents the CSV header on the yield/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/yield/history"].get.responses[
+        "200"
+      ].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(
+      csvContent.example.split("\r\n")[0],
+      "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
+    );
+  });
+});
+
+describe("handleSubnetYieldHistory CSV export", () => {
+  test("returns CSV response when ?format=csv is present", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-27",
+        stake_tao: 100,
+        emission_tao: 10,
+        validator_permit: 1,
+      },
+      {
+        snapshot_date: "2026-06-27",
+        stake_tao: 100,
+        emission_tao: 5,
+        validator_permit: 0,
+      },
+      {
+        snapshot_date: "2026-06-26",
+        stake_tao: 100,
+        emission_tao: 10,
+        validator_permit: 1,
+      },
+    ]);
+    const res = await handleSubnetYieldHistory(
+      req(`/api/v1/subnets/${NETUID}/yield/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=30d&format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(
+      res.headers
+        .get("content-disposition")
+        .includes('filename="subnet-7-yield-history.csv"'),
+    );
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
+    );
+    assert.equal(lines[1], "2026-06-26,1,1,1,0.1,0.1,0.1,0.1,0.1,0.1");
+    assert.equal(lines[2], "2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1");
+  });
+
+  test("returns CSV response when Accept: text/csv header is present", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-26",
+        stake_tao: 100,
+        emission_tao: 10,
+        validator_permit: 1,
+      },
+    ]);
+    const request = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const res = await handleSubnetYieldHistory(
+      request,
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[1], "2026-06-26,1,1,1,0.1,0.1,0.1,0.1,0.1,0.1");
+  });
+
+  test("returns header-only CSV when D1 is cold", async () => {
+    const res = await handleSubnetYieldHistory(
+      req(`/api/v1/subnets/${NETUID}/yield/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=30d&format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
+    );
+    assert.equal(lines.length, 1);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetYieldHistory(
+      req(`/api/v1/subnets/${NETUID}/yield/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=30d&format=pdf`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetYieldHistory(
+      req(`/api/v1/subnets/${NETUID}/yield/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("returns the JSON envelope when CSV is not requested", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-26",
+        stake_tao: 100,
+        emission_tao: 10,
+        validator_permit: 1,
+      },
+    ]);
+    const res = await handleSubnetYieldHistory(
+      req(`/api/v1/subnets/${NETUID}/yield/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.point_count, 1);
+    assert.equal(body.data.points[0].median_yield, 0.1);
+  });
+
+  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-26",
+        stake_tao: 100,
+        emission_tao: 10,
+        validator_permit: 1,
+      },
+    ]);
+    const request = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const res = await handleSubnetYieldHistory(
+      request,
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d&format=json`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.data.point_count, 1);
+  });
+});
+
+describe("canonicalSubnetYieldHistoryCachePath", () => {
+  test("default window stays canonical for JSON", () => {
+    assert.equal(
+      canonicalSubnetYieldHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/yield/history`),
+      ),
+      `/api/v1/subnets/${NETUID}/yield/history?window=30d`,
+    );
+  });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalSubnetYieldHistoryCachePath(
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d&format=csv`),
+    );
+    assert.equal(
+      csv,
+      `/api/v1/subnets/${NETUID}/yield/history?window=7d&format=csv`,
+    );
+
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const json = canonicalSubnetYieldHistoryCachePath(
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d&format=json`),
+      csvAccept,
+    );
+    assert.equal(json, `/api/v1/subnets/${NETUID}/yield/history?window=7d`);
+  });
+
+  test("adds format=csv when only Accept: text/csv is present", () => {
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    assert.equal(
+      canonicalSubnetYieldHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/yield/history?window=90d`),
+        csvAccept,
+      ),
+      `/api/v1/subnets/${NETUID}/yield/history?window=90d&format=csv`,
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = `/api/v1/subnets/${NETUID}/yield/history?bogus=1`;
+    assert.equal(canonicalSubnetYieldHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid format", () => {
+    const raw = `/api/v1/subnets/${NETUID}/yield/history?format=pdf`;
+    assert.equal(canonicalSubnetYieldHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window", () => {
+    const raw = `/api/v1/subnets/${NETUID}/yield/history?window=1y`;
+    assert.equal(canonicalSubnetYieldHistoryCachePath(url(raw)), raw);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1473,7 +1473,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(yieldHistoryMatch[1]),
             resolved.url,
           ),
-        canonicalSubnetYieldHistoryCachePath(resolved.url),
+        canonicalSubnetYieldHistoryCachePath(resolved.url, request),
       );
     }
     const concentrationMatch = SUBNET_CONCENTRATION_PATH_PATTERN.exec(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -312,6 +312,18 @@ const BLOCK_CSV_COLUMNS = [
   "spec_version",
   "observed_at",
 ];
+const SUBNET_YIELD_HISTORY_CSV_COLUMNS = [
+  "snapshot_date",
+  "neuron_count",
+  "validator_count",
+  "yield_count",
+  "subnet_yield",
+  "mean_yield",
+  "median_yield",
+  "p25_yield",
+  "p75_yield",
+  "p90_yield",
+];
 const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
   "extrinsic_id",
   "block_number",
@@ -924,8 +936,20 @@ export function canonicalSubnetPerformanceHistoryCachePath(url) {
   return canonicalWindowedCachePath(url, parseSubnetPerformanceHistoryWindow);
 }
 
-export function canonicalSubnetYieldHistoryCachePath(url) {
-  return canonicalWindowedCachePath(url, parseSubnetYieldHistoryWindow);
+export function canonicalSubnetYieldHistoryCachePath(url, request = null) {
+  const validationError = validateQueryParams(url, ["window", "format"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateResponseFormat(url);
+  if (formatError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseSubnetYieldHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return `${url.pathname}${url.search}`;
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 // Canonical edge-cache key for the subnet-turnover route (?window= via
@@ -1208,8 +1232,10 @@ export async function handleSubnetPerformanceHistory(
 // is the raw rows (not a GROUP BY) bounded by a row cap; a cold/absent store → 200
 // with points:[] (schema-stable, never 404).
 export async function handleSubnetYieldHistory(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateResponseFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { label, days, error } = parseSubnetYieldHistoryWindow(
     url.searchParams.get("window"),
   );
@@ -1226,6 +1252,18 @@ export async function handleSubnetYieldHistory(request, env, netuid, url) {
     window: label,
     capped: rows.length >= YIELD_HISTORY_ROW_CAP,
   });
+  if (csvRequested(url, request)) {
+    const points = [...data.points].sort((a, b) =>
+      String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
+    );
+    return csvResponse(
+      points,
+      `subnet-${netuid}-yield-history`,
+      "short",
+      request,
+      SUBNET_YIELD_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Adds `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/subnets/{netuid}/yield/history` so the per-day emission-yield distribution series (subnet yield, mean/median/p25/p75/p90) can be downloaded as CSV.

Implementation follows the same pattern as the trajectory, yield, and concentration/history CSV exports:
- handler + edge-cache changes in `workers/request-handlers/entities.mjs`
- OpenAPI/contract artifacts regenerated via `npm run build`
- CSV example isolated in `csv-route-examples.mjs`
- dedicated test file `tests/subnet-yield-history-csv.test.mjs` (avoids contending with open entity-handler PRs on shared harness files)

**10 files changed, 1 commit** — no bundled work from other open PRs. Verified locally that this merges cleanly on top of open PRs #3210, #3232, and #3238 without conflicts.

## Test plan

- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run lint` + `npm run format:check`
- [x] `tests/subnet-yield-history-csv.test.mjs` — CSV body, Accept header, cold export, JSON envelope, format validation, cache-key variants, OpenAPI CSV example
