### PR TITLE
feat(registry): enrich SN64 Chutes — add LLM invocation stats subnet-api surface

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -523,6 +523,25 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/bounties/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-llm-stats-api",
+      "kind": "subnet-api",
+      "name": "Chutes LLM invocation stats API",
+      "notes": "Public no-auth GET returning per-chute LLM invocation statistics (chute_id, name, date, total_requests). Documented in the subnet's own OpenAPI (api.chutes.ai/openapi.json, path /invocations/stats/llm); same host as the existing pricing and bounties surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.chutes.ai/openapi.json",
+        "https://chutes.ai/docs"
+      ],
+      "url": "https://api.chutes.ai/invocations/stats/llm"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Single-file append on `registry/subnets/chutes.json`.

## Surface

- Netuid: **64** (Chutes)
- Kind: **subnet-api**
- Public URL: `https://api.chutes.ai/invocations/stats/llm`
- Source URLs: https://api.chutes.ai/openapi.json, https://chutes.ai/docs

## No linked issue

Registry gap fill: SN64 has pricing, bounties, and diffusion stats surfaces; missing documented `/invocations/stats/llm` returning per-chute LLM invocation statistics.

## Conflict avoidance

Only `chutes.json`. No overlap with open PRs #3315, #3312, #3292, #3244, #3153.

## Validation

- [x] validate:surface + scan:public-safety pass
- [x] Live GET → 200 JSON array with chute_id, name, total_requests

Made with [Cursor](https://cursor.com)