### PR TITLE
feat(registry): enrich SN15 ORO — add API health subnet-api surface

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -203,6 +203,25 @@
         "https://huggingface.co/oro-ai"
       ],
       "url": "https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-sft-15k"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-health",
+      "kind": "subnet-api",
+      "name": "ORO API health",
+      "notes": "Public no-auth GET /health returning ORO API status and version. Documented in the subnet's OpenAPI spec on the same host as the existing leaderboard, suites, and snapshot surfaces.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/health"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/oro.json` for ORO SN15.
- **URL:** `https://api.oroagents.com/health` → 200 with `status` and `version`
- Documented in the ORO OpenAPI spec on the same host as existing leaderboard, suites, and snapshot surfaces.

## Surface

- Netuid: **15** (ORO)
- Kind: **subnet-api**
- Provider: **oro**
- Source URLs: OpenAPI spec + official website

## Conflict avoidance

Single-file append to `oro.json` only. No overlap with open PRs **#3263** (sn-37.json), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Simulated `git merge` against each open branch is clean for all registry-relevant PRs. Should land without rebase after those merge.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/oro.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


Made with [Cursor](https://cursor.com)