### PR TITLE
feat(mcp): add get_account_weight_setters mirroring account weight-setters REST

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -806,6 +806,19 @@ assert.equal(
   SS58,
   "get_account_deregistrations must echo the address",
 );
+const accountWeightSetters = await callOk("get_account_weight_setters", {
+  ss58: SS58,
+  window: "30d",
+});
+assert.ok(
+  Array.isArray(accountWeightSetters.subnets),
+  "get_account_weight_setters must return subnets[]",
+);
+assert.equal(
+  accountWeightSetters.address,
+  SS58,
+  "get_account_weight_setters must echo the address",
+);
 const accountBalance = await callOk("get_account_balance", { ss58: SS58 });
 assert.ok(
   "balance_tao" in accountBalance && accountBalance.ss58 === SS58,

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -279,6 +279,11 @@ assert.ok(
 );
 const gapsPage = await callOk("list_gaps", { limit: 3 });
 assert.ok(Array.isArray(gapsPage.gaps), "list_gaps must return gaps[]");
+const searchIndexPage = await callOk("list_search_index", { limit: 3 });
+assert.ok(
+  Array.isArray(searchIndexPage.documents),
+  "list_search_index must return documents[]",
+);
 const endpointPoolsPage = await callOk("list_endpoint_pools", { limit: 3 });
 assert.ok(
   Array.isArray(endpointPoolsPage.pools),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -38,6 +38,12 @@ import {
   loadGapsList,
 } from "./gaps-mcp.mjs";
 import {
+  LIST_SEARCH_INDEX_INSTRUCTIONS,
+  LIST_SEARCH_INDEX_MCP_TOOL,
+  LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
+  loadSearchIndexList,
+} from "./search-index-mcp.mjs";
+import {
   LIST_ENDPOINT_POOLS_INSTRUCTIONS,
   LIST_ENDPOINT_POOLS_MCP_TOOL,
   LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
@@ -435,7 +441,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.67.0";
+export const MCP_SERVER_VERSION = "1.68.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -540,6 +546,7 @@ export const MCP_INSTRUCTIONS =
   GET_BUILD_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
+  LIST_SEARCH_INDEX_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
   "get_subnet_gaps for one subnet's interface gap priorities and contributor " +
@@ -6353,6 +6360,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SEARCH_INDEX_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSearchIndexList(ctx, args);
+    },
+  },
+  {
     ...LIST_CURATION_MCP_TOOL,
     async handler(args, ctx) {
       return loadCurationList(ctx, args);
@@ -9999,6 +10012,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       notes: NULLABLE_STRING,
     },
   },
+  list_search_index: LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -392,6 +392,11 @@ import {
   DEFAULT_DEREGISTRATION_WINDOW as DEFAULT_ACCOUNT_DEREGISTRATION_WINDOW,
 } from "./account-deregistrations.mjs";
 import {
+  loadAccountWeightSetters,
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+} from "./account-weight-setters.mjs";
+import {
   loadSubnetMovers,
   MOVERS_WINDOWS,
   MOVERS_SORTS,
@@ -441,7 +446,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.68.0";
+export const MCP_SERVER_VERSION = "1.69.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -476,6 +481,9 @@ const ACCOUNT_REGISTRATIONS_WINDOW_KEYS = Object.keys(REGISTRATION_WINDOWS);
 const ACCOUNT_SERVING_WINDOW_KEYS = Object.keys(SERVING_WINDOWS);
 const ACCOUNT_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   ACCOUNT_DEREGISTRATION_WINDOWS,
+);
+const ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
 );
 const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
   SUBNET_EVENT_SUMMARY_WINDOWS,
@@ -629,7 +637,9 @@ export const MCP_INSTRUCTIONS =
   "get_account_serving its per-subnet AxonServed axon-endpoint serving footprint " +
   "with announcement counts, first/last timestamps, and concentration labels, " +
   "get_account_deregistrations its per-subnet NeuronDeregistered eviction footprint " +
-  "with deregistration counts, first/last timestamps, and concentration labels. For chain-wide " +
+  "with deregistration counts, first/last timestamps, and concentration labels, " +
+  "get_account_weight_setters its per-subnet WeightsSet weight-setting footprint " +
+  "with weight-set counts, first/last timestamps, and concentration labels. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_registrations the " +
@@ -4620,6 +4630,52 @@ export const MCP_TOOLS = [
         ss58,
         { windowLabel: window },
       );
+      return data;
+    },
+  },
+  {
+    name: "get_account_weight_setters",
+    title: "Get an account's weight-setting footprint",
+    description:
+      "Fetch one account's WeightsSet (weight-setting) footprint per subnet " +
+      "over the requested window (7d or 30d; default 7d): each subnet's " +
+      "weight-set count with the first and last WeightsSet timestamps, plus " +
+      "account totals, an HHI concentration of where its weight-setting " +
+      "activity is focused, and the dominant subnet. WeightsSet is a validator " +
+      "(hotkey) submitting its weight vector for a subnet's consensus. The " +
+      "account-level companion to get_chain_weight_setters and " +
+      "get_subnet_weight_setters. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 hotkey address, base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+        window: {
+          type: "string",
+          enum: ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW}).`,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
+      if (!Object.hasOwn(ACCOUNT_WEIGHT_SETTERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const { data } = await loadAccountWeightSetters(mcpD1Runner(ctx), ss58, {
+        windowLabel: window,
+      });
       return data;
     },
   },
@@ -9288,6 +9344,42 @@ const TOOL_OUTPUT_SCHEMAS = {
             deregistrations: { type: "integer" },
             first_deregistered_at: NULLABLE_STRING,
             last_deregistered_at: NULLABLE_STRING,
+          },
+        },
+      },
+    },
+  },
+  get_account_weight_setters: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "address",
+      "window",
+      "total_weight_sets",
+      "subnet_count",
+      "subnets",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      address: { type: "string" },
+      window: NULLABLE_STRING,
+      total_weight_sets: { type: "integer" },
+      subnet_count: { type: "integer" },
+      // Herfindahl-Hirschman index of WeightsSet events across subnets: 1 means
+      // all weight sets on one subnet; null when the account has none.
+      concentration: { type: ["number", "null"] },
+      dominant_netuid: NULLABLE_INT,
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["netuid", "weight_sets", "first_set_at", "last_set_at"],
+          properties: {
+            netuid: { type: "integer" },
+            weight_sets: { type: "integer" },
+            first_set_at: NULLABLE_STRING,
+            last_set_at: NULLABLE_STRING,
           },
         },
       },

--- a/src/search-index-mcp.mjs
+++ b/src/search-index-mcp.mjs
@@ -1,0 +1,193 @@
+// Search index list loader for MCP parity on GET /api/v1/search-index.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/search-index.json artifact (slim documents without token blobs).
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+
+export const SEARCH_INDEX_ARTIFACT = "/metagraph/search-index.json";
+
+const DOCUMENT_SORT_FIELDS = API_QUERY_COLLECTIONS.documents.sort_fields;
+
+export function searchIndexMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw searchIndexMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw searchIndexMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function searchIndexQueryUrl(args) {
+  const url = new URL("https://mcp.internal/search-index");
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const sort = optionalEnum(args, "sort", DOCUMENT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw searchIndexMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSearchIndexList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = searchIndexQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, SEARCH_INDEX_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw searchIndexMcpError(
+        "not_found",
+        "Search index snapshot unavailable.",
+      );
+    }
+    throw searchIndexMcpError(
+      code,
+      `Could not load ${SEARCH_INDEX_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw searchIndexMcpError(
+      "not_found",
+      "Search index snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "documents", []);
+  if (transformed.error) {
+    throw searchIndexMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.documents) ? data.documents : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    documents: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SEARCH_INDEX_INSTRUCTIONS =
+  "Use list_search_index to page the slim registry search index (title/slug " +
+  "documents without token blobs; mirrors GET /api/v1/search-index), ";
+
+export const LIST_SEARCH_INDEX_MCP_TOOL = {
+  name: "list_search_index",
+  title: "List search index documents",
+  description:
+    "Fetch slim search-index documents from the registry: subnet/provider " +
+    "entries with title, slug, kind, and netuid without the heavy per-document " +
+    "token blobs in search.json. Filter with q, sort with sort + order, project " +
+    "with fields, and page with limit (1-100) / cursor. Use semantic_search for " +
+    "meaning-based discovery or search_subnets for keyword subnet lookup. Mirrors " +
+    "GET /api/v1/search-index.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      q: {
+        type: "string",
+        description: "Keyword search across title, subtitle, slug, and tokens.",
+      },
+      sort: {
+        type: "string",
+        enum: DOCUMENT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of document fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SEARCH_INDEX_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["documents"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    documents: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -711,6 +711,23 @@ describe("get_contracts — branch coverage", () => {
   });
 });
 
+// ── list_search_index — search index artifact list ────────────────────────
+describe("list_search_index — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_search_index", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /search-index\.json/);
+  });
+});
+
 // ── get_agent_resources — AI-resources artifact ───────────────────────────
 describe("get_agent_resources — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3779,6 +3779,33 @@ describe("MCP stake-flow and movers economics tools", () => {
     };
   }
 
+  function accountWeightSettersD1(rows = [], capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (
+                    /idx_account_events_hotkey/.test(sql) &&
+                    /AS weight_sets/.test(sql) &&
+                    /first_observed/.test(sql) &&
+                    params[1] === "WeightsSet"
+                  ) {
+                    return { results: rows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
   test("get_account_deregistrations shapes per-subnet deregistration counts and concentration", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
@@ -3860,6 +3887,97 @@ describe("MCP stake-flow and movers economics tools", () => {
           {
             netuid: 7,
             deregistrations: 2,
+            first_observed: 1_717_000_000_000,
+            last_observed: 1_717_500_000_000,
+          },
+        ]),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  test("get_account_weight_setters shapes per-subnet weight-set counts and concentration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const res = await callTool(
+        "get_account_weight_setters",
+        { ss58: SS58, window: "7d" },
+        {
+          env: accountWeightSettersD1([
+            {
+              netuid: 7,
+              weight_sets: 3,
+              first_observed: 1_717_000_000_000,
+              last_observed: 1_717_500_000_000,
+            },
+            {
+              netuid: 9,
+              weight_sets: 1,
+              first_observed: 1_717_100_000_000,
+              last_observed: 1_717_100_000_000,
+            },
+          ]),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.address, SS58);
+      assert.equal(out.window, "7d");
+      assert.equal(out.total_weight_sets, 4);
+      assert.equal(out.subnet_count, 2);
+      assert.equal(out.subnets[0].netuid, 7);
+      assert.equal(out.dominant_netuid, 7);
+      assert.equal(out.subnets[0].weight_sets, 3);
+      assert.equal(
+        out.subnets[0].first_set_at,
+        new Date(1_717_000_000_000).toISOString(),
+      );
+      assert.ok(out.concentration > 0.5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("get_account_weight_setters rejects a missing ss58", async () => {
+    const res = await callTool("get_account_weight_setters", {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /ss58/i);
+  });
+
+  test("get_account_weight_setters rejects an unsupported window", async () => {
+    const res = await callTool("get_account_weight_setters", {
+      ss58: SS58,
+      window: "90d",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_account_weight_setters degrades to zeros on cold D1", async () => {
+    const res = await callTool("get_account_weight_setters", { ss58: SS58 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.address, SS58);
+    assert.equal(out.window, "7d");
+    assert.equal(out.total_weight_sets, 0);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.concentration, null);
+    assert.equal(out.dominant_netuid, null);
+    assert.deepEqual(out.subnets, []);
+  });
+
+  test("get_account_weight_setters payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_account_weight_setters",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_account_weight_setters",
+      { ss58: SS58 },
+      {
+        env: accountWeightSettersD1([
+          {
+            netuid: 7,
+            weight_sets: 2,
             first_observed: 1_717_000_000_000,
             last_observed: 1_717_500_000_000,
           },
@@ -4066,6 +4184,16 @@ describe("MCP stake-flow and movers economics tools", () => {
       assert.ok(
         validatorFor("get_account_deregistrations")(
           accountDeregistrations.body.result.structuredContent,
+        ),
+      );
+      const accountWeightSetters = await callTool(
+        "get_account_weight_setters",
+        { ss58: SS58 },
+        { env: accountWeightSettersD1([]) },
+      );
+      assert.ok(
+        validatorFor("get_account_weight_setters")(
+          accountWeightSetters.body.result.structuredContent,
         ),
       );
       const movers = await callTool(

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13018,6 +13018,60 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
   });
 
+  test("list_search_index returns filtered document rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/search-index.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        documents: [
+          {
+            id: "subnet-7",
+            kind: "subnet",
+            netuid: 7,
+            slug: "sn-7",
+            title: "Subnet Seven",
+          },
+          {
+            id: "provider-datura",
+            kind: "provider",
+            slug: "datura",
+            title: "Datura",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_search_index",
+      { q: "Subnet", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.documents[0].netuid, 7);
+  });
+
+  test("list_search_index reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_search_index", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Search index snapshot unavailable/,
+    );
+  });
+
+  test("list_search_index payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_search_index",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/search-index.json": {
+        documents: [{ id: "subnet-7", title: "Subnet Seven" }],
+      },
+    });
+    const res = await callTool("list_search_index", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_providers returns the providers index artifact", async () => {
     const deps = makeDeps({
       "/metagraph/providers.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.67.0");
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SEARCH_INDEX_INSTRUCTIONS,
+  LIST_SEARCH_INDEX_MCP_TOOL,
+  LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
+  SEARCH_INDEX_ARTIFACT,
+  loadSearchIndexList,
+  searchIndexMcpError,
+  searchIndexQueryUrl,
+} from "../src/search-index-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["slim index"],
+  documents: [
+    {
+      id: "subnet-7",
+      kind: "subnet",
+      netuid: 7,
+      slug: "sn-7",
+      title: "Subnet Seven",
+    },
+    {
+      id: "provider-datura",
+      kind: "provider",
+      slug: "datura",
+      title: "Datura",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === SEARCH_INDEX_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("search-index-mcp", () => {
+  test("searchIndexMcpError is shaped for MCP toolError handling", () => {
+    const err = searchIndexMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("searchIndexQueryUrl validates filters and cursor", () => {
+    const url = searchIndexQueryUrl({
+      q: "subnet",
+      sort: "title",
+      order: "desc",
+      fields: "id,title",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("q"), "subnet");
+    assert.equal(url.searchParams.get("sort"), "title");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("fields"), "id,title");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("searchIndexQueryUrl rejects empty q and invalid sort", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("searchIndexQueryUrl clamps limit and rejects negative cursor", () => {
+    assert.equal(
+      searchIndexQueryUrl({ limit: 500 }).searchParams.get("limit"),
+      "100",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSearchIndexList returns filtered rows with pagination meta", async () => {
+    const out = await loadSearchIndexList(
+      { env: {}, readArtifact },
+      { q: "Subnet" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.documents[0].netuid, 7);
+  });
+
+  test("loadSearchIndexList sorts and pages the collection", async () => {
+    const out = await loadSearchIndexList(
+      { env: {}, readArtifact },
+      { sort: "title", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.documents[0].slug, "sn-7");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSearchIndexList uses an injected readArtifact dep", async () => {
+    const out = await loadSearchIndexList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { documents: [{ id: "solo" }] },
+        }),
+      },
+    );
+    assert.equal(out.documents[0].id, "solo");
+  });
+
+  test("loadSearchIndexList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchIndexList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSearchIndexList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchIndexList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /search-index\.json/.test(err.message),
+    );
+  });
+
+  test("loadSearchIndexList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchIndexList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSearchIndexList projects row fields when requested", async () => {
+    const out = await loadSearchIndexList(
+      { env: {}, readArtifact },
+      { fields: "id,title", limit: 1 },
+    );
+    assert.deepEqual(out.documents[0], {
+      id: "subnet-7",
+      title: "Subnet Seven",
+    });
+  });
+
+  test("loadSearchIndexList preserves array notes from the artifact", async () => {
+    const out = await loadSearchIndexList({ env: {}, readArtifact }, {});
+    assert.deepEqual(out.notes, ["slim index"]);
+  });
+
+  test("loadSearchIndexList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSearchIndexList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { documents: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadSearchIndexList treats a non-array documents key as empty", async () => {
+    const out = await loadSearchIndexList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { documents: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.documents, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSearchIndexList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { documents: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSearchIndexList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSearchIndexList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchIndexList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSearchIndexList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchIndexList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SEARCH_INDEX_MCP_TOOL.name, "list_search_index");
+    assert.match(LIST_SEARCH_INDEX_INSTRUCTIONS, /list_search_index/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_SEARCH_INDEX_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_search_index at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.match(MCP_INSTRUCTIONS, /list_search_index/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
+    assert.ok(tool);
+    assert.equal(tool.title, "List search index documents");
+  });
+});

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -79,6 +79,43 @@ describe("search-index-mcp", () => {
     );
   });
 
+  test("searchIndexQueryUrl rejects non-string q and invalid order", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ q: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("searchIndexQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("searchIndexQueryUrl trims and forwards a fields projection", () => {
+    const url = searchIndexQueryUrl({ fields: " id,title " });
+    assert.equal(url.searchParams.get("fields"), "id,title");
+  });
+
+  test("searchIndexQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = searchIndexQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("searchIndexQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = searchIndexQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
   test("searchIndexQueryUrl clamps limit and rejects negative cursor", () => {
     assert.equal(
       searchIndexQueryUrl({ limit: 500 }).searchParams.get("limit"),
@@ -86,6 +123,10 @@ describe("search-index-mcp", () => {
     );
     assert.throws(
       () => searchIndexQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ cursor: 1.5 }),
       (err) => err.code === "invalid_params",
     );
   });


### PR DESCRIPTION
## Summary

- Adds `get_account_weight_setters` MCP tool mirroring `GET /api/v1/accounts/{ss58}/weight-setters` — the account-level companion to `get_chain_weight_setters` and `get_subnet_weight_setters` (#3210 REST endpoint).
- Supports `?window=7d|30d` (default 7d), returns per-subnet WeightsSet counts with first/last timestamps, HHI concentration, and dominant subnet.
- Wires validate-mcp, output schema, and 5 handler tests (happy path, cold D1, param validation, schema compile).

## Conflict avoidance

- Branch stacked on open **#3253** (`list_search_index`) so this PR merges cleanly **after #3253 lands** without a rebase — verified via `git merge` on top of `pr-3253` (auto-merge succeeds).
- No overlap with **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (taostats enrich).
- MCP SemVer bumped to **1.69.0** (stacks atop #3253's 1.68.0).

## Test plan

- [x] `npm run validate`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `node scripts/validate-mcp.mjs` (138 tools)
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_account_weight_setters` (5/5)
- [x] Full suite: 5960 tests passed


Made with [Cursor](https://cursor.com)