### PR TITLE
feat(mcp): add list_adapter_candidates mirroring GET /api/v1/review/adapter-candidates

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -287,6 +287,14 @@ assert.ok(
   Array.isArray(enrichmentQueuePage.queue),
   "list_enrichment_queue must return queue[]",
 );
+const adapterCandidatesPage = await callOk("list_adapter_candidates", {
+  limit: 3,
+  operational_kinds: "openapi",
+});
+assert.ok(
+  Array.isArray(adapterCandidatesPage.candidates),
+  "list_adapter_candidates must return candidates[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.70.0",
+  "version": "1.71.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/adapter-candidates-mcp.mjs
+++ b/src/adapter-candidates-mcp.mjs
@@ -1,0 +1,274 @@
+// Adapter candidates list loader for MCP parity on GET /api/v1/review/adapter-candidates.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/review/adapter-candidates.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const ADAPTER_CANDIDATES_ARTIFACT =
+  "/metagraph/review/adapter-candidates.json";
+
+const CANDIDATE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["adapter-candidates"].sort_fields;
+const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const RECOMMENDED_ADAPTER_KINDS = QUERY_ENUMS.recommendedAdapterKind;
+
+export function adapterCandidatesMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw adapterCandidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw adapterCandidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function adapterCandidatesQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/adapter-candidates");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw adapterCandidatesMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
+  if (curationLevel) url.searchParams.set("curation_level", curationLevel);
+  const candidateApiKinds = optionalEnum(
+    args,
+    "candidate_api_kinds",
+    SURFACE_KINDS,
+  );
+  if (candidateApiKinds) {
+    url.searchParams.set("candidate_api_kinds", candidateApiKinds);
+  }
+  const operationalKinds = optionalEnum(
+    args,
+    "operational_kinds",
+    SURFACE_KINDS,
+  );
+  if (operationalKinds) {
+    url.searchParams.set("operational_kinds", operationalKinds);
+  }
+  const recommendedAdapterKind = optionalEnum(
+    args,
+    "recommended_adapter_kind",
+    RECOMMENDED_ADAPTER_KINDS,
+  );
+  if (recommendedAdapterKind) {
+    url.searchParams.set("recommended_adapter_kind", recommendedAdapterKind);
+  }
+  const reasonCodes = optionalString(args, "reason_codes");
+  if (reasonCodes) url.searchParams.set("reason_codes", reasonCodes);
+  const sort = optionalEnum(args, "sort", CANDIDATE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw adapterCandidatesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadAdapterCandidatesList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = adapterCandidatesQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, ADAPTER_CANDIDATES_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw adapterCandidatesMcpError(
+        "not_found",
+        "Adapter candidates snapshot unavailable.",
+      );
+    }
+    throw adapterCandidatesMcpError(
+      code,
+      `Could not load ${ADAPTER_CANDIDATES_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw adapterCandidatesMcpError(
+      "not_found",
+      "Adapter candidates snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "adapter-candidates",
+    [],
+  );
+  if (transformed.error) {
+    throw adapterCandidatesMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.candidates) ? data.candidates : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    candidates: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_ADAPTER_CANDIDATES_INSTRUCTIONS =
+  "list_adapter_candidates subnets worth deeper adapter work (recommended_adapter_kind, " +
+  "operational_kinds, and priority_score; mirrors GET /api/v1/review/adapter-candidates), ";
+
+export const LIST_ADAPTER_CANDIDATES_MCP_TOOL = {
+  name: "list_adapter_candidates",
+  title: "List review adapter candidates",
+  description:
+    "Fetch subnets worth deeper adapter work from the registry: " +
+    "recommended_adapter_kind, operational and candidate API kinds, " +
+    "priority_score, and reason_codes per subnet. Filter by netuid, curation_level, " +
+    "candidate_api_kinds, operational_kinds, recommended_adapter_kind, or reason_codes; " +
+    "sort with sort + order; and page with limit (1-100) / cursor. Complements " +
+    "get_adapter (one adapter by slug) and list_enrichment_queue (full enrichment lanes). " +
+    "Mirrors GET /api/v1/review/adapter-candidates.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      curation_level: {
+        type: "string",
+        enum: CURATION_LEVELS,
+        description: "Filter by curation level.",
+      },
+      candidate_api_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose candidate API kinds include this surface kind.",
+      },
+      operational_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose operational kinds include this surface kind.",
+      },
+      recommended_adapter_kind: {
+        type: "string",
+        enum: RECOMMENDED_ADAPTER_KINDS,
+        description: "Filter by the recommended adapter kind.",
+      },
+      reason_codes: {
+        type: "string",
+        description: "Filter by reason_codes substring match.",
+      },
+      sort: {
+        type: "string",
+        enum: CANDIDATE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of candidate row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["candidates"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    candidates: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -44,6 +44,12 @@ import {
   loadEnrichmentQueueList,
 } from "./enrichment-queue-mcp.mjs";
 import {
+  LIST_ADAPTER_CANDIDATES_INSTRUCTIONS,
+  LIST_ADAPTER_CANDIDATES_MCP_TOOL,
+  LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
+  loadAdapterCandidatesList,
+} from "./adapter-candidates-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -458,7 +464,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.70.0";
+export const MCP_SERVER_VERSION = "1.71.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -568,6 +574,7 @@ export const MCP_INSTRUCTIONS =
   LIST_CURATION_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
   LIST_ENRICHMENT_QUEUE_INSTRUCTIONS +
+  LIST_ADAPTER_CANDIDATES_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
@@ -6453,6 +6460,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_ADAPTER_CANDIDATES_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadAdapterCandidatesList(ctx, args);
+    },
+  },
+  {
     ...LIST_ENDPOINT_POOLS_MCP_TOOL,
     async handler(args, ctx) {
       return loadEndpointPoolsList(ctx, args);
@@ -10131,6 +10144,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
   list_enrichment_queue: LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA,
+  list_adapter_candidates: LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   get_lineage: {

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  ADAPTER_CANDIDATES_ARTIFACT,
+  LIST_ADAPTER_CANDIDATES_INSTRUCTIONS,
+  LIST_ADAPTER_CANDIDATES_MCP_TOOL,
+  LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
+  adapterCandidatesMcpError,
+  adapterCandidatesQueryUrl,
+  loadAdapterCandidatesList,
+} from "../src/adapter-candidates-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["adapter shortlist"],
+  candidates: [
+    {
+      netuid: 7,
+      name: "Allways",
+      priority_score: 88,
+      operational_kinds: ["openapi"],
+      recommended_adapter_kind: "generic-openapi-or-custom",
+      reason_codes: ["existing-adapter"],
+    },
+    {
+      netuid: 12,
+      name: "Compute",
+      priority_score: 72,
+      operational_kinds: ["website"],
+      recommended_adapter_kind: "custom-adapter",
+      reason_codes: ["missing-adapter"],
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ADAPTER_CANDIDATES_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("adapter-candidates-mcp", () => {
+  test("adapterCandidatesMcpError is shaped for MCP toolError handling", () => {
+    const err = adapterCandidatesMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("adapterCandidatesQueryUrl validates filters and cursor", () => {
+    const url = adapterCandidatesQueryUrl({
+      netuid: 7,
+      curation_level: "maintainer-reviewed",
+      candidate_api_kinds: "openapi",
+      operational_kinds: "openapi",
+      recommended_adapter_kind: "generic-openapi-or-custom",
+      reason_codes: "existing-adapter",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,priority_score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("operational_kinds"), "openapi");
+    assert.equal(
+      url.searchParams.get("recommended_adapter_kind"),
+      "generic-openapi-or-custom",
+    );
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("adapterCandidatesQueryUrl rejects invalid operational_kinds", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ operational_kinds: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects invalid recommended_adapter_kind", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ recommended_adapter_kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects non-string fields and invalid order", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl trims and forwards a fields projection", () => {
+    const url = adapterCandidatesQueryUrl({
+      fields: " netuid,priority_score ",
+    });
+    assert.equal(url.searchParams.get("fields"), "netuid,priority_score");
+  });
+
+  test("adapterCandidatesQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = adapterCandidatesQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("adapterCandidatesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = adapterCandidatesQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("adapterCandidatesQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => adapterCandidatesQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("adapterCandidatesQueryUrl clamps limit above the MCP maximum", () => {
+    const url = adapterCandidatesQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadAdapterCandidatesList returns filtered rows with pagination meta", async () => {
+    const out = await loadAdapterCandidatesList(
+      { env: {}, readArtifact },
+      { operational_kinds: "openapi" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].netuid, 7);
+    assert.equal(out.candidates[0].priority_score, 88);
+  });
+
+  test("loadAdapterCandidatesList sorts and pages the collection", async () => {
+    const out = await loadAdapterCandidatesList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.candidates[0].netuid, 7);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadAdapterCandidatesList uses an injected readArtifact dep", async () => {
+    const out = await loadAdapterCandidatesList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            candidates: [
+              { netuid: 0, recommended_adapter_kind: "custom-adapter" },
+            ],
+          },
+        }),
+      },
+    );
+    assert.equal(out.candidates[0].netuid, 0);
+  });
+
+  test("loadAdapterCandidatesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadAdapterCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadAdapterCandidatesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadAdapterCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /adapter-candidates\.json/.test(err.message),
+    );
+  });
+
+  test("loadAdapterCandidatesList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadAdapterCandidatesList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadAdapterCandidatesList projects row fields when requested", async () => {
+    const out = await loadAdapterCandidatesList(
+      { env: {}, readArtifact },
+      { fields: "netuid,priority_score", limit: 1 },
+    );
+    assert.deepEqual(out.candidates[0], { netuid: 7, priority_score: 88 });
+  });
+
+  test("loadAdapterCandidatesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadAdapterCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: [{ netuid: 0, priority_score: 1 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadAdapterCandidatesList treats a non-array candidates key as empty", async () => {
+    const out = await loadAdapterCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.candidates, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadAdapterCandidatesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { candidates: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadAdapterCandidatesList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadAdapterCandidatesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadAdapterCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadAdapterCandidatesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadAdapterCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_ADAPTER_CANDIDATES_MCP_TOOL.name,
+      "list_adapter_candidates",
+    );
+    assert.match(
+      LIST_ADAPTER_CANDIDATES_INSTRUCTIONS,
+      /list_adapter_candidates/,
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
+    assert.ok(tool);
+    assert.equal(tool.title, "List review adapter candidates");
+  });
+});

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1488,6 +1488,75 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_adapter_candidates returns filtered candidate rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/adapter-candidates.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        candidates: [
+          {
+            netuid: 7,
+            priority_score: 88,
+            operational_kinds: ["openapi"],
+            recommended_adapter_kind: "generic-openapi-or-custom",
+          },
+          {
+            netuid: 12,
+            priority_score: 72,
+            operational_kinds: ["website"],
+            recommended_adapter_kind: "custom-adapter",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_adapter_candidates",
+      { operational_kinds: "openapi" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].netuid, 7);
+    assert.equal(out.candidates[0].priority_score, 88);
+  });
+
+  test("list_adapter_candidates reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_adapter_candidates",
+      {},
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Adapter candidates snapshot unavailable/,
+    );
+  });
+
+  test("list_adapter_candidates payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_adapter_candidates",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/review/adapter-candidates.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        candidates: [
+          {
+            netuid: 7,
+            priority_score: 88,
+            operational_kinds: ["openapi"],
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_adapter_candidates",
+      { limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.70.0");
+    assert.equal(MCP_SERVER_VERSION, "1.71.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Adds MCP tool `list_adapter_candidates` for REST parity with `GET /api/v1/review/adapter-candidates`, paging the baked `/metagraph/review/adapter-candidates.json` artifact via the same list-query filters as the Worker route (netuid, curation_level, candidate_api_kinds, operational_kinds, recommended_adapter_kind, reason_codes, sort/limit/cursor).
- Bumps MCP server SemVer to **1.71.0** (`MCP_SERVER_VERSION`, `server.json`, and MCP test assertions).
- Includes dedicated loader/tests (`src/adapter-candidates-mcp.mjs`, `tests/adapter-candidates-mcp.test.mjs`) with full query-URL edge-branch coverage, `validate-mcp` cold-path coverage, and 3 integration tests in `tests/mcp-server.test.mjs`.

## Why this tool
Follows the proven merge pattern from recently merged PRs like `list_enrichment_queue` (#3264) and `list_search_index` (#3253): artifact-only, read-only, REST parity, high test coverage. Complements merged `get_adapter` (single slug lookup) without overlapping it.

## Avoided overlap
- **Not** reusing closed PR #3261 (`get_subnet_stake_transfers`) or closed `list_coverage_depth` attempts (#3245/#3247/#3252).
- **Not** duplicating merged `list_enrichment_queue` (#3264).
- No conflict with the 5 currently open upstream PRs (registry enrichments / infra fixes only).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp` (141 tools)
- [x] `npx vitest run tests/adapter-candidates-mcp.test.mjs` (29 tests)
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_adapter_candidates`

Made with [Cursor](https://cursor.com)