### PR TITLE
feat(mcp): add list_coverage_depth mirroring GET /api/v1/coverage-depth

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -279,6 +279,11 @@ assert.ok(
 );
 const gapsPage = await callOk("list_gaps", { limit: 3 });
 assert.ok(Array.isArray(gapsPage.gaps), "list_gaps must return gaps[]");
+const coverageDepthPage = await callOk("list_coverage_depth", { limit: 3 });
+assert.ok(
+  Array.isArray(coverageDepthPage.rows),
+  "list_coverage_depth must return rows[]",
+);
 const endpointPoolsPage = await callOk("list_endpoint_pools", { limit: 3 });
 assert.ok(
   Array.isArray(endpointPoolsPage.pools),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.66.0",
+  "version": "1.67.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/coverage-depth-mcp.mjs
+++ b/src/coverage-depth-mcp.mjs
@@ -1,0 +1,242 @@
+// Coverage-depth list loader for MCP parity on GET /api/v1/coverage-depth.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/coverage-depth.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const COVERAGE_DEPTH_ARTIFACT = "/metagraph/coverage-depth.json";
+
+const COVERAGE_DEPTH_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["coverage-depth"].sort_fields;
+const COVERAGE_DEPTH_TIERS = QUERY_ENUMS.coverageDepthTier;
+const AGENT_READINESS_STATUSES = QUERY_ENUMS.agentReadinessStatus;
+const AGENT_BLOCKER_LEVELS = QUERY_ENUMS.agentBlockerLevel;
+
+export function coverageDepthMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw coverageDepthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw coverageDepthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function coverageDepthQueryUrl(args) {
+  const url = new URL("https://mcp.internal/coverage-depth");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw coverageDepthMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const tier = optionalEnum(args, "tier", COVERAGE_DEPTH_TIERS);
+  if (tier) url.searchParams.set("tier", tier);
+  const agentStatus = optionalEnum(
+    args,
+    "agent_status",
+    AGENT_READINESS_STATUSES,
+  );
+  if (agentStatus) url.searchParams.set("agent_status", agentStatus);
+  const blockerLevel = optionalEnum(
+    args,
+    "blocker_level",
+    AGENT_BLOCKER_LEVELS,
+  );
+  if (blockerLevel) url.searchParams.set("blocker_level", blockerLevel);
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const sort = optionalEnum(args, "sort", COVERAGE_DEPTH_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw coverageDepthMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadCoverageDepthList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = coverageDepthQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, COVERAGE_DEPTH_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw coverageDepthMcpError(
+        "not_found",
+        "Coverage-depth scorecard unavailable.",
+      );
+    }
+    throw coverageDepthMcpError(
+      code,
+      `Could not load ${COVERAGE_DEPTH_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw coverageDepthMcpError(
+      "not_found",
+      "Coverage-depth scorecard unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "coverage-depth", []);
+  if (transformed.error) {
+    throw coverageDepthMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.rows) ? data.rows : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_COVERAGE_DEPTH_INSTRUCTIONS =
+  "list_coverage_depth per-subnet coverage-depth scorecard rows (tier, " +
+  "agent_status, blocker_level, score; mirrors GET /api/v1/coverage-depth), ";
+
+export const LIST_COVERAGE_DEPTH_MCP_TOOL = {
+  name: "list_coverage_depth",
+  title: "List coverage-depth scorecard rows",
+  description:
+    "Fetch per-subnet coverage-depth scorecard rows from the registry: tier, " +
+    "agent_status, blocker_level, score, priority_score, top_gap_codes, and " +
+    "recommended_next_action for every active subnet. Filter by netuid, tier, " +
+    "agent_status, or blocker_level, search with q, sort with sort + order, and " +
+    "page with limit (1-100) / cursor. Use list_enrichment_targets for the " +
+    "ranked enrichment queue and get_coverage for registry-wide summary counts. " +
+    "Mirrors GET /api/v1/coverage-depth.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      tier: {
+        type: "string",
+        enum: COVERAGE_DEPTH_TIERS,
+        description: "Filter by coverage-depth tier.",
+      },
+      agent_status: {
+        type: "string",
+        enum: AGENT_READINESS_STATUSES,
+        description: "Filter by agent-readiness status.",
+      },
+      blocker_level: {
+        type: "string",
+        enum: AGENT_BLOCKER_LEVELS,
+        description: "Filter by blocker severity level.",
+      },
+      q: {
+        type: "string",
+        description:
+          "Free-text search across name, slug, top_gap_codes, and recommended_next_action.",
+      },
+      sort: {
+        type: "string",
+        enum: COVERAGE_DEPTH_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["rows"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    rows: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -50,6 +50,12 @@ import {
   loadEndpointIncidentsList,
 } from "./endpoint-incidents-mcp.mjs";
 import {
+  LIST_COVERAGE_DEPTH_INSTRUCTIONS,
+  LIST_COVERAGE_DEPTH_MCP_TOOL,
+  LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA,
+  loadCoverageDepthList,
+} from "./coverage-depth-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -429,7 +435,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.66.0";
+export const MCP_SERVER_VERSION = "1.67.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -534,6 +540,7 @@ export const MCP_INSTRUCTIONS =
   GET_BUILD_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
+  LIST_COVERAGE_DEPTH_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
   "get_subnet_gaps for one subnet's interface gap priorities and contributor " +
@@ -6604,6 +6611,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_COVERAGE_DEPTH_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadCoverageDepthList(ctx, args);
+    },
+  },
+  {
     name: "list_enrichment_targets",
     title: "List ranked enrichment targets",
     description:
@@ -9989,6 +10002,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
+  list_coverage_depth: LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   get_lineage: {

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/coverage-depth-mcp.test.mjs
+++ b/tests/coverage-depth-mcp.test.mjs
@@ -235,7 +235,7 @@ describe("coverage-depth-mcp", () => {
   });
 
   test("MCP server exports wire list_coverage_depth at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.65.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_coverage_depth/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_coverage_depth");
     assert.ok(tool);

--- a/tests/coverage-depth-mcp.test.mjs
+++ b/tests/coverage-depth-mcp.test.mjs
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  COVERAGE_DEPTH_ARTIFACT,
+  LIST_COVERAGE_DEPTH_INSTRUCTIONS,
+  LIST_COVERAGE_DEPTH_MCP_TOOL,
+  LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA,
+  coverageDepthMcpError,
+  coverageDepthQueryUrl,
+  loadCoverageDepthList,
+} from "../src/coverage-depth-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  rows: [
+    {
+      netuid: 7,
+      slug: "allways",
+      name: "Allways",
+      tier: "machine-usable",
+      score: 77,
+      priority_score: 86,
+      agent_status: "callable",
+      blocker_level: "none",
+      top_gap_codes: ["missing-fixture"],
+      recommended_next_action: "capture a sanitized fixture",
+    },
+    {
+      netuid: 31,
+      slug: "recall",
+      name: "Recall",
+      tier: "missing-interface",
+      score: 18,
+      priority_score: 67,
+      agent_status: "blocked",
+      blocker_level: "missing-data",
+      top_gap_codes: ["missing-callable-service"],
+      recommended_next_action: "find an official callable surface",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === COVERAGE_DEPTH_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("coverage-depth-mcp", () => {
+  test("coverageDepthMcpError is shaped for MCP toolError handling", () => {
+    const err = coverageDepthMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("coverageDepthQueryUrl validates filters, search, and cursor", () => {
+    const url = coverageDepthQueryUrl({
+      netuid: 7,
+      tier: "machine-usable",
+      agent_status: "callable",
+      blocker_level: "none",
+      q: "allways",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,tier,score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("tier"), "machine-usable");
+    assert.equal(url.searchParams.get("agent_status"), "callable");
+    assert.equal(url.searchParams.get("blocker_level"), "none");
+    assert.equal(url.searchParams.get("q"), "allways");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("fields"), "netuid,tier,score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("coverageDepthQueryUrl rejects invalid tier", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ tier: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid agent_status", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ agent_status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl clamps limit above the MCP maximum", () => {
+    const url = coverageDepthQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadCoverageDepthList returns filtered rows with pagination meta", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact },
+      { tier: "machine-usable" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.rows[0].netuid, 7);
+    assert.equal(out.rows[0].tier, "machine-usable");
+  });
+
+  test("loadCoverageDepthList sorts and pages the collection", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.rows[0].netuid, 7);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadCoverageDepthList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCoverageDepthList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCoverageDepthList projects row fields when requested", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact },
+      { fields: "netuid,tier,score", limit: 1 },
+    );
+    assert.deepEqual(out.rows[0], {
+      netuid: 7,
+      tier: "machine-usable",
+      score: 77,
+    });
+  });
+
+  test("loadCoverageDepthList treats a non-array rows key as empty", async () => {
+    const out = await loadCoverageDepthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { rows: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.rows, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadCoverageDepthList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { rows: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadCoverageDepthList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadCoverageDepthList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_COVERAGE_DEPTH_MCP_TOOL.name, "list_coverage_depth");
+    assert.match(LIST_COVERAGE_DEPTH_INSTRUCTIONS, /list_coverage_depth/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_coverage_depth at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.65.0");
+    assert.match(MCP_INSTRUCTIONS, /list_coverage_depth/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_coverage_depth");
+    assert.ok(tool);
+    assert.equal(tool.title, "List coverage-depth scorecard rows");
+  });
+});

--- a/tests/coverage-depth-mcp.test.mjs
+++ b/tests/coverage-depth-mcp.test.mjs
@@ -114,6 +114,70 @@ describe("coverage-depth-mcp", () => {
     );
   });
 
+  test("coverageDepthQueryUrl rejects invalid agent_status", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ agent_status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid blocker_level", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ blocker_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ sort: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects empty q search", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl trims and forwards a fields projection", () => {
+    const url = coverageDepthQueryUrl({ fields: " netuid,tier " });
+    assert.equal(url.searchParams.get("fields"), "netuid,tier");
+  });
+
+  test("coverageDepthQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = coverageDepthQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("coverageDepthQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = coverageDepthQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
   test("coverageDepthQueryUrl clamps limit above the MCP maximum", () => {
     const url = coverageDepthQueryUrl({ limit: 500 });
     assert.equal(url.searchParams.get("limit"), "100");
@@ -138,6 +202,85 @@ describe("coverage-depth-mcp", () => {
     assert.equal(out.total, 2);
     assert.equal(out.rows[0].netuid, 7);
     assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadCoverageDepthList uses an injected readArtifact dep", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { rows: [{ netuid: 0 }] },
+        }),
+      },
+    );
+    assert.equal(out.rows[0].netuid, 0);
+  });
+
+  test("loadCoverageDepthList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /coverage-depth\.json/.test(err.message),
+    );
+  });
+
+  test("loadCoverageDepthList preserves array notes from the artifact", async () => {
+    const out = await loadCoverageDepthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            notes: ["advisory only"],
+            rows: [{ netuid: 7 }],
+          },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.notes, ["advisory only"]);
+  });
+
+  test("loadCoverageDepthList omits nullable artifact metadata when absent", async () => {
+    const out = await loadCoverageDepthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { rows: [{ netuid: 0 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadCoverageDepthList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
   });
 
   test("loadCoverageDepthList maps artifact_not_found to not_found", async () => {

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,11 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
+<<<<<<< HEAD
     assert.equal(MCP_SERVER_VERSION, "1.66.0");
+=======
+    assert.equal(MCP_SERVER_VERSION, "1.65.0");
+>>>>>>> 21054738 (test(mcp): bump version assertions to 1.65.0 for changelog and incidents tools)
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,11 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-<<<<<<< HEAD
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
-=======
-    assert.equal(MCP_SERVER_VERSION, "1.65.0");
->>>>>>> 21054738 (test(mcp): bump version assertions to 1.65.0 for changelog and incidents tools)
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1404,6 +1404,23 @@ describe("get_changelog — branch coverage", () => {
   });
 });
 
+// ── list_coverage_depth — coverage-depth list artifact ────────────────────
+describe("list_coverage_depth — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_coverage_depth", { limit: 1 }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /coverage-depth\.json/);
+  });
+});
+
 // ── get_build — build summary artifact ────────────────────────────────────
 describe("get_build — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1429,6 +1429,81 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_coverage_depth returns filtered scorecard rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        rows: [
+          {
+            netuid: 7,
+            name: "Allways",
+            tier: "machine-usable",
+            agent_status: "callable",
+            blocker_level: "none",
+            score: 77,
+          },
+          {
+            netuid: 31,
+            name: "Recall",
+            tier: "missing-interface",
+            agent_status: "blocked",
+            blocker_level: "missing-data",
+            score: 18,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_coverage_depth",
+      { tier: "machine-usable" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.rows[0].netuid, 7);
+    assert.equal(out.rows[0].tier, "machine-usable");
+  });
+
+  test("list_coverage_depth reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_coverage_depth", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Coverage-depth scorecard unavailable/,
+    );
+  });
+
+  test("list_coverage_depth rejects invalid tier filters", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [{ netuid: 7, tier: "machine-usable" }],
+      },
+    });
+    const res = await callTool(
+      "list_coverage_depth",
+      { tier: "not-a-tier" },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /tier/);
+  });
+
+  test("list_coverage_depth payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_coverage_depth",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        notes: "ok",
+        rows: [{ netuid: 7, tier: "machine-usable", score: 77 }],
+      },
+    });
+    const res = await callTool("list_coverage_depth", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.66.0");
+    assert.equal(MCP_SERVER_VERSION, "1.67.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_coverage_depth` MCP tool with REST-parity list-query filters (netuid, tier, agent_status, blocker_level), search (`q`), sort/order, fields projection, and limit/cursor pagination over `/metagraph/coverage-depth.json`.
- Complements `get_coverage` (registry summary) and `list_enrichment_targets` (ranked enrichment queue) with full per-subnet scorecard row listing.
- Bump MCP server version to **1.67.0** (136 tools).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `vitest run tests/coverage-depth-mcp.test.mjs` (32 tests, 100% loader coverage)
- [x] `vitest run tests/mcp-server.test.mjs -t list_coverage_depth`
- [x] `vitest run tests/mcp-server-branch-coverage.test.mjs -t list_coverage_depth`


Made with [Cursor](https://cursor.com)