### PR TITLE
feat(registry): enrich SN18 Zeus — add BOREAS Edge API health subnet-api surface

### DIFF
--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -49,6 +49,25 @@
         "https://api.zeussubnet.com/openapi.json"
       ],
       "url": "https://api.zeussubnet.com/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-health",
+      "kind": "subnet-api",
+      "name": "Zeus BOREAS Edge API health",
+      "notes": "Public no-auth health probe for the Zeus BOREAS Edge API; GET /v1/health returns {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing /v1/meta subnet-api surface.",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.zeussubnet.com/openapi.json",
+        "https://docs.zeussubnet.com/docs/introduction"
+      ],
+      "url": "https://api.zeussubnet.com/v1/health"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/sn-18.json` for Zeus SN18.
- **URL:** `https://api.zeussubnet.com/v1/health` → 200 `{"status":"ok"}`
- Documented in the subnet's OpenAPI spec on the same host as the existing `/v1/meta` surface.

## Surface

- Netuid: **18** (Zeus)
- Kind: **subnet-api**
- Provider: **zeus**
- Source URLs: OpenAPI spec + official docs introduction

## Conflict avoidance

Single-file append to `sn-18.json` only. No overlap with open PRs **#3263** (sn-37), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Should merge cleanly after those land without rebase.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/sn-18.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


Made with [Cursor](https://cursor.com)