### PR TITLE
feat(registry): enrich SN7 Allways — network history API

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -312,6 +312,31 @@
       },
       "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/swaps"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-7-allways-history-api",
+      "kind": "subnet-api",
+      "name": "Allways network history API",
+      "notes": "Public no-auth GET returning time-series network volume, swap counts, fees, TPS, success rate, and average settlement time (per-bucket and cumulative). Documented in the subnet's own OpenAPI (api.all-ways.io/swagger-json, path /history); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/history"
     }
   ],
   "website_url": "https://all-ways.io/"


### PR DESCRIPTION
## Summary

Single-file registry enrichment for **SN7 Allways** (`registry/subnets/allways.json`).

Adds the public no-auth **GET `/history`** endpoint — time-series of network volume, swap counts, fees, TPS, success rate, and average settlement time (per-bucket + cumulative). Documented in the subnet's own OpenAPI at `api.all-ways.io/swagger-json`.

## Checklist

- [x] **Exactly 1 file changed** — `registry/subnets/allways.json` only (+25 lines append)
- [x] **Substantive functional endpoint** — not a health/liveness probe
- [x] **Live probe** — `curl -sS https://api.all-ways.io/history` → HTTP 200 JSON time-series
- [x] **No sensitive wording** in notes or new manifest text
- [x] `npm run validate:surface -- registry/subnets/allways.json` — passed
- [x] `npm run scan:public-safety` — passed

## Conflict avoidance

This PR touches only `allways.json`. No overlap with currently open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3326 chain/alpha-flow | No |
| #3325 portfolio-history | No |
| #3324 stake-transfers | No |
| #3315 packages/contract | No |
| #3312 coldkeys | No |
| #3292 MCP rpc pool | No |
| #3244 neuron-history | No |
| #3153 taostats enrich | Other subnet files only |

Should merge cleanly after any/all of the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)