### PR TITLE
feat(mcp): add get_adapter mirroring GET /api/v1/adapters/{slug}

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -311,6 +311,31 @@ assert.ok(changelog.subnets && typeof changelog.subnets === "object");
 const build = await callOk("get_build", {});
 assert.equal(typeof build.artifact_count, "number");
 assert.ok(Array.isArray(build.artifacts), "get_build must return artifacts[]");
+const adapterArtifactPath = artifactFilePath("adapters/gittensor.json");
+if (existsSync(adapterArtifactPath)) {
+  const adapter = await callOk("get_adapter", { slug: "gittensor" });
+  assert.equal(
+    adapter.slug,
+    "gittensor",
+    "get_adapter must return the requested adapter slug",
+  );
+  assert.ok(
+    adapter.snapshot && typeof adapter.snapshot === "object",
+    "get_adapter must return snapshot object when staged",
+  );
+} else {
+  const adapterCold = await call("get_adapter", { slug: "gittensor" });
+  assert.equal(
+    adapterCold.isError,
+    true,
+    "get_adapter must isError when the R2 adapter artifact is absent",
+  );
+  assert.match(
+    adapterCold.content[0]?.text,
+    /No adapter snapshot exists/i,
+    "get_adapter must report not_found when the artifact is missing",
+  );
+}
 
 // Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold
 // env has them only after `npm run build` stages dist/. Exercise the happy path

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/adapters-mcp.mjs
+++ b/src/adapters-mcp.mjs
@@ -1,0 +1,108 @@
+// Adapter snapshot loader for MCP parity on GET /api/v1/adapters/{slug}.
+// Serves the baked /metagraph/adapters/{slug}.json artifact (adapter-backed
+// public metrics for one subnet slug).
+
+export const ADAPTER_SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+export function adapterArtifactPath(slug) {
+  return `/metagraph/adapters/${slug}.json`;
+}
+
+export function adapterToolError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export function parseAdapterSlug(args) {
+  const slug = args?.slug;
+  if (typeof slug !== "string" || slug.trim() === "") {
+    throw adapterToolError(
+      "invalid_params",
+      "Argument `slug` must be a non-empty string.",
+    );
+  }
+  const normalized = slug.trim();
+  if (!ADAPTER_SLUG_PATTERN.test(normalized)) {
+    throw adapterToolError(
+      "invalid_params",
+      "slug must match ^[a-z0-9-]+$ (lowercase letters, digits, hyphens).",
+    );
+  }
+  return normalized;
+}
+
+export async function loadAdapter(ctx, args, { readArtifact } = {}) {
+  const slug = parseAdapterSlug(args);
+  const artifactPath = adapterArtifactPath(slug);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw adapterToolError(
+        "not_found",
+        `No adapter snapshot exists for slug '${slug}'.`,
+      );
+    }
+    throw adapterToolError(code, `Could not load ${artifactPath} (${code}).`);
+  }
+  const data = result.data;
+  if (!data || typeof data !== "object") {
+    throw adapterToolError(
+      "not_found",
+      `No adapter snapshot exists for slug '${slug}'.`,
+    );
+  }
+  return data;
+}
+
+export const GET_ADAPTER_INSTRUCTIONS =
+  "Use get_adapter to fetch one adapter-backed public metrics snapshot by slug " +
+  "(mirrors GET /api/v1/adapters/{slug}), ";
+
+export const GET_ADAPTER_MCP_TOOL = {
+  name: "get_adapter",
+  title: "Get adapter snapshot",
+  description:
+    "Fetch one adapter-backed public metrics snapshot for a subnet slug: the " +
+    "captured adapter snapshot, extension metadata, and netuid linkage. Use it " +
+    "after list_candidates or get_subnet to inspect how a subnet's public metrics " +
+    "are adapter-projected. Mirrors GET /api/v1/adapters/{slug}.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      slug: {
+        type: "string",
+        pattern: "^[a-z0-9-]+$",
+        description: "Adapter slug, e.g. 'gittensor', 'allways', or 'sn-64'.",
+      },
+    },
+    required: ["slug"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const GET_ADAPTER_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["schema_version", "slug"],
+  properties: {
+    schema_version: { type: "integer" },
+    contract_version: NULLABLE_STRING,
+    generated_at: NULLABLE_STRING,
+    slug: { type: "string" },
+    subnet: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    snapshot: { type: ["object", "null"] },
+    extensions: { type: ["object", "null"] },
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -80,6 +80,12 @@ import {
   loadBuildSummary,
 } from "./build-mcp.mjs";
 import {
+  GET_ADAPTER_INSTRUCTIONS,
+  GET_ADAPTER_MCP_TOOL,
+  GET_ADAPTER_OUTPUT_SCHEMA,
+  loadAdapter,
+} from "./adapters-mcp.mjs";
+import {
   GET_AGENT_RESOURCES_INSTRUCTIONS,
   GET_AGENT_RESOURCES_MCP_TOOL,
   GET_AGENT_RESOURCES_OUTPUT_SCHEMA,
@@ -435,7 +441,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.67.0";
+export const MCP_SERVER_VERSION = "1.68.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -538,6 +544,7 @@ export const MCP_INSTRUCTIONS =
   GET_CONTRACTS_INSTRUCTIONS +
   GET_CHANGELOG_INSTRUCTIONS +
   GET_BUILD_INSTRUCTIONS +
+  GET_ADAPTER_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
@@ -6449,6 +6456,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...GET_ADAPTER_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadAdapter(ctx, args);
+    },
+  },
+  {
     name: "get_agent_catalog",
     title: "Get the agent capability catalog",
     description:
@@ -10039,6 +10052,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   get_changelog: GET_CHANGELOG_OUTPUT_SCHEMA,
   get_build: GET_BUILD_OUTPUT_SCHEMA,
+  get_adapter: GET_ADAPTER_OUTPUT_SCHEMA,
   get_agent_catalog: {
     // Two shapes: the global index (no netuid) and a single-subnet catalog
     // (with a netuid). They share few keys, so nothing is required; the

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  GET_ADAPTER_INSTRUCTIONS,
+  GET_ADAPTER_MCP_TOOL,
+  GET_ADAPTER_OUTPUT_SCHEMA,
+  adapterArtifactPath,
+  adapterToolError,
+  loadAdapter,
+  parseAdapterSlug,
+} from "../src/adapters-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_ADAPTER = {
+  schema_version: 1,
+  contract_version: "2026-07-01",
+  generated_at: "2026-07-01T00:00:00.000Z",
+  slug: "gittensor",
+  subnet: "gittensor",
+  netuid: 74,
+  notes: ["test"],
+  snapshot: { status: "captured", adapter_kind: "generic-openapi" },
+  extensions: { generic_adapter: { kind: "generic-openapi" } },
+};
+
+describe("adapters-mcp", () => {
+  test("adapterArtifactPath builds the adapter artifact key", () => {
+    assert.equal(
+      adapterArtifactPath("gittensor"),
+      "/metagraph/adapters/gittensor.json",
+    );
+  });
+
+  test("adapterToolError is shaped for MCP toolError handling", () => {
+    const err = adapterToolError("not_found", "missing");
+    assert.equal(err.code, "not_found");
+    assert.equal(err.toolError, true);
+    assert.equal(err.message, "missing");
+  });
+
+  test("parseAdapterSlug validates and normalizes slug input", () => {
+    assert.equal(parseAdapterSlug({ slug: " sn-64 " }), "sn-64");
+  });
+
+  test("parseAdapterSlug rejects empty slug", () => {
+    assert.throws(
+      () => parseAdapterSlug({ slug: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("parseAdapterSlug rejects uppercase slug", () => {
+    assert.throws(
+      () => parseAdapterSlug({ slug: "Gittensor" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("parseAdapterSlug rejects slug with underscores", () => {
+    assert.throws(
+      () => parseAdapterSlug({ slug: "has_underscore" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("parseAdapterSlug rejects missing slug", () => {
+    assert.throws(
+      () => parseAdapterSlug({}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadAdapter returns the baked artifact payload", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async (_env, path) => ({
+        ok: true,
+        data:
+          path === "/metagraph/adapters/gittensor.json" ? SAMPLE_ADAPTER : null,
+      }),
+    };
+    const out = await loadAdapter(ctx, { slug: "gittensor" });
+    assert.equal(out.slug, "gittensor");
+    assert.equal(out.netuid, 74);
+    assert.equal(out.snapshot.status, "captured");
+  });
+
+  test("loadAdapter uses an injected readArtifact dep", async () => {
+    const out = await loadAdapter(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      { slug: "solo" },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { schema_version: 1, slug: "solo", snapshot: {} },
+        }),
+      },
+    );
+    assert.equal(out.slug, "solo");
+  });
+
+  test("loadAdapter maps artifact_not_found to not_found", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_not_found",
+      }),
+    };
+    await assert.rejects(
+      () => loadAdapter(ctx, { slug: "missing" }),
+      (err) =>
+        err.code === "not_found" &&
+        /No adapter snapshot exists for slug 'missing'/.test(err.message),
+    );
+  });
+
+  test("loadAdapter surfaces other artifact failures with the path", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+    };
+    await assert.rejects(
+      () => loadAdapter(ctx, { slug: "gittensor" }),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /adapters\/gittensor\.json/.test(err.message),
+    );
+  });
+
+  test("loadAdapter defaults code when the read result is bare", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({ ok: false }),
+    };
+    await assert.rejects(
+      () => loadAdapter(ctx, { slug: "gittensor" }),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadAdapter rejects a malformed artifact payload", async () => {
+    const ctx = {
+      env: {},
+      readArtifact: async () => ({ ok: true, data: null }),
+    };
+    await assert.rejects(
+      () => loadAdapter(ctx, { slug: "gittensor" }),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(GET_ADAPTER_MCP_TOOL.name, "get_adapter");
+    assert.match(GET_ADAPTER_INSTRUCTIONS, /get_adapter/);
+    assert.deepEqual(Object.keys(GET_ADAPTER_MCP_TOOL.inputSchema.properties), [
+      "slug",
+    ]);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(GET_ADAPTER_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("SAMPLE_ADAPTER validates against GET_ADAPTER_OUTPUT_SCHEMA", () => {
+    const validate = new Ajv2020({ strict: false }).compile(
+      GET_ADAPTER_OUTPUT_SCHEMA,
+    );
+    assert.ok(validate(SAMPLE_ADAPTER));
+  });
+
+  test("MCP server exports wire get_adapter at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.match(MCP_INSTRUCTIONS, /get_adapter/);
+    const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
+    assert.ok(tool);
+    assert.equal(tool.title, GET_ADAPTER_MCP_TOOL.title);
+  });
+});

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1421,6 +1421,23 @@ describe("get_changelog — branch coverage", () => {
   });
 });
 
+// ── get_adapter — adapter snapshot artifact ───────────────────────────────
+describe("get_adapter — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("get_adapter", { slug: "gittensor" }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /adapters\/gittensor\.json/);
+  });
+});
+
 // ── get_build — build summary artifact ────────────────────────────────────
 describe("get_build — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13555,6 +13555,71 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("get_adapter returns the adapter snapshot artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/adapters/gittensor.json": {
+        schema_version: 1,
+        slug: "gittensor",
+        netuid: 74,
+        snapshot: { status: "captured" },
+        extensions: { generic_adapter: { kind: "generic-openapi" } },
+      },
+    });
+    const res = await callTool("get_adapter", { slug: "gittensor" }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.slug, "gittensor");
+    assert.equal(out.netuid, 74);
+    assert.equal(out.snapshot.status, "captured");
+  });
+
+  test("get_adapter reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "get_adapter",
+      { slug: "missing" },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No adapter snapshot exists/i,
+    );
+  });
+
+  test("get_adapter rejects invalid slug characters", async () => {
+    const deps = makeDeps({
+      "/metagraph/adapters/gittensor.json": {
+        schema_version: 1,
+        slug: "gittensor",
+      },
+    });
+    const res = await callTool("get_adapter", { slug: "Gittensor" }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /slug must match/);
+  });
+
+  test("get_adapter rejects a missing slug argument", async () => {
+    const res = await callTool("get_adapter", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /slug/i);
+  });
+
+  test("get_adapter payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_adapter",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/adapters/gittensor.json": {
+        schema_version: 1,
+        slug: "gittensor",
+        netuid: 74,
+        snapshot: { status: "captured" },
+      },
+    });
+    const res = await callTool("get_adapter", { slug: "gittensor" }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_source_health returns the source-health artifact", async () => {
     const deps = makeDeps({
       "/metagraph/source-health.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_adapter` MCP tool to fetch one adapter-backed public metrics snapshot by slug from `/metagraph/adapters/{slug}.json`.
- Mirrors `GET /api/v1/adapters/{slug}` with slug validation (`^[a-z0-9-]+$`), not_found mapping, and declared outputSchema.
- Bump MCP server version to **1.68.0** (137 tools).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `vitest run tests/adapters-mcp.test.mjs` (16 tests, 100% loader coverage)
- [x] `vitest run tests/mcp-server.test.mjs -t get_adapter`
- [x] `vitest run tests/mcp-server-branch-coverage.test.mjs -t get_adapter`
