### PR TITLE
feat(registry): enrich SN85 Vidaio — add API health subnet-api surface

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -124,6 +124,25 @@
         "https://github.com/vidaio-subnet/vidaio-subnet/blob/b5d60ba7e2f6f9620075558f8d9098a3b2242109/services/video_scheduler/video_samples.yaml"
       ],
       "url": "https://raw.githubusercontent.com/vidaio-subnet/vidaio-subnet/b5d60ba7e2f6f9620075558f8d9098a3b2242109/services/video_scheduler/video_samples.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-85-vidaio-health",
+      "kind": "subnet-api",
+      "name": "Vidaio API health",
+      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health).",
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.vidaio.io/openapi.json",
+        "https://vidaio.io/"
+      ],
+      "url": "https://api.vidaio.io/health"
     }
   ],
   "website_url": "https://vidaio.io/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/vidaio.json`.

## Surface

- Netuid: **85** (Vidaio)
- Kind: **subnet-api**
- Public URL: `https://api.vidaio.io/health`
- Source URLs:
  - https://api.vidaio.io/openapi.json
  - https://vidaio.io/
- Provider slug: **vidaio**

## No linked issue

SN85 already has an `openapi` surface on `api.vidaio.io`; the registry was missing the corresponding `subnet-api` entry for the documented public `/health` liveness probe (same pattern as #3271 / #3265).

## Checklist

- [x] Changes exactly one `registry/subnets/vidaio.json` file (append-only)
- [x] Public no-auth URL; `/health` documented in the subnet's own OpenAPI on the same host as the existing openapi surface
- [x] Public-safe: read-only health JSON, no credentials
- [x] Does not duplicate an existing Metagraphed surface
- [x] No linked issue — registry gap fill (openapi present, subnet-api missing)

## Conflict avoidance

Single-file append to `vidaio.json` only. No overlap with open PRs:

| Open PR | Touches |
|---------|---------|
| #3275 | CSV / workers API |
| #3274 | MCP stake-transfers |
| #3273 | `graphite.json` |
| #3272 | MCP enrichment-evidence |
| #3263 | `sn-37.json` |
| #3244 | neuron-history |
| #3223 | infra/client |
| #3153 | other subnet manifests (not vidaio) |

## Validation

- [x] `npm run validate:surface -- registry/subnets/vidaio.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: `GET /health` → 200 with `{"status":"ok"}`

## Test plan

- [x] Surface validator passes for the updated manifest
- [x] Public-safety scan passes
- [x] Live `/health` returns 200 JSON on `api.vidaio.io`
