### PR TITLE
feat(mcp): add list-query parity for list_endpoints

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -360,6 +360,14 @@ assert.ok(
   Array.isArray(surfacesPage.surfaces),
   "list_surfaces must return surfaces[]",
 );
+const endpointsPage = await callOk("list_endpoints", {
+  limit: 3,
+  pool_eligible: "true",
+});
+assert.ok(
+  Array.isArray(endpointsPage.endpoints),
+  "list_endpoints must return endpoints[]",
+);
 const searchIndexPage = await callOk("list_search_index", { limit: 3 });
 assert.ok(
   Array.isArray(searchIndexPage.documents),

--- a/src/endpoints-mcp.mjs
+++ b/src/endpoints-mcp.mjs
@@ -1,0 +1,304 @@
+// Network-wide endpoint list loader for MCP parity on GET /api/v1/endpoints.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/endpoints.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const ENDPOINTS_ARTIFACT = "/metagraph/endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const BOOLEAN_STRINGS = ["true", "false"];
+const ENDPOINTS_QUERY_FILTER_NAMES = [
+  "kind",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "status",
+];
+
+export function endpointsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw endpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw endpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalNumber(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw endpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function endpointsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/endpoints");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw endpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const poolEligible = optionalEnum(args, "pool_eligible", BOOLEAN_STRINGS);
+  if (poolEligible) url.searchParams.set("pool_eligible", poolEligible);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const minLatencyMs = optionalNumber(args, "min_latency_ms");
+  if (minLatencyMs !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatencyMs));
+  }
+  const maxLatencyMs = optionalNumber(args, "max_latency_ms");
+  if (maxLatencyMs !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatencyMs));
+  }
+  const minScore = optionalNumber(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalNumber(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw endpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadEndpointsList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = endpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw endpointsMcpError("not_found", "Endpoints catalog unavailable.");
+    }
+    throw endpointsMcpError(
+      code,
+      `Could not load ${ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw endpointsMcpError("not_found", "Endpoints catalog unavailable.");
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "endpoints",
+    ENDPOINTS_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw endpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.endpoints) ? data.endpoints : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_ENDPOINTS_INSTRUCTIONS =
+  "Use list_endpoints to page the network-wide monitored endpoint-resource " +
+  "catalog with REST list-query filters (kind, layer, netuid, provider, " +
+  "status, latency/score bounds, and pagination; mirrors GET /api/v1/endpoints), ";
+
+export const LIST_ENDPOINTS_MCP_TOOL = {
+  name: "list_endpoints",
+  title: "List monitored endpoint resources",
+  description:
+    "Fetch the network-wide catalog of generalized endpoint resources: every " +
+    "monitored public endpoint/surface across providers and subnets, each with " +
+    "its kind, layer, provider, subnet (netuid), publication state, and " +
+    "probe-derived status/latency/score. Filter by kind, layer, netuid, " +
+    "provider, publication_state, status, or pool_eligible; bound latency_ms " +
+    "and score with min_/max_ params; sort with sort + order; project with " +
+    "fields; and page with limit (1-100) / cursor. Distinct from " +
+    "get_subnet_endpoints (one subnet's raw artifact dump) and " +
+    "list_subnet_endpoints (one subnet's filtered list). Mirrors " +
+    "GET /api/v1/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'subnet-api' or 'openapi'.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Endpoint layer, e.g. 'subnet-app' or 'bittensor-base'.",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
+      },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'datura'.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Publication state, e.g. 'monitored' or 'pool-eligible'.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
+      },
+      pool_eligible: {
+        type: "string",
+        enum: BOOLEAN_STRINGS,
+        description: "Filter by whether the endpoint is pool-eligible.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Inclusive minimum probe latency in milliseconds.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Inclusive maximum probe latency in milliseconds.",
+      },
+      min_score: {
+        type: "number",
+        description: "Inclusive minimum probe score.",
+      },
+      max_score: {
+        type: "number",
+        description: "Inclusive maximum probe score.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -68,6 +68,12 @@ import {
   loadReviewEnrichmentTargetsList,
 } from "./review-enrichment-targets-mcp.mjs";
 import {
+  LIST_ENDPOINTS_INSTRUCTIONS,
+  LIST_ENDPOINTS_MCP_TOOL,
+  LIST_ENDPOINTS_OUTPUT_SCHEMA,
+  loadEndpointsList,
+} from "./endpoints-mcp.mjs";
+import {
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS,
   LIST_SUBNET_ENDPOINTS_MCP_TOOL,
   LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
@@ -792,8 +798,8 @@ export const MCP_INSTRUCTIONS =
   LIST_PROVIDERS_INSTRUCTIONS +
   LIST_SURFACES_INSTRUCTIONS +
   "list_candidates the " +
-  "unpromoted candidate surfaces still pending review, list_endpoints the " +
-  "network-wide monitored endpoint-resource catalog, " +
+  "unpromoted candidate surfaces still pending review, " +
+  LIST_ENDPOINTS_INSTRUCTIONS +
   LIST_EVIDENCE_INSTRUCTIONS +
   "list_rpc_endpoints the monitored " +
   "Bittensor RPC endpoint catalog, " +
@@ -1402,19 +1408,6 @@ function requireNetuid(args) {
 function optionalBoolean(args, key) {
   const value = args?.[key];
   if (value === undefined || value === null) return false;
-  if (typeof value !== "boolean") {
-    throw toolError("invalid_params", `Argument \`${key}\` must be a boolean.`);
-  }
-  return value;
-}
-
-// Unlike optionalBoolean (which defaults an absent flag to false), a tri-state
-// filter arg must distinguish "not provided, don't filter" (null) from an
-// explicit true/false, or an absent filter would wrongly narrow to only the
-// false-valued rows.
-function optionalNullableBoolean(args, key) {
-  const value = args?.[key];
-  if (value === undefined || value === null) return null;
   if (typeof value !== "boolean") {
     throw toolError("invalid_params", `Argument \`${key}\` must be a boolean.`);
   }
@@ -6269,100 +6262,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_endpoints",
-    title: "List monitored endpoint resources",
-    description:
-      "Fetch the network-wide catalog of generalized endpoint resources: every " +
-      "monitored public endpoint/surface across providers and subnets, each " +
-      "with its kind, layer, provider, subnet (netuid), publication state, and " +
-      "probe-derived status/latency/score. Use it to discover live endpoints " +
-      "network-wide. Optionally filter by kind/layer/netuid/provider/" +
-      "publication_state/status/pool_eligible and page with limit/offset — the " +
-      "full catalog can be large. Mirrors GET /api/v1/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.surfaceKind,
-          description: "Surface kind, e.g. 'subnet-api' or 'openapi'.",
-        },
-        layer: {
-          type: "string",
-          enum: QUERY_ENUMS.endpointLayer,
-          description: "Endpoint layer, e.g. 'subnet-app' or 'bittensor-base'.",
-        },
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        provider: {
-          type: "string",
-          description: "Provider slug, e.g. 'datura'.",
-        },
-        publication_state: {
-          type: "string",
-          enum: QUERY_ENUMS.endpointPublicationState,
-          description:
-            "Publication state, e.g. 'monitored' or 'pool-eligible'.",
-        },
-        status: {
-          type: "string",
-          enum: QUERY_ENUMS.healthStatus,
-          description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
-        },
-        pool_eligible: {
-          type: "boolean",
-          description: "Only endpoints eligible (or not) for RPC pooling.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max endpoints to return. Omit for the full list.",
-          minimum: 1,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...LIST_ENDPOINTS_MCP_TOOL,
     async handler(args, ctx) {
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
-      const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
-      const netuid = optionalNonNegativeInt(args, "netuid");
-      const provider = optionalString(args, "provider");
-      const publicationState = optionalEnum(
-        args,
-        "publication_state",
-        QUERY_ENUMS.endpointPublicationState,
-      );
-      const status = optionalEnum(args, "status", QUERY_ENUMS.healthStatus);
-      const poolEligible = optionalNullableBoolean(args, "pool_eligible");
-      const limit = optionalPositiveInt(args, "limit");
-      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
-      const data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
-      const all = Array.isArray(data.endpoints) ? data.endpoints : [];
-      const filtered = all.filter(
-        (e) =>
-          (kind === null || e.kind === kind) &&
-          (layer === null || e.layer === layer) &&
-          (netuid === null || e.netuid === netuid) &&
-          (provider === null || e.provider === provider) &&
-          (publicationState === null ||
-            e.publication_state === publicationState) &&
-          (status === null || e.status === status) &&
-          (poolEligible === null || e.pool_eligible === poolEligible),
-      );
-      const page =
-        limit === null
-          ? filtered.slice(offset)
-          : filtered.slice(offset, offset + limit);
-      return {
-        ...data,
-        endpoints: page,
-        total: filtered.length,
-        returned: page.length,
-        offset,
-      };
+      return loadEndpointsList(ctx, args);
     },
   },
   {
@@ -10188,16 +10090,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
-  list_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_endpoints: LIST_ENDPOINTS_OUTPUT_SCHEMA,
   get_subnet_surfaces: {
     type: "object",
     additionalProperties: true,

--- a/tests/endpoints-mcp.test.mjs
+++ b/tests/endpoints-mcp.test.mjs
@@ -1,0 +1,397 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  ENDPOINTS_ARTIFACT,
+  LIST_ENDPOINTS_INSTRUCTIONS,
+  LIST_ENDPOINTS_MCP_TOOL,
+  LIST_ENDPOINTS_OUTPUT_SCHEMA,
+  endpointsMcpError,
+  endpointsQueryUrl,
+  loadEndpointsList,
+} from "../src/endpoints-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  endpoints: [
+    {
+      netuid: 7,
+      kind: "subnet-api",
+      layer: "subnet-app",
+      provider: "datura",
+      publication_state: "monitored",
+      status: "ok",
+      latency_ms: 120,
+      score: 92,
+      pool_eligible: false,
+    },
+    {
+      netuid: 7,
+      kind: "openapi",
+      layer: "docs-provider",
+      provider: "chutes",
+      publication_state: "verified",
+      status: "degraded",
+      latency_ms: 450,
+      score: 70,
+      pool_eligible: false,
+    },
+    {
+      netuid: 12,
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "datura",
+      publication_state: "pool-eligible",
+      status: "ok",
+      latency_ms: 80,
+      score: 95,
+      pool_eligible: true,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("endpoints-mcp", () => {
+  test("endpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = endpointsMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("endpointsQueryUrl validates filters and cursor", () => {
+    const url = endpointsQueryUrl({
+      netuid: 7,
+      kind: "subnet-api",
+      layer: "subnet-app",
+      provider: "datura",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: "false",
+      min_latency_ms: 50,
+      max_latency_ms: 200,
+      min_score: 80,
+      max_score: 95,
+      sort: "latency_ms",
+      order: "asc",
+      fields: "netuid,kind",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("layer"), "subnet-app");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("min_latency_ms"), "50");
+    assert.equal(url.searchParams.get("max_score"), "95");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("endpointsQueryUrl rejects invalid netuid and kind", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects invalid layer and status", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ layer: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ provider: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ provider: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects invalid pool_eligible and publication_state", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ pool_eligible: "yes" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ publication_state: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects non-number min_latency_ms", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ min_latency_ms: "fast" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = endpointsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("endpointsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = endpointsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("endpointsQueryUrl rejects a fractional netuid and cursor", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = endpointsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadEndpointsList returns filtered rows with pagination meta", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact },
+      { kind: "openapi" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].provider, "chutes");
+  });
+
+  test("loadEndpointsList sorts and pages the collection", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact },
+      { sort: "score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadEndpointsList combines filters with AND semantics", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact },
+      { netuid: 7, status: "ok" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].provider, "datura");
+  });
+
+  test("loadEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            endpoints: [{ netuid: 0, kind: "docs", provider: "solo" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.endpoints[0].provider, "solo");
+  });
+
+  test("loadEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadEndpointsList projects row fields when requested", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact },
+      { netuid: 7, provider: "datura", fields: "netuid,provider" },
+    );
+    assert.deepEqual(out.endpoints[0], {
+      netuid: 7,
+      provider: "datura",
+    });
+  });
+
+  test("loadEndpointsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ netuid: 0, kind: "docs" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+  });
+
+  test("loadEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ netuid: 1 }, { netuid: 2 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadEndpointsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_ENDPOINTS_MCP_TOOL.name, "list_endpoints");
+    assert.match(LIST_ENDPOINTS_INSTRUCTIONS, /list_endpoints/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_ENDPOINTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_endpoints", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_endpoints/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List monitored endpoint resources");
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14182,6 +14182,70 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.returned, 0);
   });
 
+  test("list_endpoints returns filtered endpoint rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/endpoints.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        endpoints: [
+          {
+            netuid: 7,
+            kind: "subnet-api",
+            provider: "datura",
+            status: "ok",
+            pool_eligible: false,
+          },
+          {
+            netuid: 12,
+            kind: "subtensor-rpc",
+            provider: "datura",
+            status: "ok",
+            pool_eligible: true,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_endpoints",
+      { pool_eligible: "true", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].netuid, 12);
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("list_endpoints reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_endpoints", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Endpoints catalog unavailable/,
+    );
+  });
+
+  test("list_endpoints payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_endpoints",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/endpoints.json": {
+        endpoints: [
+          {
+            netuid: 7,
+            kind: "subnet-api",
+            provider: "datura",
+            status: "ok",
+          },
+        ],
+      },
+    });
+    const res = await callTool("list_endpoints", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoints returns the endpoints catalog artifact", async () => {
     const deps = makeDeps({
       "/metagraph/endpoints.json": {
@@ -14283,7 +14347,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(byStatus.total, 1);
 
     const byPoolEligible = (
-      await callTool("list_endpoints", { pool_eligible: true }, { deps })
+      await callTool("list_endpoints", { pool_eligible: "true" }, { deps })
     ).body.result.structuredContent;
     assert.equal(byPoolEligible.total, 1);
     assert.equal(byPoolEligible.endpoints[0].netuid, 12);
@@ -14302,18 +14366,19 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.endpoints[0].provider, "datura");
   });
 
-  test("list_endpoints paginates the filtered list with limit/offset", async () => {
+  test("list_endpoints paginates the filtered list with limit/cursor", async () => {
     const deps = endpointsDeps();
     const res = await callTool(
       "list_endpoints",
-      { limit: 1, offset: 1 },
+      { sort: "provider", order: "asc", limit: 1, cursor: 1 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 1);
-    assert.equal(out.offset, 1);
-    assert.equal(out.endpoints[0].provider, "chutes");
+    assert.equal(out.cursor, 1);
+    assert.equal(out.endpoints[0].provider, "datura");
+    assert.equal(out.endpoints[0].netuid, 7);
   });
 
   test("list_endpoints rejects an unknown kind/layer/publication_state/status enum value", async () => {
@@ -14347,7 +14412,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(badStatus.body.result.isError, true);
   });
 
-  test("list_endpoints rejects a non-boolean pool_eligible", async () => {
+  test("list_endpoints rejects an unknown pool_eligible enum value", async () => {
     const deps = endpointsDeps();
     const res = await callTool(
       "list_endpoints",


### PR DESCRIPTION
## Summary
- Upgrade `list_endpoints` from hand-rolled offset/limit filtering to full REST list-query parity via `applyQueryFilters`, mirroring `GET /api/v1/endpoints`.
- Add `src/endpoints-mcp.mjs` with sort, fields, latency/score range filters, and cursor pagination (`pool_eligible` as `"true"`/`"false"` strings per REST contract).
- Add 29 unit tests plus integration coverage (filter, not_found, outputSchema, cursor pagination) and a validate-mcp cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/endpoints-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_endpoints`


Made with [Cursor](https://cursor.com)