### PR TITLE
feat(registry): enrich SN14 Cacheon — add current leader subnet-api surface

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -186,6 +186,25 @@
       },
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "url": "https://api.cacheon.ai/api/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-leader-api",
+      "kind": "subnet-api",
+      "name": "Cacheon current leader API",
+      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, hotkey, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs"
+      ],
+      "url": "https://api.cacheon.ai/api/leader"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/cacheon.json`.

## Surface

- Netuid: **14** (Cacheon)
- Kind: **subnet-api**
- Public URL: `https://api.cacheon.ai/api/leader`
- Source URLs:
  - https://api.cacheon.ai/openapi.json
  - https://cacheon.ai/docs
- Provider slug: **cacheon**

## No linked issue

SN14 already has `openapi` and a `/api/status` subnet-api on `api.cacheon.ai`; the registry was missing the documented public `/api/leader` endpoint that returns substantive coordinator data (reigning challenger UID, hotkey, score, image, per-prompt stats).

## Checklist

- [x] Changes exactly one `registry/subnets/cacheon.json` file (append-only)
- [x] Public no-auth URL; `/api/leader` documented in the subnet's own OpenAPI on the same host as existing surfaces
- [x] Public-safe: read-only coordinator JSON, no credentials
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint (not a health/liveness probe)
- [x] No linked issue — registry gap fill

## Conflict avoidance

Single-file append to `cacheon.json` only. No overlap with open PRs #3297 (`sn-36.json`), #3294 (client), #3292 (MCP), #3244 (neuron-history), #3153 (other subnet manifests).

## Validation

- [x] `npm run validate:surface -- registry/subnets/cacheon.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: `GET /api/leader` → 200 with leader record JSON

## Test plan

- [x] Surface validator passes for the updated manifest
- [x] Public-safety scan passes
- [x] Live `/api/leader` returns 200 JSON on `api.cacheon.ai`

Made with [Cursor](https://cursor.com)