### PR TITLE
feat(mcp): add get_subnet_stake_transfers mirroring GET /api/v1/subnets/{netuid}/stake-transfers

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -534,6 +534,20 @@ assert.ok(
     chainStakeTransfers.network != null,
   "get_chain_stake_transfers must return subnet_count + network + subnets[]",
 );
+const subnetStakeTransfers = await callOk("get_subnet_stake_transfers", {
+  netuid: 7,
+  window: "7d",
+});
+assert.equal(
+  subnetStakeTransfers.netuid,
+  7,
+  "get_subnet_stake_transfers must echo the netuid",
+);
+assert.ok(
+  Number.isInteger(subnetStakeTransfers.distinct_senders) &&
+    Number.isInteger(subnetStakeTransfers.transfers),
+  "get_subnet_stake_transfers must return distinct_senders + transfers",
+);
 const chainAxonRemovals = await callOk("get_chain_axon_removals", {
   window: "7d",
   limit: 5,
@@ -843,19 +857,6 @@ assert.equal(
   accountDeregistrations.address,
   SS58,
   "get_account_deregistrations must echo the address",
-);
-const accountWeightSetters = await callOk("get_account_weight_setters", {
-  ss58: SS58,
-  window: "30d",
-});
-assert.ok(
-  Array.isArray(accountWeightSetters.subnets),
-  "get_account_weight_setters must return subnets[]",
-);
-assert.equal(
-  accountWeightSetters.address,
-  SS58,
-  "get_account_weight_setters must echo the address",
 );
 const accountBalance = await callOk("get_account_balance", { ss58: SS58 });
 assert.ok(

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -312,6 +312,11 @@ import {
   DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
 } from "./subnet-stake-moves.mjs";
 import {
+  loadSubnetStakeTransfers,
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+} from "./subnet-stake-transfers.mjs";
+import {
   loadSubnetAxonRemovals,
   SUBNET_AXON_REMOVALS_WINDOWS,
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
@@ -403,11 +408,6 @@ import {
   DEFAULT_DEREGISTRATION_WINDOW as DEFAULT_ACCOUNT_DEREGISTRATION_WINDOW,
 } from "./account-deregistrations.mjs";
 import {
-  loadAccountWeightSetters,
-  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
-  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
-} from "./account-weight-setters.mjs";
-import {
   loadSubnetMovers,
   MOVERS_WINDOWS,
   MOVERS_SORTS,
@@ -457,7 +457,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.69.0";
+export const MCP_SERVER_VERSION = "1.70.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -495,9 +495,6 @@ const ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
 const ACCOUNT_SERVING_WINDOW_KEYS = Object.keys(SERVING_WINDOWS);
 const ACCOUNT_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   ACCOUNT_DEREGISTRATION_WINDOWS,
-);
-const ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
-  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
 );
 const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
   SUBNET_EVENT_SUMMARY_WINDOWS,
@@ -607,6 +604,9 @@ export const MCP_INSTRUCTIONS =
   "(the validators behind /weights ranked by activity — the setter-level drill-in of get_subnet_weights), " +
   "get_subnet_registrations the per-subnet neuron-registration activity, " +
   "get_subnet_stake_moves the per-subnet stake-relocation activity, " +
+  "get_subnet_stake_transfers the per-subnet stake-transfer activity between " +
+  "coldkeys (distinct senders, transfer count, transfers per sender — the " +
+  "between-accounts sibling of get_subnet_stake_moves), " +
   "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
   "(distinct removers, event count, removals per remover — the removal-side " +
   "companion to get_subnet_serving), get_subnet_serving the per-subnet AxonServed " +
@@ -654,9 +654,7 @@ export const MCP_INSTRUCTIONS =
   "get_account_serving its per-subnet AxonServed axon-endpoint serving footprint " +
   "with announcement counts, first/last timestamps, and concentration labels, " +
   "get_account_deregistrations its per-subnet NeuronDeregistered eviction footprint " +
-  "with deregistration counts, first/last timestamps, and concentration labels, " +
-  "get_account_weight_setters its per-subnet WeightsSet weight-setting footprint " +
-  "with weight-set counts, first/last timestamps, and concentration labels. For chain-wide " +
+  "with deregistration counts, first/last timestamps, and concentration labels. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_registrations the " +
@@ -3321,6 +3319,48 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_stake_transfers",
+    title: "Get subnet stake-transfer activity",
+    description:
+      "Fetch one subnet's stake-transfer activity over a 7d or 30d window " +
+      "(default 7d): the StakeTransferred event count, the number of distinct " +
+      "senders (coldkeys), and the transfers-per-sender intensity, computed live " +
+      "from the account_events StakeTransferred stream. StakeTransferred moves " +
+      "staked alpha between accounts on the same hotkey — ownership transfer, not " +
+      "net capital flow (see get_subnet_stake_flow). The between-coldkeys sibling of " +
+      "get_subnet_stake_moves (within-account re-delegation) and the per-subnet " +
+      "drill-in of get_chain_stake_transfers. Mirrors GET " +
+      "/api/v1/subnets/{netuid}/stake-transfers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: Object.keys(SUBNET_STAKE_TRANSFERS_WINDOWS),
+          description: `Lookback window (default ${DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
+      if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${Object.keys(SUBNET_STAKE_TRANSFERS_WINDOWS).join(", ")}.`,
+        );
+      }
+      return await loadSubnetStakeTransfers(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[window],
+      });
+    },
+  },
+  {
     name: "get_subnet_axon_removals",
     title: "Get subnet axon-removal activity",
     description:
@@ -4692,52 +4732,6 @@ export const MCP_TOOLS = [
         ss58,
         { windowLabel: window },
       );
-      return data;
-    },
-  },
-  {
-    name: "get_account_weight_setters",
-    title: "Get an account's weight-setting footprint",
-    description:
-      "Fetch one account's WeightsSet (weight-setting) footprint per subnet " +
-      "over the requested window (7d or 30d; default 7d): each subnet's " +
-      "weight-set count with the first and last WeightsSet timestamps, plus " +
-      "account totals, an HHI concentration of where its weight-setting " +
-      "activity is focused, and the dominant subnet. WeightsSet is a validator " +
-      "(hotkey) submitting its weight vector for a subnet's consensus. The " +
-      "account-level companion to get_chain_weight_setters and " +
-      "get_subnet_weight_setters. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args, ctx) {
-      const ss58 = requireSs58(args);
-      const window =
-        optionalString(args, "window") ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
-      if (!Object.hasOwn(ACCOUNT_WEIGHT_SETTERS_WINDOWS, window)) {
-        throw toolError(
-          "invalid_params",
-          `window must be one of: ${ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
-        );
-      }
-      const { data } = await loadAccountWeightSetters(mcpD1Runner(ctx), ss58, {
-        windowLabel: window,
-      });
       return data;
     },
   },
@@ -8649,6 +8643,20 @@ const TOOL_OUTPUT_SCHEMAS = {
       movements_per_mover: { type: ["number", "null"] },
     },
   },
+  get_subnet_stake_transfers: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "window", "distinct_senders", "transfers"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_senders: { type: "integer" },
+      transfers: { type: "integer" },
+      transfers_per_sender: { type: ["number", "null"] },
+    },
+  },
   get_subnet_registrations: {
     type: "object",
     additionalProperties: true,
@@ -9446,42 +9454,6 @@ const TOOL_OUTPUT_SCHEMAS = {
             deregistrations: { type: "integer" },
             first_deregistered_at: NULLABLE_STRING,
             last_deregistered_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
-  get_account_weight_setters: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_weight_sets",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_weight_sets: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of WeightsSet events across subnets: 1 means
-      // all weight sets on one subnet; null when the account has none.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: ["netuid", "weight_sets", "first_set_at", "last_set_at"],
-          properties: {
-            netuid: { type: "integer" },
-            weight_sets: { type: "integer" },
-            first_set_at: NULLABLE_STRING,
-            last_set_at: NULLABLE_STRING,
           },
         },
       },

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3895,33 +3895,6 @@ describe("MCP stake-flow and movers economics tools", () => {
     };
   }
 
-  function accountWeightSettersD1(rows = [], capture = []) {
-    return {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind(...params) {
-              capture.push({ sql, params });
-              return {
-                async all() {
-                  if (
-                    /idx_account_events_hotkey/.test(sql) &&
-                    /AS weight_sets/.test(sql) &&
-                    /first_observed/.test(sql) &&
-                    params[1] === "WeightsSet"
-                  ) {
-                    return { results: rows };
-                  }
-                  return { results: [] };
-                },
-              };
-            },
-          };
-        },
-      },
-    };
-  }
-
   test("get_account_deregistrations shapes per-subnet deregistration counts and concentration", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
@@ -4003,97 +3976,6 @@ describe("MCP stake-flow and movers economics tools", () => {
           {
             netuid: 7,
             deregistrations: 2,
-            first_observed: 1_717_000_000_000,
-            last_observed: 1_717_500_000_000,
-          },
-        ]),
-      },
-    );
-    const validate = new Ajv2020().compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
-  });
-
-  test("get_account_weight_setters shapes per-subnet weight-set counts and concentration", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
-    try {
-      const res = await callTool(
-        "get_account_weight_setters",
-        { ss58: SS58, window: "7d" },
-        {
-          env: accountWeightSettersD1([
-            {
-              netuid: 7,
-              weight_sets: 3,
-              first_observed: 1_717_000_000_000,
-              last_observed: 1_717_500_000_000,
-            },
-            {
-              netuid: 9,
-              weight_sets: 1,
-              first_observed: 1_717_100_000_000,
-              last_observed: 1_717_100_000_000,
-            },
-          ]),
-        },
-      );
-      const out = res.body.result.structuredContent;
-      assert.equal(out.address, SS58);
-      assert.equal(out.window, "7d");
-      assert.equal(out.total_weight_sets, 4);
-      assert.equal(out.subnet_count, 2);
-      assert.equal(out.subnets[0].netuid, 7);
-      assert.equal(out.dominant_netuid, 7);
-      assert.equal(out.subnets[0].weight_sets, 3);
-      assert.equal(
-        out.subnets[0].first_set_at,
-        new Date(1_717_000_000_000).toISOString(),
-      );
-      assert.ok(out.concentration > 0.5);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("get_account_weight_setters rejects a missing ss58", async () => {
-    const res = await callTool("get_account_weight_setters", {});
-    assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /ss58/i);
-  });
-
-  test("get_account_weight_setters rejects an unsupported window", async () => {
-    const res = await callTool("get_account_weight_setters", {
-      ss58: SS58,
-      window: "90d",
-    });
-    assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /window must be one of/);
-  });
-
-  test("get_account_weight_setters degrades to zeros on cold D1", async () => {
-    const res = await callTool("get_account_weight_setters", { ss58: SS58 });
-    const out = res.body.result.structuredContent;
-    assert.equal(out.address, SS58);
-    assert.equal(out.window, "7d");
-    assert.equal(out.total_weight_sets, 0);
-    assert.equal(out.subnet_count, 0);
-    assert.equal(out.concentration, null);
-    assert.equal(out.dominant_netuid, null);
-    assert.deepEqual(out.subnets, []);
-  });
-
-  test("get_account_weight_setters payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_weight_setters",
-    )?.outputSchema;
-    const res = await callTool(
-      "get_account_weight_setters",
-      { ss58: SS58 },
-      {
-        env: accountWeightSettersD1([
-          {
-            netuid: 7,
-            weight_sets: 2,
             first_observed: 1_717_000_000_000,
             last_observed: 1_717_500_000_000,
           },
@@ -4312,16 +4194,6 @@ describe("MCP stake-flow and movers economics tools", () => {
           accountDeregistrations.body.result.structuredContent,
         ),
       );
-      const accountWeightSetters = await callTool(
-        "get_account_weight_setters",
-        { ss58: SS58 },
-        { env: accountWeightSettersD1([]) },
-      );
-      assert.ok(
-        validatorFor("get_account_weight_setters")(
-          accountWeightSetters.body.result.structuredContent,
-        ),
-      );
       const movers = await callTool(
         "get_subnet_movers",
         { limit: 3 },
@@ -4532,6 +4404,90 @@ describe("MCP get_subnet_stake_moves", () => {
   test("rejects a missing netuid", async () => {
     const res = await callTool("get_subnet_stake_moves", { window: "7d" });
     assert.equal(res.body.result.isError, true);
+  });
+});
+
+describe("MCP get_subnet_stake_transfers", () => {
+  function stakeTransfersD1(row = null, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("summarizes per-subnet stake-transfer activity", async () => {
+    const res = await callTool(
+      "get_subnet_stake_transfers",
+      { netuid: 5, window: "7d" },
+      {
+        env: stakeTransfersD1({
+          transfers: 12,
+          distinct_senders: 4,
+          newest_observed: 1_717_500_000_000,
+        }),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 5);
+    assert.equal(out.transfers, 12);
+    assert.equal(out.distinct_senders, 4);
+    assert.equal(out.transfers_per_sender, 3);
+  });
+
+  test("cold subnet degrades to a schema-stable empty summary", async () => {
+    const res = await callTool(
+      "get_subnet_stake_transfers",
+      { netuid: 5 },
+      { env: stakeTransfersD1(null) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.transfers, 0);
+    assert.equal(out.distinct_senders, 0);
+    assert.equal(out.transfers_per_sender, null);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_stake_transfers", {
+      netuid: 5,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_stake_transfers", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_subnet_stake_transfers",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_subnet_stake_transfers",
+      { netuid: 5, window: "7d" },
+      {
+        env: stakeTransfersD1({
+          transfers: 6,
+          distinct_senders: 2,
+          newest_observed: 1_717_500_000_000,
+        }),
+      },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
   });
 });
 

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.69.0");
+    assert.equal(MCP_SERVER_VERSION, "1.70.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_subnet_stake_transfers` MCP tool wiring the existing `loadSubnetStakeTransfers` D1 loader: StakeTransferred event count, distinct senders, and transfers-per-sender intensity for one subnet.
- Supports `netuid` (required) and `window` (`7d` or `30d`, default `7d`). Complements `get_chain_stake_transfers` and `get_subnet_stake_moves`.
- Bump MCP server version to **1.70.0** (140 tools).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `vitest run tests/mcp-server.test.mjs -t get_subnet_stake_transfers`
