### PR TITLE
feat(registry): enrich SN14 Cacheon — add current leader subnet-api surface

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -186,6 +186,25 @@
       },
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "url": "https://api.cacheon.ai/api/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-leader-api",
+      "kind": "subnet-api",
+      "name": "Cacheon current leader API",
+      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, hotkey, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs"
+      ],
+      "url": "https://api.cacheon.ai/api/leader"
     }
   ],
   "website_url": "https://cacheon.ai/"

--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -464,7 +464,7 @@ describe("provider-endpoints-mcp", () => {
   });
 
   test("MCP server exports wire list_provider_endpoints at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_provider_endpoints/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_provider_endpoints");
     assert.ok(tool);


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/cacheon.json`.

Also includes a one-line semver test fix (`tests/provider-endpoints-mcp.test.mjs`) because **main CI is currently red** after #3290 bumped `server.json` to 1.75.0 without updating the provider-endpoints assertion — without this fix, every PR fails the `test` job and Gittensory auto-closes.

## Surface

- Netuid: **14** (Cacheon)
- Kind: **subnet-api**
- Public URL: `https://api.cacheon.ai/api/leader`
- Source URLs:
  - https://api.cacheon.ai/openapi.json
  - https://cacheon.ai/docs

## No linked issue

SN14 already has `openapi` and `/api/status` on `api.cacheon.ai`; missing the documented `/api/leader` endpoint returning substantive coordinator data (reigning challenger UID, hotkey, score, image, per-prompt stats). Not a health/liveness probe.

## Conflict avoidance

Touches `cacheon.json` only for registry data (+ required CI fix in one test file). No overlap with open PRs #3299, #3294, #3292, #3244, #3153.

## Validation

- [x] `npm run validate:surface -- registry/subnets/cacheon.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: `GET /api/leader` → 200 with leader record JSON
- [x] `tests/provider-endpoints-mcp.test.mjs` passes locally

## Test plan

- [x] Surface validator + public-safety scan pass
- [x] Full CI test job should pass (semver fix unblocks main-red test)

Made with [Cursor](https://cursor.com)