### PR TITLE
feat(mcp): add get_account_weight_setters mirroring GET /api/v1/accounts/{ss58}/weight-setters

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -800,6 +800,19 @@ assert.equal(
   SS58,
   "get_account_registrations must echo the address",
 );
+const accountWeightSetters = await callOk("get_account_weight_setters", {
+  ss58: SS58,
+  window: "7d",
+});
+assert.ok(
+  Array.isArray(accountWeightSetters.subnets),
+  "get_account_weight_setters must return subnets[]",
+);
+assert.equal(
+  accountWeightSetters.address,
+  SS58,
+  "get_account_weight_setters must echo the address",
+);
 const accountServing = await callOk("get_account_serving", {
   ss58: SS58,
   window: "30d",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -382,6 +382,11 @@ import {
   DEFAULT_REGISTRATION_WINDOW,
 } from "./account-registrations.mjs";
 import {
+  loadAccountWeightSetters,
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+} from "./account-weight-setters.mjs";
+import {
   loadAccountServing,
   SERVING_WINDOWS,
   DEFAULT_SERVING_WINDOW,
@@ -441,7 +446,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.68.0";
+export const MCP_SERVER_VERSION = "1.69.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -473,6 +478,9 @@ const ACCOUNT_STAKE_MOVES_WINDOW_KEYS = Object.keys(
 const ACCOUNT_AXON_REMOVALS_WINDOW_KEYS = Object.keys(AXON_REMOVAL_WINDOWS);
 const ACCOUNT_PROMETHEUS_WINDOW_KEYS = Object.keys(PROMETHEUS_WINDOWS);
 const ACCOUNT_REGISTRATIONS_WINDOW_KEYS = Object.keys(REGISTRATION_WINDOWS);
+const ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+);
 const ACCOUNT_SERVING_WINDOW_KEYS = Object.keys(SERVING_WINDOWS);
 const ACCOUNT_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   ACCOUNT_DEREGISTRATION_WINDOWS,
@@ -626,6 +634,8 @@ export const MCP_INSTRUCTIONS =
   "with announcement counts, first/last timestamps, and concentration labels, " +
   "get_account_registrations its per-subnet NeuronRegistered registration footprint " +
   "with registration counts, first/last timestamps, and concentration labels, " +
+  "get_account_weight_setters its per-subnet WeightsSet weight-setting footprint " +
+  "with weight-set counts, first/last timestamps, and concentration labels, " +
   "get_account_serving its per-subnet AxonServed axon-endpoint serving footprint " +
   "with announcement counts, first/last timestamps, and concentration labels, " +
   "get_account_deregistrations its per-subnet NeuronDeregistered eviction footprint " +
@@ -4523,6 +4533,51 @@ export const MCP_TOOLS = [
         );
       }
       const { data } = await loadAccountRegistrations(mcpD1Runner(ctx), ss58, {
+        windowLabel: window,
+      });
+      return data;
+    },
+  },
+  {
+    name: "get_account_weight_setters",
+    title: "Get an account's weight-setting footprint",
+    description:
+      "Fetch one account's (validator hotkey's) WeightsSet weight-setting footprint " +
+      "per subnet over the requested window (7d or 30d; default 7d): each subnet's " +
+      "weight-set count with the first and last WeightsSet timestamps, plus account " +
+      "totals, an HHI concentration of where its weight-setting activity is focused, " +
+      "and the dominant subnet. WeightsSet is a validator submitting its weight vector " +
+      "for a subnet's consensus. The account-level companion to get_chain_weight_setters " +
+      "and get_subnet_weight_setters. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 hotkey address, base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+        window: {
+          type: "string",
+          enum: ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW}).`,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
+      if (!Object.hasOwn(ACCOUNT_WEIGHT_SETTERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const { data } = await loadAccountWeightSetters(mcpD1Runner(ctx), ss58, {
         windowLabel: window,
       });
       return data;
@@ -9206,6 +9261,40 @@ const TOOL_OUTPUT_SCHEMAS = {
             registrations: { type: "integer" },
             first_registered_at: NULLABLE_STRING,
             last_registered_at: NULLABLE_STRING,
+          },
+        },
+      },
+    },
+  },
+  get_account_weight_setters: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "address",
+      "window",
+      "total_weight_sets",
+      "subnet_count",
+      "subnets",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      address: { type: "string" },
+      window: NULLABLE_STRING,
+      total_weight_sets: { type: "integer" },
+      subnet_count: { type: "integer" },
+      concentration: { type: ["number", "null"] },
+      dominant_netuid: NULLABLE_INT,
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["netuid", "weight_sets", "first_set_at", "last_set_at"],
+          properties: {
+            netuid: { type: "integer" },
+            weight_sets: { type: "integer" },
+            first_set_at: NULLABLE_STRING,
+            last_set_at: NULLABLE_STRING,
           },
         },
       },

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3634,6 +3634,122 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  function accountWeightSettersD1(rows = [], capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (
+                    /idx_account_events_hotkey/.test(sql) &&
+                    /GROUP BY netuid/.test(sql)
+                  ) {
+                    return { results: rows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("get_account_weight_setters shapes per-subnet weight-set counts and concentration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const res = await callTool(
+        "get_account_weight_setters",
+        { ss58: SS58, window: "7d" },
+        {
+          env: accountWeightSettersD1([
+            {
+              netuid: 7,
+              weight_sets: 3,
+              first_observed: 1_717_000_000_000,
+              last_observed: 1_717_500_000_000,
+            },
+            {
+              netuid: 9,
+              weight_sets: 1,
+              first_observed: 1_717_100_000_000,
+              last_observed: 1_717_100_000_000,
+            },
+          ]),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.address, SS58);
+      assert.equal(out.window, "7d");
+      assert.equal(out.total_weight_sets, 4);
+      assert.equal(out.subnet_count, 2);
+      assert.equal(out.subnets[0].netuid, 7);
+      assert.equal(out.dominant_netuid, 7);
+      assert.equal(out.subnets[0].weight_sets, 3);
+      assert.equal(
+        out.subnets[0].first_set_at,
+        new Date(1_717_000_000_000).toISOString(),
+      );
+      assert.ok(out.concentration > 0.5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("get_account_weight_setters rejects a missing ss58", async () => {
+    const res = await callTool("get_account_weight_setters", {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /ss58/i);
+  });
+
+  test("get_account_weight_setters rejects an unsupported window", async () => {
+    const res = await callTool("get_account_weight_setters", {
+      ss58: SS58,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_account_weight_setters degrades to zeros on cold D1", async () => {
+    const res = await callTool("get_account_weight_setters", { ss58: SS58 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.address, SS58);
+    assert.equal(out.window, "7d");
+    assert.equal(out.total_weight_sets, 0);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.concentration, null);
+    assert.equal(out.dominant_netuid, null);
+    assert.deepEqual(out.subnets, []);
+  });
+
+  test("get_account_weight_setters payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_account_weight_setters",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_account_weight_setters",
+      { ss58: SS58 },
+      {
+        env: accountWeightSettersD1([
+          {
+            netuid: 7,
+            weight_sets: 2,
+            first_observed: 1_717_000_000_000,
+            last_observed: 1_717_500_000_000,
+          },
+        ]),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   function accountServingD1(rows = [], capture = []) {
     return {
       METAGRAPH_HEALTH_DB: {
@@ -4046,6 +4162,16 @@ describe("MCP stake-flow and movers economics tools", () => {
       assert.ok(
         validatorFor("get_account_registrations")(
           accountRegistrations.body.result.structuredContent,
+        ),
+      );
+      const accountWeightSetters = await callTool(
+        "get_account_weight_setters",
+        { ss58: SS58 },
+        { env: accountWeightSettersD1([]) },
+      );
+      assert.ok(
+        validatorFor("get_account_weight_setters")(
+          accountWeightSetters.body.result.structuredContent,
         ),
       );
       const accountServing = await callTool(

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.68.0");
+    assert.equal(MCP_SERVER_VERSION, "1.69.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_account_weight_setters` MCP tool wiring the existing `loadAccountWeightSetters` D1 loader: per-subnet WeightsSet counts, first/last set timestamps, HHI concentration, and dominant subnet for one validator hotkey.
- Supports `ss58` (required) and `window` (`7d` or `30d`, default `7d`). Complements `get_chain_weight_setters` and `get_subnet_weight_setters`.
- Bump MCP server version to **1.69.0** (138 tools).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `vitest run tests/mcp-server.test.mjs -t get_account_weight_setters`
