### PR TITLE
feat(registry): add SN114 SOMA /api/health subnet-api surface

### DIFF
--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -159,6 +159,25 @@
         "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/114"
       ],
       "url": "https://github.com/Level114/level114-subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-114-soma-health",
+      "kind": "subnet-api",
+      "name": "SOMA API health",
+      "notes": "Public no-auth GET /api/health on thesoma.ai returning application liveness JSON. Served on the official SN114 website host registered in this manifest and linked from the DendriteHQ/SOMA source repository.",
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/DendriteHQ/SOMA/blob/main/README.md",
+        "https://thesoma.ai/"
+      ],
+      "url": "https://thesoma.ai/api/health"
     }
   ],
   "website_url": "https://thesoma.ai/"


### PR DESCRIPTION
Closes #696

## Summary
- Append `sn-114-soma-health` subnet-api surface for public GET `/api/health` on `thesoma.ai`
- Live probe returns `{"status":"ok","ts":"..."}` (application/json, no auth)
- Served on the official SN114 website host linked from the DendriteHQ/SOMA source repository

## Scope discipline
Single-file change: `registry/subnets/soma.json` only (append-only).

## Conflict notes
Merge-simulated clean against open PRs #3563, #3562, #3556, #3546. No registry file overlap.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Live curl: `https://thesoma.ai/api/health` → 200 JSON

Made with [Cursor](https://cursor.com)