### PR TITLE
feat(mcp): add list-query parity for list_rpc_endpoints

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -352,6 +352,14 @@ assert.ok(
   Array.isArray(sourceSnapshotsPage.sources),
   "list_source_snapshots must return sources[]",
 );
+const rpcEndpointsPage = await callOk("list_rpc_endpoints", {
+  limit: 3,
+  layer: "bittensor-base",
+});
+assert.ok(
+  Array.isArray(rpcEndpointsPage.endpoints),
+  "list_rpc_endpoints must return endpoints[]",
+);
 const endpointPoolsPage = await callOk("list_endpoint_pools", { limit: 3 });
 assert.ok(
   Array.isArray(endpointPoolsPage.pools),

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -110,6 +110,12 @@ import {
   loadProviderEndpointsList,
 } from "./provider-endpoints-mcp.mjs";
 import {
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  loadRpcEndpointsList,
+} from "./rpc-endpoints-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -775,8 +781,8 @@ export const MCP_INSTRUCTIONS =
   "network-wide catalog of curated public surfaces, list_candidates the " +
   "unpromoted candidate surfaces still pending review, list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, list_evidence the public " +
-  "provenance/verification evidence ledger, list_rpc_endpoints the monitored " +
-  "Bittensor RPC endpoint catalog, " +
+  "provenance/verification evidence ledger, " +
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS +
   LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS +
   "list_rpc_pools the load-balanced RPC pool " +
   "scores, " +
@@ -6483,20 +6489,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_rpc_endpoints",
-    title: "List Bittensor RPC endpoints",
-    description:
-      "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
-      "their status (each endpoint's URL, network, and probe-derived " +
-      "health/latency). This is the full-catalog view; use get_best_rpc_endpoint " +
-      "instead to pick one live-healthy endpoint. Mirrors GET /api/v1/rpc/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/rpc-endpoints.json");
+    ...LIST_RPC_ENDPOINTS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadRpcEndpointsList(ctx, args);
     },
   },
   {
@@ -10394,16 +10389,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
-  list_rpc_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_rpc_endpoints: LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
   list_evidence: {
     type: "object",
     additionalProperties: true,

--- a/src/rpc-endpoints-mcp.mjs
+++ b/src/rpc-endpoints-mcp.mjs
@@ -1,0 +1,293 @@
+// Bittensor RPC endpoint list loader for MCP parity on GET /api/v1/rpc/endpoints.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/rpc-endpoints.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const BOOLEAN_STRINGS = ["true", "false"];
+
+export function rpcEndpointsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalNumber(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function rpcEndpointsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/rpc/endpoints");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const poolEligible = optionalEnum(args, "pool_eligible", BOOLEAN_STRINGS);
+  if (poolEligible) url.searchParams.set("pool_eligible", poolEligible);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const minLatencyMs = optionalNumber(args, "min_latency_ms");
+  if (minLatencyMs !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatencyMs));
+  }
+  const maxLatencyMs = optionalNumber(args, "max_latency_ms");
+  if (maxLatencyMs !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatencyMs));
+  }
+  const minScore = optionalNumber(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalNumber(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadRpcEndpointsList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = rpcEndpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, RPC_ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw rpcEndpointsMcpError(
+        "not_found",
+        "Bittensor RPC endpoint catalog unavailable.",
+      );
+    }
+    throw rpcEndpointsMcpError(
+      code,
+      `Could not load ${RPC_ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw rpcEndpointsMcpError(
+      "not_found",
+      "Bittensor RPC endpoint catalog unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw rpcEndpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.endpoints) ? data.endpoints : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_RPC_ENDPOINTS_INSTRUCTIONS =
+  "Use list_rpc_endpoints to page the monitored Bittensor RPC endpoint catalog " +
+  "with REST list-query filters (layer, status, latency/score bounds, and " +
+  "pagination; mirrors GET /api/v1/rpc/endpoints), ";
+
+export const LIST_RPC_ENDPOINTS_MCP_TOOL = {
+  name: "list_rpc_endpoints",
+  title: "List Bittensor RPC endpoints",
+  description:
+    "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
+    "their status (each endpoint's URL, network, and probe-derived health/latency). " +
+    "Filter by kind, layer, netuid, provider, publication_state, status, or " +
+    "pool_eligible; bound latency_ms and score with min_/max_ params; sort with " +
+    "sort + order; project with fields; and page with limit (1-100) / cursor. " +
+    "Use get_best_rpc_endpoint to pick one live-healthy endpoint. Mirrors " +
+    "GET /api/v1/rpc/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Optional filter by subnet netuid when present on rows.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Filter by endpoint layer.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Filter by publication state.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      pool_eligible: {
+        type: "string",
+        enum: BOOLEAN_STRINGS,
+        description: "Filter by whether the endpoint is pool-eligible.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Inclusive minimum probe latency in milliseconds.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Inclusive maximum probe latency in milliseconds.",
+      },
+      min_score: {
+        type: "number",
+        description: "Inclusive minimum probe score.",
+      },
+      max_score: {
+        type: "number",
+        description: "Inclusive maximum probe score.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14321,22 +14321,61 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
-  test("list_rpc_endpoints returns the rpc endpoints artifact", async () => {
+  test("list_rpc_endpoints returns filtered endpoint rows", async () => {
     const deps = makeDeps({
       "/metagraph/rpc-endpoints.json": {
-        generated_at: "2026-01-01T00:00:00Z",
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        endpoints: [
+          {
+            id: "finney-wss",
+            url: "wss://rpc.finney.example",
+            network: "finney",
+            layer: "bittensor-base",
+            status: "ok",
+          },
+          {
+            id: "finney-https",
+            url: "https://rpc.finney.example",
+            network: "finney",
+            layer: "bittensor-base",
+            status: "degraded",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_rpc_endpoints",
+      { status: "ok", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].status, "ok");
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("list_rpc_endpoints reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_rpc_endpoints", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Bittensor RPC endpoint catalog unavailable/,
+    );
+  });
+
+  test("list_rpc_endpoints payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_rpc_endpoints",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/rpc-endpoints.json": {
         endpoints: [{ url: "wss://rpc.example", network: "finney" }],
       },
     });
-    const res = await callTool("list_rpc_endpoints", {}, { deps });
-    const out = res.body.result.structuredContent;
-    assert.equal(out.endpoints[0].network, "finney");
-    assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
-  });
-
-  test("list_rpc_endpoints rejects an unexpected argument", async () => {
-    const res = await callTool("list_rpc_endpoints", { netuid: 7 });
-    assert.equal(res.body.result.isError, true);
+    const res = await callTool("list_rpc_endpoints", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
   });
 
   test("list_source_snapshots returns filtered source rows", async () => {

--- a/tests/rpc-endpoints-mcp.test.mjs
+++ b/tests/rpc-endpoints-mcp.test.mjs
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  RPC_ENDPOINTS_ARTIFACT,
+  loadRpcEndpointsList,
+  rpcEndpointsMcpError,
+  rpcEndpointsQueryUrl,
+} from "../src/rpc-endpoints-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  endpoints: [
+    {
+      id: "finney-wss",
+      url: "wss://rpc.finney.example",
+      network: "finney",
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      status: "ok",
+      latency_ms: 120,
+      score: 92,
+      pool_eligible: true,
+    },
+    {
+      id: "finney-https",
+      url: "https://rpc.finney.example",
+      network: "finney",
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      status: "degraded",
+      latency_ms: 450,
+      score: 70,
+      pool_eligible: false,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === RPC_ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("rpc-endpoints-mcp", () => {
+  test("rpcEndpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = rpcEndpointsMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("rpcEndpointsQueryUrl validates filters and cursor", () => {
+    const url = rpcEndpointsQueryUrl({
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      publication_state: "verified",
+      status: "ok",
+      pool_eligible: "true",
+      min_latency_ms: 50,
+      max_latency_ms: 200,
+      min_score: 80,
+      max_score: 95,
+      sort: "latency_ms",
+      order: "asc",
+      fields: "id,network",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subtensor-wss");
+    assert.equal(url.searchParams.get("layer"), "bittensor-base");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("min_latency_ms"), "50");
+    assert.equal(url.searchParams.get("max_score"), "95");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("rpcEndpointsQueryUrl forwards an optional netuid filter", () => {
+    const url = rpcEndpointsQueryUrl({ netuid: 7, status: "ok" });
+    assert.equal(url.searchParams.get("netuid"), "7");
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid layer", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ layer: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects non-number min_latency_ms", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ min_latency_ms: "fast" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = rpcEndpointsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("rpcEndpointsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = rpcEndpointsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("rpcEndpointsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = rpcEndpointsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadRpcEndpointsList returns filtered rows with pagination meta", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact },
+      { status: "ok" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].status, "ok");
+  });
+
+  test("loadRpcEndpointsList sorts and pages the collection", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact },
+      { sort: "score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadRpcEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            endpoints: [{ id: "solo", network: "finney" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.endpoints[0].id, "solo");
+  });
+
+  test("loadRpcEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /rpc-endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadRpcEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList projects row fields when requested", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact },
+      { fields: "id,network", limit: 1 },
+    );
+    assert.deepEqual(out.endpoints[0], {
+      id: "finney-wss",
+      network: "finney",
+    });
+  });
+
+  test("loadRpcEndpointsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+  });
+
+  test("loadRpcEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadRpcEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadRpcEndpointsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadRpcEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_RPC_ENDPOINTS_MCP_TOOL.name, "list_rpc_endpoints");
+    assert.match(LIST_RPC_ENDPOINTS_INSTRUCTIONS, /list_rpc_endpoints/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_rpc_endpoints", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_rpc_endpoints/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_rpc_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List Bittensor RPC endpoints");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the zero-arg `list_rpc_endpoints` artifact dump with REST list-query parity via `applyQueryFilters` over the `endpoints` collection (kind, layer, netuid, provider, publication_state, status, pool_eligible, latency/score bounds, sort/fields, limit/cursor).
- Add `src/rpc-endpoints-mcp.mjs` plus 30 unit tests and MCP integration/schema validation coverage; extend `validate-mcp.mjs` cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/rpc-endpoints-mcp.test.mjs`
- [x] MCP integration tests for `list_rpc_endpoints` filter/not_found/outputSchema


Made with [Cursor](https://cursor.com)