### PR TITLE
feat(registry): enrich SN58 Handshake58 — add validator registry subnet-api surface

### DIFF
--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -287,6 +287,25 @@
       },
       "source_urls": ["https://handshake58.com/openapi.json"],
       "url": "https://handshake58.com/api/agent"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-58-handshake58-validator-registry-api",
+      "kind": "subnet-api",
+      "name": "Handshake58 validator miner registry API",
+      "notes": "Public no-auth GET returning the lightweight validator miner registry (approved online miners with UID, categories, and model counts). Documented in the subnet's own OpenAPI (handshake58.com/openapi.json, path /api/validator/registry); same host as existing subnet-api surfaces. Distinct from the provider directory and skills endpoints.",
+      "provider": "handshake58",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://handshake58.com/openapi.json",
+        "https://handshake58.com/skill.md"
+      ],
+      "url": "https://handshake58.com/api/validator/registry"
     }
   ],
   "website_url": "https://handshake58.com"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/handshake58.json`.

## Surface

- Netuid: **58** (Handshake58)
- Kind: **subnet-api**
- Public URL: `https://handshake58.com/api/validator/registry`
- Source URLs: https://handshake58.com/openapi.json, https://handshake58.com/skill.md

## No linked issue

Registry gap fill: SN58 has `openapi` and several subnet-api surfaces; missing the documented `/api/validator/registry` endpoint returning substantive validator miner registry data (not a health probe).

## Conflict avoidance

Only `handshake58.json`. No overlap with open PRs #3308, #3303, #3292, #3244, #3153.

## Validation

- [x] `npm run validate:surface -- registry/subnets/handshake58.json`
- [x] `npm run scan:public-safety`
- [x] Live `GET /api/validator/registry` → 200 JSON

Made with [Cursor](https://cursor.com)