### PR TITLE
feat(registry): add SN63 Enigma /api/health subnet-api surface

### DIFF
--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -65,6 +65,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Enigma source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-63-enigma-health",
+      "kind": "subnet-api",
+      "name": "qBittensor Labs API health",
+      "notes": "Public no-auth GET /api/health on www.qbittensorlabs.com returning application liveness JSON. Served on the official qBittensor Labs website host linked from the Enigma source repository README.",
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/qbittensor-labs/enigma/blob/main/README.md",
+        "https://www.qbittensorlabs.com/"
+      ],
+      "url": "https://www.qbittensorlabs.com/api/health"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #687

## Summary
- Append `sn-63-enigma-health` subnet-api surface for public GET `/api/health` on `www.qbittensorlabs.com`
- Live probe returns `{"status":"ok"}` (application/json, no auth)
- Served on the official qBittensor Labs website host linked from the Enigma source repository README

## Scope discipline
Single-file change: `registry/subnets/enigma.json` only (append-only).

## Conflict notes
Merge-simulated clean against open PRs #3560, #3556, #3546. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://www.qbittensorlabs.com/api/health` → 200 JSON

Made with [Cursor](https://cursor.com)