### PR TITLE
fix(subnet-yield): reject blank stake_tao/emission_tao cells that coerce to 0

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -21,6 +21,16 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// A finite TAO cell, or null when absent/blank/non-numeric. Blank D1 cells coerce via
+// Number("") → 0; skip those rows rather than fabricating zero-stake neurons or
+// zero-yield readings (mirrors nullableNumber in metagraph-neurons.mjs).
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
 // Sum a subnet's per-UID stake_tao/emission_tao in rao-integer BigInt space, not
 // float space -- a subnet's neuron set is often hundreds to thousands of rows, and
 // plain `+=` float accumulation compounds rounding error across the sum even when
@@ -62,9 +72,11 @@ function toIso(value) {
 }
 
 // Emission-per-stake return rate; null when stake is 0 (return is undefined with no
-// stake to earn on), so zero-stake UIDs are excluded from the distribution.
+// stake to earn on) or emission is unknown, so zero-stake / blank-emission UIDs are
+// excluded from the distribution.
 function computeYieldValue(emission, stake) {
   if (!(stake > 0)) return null;
+  if (emission == null) return null;
   return round9(emission / stake);
 }
 
@@ -120,20 +132,21 @@ export function buildSubnetYield(rows, netuid) {
         blockNumber = Number.isFinite(block) ? block : null;
       }
     }
-    const stake = toNumber(row?.stake_tao);
-    const emission = toNumber(row?.emission_tao);
+    const stake = nullableTao(row?.stake_tao);
+    if (stake == null) continue;
+    const emission = nullableTao(row?.emission_tao);
     // Match the sibling neuron formatter's SQLite 0/1 convention: only an integer 1
     // is a validator, so a numeric-string "0" cannot slip through as truthy.
     const isValidator = Number(row?.validator_permit) === 1;
     totalStakeRao += toRaoBig(stake);
-    totalEmissionRao += toRaoBig(emission);
+    if (emission != null) totalEmissionRao += toRaoBig(emission);
     if (isValidator) validatorCount += 1;
     neurons.push({
       uid,
       hotkey: row?.hotkey ?? null,
       role: isValidator ? "validator" : "miner",
       stake_tao: round9(stake),
-      emission_tao: round9(emission),
+      emission_tao: emission != null ? round9(emission) : null,
       yield: computeYieldValue(emission, stake),
     });
   }
@@ -255,12 +268,15 @@ function yieldHistoryPoint(date, dayRows) {
   let totalStakeRao = 0n;
   let totalEmissionRao = 0n;
   let validatorCount = 0;
+  let neuronCount = 0;
   const definedYields = [];
   for (const row of dayRows) {
-    const stake = toNumber(row?.stake_tao);
-    const emission = toNumber(row?.emission_tao);
+    const stake = nullableTao(row?.stake_tao);
+    if (stake == null) continue;
+    neuronCount += 1;
+    const emission = nullableTao(row?.emission_tao);
     totalStakeRao += toRaoBig(stake);
-    totalEmissionRao += toRaoBig(emission);
+    if (emission != null) totalEmissionRao += toRaoBig(emission);
     if (Number(row?.validator_permit) === 1) validatorCount += 1;
     const y = computeYieldValue(emission, stake);
     if (y != null) definedYields.push(y);
@@ -276,7 +292,7 @@ function yieldHistoryPoint(date, dayRows) {
       : null;
   return {
     snapshot_date: date,
-    neuron_count: dayRows.length,
+    neuron_count: neuronCount,
     validator_count: validatorCount,
     yield_count: definedYields.length,
     subnet_yield: totalStake > 0 ? round9(totalEmission / totalStake) : null,

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -160,7 +160,7 @@ describe("buildSubnetYield", () => {
     assert.equal(d.median_yield, 0.2); // only the defined yield counts
   });
 
-  test("skips a malformed uid and coerces non-numeric stake/emission/stamp to 0/null", () => {
+  test("skips a malformed uid and coerces non-numeric stamp to null", () => {
     const d = buildSubnetYield(
       [
         { uid: null, validator_permit: 1, stake_tao: 9, emission_tao: 9 },
@@ -174,11 +174,52 @@ describe("buildSubnetYield", () => {
       ],
       7,
     );
-    assert.equal(d.neuron_count, 1); // only uid 2 survived
-    assert.equal(d.total_stake_tao, 0); // non-numeric -> 0
-    assert.equal(d.neurons[0].yield, null); // 0 stake -> null
-    assert.equal(d.captured_at, null); // non-finite stamp -> null
-    assert.equal(d.block_number, null); // non-finite block -> null
+    assert.equal(d.neuron_count, 0);
+    assert.equal(d.captured_at, null);
+    assert.equal(d.block_number, null);
+  });
+
+  test("reject blank stake_tao/emission_tao cells that coerce to 0", () => {
+    for (const blank of ["", "   "]) {
+      const skippedStake = buildSubnetYield(
+        [neuron(1, { stake: blank, emission: 2 })],
+        7,
+      );
+      assert.equal(
+        skippedStake.neuron_count,
+        0,
+        `stake ${JSON.stringify(blank)}`,
+      );
+
+      const blankEmission = buildSubnetYield(
+        [neuron(2, { stake: 10, emission: blank })],
+        7,
+      );
+      assert.equal(blankEmission.neuron_count, 1);
+      assert.equal(blankEmission.neurons[0].emission_tao, null);
+      assert.equal(blankEmission.neurons[0].yield, null);
+      assert.equal(blankEmission.total_emission_tao, 0);
+    }
+
+    const nullStake = buildSubnetYield(
+      [neuron(3, { stake: null, emission: 2 })],
+      7,
+    );
+    assert.equal(nullStake.neuron_count, 0);
+
+    const nullEmission = buildSubnetYield(
+      [neuron(4, { stake: 10, emission: null })],
+      7,
+    );
+    assert.equal(nullEmission.neuron_count, 1);
+    assert.equal(nullEmission.neurons[0].emission_tao, null);
+    assert.equal(nullEmission.neurons[0].yield, null);
+
+    const negativeStake = buildSubnetYield(
+      [neuron(5, { stake: -1, emission: 2 })],
+      7,
+    );
+    assert.equal(negativeStake.neuron_count, 0);
   });
 
   test("a null D1 block_number stays null, not a fabricated genesis 0", () => {
@@ -446,6 +487,28 @@ describe("buildSubnetYieldHistory", () => {
       assert.deepEqual(empty.points, []);
       assert.equal(empty.window, "30d");
     }
+  });
+
+  test("reject blank stake_tao/emission_tao cells in daily history points", () => {
+    const data = buildSubnetYieldHistory(
+      [
+        { snapshot_date: "2026-06-27", stake_tao: null, emission_tao: 10 },
+        { snapshot_date: "2026-06-27", stake_tao: "", emission_tao: 10 },
+        { snapshot_date: "2026-06-27", stake_tao: 100, emission_tao: "   " },
+        {
+          snapshot_date: "2026-06-27",
+          stake_tao: 100,
+          emission_tao: 10,
+          validator_permit: 1,
+        },
+      ],
+      7,
+      { window: "7d" },
+    );
+    assert.equal(data.point_count, 1);
+    assert.equal(data.points[0].neuron_count, 2);
+    assert.equal(data.points[0].yield_count, 1);
+    assert.equal(data.points[0].median_yield, 0.1);
   });
 
   test("a day with no staked UIDs yields null distribution metrics", () => {


### PR DESCRIPTION
## Summary

- Blank D1 `stake_tao` / `emission_tao` cells coerce via `Number("") → 0`, which fabricated zero-stake neurons and zero-yield readings in snapshot and daily history rollups.
- Add `nullableTao()` (mirrors `metagraph-neurons.mjs` / #3020), skip blank stake rows, treat blank emission as unknown, and count `neuron_count` from accepted rows in history points.

**No-issue rationale:** no open issue filed; same blank-cell class as #3020 / chain-yield #2933. Scope is `src/subnet-yield.mjs` + tests only — no `workers/**` route wiring.

## Test plan

- [x] `npx vitest run tests/subnet-yield.test.mjs`
- [x] `npm run lint && npm run format:check`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)