### PR TITLE
feat(mcp): add list-query parity for list_surfaces

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -352,6 +352,14 @@ assert.ok(
   Array.isArray(providersPage.providers),
   "list_providers must return providers[]",
 );
+const surfacesPage = await callOk("list_surfaces", {
+  limit: 3,
+  kind: "openapi",
+});
+assert.ok(
+  Array.isArray(surfacesPage.surfaces),
+  "list_surfaces must return surfaces[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -98,6 +98,12 @@ import {
   loadSourceSnapshotsList,
 } from "./source-snapshots-mcp.mjs";
 import {
+  LIST_SURFACES_INSTRUCTIONS,
+  LIST_SURFACES_MCP_TOOL,
+  LIST_SURFACES_OUTPUT_SCHEMA,
+  loadSurfacesList,
+} from "./surfaces-mcp.mjs";
+import {
   LIST_ENDPOINT_POOLS_INSTRUCTIONS,
   LIST_ENDPOINT_POOLS_MCP_TOOL,
   LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
@@ -784,8 +790,8 @@ export const MCP_INSTRUCTIONS =
   GET_AGENT_RESOURCES_INSTRUCTIONS +
   "get_agent_catalog the capability catalog, " +
   LIST_PROVIDERS_INSTRUCTIONS +
-  "list_surfaces the " +
-  "network-wide catalog of curated public surfaces, list_candidates the " +
+  LIST_SURFACES_INSTRUCTIONS +
+  "list_candidates the " +
   "unpromoted candidate surfaces still pending review, list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, " +
   LIST_EVIDENCE_INSTRUCTIONS +
@@ -6186,67 +6192,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_surfaces",
-    title: "List curated public surfaces",
-    description:
-      "Fetch the catalog of curated public surfaces across all subnets: each " +
-      "surface's subnet (netuid), kind, provider, title, url, and review " +
-      "state. Use it to discover what machine-readable data surfaces the " +
-      "registry publishes network-wide, then drill into one subnet with " +
-      "get_subnet or list_subnet_apis. Optionally filter by netuid/kind/" +
-      "provider and page with limit/offset — the full catalog can be large. " +
-      "Mirrors GET /api/v1/surfaces.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.surfaceKind,
-          description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
-        },
-        provider: {
-          type: "string",
-          description: "Provider slug, e.g. 'datura'.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max surfaces to return. Omit for the full list.",
-          minimum: 1,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...LIST_SURFACES_MCP_TOOL,
     async handler(args, ctx) {
-      const netuid = optionalNonNegativeInt(args, "netuid");
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
-      const provider = optionalString(args, "provider");
-      const limit = optionalPositiveInt(args, "limit");
-      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
-      const data = await loadArtifactData(ctx, "/metagraph/surfaces.json");
-      const all = Array.isArray(data.surfaces) ? data.surfaces : [];
-      const filtered = all.filter(
-        (s) =>
-          (netuid === null || s.netuid === netuid) &&
-          (kind === null || s.kind === kind) &&
-          (provider === null || s.provider === provider),
-      );
-      const page =
-        limit === null
-          ? filtered.slice(offset)
-          : filtered.slice(offset, offset + limit);
-      return {
-        ...data,
-        surfaces: page,
-        total: filtered.length,
-        returned: page.length,
-        offset,
-      };
+      return loadSurfacesList(ctx, args);
     },
   },
   {
@@ -10229,16 +10177,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_providers: LIST_PROVIDERS_OUTPUT_SCHEMA,
-  list_surfaces: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      surfaces: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_surfaces: LIST_SURFACES_OUTPUT_SCHEMA,
   list_candidates: {
     type: "object",
     additionalProperties: true,

--- a/src/surfaces-mcp.mjs
+++ b/src/surfaces-mcp.mjs
@@ -1,0 +1,214 @@
+// Curated surfaces list loader for MCP parity on GET /api/v1/surfaces.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/surfaces.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const SURFACES_ARTIFACT = "/metagraph/surfaces.json";
+
+const SURFACE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+
+export function surfacesMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw surfacesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw surfacesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function surfacesQueryUrl(args) {
+  const url = new URL("https://mcp.internal/surfaces");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw surfacesMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const sort = optionalEnum(args, "sort", SURFACE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw surfacesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSurfacesList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = surfacesQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, SURFACES_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw surfacesMcpError(
+        "not_found",
+        "Curated surfaces catalog unavailable.",
+      );
+    }
+    throw surfacesMcpError(
+      code,
+      `Could not load ${SURFACES_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw surfacesMcpError(
+      "not_found",
+      "Curated surfaces catalog unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "curated-surfaces", []);
+  if (transformed.error) {
+    throw surfacesMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.surfaces) ? data.surfaces : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SURFACES_INSTRUCTIONS =
+  "Use list_surfaces to page the network-wide curated public-surface catalog " +
+  "with REST list-query filters (netuid, kind, provider, sort, and pagination; " +
+  "mirrors GET /api/v1/surfaces), ";
+
+export const LIST_SURFACES_MCP_TOOL = {
+  name: "list_surfaces",
+  title: "List curated public surfaces",
+  description:
+    "Fetch the catalog of curated public surfaces across all subnets: each " +
+    "surface's subnet (netuid), kind, provider, title, url, and review state. " +
+    "Filter by netuid, kind, or provider; sort with sort + order; project with " +
+    "fields; and page with limit (1-100) / cursor. Distinct from " +
+    "get_subnet_surfaces (one subnet's raw artifact dump). Mirrors " +
+    "GET /api/v1/surfaces.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'datura'.",
+      },
+      sort: {
+        type: "string",
+        enum: SURFACE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of surface fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SURFACES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["surfaces"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    surfaces: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13928,22 +13928,49 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.returned, 0);
   });
 
-  test("list_surfaces returns the surfaces catalog artifact", async () => {
+  test("list_surfaces returns filtered surface rows", async () => {
     const deps = makeDeps({
       "/metagraph/surfaces.json": {
-        generated_at: "2026-01-01T00:00:00Z",
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        surfaces: [
+          { netuid: 7, kind: "openapi", provider: "datura" },
+          { netuid: 12, kind: "openapi", provider: "datura" },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_surfaces",
+      { netuid: 7, limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].netuid, 7);
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("list_surfaces reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_surfaces", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Curated surfaces catalog unavailable/,
+    );
+  });
+
+  test("list_surfaces payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_surfaces",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/surfaces.json": {
         surfaces: [{ netuid: 7, kind: "openapi", provider: "datura" }],
       },
     });
-    const res = await callTool("list_surfaces", {}, { deps });
-    const out = res.body.result.structuredContent;
-    assert.equal(out.surfaces[0].netuid, 7);
-    assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
-  });
-
-  test("list_surfaces rejects an unexpected argument", async () => {
-    const res = await callTool("list_surfaces", { bogus: 1 });
-    assert.equal(res.body.result.isError, true);
+    const res = await callTool("list_surfaces", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
   });
 
   function surfacesDeps() {
@@ -13991,18 +14018,19 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.surfaces[0].kind, "openapi");
   });
 
-  test("list_surfaces paginates the filtered list with limit/offset", async () => {
+  test("list_surfaces paginates the filtered list with limit/cursor", async () => {
     const deps = surfacesDeps();
     const res = await callTool(
       "list_surfaces",
-      { limit: 1, offset: 1 },
+      { sort: "provider", order: "asc", limit: 1, cursor: 1 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 1);
-    assert.equal(out.offset, 1);
-    assert.equal(out.surfaces[0].provider, "chutes");
+    assert.equal(out.cursor, 1);
+    assert.equal(out.surfaces[0].provider, "datura");
+    assert.equal(out.surfaces[0].netuid, 7);
   });
 
   test("list_surfaces rejects an unknown kind enum value", async () => {

--- a/tests/surfaces-mcp.test.mjs
+++ b/tests/surfaces-mcp.test.mjs
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SURFACES_INSTRUCTIONS,
+  LIST_SURFACES_MCP_TOOL,
+  LIST_SURFACES_OUTPUT_SCHEMA,
+  SURFACES_ARTIFACT,
+  loadSurfacesList,
+  surfacesMcpError,
+  surfacesQueryUrl,
+} from "../src/surfaces-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  surfaces: [
+    {
+      id: "sn7-openapi",
+      netuid: 7,
+      kind: "openapi",
+      provider: "datura",
+      name: "SN7 OpenAPI",
+    },
+    {
+      id: "sn7-api",
+      netuid: 7,
+      kind: "subnet-api",
+      provider: "chutes",
+      name: "SN7 API",
+    },
+    {
+      id: "sn12-openapi",
+      netuid: 12,
+      kind: "openapi",
+      provider: "datura",
+      name: "SN12 OpenAPI",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === SURFACES_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("surfaces-mcp", () => {
+  test("surfacesMcpError is shaped for MCP toolError handling", () => {
+    const err = surfacesMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("surfacesQueryUrl validates filters and cursor", () => {
+    const url = surfacesQueryUrl({
+      netuid: 7,
+      kind: "openapi",
+      provider: "datura",
+      sort: "name",
+      order: "asc",
+      fields: "id,kind",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("kind"), "openapi");
+    assert.equal(url.searchParams.get("provider"), "datura");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("surfacesQueryUrl rejects empty provider and invalid kind", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => surfacesQueryUrl({ kind: "not-a-kind" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl rejects invalid sort and order", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => surfacesQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl rejects non-string provider and empty fields", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => surfacesQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl trims and forwards a fields projection", () => {
+    const url = surfacesQueryUrl({ fields: " id,kind " });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("surfacesQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = surfacesQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("surfacesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = surfacesQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("surfacesQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("surfacesQueryUrl clamps limit above the MCP maximum", () => {
+    const url = surfacesQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSurfacesList returns filtered rows with pagination meta", async () => {
+    const out = await loadSurfacesList(
+      { env: {}, readArtifact },
+      { netuid: 12 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].provider, "datura");
+  });
+
+  test("loadSurfacesList sorts and pages the collection", async () => {
+    const out = await loadSurfacesList(
+      { env: {}, readArtifact },
+      { sort: "name", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSurfacesList combines filters with AND semantics", async () => {
+    const out = await loadSurfacesList(
+      { env: {}, readArtifact },
+      { netuid: 7, provider: "datura" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].kind, "openapi");
+  });
+
+  test("loadSurfacesList uses an injected readArtifact dep", async () => {
+    const out = await loadSurfacesList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: [{ netuid: 0, kind: "docs" }] },
+        }),
+      },
+    );
+    assert.equal(out.surfaces[0].netuid, 0);
+  });
+
+  test("loadSurfacesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSurfacesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /surfaces\.json/.test(err.message),
+    );
+  });
+
+  test("loadSurfacesList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSurfacesList({ env: {}, readArtifact }, { fields: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSurfacesList projects row fields when requested", async () => {
+    const out = await loadSurfacesList(
+      { env: {}, readArtifact },
+      { netuid: 7, kind: "openapi", fields: "id,kind" },
+    );
+    assert.deepEqual(out.surfaces[0], {
+      id: "sn7-openapi",
+      kind: "openapi",
+    });
+  });
+
+  test("loadSurfacesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: [{ netuid: 0, kind: "docs" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+  });
+
+  test("loadSurfacesList treats a non-array surfaces key as empty", async () => {
+    const out = await loadSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSurfacesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ netuid: 1 }, { netuid: 2 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSurfacesList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSurfacesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSurfacesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SURFACES_MCP_TOOL.name, "list_surfaces");
+    assert.match(LIST_SURFACES_INSTRUCTIONS, /list_surfaces/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_SURFACES_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_surfaces", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_surfaces/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_surfaces");
+    assert.ok(tool);
+    assert.equal(tool.title, "List curated public surfaces");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `list_surfaces` offset/limit handler with REST list-query parity via `applyQueryFilters` over the `curated-surfaces` collection (`netuid`, `kind`, `provider`, `sort`/`order`, `fields`, `limit`/`cursor`).
- Add `src/surfaces-mcp.mjs` plus 28 unit tests and MCP integration/schema validation coverage; extend `validate-mcp.mjs` cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/surfaces-mcp.test.mjs`
- [x] MCP integration tests for `list_surfaces` filter/pagination/not_found/outputSchema


Made with [Cursor](https://cursor.com)