### PR TITLE
feat(mcp): add list_review_enrichment_targets mirroring GET /api/v1/review/enrichment-targets

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -311,6 +311,17 @@ assert.ok(
   Array.isArray(reviewGapsPage.priorities),
   "list_review_gaps must return priorities[]",
 );
+const reviewEnrichmentTargetsPage = await callOk(
+  "list_review_enrichment_targets",
+  {
+    limit: 3,
+    target_type: "surface-candidate",
+  },
+);
+assert.ok(
+  Array.isArray(reviewEnrichmentTargetsPage.targets),
+  "list_review_enrichment_targets must return targets[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -62,6 +62,12 @@ import {
   loadReviewGapsList,
 } from "./review-gaps-mcp.mjs";
 import {
+  LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS,
+  LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL,
+  LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA,
+  loadReviewEnrichmentTargetsList,
+} from "./review-enrichment-targets-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -476,7 +482,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.73.0";
+export const MCP_SERVER_VERSION = "1.74.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -589,6 +595,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ADAPTER_CANDIDATES_INSTRUCTIONS +
   LIST_ENRICHMENT_EVIDENCE_INSTRUCTIONS +
   LIST_REVIEW_GAPS_INSTRUCTIONS +
+  LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
@@ -6538,6 +6545,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadReviewEnrichmentTargetsList(ctx, args);
+    },
+  },
+  {
     ...LIST_ENDPOINT_POOLS_MCP_TOOL,
     async handler(args, ctx) {
       return loadEndpointPoolsList(ctx, args);
@@ -10219,6 +10232,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_adapter_candidates: LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
   list_enrichment_evidence: LIST_ENRICHMENT_EVIDENCE_OUTPUT_SCHEMA,
   list_review_gaps: LIST_REVIEW_GAPS_OUTPUT_SCHEMA,
+  list_review_enrichment_targets: LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   get_lineage: {

--- a/src/review-enrichment-targets-mcp.mjs
+++ b/src/review-enrichment-targets-mcp.mjs
@@ -1,0 +1,375 @@
+// Review enrichment targets list loader for MCP parity on
+// GET /api/v1/review/enrichment-targets. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/review/enrichment-targets.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const REVIEW_ENRICHMENT_TARGETS_ARTIFACT =
+  "/metagraph/review/enrichment-targets.json";
+
+const TARGET_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["enrichment-targets"].sort_fields;
+const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const EVIDENCE_ACTIONS = [
+  "submit-new-evidence",
+  "verify-existing-evidence",
+  "replace-stale-evidence",
+  "review-existing-evidence",
+  "maintainer-review-existing-evidence",
+  "monitor",
+];
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
+const LANES = [
+  "direct-submission",
+  "maintainer-review",
+  "adapter-candidate",
+  "monitoring-followup",
+  "baseline-monitoring",
+];
+const BOOLEAN_STRINGS = ["true", "false"];
+const SUBMISSION_ROUTES = [
+  "direct-candidate-pr",
+  "adapter-request",
+  "maintainer-review",
+  "status-report",
+];
+const TARGET_ACTIONS = [
+  "submit-new-candidate",
+  "replace-stale-candidate",
+  "verify-existing-candidate",
+  "review-existing-candidate",
+  "adapter-review",
+  "maintainer-review",
+  "monitoring-followup",
+];
+const TARGET_TYPES = [
+  "surface-candidate",
+  "adapter-review",
+  "maintainer-review",
+  "monitoring-followup",
+];
+
+export function reviewEnrichmentTargetsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw reviewEnrichmentTargetsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw reviewEnrichmentTargetsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function reviewEnrichmentTargetsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/enrichment-targets");
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw reviewEnrichmentTargetsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const targetType = optionalEnum(args, "target_type", TARGET_TYPES);
+  if (targetType) url.searchParams.set("target_type", targetType);
+  const targetAction = optionalEnum(args, "target_action", TARGET_ACTIONS);
+  if (targetAction) url.searchParams.set("target_action", targetAction);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const lane = optionalEnum(args, "lane", LANES);
+  if (lane) url.searchParams.set("lane", lane);
+  const evidenceAction = optionalEnum(
+    args,
+    "evidence_action",
+    EVIDENCE_ACTIONS,
+  );
+  if (evidenceAction) url.searchParams.set("evidence_action", evidenceAction);
+  const identityLevel = optionalEnum(args, "identity_level", IDENTITY_LEVELS);
+  if (identityLevel) url.searchParams.set("identity_level", identityLevel);
+  const profileLevel = optionalEnum(args, "profile_level", PROFILE_LEVELS);
+  if (profileLevel) url.searchParams.set("profile_level", profileLevel);
+  const submissionRoute = optionalEnum(
+    args,
+    "submission_route",
+    SUBMISSION_ROUTES,
+  );
+  if (submissionRoute)
+    url.searchParams.set("submission_route", submissionRoute);
+  const autoReviewCandidate = optionalEnum(
+    args,
+    "auto_review_candidate",
+    BOOLEAN_STRINGS,
+  );
+  if (autoReviewCandidate) {
+    url.searchParams.set("auto_review_candidate", autoReviewCandidate);
+  }
+  const manualReviewRequired = optionalEnum(
+    args,
+    "manual_review_required",
+    BOOLEAN_STRINGS,
+  );
+  if (manualReviewRequired) {
+    url.searchParams.set("manual_review_required", manualReviewRequired);
+  }
+  const missingKinds = optionalEnum(args, "missing_kinds", SURFACE_KINDS);
+  if (missingKinds) url.searchParams.set("missing_kinds", missingKinds);
+  const reasonCodes = optionalString(args, "reason_codes");
+  if (reasonCodes) url.searchParams.set("reason_codes", reasonCodes);
+  const sort = optionalEnum(args, "sort", TARGET_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw reviewEnrichmentTargetsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadReviewEnrichmentTargetsList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = reviewEnrichmentTargetsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, REVIEW_ENRICHMENT_TARGETS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw reviewEnrichmentTargetsMcpError(
+        "not_found",
+        "Review enrichment targets snapshot unavailable.",
+      );
+    }
+    throw reviewEnrichmentTargetsMcpError(
+      code,
+      `Could not load ${REVIEW_ENRICHMENT_TARGETS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw reviewEnrichmentTargetsMcpError(
+      "not_found",
+      "Review enrichment targets snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "enrichment-targets",
+    [],
+  );
+  if (transformed.error) {
+    throw reviewEnrichmentTargetsMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.targets) ? data.targets : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    targets: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS =
+  "list_review_enrichment_targets the contributor-facing enrichment target board " +
+  "(target_type, target_action, lane, and priority_score; mirrors " +
+  "GET /api/v1/review/enrichment-targets), ";
+
+export const LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL = {
+  name: "list_review_enrichment_targets",
+  title: "List review enrichment targets",
+  description:
+    "Fetch the contributor-facing enrichment target board from the registry: " +
+    "per-subnet target_type, target_action, lane, priority_score, missing surface " +
+    "kinds, submission_route, and recommended_action. Filter by netuid, target_type, " +
+    "target_action, kind, lane, evidence_action, identity_level, profile_level, " +
+    "submission_route, auto_review_candidate, manual_review_required, missing_kinds, " +
+    "or reason_codes; search with q; sort with sort + order; and page with limit " +
+    "(1-100) / cursor. Distinct from list_enrichment_targets (coverage-depth scorecard) " +
+    "and list_enrichment_queue (prioritized queue summary). Mirrors " +
+    "GET /api/v1/review/enrichment-targets.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      q: {
+        type: "string",
+        description:
+          "Keyword search across name, slug, contribution_prompt, recommended_action, and reason_codes.",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      target_type: {
+        type: "string",
+        enum: TARGET_TYPES,
+        description:
+          "Filter by target type (surface-candidate, adapter-review, etc.).",
+      },
+      target_action: {
+        type: "string",
+        enum: TARGET_ACTIONS,
+        description: "Filter by the recommended target action.",
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind.",
+      },
+      lane: {
+        type: "string",
+        enum: LANES,
+        description:
+          "Filter by enrichment lane (direct-submission, maintainer-review, etc.).",
+      },
+      evidence_action: {
+        type: "string",
+        enum: EVIDENCE_ACTIONS,
+        description: "Filter by the recommended evidence action.",
+      },
+      identity_level: {
+        type: "string",
+        enum: IDENTITY_LEVELS,
+        description: "Filter by subnet identity completeness.",
+      },
+      profile_level: {
+        type: "string",
+        enum: PROFILE_LEVELS,
+        description: "Filter by profile completeness.",
+      },
+      submission_route: {
+        type: "string",
+        enum: SUBMISSION_ROUTES,
+        description: "Filter by contributor submission route.",
+      },
+      auto_review_candidate: {
+        type: "string",
+        enum: BOOLEAN_STRINGS,
+        description:
+          "Filter by whether the target is an auto-review candidate.",
+      },
+      manual_review_required: {
+        type: "string",
+        enum: BOOLEAN_STRINGS,
+        description: "Filter by whether manual review is required.",
+      },
+      missing_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter rows whose missing_kinds include this kind.",
+      },
+      reason_codes: {
+        type: "string",
+        description: "Filter by reason_codes substring match.",
+      },
+      sort: {
+        type: "string",
+        enum: TARGET_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of target row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["targets"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    targets: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1687,6 +1687,77 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_review_enrichment_targets returns filtered target rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/enrichment-targets.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        targets: [
+          {
+            netuid: 7,
+            priority_score: 88,
+            target_type: "surface-candidate",
+            target_action: "submit-new-candidate",
+            missing_kinds: ["openapi"],
+          },
+          {
+            netuid: 12,
+            priority_score: 72,
+            target_type: "maintainer-review",
+            target_action: "maintainer-review",
+            missing_kinds: ["website"],
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_review_enrichment_targets",
+      { target_type: "surface-candidate" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.targets[0].netuid, 7);
+    assert.equal(out.targets[0].priority_score, 88);
+  });
+
+  test("list_review_enrichment_targets reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_review_enrichment_targets",
+      {},
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Review enrichment targets snapshot unavailable/,
+    );
+  });
+
+  test("list_review_enrichment_targets payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_review_enrichment_targets",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/review/enrichment-targets.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        targets: [
+          {
+            netuid: 7,
+            priority_score: 88,
+            target_type: "surface-candidate",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_review_enrichment_targets",
+      { limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-enrichment-targets-mcp.test.mjs
+++ b/tests/review-enrichment-targets-mcp.test.mjs
@@ -1,0 +1,401 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS,
+  LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL,
+  LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA,
+  REVIEW_ENRICHMENT_TARGETS_ARTIFACT,
+  loadReviewEnrichmentTargetsList,
+  reviewEnrichmentTargetsMcpError,
+  reviewEnrichmentTargetsQueryUrl,
+} from "../src/review-enrichment-targets-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["enrichment target drill-down"],
+  targets: [
+    {
+      netuid: 7,
+      name: "Allways",
+      target_type: "surface-candidate",
+      target_action: "submit-new-candidate",
+      lane: "direct-submission",
+      kind: "openapi",
+      priority_score: 88,
+      missing_kinds: ["openapi"],
+      submission_route: "direct-candidate-pr",
+    },
+    {
+      netuid: 12,
+      name: "Compute",
+      target_type: "maintainer-review",
+      target_action: "maintainer-review",
+      lane: "maintainer-review",
+      kind: "website",
+      priority_score: 72,
+      missing_kinds: ["website"],
+      submission_route: "maintainer-review",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === REVIEW_ENRICHMENT_TARGETS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("review-enrichment-targets-mcp", () => {
+  test("reviewEnrichmentTargetsMcpError is shaped for MCP toolError handling", () => {
+    const err = reviewEnrichmentTargetsMcpError("invalid_params", "bad lane");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl validates filters and cursor", () => {
+    const url = reviewEnrichmentTargetsQueryUrl({
+      q: "openapi",
+      netuid: 7,
+      target_type: "surface-candidate",
+      target_action: "submit-new-candidate",
+      kind: "openapi",
+      lane: "direct-submission",
+      evidence_action: "replace-stale-evidence",
+      identity_level: "partial",
+      profile_level: "identity-partial",
+      submission_route: "direct-candidate-pr",
+      auto_review_candidate: "true",
+      manual_review_required: "false",
+      missing_kinds: "openapi",
+      reason_codes: "missing-openapi",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,lane",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("q"), "openapi");
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("target_type"), "surface-candidate");
+    assert.equal(url.searchParams.get("target_action"), "submit-new-candidate");
+    assert.equal(url.searchParams.get("kind"), "openapi");
+    assert.equal(url.searchParams.get("lane"), "direct-submission");
+    assert.equal(
+      url.searchParams.get("evidence_action"),
+      "replace-stale-evidence",
+    );
+    assert.equal(url.searchParams.get("profile_level"), "identity-partial");
+    assert.equal(url.searchParams.get("auto_review_candidate"), "true");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects invalid target_type", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ target_type: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects invalid target_action", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ target_action: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects invalid lane", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ lane: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects empty q and invalid sort", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects non-string q and invalid order", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ q: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl trims and forwards a fields projection", () => {
+    const url = reviewEnrichmentTargetsQueryUrl({ fields: " netuid,lane " });
+    assert.equal(url.searchParams.get("fields"), "netuid,lane");
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = reviewEnrichmentTargetsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = reviewEnrichmentTargetsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => reviewEnrichmentTargetsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("reviewEnrichmentTargetsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = reviewEnrichmentTargetsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadReviewEnrichmentTargetsList returns filtered rows with pagination meta", async () => {
+    const out = await loadReviewEnrichmentTargetsList(
+      { env: {}, readArtifact },
+      { target_type: "surface-candidate" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.targets[0].netuid, 7);
+    assert.equal(out.targets[0].target_action, "submit-new-candidate");
+  });
+
+  test("loadReviewEnrichmentTargetsList sorts and pages the collection", async () => {
+    const out = await loadReviewEnrichmentTargetsList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.targets[0].netuid, 7);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadReviewEnrichmentTargetsList uses an injected readArtifact dep", async () => {
+    const out = await loadReviewEnrichmentTargetsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            targets: [{ netuid: 0, lane: "monitoring-followup" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.targets[0].netuid, 0);
+  });
+
+  test("loadReviewEnrichmentTargetsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewEnrichmentTargetsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadReviewEnrichmentTargetsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewEnrichmentTargetsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /enrichment-targets\.json/.test(err.message),
+    );
+  });
+
+  test("loadReviewEnrichmentTargetsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewEnrichmentTargetsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadReviewEnrichmentTargetsList projects row fields when requested", async () => {
+    const out = await loadReviewEnrichmentTargetsList(
+      { env: {}, readArtifact },
+      { fields: "netuid,lane", limit: 1 },
+    );
+    assert.deepEqual(out.targets[0], { netuid: 7, lane: "direct-submission" });
+  });
+
+  test("loadReviewEnrichmentTargetsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadReviewEnrichmentTargetsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { targets: [{ netuid: 0, lane: "direct-submission" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadReviewEnrichmentTargetsList treats a non-array targets key as empty", async () => {
+    const out = await loadReviewEnrichmentTargetsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { targets: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.targets, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadReviewEnrichmentTargetsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { targets: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadReviewEnrichmentTargetsList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadReviewEnrichmentTargetsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewEnrichmentTargetsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadReviewEnrichmentTargetsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadReviewEnrichmentTargetsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL.name,
+      "list_review_enrichment_targets",
+    );
+    assert.match(
+      LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS,
+      /list_review_enrichment_targets/,
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_review_enrichment_targets at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.match(MCP_INSTRUCTIONS, /list_review_enrichment_targets/);
+    const tool = MCP_TOOLS.find(
+      (t) => t.name === "list_review_enrichment_targets",
+    );
+    assert.ok(tool);
+    assert.equal(tool.title, "List review enrichment targets");
+  });
+});

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -339,7 +339,7 @@ describe("review-gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_review_enrichment_targets` MCP tool mirroring `GET /api/v1/review/enrichment-targets` for the contributor-facing enrichment target board
- Wire loader, query filters (target_type, target_action, kind, lane, evidence_action, identity_level, profile_level, submission_route, auto_review_candidate, manual_review_required, missing_kinds, reason_codes), handler, output schema, and validate-mcp cold path
- Add dedicated unit tests (30) plus 3 integration tests; bump MCP server version to 1.74.0 (144 tools)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/review-enrichment-targets-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_review_enrichment_targets"`


Made with [Cursor](https://cursor.com)