### PR TITLE
feat(registry): enrich SN64 Chutes — add bounty list subnet-api surface

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -504,6 +504,25 @@
       },
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/invocations/stats/diffusion"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-bounties-api",
+      "kind": "subnet-api",
+      "name": "Chutes bounty list API",
+      "notes": "Public no-auth GET returning active chute bounty listings (bounty_amount, time_remaining, chute_id). Documented in the subnet's own OpenAPI (api.chutes.ai/openapi.json, path /bounties/); same host as the existing pricing and models subnet-api surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.chutes.ai/openapi.json",
+        "https://chutes.ai/docs"
+      ],
+      "url": "https://api.chutes.ai/bounties/"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/chutes.json`.

## Surface

- Netuid: **64** (Chutes)
- Kind: **subnet-api**
- Public URL: `https://api.chutes.ai/bounties/`
- Source URLs: https://api.chutes.ai/openapi.json, https://chutes.ai/docs

## No linked issue

Registry gap fill: SN64 has pricing and models subnet-api surfaces; missing documented `/bounties/` returning active chute bounty listings.

## Conflict avoidance

Only `chutes.json`. No overlap with open PRs #3318, #3315, #3312, #3292, #3244, #3153.

## Validation

- [x] validate:surface + scan:public-safety pass
- [x] Live GET → 200 JSON array with bounty_amount, time_remaining

Made with [Cursor](https://cursor.com)