### PR TITLE
feat(mcp): add list-query parity for list_profile_completeness

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -295,6 +295,14 @@ assert.ok(
   Array.isArray(adapterCandidatesPage.candidates),
   "list_adapter_candidates must return candidates[]",
 );
+const profileCompletenessPage = await callOk("list_profile_completeness", {
+  limit: 3,
+  identity_level: "partial",
+});
+assert.ok(
+  Array.isArray(profileCompletenessPage.profiles),
+  "list_profile_completeness must return profiles[]",
+);
 const enrichmentEvidencePage = await callOk("list_enrichment_evidence", {
   limit: 3,
   evidence_action: "replace-stale-evidence",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -44,6 +44,12 @@ import {
   loadEnrichmentQueueList,
 } from "./enrichment-queue-mcp.mjs";
 import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  loadProfileCompletenessList,
+} from "./profile-completeness-mcp.mjs";
+import {
   LIST_ADAPTER_CANDIDATES_INSTRUCTIONS,
   LIST_ADAPTER_CANDIDATES_MCP_TOOL,
   LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,
@@ -644,6 +650,7 @@ export const MCP_INSTRUCTIONS =
   LIST_GAPS_INSTRUCTIONS +
   LIST_ENRICHMENT_QUEUE_INSTRUCTIONS +
   LIST_ADAPTER_CANDIDATES_INSTRUCTIONS +
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS +
   LIST_ENRICHMENT_EVIDENCE_INSTRUCTIONS +
   LIST_REVIEW_GAPS_INSTRUCTIONS +
   LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS +
@@ -6395,24 +6402,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_profile_completeness",
-    title: "List subnet profile-completeness gaps",
-    description:
-      "Fetch the contributor review queue of subnet profile-completeness gaps: " +
-      "which subnets have incomplete public-safe profiles (missing identity, " +
-      "native name, confidence, or promotion signals) and are worth profile " +
-      "enrichment. Use it to find high-value profile contributions. Mirrors " +
-      "GET /api/v1/review/profile-completeness.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      return loadArtifactData(
-        ctx,
-        "/metagraph/review/profile-completeness.json",
-      );
+    ...LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadProfileCompletenessList(ctx, args);
     },
   },
   {
@@ -10254,16 +10246,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: ["string", "integer", "null"] },
     },
   },
-  list_profile_completeness: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      subnets: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
   list_rpc_endpoints: {
     type: "object",

--- a/src/profile-completeness-mcp.mjs
+++ b/src/profile-completeness-mcp.mjs
@@ -1,0 +1,270 @@
+// Profile completeness list loader for MCP parity on
+// GET /api/v1/review/profile-completeness. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/review/profile-completeness.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const PROFILE_COMPLETENESS_ARTIFACT =
+  "/metagraph/review/profile-completeness.json";
+
+const PROFILE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["profile-completeness"].sort_fields;
+const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
+const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"];
+
+export function profileCompletenessMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function profileCompletenessQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/profile-completeness");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const profileLevel = optionalEnum(args, "profile_level", PROFILE_LEVELS);
+  if (profileLevel) url.searchParams.set("profile_level", profileLevel);
+  const confidence = optionalEnum(args, "confidence", CONFIDENCE_LEVELS);
+  if (confidence) url.searchParams.set("confidence", confidence);
+  const identityLevel = optionalEnum(args, "identity_level", IDENTITY_LEVELS);
+  if (identityLevel) url.searchParams.set("identity_level", identityLevel);
+  const identityPromotionKinds = optionalEnum(
+    args,
+    "identity_promotion_kinds",
+    SURFACE_KINDS,
+  );
+  if (identityPromotionKinds) {
+    url.searchParams.set("identity_promotion_kinds", identityPromotionKinds);
+  }
+  const nativeNameQuality = optionalEnum(
+    args,
+    "native_name_quality",
+    NATIVE_NAME_QUALITIES,
+  );
+  if (nativeNameQuality) {
+    url.searchParams.set("native_name_quality", nativeNameQuality);
+  }
+  const sort = optionalEnum(args, "sort", PROFILE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadProfileCompletenessList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = profileCompletenessQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, PROFILE_COMPLETENESS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw profileCompletenessMcpError(
+        "not_found",
+        "Profile completeness snapshot unavailable.",
+      );
+    }
+    throw profileCompletenessMcpError(
+      code,
+      `Could not load ${PROFILE_COMPLETENESS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw profileCompletenessMcpError(
+      "not_found",
+      "Profile completeness snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "profile-completeness",
+    [],
+  );
+  if (transformed.error) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.profiles) ? data.profiles : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    summary: data.summary ?? null,
+    profiles: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_PROFILE_COMPLETENESS_INSTRUCTIONS =
+  "list_profile_completeness the contributor profile-completeness gap queue " +
+  "(profile_level, identity_level, and priority_score; mirrors " +
+  "GET /api/v1/review/profile-completeness), ";
+
+export const LIST_PROFILE_COMPLETENESS_MCP_TOOL = {
+  name: "list_profile_completeness",
+  title: "List subnet profile-completeness gaps",
+  description:
+    "Fetch the contributor review queue of subnet profile-completeness gaps: " +
+    "which subnets have incomplete public-safe profiles (missing identity, native " +
+    "name, confidence, or promotion signals) and are worth profile enrichment. " +
+    "Filter by netuid, profile_level, confidence, identity_level, " +
+    "identity_promotion_kinds, or native_name_quality; sort with sort + order; " +
+    "project with fields; and page with limit (1-100) / cursor. Mirrors " +
+    "GET /api/v1/review/profile-completeness.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      profile_level: {
+        type: "string",
+        enum: PROFILE_LEVELS,
+        description:
+          "Filter by profile level, e.g. 'identity-partial' or 'operational'.",
+      },
+      confidence: {
+        type: "string",
+        enum: CONFIDENCE_LEVELS,
+        description: "Filter by profile confidence.",
+      },
+      identity_level: {
+        type: "string",
+        enum: IDENTITY_LEVELS,
+        description: "Filter by identity completeness.",
+      },
+      identity_promotion_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose identity promotion kinds include this surface kind.",
+      },
+      native_name_quality: {
+        type: "string",
+        enum: NATIVE_NAME_QUALITIES,
+        description: "Filter by native on-chain name quality.",
+      },
+      sort: {
+        type: "string",
+        enum: PROFILE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of profile row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["profiles"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    summary: { type: ["object", "null"] },
+    profiles: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14500,22 +14500,178 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_profile_completeness returns filtered profile rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        profiles: [
+          {
+            netuid: 7,
+            name: "Allways",
+            profile_level: "identity-partial",
+            identity_level: "partial",
+            priority_score: 88,
+          },
+          {
+            netuid: 12,
+            name: "Compute",
+            profile_level: "operational",
+            identity_level: "complete",
+            priority_score: 40,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { identity_level: "partial", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.profiles[0].netuid, 7);
+    assert.equal(out.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("list_profile_completeness reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_profile_completeness",
+      {},
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Profile completeness snapshot unavailable/,
+    );
+  });
+
+  test("list_profile_completeness payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_profile_completeness",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        profiles: [
+          {
+            netuid: 7,
+            profile_level: "identity-partial",
+            priority_score: 50,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_profile_completeness returns the profile-completeness artifact", async () => {
     const deps = makeDeps({
       "/metagraph/review/profile-completeness.json": {
         generated_at: "2026-01-01T00:00:00Z",
-        subnets: [{ netuid: 7, profile_level: "partial" }],
+        profiles: [
+          { netuid: 7, profile_level: "identity-partial", priority_score: 50 },
+        ],
       },
     });
     const res = await callTool("list_profile_completeness", {}, { deps });
     const out = res.body.result.structuredContent;
-    assert.equal(out.subnets[0].netuid, 7);
+    assert.equal(out.profiles[0].netuid, 7);
     assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
   });
 
-  test("list_profile_completeness rejects an unexpected argument", async () => {
-    const res = await callTool("list_profile_completeness", { netuid: 7 });
+  test("list_profile_completeness filters by netuid and profile_level", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        profiles: [
+          {
+            netuid: 7,
+            profile_level: "identity-partial",
+            priority_score: 88,
+          },
+          {
+            netuid: 12,
+            profile_level: "operational",
+            priority_score: 40,
+          },
+        ],
+      },
+    });
+    const byNetuid = (
+      await callTool("list_profile_completeness", { netuid: 12 }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byNetuid.total, 1);
+    assert.equal(byNetuid.profiles[0].netuid, 12);
+
+    const byLevel = (
+      await callTool(
+        "list_profile_completeness",
+        { profile_level: "identity-partial" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byLevel.total, 1);
+    assert.equal(byLevel.profiles[0].netuid, 7);
+  });
+
+  test("list_profile_completeness paginates the filtered list with limit/cursor", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        profiles: [
+          { netuid: 7, name: "Alpha", priority_score: 90 },
+          { netuid: 12, name: "Beta", priority_score: 80 },
+          { netuid: 19, name: "Gamma", priority_score: 70 },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { sort: "name", order: "asc", limit: 1, cursor: 1 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 1);
+    assert.equal(out.cursor, 1);
+    assert.equal(out.profiles[0].name, "Beta");
+  });
+
+  test("list_profile_completeness rejects an unknown profile_level enum value", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        profiles: [{ netuid: 7, profile_level: "identity-partial" }],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { profile_level: "partial" },
+      { deps },
+    );
     assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
+  test("list_profile_completeness rejects an unexpected argument", async () => {
+    const res = await callTool("list_profile_completeness", { bogus: 1 });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("list_profile_completeness is schema-stable when the artifact has no profiles array", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+      },
+    });
+    const res = await callTool("list_profile_completeness", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.profiles, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
   });
 
   test("list_rpc_pools returns the rpc pools artifact", async () => {

--- a/tests/profile-completeness-mcp.test.mjs
+++ b/tests/profile-completeness-mcp.test.mjs
@@ -1,0 +1,364 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  PROFILE_COMPLETENESS_ARTIFACT,
+  loadProfileCompletenessList,
+  profileCompletenessMcpError,
+  profileCompletenessQueryUrl,
+} from "../src/profile-completeness-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  summary: { profile_count: 2 },
+  profiles: [
+    {
+      netuid: 7,
+      name: "Allways",
+      profile_level: "identity-partial",
+      identity_level: "partial",
+      confidence: "medium",
+      priority_score: 88,
+    },
+    {
+      netuid: 12,
+      name: "Compute",
+      profile_level: "operational",
+      identity_level: "complete",
+      confidence: "high",
+      priority_score: 40,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === PROFILE_COMPLETENESS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("profile-completeness-mcp", () => {
+  test("profileCompletenessMcpError is shaped for MCP toolError handling", () => {
+    const err = profileCompletenessMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("profileCompletenessQueryUrl validates filters and cursor", () => {
+    const url = profileCompletenessQueryUrl({
+      netuid: 7,
+      profile_level: "identity-partial",
+      confidence: "medium",
+      identity_level: "partial",
+      identity_promotion_kinds: "openapi",
+      native_name_quality: "chain",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,priority_score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("profile_level"), "identity-partial");
+    assert.equal(url.searchParams.get("identity_level"), "partial");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid netuid and profile_level", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ profile_level: "partial" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid confidence and identity_level", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ confidence: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ identity_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid promotion kinds and native_name_quality", () => {
+    assert.throws(
+      () =>
+        profileCompletenessQueryUrl({ identity_promotion_kinds: "not-a-kind" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ native_name_quality: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects empty fields and invalid sort", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid order", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl rejects a fractional netuid and cursor", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl clamps limit above the MCP maximum", () => {
+    const url = profileCompletenessQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadProfileCompletenessList returns filtered rows with pagination meta", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { identity_level: "partial" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.profiles[0].netuid, 7);
+  });
+
+  test("loadProfileCompletenessList sorts and pages the collection", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadProfileCompletenessList combines filters with AND semantics", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { netuid: 7, profile_level: "identity-partial" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.profiles[0].name, "Allways");
+  });
+
+  test("loadProfileCompletenessList uses an injected readArtifact dep", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            profiles: [{ netuid: 99, profile_level: "operational" }],
+          },
+        }),
+      },
+    );
+    assert.equal(out.profiles[0].netuid, 99);
+  });
+
+  test("loadProfileCompletenessList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /profile-completeness\.json/.test(err.message),
+    );
+  });
+
+  test("loadProfileCompletenessList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProfileCompletenessList projects row fields when requested", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { netuid: 7, fields: "netuid,priority_score" },
+    );
+    assert.deepEqual(out.profiles[0], {
+      netuid: 7,
+      priority_score: 88,
+    });
+  });
+
+  test("loadProfileCompletenessList omits nullable artifact metadata when absent", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: [{ netuid: 0 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadProfileCompletenessList treats a non-array profiles key as empty", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.profiles, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadProfileCompletenessList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { profiles: [{ netuid: 1 }, { netuid: 2 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadProfileCompletenessList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadProfileCompletenessList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_PROFILE_COMPLETENESS_MCP_TOOL.name,
+      "list_profile_completeness",
+    );
+    assert.match(
+      LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+      /list_profile_completeness/,
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_profile_completeness", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_profile_completeness/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_profile_completeness");
+    assert.ok(tool);
+    assert.equal(tool.title, "List subnet profile-completeness gaps");
+  });
+});


### PR DESCRIPTION
## Summary
- Upgrade `list_profile_completeness` from a zero-arg artifact dump to full REST list-query parity via `applyQueryFilters`, mirroring `GET /api/v1/review/profile-completeness`.
- Add `src/profile-completeness-mcp.mjs` with filters (netuid, profile_level, confidence, identity_level, identity_promotion_kinds, native_name_quality), sort, fields, and cursor pagination; response uses `profiles[]` per the artifact/REST contract.
- Add 27 unit tests plus integration coverage (filter, not_found, outputSchema, cursor pagination, enum validation) and a validate-mcp cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/profile-completeness-mcp.test.mjs`
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_profile_completeness`


Made with [Cursor](https://cursor.com)