### PR TITLE
feat(mcp): add list-query parity for list_providers

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -344,6 +344,14 @@ assert.ok(
   Array.isArray(evidencePage.claims),
   "list_evidence must return claims[]",
 );
+const providersPage = await callOk("list_providers", {
+  limit: 3,
+  authority: "official",
+});
+assert.ok(
+  Array.isArray(providersPage.providers),
+  "list_providers must return providers[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -116,6 +116,12 @@ import {
   loadProviderEndpointsList,
 } from "./provider-endpoints-mcp.mjs";
 import {
+  LIST_PROVIDERS_INSTRUCTIONS,
+  LIST_PROVIDERS_MCP_TOOL,
+  LIST_PROVIDERS_OUTPUT_SCHEMA,
+  loadProvidersList,
+} from "./providers-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -776,8 +782,9 @@ export const MCP_INSTRUCTIONS =
   "list_chain_events the raw recent decoded event feed (filterable by " +
   "pallet/method/block). For agent bootstrap, " +
   GET_AGENT_RESOURCES_INSTRUCTIONS +
-  "get_agent_catalog the capability catalog, list_providers the full index of " +
-  "registered data providers/sources backing the registry, list_surfaces the " +
+  "get_agent_catalog the capability catalog, " +
+  LIST_PROVIDERS_INSTRUCTIONS +
+  "list_surfaces the " +
   "network-wide catalog of curated public surfaces, list_candidates the " +
   "unpromoted candidate surfaces still pending review, list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, " +
@@ -6173,71 +6180,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_providers",
-    title: "List providers and sources",
-    description:
-      "Fetch the index of registered data providers/sources backing the " +
-      "registry: each provider's id, kind, authority, name, and the subnets, " +
-      "surfaces, and endpoints it backs. This is the list counterpart to " +
-      "get_provider_detail (which fetches one provider by slug). Optionally " +
-      "filter by id/kind/authority and page with limit/offset. Mirrors " +
-      "GET /api/v1/providers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        id: { type: "string", description: "Provider slug, e.g. 'datura'." },
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.providerKind,
-          description: "Provider kind, e.g. 'data-provider' or 'registry'.",
-        },
-        authority: {
-          type: "string",
-          enum: QUERY_ENUMS.providerAuthority,
-          description: "Trust authority, e.g. 'official' or 'community'.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max providers to return. Omit for the full list.",
-          minimum: 1,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...LIST_PROVIDERS_MCP_TOOL,
     async handler(args, ctx) {
-      const id = optionalString(args, "id");
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.providerKind);
-      const authority = optionalEnum(
-        args,
-        "authority",
-        QUERY_ENUMS.providerAuthority,
-      );
-      const limit = optionalPositiveInt(args, "limit");
-      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
-      const data = await loadArtifactData(ctx, "/metagraph/providers.json");
-      const all = Array.isArray(data.providers) ? data.providers : [];
-      const filtered = all.filter(
-        (p) =>
-          (id === null || p.id === id) &&
-          (kind === null || p.kind === kind) &&
-          (authority === null || p.authority === authority),
-      );
-      const page =
-        limit === null
-          ? filtered.slice(offset)
-          : filtered.slice(offset, offset + limit);
-      return {
-        ...data,
-        providers: page,
-        total: filtered.length,
-        returned: page.length,
-        offset,
-      };
+      return loadProvidersList(ctx, args);
     },
   },
   {
@@ -10283,16 +10228,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       endpoints: { type: ["object", "array", "null"] },
     },
   },
-  list_providers: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      providers: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_providers: LIST_PROVIDERS_OUTPUT_SCHEMA,
   list_surfaces: {
     type: "object",
     additionalProperties: true,

--- a/src/providers-mcp.mjs
+++ b/src/providers-mcp.mjs
@@ -1,0 +1,200 @@
+// Providers list loader for MCP parity on GET /api/v1/providers.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/providers.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const PROVIDERS_ARTIFACT = "/metagraph/providers.json";
+
+const PROVIDER_SORT_FIELDS = API_QUERY_COLLECTIONS.providers.sort_fields;
+const PROVIDER_KINDS = QUERY_ENUMS.providerKind;
+const PROVIDER_AUTHORITIES = QUERY_ENUMS.providerAuthority;
+
+export function providersMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw providersMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw providersMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function providersQueryUrl(args) {
+  const url = new URL("https://mcp.internal/providers");
+  const id = optionalString(args, "id");
+  if (id) url.searchParams.set("id", id);
+  const kind = optionalEnum(args, "kind", PROVIDER_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const authority = optionalEnum(args, "authority", PROVIDER_AUTHORITIES);
+  if (authority) url.searchParams.set("authority", authority);
+  const sort = optionalEnum(args, "sort", PROVIDER_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw providersMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadProvidersList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = providersQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, PROVIDERS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw providersMcpError("not_found", "Providers index unavailable.");
+    }
+    throw providersMcpError(
+      code,
+      `Could not load ${PROVIDERS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw providersMcpError("not_found", "Providers index unavailable.");
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "providers", []);
+  if (transformed.error) {
+    throw providersMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.providers) ? data.providers : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    providers: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_PROVIDERS_INSTRUCTIONS =
+  "Use list_providers to page the provider/source index with REST list-query " +
+  "filters (id, kind, authority, sort, and pagination; mirrors GET /api/v1/providers), ";
+
+export const LIST_PROVIDERS_MCP_TOOL = {
+  name: "list_providers",
+  title: "List providers and sources",
+  description:
+    "Fetch the index of registered data providers/sources backing the registry: " +
+    "each provider's id, kind, authority, name, and the subnets, surfaces, and " +
+    "endpoints it backs. Filter by id, kind, or authority; sort with sort + order; " +
+    "project with fields; and page with limit (1-100) / cursor. This is the list " +
+    "counterpart to get_provider_detail (one provider by slug). Mirrors " +
+    "GET /api/v1/providers.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Provider slug, e.g. 'datura'.",
+      },
+      kind: {
+        type: "string",
+        enum: PROVIDER_KINDS,
+        description: "Provider kind, e.g. 'data-provider' or 'registry'.",
+      },
+      authority: {
+        type: "string",
+        enum: PROVIDER_AUTHORITIES,
+        description: "Trust authority, e.g. 'official' or 'community'.",
+      },
+      sort: {
+        type: "string",
+        enum: PROVIDER_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of provider fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_PROVIDERS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["providers"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    providers: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13767,22 +13767,59 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  test("list_providers returns the providers index artifact", async () => {
+  test("list_providers returns filtered provider rows", async () => {
     const deps = makeDeps({
       "/metagraph/providers.json": {
-        generated_at: "2026-01-01T00:00:00Z",
-        providers: [{ id: "datura", kind: "api", name: "Datura" }],
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        providers: [
+          {
+            id: "datura",
+            kind: "data-provider",
+            authority: "official",
+            name: "Datura",
+          },
+          {
+            id: "community-x",
+            kind: "data-provider",
+            authority: "community",
+            name: "Community X",
+          },
+        ],
       },
     });
-    const res = await callTool("list_providers", {}, { deps });
+    const res = await callTool(
+      "list_providers",
+      { authority: "official", limit: 5 },
+      { deps },
+    );
     const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
     assert.equal(out.providers[0].id, "datura");
-    assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
   });
 
-  test("list_providers rejects an unexpected argument", async () => {
-    const res = await callTool("list_providers", { netuid: 7 });
+  test("list_providers reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_providers", {}, { deps: makeDeps() });
     assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Providers index unavailable/,
+    );
+  });
+
+  test("list_providers payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_providers",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/providers.json": {
+        providers: [{ id: "datura", kind: "data-provider", name: "Datura" }],
+      },
+    });
+    const res = await callTool("list_providers", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
   });
 
   function providersDeps() {
@@ -13849,18 +13886,18 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.providers[0].id, "community-x");
   });
 
-  test("list_providers paginates the filtered list with limit/offset", async () => {
+  test("list_providers paginates the filtered list with limit/cursor", async () => {
     const deps = providersDeps();
     const res = await callTool(
       "list_providers",
-      { limit: 1, offset: 1 },
+      { sort: "name", order: "asc", limit: 1, cursor: 1 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 1);
-    assert.equal(out.offset, 1);
-    assert.equal(out.providers[0].id, "chutes");
+    assert.equal(out.cursor, 1);
+    assert.equal(out.providers[0].id, "community-x");
   });
 
   test("list_providers rejects an unknown kind/authority enum value", async () => {

--- a/tests/providers-mcp.test.mjs
+++ b/tests/providers-mcp.test.mjs
@@ -1,0 +1,342 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_PROVIDERS_INSTRUCTIONS,
+  LIST_PROVIDERS_MCP_TOOL,
+  LIST_PROVIDERS_OUTPUT_SCHEMA,
+  PROVIDERS_ARTIFACT,
+  loadProvidersList,
+  providersMcpError,
+  providersQueryUrl,
+} from "../src/providers-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  providers: [
+    {
+      id: "datura",
+      kind: "data-provider",
+      authority: "official",
+      name: "Datura",
+    },
+    {
+      id: "chutes",
+      kind: "infrastructure-provider",
+      authority: "official",
+      name: "Chutes",
+    },
+    {
+      id: "community-x",
+      kind: "data-provider",
+      authority: "community",
+      name: "Community X",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === PROVIDERS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("providers-mcp", () => {
+  test("providersMcpError is shaped for MCP toolError handling", () => {
+    const err = providersMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("providersQueryUrl validates filters and cursor", () => {
+    const url = providersQueryUrl({
+      id: "datura",
+      kind: "data-provider",
+      authority: "official",
+      sort: "name",
+      order: "asc",
+      fields: "id,name",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("id"), "datura");
+    assert.equal(url.searchParams.get("kind"), "data-provider");
+    assert.equal(url.searchParams.get("authority"), "official");
+    assert.equal(url.searchParams.get("sort"), "name");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("providersQueryUrl rejects empty id and invalid kind", () => {
+    assert.throws(
+      () => providersQueryUrl({ id: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => providersQueryUrl({ kind: "not-a-kind" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providersQueryUrl rejects invalid authority and sort", () => {
+    assert.throws(
+      () => providersQueryUrl({ authority: "not-an-authority" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => providersQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providersQueryUrl rejects non-string id and invalid order", () => {
+    assert.throws(
+      () => providersQueryUrl({ id: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => providersQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providersQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => providersQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => providersQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providersQueryUrl trims and forwards a fields projection", () => {
+    const url = providersQueryUrl({ fields: " id,name " });
+    assert.equal(url.searchParams.get("fields"), "id,name");
+  });
+
+  test("providersQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = providersQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("providersQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = providersQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("providersQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => providersQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providersQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => providersQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("providersQueryUrl clamps limit above the MCP maximum", () => {
+    const url = providersQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadProvidersList returns filtered rows with pagination meta", async () => {
+    const out = await loadProvidersList(
+      { env: {}, readArtifact },
+      { id: "chutes" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.providers[0].name, "Chutes");
+  });
+
+  test("loadProvidersList sorts and pages the collection", async () => {
+    const out = await loadProvidersList(
+      { env: {}, readArtifact },
+      { sort: "name", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadProvidersList combines filters with AND semantics", async () => {
+    const out = await loadProvidersList(
+      { env: {}, readArtifact },
+      { kind: "data-provider", authority: "community" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.providers[0].id, "community-x");
+  });
+
+  test("loadProvidersList uses an injected readArtifact dep", async () => {
+    const out = await loadProvidersList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { providers: [{ id: "solo", name: "Solo" }] },
+        }),
+      },
+    );
+    assert.equal(out.providers[0].id, "solo");
+  });
+
+  test("loadProvidersList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadProvidersList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProvidersList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadProvidersList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /providers\.json/.test(err.message),
+    );
+  });
+
+  test("loadProvidersList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadProvidersList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProvidersList projects row fields when requested", async () => {
+    const out = await loadProvidersList(
+      { env: {}, readArtifact },
+      { id: "datura", fields: "id,name" },
+    );
+    assert.deepEqual(out.providers[0], {
+      id: "datura",
+      name: "Datura",
+    });
+  });
+
+  test("loadProvidersList omits nullable artifact metadata when absent", async () => {
+    const out = await loadProvidersList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { providers: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+  });
+
+  test("loadProvidersList treats a non-array providers key as empty", async () => {
+    const out = await loadProvidersList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { providers: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.providers, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadProvidersList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { providers: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadProvidersList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadProvidersList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadProvidersList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProvidersList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadProvidersList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_PROVIDERS_MCP_TOOL.name, "list_providers");
+    assert.match(LIST_PROVIDERS_INSTRUCTIONS, /list_providers/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_PROVIDERS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_providers", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_providers/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_providers");
+    assert.ok(tool);
+    assert.equal(tool.title, "List providers and sources");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `list_providers` offset/limit handler with REST list-query parity via `applyQueryFilters` over the `providers` collection (`id`, `kind`, `authority`, `sort`/`order`, `fields`, `limit`/`cursor`).
- Add `src/providers-mcp.mjs` plus 27 unit tests and MCP integration/schema validation coverage; extend `validate-mcp.mjs` cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/providers-mcp.test.mjs`
- [x] MCP integration tests for `list_providers` filter/pagination/not_found/outputSchema


Made with [Cursor](https://cursor.com)