### PR TITLE
feat(registry): enrich SN22 Desearch — add API health subnet-api surface

### DIFF
--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -278,6 +278,25 @@
         "https://huggingface.co/desearch"
       ],
       "url": "https://huggingface.co/datasets/desearch/dataset"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-health",
+      "kind": "subnet-api",
+      "name": "Desearch API health",
+      "notes": "Public no-auth GET /health on the Desearch API host (api.desearch.ai), the same host advertised by the subnet's OpenAPI schema and existing subnet-api surface. Returns a simple health status JSON payload.",
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.desearch.ai/openapi.json",
+        "https://www.desearch.ai/docs"
+      ],
+      "url": "https://api.desearch.ai/health"
     }
   ],
   "website_url": "https://www.desearch.ai/"


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/desearch.json` for Desearch SN22.
- **URL:** `https://api.desearch.ai/health` → 200 with health status JSON
- Live on `api.desearch.ai`, the same host advertised by the subnet's OpenAPI schema and existing subnet-api surface.

## Surface

- Netuid: **22** (Desearch)
- Kind: **subnet-api**
- Provider: **desearch**
- Source URLs: API OpenAPI spec + official docs

## Conflict avoidance

Single-file append to `desearch.json` only. No overlap with open PRs **#3273** (graphite.json), **#3275** (performance/history CSV), **#3274** (MCP), **#3263** (sn-37.json), **#3244** (neuron-history), **#3223** (workspace dep), or **#3153** (other subnet manifests). Simulated `git merge` against every open branch is clean. Should land without rebase after those merge.

## Validation

- [x] `npm run surface:add` with live verification
- [x] `npm run validate:surface -- registry/subnets/desearch.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`

