### PR TITLE
feat(mcp): add list-query parity for list_candidates

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -360,6 +360,14 @@ assert.ok(
   Array.isArray(surfacesPage.surfaces),
   "list_surfaces must return surfaces[]",
 );
+const candidatesPage = await callOk("list_candidates", {
+  limit: 3,
+  state: "verified",
+});
+assert.ok(
+  Array.isArray(candidatesPage.candidates),
+  "list_candidates must return candidates[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/src/candidates-mcp.mjs
+++ b/src/candidates-mcp.mjs
@@ -1,0 +1,222 @@
+// Candidate surfaces list loader for MCP parity on GET /api/v1/candidates.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/candidates.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const CANDIDATES_ARTIFACT = "/metagraph/candidates.json";
+
+const CANDIDATE_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const CANDIDATE_STATES = QUERY_ENUMS.candidateState;
+
+export function candidatesMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw candidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw candidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function candidatesQueryUrl(args) {
+  const url = new URL("https://mcp.internal/candidates");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw candidatesMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const state = optionalEnum(args, "state", CANDIDATE_STATES);
+  if (state) url.searchParams.set("state", state);
+  const sort = optionalEnum(args, "sort", CANDIDATE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw candidatesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadCandidatesList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = candidatesQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, CANDIDATES_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw candidatesMcpError(
+        "not_found",
+        "Candidate surfaces catalog unavailable.",
+      );
+    }
+    throw candidatesMcpError(
+      code,
+      `Could not load ${CANDIDATES_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw candidatesMcpError(
+      "not_found",
+      "Candidate surfaces catalog unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "candidates", []);
+  if (transformed.error) {
+    throw candidatesMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.candidates) ? data.candidates : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    candidates: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_CANDIDATES_INSTRUCTIONS =
+  "Use list_candidates to page the network-wide unpromoted candidate-surface " +
+  "catalog with REST list-query filters (netuid, kind, provider, state, sort, " +
+  "and pagination; mirrors GET /api/v1/candidates), ";
+
+export const LIST_CANDIDATES_MCP_TOOL = {
+  name: "list_candidates",
+  title: "List unpromoted candidate surfaces",
+  description:
+    "Fetch unpromoted candidate surfaces across all subnets: surfaces that " +
+    "have been discovered or proposed but not yet curated/promoted, each with " +
+    "its subnet (netuid), kind, provider, and review state. Filter by netuid, " +
+    "kind, provider, or state; sort with sort + order; project with fields; and " +
+    "page with limit (1-100) / cursor. Distinct from get_subnet_candidates (one " +
+    "subnet's raw artifact dump). Mirrors GET /api/v1/candidates.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'datura'.",
+      },
+      state: {
+        type: "string",
+        enum: CANDIDATE_STATES,
+        description: "Review state, e.g. 'schema-valid' or 'verified'.",
+      },
+      sort: {
+        type: "string",
+        enum: CANDIDATE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of candidate fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_CANDIDATES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["candidates"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    candidates: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -122,6 +122,12 @@ import {
   loadProviderEndpointsList,
 } from "./provider-endpoints-mcp.mjs";
 import {
+  LIST_CANDIDATES_INSTRUCTIONS,
+  LIST_CANDIDATES_MCP_TOOL,
+  LIST_CANDIDATES_OUTPUT_SCHEMA,
+  loadCandidatesList,
+} from "./candidates-mcp.mjs";
+import {
   LIST_PROVIDERS_INSTRUCTIONS,
   LIST_PROVIDERS_MCP_TOOL,
   LIST_PROVIDERS_OUTPUT_SCHEMA,
@@ -791,8 +797,8 @@ export const MCP_INSTRUCTIONS =
   "get_agent_catalog the capability catalog, " +
   LIST_PROVIDERS_INSTRUCTIONS +
   LIST_SURFACES_INSTRUCTIONS +
-  "list_candidates the " +
-  "unpromoted candidate surfaces still pending review, list_endpoints the " +
+  LIST_CANDIDATES_INSTRUCTIONS +
+  "list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, " +
   LIST_EVIDENCE_INSTRUCTIONS +
   "list_rpc_endpoints the monitored " +
@@ -6198,74 +6204,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_candidates",
-    title: "List unpromoted candidate surfaces",
-    description:
-      "Fetch unpromoted candidate surfaces across all subnets: surfaces that " +
-      "have been discovered or proposed but not yet curated/promoted, each " +
-      "with its subnet (netuid), kind, provider, and review state. Use it to " +
-      "see what enrichment is still pending, versus the promoted catalog in " +
-      "list_surfaces. Optionally filter by netuid/kind/provider/state and page " +
-      "with limit/offset — the full catalog can be large. Mirrors " +
-      "GET /api/v1/candidates.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.surfaceKind,
-          description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
-        },
-        provider: {
-          type: "string",
-          description: "Provider slug, e.g. 'datura'.",
-        },
-        state: {
-          type: "string",
-          enum: QUERY_ENUMS.candidateState,
-          description: "Review state, e.g. 'schema-valid' or 'verified'.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max candidates to return. Omit for the full list.",
-          minimum: 1,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...LIST_CANDIDATES_MCP_TOOL,
     async handler(args, ctx) {
-      const netuid = optionalNonNegativeInt(args, "netuid");
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
-      const provider = optionalString(args, "provider");
-      const state = optionalEnum(args, "state", QUERY_ENUMS.candidateState);
-      const limit = optionalPositiveInt(args, "limit");
-      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
-      const data = await loadArtifactData(ctx, "/metagraph/candidates.json");
-      const all = Array.isArray(data.candidates) ? data.candidates : [];
-      const filtered = all.filter(
-        (c) =>
-          (netuid === null || c.netuid === netuid) &&
-          (kind === null || c.kind === kind) &&
-          (provider === null || c.provider === provider) &&
-          (state === null || c.state === state),
-      );
-      const page =
-        limit === null
-          ? filtered.slice(offset)
-          : filtered.slice(offset, offset + limit);
-      return {
-        ...data,
-        candidates: page,
-        total: filtered.length,
-        returned: page.length,
-        offset,
-      };
+      return loadCandidatesList(ctx, args);
     },
   },
   {
@@ -10178,16 +10119,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_providers: LIST_PROVIDERS_OUTPUT_SCHEMA,
   list_surfaces: LIST_SURFACES_OUTPUT_SCHEMA,
-  list_candidates: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      candidates: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_candidates: LIST_CANDIDATES_OUTPUT_SCHEMA,
   list_endpoints: {
     type: "object",
     additionalProperties: true,

--- a/tests/candidates-mcp.test.mjs
+++ b/tests/candidates-mcp.test.mjs
@@ -1,0 +1,354 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  CANDIDATES_ARTIFACT,
+  LIST_CANDIDATES_INSTRUCTIONS,
+  LIST_CANDIDATES_MCP_TOOL,
+  LIST_CANDIDATES_OUTPUT_SCHEMA,
+  candidatesMcpError,
+  candidatesQueryUrl,
+  loadCandidatesList,
+} from "../src/candidates-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  candidates: [
+    {
+      netuid: 7,
+      kind: "openapi",
+      provider: "datura",
+      state: "verified",
+    },
+    {
+      netuid: 7,
+      kind: "subnet-api",
+      provider: "chutes",
+      state: "schema-valid",
+    },
+    {
+      netuid: 12,
+      kind: "openapi",
+      provider: "datura",
+      state: "stale",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === CANDIDATES_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("candidates-mcp", () => {
+  test("candidatesMcpError is shaped for MCP toolError handling", () => {
+    const err = candidatesMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("candidatesQueryUrl validates filters and cursor", () => {
+    const url = candidatesQueryUrl({
+      netuid: 7,
+      kind: "openapi",
+      provider: "datura",
+      state: "verified",
+      sort: "provider",
+      order: "asc",
+      fields: "netuid,provider",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("kind"), "openapi");
+    assert.equal(url.searchParams.get("provider"), "datura");
+    assert.equal(url.searchParams.get("state"), "verified");
+    assert.equal(url.searchParams.get("sort"), "provider");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("candidatesQueryUrl rejects invalid netuid and kind", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => candidatesQueryUrl({ kind: "not-a-kind" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects empty provider and invalid state", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => candidatesQueryUrl({ state: "not-a-state" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects invalid sort and order", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => candidatesQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects non-string provider and invalid fields", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => candidatesQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => candidatesQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl trims and forwards a fields projection", () => {
+    const url = candidatesQueryUrl({ fields: " netuid,provider " });
+    assert.equal(url.searchParams.get("fields"), "netuid,provider");
+  });
+
+  test("candidatesQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = candidatesQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("candidatesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = candidatesQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("candidatesQueryUrl rejects a fractional netuid and cursor", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => candidatesQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl clamps limit above the MCP maximum", () => {
+    const url = candidatesQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadCandidatesList returns filtered rows with pagination meta", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact },
+      { provider: "chutes" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].kind, "subnet-api");
+  });
+
+  test("loadCandidatesList sorts and pages the collection", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact },
+      { sort: "provider", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadCandidatesList combines filters with AND semantics", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact },
+      { netuid: 7, provider: "datura" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].kind, "openapi");
+  });
+
+  test("loadCandidatesList uses an injected readArtifact dep", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            candidates: [{ netuid: 99, provider: "solo", state: "verified" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.candidates[0].provider, "solo");
+  });
+
+  test("loadCandidatesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCandidatesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /candidates\.json/.test(err.message),
+    );
+  });
+
+  test("loadCandidatesList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCandidatesList projects row fields when requested", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact },
+      { netuid: 7, provider: "datura", fields: "netuid,provider" },
+    );
+    assert.deepEqual(out.candidates[0], {
+      netuid: 7,
+      provider: "datura",
+    });
+  });
+
+  test("loadCandidatesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: [{ netuid: 7, provider: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+  });
+
+  test("loadCandidatesList treats a non-array candidates key as empty", async () => {
+    const out = await loadCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.candidates, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadCandidatesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { candidates: [{ netuid: 1 }, { netuid: 2 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadCandidatesList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadCandidatesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCandidatesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_CANDIDATES_MCP_TOOL.name, "list_candidates");
+    assert.match(LIST_CANDIDATES_INSTRUCTIONS, /list_candidates/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_CANDIDATES_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_candidates", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_candidates/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_candidates");
+    assert.ok(tool);
+    assert.equal(tool.title, "List unpromoted candidate surfaces");
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14054,6 +14054,63 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.returned, 0);
   });
 
+  test("list_candidates returns filtered candidate rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/candidates.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        candidates: [
+          {
+            netuid: 7,
+            kind: "openapi",
+            provider: "datura",
+            state: "verified",
+          },
+          {
+            netuid: 12,
+            kind: "openapi",
+            provider: "datura",
+            state: "stale",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_candidates",
+      { state: "verified", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].netuid, 7);
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("list_candidates reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_candidates", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Candidate surfaces catalog unavailable/,
+    );
+  });
+
+  test("list_candidates payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_candidates",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/candidates.json": {
+        candidates: [
+          { netuid: 7, kind: "openapi", provider: "datura", state: "verified" },
+        ],
+      },
+    });
+    const res = await callTool("list_candidates", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_candidates returns the candidates catalog artifact", async () => {
     const deps = makeDeps({
       "/metagraph/candidates.json": {
@@ -14139,18 +14196,19 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.candidates[0].kind, "openapi");
   });
 
-  test("list_candidates paginates the filtered list with limit/offset", async () => {
+  test("list_candidates paginates the filtered list with limit/cursor", async () => {
     const deps = candidatesDeps();
     const res = await callTool(
       "list_candidates",
-      { limit: 1, offset: 1 },
+      { sort: "provider", order: "asc", limit: 1, cursor: 1 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 1);
-    assert.equal(out.offset, 1);
-    assert.equal(out.candidates[0].provider, "chutes");
+    assert.equal(out.cursor, 1);
+    assert.equal(out.candidates[0].provider, "datura");
+    assert.equal(out.candidates[0].netuid, 7);
   });
 
   test("list_candidates rejects an unknown kind/state enum value", async () => {


### PR DESCRIPTION
## Summary
- Upgrade `list_candidates` from hand-rolled offset/limit filtering to full REST list-query parity via `applyQueryFilters`, mirroring `GET /api/v1/candidates`.
- Add `src/candidates-mcp.mjs` with sort, fields, and cursor pagination; wire into MCP server instructions, tool registry, and output schema.
- Add 27 unit tests plus integration coverage (filter, not_found, outputSchema, cursor pagination) and a validate-mcp cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/candidates-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_candidates`


Made with [Cursor](https://cursor.com)