### PR TITLE
feat(registry): enrich SN96 Verathos — add API health subnet-api surface

### DIFF
--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -290,6 +290,25 @@
         "https://verathos.ai/docs"
       ],
       "url": "https://api.verathos.ai/v1/supply/circulating"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-health",
+      "kind": "subnet-api",
+      "name": "Verathos API health",
+      "notes": "Public no-auth GET /health returning Verathos API status. Live on api.verathos.ai, the same host as the existing models subnet-api surface; documented in the subnet's OpenAPI spec.",
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://verathos.ai/openapi.json",
+        "https://verathos.ai/docs"
+      ],
+      "url": "https://api.verathos.ai/health"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/verathos.json` for Verathos SN96.
- **URL:** `https://api.verathos.ai/health` → 200 `{"status":"ok"}`
- Live on `api.verathos.ai`, the same host as the existing models subnet-api surface; documented in the subnet's OpenAPI spec.

## Surface

- Netuid: **96** (Verathos)
- Kind: **subnet-api**
- Provider: **verathos**
- Source URLs: OpenAPI spec + official docs

## Conflict avoidance

Single-file append to `verathos.json` only. No overlap with open PRs **#3263** (sn-37.json), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Simulated `git merge` against each open branch is clean for all registry-relevant PRs. Should land without rebase after those merge.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/verathos.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


Made with [Cursor](https://cursor.com)