### PR TITLE
feat(registry): add SN97 Albedo King Chat /health subnet-api surface

### DIFF
--- a/registry/subnets/albedo.json
+++ b/registry/subnets/albedo.json
@@ -46,6 +46,25 @@
         "https://github.com/unarbos/albedo/blob/main/website/js/config.js"
       ],
       "url": "https://s3.hippius.com/albedo/data/dashboard.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-97-albedo-health",
+      "kind": "subnet-api",
+      "name": "Albedo King Chat health",
+      "notes": "Public no-auth GET /health on chat.albedo.tech returning King Chat gateway liveness JSON (observed: {\"status\":true}). Documented as GET /health in chat_to_king/gateway.py on the same host as the existing config subnet-api surface.",
+      "provider": "albedo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/unarbos/albedo/blob/main/chat_to_king/gateway.py#L195-L197",
+        "https://github.com/unarbos/albedo/blob/main/website/index.html"
+      ],
+      "url": "https://chat.albedo.tech/health"
     }
   ]
 }


### PR DESCRIPTION
Closes #427

## Summary
- Append `sn-97-albedo-health` subnet-api surface for public GET `/health` on `chat.albedo.tech`
- Live probe returns `{"status":true}` (no auth) on the same host as the existing config API
- Source-backed via `chat_to_king/gateway.py` (`@app.get("/health")`) and first-party website link to `chat.albedo.tech`

## Scope discipline
Single-file change: `registry/subnets/albedo.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3538, #3537, #3536, #3534, #3331, #3326, #3312, #3292, #3244, #3153. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://chat.albedo.tech/health` → 200 JSON

Made with [Cursor](https://cursor.com)