### PR TITLE
feat(registry): enrich SN36 Eirel — current run API

### DIFF
--- a/registry/subnets/eirel.json
+++ b/registry/subnets/eirel.json
@@ -171,6 +171,22 @@
       },
       "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "url": "https://api.eirel.ai/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-runs-current-api",
+      "kind": "subnet-api",
+      "name": "Eirel current run API",
+      "notes": "Public no-auth GET /v1/runs/current on api.eirel.ai returning the active benchmark run status. Documented in the subnet OpenAPI on the same host as existing Eirel API surfaces.",
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/v1/runs/current"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #584

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/eirel.json`.

## Surface

- Netuid: **36** (Eirel)
- Kind: **subnet-api**
- Public URL: `https://api.eirel.ai/v1/runs/current`
- Source URLs:
  - https://api.eirel.ai/openapi.json
  - https://eirel.ai/
- Provider slug: **eirel**

## Checklist

- [x] Changes exactly one `registry/subnets/eirel.json` file (append-only, +16 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, or sensitive data in notes
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint — not a health/liveness probe
- [x] Live probe: `curl -sS https://api.eirel.ai/v1/runs/current` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/eirel.json` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --write registry/subnets/eirel.json` — passed (`format:check` clean)
- [x] Links tracked issue: **Closes #584**

## Conflict avoidance

Touches only `eirel.json`. No overlap with open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3557 error-capture tests | No |
| #3556 client version bump | No |
| #3546 readme catalog | `README.md` only |

Merges cleanly after the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)