### PR TITLE
fix(subnet-yield): reject blank stake_tao/emission_tao cells that coerce to 0

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -21,6 +21,16 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// A finite TAO cell, or null when absent/blank/non-numeric. Blank D1 cells coerce via
+// Number("") → 0; skip those rows rather than fabricating zero-stake neurons or
+// zero-yield readings (mirrors nullableNumber in metagraph-neurons.mjs).
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
 // Sum a subnet's per-UID stake_tao/emission_tao in rao-integer BigInt space, not
 // float space -- a subnet's neuron set is often hundreds to thousands of rows, and
 // plain `+=` float accumulation compounds rounding error across the sum even when
@@ -62,9 +72,11 @@ function toIso(value) {
 }
 
 // Emission-per-stake return rate; null when stake is 0 (return is undefined with no
-// stake to earn on), so zero-stake UIDs are excluded from the distribution.
+// stake to earn on) or emission is unknown, so zero-stake / blank-emission UIDs are
+// excluded from the distribution.
 function computeYieldValue(emission, stake) {
   if (!(stake > 0)) return null;
+  if (emission == null) return null;
   return round9(emission / stake);
 }
 
@@ -120,20 +132,21 @@ export function buildSubnetYield(rows, netuid) {
         blockNumber = Number.isFinite(block) ? block : null;
       }
     }
-    const stake = toNumber(row?.stake_tao);
-    const emission = toNumber(row?.emission_tao);
+    const stake = nullableTao(row?.stake_tao);
+    if (stake == null) continue;
+    const emission = nullableTao(row?.emission_tao);
     // Match the sibling neuron formatter's SQLite 0/1 convention: only an integer 1
     // is a validator, so a numeric-string "0" cannot slip through as truthy.
     const isValidator = Number(row?.validator_permit) === 1;
     totalStakeRao += toRaoBig(stake);
-    totalEmissionRao += toRaoBig(emission);
+    if (emission != null) totalEmissionRao += toRaoBig(emission);
     if (isValidator) validatorCount += 1;
     neurons.push({
       uid,
       hotkey: row?.hotkey ?? null,
       role: isValidator ? "validator" : "miner",
       stake_tao: round9(stake),
-      emission_tao: round9(emission),
+      emission_tao: emission != null ? round9(emission) : null,
       yield: computeYieldValue(emission, stake),
     });
   }
@@ -257,10 +270,11 @@ function yieldHistoryPoint(date, dayRows) {
   let validatorCount = 0;
   const definedYields = [];
   for (const row of dayRows) {
-    const stake = toNumber(row?.stake_tao);
-    const emission = toNumber(row?.emission_tao);
+    const stake = nullableTao(row?.stake_tao);
+    if (stake == null) continue;
+    const emission = nullableTao(row?.emission_tao);
     totalStakeRao += toRaoBig(stake);
-    totalEmissionRao += toRaoBig(emission);
+    if (emission != null) totalEmissionRao += toRaoBig(emission);
     if (Number(row?.validator_permit) === 1) validatorCount += 1;
     const y = computeYieldValue(emission, stake);
     if (y != null) definedYields.push(y);

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -160,7 +160,7 @@ describe("buildSubnetYield", () => {
     assert.equal(d.median_yield, 0.2); // only the defined yield counts
   });
 
-  test("skips a malformed uid and coerces non-numeric stake/emission/stamp to 0/null", () => {
+  test("skips a malformed uid and coerces non-numeric stamp to null", () => {
     const d = buildSubnetYield(
       [
         { uid: null, validator_permit: 1, stake_tao: 9, emission_tao: 9 },
@@ -174,11 +174,32 @@ describe("buildSubnetYield", () => {
       ],
       7,
     );
-    assert.equal(d.neuron_count, 1); // only uid 2 survived
-    assert.equal(d.total_stake_tao, 0); // non-numeric -> 0
-    assert.equal(d.neurons[0].yield, null); // 0 stake -> null
+    assert.equal(d.neuron_count, 0); // non-numeric stake is absent, not uid 0
     assert.equal(d.captured_at, null); // non-finite stamp -> null
     assert.equal(d.block_number, null); // non-finite block -> null
+  });
+
+  test("reject blank stake_tao/emission_tao cells that coerce to 0", () => {
+    for (const blank of ["", "   "]) {
+      const skippedStake = buildSubnetYield(
+        [neuron(1, { stake: blank, emission: 2 })],
+        7,
+      );
+      assert.equal(
+        skippedStake.neuron_count,
+        0,
+        `stake ${JSON.stringify(blank)}`,
+      );
+
+      const blankEmission = buildSubnetYield(
+        [neuron(2, { stake: 10, emission: blank })],
+        7,
+      );
+      assert.equal(blankEmission.neuron_count, 1);
+      assert.equal(blankEmission.neurons[0].emission_tao, null);
+      assert.equal(blankEmission.neurons[0].yield, null);
+      assert.equal(blankEmission.total_emission_tao, 0);
+    }
   });
 
   test("a null D1 block_number stays null, not a fabricated genesis 0", () => {


### PR DESCRIPTION
## Summary

Guard `buildSubnetYield` and the yield-history day rollup against blank D1 `stake_tao` / `emission_tao` cells that coerce via `Number("") → 0`.

## What Changed

- Add `nullableTao` blank-cell guard in `src/subnet-yield.mjs`
- Skip rows with blank/non-numeric stake instead of fabricating zero-stake neurons
- Treat blank emission as unknown: `yield` stays null and the value is excluded from subnet emission totals
- Extend `tests/subnet-yield.test.mjs` with blank-cell regression coverage

## No linked issue

Self-discovered bug matching the blank-cell guard pattern already used in `metagraph-neurons.mjs`, `counterparties.mjs`, and `subnet-yield` uid/block guards (#3022). No maintainer issue filed — jony376 lacks issue-create permission on this repo.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npx vitest run tests/subnet-yield.test.mjs`
- [x] `npm run validate`
- [x] `npm run validate:api`
- [x] `npm run scan:public-safety`

## Template Used

- backend-code.md

Made with [Cursor](https://cursor.com)