### PR TITLE
feat(registry): add SN36 Eirel /healthz subnet-api surface

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -155,6 +155,22 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window membership version); GET /v1/env-windows in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-healthz",
+      "kind": "subnet-api",
+      "name": "Eirel API healthz",
+      "notes": "Public no-auth GET /healthz returning Eirel owner-api liveness. Documented as GET /healthz in the subnet's OpenAPI spec on api.eirel.ai alongside the registered dashboard and metagraph subnet-api surfaces.",
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/healthz"
     }
   ],
   "social": {

--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -464,7 +464,7 @@ describe("provider-endpoints-mcp", () => {
   });
 
   test("MCP server exports wire list_provider_endpoints at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_provider_endpoints/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_provider_endpoints");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Register public `GET https://api.eirel.ai/healthz` as `sn-36-eirel-healthz` (`subnet-api`) on SN36 Eirel — documented in the owner-api OpenAPI spec alongside existing dashboard/metagraph surfaces.
- Bump `provider-endpoints-mcp` SemVer assertion to `1.75.0` to match `MCP_SERVER_VERSION` on main (unblocks CI test gate).

## Conflict notes
Append-only change to `registry/subnets/sn-36.json` only (not touched by open registry PRs #3298 / #3153). SemVer test line matches open #3294 (identical one-line fix); merge-simulated clean against all open PR branches.

## Test plan
- [x] `npx prettier --write registry/subnets/sn-36.json`
- [x] `npm run validate`
- [x] `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`
- [x] `provider-endpoints-mcp` SemVer test passes locally

Made with [Cursor](https://cursor.com)