### PR TITLE
feat(mcp): add list_review_gaps mirroring GET /api/v1/review/gaps

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -303,6 +303,14 @@ assert.ok(
   Array.isArray(enrichmentEvidencePage.entries),
   "list_enrichment_evidence must return entries[]",
 );
+const reviewGapsPage = await callOk("list_review_gaps", {
+  limit: 3,
+  curation_level: "candidate-discovered",
+});
+assert.ok(
+  Array.isArray(reviewGapsPage.priorities),
+  "list_review_gaps must return priorities[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -56,6 +56,12 @@ import {
   loadEnrichmentEvidenceList,
 } from "./enrichment-evidence-mcp.mjs";
 import {
+  LIST_REVIEW_GAPS_INSTRUCTIONS,
+  LIST_REVIEW_GAPS_MCP_TOOL,
+  LIST_REVIEW_GAPS_OUTPUT_SCHEMA,
+  loadReviewGapsList,
+} from "./review-gaps-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -470,7 +476,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.72.0";
+export const MCP_SERVER_VERSION = "1.73.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -582,6 +588,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ENRICHMENT_QUEUE_INSTRUCTIONS +
   LIST_ADAPTER_CANDIDATES_INSTRUCTIONS +
   LIST_ENRICHMENT_EVIDENCE_INSTRUCTIONS +
+  LIST_REVIEW_GAPS_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
@@ -6479,6 +6486,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_REVIEW_GAPS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadReviewGapsList(ctx, args);
+    },
+  },
+  {
     ...LIST_ENDPOINT_POOLS_MCP_TOOL,
     async handler(args, ctx) {
       return loadEndpointPoolsList(ctx, args);
@@ -10159,6 +10172,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_enrichment_queue: LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA,
   list_adapter_candidates: LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
   list_enrichment_evidence: LIST_ENRICHMENT_EVIDENCE_OUTPUT_SCHEMA,
+  list_review_gaps: LIST_REVIEW_GAPS_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   get_lineage: {

--- a/src/review-gaps-mcp.mjs
+++ b/src/review-gaps-mcp.mjs
@@ -1,0 +1,222 @@
+// Review gap priorities list loader for MCP parity on GET /api/v1/review/gaps.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/review/gap-priorities.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const REVIEW_GAPS_ARTIFACT = "/metagraph/review/gap-priorities.json";
+
+const PRIORITY_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields;
+const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
+
+export function reviewGapsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw reviewGapsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw reviewGapsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function reviewGapsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/gaps");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw reviewGapsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
+  if (curationLevel) url.searchParams.set("curation_level", curationLevel);
+  const reviewState = optionalString(args, "review_state");
+  if (reviewState) url.searchParams.set("review_state", reviewState);
+  const sort = optionalEnum(args, "sort", PRIORITY_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw reviewGapsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadReviewGapsList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = reviewGapsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, REVIEW_GAPS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw reviewGapsMcpError(
+        "not_found",
+        "Review gap priorities snapshot unavailable.",
+      );
+    }
+    throw reviewGapsMcpError(
+      code,
+      `Could not load ${REVIEW_GAPS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw reviewGapsMcpError(
+      "not_found",
+      "Review gap priorities snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "review-gap-priorities",
+    [],
+  );
+  if (transformed.error) {
+    throw reviewGapsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.priorities) ? data.priorities : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    priorities: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_REVIEW_GAPS_INSTRUCTIONS =
+  "list_review_gaps the contributor-targeted review gap priority board " +
+  "(priority_score, missing kinds, and curation_level; mirrors GET /api/v1/review/gaps), ";
+
+export const LIST_REVIEW_GAPS_MCP_TOOL = {
+  name: "list_review_gaps",
+  title: "List review gap priorities",
+  description:
+    "Fetch the contributor-targeted review gap priority board from the registry: " +
+    "per-subnet priority_score, missing surface kinds, surface and candidate counts, " +
+    "curation_level, and review_state. Filter by netuid, curation_level, or review_state; " +
+    "sort with sort + order; and page with limit (1-100) / cursor. Distinct from list_gaps " +
+    "(interface facet reports at GET /api/v1/gaps) and get_subnet_gaps (one subnet's " +
+    "detailed gap artifact). Mirrors GET /api/v1/review/gaps.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      curation_level: {
+        type: "string",
+        enum: CURATION_LEVELS,
+        description: "Filter by curation level.",
+      },
+      review_state: {
+        type: "string",
+        description: "Filter by review_state substring match.",
+      },
+      sort: {
+        type: "string",
+        enum: PRIORITY_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of priority row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_REVIEW_GAPS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["priorities"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    priorities: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1626,6 +1626,67 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_review_gaps returns filtered priority rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/gap-priorities.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        priorities: [
+          {
+            netuid: 7,
+            priority_score: 88,
+            curation_level: "candidate-discovered",
+            missing_kinds: ["openapi"],
+          },
+          {
+            netuid: 12,
+            priority_score: 72,
+            curation_level: "maintainer-reviewed",
+            missing_kinds: ["website"],
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_review_gaps",
+      { curation_level: "candidate-discovered" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.priorities[0].netuid, 7);
+    assert.equal(out.priorities[0].priority_score, 88);
+  });
+
+  test("list_review_gaps reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_review_gaps", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Review gap priorities snapshot unavailable/,
+    );
+  });
+
+  test("list_review_gaps payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_review_gaps",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/review/gap-priorities.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        priorities: [
+          {
+            netuid: 7,
+            priority_score: 88,
+            curation_level: "candidate-discovered",
+          },
+        ],
+      },
+    });
+    const res = await callTool("list_review_gaps", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_REVIEW_GAPS_INSTRUCTIONS,
+  LIST_REVIEW_GAPS_MCP_TOOL,
+  LIST_REVIEW_GAPS_OUTPUT_SCHEMA,
+  REVIEW_GAPS_ARTIFACT,
+  loadReviewGapsList,
+  reviewGapsMcpError,
+  reviewGapsQueryUrl,
+} from "../src/review-gaps-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["gap priorities"],
+  priorities: [
+    {
+      netuid: 7,
+      name: "Allways",
+      priority_score: 88,
+      curation_level: "candidate-discovered",
+      review_state: "needs-evidence",
+      missing_kinds: ["openapi"],
+    },
+    {
+      netuid: 12,
+      name: "Compute",
+      priority_score: 72,
+      curation_level: "maintainer-reviewed",
+      review_state: "accepted",
+      missing_kinds: ["website"],
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === REVIEW_GAPS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("review-gaps-mcp", () => {
+  test("reviewGapsMcpError is shaped for MCP toolError handling", () => {
+    const err = reviewGapsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("reviewGapsQueryUrl validates filters and cursor", () => {
+    const url = reviewGapsQueryUrl({
+      netuid: 7,
+      curation_level: "candidate-discovered",
+      review_state: "needs-evidence",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,priority_score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(
+      url.searchParams.get("curation_level"),
+      "candidate-discovered",
+    );
+    assert.equal(url.searchParams.get("review_state"), "needs-evidence");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("reviewGapsQueryUrl rejects invalid curation_level", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ curation_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects non-string fields and invalid order", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => reviewGapsQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects empty review_state", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ review_state: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl trims and forwards a fields projection", () => {
+    const url = reviewGapsQueryUrl({ fields: " netuid,priority_score " });
+    assert.equal(url.searchParams.get("fields"), "netuid,priority_score");
+  });
+
+  test("reviewGapsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = reviewGapsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("reviewGapsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = reviewGapsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("reviewGapsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewGapsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = reviewGapsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadReviewGapsList returns filtered rows with pagination meta", async () => {
+    const out = await loadReviewGapsList(
+      { env: {}, readArtifact },
+      { curation_level: "candidate-discovered" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.priorities[0].netuid, 7);
+    assert.equal(out.priorities[0].priority_score, 88);
+  });
+
+  test("loadReviewGapsList sorts and pages the collection", async () => {
+    const out = await loadReviewGapsList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.priorities[0].netuid, 7);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadReviewGapsList uses an injected readArtifact dep", async () => {
+    const out = await loadReviewGapsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { priorities: [{ netuid: 0, priority_score: 1 }] },
+        }),
+      },
+    );
+    assert.equal(out.priorities[0].netuid, 0);
+  });
+
+  test("loadReviewGapsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadReviewGapsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /gap-priorities\.json/.test(err.message),
+    );
+  });
+
+  test("loadReviewGapsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewGapsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadReviewGapsList projects row fields when requested", async () => {
+    const out = await loadReviewGapsList(
+      { env: {}, readArtifact },
+      { fields: "netuid,priority_score", limit: 1 },
+    );
+    assert.deepEqual(out.priorities[0], { netuid: 7, priority_score: 88 });
+  });
+
+  test("loadReviewGapsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadReviewGapsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { priorities: [{ netuid: 0, priority_score: 1 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadReviewGapsList treats a non-array priorities key as empty", async () => {
+    const out = await loadReviewGapsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { priorities: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.priorities, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadReviewGapsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { priorities: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadReviewGapsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadReviewGapsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadReviewGapsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_REVIEW_GAPS_MCP_TOOL.name, "list_review_gaps");
+    assert.match(LIST_REVIEW_GAPS_INSTRUCTIONS, /list_review_gaps/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_REVIEW_GAPS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
+    assert.ok(tool);
+    assert.equal(tool.title, "List review gap priorities");
+  });
+});

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_review_gaps` MCP tool mirroring `GET /api/v1/review/gaps` for review gap priority snapshots
- Wire loader, query filters (`netuid`, `curation_level`, `review_state`), handler, output schema, and validate-mcp cold path
- Add dedicated unit tests (29) plus 3 integration tests; bump MCP server version to 1.73.0 (143 tools)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/review-gaps-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_review_gaps"`


Made with [Cursor](https://cursor.com)