### PR TITLE
test(ui): add og-image escapeText/normalizeTitle coverage

### DIFF
--- a/apps/ui/src/lib/og-image.test.ts
+++ b/apps/ui/src/lib/og-image.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeText, normalizeTitle } from "./og-image";
+
+describe("escapeText", () => {
+  it("escapes HTML metacharacters for safe satori markup embedding", () => {
+    expect(escapeText(`Tom & Jerry say "hello" <world>`)).toBe(
+      "Tom &amp; Jerry say &quot;hello&quot; &lt;world&gt;",
+    );
+  });
+
+  it("neutralizes user-controlled markup breakout attempts in ?title=", () => {
+    expect(escapeText(`</div><img src=x onerror=alert(1)>`)).toBe(
+      "&lt;/div&gt;&lt;img src=x onerror=alert(1)&gt;",
+    );
+  });
+
+  it("leaves plain titles unchanged", () => {
+    expect(escapeText("Subnet 7 overview")).toBe("Subnet 7 overview");
+  });
+});
+
+describe("normalizeTitle", () => {
+  it("falls back to the default title when the param is absent or blank", () => {
+    expect(normalizeTitle(null)).toBe("Metagraphed");
+    expect(normalizeTitle("")).toBe("Metagraphed");
+    expect(normalizeTitle("   ")).toBe("Metagraphed");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeTitle("  Validators  ")).toBe("Validators");
+  });
+
+  it("truncates overlong titles with an ellipsis suffix", () => {
+    const long = "x".repeat(120);
+    const out = normalizeTitle(long);
+    expect(out.length).toBe(110);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.startsWith("x".repeat(109))).toBe(true);
+  });
+});

--- a/apps/ui/src/lib/og-image.ts
+++ b/apps/ui/src/lib/og-image.ts
@@ -32,7 +32,7 @@ type EdgeCache = {
 const cacheStorage = (globalThis as { caches?: { default?: EdgeCache } }).caches?.default ?? null;
 
 // Escape text for safe embedding in the HTML string satori parses.
-function escapeText(value: string): string {
+export function escapeText(value: string): string {
   return value
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -40,7 +40,7 @@ function escapeText(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function normalizeTitle(value: string | null): string {
+export function normalizeTitle(value: string | null): string {
   const trimmed = (value || DEFAULT_TITLE).trim() || DEFAULT_TITLE;
   return trimmed.length > MAX_TITLE_LENGTH ? `${trimmed.slice(0, MAX_TITLE_LENGTH - 1)}…` : trimmed;
 }


### PR DESCRIPTION
Closes #3447

## Summary
- Export `escapeText` and `normalizeTitle` from `apps/ui/src/lib/og-image.ts` so the untrusted-input HTML escaping barrier is unit-testable.
- Add regression tests for HTML metacharacter escaping, markup breakout attempts, default/blank title handling, trimming, and max-length truncation.

## Test plan
- [x] `cd apps/ui && npm test`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)