### PR TITLE
feat(registry): add SN74 Gittensor root health subnet-api surface

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -397,6 +397,25 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-health",
+      "kind": "subnet-api",
+      "name": "Gittensor API root health",
+      "notes": "Public no-auth GET / on api.gittensor.io returning API liveness (observed plain-text response: Hello World!). Documented as AppController_getHello at path / in the subnet swagger-json OpenAPI spec on the same host as the existing miners and dash subnet-api surfaces.",
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.gittensor.io/swagger-json",
+        "https://api.gittensor.io/swagger"
+      ],
+      "url": "https://api.gittensor.io/"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.gittensor.io/` as `sn-74-gittensor-health` (`subnet-api`) on SN74 Gittensor.
- Documented in swagger-json as `AppController_getHello` at path `/`; live probe returns plain-text `Hello World!`.

## Scope discipline
Single-file change: `registry/subnets/gittensor.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3334, #3333, #3331, #3326, #3315, #3312, #3292, #3244, #3153. `gittensor.json` is not touched by any open PR.

## Test plan
- [x] `npx prettier --write registry/subnets/gittensor.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)