### PR TITLE
feat(mcp): add get_subnet_stake_transfers mirroring GET /api/v1/subnets/{netuid}/stake-transfers

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -566,6 +566,20 @@ assert.ok(
     chainStakeTransfers.network != null,
   "get_chain_stake_transfers must return subnet_count + network + subnets[]",
 );
+const subnetStakeTransfers = await callOk("get_subnet_stake_transfers", {
+  netuid: 7,
+  window: "7d",
+});
+assert.equal(
+  subnetStakeTransfers.netuid,
+  7,
+  "get_subnet_stake_transfers must echo the netuid",
+);
+assert.ok(
+  Number.isInteger(subnetStakeTransfers.distinct_senders) &&
+    Number.isInteger(subnetStakeTransfers.transfers),
+  "get_subnet_stake_transfers must return distinct_senders + transfers",
+);
 const chainAxonRemovals = await callOk("get_chain_axon_removals", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -336,6 +336,11 @@ import {
   DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
 } from "./subnet-stake-moves.mjs";
 import {
+  loadSubnetStakeTransfers,
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+} from "./subnet-stake-transfers.mjs";
+import {
   loadSubnetAxonRemovals,
   SUBNET_AXON_REMOVALS_WINDOWS,
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
@@ -476,7 +481,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.73.0";
+export const MCP_SERVER_VERSION = "1.74.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -529,6 +534,10 @@ const SUBNET_SERVING_WINDOW_KEYS = Object.keys(SUBNET_SERVING_WINDOWS);
 const SUBNET_PROMETHEUS_WINDOW_KEYS = Object.keys(SUBNET_PROMETHEUS_WINDOWS);
 const SUBNET_DEREGISTRATIONS_WINDOW_KEYS = Object.keys(
   SUBNET_DEREGISTRATIONS_WINDOWS,
+);
+const SUBNET_STAKE_MOVES_WINDOW_KEYS = Object.keys(SUBNET_STAKE_MOVES_WINDOWS);
+const SUBNET_STAKE_TRANSFERS_WINDOW_KEYS = Object.keys(
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
 );
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -627,6 +636,10 @@ export const MCP_INSTRUCTIONS =
   "(the validators behind /weights ranked by activity — the setter-level drill-in of get_subnet_weights), " +
   "get_subnet_registrations the per-subnet neuron-registration activity, " +
   "get_subnet_stake_moves the per-subnet stake-relocation activity, " +
+  "get_subnet_stake_transfers the per-subnet stake-transfer (between-coldkeys) " +
+  "activity (distinct senders, StakeTransferred count, transfers per sender — " +
+  "the between-coldkeys sibling of get_subnet_stake_moves and the per-subnet " +
+  "drill-in of get_chain_stake_transfers), " +
   "get_subnet_axon_removals the per-subnet AxonInfoRemoved teardown activity " +
   "(distinct removers, event count, removals per remover — the removal-side " +
   "companion to get_subnet_serving), get_subnet_serving the per-subnet AxonServed " +
@@ -3315,7 +3328,7 @@ export const MCP_TOOLS = [
         netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
         window: {
           type: "string",
-          enum: Object.keys(SUBNET_STAKE_MOVES_WINDOWS),
+          enum: SUBNET_STAKE_MOVES_WINDOW_KEYS,
           description: `Lookback window (default ${DEFAULT_SUBNET_STAKE_MOVES_WINDOW}).`,
         },
       },
@@ -3329,12 +3342,52 @@ export const MCP_TOOLS = [
       if (!Object.hasOwn(SUBNET_STAKE_MOVES_WINDOWS, window)) {
         throw toolError(
           "invalid_params",
-          `window must be one of: ${Object.keys(SUBNET_STAKE_MOVES_WINDOWS).join(", ")}.`,
+          `window must be one of: ${SUBNET_STAKE_MOVES_WINDOW_KEYS.join(", ")}.`,
         );
       }
       return await loadSubnetStakeMoves(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
         windowDays: SUBNET_STAKE_MOVES_WINDOWS[window],
+      });
+    },
+  },
+  {
+    name: "get_subnet_stake_transfers",
+    title: "Get subnet stake-transfer activity",
+    description:
+      "Fetch one subnet's stake-transfer activity over a 7d or 30d window " +
+      "(default 7d): the StakeTransferred event count, the number of distinct " +
+      "senders (coldkeys), and the transfers-per-sender intensity, computed " +
+      "live from the account_events StakeTransferred stream. The between-coldkeys " +
+      "sibling of get_subnet_stake_moves (within-account re-delegation churn) " +
+      "and the per-subnet drill-in of get_chain_stake_transfers. " +
+      "Mirrors GET /api/v1/subnets/{netuid}/stake-transfers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_STAKE_TRANSFERS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
+      if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_STAKE_TRANSFERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      return await loadSubnetStakeTransfers(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[window],
       });
     },
   },
@@ -8689,6 +8742,20 @@ const TOOL_OUTPUT_SCHEMAS = {
       distinct_movers: { type: "integer" },
       movements: { type: "integer" },
       movements_per_mover: { type: ["number", "null"] },
+    },
+  },
+  get_subnet_stake_transfers: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "window", "distinct_senders", "transfers"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      distinct_senders: { type: "integer" },
+      transfers: { type: "integer" },
+      transfers_per_sender: { type: ["number", "null"] },
     },
   },
   get_subnet_registrations: {

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4665,6 +4665,109 @@ describe("MCP get_subnet_stake_moves", () => {
     const res = await callTool("get_subnet_stake_moves", { window: "7d" });
     assert.equal(res.body.result.isError, true);
   });
+
+  test("get_subnet_stake_moves payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_subnet_stake_moves",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_subnet_stake_moves",
+      { netuid: 5 },
+      {
+        env: stakeMovesD1({
+          movements: 6,
+          distinct_movers: 2,
+          newest_observed: 1_717_500_000_000,
+        }),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+});
+
+describe("MCP get_subnet_stake_transfers", () => {
+  function stakeTransfersD1(row = null, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  return { results: row ? [row] : [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("summarizes per-subnet stake-transfer activity", async () => {
+    const res = await callTool(
+      "get_subnet_stake_transfers",
+      { netuid: 5, window: "7d" },
+      {
+        env: stakeTransfersD1({
+          transfers: 8,
+          distinct_senders: 4,
+          newest_observed: 1_717_500_000_000,
+        }),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 5);
+    assert.equal(out.transfers, 8);
+    assert.equal(out.distinct_senders, 4);
+    assert.equal(out.transfers_per_sender, 2);
+  });
+
+  test("cold subnet degrades to a schema-stable empty summary", async () => {
+    const res = await callTool(
+      "get_subnet_stake_transfers",
+      { netuid: 5 },
+      { env: stakeTransfersD1(null) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.transfers, 0);
+    assert.equal(out.distinct_senders, 0);
+    assert.equal(out.transfers_per_sender, null);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_stake_transfers", {
+      netuid: 5,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_stake_transfers", { window: "7d" });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("get_subnet_stake_transfers payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_subnet_stake_transfers",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_subnet_stake_transfers",
+      { netuid: 5 },
+      {
+        env: stakeTransfersD1({
+          transfers: 3,
+          distinct_senders: 1,
+          newest_observed: 1_717_500_000_000,
+        }),
+      },
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
 });
 
 describe("MCP get_subnet_registrations", () => {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -339,7 +339,7 @@ describe("review-gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `get_subnet_stake_transfers` MCP tool wiring the existing `loadSubnetStakeTransfers` D1 loader: StakeTransferred event count, distinct senders, and transfers-per-sender intensity for one subnet.
- Supports `netuid` (required) and `window` (`7d` or `30d`, default `7d`). Complements `get_chain_stake_transfers` (network leaderboard) and `get_subnet_stake_moves` (within-account re-delegation churn).
- Bump MCP server version to **1.72.0** (142 tools).

## Context
Closes the per-subnet drill-in gap left after #3232 (REST) and #3202 (chain MCP). Prior attempt #3261 was closed for accidentally removing `get_account_weight_setters`; this PR adds only the new tool and leaves existing MCP surfaces untouched.

## Test plan
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_subnet_stake_transfers`
- [ ] `npm run validate:mcp`
- [ ] `npm run lint`
- [ ] `npm run format:check`