### PR TITLE
feat(mcp): add list_subnet_candidates mirroring GET /api/v1/subnets/{netuid}/candidates

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -331,6 +331,15 @@ assert.ok(
   Array.isArray(subnetEndpointsPage.endpoints),
   "list_subnet_endpoints must return endpoints[]",
 );
+const subnetCandidatesPage = await callOk("list_subnet_candidates", {
+  netuid: 7,
+  limit: 3,
+  state: "schema-valid",
+});
+assert.ok(
+  Array.isArray(subnetCandidatesPage.candidates),
+  "list_subnet_candidates must return candidates[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -74,6 +74,12 @@ import {
   loadSubnetEndpointsList,
 } from "./subnet-endpoints-mcp.mjs";
 import {
+  LIST_SUBNET_CANDIDATES_INSTRUCTIONS,
+  LIST_SUBNET_CANDIDATES_MCP_TOOL,
+  LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA,
+  loadSubnetCandidatesList,
+} from "./subnet-candidates-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -499,7 +505,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.75.0";
+export const MCP_SERVER_VERSION = "1.76.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -772,7 +778,9 @@ export const MCP_INSTRUCTIONS =
   LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS +
-  "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
+  "get_subnet_candidates its pending candidate surfaces, " +
+  LIST_SUBNET_CANDIDATES_INSTRUCTIONS +
+  "get_subnet_evidence " +
   "its provenance evidence claims, and list_fixtures " +
   "live request/response examples. All data is public and " +
   "read-only. Subnet names, descriptions, and identity text come from " +
@@ -6570,6 +6578,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_CANDIDATES_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSubnetCandidatesList(ctx, args);
+    },
+  },
+  {
     name: "get_subnet_evidence",
     title: "Get one subnet's evidence ledger",
     description:
@@ -10296,6 +10310,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
+  list_subnet_candidates: LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA,
   get_subnet_endpoints: {
     type: "object",
     additionalProperties: true,

--- a/src/subnet-candidates-mcp.mjs
+++ b/src/subnet-candidates-mcp.mjs
@@ -1,0 +1,241 @@
+// Per-subnet candidate list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/candidates. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/candidates/{netuid}.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+const CANDIDATE_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const CANDIDATE_STATES = QUERY_ENUMS.candidateState;
+const SUBNET_CANDIDATES_QUERY_FILTER_NAMES = ["kind", "provider", "state"];
+
+export function subnetCandidatesArtifactPath(netuid) {
+  return `/metagraph/candidates/${netuid}.json`;
+}
+
+export function subnetCandidatesMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(args) {
+  const netuid = args?.netuid;
+  if (!Number.isInteger(netuid) || netuid < 0) {
+    throw subnetCandidatesMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetCandidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetCandidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function subnetCandidatesQueryUrl(args) {
+  const url = new URL("https://mcp.internal/subnets/candidates");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const state = optionalEnum(args, "state", CANDIDATE_STATES);
+  if (state) url.searchParams.set("state", state);
+  const sort = optionalEnum(args, "sort", CANDIDATE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw subnetCandidatesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSubnetCandidatesList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetCandidatesQueryUrl(args);
+  const artifactPath = subnetCandidatesArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw subnetCandidatesMcpError(
+        "not_found",
+        `No candidate snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetCandidatesMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetCandidatesMcpError(
+      "not_found",
+      `No candidate snapshot exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "candidates",
+    SUBNET_CANDIDATES_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetCandidatesMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.candidates) ? data.candidates : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    netuid: data.netuid ?? netuid,
+    candidates: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_CANDIDATES_INSTRUCTIONS =
+  "list_subnet_candidates one subnet's unpromoted candidate surfaces with REST " +
+  "list-query filters (kind, provider, state, sort, and pagination; mirrors " +
+  "GET /api/v1/subnets/{netuid}/candidates), ";
+
+export const LIST_SUBNET_CANDIDATES_MCP_TOOL = {
+  name: "list_subnet_candidates",
+  title: "List one subnet's candidate surfaces",
+  description:
+    "Fetch unpromoted candidate surfaces for one subnet by netuid: surfaces " +
+    "discovered or proposed but not yet curated, each with kind, provider, and " +
+    "review state. Filter by kind, provider, or state; sort with sort + order; " +
+    "and page with limit (1-100) / cursor. Distinct from get_subnet_candidates " +
+    "(raw artifact dump) and list_candidates (network-wide catalog). Mirrors " +
+    "GET /api/v1/subnets/{netuid}/candidates.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'openapi'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      state: {
+        type: "string",
+        enum: CANDIDATE_STATES,
+        description: "Filter by candidate review state.",
+      },
+      sort: {
+        type: "string",
+        enum: CANDIDATE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of candidate row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["candidates"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    candidates: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -359,7 +359,7 @@ describe("adapter-candidates-mcp", () => {
   });
 
   test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -177,7 +177,7 @@ describe("adapters-mcp", () => {
   });
 
   test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -127,7 +127,7 @@ describe("build-mcp", () => {
   });
 
   test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -130,7 +130,7 @@ describe("changelog-mcp", () => {
   });
 
   test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -132,7 +132,7 @@ describe("contracts-mcp", () => {
   });
 
   test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -377,7 +377,7 @@ describe("endpoint-incidents-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -368,7 +368,7 @@ describe("endpoint-pools-mcp", () => {
   });
 
   test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -365,7 +365,7 @@ describe("enrichment-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -348,7 +348,7 @@ describe("enrichment-queue-mcp", () => {
   });
 
   test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -305,7 +305,7 @@ describe("gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1823,6 +1823,71 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_subnet_candidates returns filtered candidate rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/candidates/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        candidates: [
+          {
+            id: "allways-openapi",
+            netuid: 7,
+            kind: "openapi",
+            state: "schema-valid",
+          },
+          {
+            id: "allways-docs",
+            netuid: 7,
+            kind: "docs",
+            state: "maintainer-review",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_candidates",
+      { netuid: 7, state: "schema-valid" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].kind, "openapi");
+    assert.equal(out.netuid, 7);
+  });
+
+  test("list_subnet_candidates reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_subnet_candidates",
+      { netuid: 7 },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No candidate snapshot exists for netuid 7/,
+    );
+  });
+
+  test("list_subnet_candidates payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_subnet_candidates",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/candidates/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        candidates: [{ id: "allways-openapi", netuid: 7, kind: "openapi" }],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_candidates",
+      { netuid: 7, limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-enrichment-targets-mcp.test.mjs
+++ b/tests/review-enrichment-targets-mcp.test.mjs
@@ -390,7 +390,7 @@ describe("review-enrichment-targets-mcp", () => {
   });
 
   test("MCP server exports wire list_review_enrichment_targets at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_enrichment_targets/);
     const tool = MCP_TOOLS.find(
       (t) => t.name === "list_review_enrichment_targets",

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -339,7 +339,7 @@ describe("review-gaps-mcp", () => {
   });
 
   test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -314,7 +314,7 @@ describe("search-index-mcp", () => {
   });
 
   test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);

--- a/tests/subnet-candidates-mcp.test.mjs
+++ b/tests/subnet-candidates-mcp.test.mjs
@@ -1,0 +1,387 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SUBNET_CANDIDATES_INSTRUCTIONS,
+  LIST_SUBNET_CANDIDATES_MCP_TOOL,
+  LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA,
+  loadSubnetCandidatesList,
+  subnetCandidatesArtifactPath,
+  subnetCandidatesMcpError,
+  subnetCandidatesQueryUrl,
+} from "../src/subnet-candidates-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const NETUID = 7;
+const ARTIFACT = subnetCandidatesArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  netuid: NETUID,
+  candidates: [
+    {
+      id: "allways-openapi",
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      state: "schema-valid",
+      confidence: 0.92,
+    },
+    {
+      id: "allways-docs",
+      netuid: NETUID,
+      kind: "docs",
+      provider: "allways",
+      state: "maintainer-review",
+      confidence: 0.71,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-candidates-mcp", () => {
+  test("subnetCandidatesArtifactPath builds the per-subnet artifact key", () => {
+    assert.equal(
+      subnetCandidatesArtifactPath(7),
+      "/metagraph/candidates/7.json",
+    );
+  });
+
+  test("subnetCandidatesMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetCandidatesMcpError("invalid_params", "bad state");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetCandidatesQueryUrl validates filters and cursor", () => {
+    const url = subnetCandidatesQueryUrl({
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      state: "schema-valid",
+      sort: "confidence",
+      order: "desc",
+      fields: "id,kind",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "openapi");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("state"), "schema-valid");
+    assert.equal(url.searchParams.get("sort"), "confidence");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetCandidatesQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects invalid state", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, state: "approved" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl trims and forwards a fields projection", () => {
+    const url = subnetCandidatesQueryUrl({
+      netuid: NETUID,
+      fields: " id,kind ",
+    });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("subnetCandidatesQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetCandidatesQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetCandidatesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetCandidatesQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetCandidatesQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetCandidatesQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetCandidatesQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetCandidatesQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetCandidatesList returns filtered rows with pagination meta", async () => {
+    const out = await loadSubnetCandidatesList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, state: "schema-valid" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].kind, "openapi");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetCandidatesList sorts and pages the collection", async () => {
+    const out = await loadSubnetCandidatesList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, sort: "confidence", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetCandidatesList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetCandidatesList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            candidates: [{ netuid: 0, kind: "docs", state: "schema-valid" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.candidates[0].netuid, 0);
+  });
+
+  test("loadSubnetCandidatesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetCandidatesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /candidates\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetCandidatesList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetCandidatesList(
+          { env: {}, readArtifact },
+          { netuid: NETUID, fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetCandidatesList projects row fields when requested", async () => {
+    const out = await loadSubnetCandidatesList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, fields: "id,kind", limit: 1 },
+    );
+    assert.deepEqual(out.candidates[0], {
+      id: "allways-openapi",
+      kind: "openapi",
+    });
+  });
+
+  test("loadSubnetCandidatesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            candidates: [{ netuid: 0, kind: "docs", state: "schema-valid" }],
+          },
+        }),
+      },
+      { netuid: 0 },
+    );
+    assert.equal(out.generated_at, null);
+  });
+
+  test("loadSubnetCandidatesList treats a non-array candidates key as empty", async () => {
+    const out = await loadSubnetCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: null },
+        }),
+      },
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.candidates, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetCandidatesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { candidates: [{ netuid: 9 }, { netuid: 9 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetCandidatesList(
+        { env: {}, readArtifact },
+        { netuid: NETUID },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetCandidatesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetCandidatesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetCandidatesList rejects missing netuid", async () => {
+    await assert.rejects(
+      () => loadSubnetCandidatesList({ env: {}, readArtifact }, {}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_SUBNET_CANDIDATES_MCP_TOOL.name,
+      "list_subnet_candidates",
+    );
+    assert.match(LIST_SUBNET_CANDIDATES_INSTRUCTIONS, /list_subnet_candidates/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_candidates at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_candidates/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_candidates");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's candidate surfaces");
+  });
+});

--- a/tests/subnet-endpoints-mcp.test.mjs
+++ b/tests/subnet-endpoints-mcp.test.mjs
@@ -386,7 +386,7 @@ describe("subnet-endpoints-mcp", () => {
   });
 
   test("MCP server exports wire list_subnet_endpoints at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+    assert.equal(MCP_SERVER_VERSION, "1.76.0");
     assert.match(MCP_INSTRUCTIONS, /list_subnet_endpoints/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_endpoints");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_subnet_candidates` MCP tool mirroring `GET /api/v1/subnets/{netuid}/candidates` for per-subnet unpromoted candidate listings
- Wire loader, query filters (`kind`, `provider`, `state`), handler, output schema, and validate-mcp cold path
- Add dedicated unit tests (31) plus 3 integration tests; bump MCP server version to 1.76.0 (148 tools)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/subnet-candidates-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_subnet_candidates"`


Made with [Cursor](https://cursor.com)