### PR TITLE
feat(registry): enrich SN36 Eirel — add owner-api healthz subnet-api surface

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -155,6 +155,25 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window membership version); GET /v1/env-windows in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-healthz",
+      "kind": "subnet-api",
+      "name": "Eirel owner-api healthz",
+      "notes": "Public no-auth GET /healthz returning owner-api liveness (status, mode, database/redis checks). Documented in the subnet's OpenAPI spec on the same host as the existing dashboard and metagraph subnet-api surfaces.",
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.eirel.ai/openapi.json",
+        "https://eirel.ai/"
+      ],
+      "url": "https://api.eirel.ai/healthz"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

- Appends one `subnet-api` surface on `registry/subnets/sn-36.json` for Eirel SN36.
- **URL:** `https://api.eirel.ai/healthz` → 200 with `status`, `mode`, and database/redis checks
- Documented as `GET /healthz` in the Eirel OpenAPI spec on the same host as existing dashboard/metagraph surfaces.

## Conflict avoidance

Single-file append to `sn-36.json` only. Simulated `git merge` against open PRs **#3294**, **#3292**, **#3275**, **#3244**, and **#3153** is clean.

## Validation

- [x] Live probe + `npm run surface:add` verification
- [x] `npm run validate:surface`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `npm run lint` / `npm run format:check`


Made with [Cursor](https://cursor.com)