### PR TITLE
feat(registry): add SN82 Compelle /api/health subnet-api surface

### DIFF
--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -1,69 +1,88 @@
 {
-  "schema_version": 1,
-  "netuid": 82,
-  "name": "Compelle",
-  "slug": "sn-82",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/compelle/compelle-validator",
-  "dashboard_url": "https://taomarketcap.com/subnets/82",
-  "website_url": "https://compelle.com/",
-  "notes": "Reviewed overlay for SN82 using the official Compelle website and validator repository.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T10:10:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/82",
+  "name": "Compelle",
+  "netuid": 82,
+  "notes": "Reviewed overlay for SN82 using the official Compelle website and validator repository.",
+  "schema_version": 1,
+  "slug": "sn-82",
+  "source_repo": "https://github.com/compelle/compelle-validator",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-82-compelle-website",
-      "name": "Compelle website",
-      "kind": "website",
-      "url": "https://compelle.com/",
-      "provider": "compelle",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "id": "sn-82-compelle-website",
+      "kind": "website",
+      "name": "Compelle website",
+      "notes": "Official Compelle website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Compelle website."
+      "provider": "compelle",
+      "public_safe": true,
+      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "url": "https://compelle.com/"
     },
     {
-      "id": "sn-82-compelle-source",
-      "name": "Compelle validator repository",
-      "kind": "source-repo",
-      "url": "https://github.com/compelle/compelle-validator",
-      "provider": "compelle",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "id": "sn-82-compelle-source",
+      "kind": "source-repo",
+      "name": "Compelle validator repository",
+      "notes": "Official Compelle validator repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Compelle validator repository."
+      "provider": "compelle",
+      "public_safe": true,
+      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "url": "https://github.com/compelle/compelle-validator"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-82-compelle-health",
+      "kind": "subnet-api",
+      "name": "Compelle public aggregation health",
+      "notes": "Public no-auth GET /api/health on compelle.com returning subnet aggregation liveness JSON (observed: {\"ok\":true,\"games\":...,\"miners\":...}). Served on the official SN82 website host alongside the public debate arena; validators POST epoch results to the aggregation pipeline documented in compelle-validator.",
+      "provider": "compelle",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://compelle.com/",
+        "https://github.com/compelle/compelle-validator"
+      ],
+      "url": "https://compelle.com/api/health"
     }
-  ]
+  ],
+  "website_url": "https://compelle.com/"
 }


### PR DESCRIPTION
## Summary
- Append `sn-82-compelle-health` subnet-api surface for public GET `/api/health` on `compelle.com`
- Live probe returns `{"ok":true,"db_size_bytes":...,"games":...,"miners":...}` (application/json, no auth)

Closes #685

## Why
SN82 Compelle runs a public debate arena on compelle.com (netuid 82). The `/api/health` endpoint exposes aggregation-service liveness stats and is reachable without credentials. The official website and validator repository confirm SN82 identity; validators push epoch results to the public aggregation pipeline per the README.

## Conflict notes
Merge-simulated clean against open PRs (#3544, #3541, #3331, #3326, #3312, #3292, #3244, #3153). Touches only `registry/subnets/compelle.json`.

## Test plan
- [x] `npm run validate:surface -- registry/subnets/compelle.json`
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://compelle.com/api/health` → 200 JSON `{"ok":true,...}`

Made with [Cursor](https://cursor.com)