### PR TITLE
feat(ui): add cross-subnet neuron portfolio summary to the account page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-portfolio.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-portfolio.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { normalizePortfolioConcentration, normalizePortfolioPosition } from "./queries";
+
+describe("normalizePortfolioPosition", () => {
+  it("coerces a well-formed position and passes yield through unchanged", () => {
+    expect(
+      normalizePortfolioPosition({
+        netuid: 7,
+        uid: 42,
+        role: "validator",
+        active: true,
+        stake_tao: 1250.5,
+        emission_tao: 3.2,
+        rank: 0.9,
+        trust: 0.8,
+        incentive: 0.5,
+        dividends: 0.4,
+        yield: 0.00256,
+      }),
+    ).toEqual({
+      netuid: 7,
+      uid: 42,
+      role: "validator",
+      active: true,
+      stake_tao: 1250.5,
+      emission_tao: 3.2,
+      rank: 0.9,
+      trust: 0.8,
+      incentive: 0.5,
+      dividends: 0.4,
+      yield: 0.00256,
+    });
+  });
+
+  it("nulls object/string economic cells and rejects an unknown role", () => {
+    // Numeric-looking strings are not finite numbers to the strict coercer — they
+    // drop to null rather than render as `[object Object]` or NaN.
+    expect(
+      normalizePortfolioPosition({
+        netuid: 3,
+        uid: { attacker: true },
+        role: "overlord",
+        stake_tao: { attacker: true },
+        emission_tao: "1.5",
+        yield: null,
+      }),
+    ).toEqual({
+      netuid: 3,
+      uid: null,
+      role: null,
+      active: undefined,
+      stake_tao: null,
+      emission_tao: null,
+      rank: null,
+      trust: null,
+      incentive: null,
+      dividends: null,
+      yield: null,
+    });
+  });
+
+  it("keeps the miner role and a zero-stake null yield", () => {
+    const position = normalizePortfolioPosition({
+      netuid: 0,
+      uid: 1,
+      role: "miner",
+      active: false,
+      stake_tao: 0,
+      emission_tao: 0,
+      yield: null,
+    });
+    expect(position?.role).toBe("miner");
+    expect(position?.active).toBe(false);
+    expect(position?.yield).toBeNull();
+  });
+
+  it("drops a row with no numeric netuid or a non-object input", () => {
+    expect(normalizePortfolioPosition({ netuid: "abc", uid: 1 })).toBeNull();
+    expect(normalizePortfolioPosition(null)).toBeNull();
+    expect(normalizePortfolioPosition("nope")).toBeNull();
+  });
+});
+
+describe("normalizePortfolioConcentration", () => {
+  it("keeps finite lenses, nulls a junk typed cell, and passes extra fields through", () => {
+    expect(
+      normalizePortfolioConcentration({
+        holders: 5,
+        gini: { attacker: true }, // junk in a typed cell → null (never rendered raw)
+        hhi_normalized: 0.31,
+        nakamoto_coefficient: 2,
+        total: 1000, // an un-typed lens field passes through untouched
+      }),
+    ).toEqual({
+      holders: 5,
+      gini: null,
+      hhi_normalized: 0.31,
+      nakamoto_coefficient: 2,
+      total: 1000,
+    });
+  });
+
+  it("returns null for a null / non-object distribution (cold wallet)", () => {
+    expect(normalizePortfolioConcentration(null)).toBeNull();
+    expect(normalizePortfolioConcentration(undefined)).toBeNull();
+    expect(normalizePortfolioConcentration(42)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -32,9 +32,12 @@ import type {
   AccountEvent,
   AccountEventsPage,
   AccountHistory,
+  AccountPortfolio,
   AccountRegistration,
   AccountSubnets,
   AccountSummary,
+  PortfolioConcentration,
+  PortfolioPosition,
   Block,
   ChainActivity,
   ChainActivityDay,
@@ -138,6 +141,7 @@ const MAX_EXTRINSIC_VALUE_DEPTH = 8;
 const MAX_EXTRINSIC_COLLECTION_ENTRIES = 64;
 const MAX_EXTRINSIC_STRING_LENGTH = 2_000;
 const MAX_ACCOUNT_REGISTRATIONS = 100;
+const MAX_ACCOUNT_POSITIONS = 256;
 const MAX_ACCOUNT_HISTORY_DAYS = 180;
 const MAX_ACCOUNT_DAY_EVENT_KINDS = 32;
 const MAX_CHAIN_ACTIVITY_DAYS = 31;
@@ -1745,6 +1749,43 @@ function normalizeAccountRegistration(raw: unknown): AccountRegistration | null 
   return registration.netuid != null || registration.uid != null ? registration : null;
 }
 
+// One cross-subnet neuron position (#3491). Strict on render fields — object/junk
+// economic cells coerce to null (never NaN or `[object Object]`), an unknown role
+// drops to null — and a row with no numeric netuid is discarded.
+export function normalizePortfolioPosition(raw: unknown): PortfolioPosition | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  const role = firstString(raw.role);
+  return {
+    ...(raw as object),
+    netuid,
+    uid: firstFiniteNumber(raw.uid) ?? null,
+    role: role === "validator" || role === "miner" ? role : null,
+    active: booleanValue(raw.active),
+    stake_tao: firstFiniteNumber(raw.stake_tao) ?? null,
+    emission_tao: firstFiniteNumber(raw.emission_tao) ?? null,
+    rank: firstFiniteNumber(raw.rank) ?? null,
+    trust: firstFiniteNumber(raw.trust) ?? null,
+    incentive: firstFiniteNumber(raw.incentive) ?? null,
+    dividends: firstFiniteNumber(raw.dividends) ?? null,
+    yield: firstFiniteNumber(raw.yield) ?? null,
+  };
+}
+
+// The portfolio's stake-concentration lens (#3491) — null when the wallet holds
+// no stake (a cold or all-zero distribution). Extra lens fields pass through.
+export function normalizePortfolioConcentration(raw: unknown): PortfolioConcentration | null {
+  if (!isRecord(raw)) return null;
+  return {
+    ...(raw as object),
+    holders: firstFiniteNumber(raw.holders) ?? null,
+    gini: firstFiniteNumber(raw.gini) ?? null,
+    hhi_normalized: firstFiniteNumber(raw.hhi_normalized) ?? null,
+    nakamoto_coefficient: firstFiniteNumber(raw.nakamoto_coefficient) ?? null,
+  };
+}
+
 function accountEventString(value: unknown): string | undefined {
   if (typeof value === "string") return value.trim() ? value : undefined;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
@@ -2059,6 +2100,44 @@ export const accountSubnetsQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountSubnets>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3491: the economics-rich companion to accountSubnetsQuery — every neuron
+// position under this hotkey with stake/emission/yield, plus wallet aggregates.
+// Non-blocking on the entity page; a cold wallet returns an empty positions[].
+export const accountPortfolioQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-portfolio", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/portfolio`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const positions = Array.isArray(d.positions)
+        ? d.positions.slice(0, MAX_ACCOUNT_POSITIONS).flatMap((position) => {
+            const normalized = normalizePortfolioPosition(position);
+            return normalized ? [normalized] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          captured_at: firstString(d.captured_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? positions.length,
+          position_count: firstFiniteNumber(d.position_count) ?? positions.length,
+          validator_count: firstFiniteNumber(d.validator_count) ?? 0,
+          miner_count: firstFiniteNumber(d.miner_count) ?? 0,
+          total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? null,
+          total_emission_tao: firstFiniteNumber(d.total_emission_tao) ?? null,
+          overall_yield: firstFiniteNumber(d.overall_yield) ?? null,
+          stake_concentration: normalizePortfolioConcentration(d.stake_concentration),
+          positions,
+        } as AccountPortfolio,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountPortfolio>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -901,6 +901,61 @@ export interface AccountSubnets {
   [key: string]: unknown;
 }
 
+/**
+ * One neuron position a wallet holds on a subnet, from
+ * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.
+ * Score cells are null when absent; `yield` is null with zero stake.
+ */
+export interface PortfolioPosition {
+  netuid: number;
+  uid: number | null;
+  role: "validator" | "miner" | null;
+  active?: boolean;
+  stake_tao: number | null;
+  emission_tao: number | null;
+  rank: number | null;
+  trust: number | null;
+  incentive: number | null;
+  dividends: number | null;
+  /** Emission-per-stake return (a fraction; null with zero stake). */
+  yield: number | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Stake-concentration lens over a wallet's per-subnet stake (Gini / normalized
+ * HHI / Nakamoto coefficient), from the portfolio's `stake_concentration`. Null
+ * when the wallet holds no stake.
+ */
+export interface PortfolioConcentration {
+  holders: number | null;
+  gini: number | null;
+  hhi_normalized: number | null;
+  nakamoto_coefficient: number | null;
+  [key: string]: unknown;
+}
+
+/**
+ * A wallet's cross-subnet neuron portfolio from /api/v1/accounts/{ss58}/portfolio:
+ * every position's economics + yield plus wallet-level aggregates (totals, role
+ * counts, overall return, stake concentration). Richer than the registrations-only
+ * AccountSubnets footprint.
+ */
+export interface AccountPortfolio {
+  ss58: string;
+  captured_at?: string | null;
+  subnet_count: number;
+  position_count: number;
+  validator_count: number;
+  miner_count: number;
+  total_stake_tao: number | null;
+  total_emission_tao: number | null;
+  overall_yield: number | null;
+  stake_concentration: PortfolioConcentration | null;
+  positions: PortfolioPosition[];
+  [key: string]: unknown;
+}
+
 /** Cross-subnet activity summary for one account from /api/v1/accounts/{ss58}. */
 export interface AccountSummary {
   ss58: string;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -30,6 +30,7 @@ import {
   accountBalanceQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
+  accountPortfolioQuery,
   accountQuery,
   accountSubnetsQuery,
   accountTransfersQuery,
@@ -121,6 +122,12 @@ function fmtTao(v: number): string {
   if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
   if (v >= 1) return `${v.toFixed(2)} τ`;
   return `${v.toFixed(4)} τ`;
+}
+
+// Render an emission/stake yield ratio (a fraction) as a percentage.
+function fmtPct(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(2)}%`;
 }
 
 function ValidAccountDetail({ ss58 }: { ss58: string }) {
@@ -242,6 +249,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
+      <AccountPortfolioSection ss58={ss58} />
+
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
           id="kinds"
@@ -299,6 +308,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
+            { label: "portfolio", path: `/api/v1/accounts/${sourceRef}/portfolio` },
           ]}
         />
       </SectionAnchor>
@@ -309,6 +319,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/history`,
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
+          `/api/v1/accounts/${sourceRef}/portfolio`,
         ]}
       />
     </>
@@ -604,6 +615,119 @@ function AccountFootprintSection({
                       idle
                     </span>
                   )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </DataPanel>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Cross-subnet neuron portfolio (#3491) — the economics-rich companion to the
+ * registration footprint above: per-position stake, emission, and yield from the
+ * neurons D1 tier (/portfolio), plus wallet-level aggregates (role split, totals,
+ * overall return, stake concentration). Non-blocking: while the query loads (or if
+ * it fails, or the wallet is cold with no positions) the section stays hidden so it
+ * never stalls the page or renders an empty shell.
+ */
+function AccountPortfolioSection({ ss58 }: { ss58: string }) {
+  const portfolio = useQuery(accountPortfolioQuery(ss58)).data?.data;
+  const positions = portfolio?.positions ?? [];
+  if (positions.length === 0) return null;
+
+  const concentration = portfolio?.stake_concentration ?? null;
+
+  return (
+    <SectionAnchor
+      id="portfolio"
+      title="Neuron portfolio"
+      subtitle="Cross-subnet neuron positions with per-position stake, emission, and yield — the economics view behind the registration footprint."
+      tone="accent"
+      info="Yield is emission per stake for each position (null with zero stake). This is neuron-registration analytics, not wallet PnL."
+      right={<SectionBadge tone="accent">{formatNumber(positions.length)} positions</SectionBadge>}
+    >
+      <div className="mb-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <StatTile
+          eyebrow="Positions"
+          tone="accent"
+          value={formatNumber(portfolio?.position_count ?? positions.length)}
+          hint={`${formatNumber(portfolio?.subnet_count ?? positions.length)} subnets`}
+        />
+        <StatTile
+          eyebrow="Roles"
+          value={`${formatNumber(portfolio?.validator_count ?? 0)} / ${formatNumber(
+            portfolio?.miner_count ?? 0,
+          )}`}
+          hint="validators / miners"
+        />
+        <StatTile
+          eyebrow="Overall yield"
+          value={fmtPct(portfolio?.overall_yield)}
+          hint="emission / stake"
+        />
+        <StatTile eyebrow="Total stake" value={fmtTao(portfolio?.total_stake_tao ?? 0)} />
+        <StatTile eyebrow="Total emission" value={fmtTao(portfolio?.total_emission_tao ?? 0)} />
+        <StatTile
+          eyebrow="Stake concentration"
+          value={concentration?.gini != null ? concentration.gini.toFixed(3) : "—"}
+          hint={
+            concentration?.nakamoto_coefficient != null
+              ? `Gini · Nakamoto ${formatNumber(concentration.nakamoto_coefficient)}`
+              : "Gini across subnets"
+          }
+        />
+      </div>
+      <DataPanel>
+        <table className="w-full text-left text-sm">
+          <thead className="bg-surface/50">
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={TH}>Role</th>
+              <th className={`${TH} text-right`}>UID</th>
+              <th className={`${TH} text-right`}>Stake</th>
+              <th className={`${TH} text-right`}>Emission</th>
+              <th className={`${TH} text-right`}>Yield</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {positions.map((p) => (
+              <tr key={`${p.netuid}-${p.uid}`} className="hover:bg-surface/30">
+                <td className="px-5 py-4 font-mono text-[12px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: p.netuid }}
+                    className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
+                  >
+                    SN{p.netuid}
+                  </Link>
+                </td>
+                <td className="px-5 py-4 font-mono text-[11px]">
+                  {p.role === "validator" ? (
+                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+                      validator
+                    </span>
+                  ) : p.role === "miner" ? (
+                    <span className="inline-flex rounded-full bg-surface px-2 py-0.5 text-ink-muted">
+                      miner
+                    </span>
+                  ) : (
+                    <span className="text-ink-muted">—</span>
+                  )}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {p.uid != null ? formatNumber(p.uid) : "—"}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {fmtStake(p.stake_tao)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {fmtStake(p.emission_tao)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {fmtPct(p.yield)}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary

Closes #3491

Adds a **Neuron portfolio** section to the account page (`/accounts/$ss58`). This section consumes the existing `GET /api/v1/accounts/{ss58}/portfolio` endpoint and displays per-neuron positions under a hotkey, including **stake, emission, and yield**, along with wallet-level aggregates such as position/subnet counts, validator vs miner split, total stake/emission, overall return, and stake concentration.

This extends the existing account view with an economics-focused layer on top of the registration data already shown — providing **neuron-level portfolio analytics rather than wallet PnL**.

## Details

- `accountPortfolioQuery` mirrors `accountSubnetsQuery` with strict normalization for:
  - `PortfolioPosition`
  - `PortfolioConcentration`
- Invalid or malformed economic fields are safely coerced:
  - object/junk values → `null` (never `NaN` or `[object Object]`)
  - unknown roles → `null`
  - rows missing numeric `netuid` → dropped
- Non-blocking data fetch:
  - failures do not block page rendering
  - section is hidden for wallets without positions
- UI reuse:
  - `StatTile`, `SectionAnchor`, and `DataPanel` components
  - shared `format.ts` utilities (no custom formatting added)
- API documentation updated:
  - includes `/portfolio` endpoint in snippet and footer

## Screenshots

| Page / Feature | Before | After |
|----------------|--------|-------|
| `/accounts/{ss58}` — Neuron portfolio | *(no portfolio section on main branch)* | *(new Neuron portfolio section added)* |

## Validation

- `npm run lint --workspace=apps/ui` → 0 errors
- `npm run typecheck --workspace=apps/ui` → clean
- `npm test --workspace=apps/ui` → 175 passing (including 6 new portfolio normalizer tests)
- `npm run build --workspace=apps/ui` → success
