### PR TITLE
feat(mcp): add list_provider_endpoints mirroring GET /api/v1/providers/{slug}/endpoints

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -339,6 +339,19 @@ assert.ok(
   Array.isArray(endpointIncidentsPage.incidents),
   "list_endpoint_incidents must return incidents[]",
 );
+const providerEndpointsPage = await callOk("list_provider_endpoints", {
+  slug: "allways",
+  limit: 3,
+});
+assert.ok(
+  Array.isArray(providerEndpointsPage.endpoints),
+  "list_provider_endpoints must return endpoints[]",
+);
+assert.equal(
+  providerEndpointsPage.slug,
+  "allways",
+  "list_provider_endpoints must echo the requested slug",
+);
 await callOk("registry_summary", {});
 await callOk("get_coverage", {});
 const contracts = await callOk("get_contracts", {});

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -86,6 +86,12 @@ import {
   loadEndpointIncidentsList,
 } from "./endpoint-incidents-mcp.mjs";
 import {
+  LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS,
+  LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
+  LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
+  loadProviderEndpointsList,
+} from "./provider-endpoints-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -744,6 +750,7 @@ export const MCP_INSTRUCTIONS =
   "scores, " +
   LIST_ENDPOINT_POOLS_INSTRUCTIONS +
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS +
+  LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
   "its provenance evidence claims, and list_fixtures " +
@@ -6613,6 +6620,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadProviderEndpointsList(ctx, args);
+    },
+  },
+  {
     name: "get_lineage",
     title: "Get cross-network subnet lineage",
     description:
@@ -10285,6 +10298,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_review_enrichment_targets: LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA,
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
+  list_provider_endpoints: LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
   get_lineage: {
     type: "object",
     additionalProperties: true,

--- a/src/provider-endpoints-mcp.mjs
+++ b/src/provider-endpoints-mcp.mjs
@@ -1,0 +1,335 @@
+// Provider endpoint list loader for MCP parity on
+// GET /api/v1/providers/{slug}/endpoints. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/providers/{slug}/endpoints.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const PROVIDER_SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+
+export function providerEndpointsArtifactPath(slug) {
+  return `/metagraph/providers/${slug}/endpoints.json`;
+}
+
+export function providerEndpointsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw providerEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw providerEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw providerEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function parseProviderSlug(args) {
+  const slug = args?.slug;
+  if (typeof slug !== "string" || slug.trim() === "") {
+    throw providerEndpointsMcpError(
+      "invalid_params",
+      "Argument `slug` must be a non-empty string.",
+    );
+  }
+  const normalized = slug.trim();
+  if (!PROVIDER_SLUG_PATTERN.test(normalized)) {
+    throw providerEndpointsMcpError(
+      "invalid_params",
+      "slug must match ^[a-z0-9-]+$ (lowercase letters, digits, hyphens).",
+    );
+  }
+  return normalized;
+}
+
+export function providerEndpointsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/provider-endpoints");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw providerEndpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  if (args?.pool_eligible !== undefined) {
+    if (typeof args.pool_eligible !== "boolean") {
+      throw providerEndpointsMcpError(
+        "invalid_params",
+        "pool_eligible must be a boolean when provided.",
+      );
+    }
+    url.searchParams.set("pool_eligible", String(args.pool_eligible));
+  }
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  const minLatency = optionalRangeBound(args, "min_latency_ms");
+  if (minLatency !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatency));
+  }
+  const maxLatency = optionalRangeBound(args, "max_latency_ms");
+  if (maxLatency !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatency));
+  }
+  const minScore = optionalRangeBound(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalRangeBound(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw providerEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadProviderEndpointsList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const slug = parseProviderSlug(args);
+  const queryUrl = providerEndpointsQueryUrl(args);
+  const artifactPath = providerEndpointsArtifactPath(slug);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw providerEndpointsMcpError(
+        "not_found",
+        `No endpoint catalog exists for provider '${slug}'.`,
+      );
+    }
+    throw providerEndpointsMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw providerEndpointsMcpError(
+      "not_found",
+      `No endpoint catalog exists for provider '${slug}'.`,
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw providerEndpointsMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.endpoints) ? data.endpoints : [];
+  const rowLen = rows.length;
+  return {
+    slug,
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS =
+  "list_provider_endpoints one provider's endpoint resources (filterable; " +
+  "mirrors GET /api/v1/providers/{slug}/endpoints), ";
+
+export const LIST_PROVIDER_ENDPOINTS_MCP_TOOL = {
+  name: "list_provider_endpoints",
+  title: "List one provider's endpoint resources",
+  description:
+    "Fetch the monitored endpoint resources for one provider by slug: each " +
+    "endpoint/surface with its kind, layer, subnet (netuid), publication state, " +
+    "and probe-derived status/latency/score. Filter by kind/layer/netuid/" +
+    "publication_state/status/pool_eligible, threshold with min_/max_latency_ms " +
+    "and min_/max_score, sort with sort + order, and page with limit (1-100) / " +
+    "cursor. The per-provider view of list_endpoints (the network-wide catalog). " +
+    "Complements get_provider_detail (identity + optional endpoints attachment). " +
+    "Mirrors GET /api/v1/providers/{slug}/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      slug: {
+        type: "string",
+        pattern: "^[a-z0-9-]+$",
+        description: "Provider slug, e.g. 'datura' or 'allways'.",
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Filter by endpoint layer.",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter to endpoints for one subnet netuid.",
+        minimum: 0,
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Filter by publication state.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      pool_eligible: {
+        type: "boolean",
+        description: "Only endpoints eligible (or not) for RPC pooling.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Keep endpoints with latency_ms >= this bound.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Keep endpoints with latency_ms <= this bound.",
+      },
+      min_score: {
+        type: "number",
+        description: "Keep endpoints with score >= this bound.",
+      },
+      max_score: {
+        type: "number",
+        description: "Keep endpoints with score <= this bound.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["slug"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["slug", "endpoints"],
+  properties: {
+    slug: { type: "string" },
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1856,7 +1856,11 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_provider_endpoints rejects a missing slug", async () => {
-    const res = await callTool("list_provider_endpoints", {}, { deps: makeDeps() });
+    const res = await callTool(
+      "list_provider_endpoints",
+      {},
+      { deps: makeDeps() },
+    );
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /slug/);
   });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1813,6 +1813,72 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_provider_endpoints returns filtered endpoint rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/providers/datura/endpoints.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        endpoints: [
+          {
+            surface_id: "datura-api",
+            kind: "subnet-api",
+            status: "ok",
+          },
+          {
+            surface_id: "datura-rpc",
+            kind: "rpc",
+            status: "degraded",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_provider_endpoints",
+      { slug: "datura", kind: "subnet-api" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.slug, "datura");
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].surface_id, "datura-api");
+  });
+
+  test("list_provider_endpoints reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_provider_endpoints",
+      { slug: "ghost" },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No endpoint catalog exists for provider 'ghost'/,
+    );
+  });
+
+  test("list_provider_endpoints rejects a missing slug", async () => {
+    const res = await callTool("list_provider_endpoints", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /slug/);
+  });
+
+  test("list_provider_endpoints payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_provider_endpoints",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/providers/datura/endpoints.json": {
+        endpoints: [{ surface_id: "datura-api", status: "ok" }],
+      },
+    });
+    const res = await callTool(
+      "list_provider_endpoints",
+      { slug: "datura", limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_incidents returns filtered incident rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-incidents.json": {

--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -138,10 +138,7 @@ describe("provider-endpoints-mcp", () => {
   test("loadProviderEndpointsList reports not_found when the artifact is absent", async () => {
     await assert.rejects(
       () =>
-        loadProviderEndpointsList(
-          { env: {}, readArtifact },
-          { slug: "ghost" },
-        ),
+        loadProviderEndpointsList({ env: {}, readArtifact }, { slug: "ghost" }),
       (err) => err.code === "not_found",
     );
   });
@@ -227,7 +224,10 @@ describe("provider-endpoints-mcp", () => {
       LIST_PROVIDER_ENDPOINTS_MCP_TOOL.name,
       "list_provider_endpoints",
     );
-    assert.match(LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS, /list_provider_endpoints/);
+    assert.match(
+      LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS,
+      /list_provider_endpoints/,
+    );
     assert.ok(
       new Ajv2020({ strict: false }).compile(
         LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,

--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -7,6 +7,7 @@ import {
   LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
   LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
   loadProviderEndpointsList,
+  parseProviderSlug,
   providerEndpointsArtifactPath,
   providerEndpointsMcpError,
   providerEndpointsQueryUrl,
@@ -54,6 +55,24 @@ function readArtifact(_env, path) {
 }
 
 describe("provider-endpoints-mcp", () => {
+  test("providerEndpointsArtifactPath builds the per-provider artifact key", () => {
+    assert.equal(
+      providerEndpointsArtifactPath("datura"),
+      "/metagraph/providers/datura/endpoints.json",
+    );
+  });
+
+  test("parseProviderSlug trims whitespace and accepts valid slugs", () => {
+    assert.equal(parseProviderSlug({ slug: "  datura  " }), "datura");
+  });
+
+  test("parseProviderSlug rejects an empty slug", () => {
+    assert.throws(
+      () => parseProviderSlug({ slug: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
   test("providerEndpointsMcpError is shaped for MCP toolError handling", () => {
     const err = providerEndpointsMcpError("invalid_params", "bad sort");
     assert.equal(err.code, "invalid_params");
@@ -100,6 +119,108 @@ describe("provider-endpoints-mcp", () => {
     );
   });
 
+  test("providerEndpointsQueryUrl rejects invalid layer", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ layer: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects invalid publication_state", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ publication_state: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ sort: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects invalid order", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ order: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects non-numeric range bounds", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ min_latency_ms: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl trims and forwards a fields projection", () => {
+    const url = providerEndpointsQueryUrl({ fields: " surface_id,status " });
+    assert.equal(url.searchParams.get("fields"), "surface_id,status");
+  });
+
+  test("providerEndpointsQueryUrl forwards pool_eligible=false", () => {
+    const url = providerEndpointsQueryUrl({ pool_eligible: false });
+    assert.equal(url.searchParams.get("pool_eligible"), "false");
+  });
+
+  test("providerEndpointsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = providerEndpointsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("providerEndpointsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = providerEndpointsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("providerEndpointsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = providerEndpointsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
   test("providerEndpointsQueryUrl rejects non-boolean pool_eligible", () => {
     assert.throws(
       () => providerEndpointsQueryUrl({ pool_eligible: "yes" }),
@@ -133,6 +254,113 @@ describe("provider-endpoints-mcp", () => {
     assert.equal(out.slug, "datura");
     assert.equal(out.returned, 1);
     assert.equal(out.endpoints[0].surface_id, "datura-api");
+  });
+
+  test("loadProviderEndpointsList sorts and pages the collection", async () => {
+    const out = await loadProviderEndpointsList(
+      { env: {}, readArtifact },
+      { slug: "datura", sort: "latency_ms", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.endpoints[0].surface_id, "datura-rpc");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadProviderEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadProviderEndpointsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      { slug: "solo" },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ surface_id: "solo" }] },
+        }),
+      },
+    );
+    assert.equal(out.endpoints[0].surface_id, "solo");
+  });
+
+  test("loadProviderEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          { slug: "ghost" },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProviderEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          { slug: "datura" },
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /providers\/datura\/endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadProviderEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          { env: {}, readArtifact },
+          { slug: "datura", fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProviderEndpointsList rejects contradictory latency range bounds", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          { env: {}, readArtifact },
+          { slug: "datura", min_latency_ms: 500, max_latency_ms: 100 },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProviderEndpointsList preserves array notes from the artifact", async () => {
+    const out = await loadProviderEndpointsList(
+      { env: {}, readArtifact },
+      { slug: "datura", limit: 1 },
+    );
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(out.notes, "test");
+  });
+
+  test("loadProviderEndpointsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadProviderEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ surface_id: "solo" }] },
+        }),
+      },
+      { slug: "solo" },
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
   });
 
   test("loadProviderEndpointsList reports not_found when the artifact is absent", async () => {

--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS,
+  LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
+  LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
+  loadProviderEndpointsList,
+  providerEndpointsArtifactPath,
+  providerEndpointsMcpError,
+  providerEndpointsQueryUrl,
+} from "../src/provider-endpoints-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  endpoints: [
+    {
+      surface_id: "datura-api",
+      kind: "subnet-api",
+      layer: "subnet-app",
+      netuid: 1,
+      status: "ok",
+      latency_ms: 120,
+      score: 0.9,
+      pool_eligible: true,
+      publication_state: "monitored",
+    },
+    {
+      surface_id: "datura-rpc",
+      kind: "rpc",
+      layer: "bittensor-base",
+      netuid: 1,
+      status: "degraded",
+      latency_ms: 400,
+      score: 0.4,
+      pool_eligible: false,
+      publication_state: "monitored",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === providerEndpointsArtifactPath("datura")) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("provider-endpoints-mcp", () => {
+  test("providerEndpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = providerEndpointsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("providerEndpointsQueryUrl validates filters, range bounds, and cursor", () => {
+    const url = providerEndpointsQueryUrl({
+      netuid: 1,
+      kind: "subnet-api",
+      layer: "subnet-app",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      min_latency_ms: 100,
+      max_latency_ms: 500,
+      min_score: 0.5,
+      max_score: 1,
+      sort: "latency_ms",
+      order: "asc",
+      fields: "surface_id,status",
+      limit: 10,
+      cursor: 2,
+    });
+    assert.equal(url.searchParams.get("netuid"), "1");
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("layer"), "subnet-app");
+    assert.equal(url.searchParams.get("publication_state"), "monitored");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("pool_eligible"), "true");
+    assert.equal(url.searchParams.get("min_latency_ms"), "100");
+    assert.equal(url.searchParams.get("max_latency_ms"), "500");
+    assert.equal(url.searchParams.get("min_score"), "0.5");
+    assert.equal(url.searchParams.get("max_score"), "1");
+    assert.equal(url.searchParams.get("sort"), "latency_ms");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "2");
+  });
+
+  test("providerEndpointsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ kind: "not-a-kind" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providerEndpointsQueryUrl rejects non-boolean pool_eligible", () => {
+    assert.throws(
+      () => providerEndpointsQueryUrl({ pool_eligible: "yes" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProviderEndpointsList requires slug", async () => {
+    await assert.rejects(
+      () => loadProviderEndpointsList({ env: {}, readArtifact }, {}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProviderEndpointsList rejects an invalid slug", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          { env: {}, readArtifact },
+          { slug: "../secrets" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProviderEndpointsList returns filtered endpoint rows", async () => {
+    const out = await loadProviderEndpointsList(
+      { env: {}, readArtifact },
+      { slug: "datura", kind: "subnet-api" },
+    );
+    assert.equal(out.slug, "datura");
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].surface_id, "datura-api");
+  });
+
+  test("loadProviderEndpointsList reports not_found when the artifact is absent", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          { env: {}, readArtifact },
+          { slug: "ghost" },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProviderEndpointsList projects row fields when requested", async () => {
+    const out = await loadProviderEndpointsList(
+      { env: {}, readArtifact },
+      { slug: "datura", fields: "surface_id,status", limit: 1 },
+    );
+    assert.deepEqual(out.endpoints[0], {
+      surface_id: "datura-api",
+      status: "ok",
+    });
+  });
+
+  test("loadProviderEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadProviderEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      },
+      { slug: "solo" },
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadProviderEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ surface_id: "a" }, { surface_id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadProviderEndpointsList(
+        { env: {}, readArtifact },
+        { slug: "datura" },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadProviderEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          { slug: "datura" },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProviderEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadProviderEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          { slug: "datura" },
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_PROVIDER_ENDPOINTS_MCP_TOOL.name,
+      "list_provider_endpoints",
+    );
+    assert.match(LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS, /list_provider_endpoints/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_provider_endpoints at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.match(MCP_INSTRUCTIONS, /list_provider_endpoints/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_provider_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one provider's endpoint resources");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `list_provider_endpoints` MCP tool for filterable, paginated access to one provider's endpoint catalog (`/metagraph/providers/{slug}/endpoints.json`), mirroring `GET /api/v1/providers/{slug}/endpoints`.
- Supports the same list-query surface as the REST route: `kind`, `layer`, `netuid`, `publication_state`, `status`, `pool_eligible`, latency/score range bounds, `sort`/`order`, `fields`, and `limit`/`cursor`.
- Complements `get_provider_detail` (identity snapshot) and `list_endpoints` (network-wide catalog) without duating open PRs for profile-completeness, subnet-surfaces, or stake-transfers.

## Test plan
- [x] `npm test -- tests/provider-endpoints-mcp.test.mjs`
- [x] `npm test -- tests/mcp-server.test.mjs -t list_provider_endpoints`
- [x] `node scripts/validate-mcp.mjs` (145 tools, cold artifact env)