### PR TITLE
feat(registry): add SN106 Nodexo /api/health subnet-api surface

### DIFF
--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -116,6 +116,25 @@
         "submitted_by": "seekmistar01"
       },
       "notes": "Public Nodexo (SN106) GPU marketplace inventory API. Returns live JSON offers with GPU model, VRAM, pricing (USDC/hour), availability, and reliability metrics. No auth required."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-106-nodexo-health",
+      "kind": "subnet-api",
+      "name": "Nodexo app health",
+      "notes": "Public no-auth GET /api/health on nodexo.ai returning app liveness JSON with database, redis, and validator checks (observed: {\"ok\":true,\"service\":\"nodexo-app\",...}). Served on the same host as the existing inventory subnet-api surface.",
+      "provider": "nodexo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/nodexo-ai/nodexo",
+        "https://nodexo.ai/"
+      ],
+      "url": "https://nodexo.ai/api/health"
     }
   ]
 }


### PR DESCRIPTION
Closes #956

## Summary
- Append `sn-106-nodexo-health` subnet-api surface for public GET `/api/health` on `nodexo.ai`
- Live probe returns `{"ok":true,"service":"nodexo-app",...}` with database/redis/validator checks (no auth)
- Same host as the existing inventory subnet-api surface

## Scope discipline
Single-file change: `registry/subnets/nodexo.json` only.

## Conflict notes
Merge-simulated clean against open PRs #3545, #3331, #3312, #3292, #3244, #3153. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://nodexo.ai/api/health` → 200 JSON

Made with [Cursor](https://cursor.com)