### PR TITLE
feat(registry): add SN103 Djinn /api/health subnet-api surface

### DIFF
--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -64,6 +64,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Djinn source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-103-djinn-health",
+      "kind": "subnet-api",
+      "name": "Djinn API health",
+      "notes": "Public no-auth GET /api/health on www.djinn.gg returning application liveness JSON. Implemented in the official Djinn web repository on the same host as the registered website surface.",
+      "provider": "djinn",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn/blob/main/web/app/api/health/route.ts",
+        "https://www.djinn.gg/"
+      ],
+      "url": "https://www.djinn.gg/api/health"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #695

## Summary
- Append `sn-103-djinn-health` subnet-api surface for public GET `/api/health` on `www.djinn.gg`
- Live probe returns `{"status":"ok","version":"0.1.0","timestamp":"..."}` (application/json, no auth)
- Route implemented in the official Djinn web repository on the same host as the registered website surface

## Scope discipline
Single-file change: `registry/subnets/djinn.json` only (append-only).

## Conflict notes
Merge-simulated clean against open PRs #3556, #3546. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://www.djinn.gg/api/health` → 200 JSON

Made with [Cursor](https://cursor.com)