### PR TITLE
feat(registry): add SN64 Chutes /ping subnet-api surface

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -523,6 +523,25 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/bounties/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-ping",
+      "kind": "subnet-api",
+      "name": "Chutes API ping",
+      "notes": "Public no-auth GET /ping on api.chutes.ai returning API liveness (observed plain-text response: ok). Documented as GET /ping in the subnet OpenAPI spec on the same host as the existing pricing, models, and bounties subnet-api surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.chutes.ai/openapi.json",
+        "https://chutes.ai/docs"
+      ],
+      "url": "https://api.chutes.ai/ping"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.chutes.ai/ping` as `sn-64-chutes-ping` (`subnet-api`) on SN64 Chutes.
- Endpoint is documented in the Chutes OpenAPI spec (`GET /ping`); live probe returns plain-text `ok`.

## Scope discipline
Single-file change: `registry/subnets/chutes.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3315, #3312, #3292, #3244, #3153. `chutes.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/chutes.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)