### PR TITLE
feat(mcp): add get_contracts

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -293,6 +293,12 @@ assert.ok(
 );
 await callOk("registry_summary", {});
 await callOk("get_coverage", {});
+const contracts = await callOk("get_contracts", {});
+assert.equal(contracts.schema_version, 1);
+assert.ok(
+  Array.isArray(contracts.artifacts) && contracts.artifacts.length > 0,
+  "get_contracts must return artifacts[]",
+);
 const changelog = await callOk("get_changelog", {});
 assert.equal(
   changelog.source,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.64.0",
+  "version": "1.67.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/contracts-mcp.mjs
+++ b/src/contracts-mcp.mjs
@@ -1,0 +1,76 @@
+// Artifact contracts loader for MCP parity on GET /api/v1/contracts.
+// Serves the baked /metagraph/contracts.json artifact (public artifact
+// contract metadata for registry consumers).
+
+export const CONTRACTS_ARTIFACT = "/metagraph/contracts.json";
+
+export function contractsToolError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export async function loadContracts(ctx, { readArtifact } = {}) {
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, CONTRACTS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw contractsToolError(
+        "not_found",
+        "The artifact contract metadata is unavailable in this environment.",
+      );
+    }
+    throw contractsToolError(
+      code,
+      `Could not load ${CONTRACTS_ARTIFACT} (${code}).`,
+    );
+  }
+  return result.data;
+}
+
+export const GET_CONTRACTS_INSTRUCTIONS =
+  "Use get_contracts to fetch the public artifact contract metadata (paths, " +
+  "storage tiers, and schema refs; mirrors GET /api/v1/contracts), ";
+
+export const GET_CONTRACTS_MCP_TOOL = {
+  name: "get_contracts",
+  title: "Get artifact contract metadata",
+  description:
+    "Fetch the registry's public artifact contract metadata: every baked " +
+    "artifact path, storage tier, schema reference, and consumer notes. Use it " +
+    "to discover which artifacts exist and how to read them before calling " +
+    "get_api_schema or list_schemas. Mirrors GET /api/v1/contracts.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+
+export const GET_CONTRACTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["schema_version", "artifacts"],
+  properties: {
+    schema_version: { type: "integer" },
+    contract_version: NULLABLE_STRING,
+    generated_at: NULLABLE_STRING,
+    name: NULLABLE_STRING,
+    base_path: NULLABLE_STRING,
+    primary_domain: NULLABLE_STRING,
+    openapi_url: NULLABLE_STRING,
+    type_definitions_url: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    artifacts: {
+      type: "array",
+      items: { type: "object" },
+    },
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -62,6 +62,12 @@ import {
   loadRegistryCoverage,
 } from "./registry-coverage.mjs";
 import {
+  GET_CONTRACTS_INSTRUCTIONS,
+  GET_CONTRACTS_MCP_TOOL,
+  GET_CONTRACTS_OUTPUT_SCHEMA,
+  loadContracts,
+} from "./contracts-mcp.mjs";
+import {
   GET_CHANGELOG_INSTRUCTIONS,
   GET_CHANGELOG_MCP_TOOL,
   GET_CHANGELOG_OUTPUT_SCHEMA,
@@ -423,7 +429,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.64.0";
+export const MCP_SERVER_VERSION = "1.67.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -524,6 +530,7 @@ export const MCP_INSTRUCTIONS =
   "list_subnet_apis + get_api_schema to integrate a subnet's API, and " +
   "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
   GET_COVERAGE_INSTRUCTIONS +
+  GET_CONTRACTS_INSTRUCTIONS +
   GET_CHANGELOG_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
@@ -6400,6 +6407,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...GET_CONTRACTS_MCP_TOOL,
+    async handler(_args, ctx) {
+      return loadContracts(ctx);
+    },
+  },
+  {
     name: "get_source_health",
     title: "Get per-provider source health",
     description:
@@ -10002,6 +10015,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       generated_at: NULLABLE_STRING,
     },
   },
+  get_contracts: GET_CONTRACTS_OUTPUT_SCHEMA,
   get_source_health: {
     type: "object",
     additionalProperties: true,

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  CONTRACTS_ARTIFACT,
+  GET_CONTRACTS_INSTRUCTIONS,
+  GET_CONTRACTS_MCP_TOOL,
+  GET_CONTRACTS_OUTPUT_SCHEMA,
+  contractsToolError,
+  loadContracts,
+} from "../src/contracts-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_CONTRACTS = {
+  schema_version: 1,
+  contract_version: "2026-07-03.2",
+  generated_at: "2026-07-01T00:00:00.000Z",
+  name: "Metagraphed public backend artifact contract",
+  base_path: "/metagraph",
+  primary_domain: "api.metagraph.sh",
+  openapi_url: "/metagraph/openapi.json",
+  type_definitions_url: "/metagraph/types.d.ts",
+  notes: ["Native Bittensor chain data is canonical."],
+  artifacts: [
+    {
+      id: "contracts",
+      path: "/metagraph/contracts.json",
+      storage_tier: "dual",
+    },
+  ],
+};
+
+describe("contracts-mcp", () => {
+  test("contractsToolError is shaped for MCP toolError handling", () => {
+    const err = contractsToolError("not_found", "missing");
+    assert.equal(err.code, "not_found");
+    assert.equal(err.toolError, true);
+    assert.equal(err.message, "missing");
+  });
+
+  test("loadContracts returns the baked artifact payload", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async (_env, path) => ({
+        ok: true,
+        data: path === CONTRACTS_ARTIFACT ? SAMPLE_CONTRACTS : null,
+      }),
+    };
+    const out = await loadContracts(ctx);
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.artifacts.length, 1);
+    assert.equal(out.artifacts[0].id, "contracts");
+  });
+
+  test("loadContracts uses an injected readArtifact dep", async () => {
+    const out = await loadContracts(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { schema_version: 1, artifacts: [] },
+        }),
+      },
+    );
+    assert.deepEqual(out.artifacts, []);
+  });
+
+  test("loadContracts maps artifact_not_found to not_found", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_not_found",
+      }),
+    };
+    await assert.rejects(
+      () => loadContracts(ctx),
+      (err) =>
+        err.code === "not_found" &&
+        err.toolError === true &&
+        /unavailable in this environment/.test(err.message),
+    );
+  });
+
+  test("loadContracts surfaces other artifact failures with the path", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+    };
+    await assert.rejects(
+      () => loadContracts(ctx),
+      (err) =>
+        err.code === "artifact_timeout" && /contracts\.json/.test(err.message),
+    );
+  });
+
+  test("loadContracts defaults code when the read result is bare", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({ ok: false }),
+    };
+    await assert.rejects(
+      () => loadContracts(ctx),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(GET_CONTRACTS_MCP_TOOL.name, "get_contracts");
+    assert.match(GET_CONTRACTS_INSTRUCTIONS, /get_contracts/);
+    assert.deepEqual(
+      Object.keys(GET_CONTRACTS_MCP_TOOL.inputSchema.properties),
+      [],
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(GET_CONTRACTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("SAMPLE_CONTRACTS validates against GET_CONTRACTS_OUTPUT_SCHEMA", () => {
+    const validate = new Ajv2020({ strict: false }).compile(
+      GET_CONTRACTS_OUTPUT_SCHEMA,
+    );
+    assert.ok(validate(SAMPLE_CONTRACTS));
+  });
+
+  test("MCP server exports wire get_contracts at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.match(MCP_INSTRUCTIONS, /get_contracts/);
+    const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
+    assert.ok(tool);
+    assert.equal(tool.title, GET_CONTRACTS_MCP_TOOL.title);
+  });
+});

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -694,6 +694,23 @@ describe("list_endpoint_incidents — branch coverage", () => {
   });
 });
 
+// ── get_contracts — contracts artifact ────────────────────────────────────
+describe("get_contracts — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("get_contracts", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /contracts\.json/);
+  });
+});
+
 // ── get_agent_resources — AI-resources artifact ───────────────────────────
 describe("get_agent_resources — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13476,6 +13476,44 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.links[0].mainnet_netuid, 1);
   });
 
+  test("get_contracts returns the contracts artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/contracts.json": {
+        schema_version: 1,
+        contract_version: "2026-07-03.2",
+        artifacts: [{ id: "subnets", path: "/metagraph/subnets.json" }],
+      },
+    });
+    const res = await callTool("get_contracts", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.artifacts[0].id, "subnets");
+  });
+
+  test("get_contracts reports not_found when the artifact is absent", async () => {
+    const res = await callTool("get_contracts", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /unavailable in this environment/,
+    );
+  });
+
+  test("get_contracts payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_contracts",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/contracts.json": {
+        schema_version: 1,
+        artifacts: [{ id: "contracts", path: "/metagraph/contracts.json" }],
+      },
+    });
+    const res = await callTool("get_contracts", {}, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_source_health returns the source-health artifact", async () => {
     const deps = makeDeps({
       "/metagraph/source-health.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.64.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_contracts` MCP tool mirroring `GET /api/v1/contracts` (baked `/metagraph/contracts.json` artifact contract metadata).
- Extract loader to `src/contracts-mcp.mjs` with full unit + integration tests (100% line/branch coverage on the new module).
- Bump MCP server SemVer **1.64.0 → 1.67.0** (`server.json`, `validate-mcp.mjs`). Skips **1.66.0** for open PR #3246 (`get_build`).
- **Conflict avoidance:** wires after `get_freshness` (disjoint from #3246 `get_build` after `get_changelog`); instructions inserted before `GET_CHANGELOG_INSTRUCTIONS`; branch-coverage tests placed after `list_endpoint_incidents` (not at file end where #3246 appends `get_build`).

## Test plan
- [x] `npm run lint` + `npm run format:check`
- [x] `npx vitest run tests/contracts-mcp.test.mjs` (100% coverage on new module)
- [x] `npx vitest run tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs` (get_contracts paths)
- [x] `npm run build` + `node scripts/validate-mcp.mjs` (135 tools)
- [x] SemVer asserts updated across MCP test suites
- [x] Simulated merge: `main` + #3246 + this branch → only semver auto-resolve (no wiring/test-region conflicts)

Made with [Cursor](https://cursor.com)