### PR TITLE
fix(test): align provider-endpoints MCP semver with server.json 1.75.0

### DIFF
--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -464,7 +464,7 @@ describe("provider-endpoints-mcp", () => {
   });
 
   test("MCP server exports wire list_provider_endpoints at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.74.0");
+    assert.equal(MCP_SERVER_VERSION, "1.75.0");
     assert.match(MCP_INSTRUCTIONS, /list_provider_endpoints/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_provider_endpoints");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Fixes the failing assertion in `tests/provider-endpoints-mcp.test.mjs` after #3290 bumped `server.json` to **1.75.0** without updating this test. Main `Validate` workflow is currently red on every PR because of this mismatch.

## Test plan

- [x] `npx vitest run tests/provider-endpoints-mcp.test.mjs` passes locally

Made with [Cursor](https://cursor.com)