### PR TITLE
fix(neuron-history): batch prunable archive cleanup

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -117,6 +117,9 @@ export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
 // because the write outage is the more severe problem. Raise this once the raw
 // chain data moves to self-hosted Postgres (no cap) per ADR 0013, not before.
 export const NEURON_DAILY_RETENTION_DAYS = 90;
+// Bound cold-archive work per cron tick so a large retention cut/backlog cannot
+// consume the whole Worker invocation before any D1 space is recovered.
+export const NEURON_DAILY_ARCHIVE_BATCH_DAYS = 7;
 
 // R2 cold-archive key: one immutable gzip-NDJSON object per subnet per UTC day.
 export function coldArchiveKey(netuid, day) {
@@ -193,25 +196,34 @@ function neuronDailyRetentionCutoff(now = Date.now()) {
     .slice(0, 10);
 }
 
-async function prunableDays(db, cutoff) {
+async function prunableDays(
+  db,
+  cutoff,
+  limit = NEURON_DAILY_ARCHIVE_BATCH_DAYS,
+) {
   const res = await db
     .prepare(
       "SELECT DISTINCT snapshot_date AS day FROM neuron_daily " +
-        "WHERE snapshot_date < ? ORDER BY snapshot_date",
+        "WHERE snapshot_date < ? ORDER BY snapshot_date LIMIT ?",
     )
-    .bind(cutoff)
+    .bind(cutoff, limit)
     .all();
   return (res?.results ?? []).map((r) => r.day).filter(Boolean);
 }
 
 /**
- * Archive every neuron_daily day that would be removed by the retention prune.
+ * Archive a bounded batch of neuron_daily days eligible for the retention prune.
  * This closes the data-loss gap where a successful latest-day archive could gate
  * deletion of older days that had never been written to R2.
  */
 export async function archivePrunableNeuronDaily(
   env,
-  { now = Date.now(), db, bucket } = {},
+  {
+    now = Date.now(),
+    db,
+    bucket,
+    limit = NEURON_DAILY_ARCHIVE_BATCH_DAYS,
+  } = {},
 ) {
   const database = db || env?.METAGRAPH_HEALTH_DB;
   const r2 = bucket || env?.METAGRAPH_ARCHIVE;
@@ -219,7 +231,7 @@ export async function archivePrunableNeuronDaily(
     return { archived: false, reason: "no-binding" };
   }
   const cutoff = neuronDailyRetentionCutoff(now);
-  const days = await prunableDays(database, cutoff);
+  const days = await prunableDays(database, cutoff, limit);
   let rows = 0;
   let subnets = 0;
   const archivedDays = [];
@@ -243,7 +255,14 @@ export async function archivePrunableNeuronDaily(
     rows += res.rows ?? 0;
     subnets += res.subnets ?? 0;
   }
-  return { archived: true, cutoff, days: archivedDays, subnets, rows };
+  return {
+    archived: true,
+    cutoff,
+    days: archivedDays,
+    complete: days.length < limit,
+    subnets,
+    rows,
+  };
 }
 
 /**
@@ -251,10 +270,26 @@ export async function archivePrunableNeuronDaily(
  * gates this on a successful archive so a day is never deleted before it exists
  * in the R2 cold tier. Returns {pruned, cutoff, rows}.
  */
-export async function pruneNeuronDaily(env, { now = Date.now() } = {}) {
+export async function pruneNeuronDaily(env, { now = Date.now(), days } = {}) {
   const db = env?.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return { pruned: false, reason: "no-db" };
   const cutoff = neuronDailyRetentionCutoff(now);
+  const archivedDays = Array.isArray(days) ? days.filter(Boolean) : [];
+  if (archivedDays.length > 0) {
+    const placeholders = archivedDays.map(() => "?").join(", ");
+    const res = await db
+      .prepare(
+        `DELETE FROM neuron_daily WHERE snapshot_date IN (${placeholders})`,
+      )
+      .bind(...archivedDays)
+      .run();
+    return {
+      pruned: true,
+      cutoff,
+      days: archivedDays,
+      rows: res?.meta?.changes ?? null,
+    };
+  }
   const res = await db
     .prepare("DELETE FROM neuron_daily WHERE snapshot_date < ?")
     .bind(cutoff)

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -1029,6 +1029,22 @@ describe("R2 cold archive + prune (PR-A2)", () => {
     assert.deepEqual(captured.params, ["2026-03-20", "2026-03-21"]);
   });
 
+  test("pruneNeuronDaily reports rows:null for a backlog-days delete that omits meta.changes", async () => {
+    const db = {
+      prepare() {
+        return { bind: () => ({ run: () => Promise.resolve({}) }) };
+      },
+    };
+
+    const res = await pruneNeuronDaily(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: Date.parse("2026-06-22T00:00:00Z"), days: ["2026-03-20"] },
+    );
+
+    assert.equal(res.pruned, true);
+    assert.equal(res.rows, null);
+  });
+
   test("pruneNeuronDaily no-ops without a DB binding (returns no-db, never throws)", async () => {
     assert.deepEqual(await pruneNeuronDaily({}), {
       pruned: false,

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -9,6 +9,7 @@ import {
   coldArchiveKey,
   isValidSnapshotDate,
   NEURON_DAILY_RETENTION_DAYS,
+  NEURON_DAILY_ARCHIVE_BATCH_DAYS,
   neuronDailyUpsertStatements,
   validNeuronDailyRows,
   buildNeuronHistory,
@@ -880,6 +881,49 @@ describe("R2 cold archive + prune (PR-A2)", () => {
     assert.equal(puts.includes(coldArchiveKey(9, latestDay)), false);
   });
 
+  test("archivePrunableNeuronDaily caps each cron batch and marks it incomplete", async () => {
+    const days = Array.from(
+      { length: NEURON_DAILY_ARCHIVE_BATCH_DAYS },
+      (_, i) => `2026-03-${String(i + 1).padStart(2, "0")}`,
+    );
+    const captured = {};
+    const db = {
+      prepare(sql) {
+        if (sql.includes("DISTINCT snapshot_date")) captured.sql = sql;
+        return {
+          bind(...params) {
+            if (sql.includes("DISTINCT snapshot_date")) {
+              captured.params = params;
+            }
+            return {
+              all: () => {
+                if (sql.includes("DISTINCT snapshot_date")) {
+                  return Promise.resolve({
+                    results: days.map((day) => ({ day })),
+                  });
+                }
+                return Promise.resolve({
+                  results: [{ netuid: 7, uid: 0, snapshot_date: params[0] }],
+                });
+              },
+            };
+          },
+        };
+      },
+    };
+    const bucket = { put: () => Promise.resolve() };
+    const res = await archivePrunableNeuronDaily(
+      {},
+      { db, bucket, now: Date.parse("2026-06-22T00:00:00Z") },
+    );
+
+    assert.equal(res.archived, true);
+    assert.equal(res.complete, false);
+    assert.deepEqual(res.days, days);
+    assert.match(captured.sql, /LIMIT \?/);
+    assert.equal(captured.params[1], NEURON_DAILY_ARCHIVE_BATCH_DAYS);
+  });
+
   test("archivePrunableNeuronDaily no-ops without bindings", async () => {
     assert.deepEqual(await archivePrunableNeuronDaily({}), {
       archived: false,
@@ -955,6 +999,34 @@ describe("R2 cold archive + prune (PR-A2)", () => {
       .toISOString()
       .slice(0, 10);
     assert.deepEqual(cap.params, [expectedCutoff]);
+  });
+
+  test("pruneNeuronDaily can delete only confirmed archived backlog days", async () => {
+    const captured = {};
+    const db = {
+      prepare(sql) {
+        captured.sql = sql;
+        return {
+          bind(...params) {
+            captured.params = params;
+            return { run: () => Promise.resolve({ meta: { changes: 2 } }) };
+          },
+        };
+      },
+    };
+
+    const res = await pruneNeuronDaily(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        now: Date.parse("2026-06-22T00:00:00Z"),
+        days: ["2026-03-20", "2026-03-21"],
+      },
+    );
+
+    assert.equal(res.pruned, true);
+    assert.deepEqual(res.days, ["2026-03-20", "2026-03-21"]);
+    assert.match(captured.sql, /snapshot_date IN \(\?, \?\)/);
+    assert.deepEqual(captured.params, ["2026-03-20", "2026-03-21"]);
   });
 
   test("pruneNeuronDaily no-ops without a DB binding (returns no-db, never throws)", async () => {
@@ -1106,6 +1178,67 @@ describe("handleScheduled rollup cron (#1345)", () => {
     assert.equal(result.archivedPrunable.archived, true);
     assert.equal(result.pruned.pruned, true);
     assert.equal(deleted, true);
+  });
+
+  test("prunes only the archived backlog batch when more prunable days remain", async () => {
+    const latestDay = "2026-06-21";
+    const oldDays = Array.from(
+      { length: NEURON_DAILY_ARCHIVE_BATCH_DAYS },
+      (_, i) => `2026-03-${String(i + 1).padStart(2, "0")}`,
+    );
+    const capturedDeletes = [];
+    const db = {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            return {
+              run: () => {
+                if (sql.startsWith("DELETE")) {
+                  capturedDeletes.push({ sql, params });
+                }
+                return Promise.resolve({ meta: { changes: 1 } });
+              },
+              all: () => {
+                if (sql.includes("MAX(snapshot_date)")) {
+                  return Promise.resolve({ results: [{ day: latestDay }] });
+                }
+                if (sql.includes("DISTINCT snapshot_date")) {
+                  return Promise.resolve({
+                    results: oldDays.map((day) => ({ day })),
+                  });
+                }
+                return Promise.resolve({
+                  results: [
+                    {
+                      netuid: 7,
+                      uid: 0,
+                      snapshot_date: params[0],
+                      stake_tao: 1,
+                    },
+                  ],
+                });
+              },
+            };
+          },
+        };
+      },
+    };
+    const env = {
+      METAGRAPH_HEALTH_DB: db,
+      METAGRAPH_ARCHIVE: { put: () => Promise.resolve() },
+    };
+
+    const result = await handleScheduled(
+      { cron: NEURON_HISTORY_ROLLUP_CRON },
+      env,
+      ctx,
+    );
+
+    assert.equal(result.archivedPrunable.complete, false);
+    assert.equal(result.pruned.pruned, true);
+    assert.deepEqual(result.pruned.days, oldDays);
+    assert.match(capturedDeletes[0].sql, /snapshot_date IN/);
+    assert.deepEqual(capturedDeletes[0].params, oldDays);
   });
 
   test("isolates a rejected backlog archive and skips the gated prune", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -924,7 +924,10 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
     }));
     const pruned =
       archived.archived && archivedPrunable.archived
-        ? await pruneNeuronDaily(env, { now }).catch(() => ({ pruned: false }))
+        ? await pruneNeuronDaily(env, {
+            now,
+            days: archivedPrunable.complete ? undefined : archivedPrunable.days,
+          }).catch(() => ({ pruned: false }))
         : { pruned: false, reason: "archive-not-confirmed" };
     return { rolled, archived, archivedPrunable, pruned };
   }


### PR DESCRIPTION
### Motivation
- A large one-time retention cut (400 → 90 days) can create hundreds of prunable days and cause the scheduled Worker to attempt to archive every eligible day in one invocation, which may time out or exhaust R2/Worker limits and thereby prevent the gated D1 prune from running.
- The change limits per-tick cold-archive work and allows the prune to make forward progress by deleting only the backlog days that have been successfully archived in that batch.

### Description
- Added `NEURON_DAILY_ARCHIVE_BATCH_DAYS` and capped the prunable-days query with `LIMIT` so each cron tick archives at most a bounded batch of days via `prunableDays(db, cutoff, limit)`.
- Updated `archivePrunableNeuronDaily` to accept a `limit` argument, archive only that batch, and return `complete` to indicate whether the full backlog was covered (`complete: days.length < limit`).
- Updated `pruneNeuronDaily` to accept an explicit `days` array and delete only the exact confirmed archived days when provided, while preserving the original cutoff-based delete when `days` is not supplied.
- Updated the scheduled rollup handler to pass the archived batch days into `pruneNeuronDaily` when the archive batch is incomplete so D1 cleanup can progress incrementally across ticks.
- Added regression tests covering batch limiting, exact-day prune behavior, and scheduled cleanup progress in `tests/neuron-history.test.mjs`.

### Testing
- Ran the focused unit suite with `npm test -- tests/neuron-history.test.mjs` and all tests passed (60/60).
- Ran formatting and lint checks with `npm run format:check` and `npm run lint`, both succeeded after formatting adjustments.
- Attempted repository `npm run validate`, which failed in this checkout due to missing generated artifact `public/metagraph/providers.json` (expected when running full `validate` without prior `npm run build` / generated artifacts), but local unit, lint and format validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4954f6ec3c832c83f5355af7974696)