### PR TITLE
feat(registry): enrich SN94 Bitsota — add coordinator health subnet-api surface

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -64,6 +64,25 @@
       },
       "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
       "url": "https://autoresearch.bitsota.com/api/v1/idea-rewards"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-alveus-labs-health",
+      "kind": "subnet-api",
+      "name": "Bitsota AutoResearch coordinator health",
+      "notes": "Public no-auth GET /healthz returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi and subnet-api surfaces (autoresearch.bitsota.com/openapi.json, path /healthz).",
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://autoresearch.bitsota.com/openapi.json",
+        "https://bitsota.ai/docs/autoresearch-backend-routes"
+      ],
+      "url": "https://autoresearch.bitsota.com/healthz"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/bitsota.json`.

## Surface

- Netuid: **94** (Bitsota)
- Kind: **subnet-api**
- Public URL: `https://autoresearch.bitsota.com/healthz`
- Source URLs:
  - https://autoresearch.bitsota.com/openapi.json
  - https://bitsota.ai/docs/autoresearch-backend-routes
- Provider slug: **alveus-labs**

## No linked issue

SN94 already has `openapi` and functional `subnet-api` surfaces on `autoresearch.bitsota.com`; the registry was missing the corresponding health/liveness entry for the documented public `/healthz` probe (same pattern as #3278 / #3271).

## Checklist

- [x] Changes exactly one `registry/subnets/bitsota.json` file (append-only)
- [x] Public no-auth URL; `/healthz` documented in the subnet's own OpenAPI on the same host as existing surfaces
- [x] Public-safe: read-only health JSON, no credentials
- [x] Does not duplicate an existing Metagraphed surface
- [x] No linked issue — registry gap fill (openapi + subnet-api present, health missing)

## Conflict avoidance

Single-file append to `bitsota.json` only. No overlap with open PRs:

| Open PR | Touches |
|---------|---------|
| #3277 | `desearch.json` |
| #3275 | CSV / workers API |
| #3274 | MCP stake-transfers |
| #3244 | neuron-history |
| #3223 | infra/client |
| #3153 | other subnet manifests (not bitsota) |

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitsota.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: `GET /healthz` → 200 with `{"status":"ok"}`

## Test plan

- [x] Surface validator passes for the updated manifest
- [x] Public-safety scan passes
- [x] Live `/healthz` returns 200 JSON on `autoresearch.bitsota.com`

Made with [Cursor](https://cursor.com)