### PR TITLE
fix(ui): point omnibox/command-palette typeahead at the slim /search-index

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4107,10 +4107,13 @@ export const changelogQuery = () =>
 
 export const searchQuery = (q: string, limit = 20) =>
   queryOptions({
-    queryKey: k("search", q, limit),
+    queryKey: k("search-index", q, limit),
+    // Typeahead uses the slim /search-index (the same documents, ranking, and q/limit
+    // filtering as /search, but without the per-document token blobs) for a lighter,
+    // faster browser round-trip on every keystroke (#3490).
     queryFn: ({ signal }) =>
       fetchList<{ id: string; kind?: string; title?: string; url?: string }>(
-        "/api/v1/search",
+        "/api/v1/search-index",
         "documents",
         { q, limit },
         signal,


### PR DESCRIPTION
## What

Points the ⌘K command palette and nav omnibox typeahead at the slim `GET /api/v1/search-index` instead of the heavier `GET /api/v1/search`.

`/search-index` is the purpose-built slim variant: the **same documents, ranking, and `q`/`limit` filtering** as `/search`, just without the per-document token blobs. For typeahead — which fires a request on every keystroke — that's a lighter, faster browser round-trip with no behavioral change.

Verified against the live API that `/search-index?q=…&limit=…` returns byte-identical `documents` (same ids, titles, order) to `/search?q=…` across sample queries; the palette/omnibox only consume `{id, kind, title, url}`, all present on the slim index.

Closes #3490.

## How

- `apps/ui/src/lib/metagraphed/queries.ts`: `searchQuery` now fetches `/api/v1/search-index` (same `documents` collection, same `{q, limit}` params) and uses a distinct `search-index` query key so its cache doesn't collide with any full-`/search` usage.

Both consumers (`command-palette-body.tsx`, `nav-omnibox.tsx`) go through `searchQuery`, so both get the win from the one change. No response-shape changes, so no consumer edits needed.