### PR TITLE
feat(registry): add SN94 Bitsota /healthz subnet-api surface

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -64,6 +64,25 @@
       },
       "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
       "url": "https://autoresearch.bitsota.com/api/v1/idea-rewards"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-healthz",
+      "kind": "subnet-api",
+      "name": "Bitsota AutoResearch coordinator healthz",
+      "notes": "Public no-auth GET /healthz on autoresearch.bitsota.com returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /healthz in the subnet OpenAPI spec on the same host as the registered tasks and idea-rewards surfaces.",
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://autoresearch.bitsota.com/openapi.json",
+        "https://bitsota.ai/docs/autoresearch-backend-routes"
+      ],
+      "url": "https://autoresearch.bitsota.com/healthz"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://autoresearch.bitsota.com/healthz` as `sn-94-bitsota-healthz` (`subnet-api`) on SN94 Bitsota.
- Endpoint is documented in the AutoResearch coordinator OpenAPI spec; live probe returns `{"status":"ok"}`.

## Scope discipline
Single-file change: `registry/subnets/bitsota.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3306, #3305, #3303, #3292, #3244, #3153. `bitsota.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/bitsota.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)