### PR TITLE
fix(mcp): overlay live rpc pool health

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -6430,7 +6430,28 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/rpc/pools.json");
+      const staticData = await loadArtifactData(
+        ctx,
+        "/metagraph/rpc/pools.json",
+      );
+      const livePool = ctx.readHealthKv
+        ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+        : null;
+      if (
+        livePool &&
+        Array.isArray(livePool.endpoints) &&
+        Array.isArray(staticData?.pools)
+      ) {
+        return {
+          ...staticData,
+          source: "live-cron-prober",
+          operational_observed_at: livePool.last_run_at || null,
+          pools: staticData.pools.map((pool) =>
+            overlayRpcPoolEligibility(pool, livePool),
+          ),
+        };
+      }
+      return staticData;
     },
   },
   {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14531,6 +14531,53 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
   });
 
+  test("list_rpc_pools overlays live RPC pool eligibility", async () => {
+    const deps = makeDeps(
+      {
+        "/metagraph/rpc/pools.json": {
+          generated_at: "2026-01-01T00:00:00Z",
+          source: "build-prober",
+          pools: [
+            {
+              network: "finney",
+              endpoints: [
+                {
+                  id: "attacker-wrong-chain",
+                  status: "ok",
+                  health_source: "build-prober",
+                  pool_eligible: true,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        [KV_HEALTH_RPC_POOL]: {
+          last_run_at: "2026-01-01T00:15:00Z",
+          endpoints: [
+            {
+              id: "attacker-wrong-chain",
+              status: "ok",
+              classification: "wrong-chain",
+              latency_ms: 321,
+              latest_block: 12345,
+            },
+          ],
+        },
+      },
+    );
+    const res = await callTool("list_rpc_pools", {}, { deps });
+    const out = res.body.result.structuredContent;
+    const endpoint = out.pools[0].endpoints[0];
+    assert.equal(out.source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, "2026-01-01T00:15:00Z");
+    assert.equal(endpoint.pool_eligible, false);
+    assert.equal(endpoint.health_source, "live-cron-prober");
+    assert.equal(endpoint.latency_ms, 321);
+    assert.equal(endpoint.latest_block, 12345);
+  });
+
   test("list_rpc_pools rejects an unexpected argument", async () => {
     const res = await callTool("list_rpc_pools", { netuid: 7 });
     assert.equal(res.body.result.isError, true);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14633,6 +14633,22 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.source, "build-prober");
   });
 
+  test("list_rpc_pools reports operational_observed_at:null when the live snapshot has no last_run_at", async () => {
+    const deps = makeDeps(
+      {
+        "/metagraph/rpc/pools.json": {
+          generated_at: "2026-01-01T00:00:00Z",
+          pools: [{ network: "finney", endpoints: [] }],
+        },
+      },
+      { [KV_HEALTH_RPC_POOL]: { endpoints: [{ id: "a", status: "ok" }] } },
+    );
+    const res = await callTool("list_rpc_pools", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, null);
+  });
+
   test("list_rpc_pools rejects an unexpected argument", async () => {
     const res = await callTool("list_rpc_pools", { netuid: 7 });
     assert.equal(res.body.result.isError, true);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14578,6 +14578,61 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(endpoint.latest_block, 12345);
   });
 
+  test("list_rpc_pools falls back to the static pools when no readHealthKv dep is provided", async () => {
+    const depsNoKvFn = {
+      readArtifact() {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            generated_at: "2026-01-01T00:00:00Z",
+            source: "build-prober",
+            pools: [{ network: "finney", endpoints: [] }],
+          },
+        });
+      },
+    };
+    const res = await callTool("list_rpc_pools", {}, { deps: depsNoKvFn });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "build-prober");
+  });
+
+  test("list_rpc_pools falls back to the static pools when the live snapshot has no endpoints array", async () => {
+    const deps = makeDeps(
+      {
+        "/metagraph/rpc/pools.json": {
+          generated_at: "2026-01-01T00:00:00Z",
+          source: "build-prober",
+          pools: [{ network: "finney", endpoints: [] }],
+        },
+      },
+      { [KV_HEALTH_RPC_POOL]: { last_run_at: "2026-01-01T00:15:00Z" } },
+    );
+    const res = await callTool("list_rpc_pools", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "build-prober");
+  });
+
+  test("list_rpc_pools falls back to the static artifact when its pools field is not an array", async () => {
+    const deps = makeDeps(
+      {
+        "/metagraph/rpc/pools.json": {
+          generated_at: "2026-01-01T00:00:00Z",
+          source: "build-prober",
+          pools: { 0: { network: "finney", endpoints: [] } },
+        },
+      },
+      {
+        [KV_HEALTH_RPC_POOL]: {
+          last_run_at: "2026-01-01T00:15:00Z",
+          endpoints: [{ id: "a", status: "ok" }],
+        },
+      },
+    );
+    const res = await callTool("list_rpc_pools", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "build-prober");
+  });
+
   test("list_rpc_pools rejects an unexpected argument", async () => {
     const res = await callTool("list_rpc_pools", { netuid: 7 });
     assert.equal(res.body.result.isError, true);


### PR DESCRIPTION
### Motivation
- The `list_rpc_pools` MCP tool returned the static `/metagraph/rpc/pools.json` artifact without applying the live KV health overlay, causing MCP clients to see stale `pool_eligible`/status data that the REST route and RPC proxy would suppress.
- This mismatch can lead to integrity issues in client-side routing (wrong-chain or sustained-down endpoints appearing eligible), so parity with the REST/proxy overlay logic is required.

### Description
- Update `list_rpc_pools` in `src/mcp-server.mjs` to `loadArtifactData` the static `/metagraph/rpc/pools.json`, read the live `KV_HEALTH_RPC_POOL` via `ctx.readHealthKv` when available, and apply `overlayRpcPoolEligibility` to each pool before returning (falling back to the static artifact when live data is absent). 
- Ensure the returned payload carries `source: "live-cron-prober"` and `operational_observed_at` when live health is applied so consumers can see the prober provenance. 
- Add a regression test in `tests/mcp-server.test.mjs` that proves a statically-eligible endpoint classified as `wrong-chain` by live health is marked `pool_eligible: false` and receives the live prober metadata. 
- Run formatting and lint fixes to keep code style aligned with repository rules.

### Testing
- Ran `npm run format:check` which succeeded. 
- Ran `npm run lint -- --max-warnings=0` which succeeded. 
- Ran the focused test `npx vitest run tests/mcp-server.test.mjs -t "list_rpc_pools"` which passed and verified the live-overlay behavior. 
- Ran the file-level test `npm test -- tests/mcp-server.test.mjs` and observed one unrelated, environment-dependent pre-existing assertion failure elsewhere in that test file, while the new `list_rpc_pools` regression test passed.

Related to #3515 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49afb4c46c832c9ec6eafee6166eda)