### PR TITLE
feat(registry): enrich SN43 Graphite — miner stats API

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -174,6 +174,31 @@
         "https://api.graphite-ai.net/docs"
       ],
       "url": "https://api.graphite-ai.net/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-43-graphite-miners-stats-api",
+      "kind": "subnet-api",
+      "name": "Graphite miner stats API",
+      "notes": "Public no-auth GET returning per-miner contribution counts and last contribution timestamps (uid, contributions, last_contribution_at). Documented in the subnet's own OpenAPI (api.graphite-ai.net/openapi.json, path /api/v1/miners/stats, public tag); same host as existing stats and health surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.graphite-ai.net/openapi.json",
+        "https://api.graphite-ai.net/docs"
+      ],
+      "url": "https://api.graphite-ai.net/api/v1/miners/stats"
     }
   ],
   "website_url": "https://graphite-ai.net/"


### PR DESCRIPTION
## Summary

Single-file registry enrichment for **SN43 Graphite** (`registry/subnets/graphite.json`).

Adds the public no-auth **GET `/api/v1/miners/stats`** endpoint — per-miner contribution counts and last contribution timestamps. Documented in the subnet's own OpenAPI at `api.graphite-ai.net/openapi.json` (public tag).

## Checklist

- [x] **Exactly 1 file changed** — `registry/subnets/graphite.json` only (+25 lines append)
- [x] **Substantive functional endpoint** — not a health/liveness probe
- [x] **Live probe** — `curl -sS https://api.graphite-ai.net/api/v1/miners/stats` → HTTP 200 JSON
- [x] **No sensitive wording** in notes or new manifest text
- [x] `npm run validate:surface -- registry/subnets/graphite.json` — passed
- [x] `npm run scan:public-safety` — passed

## Conflict avoidance

This PR touches only `graphite.json`. No overlap with currently open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3330 streamer ingest fix | No |
| #3329 MCP subnet evidence | No |
| #3328 Chutes /ping | `chutes.json` only |
| #3326 chain/alpha-flow | No |
| #3324 stake-transfers | No |
| #3315 packages/contract | No |
| #3312 coldkeys | No |
| #3292 MCP rpc pool | No |
| #3244 neuron-history | No |
| #3153 taostats enrich | Other subnet files only |

Should merge cleanly after any/all of the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)