### PR TITLE
feat(mcp): add list_subnet_evidence mirroring GET /api/v1/subnets/{netuid}/evidence

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -331,6 +331,14 @@ assert.ok(
   Array.isArray(subnetEndpointsPage.endpoints),
   "list_subnet_endpoints must return endpoints[]",
 );
+const subnetEvidencePage = await callOk("list_subnet_evidence", {
+  netuid: 7,
+  limit: 3,
+});
+assert.ok(
+  Array.isArray(subnetEvidencePage.claims),
+  "list_subnet_evidence must return claims[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -74,6 +74,12 @@ import {
   loadSubnetEndpointsList,
 } from "./subnet-endpoints-mcp.mjs";
 import {
+  LIST_SUBNET_EVIDENCE_INSTRUCTIONS,
+  LIST_SUBNET_EVIDENCE_MCP_TOOL,
+  LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
+  loadSubnetEvidenceList,
+} from "./subnet-evidence-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -499,7 +505,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.77.0";
+export const MCP_SERVER_VERSION = "1.78.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -773,7 +779,9 @@ export const MCP_INSTRUCTIONS =
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS +
   "get_subnet_candidates its pending candidate surfaces, get_subnet_evidence " +
-  "its provenance evidence claims, get_subnet_surfaces its curated public " +
+  "its provenance evidence claims, " +
+  LIST_SUBNET_EVIDENCE_INSTRUCTIONS +
+  "get_subnet_surfaces its curated public " +
   "surfaces, and list_fixtures " +
   "live request/response examples. All data is public and " +
   "read-only. Subnet names, descriptions, and identity text come from " +
@@ -6613,6 +6621,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_EVIDENCE_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSubnetEvidenceList(ctx, args);
+    },
+  },
+  {
     name: "get_subnet_surfaces",
     title: "Get one subnet's curated surfaces",
     description:
@@ -10340,6 +10354,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
+  list_subnet_evidence: LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
   get_subnet_candidates: {
     type: "object",
     additionalProperties: true,

--- a/src/subnet-evidence-mcp.mjs
+++ b/src/subnet-evidence-mcp.mjs
@@ -1,0 +1,216 @@
+// Per-subnet evidence claims list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/evidence. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/evidence/{netuid}.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+
+const CLAIM_SORT_FIELDS = API_QUERY_COLLECTIONS.claims.sort_fields;
+
+export function subnetEvidenceArtifactPath(netuid) {
+  return `/metagraph/evidence/${netuid}.json`;
+}
+
+export function subnetEvidenceMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(args) {
+  const netuid = args?.netuid;
+  if (!Number.isInteger(netuid) || netuid < 0) {
+    throw subnetEvidenceMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetEvidenceMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetEvidenceMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function subnetEvidenceQueryUrl(args) {
+  const url = new URL("https://mcp.internal/subnets/evidence");
+  requireNetuid(args);
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const sort = optionalEnum(args, "sort", CLAIM_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw subnetEvidenceMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSubnetEvidenceList(ctx, args, { readArtifact } = {}) {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetEvidenceQueryUrl(args);
+  const artifactPath = subnetEvidenceArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw subnetEvidenceMcpError(
+        "not_found",
+        `No evidence snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetEvidenceMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetEvidenceMcpError(
+      "not_found",
+      `No evidence snapshot exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "claims", []);
+  if (transformed.error) {
+    throw subnetEvidenceMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.claims) ? data.claims : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    netuid: data.netuid ?? netuid,
+    claims: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_EVIDENCE_INSTRUCTIONS =
+  "list_subnet_evidence one subnet's evidence ledger claims with REST list-query " +
+  "filters (q, sort, and pagination; mirrors GET /api/v1/subnets/{netuid}/evidence), ";
+
+export const LIST_SUBNET_EVIDENCE_MCP_TOOL = {
+  name: "list_subnet_evidence",
+  title: "List one subnet's evidence claims",
+  description:
+    "Fetch public evidence-ledger claims for one subnet by netuid: provenance " +
+    "and verification evidence recorded for that subnet's surfaces (what was " +
+    "checked and the outcome). Search with q across subject, claim, source_url, " +
+    "and support_summary; sort with sort + order; and page with limit (1-100) / " +
+    "cursor. Distinct from get_subnet_evidence (raw artifact dump) and " +
+    "list_evidence (network-wide ledger). Mirrors " +
+    "GET /api/v1/subnets/{netuid}/evidence.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      q: {
+        type: "string",
+        description:
+          "Keyword search across subject, claim, source_url, and support_summary.",
+      },
+      sort: {
+        type: "string",
+        enum: CLAIM_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of claim row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["claims"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    claims: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14454,6 +14454,67 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
+  test("list_subnet_evidence returns filtered claim rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/evidence/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        claims: [
+          {
+            subject: "SN7 openapi",
+            claim: "SN7 publishes machine-readable OpenAPI",
+          },
+          {
+            subject: "SN7 website",
+            claim: "SN7 website documents integration",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_evidence",
+      { netuid: 7, q: "openapi" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.match(out.claims[0].claim, /OpenAPI/);
+    assert.equal(out.netuid, 7);
+  });
+
+  test("list_subnet_evidence reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_subnet_evidence",
+      { netuid: 7 },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No evidence snapshot exists for netuid 7/,
+    );
+  });
+
+  test("list_subnet_evidence payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_subnet_evidence",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/evidence/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        claims: [{ subject: "SN7", claim: "verified openapi" }],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_evidence",
+      { netuid: 7, limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_subnet_surfaces returns one subnet's surfaces artifact", async () => {
     const deps = makeDeps({
       "/metagraph/surfaces/5.json": {

--- a/tests/subnet-evidence-mcp.test.mjs
+++ b/tests/subnet-evidence-mcp.test.mjs
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SUBNET_EVIDENCE_INSTRUCTIONS,
+  LIST_SUBNET_EVIDENCE_MCP_TOOL,
+  LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
+  loadSubnetEvidenceList,
+  subnetEvidenceArtifactPath,
+  subnetEvidenceMcpError,
+  subnetEvidenceQueryUrl,
+} from "../src/subnet-evidence-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const NETUID = 7;
+const ARTIFACT = subnetEvidenceArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  netuid: NETUID,
+  claims: [
+    {
+      subject: "SN7 openapi",
+      claim: "SN7 publishes machine-readable OpenAPI",
+      source_url: "https://example.com/openapi.json",
+      support_summary: "verified live",
+      verified_at: "2026-06-01T00:00:00.000Z",
+    },
+    {
+      subject: "SN7 website",
+      claim: "SN7 website documents integration",
+      source_url: "https://example.com/docs",
+      support_summary: "needs review",
+      verified_at: "2026-05-01T00:00:00.000Z",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-evidence-mcp", () => {
+  test("subnetEvidenceArtifactPath builds the per-subnet artifact key", () => {
+    assert.equal(subnetEvidenceArtifactPath(7), "/metagraph/evidence/7.json");
+  });
+
+  test("subnetEvidenceMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetEvidenceMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetEvidenceQueryUrl validates filters and cursor", () => {
+    const url = subnetEvidenceQueryUrl({
+      netuid: NETUID,
+      q: "openapi",
+      sort: "verified_at",
+      order: "desc",
+      fields: "subject,claim",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("q"), "openapi");
+    assert.equal(url.searchParams.get("sort"), "verified_at");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetEvidenceQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl rejects empty q and invalid sort", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl rejects non-string q and invalid order", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, q: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl trims and forwards a fields projection", () => {
+    const url = subnetEvidenceQueryUrl({
+      netuid: NETUID,
+      fields: " subject,claim ",
+    });
+    assert.equal(url.searchParams.get("fields"), "subject,claim");
+  });
+
+  test("subnetEvidenceQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetEvidenceQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetEvidenceQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetEvidenceQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetEvidenceQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetEvidenceQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetEvidenceQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetEvidenceQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetEvidenceList returns filtered rows with pagination meta", async () => {
+    const out = await loadSubnetEvidenceList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, q: "openapi" },
+    );
+    assert.equal(out.returned, 1);
+    assert.match(out.claims[0].claim, /OpenAPI/);
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetEvidenceList sorts and pages the collection", async () => {
+    const out = await loadSubnetEvidenceList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, sort: "verified_at", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetEvidenceList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetEvidenceList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            claims: [{ subject: "SN0", claim: "test claim" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.claims[0].subject, "SN0");
+  });
+
+  test("loadSubnetEvidenceList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEvidenceList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetEvidenceList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEvidenceList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /evidence\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetEvidenceList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEvidenceList(
+          { env: {}, readArtifact },
+          { netuid: NETUID, fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetEvidenceList projects row fields when requested", async () => {
+    const out = await loadSubnetEvidenceList(
+      { env: {}, readArtifact },
+      { netuid: NETUID, fields: "subject,claim", limit: 1 },
+    );
+    assert.deepEqual(out.claims[0], {
+      subject: "SN7 openapi",
+      claim: "SN7 publishes machine-readable OpenAPI",
+    });
+  });
+
+  test("loadSubnetEvidenceList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetEvidenceList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { claims: [{ subject: "SN0", claim: "test" }] },
+        }),
+      },
+      { netuid: 0 },
+    );
+    assert.equal(out.generated_at, null);
+  });
+
+  test("loadSubnetEvidenceList treats a non-array claims key as empty", async () => {
+    const out = await loadSubnetEvidenceList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { claims: null },
+        }),
+      },
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.claims, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetEvidenceList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { claims: [{ subject: "a" }, { subject: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetEvidenceList(
+        { env: {}, readArtifact },
+        { netuid: NETUID },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetEvidenceList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEvidenceList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetEvidenceList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetEvidenceList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          { netuid: NETUID },
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetEvidenceList rejects missing netuid", async () => {
+    await assert.rejects(
+      () => loadSubnetEvidenceList({ env: {}, readArtifact }, {}),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_EVIDENCE_MCP_TOOL.name, "list_subnet_evidence");
+    assert.match(LIST_SUBNET_EVIDENCE_INSTRUCTIONS, /list_subnet_evidence/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_evidence at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.78.0");
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_evidence/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_evidence");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's evidence claims");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `list_subnet_evidence` MCP tool mirroring `GET /api/v1/subnets/{netuid}/evidence` for per-subnet evidence claim listings
- Wire loader, query filters (`q`, `sort`, `order`, `fields`, `limit`, `cursor`), handler, output schema, and validate-mcp cold path
- Add dedicated unit tests (29) plus 3 integration tests; bump MCP server version to 1.78.0 (150 tools)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/subnet-evidence-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_subnet_evidence"`


Made with [Cursor](https://cursor.com)