### PR TITLE
feat(registry): add SN59 Babelbit /health subnet-api surface

### DIFF
--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -30,6 +30,25 @@
         "https://api.babelbit.ai/docs"
       ],
       "url": "https://api.babelbit.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-59-babelbit-health",
+      "kind": "subnet-api",
+      "name": "Babelbit utterance engine health",
+      "notes": "Public no-auth GET /health on api.babelbit.ai returning utterance-engine liveness JSON (observed: {\"status\":\"healthy\",...}). Documented in the registered OpenAPI schema on the same host; distinct from validator-authenticated challenge endpoints.",
+      "provider": "babelbit",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.babelbit.ai/openapi.json",
+        "https://github.com/babelbit/babelbit_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.babelbit.ai/health"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Append `sn-59-babelbit-health` subnet-api surface for public GET `/health` on `api.babelbit.ai`
- Live probe returns `{"status":"healthy",...}` (application/json, no auth); path is documented in the registered OpenAPI schema on the same host

Refs #464

## Why
SN59 already has the utterance-engine OpenAPI surface (#2471 / #464), but the registry still lacked a promoted no-auth subnet-api endpoint. The OpenAPI spec lists `/health` under `public_endpoints` alongside `/` and `/docs`.

## Conflict notes
Merge-simulated clean against open PRs (#3539, #3331, #3326, #3312, #3292, #3244, #3153). Touches only `registry/subnets/babelbit.json` with no overlap on other registry files.

## Test plan
- [x] `npm run validate:surface -- registry/subnets/babelbit.json`
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://api.babelbit.ai/health` → 200 JSON `{"status":"healthy",...}`

Made with [Cursor](https://cursor.com)