### PR TITLE
feat(registry): add SN90 DegenBrain root health subnet-api surface

### DIFF
--- a/registry/subnets/degenbrain.json
+++ b/registry/subnets/degenbrain.json
@@ -145,6 +145,25 @@
         "https://subnet90.com/"
       ],
       "url": "https://api.subnet90.com/api/test/progress"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-90-degenbrain-health",
+      "kind": "subnet-api",
+      "name": "DegenBrain API health",
+      "notes": "Public no-auth GET / on api.subnet90.com returning Brain-API service info JSON (observed: service Brain-API, version 1.0.0, description for Bittensor Subnet 90). Documented in the subnet OpenAPI spec as \"Health check and service info\" on the same host as the existing markets and resolutions subnet-api surfaces.",
+      "provider": "degenbrain",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.subnet90.com/openapi.json",
+        "https://subnet90.com/"
+      ],
+      "url": "https://api.subnet90.com/"
     }
   ],
   "website_url": "https://subnet90.com/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.subnet90.com/` as `sn-90-degenbrain-health` (`subnet-api`) on SN90 DegenBrain.
- OpenAPI documents this route as "Health check and service info"; live probe returns Brain-API service metadata JSON.

## Scope discipline
Single-file change: `registry/subnets/degenbrain.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3330, #3329, #3326, #3324, #3315, #3312, #3292, #3244, #3153. `degenbrain.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/degenbrain.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)