### PR TITLE
feat(mcp): add list_profile_completeness mirroring GET /api/v1/review/profile-completeness

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -295,6 +295,14 @@ assert.ok(
   Array.isArray(adapterCandidatesPage.candidates),
   "list_adapter_candidates must return candidates[]",
 );
+const profileCompletenessPage = await callOk("list_profile_completeness", {
+  limit: 3,
+  identity_level: "partial",
+});
+assert.ok(
+  Array.isArray(profileCompletenessPage.profiles),
+  "list_profile_completeness must return profiles[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -50,6 +50,12 @@ import {
   loadAdapterCandidatesList,
 } from "./adapter-candidates-mcp.mjs";
 import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  loadProfileCompletenessList,
+} from "./profile-completeness-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -464,7 +470,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.71.0";
+export const MCP_SERVER_VERSION = "1.72.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -575,6 +581,7 @@ export const MCP_INSTRUCTIONS =
   LIST_GAPS_INSTRUCTIONS +
   LIST_ENRICHMENT_QUEUE_INSTRUCTIONS +
   LIST_ADAPTER_CANDIDATES_INSTRUCTIONS +
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
@@ -6466,6 +6473,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadProfileCompletenessList(ctx, args);
+    },
+  },
+  {
     ...LIST_ENDPOINT_POOLS_MCP_TOOL,
     async handler(args, ctx) {
       return loadEndpointPoolsList(ctx, args);
@@ -10145,6 +10158,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
   list_enrichment_queue: LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA,
   list_adapter_candidates: LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
+  list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   get_lineage: {

--- a/src/profile-completeness-mcp.mjs
+++ b/src/profile-completeness-mcp.mjs
@@ -1,0 +1,267 @@
+// Profile completeness list loader for MCP parity on GET /api/v1/review/profile-completeness.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/review/profile-completeness.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const PROFILE_COMPLETENESS_ARTIFACT =
+  "/metagraph/review/profile-completeness.json";
+
+const PROFILE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["profile-completeness"].sort_fields;
+const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
+const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"];
+
+export function profileCompletenessMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function profileCompletenessQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/profile-completeness");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const profileLevel = optionalEnum(args, "profile_level", PROFILE_LEVELS);
+  if (profileLevel) url.searchParams.set("profile_level", profileLevel);
+  const confidence = optionalEnum(args, "confidence", CONFIDENCE_LEVELS);
+  if (confidence) url.searchParams.set("confidence", confidence);
+  const identityLevel = optionalEnum(args, "identity_level", IDENTITY_LEVELS);
+  if (identityLevel) url.searchParams.set("identity_level", identityLevel);
+  const identityPromotionKinds = optionalEnum(
+    args,
+    "identity_promotion_kinds",
+    SURFACE_KINDS,
+  );
+  if (identityPromotionKinds) {
+    url.searchParams.set("identity_promotion_kinds", identityPromotionKinds);
+  }
+  const nativeNameQuality = optionalEnum(
+    args,
+    "native_name_quality",
+    NATIVE_NAME_QUALITIES,
+  );
+  if (nativeNameQuality) {
+    url.searchParams.set("native_name_quality", nativeNameQuality);
+  }
+  const sort = optionalEnum(args, "sort", PROFILE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadProfileCompletenessList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = profileCompletenessQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, PROFILE_COMPLETENESS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw profileCompletenessMcpError(
+        "not_found",
+        "Profile completeness snapshot unavailable.",
+      );
+    }
+    throw profileCompletenessMcpError(
+      code,
+      `Could not load ${PROFILE_COMPLETENESS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw profileCompletenessMcpError(
+      "not_found",
+      "Profile completeness snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "profile-completeness",
+    [],
+  );
+  if (transformed.error) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.profiles) ? data.profiles : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    summary: data.summary ?? null,
+    profiles: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_PROFILE_COMPLETENESS_INSTRUCTIONS =
+  "list_profile_completeness per-subnet profile completeness scores (completeness_score, " +
+  "identity_level, priority_score; mirrors GET /api/v1/review/profile-completeness), ";
+
+export const LIST_PROFILE_COMPLETENESS_MCP_TOOL = {
+  name: "list_profile_completeness",
+  title: "List review profile completeness",
+  description:
+    "Fetch per-subnet profile completeness reports from the registry: " +
+    "completeness_score, profile_level, identity_level, missing critical kinds, " +
+    "and priority_score for contributor targeting. Filter by netuid, profile_level, " +
+    "confidence, identity_level, identity_promotion_kinds, or native_name_quality; " +
+    "sort with sort + order; and page with limit (1-100) / cursor. Complements " +
+    "list_gaps (interface facet gaps) and list_enrichment_queue (actionable lanes). " +
+    "Mirrors GET /api/v1/review/profile-completeness.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      profile_level: {
+        type: "string",
+        enum: PROFILE_LEVELS,
+        description: "Filter by profile level.",
+      },
+      confidence: {
+        type: "string",
+        enum: CONFIDENCE_LEVELS,
+        description: "Filter by profile confidence.",
+      },
+      identity_level: {
+        type: "string",
+        enum: IDENTITY_LEVELS,
+        description: "Filter by on-chain identity completeness.",
+      },
+      identity_promotion_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose promotable identity kinds include this surface kind.",
+      },
+      native_name_quality: {
+        type: "string",
+        enum: NATIVE_NAME_QUALITIES,
+        description: "Filter by native on-chain name quality.",
+      },
+      sort: {
+        type: "string",
+        enum: PROFILE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of profile row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["profiles"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    summary: { type: ["object", "null"] },
+    profiles: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1557,6 +1557,76 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_profile_completeness returns filtered profile rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        summary: { average_score: 60 },
+        profiles: [
+          {
+            netuid: 73,
+            completeness_score: 25,
+            identity_level: "partial",
+            priority_score: 119,
+          },
+          {
+            netuid: 1,
+            completeness_score: 85,
+            identity_level: "complete",
+            priority_score: 10,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { identity_level: "partial" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.profiles[0].netuid, 73);
+    assert.equal(out.profiles[0].priority_score, 119);
+  });
+
+  test("list_profile_completeness reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_profile_completeness",
+      {},
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Profile completeness snapshot unavailable/,
+    );
+  });
+
+  test("list_profile_completeness payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_profile_completeness",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        profiles: [
+          {
+            netuid: 73,
+            completeness_score: 25,
+            identity_level: "partial",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profile-completeness-mcp.test.mjs
+++ b/tests/profile-completeness-mcp.test.mjs
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  PROFILE_COMPLETENESS_ARTIFACT,
+  loadProfileCompletenessList,
+  profileCompletenessMcpError,
+  profileCompletenessQueryUrl,
+} from "../src/profile-completeness-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  summary: { average_score: 60 },
+  profiles: [
+    {
+      netuid: 73,
+      name: "MetaHash",
+      completeness_score: 25,
+      identity_level: "partial",
+      priority_score: 119,
+      profile_level: "identity-partial",
+    },
+    {
+      netuid: 31,
+      name: "Recall",
+      completeness_score: 25,
+      identity_level: "partial",
+      priority_score: 118,
+      profile_level: "identity-partial",
+    },
+    {
+      netuid: 1,
+      name: "Prompting",
+      completeness_score: 85,
+      identity_level: "complete",
+      priority_score: 10,
+      profile_level: "adapter-backed",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === PROFILE_COMPLETENESS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("profile-completeness-mcp", () => {
+  test("profileCompletenessMcpError is shaped for MCP toolError handling", () => {
+    const err = profileCompletenessMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("profileCompletenessQueryUrl validates filters and cursor", () => {
+    const url = profileCompletenessQueryUrl({
+      netuid: 73,
+      profile_level: "identity-partial",
+      confidence: "medium",
+      identity_level: "partial",
+      identity_promotion_kinds: "source-repo",
+      native_name_quality: "chain",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,priority_score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "73");
+    assert.equal(url.searchParams.get("identity_level"), "partial");
+    assert.equal(url.searchParams.get("identity_promotion_kinds"), "source-repo");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid identity_level", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ identity_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid identity_promotion_kinds", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ identity_promotion_kinds: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid native_name_quality", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ native_name_quality: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects non-string fields and invalid order", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl trims and forwards a fields projection", () => {
+    const url = profileCompletenessQueryUrl({
+      fields: " netuid,priority_score ",
+    });
+    assert.equal(url.searchParams.get("fields"), "netuid,priority_score");
+  });
+
+  test("profileCompletenessQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl clamps limit above the MCP maximum", () => {
+    const url = profileCompletenessQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadProfileCompletenessList returns filtered rows with pagination meta", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { identity_level: "partial" },
+    );
+    assert.equal(out.returned, 2);
+    assert.equal(out.profiles[0].netuid, 73);
+    assert.equal(out.profiles[0].priority_score, 119);
+    assert.deepEqual(out.summary, { average_score: 60 });
+  });
+
+  test("loadProfileCompletenessList sorts and pages the collection", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.profiles[0].netuid, 73);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadProfileCompletenessList uses an injected readArtifact dep", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            profiles: [{ netuid: 0, completeness_score: 10 }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.profiles[0].netuid, 0);
+  });
+
+  test("loadProfileCompletenessList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /profile-completeness\.json/.test(err.message),
+    );
+  });
+
+  test("loadProfileCompletenessList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProfileCompletenessList projects row fields when requested", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { fields: "netuid,priority_score", limit: 1, sort: "priority_score", order: "desc" },
+    );
+    assert.deepEqual(out.profiles[0], { netuid: 73, priority_score: 119 });
+  });
+
+  test("loadProfileCompletenessList omits nullable artifact metadata when absent", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: [{ netuid: 0, completeness_score: 1 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadProfileCompletenessList treats a non-array profiles key as empty", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.profiles, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadProfileCompletenessList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { profiles: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadProfileCompletenessList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadProfileCompletenessList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_PROFILE_COMPLETENESS_MCP_TOOL.name,
+      "list_profile_completeness",
+    );
+    assert.match(
+      LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+      /list_profile_completeness/,
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_profile_completeness at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.match(MCP_INSTRUCTIONS, /list_profile_completeness/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_profile_completeness");
+    assert.ok(tool);
+    assert.equal(tool.title, "List review profile completeness");
+  });
+});

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.71.0");
+    assert.equal(MCP_SERVER_VERSION, "1.72.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_profile_completeness` MCP tool with REST parity on `GET /api/v1/review/profile-completeness` over `/metagraph/review/profile-completeness.json`.
- Extract loader to `src/profile-completeness-mcp.mjs` with unit and integration tests; bump MCP SemVer to **1.72.0**.
- Wire into `scripts/validate-mcp.mjs` smoke checks.

## Conflict avoidance
- Fills the gap left by closed #3258 (that PR stacked on another branch and accidentally removed `get_account_weight_setters`).
- No overlap with open PRs: #3272 (`list_enrichment_evidence`), #3273/#3263 (subnet-api surfaces), #3244 (neuron-history).
- Follows the same pattern as merged #3270 (`list_adapter_candidates`) and #3264 (`list_enrichment_queue`).

## Test plan
- [x] `npx vitest run tests/profile-completeness-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_profile_completeness`
- [x] `node scripts/validate-mcp.mjs`