### PR TITLE
feat(mcp): add list_subnet_surfaces mirroring GET /api/v1/subnets/{netuid}/surfaces

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -311,6 +311,15 @@ assert.ok(
   Array.isArray(reviewGapsPage.priorities),
   "list_review_gaps must return priorities[]",
 );
+const subnetSurfacesPage = await callOk("list_subnet_surfaces", {
+  netuid: 7,
+  limit: 3,
+  kind: "subnet-api",
+});
+assert.ok(
+  Array.isArray(subnetSurfacesPage.surfaces),
+  "list_subnet_surfaces must return surfaces[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -62,6 +62,12 @@ import {
   loadReviewGapsList,
 } from "./review-gaps-mcp.mjs";
 import {
+  LIST_SUBNET_SURFACES_INSTRUCTIONS,
+  LIST_SUBNET_SURFACES_MCP_TOOL,
+  LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+  loadSubnetSurfacesList,
+} from "./subnet-surfaces-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -476,7 +482,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.73.0";
+export const MCP_SERVER_VERSION = "1.74.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -738,6 +744,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ENDPOINT_POOLS_INSTRUCTIONS +
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
+  LIST_SUBNET_SURFACES_INSTRUCTIONS +
   "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
   "its provenance evidence claims, and list_fixtures " +
   "live request/response examples. All data is public and " +
@@ -6468,6 +6475,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_SURFACES_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSubnetSurfacesList(ctx, args);
+    },
+  },
+  {
     name: "get_subnet_candidates",
     title: "Get one subnet's candidate surfaces",
     description:
@@ -10201,6 +10214,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
+  list_subnet_surfaces: LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
   list_rpc_pools: {
     type: "object",
     additionalProperties: true,

--- a/src/subnet-surfaces-mcp.mjs
+++ b/src/subnet-surfaces-mcp.mjs
@@ -1,0 +1,229 @@
+// Per-subnet curated surfaces list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/surfaces. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/surfaces/{netuid}.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+const SURFACE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const SUBNET_SURFACES_QUERY_FILTER_NAMES = ["kind", "provider"];
+
+export function subnetSurfacesArtifactPath(netuid) {
+  return `/metagraph/surfaces/${netuid}.json`;
+}
+
+export function subnetSurfacesMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(args) {
+  const netuid = args?.netuid;
+  if (!Number.isInteger(netuid) || netuid < 0) {
+    throw subnetSurfacesMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetSurfacesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetSurfacesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function subnetSurfacesQueryUrl(args) {
+  const url = new URL("https://mcp.internal/subnets/surfaces");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const sort = optionalEnum(args, "sort", SURFACE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw subnetSurfacesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSubnetSurfacesList(ctx, args, { readArtifact } = {}) {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetSurfacesQueryUrl(args);
+  const artifactPath = subnetSurfacesArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw subnetSurfacesMcpError(
+        "not_found",
+        `No curated surfaces snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetSurfacesMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetSurfacesMcpError(
+      "not_found",
+      `No curated surfaces snapshot exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "curated-surfaces",
+    SUBNET_SURFACES_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetSurfacesMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.surfaces) ? data.surfaces : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    netuid: data.netuid ?? netuid,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_SURFACES_INSTRUCTIONS =
+  "list_subnet_surfaces one subnet's curated public surfaces with REST list-query " +
+  "filters (kind, provider, sort, and pagination; mirrors " +
+  "GET /api/v1/subnets/{netuid}/surfaces), ";
+
+export const LIST_SUBNET_SURFACES_MCP_TOOL = {
+  name: "list_subnet_surfaces",
+  title: "List one subnet's curated surfaces",
+  description:
+    "Fetch the curated public surfaces for one subnet by netuid: each surface's " +
+    "kind, provider, title, url, and review state. Filter by kind or provider; " +
+    "sort with sort + order; and page with limit (1-100) / cursor. Distinct from " +
+    "list_surfaces (network-wide catalog) and get_subnet (full subnet detail bundle). " +
+    "Mirrors GET /api/v1/subnets/{netuid}/surfaces.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'openapi' or 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug, e.g. 'datura'.",
+      },
+      sort: {
+        type: "string",
+        enum: SURFACE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of surface row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_SURFACES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["surfaces"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    surfaces: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1687,6 +1687,71 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_subnet_surfaces returns filtered surface rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/surfaces/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        surfaces: [
+          {
+            id: "allways-openapi",
+            netuid: 7,
+            kind: "openapi",
+            provider: "allways",
+          },
+          {
+            id: "allways-subnet-api",
+            netuid: 7,
+            kind: "subnet-api",
+            provider: "allways",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_surfaces",
+      { netuid: 7, kind: "subnet-api" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].kind, "subnet-api");
+    assert.equal(out.netuid, 7);
+  });
+
+  test("list_subnet_surfaces reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_subnet_surfaces",
+      { netuid: 7 },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No curated surfaces snapshot exists for netuid 7/,
+    );
+  });
+
+  test("list_subnet_surfaces payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_subnet_surfaces",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/surfaces/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        surfaces: [{ id: "allways-openapi", netuid: 7, kind: "openapi" }],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_surfaces",
+      { netuid: 7, limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -339,7 +339,7 @@ describe("review-gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.73.0");
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);

--- a/tests/subnet-surfaces-mcp.test.mjs
+++ b/tests/subnet-surfaces-mcp.test.mjs
@@ -1,0 +1,371 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SUBNET_SURFACES_INSTRUCTIONS,
+  LIST_SUBNET_SURFACES_MCP_TOOL,
+  LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+  loadSubnetSurfacesList,
+  subnetSurfacesArtifactPath,
+  subnetSurfacesMcpError,
+  subnetSurfacesQueryUrl,
+} from "../src/subnet-surfaces-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const NETUID = 7;
+const ARTIFACT = subnetSurfacesArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  netuid: NETUID,
+  surfaces: [
+    {
+      id: "allways-openapi",
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      name: "Allways OpenAPI",
+    },
+    {
+      id: "allways-subnet-api",
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      name: "Allways API",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-surfaces-mcp", () => {
+  test("subnetSurfacesMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetSurfacesMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetSurfacesQueryUrl validates filters and cursor", () => {
+    const url = subnetSurfacesQueryUrl({
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      sort: "kind",
+      order: "desc",
+      fields: "id,kind",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "openapi");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("sort"), "kind");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetSurfacesQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl trims and forwards a fields projection", () => {
+    const url = subnetSurfacesQueryUrl({
+      netuid: NETUID,
+      fields: " id,kind ",
+    });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("subnetSurfacesQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetSurfacesQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetSurfacesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetSurfacesQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetSurfacesQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetSurfacesQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetSurfacesList returns filtered rows with pagination meta", async () => {
+    const out = await loadSubnetSurfacesList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, kind: "openapi" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].kind, "openapi");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetSurfacesList sorts and pages the collection", async () => {
+    const out = await loadSubnetSurfacesList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, sort: "kind", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetSurfacesList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetSurfacesList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            surfaces: [{ netuid: 0, kind: "docs" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.surfaces[0].netuid, 0);
+  });
+
+  test("loadSubnetSurfacesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetSurfacesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /surfaces\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetSurfacesList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          { env: {}, readArtifact },
+          { netuid: NETUID, fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetSurfacesList projects row fields when requested", async () => {
+    const out = await loadSubnetSurfacesList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, fields: "id,kind", limit: 1 },
+    );
+    assert.deepEqual(out.surfaces[0], {
+      id: "allways-openapi",
+      kind: "openapi",
+    });
+  });
+
+  test("loadSubnetSurfacesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: [{ netuid: 0, kind: "docs" }] },
+        }),
+      },
+      { netuid: 0 },
+    );
+    assert.equal(out.generated_at, null);
+  });
+
+  test("loadSubnetSurfacesList treats a non-array surfaces key as empty", async () => {
+    const out = await loadSubnetSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: null },
+        }),
+      },
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetSurfacesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ netuid: 9 }, { netuid: 9 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetSurfacesList(
+        { env: {}, readArtifact },
+        { netuid: NETUID },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetSurfacesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetSurfacesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetSurfacesList rejects missing netuid", async () => {
+    await assert.rejects(
+      () => loadSubnetSurfacesList({ env: {}, readArtifact }, {}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_SURFACES_MCP_TOOL.name, "list_subnet_surfaces");
+    assert.match(LIST_SUBNET_SURFACES_INSTRUCTIONS, /list_subnet_surfaces/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_surfaces at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_surfaces/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_surfaces");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's curated surfaces");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `list_subnet_surfaces` MCP tool mirroring `GET /api/v1/subnets/{netuid}/surfaces` for per-subnet curated surface listings
- Wire loader, query filters (`kind`, `provider`), handler, output schema, and validate-mcp cold path
- Add dedicated unit tests (30) plus 3 integration tests; bump MCP server version to 1.74.0 (144 tools)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/subnet-surfaces-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_subnet_surfaces"`


Made with [Cursor](https://cursor.com)