### PR TITLE
feat(registry): enrich SN37 Aurelius — add Central API health subnet-api surface

### DIFF
--- a/registry/subnets/sn-37.json
+++ b/registry/subnets/sn-37.json
@@ -48,6 +48,25 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Machine-readable OpenAPI spec for the mainnet (SN37) Aurelius Central API — the same spec the existing /docs Swagger UI renders. The official README documents this production host as the finney/mainnet api_url (the -staging host is testnet SN455)."
+    },
+    {
+      "id": "sn-37-aurelius-subnet-api",
+      "name": "Aurelius Central API health",
+      "kind": "subnet-api",
+      "url": "https://new-collector-api-production.up.railway.app/health",
+      "provider": "aurelius",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md",
+        "https://new-collector-api-production.up.railway.app/openapi.json"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "notes": "Public no-auth GET returning Central API health (status, db, db_pool, classifier, novelty). Documented in the subnet's own OpenAPI (new-collector-api-production.up.railway.app/openapi.json, path /health); same host as the existing openapi + docs surfaces. The official README documents this production host as the finney/mainnet api_url and recommends curl against /health for connectivity checks."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/sn-37.json`.

## Surface

- Netuid: **37** (Aurelius)
- Kind: **subnet-api**
- Public URL: `https://new-collector-api-production.up.railway.app/health`
- Source URLs:
  - https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md
  - https://new-collector-api-production.up.railway.app/openapi.json
- Provider slug: **aurelius**

## No linked issue

SN37 already has `docs` and `openapi` surfaces on the Aurelius Central API host; the registry was missing the corresponding `subnet-api` entry for the documented public `/health` probe. This is a small registry gap fill (same pattern as #3265 for SN18), not a feature request requiring an issue.

## Checklist

- [x] Changes exactly one `registry/subnets/sn-37.json` file (append-only)
- [x] Generated with `npm run surface:add` then minimized to append-only diff
- [x] Public no-auth URL; `/health` documented in the subnet's own OpenAPI on the same host as existing docs/openapi surfaces
- [x] Public-safe: read-only health JSON, no credentials
- [x] Does not duplicate an existing Metagraphed surface
- [x] No linked issue — registry gap fill (openapi + docs present, subnet-api missing)

## Conflict avoidance

Single-file append to `sn-37.json` only. No overlap with open PRs #3244 (neuron-history), #3223 (infra/client), or #3153 (other subnet manifests).

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-37.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: `GET /health` → 200 with `{"status":"ok",...}`
