### PR TITLE
docs: document version-bump automation for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,10 @@ process evolves — edits to those files improve both Claude Code and Codex.
    `npm run build`, commit the regenerated `openapi.json` + generated types in the same PR, or
    `validate:contract-drift` fails CI. Never hand-edit generated artifacts under `public/`. Do **not**
    bump `packages/client/package.json` in your PR — the `sync-client-version` workflow handles that
-   post-merge. MCP tool additions do **not** require a server-card regen (it's worker-computed).
+   post-merge. Likewise, do **not** hand-bump `MCP_SERVER_VERSION` (`src/mcp-server.mjs`) or
+   `server.json`'s `"version"` — `sync-mcp-version` bumps both automatically after a tool-registry
+   change lands on main. MCP tool additions do **not** require a server-card regen (it's
+   worker-computed).
 5. **House rules:** Conventional Commits, **no AI/Claude/agent attribution** in commits or PR text; no
    secrets / PATs / wallet paths / private URLs anywhere; health/uptime/latency is **probe-derived
    only** (never hand-set); one focused change per PR. **UI/frontend work now lives in this repo**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,15 @@ The contract is generated, so you never edit it by hand:
 
 Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the source of truth; everything downstream follows.
 
+## Don't hand-bump version fields
+
+These are bumped automatically after your PR merges — leave them alone:
+
+- `packages/client/package.json`'s `"version"`.
+- `src/mcp-server.mjs`'s `MCP_SERVER_VERSION` and the matching `"version"` in `server.json`.
+
+CI never requires you to bump these yourself — a PR that changes the contract or adds an MCP tool is valid without touching either. Bumping one of them in your own PR doesn't help and risks a version conflict with the automation's own follow-up PR; expect it to be closed with a request to resubmit without that edit.
+
 ## Where to start
 
 - **Enrich a subnet** (the best first PR) — we track one scoped task per subnet under the [surface-enrichment epic #427](https://github.com/JSONbored/metagraphed/issues/427). Browse [`good first issue`](https://github.com/JSONbored/metagraphed/labels/good%20first%20issue) + [`help wanted`](https://github.com/JSONbored/metagraphed/labels/help%20wanted): pick a subnet, find its real public API / OpenAPI / data artifact, and add it as a surface on the subnet's file ([Community submissions](#community-submissions) below). Each issue links the `surface:add` command and flags `subnet:new` when the subnet file does not exist yet.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,8 +35,12 @@ is listed in three registries. **Run these after changing MCP tools / prompts /
 resources or `server.json` metadata** so the listings reflect the live server:
 
 1. **Canonical** — `registry.modelcontextprotocol.io`
-   - First **bump `version` in `server.json`** (the registry rejects re-publishing
-     an existing version).
+   - `sync-mcp-version.yml` bumps `server.json`'s `version` (and the matching
+     `MCP_SERVER_VERSION`) automatically once a tool-registry change lands on
+     main, so it's normally already ahead of the last-published version by the
+     time you run this. If it isn't (e.g. a metadata-only `server.json` edit
+     the automation doesn't watch), bump `version` in `server.json` yourself
+     first — the registry rejects re-publishing an existing version.
    - Actions → **Publish MCP Registry** (`publish-mcp-registry.yml`). GitHub OIDC,
      no secret.
 2. **Smithery** — `smithery.ai/servers/metagraphed/metagraphed`

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -40,11 +40,15 @@ door; the server-card remains the authoritative, always-current description.
 
 ### Re-publishing / version bumps
 
-The registry **rejects a re-publish of an existing `version`**. To ship a
-change, bump `version` in `server.json` (it is an independent listing version —
-not the live `serverInfo.version`, which tracks the API contract) and re-run the
-workflow. Editing `server.json` without bumping the version will fail the
-publish step, by design.
+The registry **rejects a re-publish of an existing `version`**. `server.json`'s
+`version` must equal the live `MCP_SERVER_VERSION` / `serverInfo.version` —
+`scripts/validate-mcp.mjs` enforces this in CI, so the three can't drift apart.
+The [`sync-mcp-version`](../.github/workflows/sync-mcp-version.yml) workflow
+keeps `server.json` bumped in lockstep with `MCP_SERVER_VERSION` automatically
+whenever the tool registry changes on main, so by the time you dispatch this
+publish workflow `server.json` is normally already ahead of the last-published
+`version` — just run it. Editing `server.json` without bumping the version
+will fail the publish step, by design.
 
 ## Verifying a published listing
 


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` and `AGENTS.md` had no mention that `MCP_SERVER_VERSION`, `server.json`'s version, and `packages/client/package.json`'s version are now bumped automatically post-merge (#3530) -- contributors had no way to know not to hand-edit them. Adds a plain "don't hand-bump" note to both.
- Fixes stale prose in `docs/mcp-registry.md` claiming `server.json`'s version is independent of `serverInfo.version` -- `scripts/validate-mcp.mjs` has enforced their equality since #393, predating this PR; the doc never caught up.
- Updates `RELEASING.md`'s MCP publish runbook so the manual-bump step reads as the override path (automation normally keeps it pre-bumped), not the primary instruction.

## Test plan
- [x] `npx prettier --check` on all four touched files
- [x] `node scripts/validate-mcp.mjs` -- 150 tools, invariant still holds
- [x] `node scripts/validate-workflows.mjs` -- 18 workflow files validated
- [x] Docs-only change, no code/schema/contract touched