### PR TITLE
feat(mcp): filter and paginate list_providers

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -470,7 +470,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.72.0";
+export const MCP_SERVER_VERSION = "1.73.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -6072,18 +6072,68 @@ export const MCP_TOOLS = [
     name: "list_providers",
     title: "List providers and sources",
     description:
-      "Fetch the full index of registered data providers/sources backing the " +
+      "Fetch the index of registered data providers/sources backing the " +
       "registry: each provider's id, kind, authority, name, and the subnets, " +
       "surfaces, and endpoints it backs. This is the list counterpart to " +
-      "get_provider_detail (which fetches one provider by slug). Mirrors " +
+      "get_provider_detail (which fetches one provider by slug). Optionally " +
+      "filter by id/kind/authority and page with limit/offset. Mirrors " +
       "GET /api/v1/providers.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        id: { type: "string", description: "Provider slug, e.g. 'datura'." },
+        kind: {
+          type: "string",
+          enum: QUERY_ENUMS.providerKind,
+          description: "Provider kind, e.g. 'data-provider' or 'registry'.",
+        },
+        authority: {
+          type: "string",
+          enum: QUERY_ENUMS.providerAuthority,
+          description: "Trust authority, e.g. 'official' or 'community'.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max providers to return. Omit for the full list.",
+          minimum: 1,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset into the (filtered) list. Default 0.",
+          minimum: 0,
+        },
+      },
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/providers.json");
+    async handler(args, ctx) {
+      const id = optionalString(args, "id");
+      const kind = optionalEnum(args, "kind", QUERY_ENUMS.providerKind);
+      const authority = optionalEnum(
+        args,
+        "authority",
+        QUERY_ENUMS.providerAuthority,
+      );
+      const limit = optionalPositiveInt(args, "limit");
+      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const data = await loadArtifactData(ctx, "/metagraph/providers.json");
+      const all = Array.isArray(data.providers) ? data.providers : [];
+      const filtered = all.filter(
+        (p) =>
+          (id === null || p.id === id) &&
+          (kind === null || p.kind === kind) &&
+          (authority === null || p.authority === authority),
+      );
+      const page =
+        limit === null
+          ? filtered.slice(offset)
+          : filtered.slice(offset, offset + limit);
+      return {
+        ...data,
+        providers: page,
+        total: filtered.length,
+        returned: page.length,
+        offset,
+      };
     },
   },
   {

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13415,6 +13415,112 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
+  function providersDeps() {
+    return makeDeps({
+      "/metagraph/providers.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        providers: [
+          {
+            id: "datura",
+            kind: "data-provider",
+            authority: "official",
+            name: "Datura",
+          },
+          {
+            id: "chutes",
+            kind: "infrastructure-provider",
+            authority: "official",
+            name: "Chutes",
+          },
+          {
+            id: "community-x",
+            kind: "data-provider",
+            authority: "community",
+            name: "Community X",
+          },
+        ],
+      },
+    });
+  }
+
+  test("list_providers filters by id, kind, and authority", async () => {
+    const deps = providersDeps();
+    const byId = (await callTool("list_providers", { id: "chutes" }, { deps }))
+      .body.result.structuredContent;
+    assert.equal(byId.total, 1);
+    assert.equal(byId.providers[0].name, "Chutes");
+
+    const byKind = (
+      await callTool(
+        "list_providers",
+        { kind: "infrastructure-provider" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byKind.total, 1);
+    assert.equal(byKind.providers[0].id, "chutes");
+
+    const byAuthority = (
+      await callTool("list_providers", { authority: "official" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byAuthority.total, 2);
+  });
+
+  test("list_providers combines filters (AND) and reports total vs returned", async () => {
+    const deps = providersDeps();
+    const res = await callTool(
+      "list_providers",
+      { kind: "data-provider", authority: "community" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.providers[0].id, "community-x");
+  });
+
+  test("list_providers paginates the filtered list with limit/offset", async () => {
+    const deps = providersDeps();
+    const res = await callTool(
+      "list_providers",
+      { limit: 1, offset: 1 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 1);
+    assert.equal(out.offset, 1);
+    assert.equal(out.providers[0].id, "chutes");
+  });
+
+  test("list_providers rejects an unknown kind/authority enum value", async () => {
+    const deps = providersDeps();
+    const badKind = await callTool(
+      "list_providers",
+      { kind: "not-a-kind" },
+      { deps },
+    );
+    assert.equal(badKind.body.result.isError, true);
+
+    const badAuthority = await callTool(
+      "list_providers",
+      { authority: "not-an-authority" },
+      { deps },
+    );
+    assert.equal(badAuthority.body.result.isError, true);
+  });
+
+  test("list_providers is schema-stable when the artifact has no providers array", async () => {
+    const deps = makeDeps({
+      "/metagraph/providers.json": { generated_at: "2026-01-01T00:00:00Z" },
+    });
+    const res = await callTool("list_providers", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.providers, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
+  });
+
   test("list_surfaces returns the surfaces catalog artifact", async () => {
     const deps = makeDeps({
       "/metagraph/surfaces.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.72.0");
+    assert.equal(MCP_SERVER_VERSION, "1.73.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

`list_providers` returns the entire provider/source index with no way to narrow or page it — unlike most other `list_*` MCP tools (following the same pattern already merged for `list_candidates`/#3203 and `list_endpoints`/#3201).

Adds optional `id` / `kind` / `authority` filters (`kind`/`authority` validated against `QUERY_ENUMS.providerKind`/`QUERY_ENUMS.providerAuthority`, the same enums the REST contract uses) plus `limit`/`offset` pagination over the filtered result.

**Omitting every arg keeps the response backward compatible** — `providers` is unchanged; `total`/`returned`/`offset` are simply added.

Additive tool input, so `MCP_SERVER_VERSION` and `server.json` both move 1.72.0 -> 1.73.0 per the bump policy (#393); the 17 other test files that hardcode the prior version literal are updated in the same commit (this list has grown as more tools were added — re-grepped fresh for this PR).

## Changes
- `src/mcp-server.mjs`: filter + pagination logic on `list_providers`'s handler; inputSchema gains the 5 new optional args; version bump.
- `server.json`: version bump to match.
- `tests/mcp-server.test.mjs`: per-field filters, combined (AND) filtering, limit/offset pagination, invalid enum rejection, missing-array schema-stability (branch-coverage complete, verified locally with no partial branches in the touched region before push).
- The 17 version-literal files: bumped to match.

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed.

## Validation
- `node scripts/validate-mcp.mjs` (142 tools, version consistency) — green
- Full relevant suite (`mcp-server.test.mjs` + the 17 version-literal files) — 995 passed; new lines fully covered (statement + branch)
- `npm run lint`, `npm run format:check` — clean