### PR TITLE
feat(ui): add reusable DownloadCsvButton component

### DIFF
--- a/apps/ui/src/components/metagraphed/download-csv-button.test.ts
+++ b/apps/ui/src/components/metagraphed/download-csv-button.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildCsvDownloadUrl, startCsvDownload } from "@/lib/metagraphed/client";
+import { setApiBase, setNetwork } from "@/lib/metagraphed/config";
+
+describe("buildCsvDownloadUrl", () => {
+  beforeEach(() => {
+    setApiBase("https://api.metagraph.sh");
+    setNetwork("mainnet");
+  });
+
+  afterEach(() => {
+    setApiBase("https://api.metagraph.sh");
+    setNetwork("mainnet");
+  });
+
+  it("appends format=csv while preserving list query params", () => {
+    const url = buildCsvDownloadUrl("/api/v1/subnets", {
+      fields: "netuid,name",
+      sort: "netuid",
+      limit: 50,
+    });
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe("https://api.metagraph.sh");
+    expect(parsed.pathname).toBe("/api/v1/subnets");
+    expect(parsed.searchParams.get("format")).toBe("csv");
+    expect(parsed.searchParams.get("fields")).toBe("netuid,name");
+    expect(parsed.searchParams.get("sort")).toBe("netuid");
+    expect(parsed.searchParams.get("limit")).toBe("50");
+  });
+
+  it("inserts the selected network prefix before format=csv", () => {
+    setNetwork("testnet");
+    const url = buildCsvDownloadUrl("/api/v1/blocks", { limit: 10 });
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/api/v1/testnet/blocks");
+    expect(parsed.searchParams.get("format")).toBe("csv");
+    expect(parsed.searchParams.get("limit")).toBe("10");
+  });
+});
+
+describe("startCsvDownload", () => {
+  it("creates a temporary anchor with the CSV URL and optional filename", () => {
+    const click = vi.fn();
+    const remove = vi.fn();
+    const anchor = {
+      href: "",
+      download: "",
+      rel: "",
+      style: { display: "" },
+      click,
+      remove,
+    } as unknown as HTMLAnchorElement;
+    const createElement = vi.fn(() => anchor);
+    const appendChild = vi.fn();
+    vi.stubGlobal("document", {
+      createElement,
+      body: { appendChild },
+    });
+
+    startCsvDownload("https://api.metagraph.sh/api/v1/subnets?format=csv", "subnets.csv");
+
+    expect(createElement).toHaveBeenCalledWith("a");
+    expect(anchor.href).toBe("https://api.metagraph.sh/api/v1/subnets?format=csv");
+    expect(anchor.download).toBe("subnets.csv");
+    expect(anchor.rel).toBe("noopener");
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(appendChild).toHaveBeenCalledWith(anchor);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/ui/src/components/metagraphed/download-csv-button.tsx
+++ b/apps/ui/src/components/metagraphed/download-csv-button.tsx
@@ -1,0 +1,50 @@
+import { Download } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+import {
+  buildCsvDownloadUrl,
+  startCsvDownload,
+  type QueryParams,
+} from "@/lib/metagraphed/client";
+
+interface Props {
+  /** API path, e.g. `/api/v1/subnets`. */
+  path: string;
+  /** Query params to preserve alongside `format=csv` (sort, filters, limit, fields, …). */
+  params?: QueryParams;
+  /** Optional download filename hint for the browser. */
+  filename?: string;
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Reusable CSV export trigger for list/table pages. Wires the backend's
+ * standardized `?format=csv` download without page-specific layout.
+ */
+export function DownloadCsvButton({
+  path,
+  params,
+  filename,
+  label = "Download CSV",
+  className,
+}: Props) {
+  const onClick = () => {
+    startCsvDownload(buildCsvDownloadUrl(path, params), filename);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${label} for the current filters and sort`}
+      title={`${label} for the current filters and sort`}
+      className={classNames(
+        "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+        className,
+      )}
+    >
+      <Download className="size-3 text-ink-muted" aria-hidden />
+      {label}
+    </button>
+  );
+}

--- a/apps/ui/src/components/metagraphed/download-csv-button.tsx
+++ b/apps/ui/src/components/metagraphed/download-csv-button.tsx
@@ -1,10 +1,6 @@
 import { Download } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
-import {
-  buildCsvDownloadUrl,
-  startCsvDownload,
-  type QueryParams,
-} from "@/lib/metagraphed/client";
+import { buildCsvDownloadUrl, startCsvDownload, type QueryParams } from "@/lib/metagraphed/client";
 
 interface Props {
   /** API path, e.g. `/api/v1/subnets`. */

--- a/apps/ui/src/lib/metagraphed/client.ts
+++ b/apps/ui/src/lib/metagraphed/client.ts
@@ -59,6 +59,24 @@ function buildUrl(path: string, params?: QueryParams): string {
   return url.toString();
 }
 
+/** Build an absolute API URL for a CSV download (`?format=csv`). */
+export function buildCsvDownloadUrl(path: string, params?: QueryParams): string {
+  return buildUrl(path, { ...params, format: "csv" });
+}
+
+/** Start a browser download for a CSV URL produced by the API. */
+export function startCsvDownload(url: string, filename?: string): void {
+  if (typeof document === "undefined") return;
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  if (filename) anchor.download = filename;
+  anchor.rel = "noopener";
+  anchor.style.display = "none";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
 function redactUrlForError(url: string): string {
   const redacted = new URL(url);
   redacted.search = "";


### PR DESCRIPTION
Closes #3402

## Summary
- Add `DownloadCsvButton`, a reusable CSV export trigger for list/table pages (no page wiring in this PR).
- Export `buildCsvDownloadUrl` and `startCsvDownload` from the metagraphed client so downloads preserve API base, network prefix, filters, sort, and `?format=csv`.

## Test plan
- [x] `cd apps/ui && npm test`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)