### PR TITLE
feat(registry): add SN59 Babelbit /health subnet-api surface

### DIFF
--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -33,6 +33,25 @@
         "https://api.babelbit.ai/docs"
       ],
       "url": "https://api.babelbit.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-59-babelbit-health",
+      "kind": "subnet-api",
+      "name": "Babelbit utterance engine health",
+      "notes": "Public no-auth GET /health on api.babelbit.ai returning utterance-engine liveness JSON. Documented as a no-security operation in the registered OpenAPI schema on the same host; distinct from validator-authenticated challenge endpoints.",
+      "provider": "babelbit",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.babelbit.ai/openapi.json",
+        "https://github.com/babelbit/babelbit_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.babelbit.ai/health"
     }
   ]
 }


### PR DESCRIPTION
Closes #464

## Summary
- Append `sn-59-babelbit-health` subnet-api surface for public GET `/health` on `api.babelbit.ai`
- Live probe returns `{"status":"healthy","active_sessions":{...}}` (application/json, no auth)
- Path is documented in the registered OpenAPI schema on the same host

## Scope discipline
Single-file change: `registry/subnets/babelbit.json` only (append-only).

## Conflict notes
Merge-simulated clean against open PRs #3551, #3546, #3552. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://api.babelbit.ai/health` → 200 JSON

Made with [Cursor](https://cursor.com)