### PR TITLE
feat(registry): enrich SN36 Eirel — current run API

### DIFF
--- a/registry/subnets/eirel.json
+++ b/registry/subnets/eirel.json
@@ -171,6 +171,31 @@
       },
       "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "url": "https://api.eirel.ai/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-runs-current-api",
+      "kind": "subnet-api",
+      "name": "Eirel current run API",
+      "notes": "Public no-auth GET returning the active Eirel benchmark run (run_id, sequence, status, benchmark/rubric versions, schedule window). Documented in the subnet's own OpenAPI (api.eirel.ai/openapi.json, path /v1/runs/current); same host as the existing dashboard and metagraph subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.eirel.ai/openapi.json",
+        "https://eirel.ai/"
+      ],
+      "url": "https://api.eirel.ai/v1/runs/current"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/eirel.json`.

## Surface

- Netuid: **36** (Eirel)
- Kind: **subnet-api**
- Public URL: `https://api.eirel.ai/v1/runs/current`
- Source URLs:
  - https://api.eirel.ai/openapi.json
  - https://eirel.ai/
- Provider slug: **eirel**

## No linked issue

SN36 already has `openapi`, dashboard overview/runs, metagraph status, workflow-specs, and env-windows surfaces on `api.eirel.ai`; the registry was missing the corresponding `subnet-api` entry for the documented public `/v1/runs/current` current-run status endpoint. This is a registry gap fill (same pattern as #3327 / #3331).

## Checklist

- [x] Changes exactly one `registry/subnets/eirel.json` file (append-only, +25 lines)
- [x] Generated manually following `npm run surface:add` conventions (`authority: community`, `review.state: community-submitted`)
- [x] Public URL is safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, or sensitive data in notes
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint — not a health/liveness probe
- [x] Live probe: `curl -sS https://api.eirel.ai/v1/runs/current` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/eirel.json` — passed
- [x] `npm run scan:public-safety` — passed

## Conflict avoidance

Touches only `eirel.json`. No overlap with open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3550 Compelle /api/health | `compelle.json` only |
| #3546 readme catalog | `README.md` only |

Merges cleanly after the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)