### PR TITLE
test(api): cover subnet stake-transfers handler happy path

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -844,16 +844,16 @@ assert.equal(
   SS58,
   "get_account_deregistrations must echo the address",
 );
-const accountWeightSetters = await callOk("get_account_weight_setters", {
+const accountWeightSetters30d = await callOk("get_account_weight_setters", {
   ss58: SS58,
   window: "30d",
 });
 assert.ok(
-  Array.isArray(accountWeightSetters.subnets),
+  Array.isArray(accountWeightSetters30d.subnets),
   "get_account_weight_setters must return subnets[]",
 );
 assert.equal(
-  accountWeightSetters.address,
+  accountWeightSetters30d.address,
   SS58,
   "get_account_weight_setters must echo the address",
 );

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -403,11 +403,6 @@ import {
   DEFAULT_DEREGISTRATION_WINDOW as DEFAULT_ACCOUNT_DEREGISTRATION_WINDOW,
 } from "./account-deregistrations.mjs";
 import {
-  loadAccountWeightSetters,
-  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
-  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
-} from "./account-weight-setters.mjs";
-import {
   loadSubnetMovers,
   MOVERS_WINDOWS,
   MOVERS_SORTS,
@@ -495,9 +490,6 @@ const ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
 const ACCOUNT_SERVING_WINDOW_KEYS = Object.keys(SERVING_WINDOWS);
 const ACCOUNT_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   ACCOUNT_DEREGISTRATION_WINDOWS,
-);
-const ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS = Object.keys(
-  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
 );
 const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
   SUBNET_EVENT_SUMMARY_WINDOWS,
@@ -654,9 +646,7 @@ export const MCP_INSTRUCTIONS =
   "get_account_serving its per-subnet AxonServed axon-endpoint serving footprint " +
   "with announcement counts, first/last timestamps, and concentration labels, " +
   "get_account_deregistrations its per-subnet NeuronDeregistered eviction footprint " +
-  "with deregistration counts, first/last timestamps, and concentration labels, " +
-  "get_account_weight_setters its per-subnet WeightsSet weight-setting footprint " +
-  "with weight-set counts, first/last timestamps, and concentration labels. For chain-wide " +
+  "with deregistration counts, first/last timestamps, and concentration labels. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_registrations the " +
@@ -4692,52 +4682,6 @@ export const MCP_TOOLS = [
         ss58,
         { windowLabel: window },
       );
-      return data;
-    },
-  },
-  {
-    name: "get_account_weight_setters",
-    title: "Get an account's weight-setting footprint",
-    description:
-      "Fetch one account's WeightsSet (weight-setting) footprint per subnet " +
-      "over the requested window (7d or 30d; default 7d): each subnet's " +
-      "weight-set count with the first and last WeightsSet timestamps, plus " +
-      "account totals, an HHI concentration of where its weight-setting " +
-      "activity is focused, and the dominant subnet. WeightsSet is a validator " +
-      "(hotkey) submitting its weight vector for a subnet's consensus. The " +
-      "account-level companion to get_chain_weight_setters and " +
-      "get_subnet_weight_setters. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args, ctx) {
-      const ss58 = requireSs58(args);
-      const window =
-        optionalString(args, "window") ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
-      if (!Object.hasOwn(ACCOUNT_WEIGHT_SETTERS_WINDOWS, window)) {
-        throw toolError(
-          "invalid_params",
-          `window must be one of: ${ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS.join(", ")}.`,
-        );
-      }
-      const { data } = await loadAccountWeightSetters(mcpD1Runner(ctx), ss58, {
-        windowLabel: window,
-      });
       return data;
     },
   },
@@ -9446,42 +9390,6 @@ const TOOL_OUTPUT_SCHEMAS = {
             deregistrations: { type: "integer" },
             first_deregistered_at: NULLABLE_STRING,
             last_deregistered_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
-  get_account_weight_setters: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_weight_sets",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_weight_sets: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of WeightsSet events across subnets: 1 means
-      // all weight sets on one subnet; null when the account has none.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: ["netuid", "weight_sets", "first_set_at", "last_set_at"],
-          properties: {
-            netuid: { type: "integer" },
-            weight_sets: { type: "integer" },
-            first_set_at: NULLABLE_STRING,
-            last_set_at: NULLABLE_STRING,
           },
         },
       },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3634,122 +3634,6 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  function accountWeightSettersD1(rows = [], capture = []) {
-    return {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind(...params) {
-              capture.push({ sql, params });
-              return {
-                async all() {
-                  if (
-                    /idx_account_events_hotkey/.test(sql) &&
-                    /GROUP BY netuid/.test(sql)
-                  ) {
-                    return { results: rows };
-                  }
-                  return { results: [] };
-                },
-              };
-            },
-          };
-        },
-      },
-    };
-  }
-
-  test("get_account_weight_setters shapes per-subnet weight-set counts and concentration", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
-    try {
-      const res = await callTool(
-        "get_account_weight_setters",
-        { ss58: SS58, window: "7d" },
-        {
-          env: accountWeightSettersD1([
-            {
-              netuid: 7,
-              weight_sets: 3,
-              first_observed: 1_717_000_000_000,
-              last_observed: 1_717_500_000_000,
-            },
-            {
-              netuid: 9,
-              weight_sets: 1,
-              first_observed: 1_717_100_000_000,
-              last_observed: 1_717_100_000_000,
-            },
-          ]),
-        },
-      );
-      const out = res.body.result.structuredContent;
-      assert.equal(out.address, SS58);
-      assert.equal(out.window, "7d");
-      assert.equal(out.total_weight_sets, 4);
-      assert.equal(out.subnet_count, 2);
-      assert.equal(out.subnets[0].netuid, 7);
-      assert.equal(out.dominant_netuid, 7);
-      assert.equal(out.subnets[0].weight_sets, 3);
-      assert.equal(
-        out.subnets[0].first_set_at,
-        new Date(1_717_000_000_000).toISOString(),
-      );
-      assert.ok(out.concentration > 0.5);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  test("get_account_weight_setters rejects a missing ss58", async () => {
-    const res = await callTool("get_account_weight_setters", {});
-    assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /ss58/i);
-  });
-
-  test("get_account_weight_setters rejects an unsupported window", async () => {
-    const res = await callTool("get_account_weight_setters", {
-      ss58: SS58,
-      window: "1y",
-    });
-    assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /window must be one of/);
-  });
-
-  test("get_account_weight_setters degrades to zeros on cold D1", async () => {
-    const res = await callTool("get_account_weight_setters", { ss58: SS58 });
-    const out = res.body.result.structuredContent;
-    assert.equal(out.address, SS58);
-    assert.equal(out.window, "7d");
-    assert.equal(out.total_weight_sets, 0);
-    assert.equal(out.subnet_count, 0);
-    assert.equal(out.concentration, null);
-    assert.equal(out.dominant_netuid, null);
-    assert.deepEqual(out.subnets, []);
-  });
-
-  test("get_account_weight_setters payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_weight_setters",
-    )?.outputSchema;
-    const res = await callTool(
-      "get_account_weight_setters",
-      { ss58: SS58 },
-      {
-        env: accountWeightSettersD1([
-          {
-            netuid: 7,
-            weight_sets: 2,
-            first_observed: 1_717_000_000_000,
-            last_observed: 1_717_500_000_000,
-          },
-        ]),
-      },
-    );
-    const validate = new Ajv2020().compile(schema);
-    assert.ok(validate(res.body.result.structuredContent));
-  });
-
   function accountServingD1(rows = [], capture = []) {
     return {
       METAGRAPH_HEALTH_DB: {
@@ -4310,16 +4194,6 @@ describe("MCP stake-flow and movers economics tools", () => {
       assert.ok(
         validatorFor("get_account_deregistrations")(
           accountDeregistrations.body.result.structuredContent,
-        ),
-      );
-      const accountWeightSetters = await callTool(
-        "get_account_weight_setters",
-        { ss58: SS58 },
-        { env: accountWeightSettersD1([]) },
-      );
-      assert.ok(
-        validatorFor("get_account_weight_setters")(
-          accountWeightSetters.body.result.structuredContent,
         ),
       );
       const movers = await callTool(

--- a/tests/subnet-stake-transfers-handler.test.mjs
+++ b/tests/subnet-stake-transfers-handler.test.mjs
@@ -1,0 +1,164 @@
+// Handler tests for GET /api/v1/subnets/{netuid}/stake-transfers — kept in a
+// dedicated file so this PR does not contend with open entity-handler PRs on the
+// shared request-handlers-entities.test.mjs harness.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { STAKE_TRANSFERRED_EVENT_KIND } from "../src/subnet-stake-transfers.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  canonicalSubnetStakeTransfersCachePath,
+  handleSubnetStakeTransfers,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+const OBSERVED_MS = 1_750_000_000_000;
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function json(res) {
+  assert.equal(res.status, 200, `expected 200, got ${res.status}`);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  return body;
+}
+
+function stakeTransfersEnv(row, capture = []) {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            capture.push({ sql, params });
+            return {
+              all: async () => {
+                if (
+                  /COUNT\(\*\) AS transfers/.test(sql) &&
+                  /COUNT\(DISTINCT coldkey\) AS distinct_senders/.test(sql) &&
+                  /FROM account_events WHERE netuid = \? AND event_kind = \?/.test(
+                    sql,
+                  )
+                ) {
+                  return { results: row ? [row] : [] };
+                }
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+async function assertValidComponent(componentName, data) {
+  const generatedAt = "2026-06-24T12:00:00.000Z";
+  const openapi = buildOpenApiArtifact(
+    generatedAt,
+    await loadOpenApiComponentSchemas(generatedAt),
+  );
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+  const validate = ajv.compile({
+    $id: `https://metagraph.sh/test/${componentName}.json`,
+    components: openapi.components,
+    $ref: `#/components/schemas/${componentName}`,
+  });
+  assert.equal(validate(data), true, ajv.errorsText(validate.errors));
+}
+
+describe("handleSubnetStakeTransfers happy path", () => {
+  test("computes distinct senders, transfer count, and transfers-per-sender over 7d", async () => {
+    const capture = [];
+    const env = stakeTransfersEnv(
+      {
+        transfers: 40,
+        distinct_senders: 4,
+        newest_observed: OBSERVED_MS,
+      },
+      capture,
+    );
+    const body = await json(
+      await handleSubnetStakeTransfers(
+        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-transfers?window=7d`),
+      ),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.window, "7d");
+    assert.equal(body.data.distinct_senders, 4);
+    assert.equal(body.data.transfers, 40);
+    assert.equal(body.data.transfers_per_sender, 10);
+    assert.equal(body.data.observed_at, new Date(OBSERVED_MS).toISOString());
+    assert.equal(body.meta.source, "chain-events");
+    assert.equal(
+      body.meta.artifact_path,
+      `/metagraph/subnets/${NETUID}/stake-transfers.json`,
+    );
+    assert.equal(body.meta.generated_at, new Date(OBSERVED_MS).toISOString());
+    await assertValidComponent("SubnetStakeTransfersArtifact", body.data);
+    const captured = capture[0];
+    assert.ok(captured);
+    assert.equal(captured.params[0], NETUID);
+    assert.equal(captured.params[1], STAKE_TRANSFERRED_EVENT_KIND);
+    assert.equal(typeof captured.params[2], "number");
+  });
+
+  test("defaults to the 7d window when ?window is omitted", async () => {
+    const body = await json(
+      await handleSubnetStakeTransfers(
+        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
+        stakeTransfersEnv({
+          transfers: 10,
+          distinct_senders: 2,
+          newest_observed: OBSERVED_MS,
+        }),
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-transfers`),
+      ),
+    );
+    assert.equal(body.data.window, "7d");
+    assert.equal(body.data.transfers, 10);
+    assert.equal(body.data.transfers_per_sender, 5);
+  });
+
+  test("honours an explicit 30d window", async () => {
+    const body = await json(
+      await handleSubnetStakeTransfers(
+        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
+        stakeTransfersEnv({
+          transfers: 15,
+          distinct_senders: 3,
+          newest_observed: OBSERVED_MS,
+        }),
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-transfers?window=30d`),
+      ),
+    );
+    assert.equal(body.data.window, "30d");
+    assert.equal(body.data.transfers, 15);
+    assert.equal(body.data.transfers_per_sender, 5);
+  });
+});
+
+describe("canonicalSubnetStakeTransfersCachePath", () => {
+  test("maps a 30d window to a distinct cache key", () => {
+    assert.equal(
+      canonicalSubnetStakeTransfersCachePath(
+        url(`/api/v1/subnets/${NETUID}/stake-transfers?window=30d`),
+      ),
+      `/api/v1/subnets/${NETUID}/stake-transfers?window=30d`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add dedicated handler tests for `GET /api/v1/subnets/{netuid}/stake-transfers` (7d/30d windows, distinct senders, transfers-per-sender, OpenAPI schema validation, cache path) in `tests/subnet-stake-transfers-handler.test.mjs` to avoid contending on the shared `request-handlers-entities.test.mjs` harness used by open PRs.
- Fix duplicate `get_account_weight_setters` artifacts left by the #3260 squash merge (duplicate imports, tool definition, output schema, and test blocks) so lint/validate/mcp-server load succeed on current `main`.

## Conflict avoidance
Touches only `tests/subnet-stake-transfers-handler.test.mjs` for the new coverage; the #3260 cleanup is limited to files broken on `main`. No overlap with open PRs #3244 (neuron-history), #3223 (workspace dep), or #3153 (registry enrich). Simulated `merge-tree` against each is clean.

## Test plan
- [x] `npx vitest run tests/subnet-stake-transfers-handler.test.mjs`
- [x] `npm run lint`
- [x] `npm run validate`
- [x] `npm run format:check`
- [ ] CI: codecov patch/project, test, checks, validate


Made with [Cursor](https://cursor.com)