### PR TITLE
feat(registry): enrich SN62 Ridges — add benchmark agents subnet-api surface

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-benchmark-agents-api",
+      "kind": "subnet-api",
+      "name": "Ridges benchmark agents API",
+      "notes": "Public no-auth GET returning scored SWE benchmark agent records (name, version, status). Documented in the subnet's own OpenAPI (agent-upload.ridges.ai/openapi.json, path /retrieval/benchmark-agents); same host as the existing top-agents subnet-api surface.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://agent-upload.ridges.ai/openapi.json",
+        "https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py"
+      ],
+      "url": "https://agent-upload.ridges.ai/retrieval/benchmark-agents"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/ridges.json`.

## Surface

- Netuid: **62** (Ridges)
- Kind: **subnet-api**
- Public URL: `https://agent-upload.ridges.ai/retrieval/benchmark-agents`
- Source URLs:
  - https://agent-upload.ridges.ai/openapi.json
  - https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py

## No linked issue

Registry gap fill: SN62 has `openapi` and `/retrieval/top-agents`; missing the documented `/retrieval/benchmark-agents` endpoint returning substantive SWE benchmark records (not a health probe).

## Conflict avoidance

Only `ridges.json`. No overlap with open PRs #3303, #3292, #3244, #3153.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`
- [x] Live `GET /retrieval/benchmark-agents` → 200 JSON array

Made with [Cursor](https://cursor.com)