### PR TITLE
feat(registry): enrich SN94 Bitsota — dashboard snapshot API

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -83,6 +83,31 @@
         "https://bitsota.ai/docs/autoresearch-backend-routes"
       ],
       "url": "https://autoresearch.bitsota.com/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-dashboard-api",
+      "kind": "subnet-api",
+      "name": "Bitsota dashboard snapshot API",
+      "notes": "Public no-auth GET returning an aggregate dashboard snapshot (task counts, active claims, submission and verification pipeline totals). Documented in the subnet's own OpenAPI (autoresearch.bitsota.com/openapi.json, path /api/v1/dashboard); same host as the existing tasks and idea-rewards surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://autoresearch.bitsota.com/openapi.json",
+        "https://bitsota.ai/docs/autoresearch-backend-routes"
+      ],
+      "url": "https://autoresearch.bitsota.com/api/v1/dashboard"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Single-file registry enrichment for **SN94 Bitsota** (`registry/subnets/bitsota.json`).

Adds the public no-auth **GET `/api/v1/dashboard`** endpoint — aggregate dashboard snapshot with task counts, active claims, and submission/verification pipeline totals. Documented in the subnet's own OpenAPI at `autoresearch.bitsota.com/openapi.json`.

## Checklist

- [x] **Exactly 1 file changed** — `registry/subnets/bitsota.json` only (+25 lines append)
- [x] **Substantive functional endpoint** — not a health/liveness probe
- [x] **Live probe** — `curl -sS https://autoresearch.bitsota.com/api/v1/dashboard` → HTTP 200 JSON
- [x] **No sensitive wording** in notes or new manifest text
- [x] `npm run validate:surface -- registry/subnets/bitsota.json` — passed
- [x] `npm run scan:public-safety` — passed

## Conflict avoidance

This PR touches only `bitsota.json`. No overlap with currently open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3547 Nodexo /api/health | `nodexo.json` only |
| #3546 readme catalog | `README.md` only |

Should merge cleanly after any/all of the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes

Closes #594 

Made with [Cursor](https://cursor.com)