### PR TITLE
fix(ui): block reserved external link hosts

### DIFF
--- a/apps/ui/src/components/metagraphed/external-link.test.ts
+++ b/apps/ui/src/components/metagraphed/external-link.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { safeExternalUrl } from "./external-link";
+
+describe("safeExternalUrl", () => {
+  it("allows ordinary public http(s) URLs", () => {
+    expect(safeExternalUrl("https://example.com/path?q=1")).toBe("https://example.com/path?q=1");
+    expect(safeExternalUrl("http://docs.example.com/")).toBe("http://docs.example.com/");
+  });
+
+  it("blocks non-http schemes and credentialed URLs", () => {
+    expect(safeExternalUrl("javascript:alert(1)")).toBeUndefined();
+    expect(safeExternalUrl("data:text/html,hi")).toBeUndefined();
+    expect(safeExternalUrl("https://user:pass@example.com/")).toBeUndefined();
+  });
+
+  it("blocks private, reserved, and local host targets", () => {
+    const unsafe = [
+      "http://localhost/",
+      "http://service.local/",
+      "http://0.0.0.0/",
+      "http://10.0.0.1/",
+      "http://100.64.0.1/",
+      "http://127.0.0.1/",
+      "http://169.254.169.254/",
+      "http://172.16.0.1/",
+      "http://192.0.2.1/",
+      "http://192.168.0.1/",
+      "http://198.18.0.1/",
+      "http://198.51.100.1/",
+      "http://203.0.113.1/",
+      "http://224.0.0.1/",
+      "http://[::1]/",
+      "http://[::ffff:7f00:1]/",
+      "http://[fc00::1]/",
+      "http://[fe80::1]/",
+      "http://[ff02::1]/",
+    ];
+
+    for (const href of unsafe) {
+      expect(safeExternalUrl(href), href).toBeUndefined();
+    }
+  });
+});

--- a/apps/ui/src/components/metagraphed/external-link.tsx
+++ b/apps/ui/src/components/metagraphed/external-link.tsx
@@ -11,38 +11,63 @@ interface Props {
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
 
+function isBlockedIpv4(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    return value >= 0 && value <= 255 ? value : null;
+  });
+  if (octets.some((value) => value === null)) return false;
+  const [a, b, c] = octets as [number, number, number, number];
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function isBlockedIpv6(hostname: string): boolean {
+  if (!hostname.includes(":")) return false;
+  return (
+    hostname === "" ||
+    hostname === "::" ||
+    hostname === "::1" ||
+    hostname.startsWith("fc") ||
+    hostname.startsWith("fd") ||
+    hostname.startsWith("fe8") ||
+    hostname.startsWith("fe9") ||
+    hostname.startsWith("fea") ||
+    hostname.startsWith("feb") ||
+    hostname.startsWith("ff") ||
+    hostname.startsWith("::ffff:")
+  );
+}
+
 function isPrivateHostname(hostname: string) {
-  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
   if (
     normalized === "localhost" ||
     normalized.endsWith(".localhost") ||
-    normalized.endsWith(".local") ||
-    (normalized.includes(":") &&
-      (normalized === "::1" ||
-        normalized.startsWith("fe80:") ||
-        normalized.startsWith("fc") ||
-        normalized.startsWith("fd")))
+    normalized.endsWith(".local")
   ) {
     return true;
   }
-
-  const octets = normalized.split(".").map((part) => Number(part));
-  if (
-    octets.length !== 4 ||
-    octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
-  ) {
-    return false;
-  }
-
-  const [first, second] = octets;
-  return (
-    first === 0 ||
-    first === 10 ||
-    first === 127 ||
-    (first === 169 && second === 254) ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168)
-  );
+  return isBlockedIpv4(normalized) || isBlockedIpv6(normalized);
 }
 
 export function safeExternalUrl(href?: string) {


### PR DESCRIPTION
### Motivation
- Prevent unsafe outbound links and XSS/SSRF attack surfaces by ensuring any external URL rendered into an <a> is an http(s) public origin and not a private/local/reserved or credentialed target.
- Make the external-link sanitizer consistent with the other URL safety gates used elsewhere in the UI (favicon/icon proxy, brand overrides, image loading). 

### Description
- Harden `safeExternalUrl` by adding IPv4 and IPv6 blocked-range checks and normalizing hostnames before validation so private, localhost, carrier-grade NAT, documentation/test, reserved, multicast, IPv6 ULA/link-local, IPv4-mapped IPv6 and credentialed URLs are rejected; the helper now returns `undefined` for any unsafe target. (edited file: `apps/ui/src/components/metagraphed/external-link.tsx`).
- Replace the previous ad-hoc `isPrivateHostname` logic with a normalized, trimmed host check that delegates to `isBlockedIpv4`/`isBlockedIpv6` for comprehensive coverage and correct bracketed IPv6 handling. (edited file: `apps/ui/src/components/metagraphed/external-link.tsx`).
- Add focused unit tests for the sanitizer covering allowed public http(s) URLs, non-http schemes and credentialed URLs, and a broad set of private/reserved/local host examples. (new file: `apps/ui/src/components/metagraphed/external-link.test.ts`).

### Testing
- `git diff --check` was run and reported no whitespace/format errors. 
- Added a Vitest unit test exercising `safeExternalUrl` (`apps/ui/src/components/metagraphed/external-link.test.ts`), but running the test runner in this environment failed because the test runner binary could not be executed/installed (`vitest` not available / npm registry fetch returned 403). 
- Attempts to run `npx vitest` also failed due to the environment/npm registry restriction, so the new tests are present but could not be executed here; they are runnable in CI or a normal developer environment where `npm install`/`vitest` succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49fe4df520832cb563c1748ea3cb96)