### PR TITLE
ci(mcp): automate MCP server version bumps

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -290,8 +290,22 @@ local paths, env dumps, or private notes.
   types/clients. `validate:contract-drift` + `validate:schema-enums` + `validate:committed-seed` guard it.
 - **Client SDK version: do NOT bump in your PR.** `packages/client/package.json` is versioned by the
   post-merge `sync-client-version` workflow, which auto-opens a `chore/sync-client-version` PR whenever
-  a contract file lands on main. `validate:client-sdk-sync` now emits a notice (not a failure) when the
-  version isn't bumped in a contributor PR.
+  a contract file lands on main. `validate:client-sdk-sync` emits a notice (not a failure) either way:
+  when the version isn't bumped in a contributor PR (expected — automation handles it), and _also_ when
+  a contributor bumps it themselves anyway (unnecessary — the workflow's own diff-since-last-bump check
+  doesn't look for a manual bump, only for contract-file changes since its last `chore(client): bump
+SDK` commit, so a hand-bump here is redundant at best and a conflicting version at worst once the
+  auto PR lands).
+- **MCP server version: do NOT bump in your PR, same as the client SDK above.** `MCP_SERVER_VERSION`
+  (`src/mcp-server.mjs`) and `server.json`'s `"version"` are versioned by the post-merge
+  `sync-mcp-version` workflow — same shape as `sync-client-version`, watching `src/mcp-server.mjs` since
+  its last `chore(mcp): bump server version` commit and bumping both files together when a tool was
+  added/changed. `validate:mcp` only checks _internal_ consistency (`MCP_SERVER_VERSION` ==
+  `serverInfo.version` == `server.json`'s version) — it stays green regardless of what number those
+  hold, so a PR that adds an MCP tool without touching either file passes CI fine; the workflow is what
+  actually advances the number, entirely after the fact. A contributor hand-bumping either file is pure
+  unrewarded toil (and setup for a merge conflict with the auto-opened `chore/sync-mcp-version` PR) —
+  flag it in review the same way as a manual client-SDK bump.
 - **`packages/client` is an npm workspace (#3066), with no lockfile of its own.** `apps/ui` consumes it
   as a live workspace link (`"@jsonbored/metagraphed": "*"` in `apps/ui/package.json`, resolved from
   `packages/client` directly) instead of round-tripping through the published npm package. Verified

--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -1,0 +1,150 @@
+name: Sync MCP server version
+
+# Auto-opens a chore/sync-mcp-version PR whenever the MCP tool registry
+# (src/mcp-server.mjs) changes on main without a matching MCP_SERVER_VERSION
+# bump. This decouples the version bump from the contributor PR, the same
+# way sync-client-version.yml already does for the published SDK --
+# eliminating both the manual toil (every "add an MCP tool" PR previously
+# had to hand-edit src/mcp-server.mjs's MCP_SERVER_VERSION constant AND
+# server.json's "version" field to match) and the merge conflicts that
+# come from many concurrent tool-adding PRs all touching the same
+# version-bump line (this repo gets hundreds of contributor PRs; MCP tool
+# additions are one of the highest-volume categories among them).
+#
+# Contributors should NEVER touch MCP_SERVER_VERSION or server.json's
+# version themselves -- see .claude/skills/metagraphed/reference.md.
+# scripts/validate-mcp.mjs's own check only verifies INTERNAL consistency
+# (MCP_SERVER_VERSION == serverInfo.version == server.json's version), which
+# stays true regardless of what number it currently holds, so a
+# contributor's PR that adds a tool without touching either file still
+# passes CI -- this workflow is what actually advances the number,
+# entirely after the fact.
+#
+# Runs on a schedule rather than on every push to main, and batches
+# multiple tool additions into one bump, for the exact same reasons
+# sync-client-version.yml does (see that workflow's own comment for the
+# full rationale) -- an unconditional per-push bump would be noisy and
+# racy under concurrent merges; the change-detection guard below (diffing
+# since the last bump commit) is what actually prevents a needless bump,
+# not the schedule itself.
+# 07:00 UTC -- after sync-client-version.yml's 06:00 UTC run and before
+# release-please.yml's 09:00 UTC run, so this repo's three post-merge sync
+# workflows (client SDK, MCP server, release-please) run in a fixed,
+# non-overlapping order on the same schedule. workflow_dispatch stays
+# available for an on-demand run.
+on:
+  schedule:
+    - cron: "0 7 */2 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-mcp-version
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Open MCP version bump PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Real change-detection: every MCP tool addition necessarily imports
+      # and registers the new tool in src/mcp-server.mjs's MCP_TOOLS array,
+      # so that file changing since the last bump is a reliable, sufficient
+      # signal -- the same pragmatic "watch the one file everything routes
+      # through" approach sync-client-version.yml uses for its own three
+      # contract paths, not a precise "did the tool count specifically
+      # change" AST diff. No prior bump commit found (first run ever) or a
+      # non-empty diff since the last one ⇒ proceed; an empty diff ⇒ skip
+      # every subsequent step via its `if:` so the job still exits cleanly.
+      - name: Check for MCP tool changes since the last version bump
+        id: mcp-diff
+        run: |
+          last_bump="$(git log --grep '^chore(mcp): bump server version' --format=%H -n 1 main)"
+          if [ -z "$last_bump" ]; then
+            echo "no prior 'chore(mcp): bump server version' commit found; treating as first run"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "last MCP version bump commit: ${last_bump}"
+            if git diff --quiet "${last_bump}" HEAD -- src/mcp-server.mjs; then
+              echo "no MCP tool registry changes since ${last_bump}; skipping version bump"
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "MCP tool registry changes found since ${last_bump}"
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Setup Node
+        if: steps.mcp-diff.outputs.changed == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+
+      # MCP_SERVER_VERSION lives in a JS source file, not JSON, so this is a
+      # regex extract/replace rather than a JSON.parse/stringify round-trip
+      # (matching the exact literal form the constant is always declared
+      # in: `export const MCP_SERVER_VERSION = "X.Y.Z";`).
+      - name: Compute next patch version
+        if: steps.mcp-diff.outputs.changed == 'true'
+        id: version
+        run: |
+          current=$(node -p "
+            require('fs').readFileSync('src/mcp-server.mjs', 'utf8')
+              .match(/export const MCP_SERVER_VERSION = \"([^\"]+)\"/)[1]
+          ")
+          IFS='.' read -r maj min pat <<< "$current"
+          next="${maj}.${min}.$((pat + 1))"
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Bump MCP_SERVER_VERSION in src/mcp-server.mjs
+        if: steps.mcp-diff.outputs.changed == 'true'
+        run: |
+          node -e "
+          const fs = require('fs');
+          const path = 'src/mcp-server.mjs';
+          const content = fs.readFileSync(path, 'utf8');
+          const updated = content.replace(
+            /export const MCP_SERVER_VERSION = \"[^\"]+\"/,
+            'export const MCP_SERVER_VERSION = \"${{ steps.version.outputs.next }}\"',
+          );
+          fs.writeFileSync(path, updated, 'utf8');
+          "
+
+      - name: Bump server.json to match
+        if: steps.mcp-diff.outputs.changed == 'true'
+        run: |
+          node -e "
+          const fs = require('fs');
+          const p = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+          p.version = '${{ steps.version.outputs.next }}';
+          fs.writeFileSync('server.json', JSON.stringify(p, null, 2) + '\n');
+          "
+
+      - name: Open sync PR (no-op if unchanged)
+        if: steps.mcp-diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-mcp-version
+          delete-branch: true
+          add-paths: |
+            src/mcp-server.mjs
+            server.json
+          title: "chore(mcp): bump server version to ${{ steps.version.outputs.next }}"
+          commit-message: "chore(mcp): bump server version to ${{ steps.version.outputs.next }}"
+          body: |
+            Auto-bumps `MCP_SERVER_VERSION` (and the matching `server.json` MCP Registry listing) from `${{ steps.version.outputs.current }}` to `${{ steps.version.outputs.next }}` because `src/mcp-server.mjs`'s tool registry changed on main.
+          labels: |
+            automation

--- a/scripts/validate-client-sdk-sync.mjs
+++ b/scripts/validate-client-sdk-sync.mjs
@@ -14,6 +14,15 @@
 // changed versus the merge base BUT `packages/client/package.json` "version" did
 // NOT change, fail with a clear remediation message. It is diff-scoped, so a PR
 // that touches no contract file never fires — only contract changes are gated.
+//
+// The reverse case (a contributor manually bumps the version themselves) is
+// NOT a failure either -- the post-merge sync-client-version workflow does not
+// look at whether the version already moved, only whether a contract file
+// changed since its own last bump commit, so a hand-bump here is at best
+// redundant and at worst a merge conflict with that auto-opened PR. `main()`
+// emits a non-blocking notice for this case; enforcing it against contributor
+// PRs (vs. a maintainer's deliberate off-cycle bump) is a judgment call left to
+// the Gittensory Gate review, not this deterministic CI gate.
 
 import { execFileSync } from "node:child_process";
 import path from "node:path";
@@ -154,6 +163,13 @@ async function main() {
     console.log(
       `✓ Contract changed and packages/client "version" bumped ` +
         `(${baseVersion} → ${headVersion}) — client SDK in sync.`,
+    );
+    console.log(
+      `ℹ Note: this bump was unnecessary -- the post-merge sync-client-version ` +
+        `workflow bumps ${CLIENT_MANIFEST_PATH} automatically whenever a contract ` +
+        `file lands on main. A contributor PR should not hand-bump this; consider ` +
+        `reverting it to avoid a conflicting version once the auto-opened ` +
+        `chore/sync-client-version PR merges.`,
     );
   } else {
     console.log("✓ No contract files changed — client-SDK drift gate N/A.");


### PR DESCRIPTION
## Summary
- Adds `sync-mcp-version.yml`, mirroring `sync-client-version.yml`: a scheduled + dispatchable workflow that bumps `MCP_SERVER_VERSION` (`src/mcp-server.mjs`) and `server.json`'s version together whenever the MCP tool registry changes on main, so contributors never need to hand-edit either field.
- Extends `validate-client-sdk-sync.mjs` to also flag (non-blocking notice) when a contributor manually bumps `packages/client/package.json`'s version themselves — the automation doesn't check for a prior manual bump, so a hand-bump is redundant at best and a merge conflict with the auto-opened PR at worst.
- Documents both in the metagraphed skill reference.

## Test plan
- [x] `node scripts/validate-workflows.mjs` — 18 workflow files validated
- [x] `node scripts/validate-mcp.mjs` — 150 tools, internal consistency passes
- [x] `npx vitest run tests/validate-client-sdk-sync.test.mjs` — 9/9 pass, unchanged
- [x] `npx prettier --check` on all touched files
- [x] YAML syntax validated for the new workflow