### PR TITLE
feat(ui): add shared event-kind label and category map

### DIFF
--- a/apps/ui/src/lib/metagraphed/event-kinds.test.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EVENT_KIND_CATEGORIES,
+  eventKindCategory,
+  eventKindCategoryLabel,
+  eventKindLabel,
+} from "./event-kinds";
+
+describe("eventKindCategory", () => {
+  it("maps known kinds to the same categories as account-events.mjs", () => {
+    expect(eventKindCategory("StakeAdded")).toBe("stake");
+    expect(eventKindCategory("AxonServed")).toBe("serving");
+    expect(eventKindCategory("Transfer")).toBe("transfer");
+    expect(Object.keys(EVENT_KIND_CATEGORIES)).toHaveLength(25);
+  });
+
+  it("returns other for unknown or missing kinds", () => {
+    expect(eventKindCategory(null)).toBe("other");
+    expect(eventKindCategory("")).toBe("other");
+    expect(eventKindCategory("FutureEventKind")).toBe("other");
+  });
+});
+
+describe("eventKindLabel", () => {
+  it("returns human-readable labels for known kinds", () => {
+    expect(eventKindLabel("NeuronRegistered")).toBe("Neuron registered");
+    expect(eventKindLabel("StakeTransferred")).toBe("Stake transferred");
+    expect(eventKindLabel("PrometheusServed")).toBe("Prometheus served");
+  });
+
+  it("falls back to spaced CamelCase for unknown kinds", () => {
+    expect(eventKindLabel("CustomSubnetEvent")).toBe("Custom Subnet Event");
+  });
+
+  it("returns a stable placeholder for missing kinds", () => {
+    expect(eventKindLabel(null)).toBe("Unknown event");
+  });
+});
+
+describe("eventKindCategoryLabel", () => {
+  it("returns explorer-facing category names", () => {
+    expect(eventKindCategoryLabel("stake")).toBe("Stake");
+    expect(eventKindCategoryLabel("other")).toBe("Other");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/event-kinds.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.ts
@@ -1,0 +1,103 @@
+// Human-readable event-kind labels + category map for the explorer UI. Mirrors the
+// backend EVENT_KIND_CATEGORIES in src/account-events.mjs so the client can group
+// and label chain events without duplicating the normalization logic inline.
+
+export type EventKindCategory =
+  | "registration"
+  | "stake"
+  | "serving"
+  | "consensus"
+  | "delegation"
+  | "identity"
+  | "governance"
+  | "transfer"
+  | "other";
+
+/** Category slug for each known on-chain event kind (keep in sync with account-events.mjs). */
+export const EVENT_KIND_CATEGORIES: Record<string, EventKindCategory> = {
+  NeuronRegistered: "registration",
+  NeuronDeregistered: "registration",
+  NetworkAdded: "registration",
+  NetworkRemoved: "registration",
+  RegistrationAllowed: "registration",
+  PowRegistrationAllowed: "registration",
+  Faucet: "registration",
+  StakeAdded: "stake",
+  StakeRemoved: "stake",
+  StakeMoved: "stake",
+  StakeTransferred: "stake",
+  AxonServed: "serving",
+  PrometheusServed: "serving",
+  AxonInfoRemoved: "serving",
+  WeightsSet: "consensus",
+  RootClaimed: "consensus",
+  DelegateAdded: "delegation",
+  TakeDecreased: "delegation",
+  TakeIncreased: "delegation",
+  HotkeySwapped: "identity",
+  ColdkeySwapped: "identity",
+  ColdkeySwapScheduled: "identity",
+  SubnetOwnerHotkeySet: "governance",
+  BurnSet: "governance",
+  Transfer: "transfer",
+};
+
+/** Explorer-facing labels for known event kinds. */
+export const EVENT_KIND_LABELS: Record<string, string> = {
+  NeuronRegistered: "Neuron registered",
+  NeuronDeregistered: "Neuron deregistered",
+  NetworkAdded: "Network added",
+  NetworkRemoved: "Network removed",
+  RegistrationAllowed: "Registration allowed",
+  PowRegistrationAllowed: "PoW registration allowed",
+  Faucet: "Faucet",
+  StakeAdded: "Stake added",
+  StakeRemoved: "Stake removed",
+  StakeMoved: "Stake moved",
+  StakeTransferred: "Stake transferred",
+  AxonServed: "Axon served",
+  PrometheusServed: "Prometheus served",
+  AxonInfoRemoved: "Axon removed",
+  WeightsSet: "Weights set",
+  RootClaimed: "Root claimed",
+  DelegateAdded: "Delegate added",
+  TakeDecreased: "Take decreased",
+  TakeIncreased: "Take increased",
+  HotkeySwapped: "Hotkey swapped",
+  ColdkeySwapped: "Coldkey swapped",
+  ColdkeySwapScheduled: "Coldkey swap scheduled",
+  SubnetOwnerHotkeySet: "Subnet owner hotkey set",
+  BurnSet: "Burn set",
+  Transfer: "Transfer",
+};
+
+/** Short category labels for chips / filters. */
+export const EVENT_KIND_CATEGORY_LABELS: Record<EventKindCategory, string> = {
+  registration: "Registration",
+  stake: "Stake",
+  serving: "Serving",
+  consensus: "Consensus",
+  delegation: "Delegation",
+  identity: "Identity",
+  governance: "Governance",
+  transfer: "Transfer",
+  other: "Other",
+};
+
+function fallbackEventKindLabel(kind: string): string {
+  return kind.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/^./, (c) => c.toUpperCase());
+}
+
+export function eventKindCategory(kind: string | null | undefined): EventKindCategory {
+  if (!kind) return "other";
+  return EVENT_KIND_CATEGORIES[kind] ?? "other";
+}
+
+export function eventKindLabel(kind: string | null | undefined): string {
+  if (!kind) return "Unknown event";
+  return EVENT_KIND_LABELS[kind] ?? fallbackEventKindLabel(kind);
+}
+
+export function eventKindCategoryLabel(category: EventKindCategory): string {
+  return EVENT_KIND_CATEGORY_LABELS[category];
+}


### PR DESCRIPTION
Closes #3366

## Summary
- Add `apps/ui/src/lib/metagraphed/event-kinds.ts`: human-readable event-kind labels and category slugs mirrored from `src/account-events.mjs`.
- Export pure helpers (`eventKindLabel`, `eventKindCategory`, `eventKindCategoryLabel`) for upcoming explorer UI work — **no React components or page wiring** in this PR.

## Why this shape
- Issue asks for a reusable FE map (foundational lib), not a new UI component.
- Avoids the #3560 gate blocker (`DownloadCsvButton` component rejected as out-of-repo UI surface).

## Test plan
- [x] `cd apps/ui && npm run lint && npm test`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)