### PR TITLE
feat(registry): add SN64 Chutes /ping subnet-api surface

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -542,6 +542,25 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/invocations/stats/llm"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-ping",
+      "kind": "subnet-api",
+      "name": "Chutes API ping",
+      "notes": "Public no-auth GET /ping on api.chutes.ai returning API liveness (observed plain-text response: ok). Documented as GET /ping in the subnet OpenAPI spec on the same host as the existing pricing, bounties, and LLM-stats subnet-api surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.chutes.ai/openapi.json",
+        "https://chutes.ai/docs"
+      ],
+      "url": "https://api.chutes.ai/ping"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.chutes.ai/ping` as `sn-64-chutes-ping` (`subnet-api`) on SN64 Chutes.
- Endpoint is documented in the Chutes OpenAPI spec (`GET /ping`); live probe returns plain-text `ok`.

## Scope discipline
Single-file change: `registry/subnets/chutes.json` only.

## Conflict notes
Rebased on main after #3323 (LLM stats). Merge-simulated clean against open PRs #3326, #3325, #3324, #3315, #3312, #3292, #3244, #3153. No open PR touches `chutes.json`.

## Test plan
- [x] `npx prettier --write registry/subnets/chutes.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)