### PR TITLE
feat(mcp): add list_subnet_endpoints mirroring GET /api/v1/subnets/{netuid}/endpoints

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -322,6 +322,15 @@ assert.ok(
   Array.isArray(reviewEnrichmentTargetsPage.targets),
   "list_review_enrichment_targets must return targets[]",
 );
+const subnetEndpointsPage = await callOk("list_subnet_endpoints", {
+  netuid: 7,
+  limit: 3,
+  kind: "subnet-api",
+});
+assert.ok(
+  Array.isArray(subnetEndpointsPage.endpoints),
+  "list_subnet_endpoints must return endpoints[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -68,6 +68,12 @@ import {
   loadReviewEnrichmentTargetsList,
 } from "./review-enrichment-targets-mcp.mjs";
 import {
+  LIST_SUBNET_ENDPOINTS_INSTRUCTIONS,
+  LIST_SUBNET_ENDPOINTS_MCP_TOOL,
+  LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
+  loadSubnetEndpointsList,
+} from "./subnet-endpoints-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -487,7 +493,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.74.0";
+export const MCP_SERVER_VERSION = "1.75.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -758,6 +764,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ENDPOINT_POOLS_INSTRUCTIONS +
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
+  LIST_SUBNET_ENDPOINTS_INSTRUCTIONS +
   "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
   "its provenance evidence claims, and list_fixtures " +
   "live request/response examples. All data is public and " +
@@ -6528,6 +6535,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_ENDPOINTS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSubnetEndpointsList(ctx, args);
+    },
+  },
+  {
     name: "get_subnet_candidates",
     title: "Get one subnet's candidate surfaces",
     description:
@@ -10281,6 +10294,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
+  list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
   list_rpc_pools: {
     type: "object",
     additionalProperties: true,

--- a/src/subnet-endpoints-mcp.mjs
+++ b/src/subnet-endpoints-mcp.mjs
@@ -1,0 +1,319 @@
+// Per-subnet endpoint list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/endpoints. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/endpoints/{netuid}.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const BOOLEAN_STRINGS = ["true", "false"];
+const SUBNET_ENDPOINTS_QUERY_FILTER_NAMES = [
+  "kind",
+  "layer",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "status",
+];
+
+export function subnetEndpointsArtifactPath(netuid) {
+  return `/metagraph/endpoints/${netuid}.json`;
+}
+
+export function subnetEndpointsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(args) {
+  const netuid = args?.netuid;
+  if (!Number.isInteger(netuid) || netuid < 0) {
+    throw subnetEndpointsMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalNumber(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw subnetEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function subnetEndpointsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/subnets/endpoints");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const poolEligible = optionalEnum(args, "pool_eligible", BOOLEAN_STRINGS);
+  if (poolEligible) url.searchParams.set("pool_eligible", poolEligible);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const minLatencyMs = optionalNumber(args, "min_latency_ms");
+  if (minLatencyMs !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatencyMs));
+  }
+  const maxLatencyMs = optionalNumber(args, "max_latency_ms");
+  if (maxLatencyMs !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatencyMs));
+  }
+  const minScore = optionalNumber(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalNumber(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw subnetEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSubnetEndpointsList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetEndpointsQueryUrl(args);
+  const artifactPath = subnetEndpointsArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw subnetEndpointsMcpError(
+        "not_found",
+        `No endpoint snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetEndpointsMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetEndpointsMcpError(
+      "not_found",
+      `No endpoint snapshot exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "endpoints",
+    SUBNET_ENDPOINTS_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetEndpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.endpoints) ? data.endpoints : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    netuid: data.netuid ?? netuid,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_ENDPOINTS_INSTRUCTIONS =
+  "list_subnet_endpoints one subnet's endpoint resources with REST list-query " +
+  "filters (kind, layer, status, latency/score bounds, and pagination; mirrors " +
+  "GET /api/v1/subnets/{netuid}/endpoints), ";
+
+export const LIST_SUBNET_ENDPOINTS_MCP_TOOL = {
+  name: "list_subnet_endpoints",
+  title: "List one subnet's endpoint resources",
+  description:
+    "Fetch monitored endpoint resources for one subnet by netuid: each endpoint " +
+    "with kind, layer, provider, publication state, and probe-derived status, " +
+    "latency, and score. Filter by kind, layer, provider, publication_state, " +
+    "status, or pool_eligible; bound latency_ms and score with min_/max_ params; " +
+    "sort with sort + order; and page with limit (1-100) / cursor. Distinct from " +
+    "get_subnet_endpoints (raw artifact dump) and list_endpoints (network-wide " +
+    "catalog). Mirrors GET /api/v1/subnets/{netuid}/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Filter by endpoint layer.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Filter by publication state.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      pool_eligible: {
+        type: "string",
+        enum: BOOLEAN_STRINGS,
+        description: "Filter by whether the endpoint is pool-eligible.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Inclusive minimum probe latency in milliseconds.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Inclusive maximum probe latency in milliseconds.",
+      },
+      min_score: {
+        type: "number",
+        description: "Inclusive minimum probe score.",
+      },
+      max_score: {
+        type: "number",
+        description: "Inclusive maximum probe score.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1758,6 +1758,71 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_subnet_endpoints returns filtered endpoint rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/endpoints/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        endpoints: [
+          {
+            id: "allways-api",
+            netuid: 7,
+            kind: "subnet-api",
+            status: "ok",
+          },
+          {
+            id: "allways-openapi",
+            netuid: 7,
+            kind: "openapi",
+            status: "degraded",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_endpoints",
+      { netuid: 7, kind: "subnet-api" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].kind, "subnet-api");
+    assert.equal(out.netuid, 7);
+  });
+
+  test("list_subnet_endpoints reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_subnet_endpoints",
+      { netuid: 7 },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No endpoint snapshot exists for netuid 7/,
+    );
+  });
+
+  test("list_subnet_endpoints payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_subnet_endpoints",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/endpoints/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        endpoints: [{ id: "allways-api", netuid: 7, kind: "subnet-api" }],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_endpoints",
+      { netuid: 7, limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-enrichment-targets-mcp.test.mjs
+++ b/tests/review-enrichment-targets-mcp.test.mjs
@@ -390,7 +390,7 @@ describe("review-enrichment-targets-mcp", () => {
   });
 
   test("MCP server exports wire list_review_enrichment_targets at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_enrichment_targets/);
     const tool = MCP_TOOLS.find(
       (t) => t.name === "list_review_enrichment_targets",

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -339,7 +339,7 @@ describe("review-gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);

--- a/tests/subnet-endpoints-mcp.test.mjs
+++ b/tests/subnet-endpoints-mcp.test.mjs
@@ -1,0 +1,395 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SUBNET_ENDPOINTS_INSTRUCTIONS,
+  LIST_SUBNET_ENDPOINTS_MCP_TOOL,
+  LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
+  loadSubnetEndpointsList,
+  subnetEndpointsArtifactPath,
+  subnetEndpointsMcpError,
+  subnetEndpointsQueryUrl,
+} from "../src/subnet-endpoints-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const NETUID = 7;
+const ARTIFACT = subnetEndpointsArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  netuid: NETUID,
+  endpoints: [
+    {
+      id: "allways-api",
+      netuid: NETUID,
+      kind: "subnet-api",
+      layer: "bittensor-base",
+      provider: "allways",
+      status: "ok",
+      latency_ms: 120,
+      score: 92,
+      pool_eligible: true,
+    },
+    {
+      id: "allways-openapi",
+      netuid: NETUID,
+      kind: "openapi",
+      layer: "bittensor-base",
+      provider: "allways",
+      status: "degraded",
+      latency_ms: 450,
+      score: 70,
+      pool_eligible: false,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-endpoints-mcp", () => {
+  test("subnetEndpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetEndpointsMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetEndpointsQueryUrl validates filters and cursor", () => {
+    const url = subnetEndpointsQueryUrl({
+      netuid: NETUID,
+      kind: "subnet-api",
+      layer: "bittensor-base",
+      provider: "allways",
+      publication_state: "verified",
+      status: "ok",
+      pool_eligible: "true",
+      min_latency_ms: 50,
+      max_latency_ms: 200,
+      min_score: 80,
+      max_score: 95,
+      sort: "latency_ms",
+      order: "asc",
+      fields: "id,kind",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("layer"), "bittensor-base");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("min_latency_ms"), "50");
+    assert.equal(url.searchParams.get("max_score"), "95");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetEndpointsQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects invalid layer", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, layer: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects non-number min_latency_ms", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, min_latency_ms: "fast" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetEndpointsQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetEndpointsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetEndpointsQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetEndpointsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetEndpointsQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEndpointsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetEndpointsQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetEndpointsList returns filtered rows with pagination meta", async () => {
+    const out = await loadSubnetEndpointsList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, kind: "subnet-api" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].kind, "subnet-api");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetEndpointsList sorts and pages the collection", async () => {
+    const out = await loadSubnetEndpointsList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, sort: "score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetEndpointsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            endpoints: [{ netuid: 0, kind: "docs" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.endpoints[0].netuid, 0);
+  });
+
+  test("loadSubnetEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /endpoints\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEndpointsList(
+          { env: {}, readArtifact },
+          { netuid: NETUID, fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetEndpointsList projects row fields when requested", async () => {
+    const out = await loadSubnetEndpointsList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, fields: "id,kind", limit: 1 },
+    );
+    assert.deepEqual(out.endpoints[0], {
+      id: "allways-api",
+      kind: "subnet-api",
+    });
+  });
+
+  test("loadSubnetEndpointsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ netuid: 0, kind: "docs" }] },
+        }),
+      },
+      { netuid: 0 },
+    );
+    assert.equal(out.generated_at, null);
+  });
+
+  test("loadSubnetEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadSubnetEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      },
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ netuid: 9 }, { netuid: 9 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetEndpointsList(
+        { env: {}, readArtifact },
+        { netuid: NETUID },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetEndpointsList rejects missing netuid", async () => {
+    await assert.rejects(
+      () => loadSubnetEndpointsList({ env: {}, readArtifact }, {}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_ENDPOINTS_MCP_TOOL.name, "list_subnet_endpoints");
+    assert.match(LIST_SUBNET_ENDPOINTS_INSTRUCTIONS, /list_subnet_endpoints/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_endpoints at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_endpoints/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's endpoint resources");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `list_subnet_endpoints` MCP tool mirroring `GET /api/v1/subnets/{netuid}/endpoints` for per-subnet endpoint listings with REST list-query parity
- Wire loader, query filters (`kind`, `layer`, `provider`, `publication_state`, `status`, `pool_eligible`, latency/score bounds), handler, output schema, and validate-mcp cold path
- Add dedicated unit tests (31) plus 3 integration tests; bump MCP server version to 1.75.0 (146 tools)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/subnet-endpoints-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_subnet_endpoints"`


Made with [Cursor](https://cursor.com)