### PR TITLE
feat(api): add CSV export for subnet performance/history endpoint

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2051,7 +2051,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. */
+        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetPerformanceHistory"];
         put?: never;
         post?: never;
@@ -23713,6 +23713,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -23722,7 +23724,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -23773,6 +23775,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetPerformanceHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median
+                     *     2026-06-27,2,1,2,0.447368,1,0.947368,0,1,1,0.5,0.5,0.4,0.4,0.85,0.85
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4856,7 +4856,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/performance/history.json",
       "cache": "short",
-      "description": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+      "description": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
       "id": "subnet-performance-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/performance/history",
@@ -4871,6 +4871,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -489,7 +489,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history (no static file). The reward-flow twin of /concentration/history.",
+      "description": "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history; pass ?format=csv to download the per-day series as CSV (no static file). The reward-flow twin of /concentration/history.",
       "id": "subnet-performance-history",
       "path": "/metagraph/subnets/{netuid}/performance/history.json",
       "schema_ref": "#/components/schemas/SubnetPerformanceHistoryArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -44437,6 +44437,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -44495,9 +44508,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median\r\n2026-06-27,2,1,2,0.447368,1,0.947368,0,1,1,0.5,0.5,0.4,0.4,0.85,0.85",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -44554,7 +44573,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+        "summary": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 79,
+  "surface_count": 80,
   "surfaces": [
     {
       "auth_required": false,
@@ -551,6 +551,24 @@
       "surface_id": "sn-24-website-link-silxinc-com-data-artifact-3",
       "surface_key": "srf-319b61d8ff50a870",
       "url": "https://silxinc.com/blog/silx-ai-partners-with-adaption-labs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 25,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "Mainframe",
+      "subnet_slug": "sn-25",
+      "surface_id": "sn-25-macrocosm-os-macrobench-benchmark-dataset",
+      "surface_key": "srf-2c94a06dbd4dc428",
+      "url": "https://huggingface.co/datasets/macrocosm-os/macrobench-bittensor-01"
     },
     {
       "auth_required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2051,7 +2051,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. */
+        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetPerformanceHistory"];
         put?: never;
         post?: never;
@@ -23713,6 +23713,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -23722,7 +23724,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -23773,6 +23775,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetPerformanceHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median
+                     *     2026-06-27,2,1,2,0.447368,1,0.947368,0,1,1,0.5,0.5,0.4,0.4,0.85,0.85
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -944,7 +944,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-performance-history",
     "/metagraph/subnets/{netuid}/performance/history.json",
-    "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history (no static file). The reward-flow twin of /concentration/history.",
+    "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history; pass ?format=csv to download the per-day series as CSV (no static file). The reward-flow twin of /concentration/history.",
     "SubnetPerformanceHistoryArtifact",
   ),
   artifact(
@@ -2029,15 +2029,15 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/performance/history",
     "/metagraph/subnets/{netuid}/performance/history.json",
-    "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+    "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
       },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -21,6 +21,10 @@ export const ROUTE_CSV_EXAMPLES = {
     "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
     "2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1",
   ].join("\r\n"),
+  "subnet-performance-history": [
+    "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median",
+    "2026-06-27,2,1,2,0.447368,1,0.947368,0,1,1,0.5,0.5,0.4,0.4,0.85,0.85",
+  ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
   // The Postgres all-events feed: flat scalar columns of each raw pallet.method

--- a/tests/subnet-performance-history-csv.test.mjs
+++ b/tests/subnet-performance-history-csv.test.mjs
@@ -1,0 +1,329 @@
+// CSV export tests for GET /api/v1/subnets/{netuid}/performance/history — kept in a
+// dedicated file so this PR does not contend with open entity-handler PRs on the
+// shared request-handlers-entities.test.mjs harness.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  canonicalSubnetPerformanceHistoryCachePath,
+  handleSubnetPerformanceHistory,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+function neuronDailyEnv(rows) {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(..._params) {
+            return {
+              all: async () => {
+                if (/FROM neuron_daily WHERE netuid = \?/.test(sql)) {
+                  return { results: rows };
+                }
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("subnet performance history OpenAPI CSV contract", () => {
+  test("documents the CSV header on the performance/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/performance/history"].get
+        .responses["200"].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(
+      csvContent.example.split("\r\n")[0],
+      "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median",
+    );
+  });
+});
+
+describe("handleSubnetPerformanceHistory CSV export", () => {
+  test("returns CSV response when ?format=csv is present", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-27",
+        incentive: 0.9,
+        dividends: 0.9,
+        trust: 0.8,
+        consensus: 0.7,
+        validator_trust: 0.85,
+        validator_permit: 1,
+        active: 1,
+      },
+      {
+        snapshot_date: "2026-06-27",
+        incentive: 0.05,
+        dividends: 0,
+        trust: 0.2,
+        consensus: 0.1,
+        validator_trust: 0,
+        validator_permit: 0,
+        active: 1,
+      },
+      {
+        snapshot_date: "2026-06-26",
+        incentive: 0.5,
+        dividends: 0.5,
+        trust: 0.5,
+        consensus: 0.5,
+        validator_trust: 0.5,
+        validator_permit: 1,
+        active: 1,
+      },
+    ]);
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(
+      res.headers
+        .get("content-disposition")
+        .includes('filename="subnet-7-performance-history.csv"'),
+    );
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median",
+    );
+    assert.equal(
+      lines[1],
+      "2026-06-26,1,1,1,0,1,1,0,1,1,0.5,0.5,0.5,0.5,0.5,0.5",
+    );
+    assert.equal(
+      lines[2],
+      "2026-06-27,2,1,2,0.447368,1,0.947368,0,1,1,0.5,0.5,0.4,0.4,0.85,0.85",
+    );
+  });
+
+  test("returns CSV response when Accept: text/csv header is present", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-26",
+        incentive: 0.5,
+        dividends: 0.5,
+        trust: 0.5,
+        consensus: 0.5,
+        validator_trust: 0.5,
+        validator_permit: 1,
+        active: 1,
+      },
+    ]);
+    const request = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const res = await handleSubnetPerformanceHistory(
+      request,
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/performance/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[1],
+      "2026-06-26,1,1,1,0,1,1,0,1,1,0.5,0.5,0.5,0.5,0.5,0.5",
+    );
+  });
+
+  test("returns header-only CSV when D1 is cold", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median",
+    );
+    assert.equal(lines.length, 1);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=pdf`,
+      ),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/performance/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("returns the JSON envelope when CSV is not requested", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-26",
+        incentive: 0.5,
+        dividends: 0.5,
+        trust: 0.5,
+        consensus: 0.5,
+        validator_trust: 0.5,
+        validator_permit: 1,
+        active: 1,
+      },
+    ]);
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/performance/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.point_count, 1);
+    assert.equal(body.data.points[0].trust_mean, 0.5);
+  });
+
+  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
+    const env = neuronDailyEnv([
+      {
+        snapshot_date: "2026-06-26",
+        incentive: 0.5,
+        dividends: 0.5,
+        trust: 0.5,
+        consensus: 0.5,
+        validator_trust: 0.5,
+        validator_permit: 1,
+        active: 1,
+      },
+    ]);
+    const request = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const res = await handleSubnetPerformanceHistory(
+      request,
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=json`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.data.point_count, 1);
+  });
+});
+
+describe("canonicalSubnetPerformanceHistoryCachePath", () => {
+  test("default window stays canonical for JSON", () => {
+    assert.equal(
+      canonicalSubnetPerformanceHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/performance/history`),
+      ),
+      `/api/v1/subnets/${NETUID}/performance/history?window=30d`,
+    );
+  });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalSubnetPerformanceHistoryCachePath(
+      url(`/api/v1/subnets/${NETUID}/performance/history?window=7d&format=csv`),
+    );
+    assert.equal(
+      csv,
+      `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=csv`,
+    );
+
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const json = canonicalSubnetPerformanceHistoryCachePath(
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=json`,
+      ),
+      csvAccept,
+    );
+    assert.equal(
+      json,
+      `/api/v1/subnets/${NETUID}/performance/history?window=7d`,
+    );
+  });
+
+  test("adds format=csv when only Accept: text/csv is present", () => {
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    assert.equal(
+      canonicalSubnetPerformanceHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/performance/history?window=90d`),
+        csvAccept,
+      ),
+      `/api/v1/subnets/${NETUID}/performance/history?window=90d&format=csv`,
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?bogus=1`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid format", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?format=pdf`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?window=1y`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1457,7 +1457,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(performanceHistoryMatch[1]),
             resolved.url,
           ),
-        canonicalSubnetPerformanceHistoryCachePath(resolved.url),
+        canonicalSubnetPerformanceHistoryCachePath(resolved.url, request),
       );
     }
     const yieldHistoryMatch = SUBNET_YIELD_HISTORY_PATH_PATTERN.exec(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -344,6 +344,24 @@ const SUBNET_YIELD_HISTORY_CSV_COLUMNS = [
   "p75_yield",
   "p90_yield",
 ];
+const SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS = [
+  "snapshot_date",
+  "neuron_count",
+  "validator_count",
+  "active_count",
+  "incentive_gini",
+  "incentive_nakamoto_coefficient",
+  "incentive_top_10pct_share",
+  "dividends_gini",
+  "dividends_nakamoto_coefficient",
+  "dividends_top_10pct_share",
+  "trust_mean",
+  "trust_median",
+  "consensus_mean",
+  "consensus_median",
+  "validator_trust_mean",
+  "validator_trust_median",
+];
 const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
   "extrinsic_id",
   "block_number",
@@ -967,8 +985,23 @@ export function canonicalSubnetConcentrationHistoryCachePath(
   );
 }
 
-export function canonicalSubnetPerformanceHistoryCachePath(url) {
-  return canonicalWindowedCachePath(url, parseSubnetPerformanceHistoryWindow);
+export function canonicalSubnetPerformanceHistoryCachePath(
+  url,
+  request = null,
+) {
+  const validationError = validateQueryParams(url, ["window", "format"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateResponseFormat(url);
+  if (formatError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseSubnetPerformanceHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return `${url.pathname}${url.search}`;
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 export function canonicalSubnetYieldHistoryCachePath(url, request = null) {
@@ -1241,8 +1274,10 @@ export async function handleSubnetPerformanceHistory(
   netuid,
   url,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateResponseFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { label, days, error } = parseSubnetPerformanceHistoryWindow(
     url.searchParams.get("window"),
   );
@@ -1259,6 +1294,18 @@ export async function handleSubnetPerformanceHistory(
     window: label,
     capped: rows.length >= PERFORMANCE_HISTORY_ROW_CAP,
   });
+  if (csvRequested(url, request)) {
+    const points = [...data.points].sort((a, b) =>
+      String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
+    );
+    return csvResponse(
+      points,
+      `subnet-${netuid}-performance-history`,
+      "short",
+      request,
+      SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- Adds `?format=csv` and `Accept: text/csv` support to `GET /api/v1/subnets/{netuid}/performance/history`, completing the history-endpoint CSV trio alongside concentration/history (#3238) and yield/history (#3243).
- Exports 16 per-day columns: neuron/validator/active counts, incentive & dividends concentration metrics (Gini, Nakamoto, top-10% share), and trust/consensus/validator_trust mean & median.
- Updates OpenAPI/contracts artifacts, edge-cache canonical path (CSV vs JSON variants), and adds dedicated `tests/subnet-performance-history-csv.test.mjs` (14 tests) to avoid contending with open entity-handler PRs.

## Conflict avoidance

- Rebased on latest `main` (`7f988479`, includes #3246 get_build).
- Verified auto-merge with open #3244 (`workers/api.mjs` overlap) — `git merge pr-3244` succeeds with no conflicts.
- No overlap with #3249 (MCP contracts), #3250 (candidates test), #3223, #3220, or #3153.

## Test plan

- [x] `npm run validate`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx vitest run tests/subnet-performance-history-csv.test.mjs` (14/14)
- [x] Full suite: 5928 tests passed


Made with [Cursor](https://cursor.com)