### PR TITLE
feat(mcp): add get_build

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -302,6 +302,9 @@ assert.equal(
 assert.ok(changelog.summary && typeof changelog.summary === "object");
 assert.ok(changelog.artifacts && typeof changelog.artifacts === "object");
 assert.ok(changelog.subnets && typeof changelog.subnets === "object");
+const build = await callOk("get_build", {});
+assert.equal(typeof build.artifact_count, "number");
+assert.ok(Array.isArray(build.artifacts), "get_build must return artifacts[]");
 
 // Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold
 // env has them only after `npm run build` stages dist/. Exercise the happy path

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.64.0",
+  "version": "1.66.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/build-mcp.mjs
+++ b/src/build-mcp.mjs
@@ -1,0 +1,76 @@
+// Build summary loader for MCP parity on GET /api/v1/build.
+// Serves the baked /metagraph/build-summary.json artifact (artifact inventory,
+// counts, and publish metadata).
+
+export const BUILD_SUMMARY_ARTIFACT = "/metagraph/build-summary.json";
+
+export function buildToolError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export async function loadBuildSummary(ctx, { readArtifact } = {}) {
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, BUILD_SUMMARY_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw buildToolError(
+        "not_found",
+        "The registry build summary is unavailable in this environment.",
+      );
+    }
+    throw buildToolError(
+      code,
+      `Could not load ${BUILD_SUMMARY_ARTIFACT} (${code}).`,
+    );
+  }
+  return result.data;
+}
+
+export const GET_BUILD_INSTRUCTIONS =
+  "Use get_build to fetch the generated build summary (artifact inventory, " +
+  "counts, and publish metadata; mirrors GET /api/v1/build), ";
+
+export const GET_BUILD_MCP_TOOL = {
+  name: "get_build",
+  title: "Get build summary",
+  description:
+    "Fetch the generated build summary: artifact inventory counts and sizes, " +
+    "subnet/provider/surface totals, coverage rollup, and publish metadata. " +
+    "Use it to inspect the latest registry publish footprint before drilling " +
+    "into get_changelog or get_freshness. Mirrors GET /api/v1/build.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+
+export const GET_BUILD_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["schema_version", "artifact_count"],
+  properties: {
+    schema_version: { type: "integer" },
+    contract_version: NULLABLE_STRING,
+    generated_at: NULLABLE_STRING,
+    published_at: NULLABLE_STRING,
+    adapter_count: { type: ["integer", "null"] },
+    artifact_count: { type: "integer" },
+    artifact_size_bytes: { type: ["integer", "null"] },
+    subnet_count: { type: ["integer", "null"] },
+    surface_count: { type: ["integer", "null"] },
+    provider_count: { type: ["integer", "null"] },
+    artifacts: {
+      type: ["array", "null"],
+      items: { type: "object" },
+    },
+    coverage: { type: ["object", "null"] },
+    artifact_budget_summary: { type: ["object", "null"] },
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -68,6 +68,12 @@ import {
   loadChangelog,
 } from "./changelog-mcp.mjs";
 import {
+  GET_BUILD_INSTRUCTIONS,
+  GET_BUILD_MCP_TOOL,
+  GET_BUILD_OUTPUT_SCHEMA,
+  loadBuildSummary,
+} from "./build-mcp.mjs";
+import {
   GET_AGENT_RESOURCES_INSTRUCTIONS,
   GET_AGENT_RESOURCES_MCP_TOOL,
   GET_AGENT_RESOURCES_OUTPUT_SCHEMA,
@@ -423,7 +429,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.64.0";
+export const MCP_SERVER_VERSION = "1.66.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -525,6 +531,7 @@ export const MCP_INSTRUCTIONS =
   "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
   GET_COVERAGE_INSTRUCTIONS +
   GET_CHANGELOG_INSTRUCTIONS +
+  GET_BUILD_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
@@ -6424,6 +6431,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...GET_BUILD_MCP_TOOL,
+    async handler(_args, ctx) {
+      return loadBuildSummary(ctx);
+    },
+  },
+  {
     name: "get_agent_catalog",
     title: "Get the agent capability catalog",
     description:
@@ -10012,6 +10025,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   get_changelog: GET_CHANGELOG_OUTPUT_SCHEMA,
+  get_build: GET_BUILD_OUTPUT_SCHEMA,
   get_agent_catalog: {
     // Two shapes: the global index (no netuid) and a single-subnet catalog
     // (with a netuid). They share few keys, so nothing is required; the

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  BUILD_SUMMARY_ARTIFACT,
+  GET_BUILD_INSTRUCTIONS,
+  GET_BUILD_MCP_TOOL,
+  GET_BUILD_OUTPUT_SCHEMA,
+  buildToolError,
+  loadBuildSummary,
+} from "../src/build-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BUILD = {
+  schema_version: 1,
+  contract_version: "2026-07-01",
+  generated_at: "2026-07-01T00:00:00.000Z",
+  published_at: null,
+  artifact_count: 42,
+  artifact_size_bytes: 123456,
+  subnet_count: 129,
+  surface_count: 80,
+  provider_count: 12,
+  artifacts: [{ path: "subnets.json", size_bytes: 1000 }],
+  coverage: { surface_count: 80 },
+  artifact_budget_summary: { ok_count: 40, warn_count: 2, fail_count: 0 },
+};
+
+describe("build-mcp", () => {
+  test("buildToolError is shaped for MCP toolError handling", () => {
+    const err = buildToolError("not_found", "missing");
+    assert.equal(err.code, "not_found");
+    assert.equal(err.toolError, true);
+    assert.equal(err.message, "missing");
+  });
+
+  test("loadBuildSummary returns the baked artifact payload", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async (_env, path) => ({
+        ok: true,
+        data: path === BUILD_SUMMARY_ARTIFACT ? SAMPLE_BUILD : null,
+      }),
+    };
+    const out = await loadBuildSummary(ctx);
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.artifact_count, 42);
+    assert.equal(out.artifacts.length, 1);
+  });
+
+  test("loadBuildSummary uses an injected readArtifact dep", async () => {
+    const out = await loadBuildSummary(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { schema_version: 1, artifact_count: 0, artifacts: [] },
+        }),
+      },
+    );
+    assert.equal(out.artifact_count, 0);
+  });
+
+  test("loadBuildSummary maps artifact_not_found to not_found", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_not_found",
+      }),
+    };
+    await assert.rejects(
+      () => loadBuildSummary(ctx),
+      (err) =>
+        err.code === "not_found" &&
+        err.toolError === true &&
+        /unavailable in this environment/.test(err.message),
+    );
+  });
+
+  test("loadBuildSummary surfaces other artifact failures with the path", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+    };
+    await assert.rejects(
+      () => loadBuildSummary(ctx),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /build-summary\.json/.test(err.message),
+    );
+  });
+
+  test("loadBuildSummary defaults code when the read result is bare", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({ ok: false }),
+    };
+    await assert.rejects(
+      () => loadBuildSummary(ctx),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(GET_BUILD_MCP_TOOL.name, "get_build");
+    assert.match(GET_BUILD_INSTRUCTIONS, /get_build/);
+    assert.deepEqual(
+      Object.keys(GET_BUILD_MCP_TOOL.inputSchema.properties),
+      [],
+    );
+    assert.ok(new Ajv2020({ strict: false }).compile(GET_BUILD_OUTPUT_SCHEMA));
+  });
+
+  test("SAMPLE_BUILD validates against GET_BUILD_OUTPUT_SCHEMA", () => {
+    const validate = new Ajv2020({ strict: false }).compile(
+      GET_BUILD_OUTPUT_SCHEMA,
+    );
+    assert.ok(validate(SAMPLE_BUILD));
+  });
+
+  test("MCP server exports wire get_build at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.match(MCP_INSTRUCTIONS, /get_build/);
+    const tool = MCP_TOOLS.find((t) => t.name === "get_build");
+    assert.ok(tool);
+    assert.equal(tool.title, GET_BUILD_MCP_TOOL.title);
+  });
+});

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1403,3 +1403,20 @@ describe("get_changelog — branch coverage", () => {
     assert.match(res.body.result.content[0].text, /changelog\.json/);
   });
 });
+
+// ── get_build — build summary artifact ────────────────────────────────────
+describe("get_build — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("get_build", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /build-summary\.json/);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1625,6 +1625,47 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("get_build returns the build summary artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/build-summary.json": {
+        schema_version: 1,
+        artifact_count: 99,
+        artifacts: [{ path: "subnets.json", size_bytes: 1000 }],
+        subnet_count: 129,
+      },
+    });
+    const res = await callTool("get_build", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.artifact_count, 99);
+    assert.equal(out.artifacts.length, 1);
+  });
+
+  test("get_build reports not_found when the artifact is absent", async () => {
+    const res = await callTool("get_build", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /unavailable in this environment/,
+    );
+  });
+
+  test("get_build payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_build",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/build-summary.json": {
+        schema_version: 1,
+        artifact_count: 0,
+        artifacts: [],
+      },
+    });
+    const res = await callTool("get_build", {}, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_enrichment_targets returns ranked coverage-depth targets", async () => {
     const res = await callTool(
       "list_enrichment_targets",

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.66.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_build` MCP tool mirroring `GET /api/v1/build` (baked `/metagraph/build-summary.json` artifact: artifact inventory, counts, publish metadata).
- Extract loader to `src/build-mcp.mjs` with full unit + integration tests (100% line/branch coverage on the new module).
- Bump MCP server SemVer **1.64.0 → 1.66.0** (`server.json`, `validate-mcp.mjs`). Skips **1.65.0** for open PR #3245 (`list_coverage_depth`).
- **Conflict avoidance:** wires after `get_changelog` (disjoint from #3245 `list_coverage_depth` after `list_gaps`); branch-coverage tests appended after `get_changelog` block at file end.

## Test plan
- [x] `npm run lint` + `npm run format:check`
- [x] `npx vitest run tests/build-mcp.test.mjs` (100% coverage on new module)
- [x] `npx vitest run tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs` (get_build paths)
- [x] `npm run build` + `node scripts/validate-mcp.mjs` (135 tools)
- [x] SemVer asserts updated across MCP test suites

Made with [Cursor](https://cursor.com)