### PR TITLE
feat(registry): add SN22 Desearch /health subnet-api surface

### DIFF
--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -278,6 +278,25 @@
         "https://huggingface.co/desearch"
       ],
       "url": "https://huggingface.co/datasets/desearch/dataset"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-health",
+      "kind": "subnet-api",
+      "name": "Desearch API health",
+      "notes": "Public no-auth GET /health on api.desearch.ai returning API liveness JSON (observed: {\"status\":\"health\"}). Served on the API host advertised by the Desearch OpenAPI schemas (www.desearch.ai/openapi.json and api.desearch.ai/openapi.json) alongside the existing sn-22-desearch-api surface.",
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.desearch.ai/openapi.json",
+        "https://www.desearch.ai/openapi.json"
+      ],
+      "url": "https://api.desearch.ai/health"
     }
   ],
   "website_url": "https://www.desearch.ai/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.desearch.ai/health` as `sn-22-desearch-health` (`subnet-api`) on SN22 Desearch.
- Live probe returns `{"status":"health"}` on the API host advertised by the Desearch OpenAPI schemas.

## Scope discipline
Single-file change: `registry/subnets/desearch.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3317, #3316, #3315, #3312, #3292, #3244, #3153. `desearch.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/desearch.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)