### PR TITLE
feat(registry): add SN14 Cacheon /api/health subnet-api surface

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -205,6 +205,25 @@
         "https://cacheon.ai/docs/miners/api-contract"
       ],
       "url": "https://api.cacheon.ai/api/leader"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-health",
+      "kind": "subnet-api",
+      "name": "Cacheon API health",
+      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/health"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.cacheon.ai/api/health` as `sn-14-cacheon-health` (`subnet-api`) on SN14 Cacheon.
- Endpoint is documented in the coordinator OpenAPI spec (`/api/health`); live probe returns `{"status":"ok"}`.

## Scope discipline
Single-file change: `registry/subnets/cacheon.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3313, #3312, #3303, #3292, #3244, #3153. `cacheon.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/cacheon.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)