### PR TITLE
feat(registry): enrich SN43 Graphite — add API health subnet-api surface

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -155,6 +155,25 @@
         "https://api.graphite-ai.net/docs"
       ],
       "url": "https://api.graphite-ai.net/api/v1/stats/coverage"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-43-graphite-health",
+      "kind": "subnet-api",
+      "name": "Graphite API health",
+      "notes": "Public no-auth GET /health returning Graphite API status plus knowledge-graph entity/relationship/fact counts. Documented as GET /health in the subnet's OpenAPI spec on the same host as the existing stats subnet-api surface.",
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.graphite-ai.net/openapi.json",
+        "https://api.graphite-ai.net/docs"
+      ],
+      "url": "https://api.graphite-ai.net/health"
     }
   ],
   "website_url": "https://graphite-ai.net/"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/graphite.json` for Graphite SN43.
- **URL:** `https://api.graphite-ai.net/health` → 200 with `status` plus knowledge-graph counts
- Documented as `GET /health` in the Graphite OpenAPI spec on the same host as the existing stats subnet-api surface.

## Surface

- Netuid: **43** (Graphite)
- Kind: **subnet-api**
- Provider: **graphite-ai**
- Source URLs: OpenAPI spec + API docs

## Conflict avoidance

Single-file append to `graphite.json` only. No overlap with open PRs **#3263** (sn-37.json), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Simulated `git merge` against each open branch is clean for all registry-relevant PRs. Should land without rebase after those merge.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/graphite.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


