### PR TITLE
feat(registry): enrich SN19 BlockMachine — add API health subnet-api surface

### DIFF
--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -183,6 +183,25 @@
         "https://api.blockmachine.io/openapi.json"
       ],
       "url": "https://api.blockmachine.io/epochs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-19-blockmachine-health",
+      "kind": "subnet-api",
+      "name": "BlockMachine API health",
+      "notes": "Public no-auth GET /health returning BlockMachine API status and version. Documented in the subnet's OpenAPI spec on the same host as the existing leaderboard and epoch snapshot surfaces.",
+      "provider": "blockmachine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.blockmachine.io/openapi.json",
+        "https://blockmachine.io/"
+      ],
+      "url": "https://api.blockmachine.io/health"
     }
   ],
   "website_url": "https://blockmachine.io/"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/blockmachine.json` for BlockMachine SN19.
- **URL:** `https://api.blockmachine.io/health` → 200 with `status` and `version`
- Documented in the BlockMachine OpenAPI spec on the same host as existing leaderboard and epoch snapshot surfaces.

## Surface

- Netuid: **19** (BlockMachine)
- Kind: **subnet-api**
- Provider: **blockmachine**
- Source URLs: OpenAPI spec + official website

## Conflict avoidance

Single-file append to `blockmachine.json` only. No overlap with open PRs **#3263** (sn-37.json), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Simulated `git merge` against each open branch is clean for all registry-relevant PRs (MCP-only **#3264** also merges cleanly). Should land without rebase after those merge.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/blockmachine.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


Made with [Cursor](https://cursor.com)