### PR TITLE
feat(registry): add SN42 Gopher X trending-topics dataset data-artifact

### DIFF
--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -165,6 +165,25 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Public Gopher-Lab HuggingFace example of the SN42 web-scraper output (title/url/description/content columns of cleaned, structured page text; tagged Bittensor / Subnet / Masa), MIT-licensed and not gated. The subnet-42 repo (source) and developer portal declare the Bittensor subnet, and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org."
+    },
+    {
+      "id": "sn-42-gopher-x-trending-topics",
+      "name": "Gopher X/Twitter trending-topics dataset",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/datasets/Gopher-Lab/X_Twitter_Trending_Topics_August2025",
+      "provider": "gopher-ai",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/gopher-lab/subnet-42",
+        "https://huggingface.co/Gopher-Lab"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "notes": "Public Gopher-Lab HuggingFace dataset of X/Twitter trending-topics scraped by the SN42 Gopher data network, not gated. The subnet-42 repo (source) declares the Bittensor subnet and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org. Distinct from the subnet's registered web-scrape example dataset."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/gopher.json` (SN42 Gopher). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds a Gopher X/Twitter trending-topics dataset on Hugging Face (`Gopher-Lab/X_Twitter_Trending_Topics_August2025`) — scraped output from the SN42 Gopher data network. First-party: the `Gopher-Lab` HF org matches the subnet operator, and the `gopher-lab/subnet-42` repo README declares the Bittensor subnet.

This is a distinct dataset from the subnet's already-registered `Gopher-Lab/Bittensor_Whitepaper_Webscrape_Example` data-artifact.

## Surface

- Netuid: 42
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/Gopher-Lab/X_Twitter_Trending_Topics_August2025
- Source URLs: https://github.com/gopher-lab/subnet-42 , https://huggingface.co/Gopher-Lab
- Provider slug: gopher-ai

Same first-party provenance as the sibling web-scrape example dataset already in the registry.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this dataset, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public dataset plus the first-party subnet-42 repo/org sources establish and verify the claim.

## Validation

- `npm run validate:surface -- registry/subnets/gopher.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` (full suite) — passed
