### PR TITLE
feat(registry): add SN56 Gradients /healthz subnet-api surface

### DIFF
--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -236,6 +236,25 @@
         "https://www.gradients.io/"
       ],
       "url": "https://api.gradients.io/v1/network/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-healthz",
+      "kind": "subnet-api",
+      "name": "Gradients API healthz",
+      "notes": "Public no-auth GET /healthz on api.gradients.io returning API liveness JSON (observed: {\"ok\":true}). Served on the Gradients API host documented by the subnet OpenAPI spec alongside the existing performance and network-status subnet-api surfaces.",
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.gradients.io/openapi.json",
+        "https://www.gradients.io/"
+      ],
+      "url": "https://api.gradients.io/healthz"
     }
   ],
   "website_url": "https://www.gradients.io/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.gradients.io/healthz` as `sn-56-gradients-healthz` (`subnet-api`) on SN56 Gradients.
- Live probe returns `{"ok":true}` on the Gradients API host documented by the subnet OpenAPI spec.

## Scope discipline
Single-file change: `registry/subnets/gradients.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3319, #3315, #3312, #3292, #3244, #3153. `gradients.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/gradients.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)