### PR TITLE
feat(registry): add SN75 Hippius registry health subnet-api surface

### DIFF
--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -186,6 +186,25 @@
         "https://hippius.com/"
       ],
       "url": "https://api.hippius.com/api/models/formats/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-75-hippius-health",
+      "kind": "subnet-api",
+      "name": "Hippius registry health",
+      "notes": "Public no-auth GET /api/registry/health/ returning Hippius registry reachability JSON (observed: {\"ok\":true,\"latency_ms\":133}). Documented in the subnet swagger.json as a lightweight Harbor reachability check on the same api.hippius.com host as the existing models subnet-api surface.",
+      "provider": "hippius",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.hippius.com/swagger.json",
+        "https://hippius.com/"
+      ],
+      "url": "https://api.hippius.com/api/registry/health/"
     }
   ],
   "website_url": "https://hippius.com/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.hippius.com/api/registry/health/` as `sn-75-hippius-health` (`subnet-api`) on SN75 Hippius.
- Documented in swagger.json as a lightweight Harbor reachability check; live probe returns `{"ok":true,"latency_ms":...}`.

## Scope discipline
Single-file change: `registry/subnets/hippius.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3336, #3331, #3326, #3324, #3315, #3312, #3292, #3244, #3153 for `hippius.json`. No open PR touches `hippius.json`.

## Test plan
- [x] `npx prettier --write registry/subnets/hippius.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)