### PR TITLE
fix(mcp): align list_evidence output schema

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -9961,7 +9961,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     additionalProperties: true,
     required: [],
     properties: {
-      evidence: { type: "array", items: { type: "object" } },
+      claims: { type: "array", items: { type: "object" } },
       generated_at: NULLABLE_STRING,
       schema_version: { type: ["string", "integer", "null"] },
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13372,12 +13372,12 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     const deps = makeDeps({
       "/metagraph/evidence-ledger.json": {
         generated_at: "2026-01-01T00:00:00Z",
-        evidence: [{ netuid: 7, check: "openapi", outcome: "verified" }],
+        claims: [{ netuid: 7, check: "openapi", outcome: "verified" }],
       },
     });
     const res = await callTool("list_evidence", {}, { deps });
     const out = res.body.result.structuredContent;
-    assert.equal(out.evidence[0].netuid, 7);
+    assert.equal(out.claims[0].netuid, 7);
     assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
   });
 


### PR DESCRIPTION
### Motivation
- The MCP `list_evidence` tool returned the production evidence-ledger artifact but advertised an `evidence` top-level array in its output schema and test fixture, while the artifact builder returns a `claims` array, creating a schema/fixture drift that can break schema-driven clients.

### Description
- Update the `list_evidence` advertised output schema to expose a `claims` array (replacing `evidence`) so it matches the `/metagraph/evidence-ledger.json` artifact shape in `src/mcp-server.mjs`.
- Update the regression fixture and assertion in `tests/mcp-server.test.mjs` to use `claims` instead of `evidence` so the test validates the real artifact shape.

### Testing
- Ran the focused test: `npm test -- tests/mcp-server.test.mjs -t "list_evidence"`, which passed and exercised the updated fixture and schema mapping.
- Ran the full MCP test file: `npm test -- tests/mcp-server.test.mjs`, where the `list_evidence` tests passed but the run surfaced an unrelated existing failure (`service_count >= 1`) elsewhere in the suite. 
- Ran `npm run validate:mcp`, which failed due to missing local artifact data required by other MCP validators and is unrelated to this schema alignment change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b14b7014832c95e5a8a36e7b0e01)