### PR TITLE
feat(registry): enrich SN49 Nepher — add tournament current block subnet-api surface

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -263,6 +263,25 @@
         "https://docs.nepher.ai/"
       ],
       "url": "https://tournament-api.nepher.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-current-block-api",
+      "kind": "subnet-api",
+      "name": "Nepher tournament current block API",
+      "notes": "Public no-auth GET returning the current finney chain block height used for tournament scheduling (current_block, network). Documented in the subnet's own OpenAPI (tournament-api.nepher.ai/openapi.json, path /api/v1/tournaments/current-block); same host as existing tournament surfaces. Distinct from the active-tournaments list and health endpoints.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://docs.nepher.ai/"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/current-block"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/nepher-robotics.json`.

## Surface

- Netuid: **49** (Nepher Robotics)
- Kind: **subnet-api**
- Public URL: `https://tournament-api.nepher.ai/api/v1/tournaments/current-block`
- Source URLs: https://tournament-api.nepher.ai/openapi.json, https://docs.nepher.ai/

## No linked issue

Registry gap fill: SN49 has tournament openapi, health, and active-tournaments surfaces; missing documented current-block endpoint returning finney chain height for tournament scheduling.

## Conflict avoidance

Only `nepher-robotics.json`. No overlap with open PRs #3314, #3312, #3292, #3244, #3153.

## Validation

- [x] validate:surface + scan:public-safety pass
- [x] Live GET → 200 `{"current_block":8552986,"network":"finney"}`

Made with [Cursor](https://cursor.com)