### PR TITLE
feat(registry): enrich SN15 ORO — add current active suite subnet-api surface

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -222,6 +222,25 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-current-suite-api",
+      "kind": "subnet-api",
+      "name": "ORO current active suite API",
+      "notes": "Public no-auth GET returning the currently active ORO evaluation problem suite (suite_id, suite_version, is_active). Documented in the subnet's own OpenAPI (api.oroagents.com/openapi.json, path /v1/public/suites/current); same host as the existing suites catalog and leaderboard surfaces.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/v1/public/suites/current"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/oro.json`.

## Surface

- Netuid: **15** (ORO)
- Kind: **subnet-api**
- Public URL: `https://api.oroagents.com/v1/public/suites/current`
- Source URLs: https://api.oroagents.com/openapi.json, https://oroagents.com/

## No linked issue

Registry gap fill: SN15 has suites catalog + leaderboard; missing documented `/v1/public/suites/current` returning the active evaluation suite metadata.

## Conflict avoidance

Only `oro.json`. No overlap with open PRs #3303, #3292, #3244, #3153.

## Validation

- [x] validate:surface + scan:public-safety pass
- [x] Live GET → 200 `{"suite_id":3,"suite_version":3,"is_active":true}`

Made with [Cursor](https://cursor.com)