### PR TITLE
feat(registry): add SN59 Babelbit /health subnet-api surface

### DIFF
--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -30,6 +30,25 @@
         "https://api.babelbit.ai/docs"
       ],
       "url": "https://api.babelbit.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-59-babelbit-health",
+      "kind": "subnet-api",
+      "name": "Babelbit utterance engine health",
+      "notes": "Public no-auth GET /health on api.babelbit.ai returning utterance-engine liveness JSON (observed: {\"status\":\"healthy\",\"active_sessions\":{\"source_audio\":N,\"target_audio\":N,\"solo\":N}}). The API root advertises /health under public_endpoints and the official babelbit_subnet README documents it (\"arena health checks expect GET /health\"); it is a no-security GET in the OpenAPI schema. Served on the same host as the existing openapi surface.",
+      "provider": "babelbit",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "e11734937-beep"
+      },
+      "source_urls": [
+        "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
+        "https://api.babelbit.ai/openapi.json"
+      ],
+      "url": "https://api.babelbit.ai/health"
     }
   ]
 }


### PR DESCRIPTION
## What
Adds the public no-auth `GET /health` surface for **SN59 (Babelbit)** to its existing registry entry (which already carries the OpenAPI surface).

## Evidence it is a real, public-safe surface
- **Live:** `GET https://api.babelbit.ai/health` returns utterance-engine liveness JSON, e.g. `{"status":"healthy","active_sessions":{"source_audio":19,"target_audio":0,"solo":0}}`.
- **Documented:** it is a no-security `GET` in the subnet OpenAPI schema (`https://api.babelbit.ai/openapi.json`), and the official `babelbit/babelbit_subnet` README documents it (arena health checks expect `GET /health`).
- Served on the same host as the already-registered OpenAPI surface; `public_safe: true`, `auth_required: false`.

Follows the format of the existing surface entries. Local validation passes: `validate:schemas`, `validate:surface`, `validate:committed-seed`, `validate:api`, `validate:private-boundary`.
