### PR TITLE
feat(ui): add validatorsQuery and GlobalValidator types

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -94,6 +94,10 @@ import type {
   MetagraphNeuron,
   SubnetMetagraph,
   SubnetValidators,
+  GlobalValidator,
+  GlobalValidators,
+  GlobalValidatorSort,
+  GlobalValidatorSubnet,
   SubnetNeuronSnapshot,
   ConcentrationMetrics,
   SubnetConcentration,
@@ -2789,6 +2793,83 @@ function normalizeSubnetValidators(netuid: number, raw: unknown): SubnetValidato
   };
 }
 
+const GLOBAL_VALIDATOR_SORTS: GlobalValidatorSort[] = [
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+  "subnet_count",
+  "total_emission",
+  "total_stake",
+  "uid_count",
+];
+
+function normalizeGlobalValidatorSubnet(raw: unknown): GlobalValidatorSubnet | null {
+  if (!isPlainRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  const uid = coerceFiniteNumber(raw.uid);
+  if (netuid == null || uid == null) return null;
+  return {
+    netuid,
+    uid,
+    stake_tao: coerceFiniteNumber(raw.stake_tao) ?? 0,
+    emission_tao: coerceFiniteNumber(raw.emission_tao) ?? 0,
+    validator_trust:
+      raw.validator_trust == null ? null : (coerceFiniteNumber(raw.validator_trust) ?? null),
+  };
+}
+
+function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
+  if (!isPlainRecord(raw)) return null;
+  const hotkey = coerceString(raw.hotkey);
+  if (!hotkey) return null;
+  const subnets = Array.isArray(raw.subnets)
+    ? raw.subnets.flatMap((subnet) => {
+        const normalized = normalizeGlobalValidatorSubnet(subnet);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  const nullableNum = (value: unknown): number | null =>
+    value == null ? null : (coerceFiniteNumber(value) ?? null);
+  return {
+    hotkey,
+    coldkey: typeof raw.coldkey === "string" ? raw.coldkey : null,
+    coldkey_count: coerceFiniteNumber(raw.coldkey_count) ?? 0,
+    subnet_count: coerceFiniteNumber(raw.subnet_count) ?? 0,
+    uid_count: coerceFiniteNumber(raw.uid_count) ?? 0,
+    total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? 0,
+    total_emission_tao: coerceFiniteNumber(raw.total_emission_tao) ?? 0,
+    avg_validator_trust: nullableNum(raw.avg_validator_trust),
+    max_validator_trust: nullableNum(raw.max_validator_trust),
+    stake_dominance: nullableNum(raw.stake_dominance),
+    latest_captured_at: typeof raw.latest_captured_at === "string" ? raw.latest_captured_at : null,
+    latest_block_number: nullableNum(raw.latest_block_number),
+    subnets,
+  };
+}
+
+export function normalizeGlobalValidators(raw: unknown): GlobalValidators {
+  const d = isPlainRecord(raw) ? raw : {};
+  const sortRaw = coerceString(d.sort);
+  const sort = GLOBAL_VALIDATOR_SORTS.includes(sortRaw as GlobalValidatorSort)
+    ? (sortRaw as GlobalValidatorSort)
+    : "subnet_count";
+  const validators = Array.isArray(d.validators)
+    ? d.validators.flatMap((validator) => {
+        const normalized = normalizeGlobalValidator(validator);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: coerceFiniteNumber(d.schema_version),
+    sort,
+    limit: coerceFiniteNumber(d.limit) ?? validators.length,
+    validator_count: coerceFiniteNumber(d.validator_count) ?? validators.length,
+    captured_at: coerceString(d.captured_at),
+    block_number: coerceFiniteNumber(d.block_number),
+    validators,
+  };
+}
+
 function normalizeNeuronSnapshot(netuid: number, uid: number, raw: unknown): SubnetNeuronSnapshot {
   const d = isPlainRecord(raw) ? raw : {};
   return {
@@ -2904,6 +2985,27 @@ export const subnetValidatorsQuery = (netuid: number) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<SubnetValidators>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+/** Network-wide validator/operator leaderboard grouped by hotkey. */
+export const validatorsQuery = ({
+  sort = "subnet_count",
+  limit = 20,
+}: { sort?: GlobalValidatorSort; limit?: number } = {}) =>
+  queryOptions({
+    queryKey: k("global-validators", sort, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<GlobalValidators>>("/api/v1/validators", {
+        params: { sort, limit },
+        signal,
+      });
+      return {
+        data: normalizeGlobalValidators(res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<GlobalValidators>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1104,6 +1104,53 @@ export interface SubnetValidators {
   validators: MetagraphNeuron[];
 }
 
+/** Supported sort keys for GET /api/v1/validators. */
+export type GlobalValidatorSort =
+  | "avg_validator_trust"
+  | "max_validator_trust"
+  | "stake_dominance"
+  | "subnet_count"
+  | "total_emission"
+  | "total_stake"
+  | "uid_count";
+
+/** One current subnet membership in the network-wide validator leaderboard. */
+export interface GlobalValidatorSubnet {
+  netuid: number;
+  uid: number;
+  stake_tao: number;
+  emission_tao: number;
+  validator_trust: number | null;
+}
+
+/** One validator/operator row grouped by hotkey across subnet memberships. */
+export interface GlobalValidator {
+  hotkey: string;
+  coldkey: string | null;
+  coldkey_count: number;
+  subnet_count: number;
+  uid_count: number;
+  total_stake_tao: number;
+  total_emission_tao: number;
+  avg_validator_trust: number | null;
+  max_validator_trust: number | null;
+  stake_dominance: number | null;
+  latest_captured_at: string | null;
+  latest_block_number: number | null;
+  subnets: GlobalValidatorSubnet[];
+}
+
+/** Network-wide validator leaderboard from GET /api/v1/validators. */
+export interface GlobalValidators {
+  schema_version?: number;
+  sort: GlobalValidatorSort;
+  limit: number;
+  validator_count: number;
+  captured_at?: string;
+  block_number?: number;
+  validators: GlobalValidator[];
+}
+
 /** A single neuron snapshot from /api/v1/subnets/{netuid}/neurons/{uid}. */
 export interface SubnetNeuronSnapshot {
   netuid: number;

--- a/apps/ui/src/lib/metagraphed/validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeGlobalValidators, validatorsQuery } from "./queries";
+
+describe("normalizeGlobalValidators", () => {
+  it("normalizes a representative global validators payload", () => {
+    const out = normalizeGlobalValidators({
+      schema_version: 1,
+      sort: "subnet_count",
+      limit: 20,
+      validator_count: 1,
+      captured_at: "2026-01-01T00:00:00Z",
+      block_number: 100,
+      validators: [
+        {
+          hotkey: "5Hotkey",
+          coldkey: "5Coldkey",
+          coldkey_count: 1,
+          subnet_count: 2,
+          uid_count: 3,
+          total_stake_tao: 100.5,
+          total_emission_tao: 1.25,
+          avg_validator_trust: 0.99,
+          max_validator_trust: 1,
+          stake_dominance: 0.05,
+          latest_captured_at: "2026-01-01T00:00:00Z",
+          latest_block_number: 100,
+          subnets: [
+            {
+              netuid: 1,
+              uid: 0,
+              stake_tao: 50,
+              emission_tao: 0.5,
+              validator_trust: 1,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(out).toMatchObject({
+      schema_version: 1,
+      sort: "subnet_count",
+      limit: 20,
+      validator_count: 1,
+      captured_at: "2026-01-01T00:00:00Z",
+      block_number: 100,
+    });
+    expect(out.validators).toHaveLength(1);
+    expect(out.validators[0]).toMatchObject({
+      hotkey: "5Hotkey",
+      coldkey: "5Coldkey",
+      subnet_count: 2,
+      uid_count: 3,
+      subnets: [{ netuid: 1, uid: 0, stake_tao: 50, emission_tao: 0.5, validator_trust: 1 }],
+    });
+  });
+
+  it("drops validator rows with a missing hotkey", () => {
+    const out = normalizeGlobalValidators({
+      sort: "uid_count",
+      limit: 10,
+      validators: [{ coldkey: "5Coldkey", subnet_count: 1, uid_count: 1, subnets: [] }],
+    });
+
+    expect(out.validators).toHaveLength(0);
+    expect(out.validator_count).toBe(0);
+  });
+
+  it("defaults an unsupported sort to subnet_count", () => {
+    const out = normalizeGlobalValidators({ sort: "bogus", limit: 5, validators: [] });
+    expect(out.sort).toBe("subnet_count");
+  });
+
+  it("coerces string numerics from live API payloads", () => {
+    const out = normalizeGlobalValidators({
+      sort: "total_stake",
+      limit: "3",
+      validator_count: "1",
+      validators: [
+        {
+          hotkey: "hk",
+          subnet_count: "2",
+          uid_count: "4",
+          total_stake_tao: "10.5",
+          subnets: [{ netuid: "7", uid: "1", stake_tao: "10.5", emission_tao: "0" }],
+        },
+      ],
+    });
+
+    expect(out.limit).toBe(3);
+    expect(out.validator_count).toBe(1);
+    expect(out.validators[0].subnet_count).toBe(2);
+    expect(out.validators[0].subnets[0].netuid).toBe(7);
+  });
+});
+
+describe("validatorsQuery", () => {
+  it("includes sort and limit in the query key", () => {
+    const options = validatorsQuery({ sort: "uid_count", limit: 50 });
+    expect(options.queryKey).toContain("global-validators");
+    expect(options.queryKey).toContain("uid_count");
+    expect(options.queryKey).toContain(50);
+  });
+
+  it("defaults sort and limit when omitted", () => {
+    const options = validatorsQuery();
+    expect(options.queryKey).toContain("subnet_count");
+    expect(options.queryKey).toContain(20);
+  });
+});


### PR DESCRIPTION
Closes #3357

## Summary
- Add `GlobalValidator`, `GlobalValidatorSubnet`, and `GlobalValidators` types mirroring GET `/api/v1/validators`.
- Add `validatorsQuery({ sort, limit })` with normalization for the network-wide validator leaderboard.
- Add unit tests for normalization and query-key wiring.

Data-layer only — no new React components or page wiring (foundational hook for #3358).

## Test plan
- [x] `cd apps/ui && npm run lint`
- [x] `cd apps/ui && npm test`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`

Made with [Cursor](https://cursor.com)