### PR TITLE
test(ui): cover error-capture consume-once and TTL semantics

### DIFF
--- a/apps/ui/src/lib/error-capture.test.ts
+++ b/apps/ui/src/lib/error-capture.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("consumeLastCapturedError", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function loadModule() {
+    return import("./error-capture");
+  }
+
+  it("returns undefined when nothing was captured", async () => {
+    const { consumeLastCapturedError } = await loadModule();
+    expect(consumeLastCapturedError()).toBeUndefined();
+  });
+
+  it("returns the captured error once, then clears it (consume-once)", async () => {
+    const { consumeLastCapturedError, recordCapturedError } = await loadModule();
+    const err = new Error("ssr blew up");
+    recordCapturedError(err);
+    expect(consumeLastCapturedError()).toBe(err);
+    expect(consumeLastCapturedError()).toBeUndefined();
+  });
+
+  it("returns undefined after the 5s TTL expires", async () => {
+    const { consumeLastCapturedError, recordCapturedError } = await loadModule();
+    recordCapturedError(new Error("stale"));
+    vi.advanceTimersByTime(5_001);
+    expect(consumeLastCapturedError()).toBeUndefined();
+  });
+
+  it("still returns the error just before the TTL boundary", async () => {
+    const { consumeLastCapturedError, recordCapturedError } = await loadModule();
+    const err = new Error("fresh");
+    recordCapturedError(err);
+    vi.advanceTimersByTime(5_000);
+    expect(consumeLastCapturedError()).toBe(err);
+  });
+});

--- a/apps/ui/src/lib/error-capture.ts
+++ b/apps/ui/src/lib/error-capture.ts
@@ -4,14 +4,16 @@
 let lastCapturedError: { error: unknown; at: number } | undefined;
 const TTL_MS = 5_000;
 
-function record(error: unknown) {
+export function recordCapturedError(error: unknown) {
   lastCapturedError = { error, at: Date.now() };
 }
 
 if (typeof globalThis.addEventListener === "function") {
-  globalThis.addEventListener("error", (event) => record((event as ErrorEvent).error ?? event));
+  globalThis.addEventListener("error", (event) =>
+    recordCapturedError((event as ErrorEvent).error ?? event),
+  );
   globalThis.addEventListener("unhandledrejection", (event) =>
-    record((event as PromiseRejectionEvent).reason),
+    recordCapturedError((event as PromiseRejectionEvent).reason),
   );
 }
 


### PR DESCRIPTION
Closes #3448

## Summary
- Export `recordCapturedError` so the SSR error-recovery buffer is unit-testable without simulating browser events.
- Add tests for `consumeLastCapturedError`: empty buffer, consume-once clearing, TTL expiry, and boundary at 5s.

## Test plan
- [x] `cd apps/ui && npm test`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)