### PR TITLE
fix(streamer): stop retrying permanent ingest errors

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -63,6 +63,7 @@ PUSH_RETRY_MAX_SECONDS = max(
     PUSH_RETRY_INITIAL_SECONDS,
     int(os.environ.get("EVENTS_PUSH_RETRY_MAX_SECONDS", "60")),
 )
+RETRYABLE_HTTP_STATUS = {408, 429}
 SUMMARY_EVERY = max(1, int(os.environ.get("EVENTS_SUMMARY_EVERY_BLOCKS", "20")))
 MAX_BACKOFF = 60
 # Mirrors the Worker's own caps (workers/config.mjs MAX_EVENTS_INGEST_ROWS /
@@ -235,6 +236,14 @@ def push(url, payload):
                     body,
                 )
                 sys.exit(1)
+            if 400 <= e.code < 500 and e.code not in RETRYABLE_HTTP_STATUS:
+                log.error(
+                    "ingest push rejected (HTTP %s): %s — permanent client error; "
+                    "dropping this payload instead of retrying forever",
+                    e.code,
+                    body,
+                )
+                return False
             log.warning(
                 "ingest push rejected (HTTP %s): %s — retrying in %ss before advancing",
                 e.code,

--- a/scripts/test_stream_events.py
+++ b/scripts/test_stream_events.py
@@ -46,6 +46,16 @@ class PushAuthFatalTest(unittest.TestCase):
                 _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
         self.assertEqual(cm.exception.code, 1)
 
+    def test_permanent_http_error_returns_false_without_retrying(self):
+        with patch.object(
+            _se.urllib.request, "urlopen", side_effect=_http_error(413)
+        ) as urlopen:
+            with patch.object(_se.time, "sleep") as sleep:
+                result = _se.push("https://api.metagraph.sh/api/v1/internal/blocks", {})
+        self.assertFalse(result)
+        self.assertEqual(urlopen.call_count, 1)
+        sleep.assert_not_called()
+
     def test_other_http_error_retries_before_returning(self):
         ok_response = Mock()
         ok_response.__enter__ = Mock(return_value=ok_response)


### PR DESCRIPTION
### Motivation
- Avoid the streamer getting stuck retrying permanent client errors (notably HTTP 413 payload-too-large) which can be triggered by unbounded extrinsic `call_args` and indefinitely stall realtime ingestion.

### Description
- Introduce `RETRYABLE_HTTP_STATUS = {408, 429}` and keep server 5xx / network failures retryable.  
- Update `push()` to treat 4xx responses (400–499) as permanent client errors unless listed in `RETRYABLE_HTTP_STATUS`, logging and returning `False` instead of retrying forever, while preserving the existing 401/403 fatal-exit behavior.  
- Add a unit test `test_permanent_http_error_returns_false_without_retrying` to `scripts/test_stream_events.py` that asserts HTTP 413 does not trigger retries or `sleep` and returns `False` after one request.

### Testing
- Ran `python3 scripts/test_stream_events.py` and the new/existing tests passed (4 tests OK).  
- Ran `python3 -m unittest scripts.test_stream_events` and it succeeded (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49dfe52834832cbc0f81631868d725)