### PR TITLE
fix(mcp): align subnet evidence output schema

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -10344,7 +10344,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     required: [],
     properties: {
       netuid: { type: ["integer", "null"] },
-      evidence: { type: "array", items: { type: "object" } },
+      claims: { type: "array", items: { type: "object" } },
       generated_at: NULLABLE_STRING,
       schema_version: { type: ["string", "integer", "null"] },
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14482,13 +14482,13 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
       "/metagraph/evidence/5.json": {
         generated_at: "2026-01-01T00:00:00Z",
         netuid: 5,
-        evidence: [{ check: "openapi", outcome: "verified" }],
+        claims: [{ check: "openapi", outcome: "verified" }],
       },
     });
     const res = await callTool("get_subnet_evidence", { netuid: 5 }, { deps });
     const out = res.body.result.structuredContent;
     assert.equal(out.netuid, 5);
-    assert.equal(out.evidence[0].outcome, "verified");
+    assert.equal(out.claims[0].outcome, "verified");
   });
 
   test("get_subnet_evidence rejects a missing netuid", async () => {


### PR DESCRIPTION
### Motivation
- The `get_subnet_evidence` MCP tool advertised an `evidence` array while the build and REST contract produce a top-level `claims` array, causing an API contract mismatch that can break MCP clients.
- Tests and the MCP output schema needed to match the actual `/metagraph/evidence/{netuid}.json` artifact shape to ensure clients and generated contracts parse real data correctly.

### Description
- Replace the `evidence` output property with `claims` in the `get_subnet_evidence` tool schema in `src/mcp-server.mjs` so the MCP tool advertises the production artifact shape (`claims`).
- Update the targeted test fixture and assertion in `tests/mcp-server.test.mjs` to populate and assert `claims` instead of `evidence` to exercise the real artifact shape.

### Testing
- Ran the targeted unit test with `npx vitest run tests/mcp-server.test.mjs -t "get_subnet_evidence" --reporter=dot`, and the test passed.
- Performed file checks to verify the schema and test updates (`src/mcp-server.mjs` and `tests/mcp-server.test.mjs`) are consistent with the generated artifact shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a018ff8d8832c91ae1ead81b7c8c8)