### PR TITLE
fix(concentration): reject blank stake cells without phantom counts

### DIFF
--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -50,6 +50,29 @@ function raoBigToTao(rao) {
   return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
 }
 
+// A finite TAO cell, or null when absent/blank/non-numeric. Blank D1 cells coerce via
+// Number("") → 0; skip those rows rather than fabricating zero-stake neurons or
+// phantom controlling entities (mirrors chain-yield.mjs / subnet-yield.mjs).
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+// Rows that carry a known stake_tao cell — the population every concentration lens
+// and neuron/entity count is measured over (junk rows and blank-stake cells drop out).
+function stakeAcceptedRows(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const accepted = [];
+  for (const row of list) {
+    if (row == null || typeof row !== "object") continue;
+    if (nullableTao(row?.stake_tao) == null) continue;
+    accepted.push(row);
+  }
+  return accepted;
+}
+
 function epochMsStamp(ms) {
   if (!Number.isFinite(ms) || ms <= 0) return null;
   const date = new Date(ms);
@@ -227,10 +250,11 @@ function groupByEntity(rows) {
 // Null-safe on junk/sparse rows — an empty array yields a schema-stable zero
 // (every metric block null).
 export function buildConcentration(rows, netuid) {
-  const list = Array.isArray(rows) ? rows : [];
+  const rawList = Array.isArray(rows) ? rows : [];
+  const list = stakeAcceptedRows(rawList);
   // The rows share one cron capture, but don't assume an order — take the newest.
   let capturedAt = null;
-  for (const row of list) {
+  for (const row of rawList) {
     const captured = captureStamp(row?.captured_at);
     if (captured && (capturedAt == null || captured.ms > capturedAt.ms)) {
       capturedAt = captured;
@@ -274,15 +298,18 @@ export const CHAIN_CONCENTRATION_READ_COLUMNS =
 // snapshot spans. Null-safe: an empty array yields a schema-stable zero (every
 // metric block null), matching buildConcentration.
 export function buildChainConcentration(rows) {
-  const list = Array.isArray(rows) ? rows : [];
+  const rawList = Array.isArray(rows) ? rows : [];
+  const list = stakeAcceptedRows(rawList);
   // One cron capture underlies the rows, but don't assume order — take the newest.
   let capturedAt = null;
   const netuids = new Set();
-  for (const row of list) {
+  for (const row of rawList) {
     const captured = captureStamp(row?.captured_at);
     if (captured && (capturedAt == null || captured.ms > capturedAt.ms)) {
       capturedAt = captured;
     }
+  }
+  for (const row of list) {
     const rawNetuid = row?.netuid;
     if (rawNetuid != null) {
       // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.

--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -251,7 +251,7 @@ function groupByEntity(rows) {
 // (every metric block null).
 export function buildConcentration(rows, netuid) {
   const rawList = Array.isArray(rows) ? rows : [];
-  const list = stakeAcceptedRows(rawList);
+  const list = stakeAcceptedRows(rows);
   // The rows share one cron capture, but don't assume an order — take the newest.
   let capturedAt = null;
   for (const row of rawList) {
@@ -299,7 +299,7 @@ export const CHAIN_CONCENTRATION_READ_COLUMNS =
 // metric block null), matching buildConcentration.
 export function buildChainConcentration(rows) {
   const rawList = Array.isArray(rows) ? rows : [];
-  const list = stakeAcceptedRows(rawList);
+  const list = stakeAcceptedRows(rows);
   // One cron capture underlies the rows, but don't assume order — take the newest.
   let capturedAt = null;
   const netuids = new Set();

--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -146,6 +146,16 @@ describe("buildChainConcentration", () => {
     assert.equal(out.subnet_count, 1); // still only subnet 5
   });
 
+  test("subnet_count ignores skipped blank-stake rows", () => {
+    const out = buildChainConcentration([
+      { stake_tao: "", coldkey: "a", netuid: 12 },
+      { stake_tao: "   ", coldkey: "b", netuid: 99 },
+      { stake_tao: 10, coldkey: "c", netuid: 7 },
+    ]);
+    assert.equal(out.subnet_count, 1);
+    assert.equal(out.neuron_count, 1);
+  });
+
   test("counts root subnet (netuid 0) when explicitly present", () => {
     const out = buildChainConcentration([
       { stake_tao: 1, coldkey: "a", netuid: 0 },

--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -192,6 +192,7 @@ describe("buildChainConcentration", () => {
     const out = buildChainConcentration([
       null,
       "nope",
+      42,
       {
         stake_tao: 10,
         emission_tao: 1,

--- a/tests/concentration.test.mjs
+++ b/tests/concentration.test.mjs
@@ -196,6 +196,20 @@ describe("buildConcentration", () => {
     assert.equal(data.emission.total, 1);
   });
 
+  test("reject negative, non-numeric, and missing stake_tao cells", () => {
+    const data = buildConcentration(
+      [
+        { stake_tao: 10, coldkey: "ck-a" },
+        { stake_tao: -1, coldkey: "ck-b" },
+        { stake_tao: "abc", coldkey: "ck-c" },
+        { coldkey: "ck-d" },
+      ],
+      7,
+    );
+    assert.equal(data.neuron_count, 1);
+    assert.equal(data.entity_count, 1);
+  });
+
   test("converts D1 epoch-millisecond captured_at values to ISO strings", () => {
     const data = buildConcentration(
       [

--- a/tests/concentration.test.mjs
+++ b/tests/concentration.test.mjs
@@ -177,6 +177,25 @@ describe("buildConcentration", () => {
     assert.equal(data.entity_stake.holders, 3);
   });
 
+  test("reject blank stake_tao cells that coerce to 0 (not phantom neurons/entities)", () => {
+    const data = buildConcentration(
+      [
+        { stake_tao: 10, emission_tao: 1, coldkey: "ck-a" },
+        { stake_tao: "", emission_tao: 2, coldkey: "ck-b" },
+        { stake_tao: "   ", emission_tao: 3, coldkey: "ck-c" },
+        { stake_tao: null, emission_tao: 4, coldkey: "ck-d" },
+      ],
+      7,
+    );
+    assert.equal(data.neuron_count, 1);
+    assert.equal(data.entity_count, 1);
+    assert.equal(data.stake.holders, 1);
+    assert.equal(data.stake.total, 10);
+    // Blank-stake rows must not inflate the emission lens either.
+    assert.equal(data.emission.holders, 1);
+    assert.equal(data.emission.total, 1);
+  });
+
   test("converts D1 epoch-millisecond captured_at values to ISO strings", () => {
     const data = buildConcentration(
       [
@@ -221,14 +240,16 @@ describe("buildConcentration", () => {
   test("tolerates rows missing captured_at / value columns", () => {
     const data = buildConcentration(
       [
-        { stake_tao: 8 },
-        { emission_tao: 2, captured_at: "2026-06-26T03:00:00Z" },
+        { stake_tao: 8, emission_tao: 2 },
+        { emission_tao: 3, captured_at: "2026-06-26T03:00:00Z" },
       ],
       1,
     );
     assert.equal(data.captured_at, "2026-06-26T03:00:00Z");
+    assert.equal(data.neuron_count, 1);
     assert.equal(data.stake.holders, 1);
     assert.equal(data.emission.holders, 1);
+    assert.equal(data.emission.total, 2);
   });
 });
 


### PR DESCRIPTION
## Summary
- Skip rows with absent/blank/non-numeric `stake_tao` before measuring concentration lenses and neuron/entity counts, mirroring the merged chain-yield blank-cell guard in #3525.
- Track `subnet_count` in `buildChainConcentration` only from stake-validated rows so blank-stake rows cannot inflate network subnet coverage.

Replaces #3529 (auto-closed on codecov/patch); adds branch-coverage tests for invalid stake rows and non-object junk entries.

## Test plan
- [x] `npx vitest run tests/concentration.test.mjs tests/chain-concentration.test.mjs`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)