### PR TITLE
feat(registry): enrich SN14 Cacheon — add current leader subnet-api surface

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -186,6 +186,25 @@
       },
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "url": "https://api.cacheon.ai/api/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-leader-api",
+      "kind": "subnet-api",
+      "name": "Cacheon current leader API",
+      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, hotkey, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs"
+      ],
+      "url": "https://api.cacheon.ai/api/leader"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/cacheon.json`.

## Surface

- Netuid: **14** (Cacheon)
- Kind: **subnet-api**
- Public URL: `https://api.cacheon.ai/api/leader`
- Source URLs: https://api.cacheon.ai/openapi.json, https://cacheon.ai/docs

## No linked issue

Registry gap fill: SN14 has `openapi` + `/api/status`; missing documented `/api/leader` returning substantive coordinator data (not a health probe).

## Conflict avoidance

Only `cacheon.json`. No overlap with open PRs #3299, #3294, #3292, #3244, #3153.

## Validation

- [x] `npm run validate:surface -- registry/subnets/cacheon.json`
- [x] `npm run scan:public-safety`
- [x] Live `GET /api/leader` → 200 JSON

Made with [Cursor](https://cursor.com)