### PR TITLE
feat(registry): add SN82 Compelle /api/health subnet-api surface

### DIFF
--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -64,6 +64,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Compelle validator repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-82-compelle-health",
+      "kind": "subnet-api",
+      "name": "Compelle aggregation health",
+      "notes": "Public no-auth GET /api/health on compelle.com returning aggregation-service liveness JSON (observed: {\"ok\":true,\"db_size_bytes\":...,\"games\":...,\"miners\":...}). Served on the official Compelle SN82 debate arena host linked from the validator repository.",
+      "provider": "compelle",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/compelle/compelle-validator",
+        "https://compelle.com/"
+      ],
+      "url": "https://compelle.com/api/health"
     }
   ]
 }


### PR DESCRIPTION
Closes #685

## Summary
- Append `sn-82-compelle-health` subnet-api surface for public GET `/api/health` on `compelle.com`
- Live probe returns `{"ok":true,"db_size_bytes":...,"games":...,"miners":...}` (application/json, no auth)
- Official SN82 debate arena aggregation host linked from the validator repository

## Scope discipline
Single-file change: `registry/subnets/compelle.json` only (append-only).

## Conflict notes
Merge-simulated clean against open PRs #3549, #3546. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://compelle.com/api/health` → 200 JSON

Made with [Cursor](https://cursor.com)