### PR TITLE
chore(tests): stop hardcoding MCP_SERVER_VERSION across 21 test files

### DIFF
--- a/tests/adapter-candidates-mcp.test.mjs
+++ b/tests/adapter-candidates-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   adapterCandidatesQueryUrl,
   loadAdapterCandidatesList,
 } from "../src/adapter-candidates-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -358,8 +354,7 @@ describe("adapter-candidates-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_adapter_candidates at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_adapter_candidates", () => {
     assert.match(MCP_INSTRUCTIONS, /list_adapter_candidates/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_adapter_candidates");
     assert.ok(tool);

--- a/tests/adapters-mcp.test.mjs
+++ b/tests/adapters-mcp.test.mjs
@@ -10,11 +10,7 @@ import {
   loadAdapter,
   parseAdapterSlug,
 } from "../src/adapters-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_ADAPTER = {
   schema_version: 1,
@@ -176,8 +172,7 @@ describe("adapters-mcp", () => {
     assert.ok(validate(SAMPLE_ADAPTER));
   });
 
-  test("MCP server exports wire get_adapter at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_adapter", () => {
     assert.match(MCP_INSTRUCTIONS, /get_adapter/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_adapter");
     assert.ok(tool);

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -9,11 +9,7 @@ import {
   agentResourcesToolError,
   loadAgentResources,
 } from "../src/agent-resources-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_RESOURCES = {
   summary: { subnet_count: 129, callable_service_count: 42 },
@@ -144,8 +140,7 @@ describe("agent-resources-mcp", () => {
     );
   });
 
-  test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_agent_resources", () => {
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/build-mcp.test.mjs
+++ b/tests/build-mcp.test.mjs
@@ -9,11 +9,7 @@ import {
   buildToolError,
   loadBuildSummary,
 } from "../src/build-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BUILD = {
   schema_version: 1,
@@ -126,8 +122,7 @@ describe("build-mcp", () => {
     assert.ok(validate(SAMPLE_BUILD));
   });
 
-  test("MCP server exports wire get_build at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_build", () => {
     assert.match(MCP_INSTRUCTIONS, /get_build/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_build");
     assert.ok(tool);

--- a/tests/changelog-mcp.test.mjs
+++ b/tests/changelog-mcp.test.mjs
@@ -9,11 +9,7 @@ import {
   changelogToolError,
   loadChangelog,
 } from "../src/changelog-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_CHANGELOG = {
   source: "generated-artifact-diff",
@@ -129,8 +125,7 @@ describe("changelog-mcp", () => {
     assert.ok(validate(SAMPLE_CHANGELOG));
   });
 
-  test("MCP server exports wire get_changelog at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_changelog", () => {
     assert.match(MCP_INSTRUCTIONS, /get_changelog/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_changelog");
     assert.ok(tool);

--- a/tests/contracts-mcp.test.mjs
+++ b/tests/contracts-mcp.test.mjs
@@ -9,11 +9,7 @@ import {
   contractsToolError,
   loadContracts,
 } from "../src/contracts-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_CONTRACTS = {
   schema_version: 1,
@@ -131,8 +127,7 @@ describe("contracts-mcp", () => {
     assert.ok(validate(SAMPLE_CONTRACTS));
   });
 
-  test("MCP server exports wire get_contracts at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_contracts", () => {
     assert.match(MCP_INSTRUCTIONS, /get_contracts/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_contracts");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   curationQueryUrl,
   loadCurationList,
 } from "../src/curation-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -302,8 +298,7 @@ describe("curation-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_curation", () => {
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   endpointIncidentsQueryUrl,
   loadEndpointIncidentsList,
 } from "../src/endpoint-incidents-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -376,8 +372,7 @@ describe("endpoint-incidents-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_endpoint_incidents at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_endpoint_incidents", () => {
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_incidents/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_incidents");
     assert.ok(tool);

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   endpointPoolsQueryUrl,
   loadEndpointPoolsList,
 } from "../src/endpoint-pools-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -367,8 +363,7 @@ describe("endpoint-pools-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_endpoint_pools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_endpoint_pools", () => {
     assert.match(MCP_INSTRUCTIONS, /list_endpoint_pools/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_endpoint_pools");
     assert.ok(tool);

--- a/tests/enrichment-evidence-mcp.test.mjs
+++ b/tests/enrichment-evidence-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   enrichmentEvidenceQueryUrl,
   loadEnrichmentEvidenceList,
 } from "../src/enrichment-evidence-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -364,8 +360,7 @@ describe("enrichment-evidence-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_enrichment_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_enrichment_evidence", () => {
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_evidence");
     assert.ok(tool);

--- a/tests/enrichment-queue-mcp.test.mjs
+++ b/tests/enrichment-queue-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   enrichmentQueueQueryUrl,
   loadEnrichmentQueueList,
 } from "../src/enrichment-queue-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -347,8 +343,7 @@ describe("enrichment-queue-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_enrichment_queue at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_enrichment_queue", () => {
     assert.match(MCP_INSTRUCTIONS, /list_enrichment_queue/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_enrichment_queue");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   gapsQueryUrl,
   loadGapsList,
 } from "../src/gaps-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -304,8 +300,7 @@ describe("gaps-mcp", () => {
     assert.ok(new Ajv2020({ strict: false }).compile(LIST_GAPS_OUTPUT_SCHEMA));
   });
 
-  test("MCP server exports wire list_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_gaps", () => {
     assert.match(MCP_INSTRUCTIONS, /list_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -9,11 +9,7 @@ import {
   loadGlobalOperationalHealth,
   unknownGlobalHealth,
 } from "../src/global-operational-health.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const FRESH_RUN = new Date(Date.now() - 60_000).toISOString();
 
@@ -125,8 +121,7 @@ describe("global-operational-health", () => {
     );
   });
 
-  test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_network_health", () => {
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -12,11 +12,7 @@ import {
   healthHistoryQueryUrl,
   loadHealthHistory,
 } from "../src/health-history-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const HISTORY_DATE = await latestArtifactDate("health/history");
 const SURFACE_ROW = {
@@ -283,8 +279,7 @@ describe("health-history-mcp — MCP metadata", () => {
     );
   });
 
-  test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_health_history", () => {
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -13,11 +13,7 @@ import {
   profilesMcpError,
   profilesQueryUrl,
 } from "../src/profiles-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const PROFILE_ROW = {
   netuid: 7,
@@ -294,8 +290,7 @@ describe("profiles-mcp — MCP metadata", () => {
     assert.ok(ajv.compile(GET_SUBNET_PROFILE_OUTPUT_SCHEMA));
   });
 
-  test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire profile tools", () => {
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/provider-endpoints-mcp.test.mjs
+++ b/tests/provider-endpoints-mcp.test.mjs
@@ -12,11 +12,7 @@ import {
   providerEndpointsMcpError,
   providerEndpointsQueryUrl,
 } from "../src/provider-endpoints-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -463,8 +459,7 @@ describe("provider-endpoints-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_provider_endpoints at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_provider_endpoints", () => {
     assert.match(MCP_INSTRUCTIONS, /list_provider_endpoints/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_provider_endpoints");
     assert.ok(tool);

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -9,11 +9,7 @@ import {
   loadRegistryCoverage,
   registryCoverageToolError,
 } from "../src/registry-coverage.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_COVERAGE = {
   surface_count: 120,
@@ -108,8 +104,7 @@ describe("registry-coverage", () => {
     );
   });
 
-  test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire get_coverage", () => {
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);

--- a/tests/review-enrichment-targets-mcp.test.mjs
+++ b/tests/review-enrichment-targets-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   reviewEnrichmentTargetsMcpError,
   reviewEnrichmentTargetsQueryUrl,
 } from "../src/review-enrichment-targets-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -389,8 +385,7 @@ describe("review-enrichment-targets-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_review_enrichment_targets at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_review_enrichment_targets", () => {
     assert.match(MCP_INSTRUCTIONS, /list_review_enrichment_targets/);
     const tool = MCP_TOOLS.find(
       (t) => t.name === "list_review_enrichment_targets",

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   reviewGapsMcpError,
   reviewGapsQueryUrl,
 } from "../src/review-gaps-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -338,8 +334,7 @@ describe("review-gaps-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_review_gaps at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_review_gaps", () => {
     assert.match(MCP_INSTRUCTIONS, /list_review_gaps/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_review_gaps");
     assert.ok(tool);

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   searchIndexMcpError,
   searchIndexQueryUrl,
 } from "../src/search-index-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",
@@ -313,8 +309,7 @@ describe("search-index-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_search_index at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_search_index", () => {
     assert.match(MCP_INSTRUCTIONS, /list_search_index/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_search_index");
     assert.ok(tool);

--- a/tests/subnet-endpoints-mcp.test.mjs
+++ b/tests/subnet-endpoints-mcp.test.mjs
@@ -11,11 +11,7 @@ import {
   subnetEndpointsMcpError,
   subnetEndpointsQueryUrl,
 } from "../src/subnet-endpoints-mcp.mjs";
-import {
-  MCP_INSTRUCTIONS,
-  MCP_SERVER_VERSION,
-  MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const NETUID = 7;
 const ARTIFACT = subnetEndpointsArtifactPath(NETUID);
@@ -385,8 +381,7 @@ describe("subnet-endpoints-mcp", () => {
     );
   });
 
-  test("MCP server exports wire list_subnet_endpoints at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.75.0");
+  test("MCP server exports wire list_subnet_endpoints", () => {
     assert.match(MCP_INSTRUCTIONS, /list_subnet_endpoints/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_endpoints");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

This repo gets hundreds of contributor PRs daily, and every MCP tool addition bumps the shared `MCP_SERVER_VERSION` constant — which every one of `tests/*-mcp.test.mjs`'s 21 files **also** hardcoded as its own exact-value assertion. That means adding one new tool requires touching 21+ unrelated files in lockstep, and missing even one leaves a stale assertion that breaks the next unrelated PR that happens to rebase past it — exactly what just happened: #3290 bumped `1.74.0` → `1.75.0` and missed `provider-endpoints-mcp.test.mjs`, breaking #3294's CI for a reason that had nothing to do with that PR.

These assertions were pure duplication: they only ever checked whatever the *current* global version happened to be, nothing specific to the tool the test was actually about. Every scenario they'd meaningfully guard against — SemVer format, and that the constant matches `serverInfo.version`/`server.json` — is already independently and correctly enforced by `scripts/validate-mcp.mjs`, which isn't touched here.

Removed the assertion + the now-unused `MCP_SERVER_VERSION` import from all 21 files, and dropped the now-inaccurate "at the bumped SemVer" from each test's name. Adding a new MCP tool never again needs to touch any of these files.

## Test plan
- [x] All 21 files individually: 462/462 tests passed
- [x] Full suite: 6246/6246 (one pre-existing, unrelated local-state flake in `tests/artifacts.test.mjs` that passes cleanly in isolation — not introduced by this PR)
- [x] `npm run lint` clean
- [x] `scripts/validate-mcp.mjs`'s own checks untouched and still the real enforcement mechanism