### PR TITLE
feat(registry): add SN36 Eirel /healthz subnet-api surface

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -155,6 +155,22 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window membership version); GET /v1/env-windows in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-healthz",
+      "kind": "subnet-api",
+      "name": "Eirel API healthz",
+      "notes": "Public no-auth GET /healthz on api.eirel.ai returning Eirel owner-api liveness JSON (observed: {\"status\":\"ok\",\"mode\":\"managed-execution\",\"checks\":{\"database\":\"ok\",\"redis\":\"ok\"}}). Documented as GET /healthz in the subnet OpenAPI spec alongside the registered dashboard and metagraph subnet-api surfaces.",
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/healthz"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.eirel.ai/healthz` as `sn-36-eirel-healthz` (`subnet-api`) on SN36 Eirel.
- Endpoint is documented in the owner-api OpenAPI spec; live probe returns `{"status":"ok","mode":"managed-execution","checks":{"database":"ok","redis":"ok"}}`.

## Scope discipline
Single-file change: `registry/subnets/sn-36.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3302, #3292, #3244, #3153. `sn-36.json` is not touched by #3153 taostats enrich.

## Test plan
- [x] `npx prettier --write registry/subnets/sn-36.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)