### PR TITLE
feat(registry): add SN110 Green Compute /healthz subnet-api surface

### DIFF
--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -177,6 +177,25 @@
       "public_safe": true,
       "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/110"],
       "url": "https://taomarketcap.com/subnets/110"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-110-green-compute-healthz",
+      "kind": "subnet-api",
+      "name": "Green Compute gateway healthz",
+      "notes": "Public no-auth GET /healthz on api.green-compute.com returning gateway liveness JSON (observed: {\"status\":\"ok\",\"service\":\"greencompute-gateway\"}). Documented as GET /healthz in the subnet OpenAPI spec on the same host as the existing chat-completions and openapi surfaces.",
+      "provider": "green-compute",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.green-compute.com/openapi.json",
+        "https://www.green-compute.com/"
+      ],
+      "url": "https://api.green-compute.com/healthz"
     }
   ],
   "website_url": "https://www.green-compute.com/"


### PR DESCRIPTION
## Summary
- Append-only registry update: register `GET https://api.green-compute.com/healthz` as `sn-110-green-compute-healthz` (`subnet-api`) on SN110 Green Compute.
- Documented in the gateway OpenAPI spec (`GET /healthz`); live probe returns `{"status":"ok","service":"greencompute-gateway"}`.

## Scope discipline
Single-file change: `registry/subnets/green-compute.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3518, #3517, #3331, #3326, #3312, #3292, #3244, #3153 (including taostats enrich append to `social` block — orthogonal to surfaces append).

## Test plan
- [x] `npx prettier --write registry/subnets/green-compute.json`
- [x] `npm run validate` / `npm run scan:public-safety`
- [x] `npm run lint` / `npm run format:check`

Made with [Cursor](https://cursor.com)