### PR TITLE
feat(mcp): add list_profile_completeness mirroring GET /api/v1/review/profile-completeness

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.76.0",
+  "version": "1.77.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -499,7 +499,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.76.0";
+export const MCP_SERVER_VERSION = "1.77.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -6503,6 +6503,27 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "list_profile_completeness",
+    title: "List subnet profile-completeness gaps",
+    description:
+      "Fetch the contributor review queue of subnet profile-completeness gaps: " +
+      "which subnets have incomplete public-safe profiles (missing identity, " +
+      "native name, confidence, or promotion signals) and are worth profile " +
+      "enrichment. Use it to find high-value profile contributions. Mirrors " +
+      "GET /api/v1/review/profile-completeness.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(
+        ctx,
+        "/metagraph/review/profile-completeness.json",
+      );
+    },
+  },
+  {
     name: "list_rpc_pools",
     title: "List Bittensor RPC pools",
     description:
@@ -10348,6 +10369,16 @@ const TOOL_OUTPUT_SCHEMAS = {
     required: [],
     properties: {
       pools: { type: "array", items: { type: "object" } },
+      generated_at: NULLABLE_STRING,
+      schema_version: { type: ["string", "integer", "null"] },
+    },
+  },
+  list_profile_completeness: {
+    type: "object",
+    additionalProperties: true,
+    required: [],
+    properties: {
+      subnets: { type: "array", items: { type: "object" } },
       generated_at: NULLABLE_STRING,
       schema_version: { type: ["string", "integer", "null"] },
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14357,6 +14357,24 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
+  test("list_profile_completeness returns the profile-completeness artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        subnets: [{ netuid: 7, profile_level: "partial" }],
+      },
+    });
+    const res = await callTool("list_profile_completeness", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnets[0].netuid, 7);
+    assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
+  });
+
+  test("list_profile_completeness rejects an unexpected argument", async () => {
+    const res = await callTool("list_profile_completeness", { netuid: 7 });
+    assert.equal(res.body.result.isError, true);
+  });
+
   test("list_rpc_pools returns the rpc pools artifact", async () => {
     const deps = makeDeps({
       "/metagraph/rpc/pools.json": {


### PR DESCRIPTION
## What

Adds a new MCP tool **`list_profile_completeness`** that mirrors the existing
`GET /api/v1/review/profile-completeness` REST endpoint — the contributor review
queue of subnet profile-completeness gaps.

It returns which subnets have incomplete public-safe profiles (missing identity,
native name, confidence, or promotion signals) and are worth profile enrichment,
by reading the same `/metagraph/review/profile-completeness.json` artifact the
REST route serves. Modeled on the minimal `list_providers` / `list_endpoints`
tools.

## Why

The contributor-targeting review queues are exposed over REST but this one had no
MCP counterpart, so an agent looking for high-value profile-enrichment work had
to fall back to a raw HTTP call. This closes that gap with no new data surface.

## Notes

- Pure MCP wiring over an existing artifact — no REST contract change, so no
  OpenAPI/type regeneration.
- Bumps the MCP server version to 1.77.0 (`server.json` updated to match, per
  `validate:mcp`).
- Tests cover the happy path (returns the artifact) and `additionalProperties`
  rejection. `validate:mcp` reports the new tool;
  `validate:contract-drift`, lint, and prettier pass.