### PR TITLE
feat(registry): enrich SN49 Nepher — add tournament API health subnet-api surface

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -244,6 +244,25 @@
       },
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/list"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-tournament-health",
+      "kind": "subnet-api",
+      "name": "Nepher tournament API health",
+      "notes": "Public no-auth GET /health returning tournament-backend service health (status, timestamp, service, version). Documented in the subnet's OpenAPI spec on the same host as the existing tournament subnet-api surfaces.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://docs.nepher.ai/"
+      ],
+      "url": "https://tournament-api.nepher.ai/health"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/nepher-robotics.json` for Nepher Robotics SN49.
- **URL:** `https://tournament-api.nepher.ai/health` → 200 with `status`, `timestamp`, `service`, `version`
- Documented in the tournament backend OpenAPI spec on the same host as existing tournament API surfaces.

## Surface

- Netuid: **49** (Nepher Robotics)
- Kind: **subnet-api**
- Provider: **nepher-robotics**
- Source URLs: tournament OpenAPI spec + official docs

## Conflict avoidance

Single-file append to `nepher-robotics.json` only. No overlap with open PRs **#3266** (gopher.json), **#3263** (sn-37.json), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Simulated `git merge` against each open branch is clean for all except **#3264** (MCP — unrelated files) and **#3263** (MCP test harness only when stacked on that branch; no registry file overlap). Should merge cleanly after those land without rebase.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/nepher-robotics.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


Made with [Cursor](https://cursor.com)