### PR TITLE
feat(mcp): add list-query parity for list_source_snapshots

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -344,6 +344,14 @@ assert.ok(
   Array.isArray(searchIndexPage.documents),
   "list_search_index must return documents[]",
 );
+const sourceSnapshotsPage = await callOk("list_source_snapshots", {
+  limit: 3,
+  q: "native",
+});
+assert.ok(
+  Array.isArray(sourceSnapshotsPage.sources),
+  "list_source_snapshots must return sources[]",
+);
 const endpointPoolsPage = await callOk("list_endpoint_pools", { limit: 3 });
 assert.ok(
   Array.isArray(endpointPoolsPage.pools),

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -86,6 +86,12 @@ import {
   loadSearchIndexList,
 } from "./search-index-mcp.mjs";
 import {
+  LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS,
+  LIST_SOURCE_SNAPSHOTS_MCP_TOOL,
+  LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
+  loadSourceSnapshotsList,
+} from "./source-snapshots-mcp.mjs";
+import {
   LIST_ENDPOINT_POOLS_INSTRUCTIONS,
   LIST_ENDPOINT_POOLS_MCP_TOOL,
   LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
@@ -770,8 +776,9 @@ export const MCP_INSTRUCTIONS =
   "unpromoted candidate surfaces still pending review, list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, list_evidence the public " +
   "provenance/verification evidence ledger, list_rpc_endpoints the monitored " +
-  "Bittensor RPC endpoint catalog, list_source_snapshots the per-source " +
-  "input-hash/record-count ledger, list_rpc_pools the load-balanced RPC pool " +
+  "Bittensor RPC endpoint catalog, " +
+  LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS +
+  "list_rpc_pools the load-balanced RPC pool " +
   "scores, " +
   LIST_ENDPOINT_POOLS_INSTRUCTIONS +
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS +
@@ -6493,21 +6500,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_source_snapshots",
-    title: "List source input snapshots",
-    description:
-      "Fetch the source-snapshot ledger: the per-source input hash and record " +
-      "count captured for each registry data source at ingest time. Use it to " +
-      "detect when a source's underlying data changed (hash drift) or to see " +
-      "how many records each source contributed. Mirrors " +
-      "GET /api/v1/source-snapshots.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/source-snapshots.json");
+    ...LIST_SOURCE_SNAPSHOTS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSourceSnapshotsList(ctx, args);
     },
   },
   {
@@ -10398,16 +10393,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
-  list_source_snapshots: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      sources: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
   list_rpc_endpoints: {
     type: "object",
     additionalProperties: true,

--- a/src/source-snapshots-mcp.mjs
+++ b/src/source-snapshots-mcp.mjs
@@ -1,0 +1,196 @@
+// Source snapshots list loader for MCP parity on GET /api/v1/source-snapshots.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/source-snapshots.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+
+export const SOURCE_SNAPSHOTS_ARTIFACT = "/metagraph/source-snapshots.json";
+
+const SOURCE_SORT_FIELDS = API_QUERY_COLLECTIONS.sources.sort_fields;
+
+export function sourceSnapshotsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw sourceSnapshotsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw sourceSnapshotsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function sourceSnapshotsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/source-snapshots");
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const sort = optionalEnum(args, "sort", SOURCE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw sourceSnapshotsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSourceSnapshotsList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = sourceSnapshotsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, SOURCE_SNAPSHOTS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw sourceSnapshotsMcpError(
+        "not_found",
+        "Source snapshots ledger unavailable.",
+      );
+    }
+    throw sourceSnapshotsMcpError(
+      code,
+      `Could not load ${SOURCE_SNAPSHOTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw sourceSnapshotsMcpError(
+      "not_found",
+      "Source snapshots ledger unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "sources", []);
+  if (transformed.error) {
+    throw sourceSnapshotsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.sources) ? data.sources : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    summary: data.summary ?? null,
+    sources: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS =
+  "Use list_source_snapshots to page the per-source input-hash ledger " +
+  "(mirrors GET /api/v1/source-snapshots), ";
+
+export const LIST_SOURCE_SNAPSHOTS_MCP_TOOL = {
+  name: "list_source_snapshots",
+  title: "List source input snapshots",
+  description:
+    "Fetch the source-snapshot ledger: the per-source input hash and record " +
+    "count captured for each registry data source at ingest time. Filter with " +
+    "q, sort with sort + order, project with fields, and page with limit " +
+    "(1-100) / cursor. Use it to detect when a source's underlying data " +
+    "changed (hash drift) or to see how many records each source contributed. " +
+    "Mirrors GET /api/v1/source-snapshots.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      q: {
+        type: "string",
+        description: "Keyword search across source id, kind, and path.",
+      },
+      sort: {
+        type: "string",
+        enum: SOURCE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of source fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["sources"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    summary: { type: ["object", "null"] },
+    sources: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14339,22 +14339,64 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
-  test("list_source_snapshots returns the source-snapshot artifact", async () => {
+  test("list_source_snapshots returns filtered source rows", async () => {
     const deps = makeDeps({
       "/metagraph/source-snapshots.json": {
         generated_at: "2026-01-01T00:00:00Z",
-        sources: [{ id: "chain", hash: "0xabc", record_count: 42 }],
+        schema_version: 1,
+        summary: { source_count: 2 },
+        sources: [
+          {
+            id: "native-subnets",
+            kind: "native",
+            path: "/native/subnets",
+            record_count: 42,
+          },
+          {
+            id: "chain",
+            kind: "chain",
+            path: "/chain",
+            record_count: 10,
+          },
+        ],
       },
     });
-    const res = await callTool("list_source_snapshots", {}, { deps });
+    const res = await callTool(
+      "list_source_snapshots",
+      { q: "native", limit: 5 },
+      { deps },
+    );
     const out = res.body.result.structuredContent;
-    assert.equal(out.sources[0].id, "chain");
+    assert.equal(out.returned, 1);
+    assert.equal(out.sources[0].id, "native-subnets");
     assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
   });
 
-  test("list_source_snapshots rejects an unexpected argument", async () => {
-    const res = await callTool("list_source_snapshots", { netuid: 7 });
+  test("list_source_snapshots reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_source_snapshots",
+      {},
+      { deps: makeDeps() },
+    );
     assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Source snapshots ledger unavailable/,
+    );
+  });
+
+  test("list_source_snapshots payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_source_snapshots",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/source-snapshots.json": {
+        sources: [{ id: "chain", hash: "0xabc", record_count: 42 }],
+      },
+    });
+    const res = await callTool("list_source_snapshots", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
   });
 
   test("list_profile_completeness returns the profile-completeness artifact", async () => {

--- a/tests/source-snapshots-mcp.test.mjs
+++ b/tests/source-snapshots-mcp.test.mjs
@@ -1,0 +1,323 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS,
+  LIST_SOURCE_SNAPSHOTS_MCP_TOOL,
+  LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
+  SOURCE_SNAPSHOTS_ARTIFACT,
+  loadSourceSnapshotsList,
+  sourceSnapshotsMcpError,
+  sourceSnapshotsQueryUrl,
+} from "../src/source-snapshots-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  summary: { source_count: 2 },
+  sources: [
+    {
+      id: "native-subnets",
+      kind: "native",
+      path: "/native/subnets",
+      hash: "0xabc",
+      record_count: 42,
+    },
+    {
+      id: "chain-rpc",
+      kind: "chain",
+      path: "/chain/rpc",
+      hash: "0xdef",
+      record_count: 10,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === SOURCE_SNAPSHOTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("source-snapshots-mcp", () => {
+  test("sourceSnapshotsMcpError is shaped for MCP toolError handling", () => {
+    const err = sourceSnapshotsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("sourceSnapshotsQueryUrl validates filters and cursor", () => {
+    const url = sourceSnapshotsQueryUrl({
+      q: "native",
+      sort: "record_count",
+      order: "desc",
+      fields: "id,kind",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("q"), "native");
+    assert.equal(url.searchParams.get("sort"), "record_count");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("sourceSnapshotsQueryUrl rejects empty q and invalid sort", () => {
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("sourceSnapshotsQueryUrl rejects non-string q and invalid order", () => {
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ q: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("sourceSnapshotsQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("sourceSnapshotsQueryUrl trims and forwards a fields projection", () => {
+    const url = sourceSnapshotsQueryUrl({ fields: " id,kind " });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("sourceSnapshotsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = sourceSnapshotsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("sourceSnapshotsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = sourceSnapshotsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("sourceSnapshotsQueryUrl clamps limit and rejects negative cursor", () => {
+    assert.equal(
+      sourceSnapshotsQueryUrl({ limit: 500 }).searchParams.get("limit"),
+      "100",
+    );
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSourceSnapshotsList returns filtered rows with pagination meta", async () => {
+    const out = await loadSourceSnapshotsList(
+      { env: {}, readArtifact },
+      { q: "native" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.sources[0].id, "native-subnets");
+  });
+
+  test("loadSourceSnapshotsList sorts and pages the collection", async () => {
+    const out = await loadSourceSnapshotsList(
+      { env: {}, readArtifact },
+      { sort: "record_count", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.sources[0].id, "native-subnets");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSourceSnapshotsList uses an injected readArtifact dep", async () => {
+    const out = await loadSourceSnapshotsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { sources: [{ id: "solo" }] },
+        }),
+      },
+    );
+    assert.equal(out.sources[0].id, "solo");
+  });
+
+  test("loadSourceSnapshotsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSourceSnapshotsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSourceSnapshotsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSourceSnapshotsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /source-snapshots\.json/.test(err.message),
+    );
+  });
+
+  test("loadSourceSnapshotsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSourceSnapshotsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSourceSnapshotsList projects row fields when requested", async () => {
+    const out = await loadSourceSnapshotsList(
+      { env: {}, readArtifact },
+      { fields: "id,kind", limit: 1 },
+    );
+    assert.deepEqual(out.sources[0], {
+      id: "native-subnets",
+      kind: "native",
+    });
+  });
+
+  test("loadSourceSnapshotsList preserves summary from the artifact", async () => {
+    const out = await loadSourceSnapshotsList({ env: {}, readArtifact }, {});
+    assert.deepEqual(out.summary, { source_count: 2 });
+  });
+
+  test("loadSourceSnapshotsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSourceSnapshotsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { sources: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadSourceSnapshotsList treats a non-array sources key as empty", async () => {
+    const out = await loadSourceSnapshotsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { sources: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.sources, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSourceSnapshotsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { sources: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSourceSnapshotsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSourceSnapshotsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSourceSnapshotsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSourceSnapshotsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSourceSnapshotsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SOURCE_SNAPSHOTS_MCP_TOOL.name, "list_source_snapshots");
+    assert.match(LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS, /list_source_snapshots/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_source_snapshots", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_source_snapshots/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_source_snapshots");
+    assert.ok(tool);
+    assert.equal(tool.title, "List source input snapshots");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the zero-arg `list_source_snapshots` artifact dump with REST list-query parity via `applyQueryFilters` over the `sources` collection (`q`, `sort`/`order`, `fields`, `limit`/`cursor`).
- Add `src/source-snapshots-mcp.mjs` plus 24 unit tests and MCP integration/schema validation coverage; extend `validate-mcp.mjs` cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/source-snapshots-mcp.test.mjs`
- [x] MCP integration tests for `list_source_snapshots` filter/not_found/outputSchema


Made with [Cursor](https://cursor.com)