### PR TITLE
feat(registry): enrich SN46 Zipcode — daily emissions API

### DIFF
--- a/registry/subnets/zipcode.json
+++ b/registry/subnets/zipcode.json
@@ -71,6 +71,25 @@
         "https://zipcode.ai/api/dashboard/docs"
       ],
       "url": "https://zipcode.ai/api/dashboard/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-emissions-api",
+      "kind": "subnet-api",
+      "name": "Zipcode daily emissions API",
+      "notes": "Public no-auth GET /api/dashboard/stats/emissions on zipcode.ai returning SN46 daily TAO emissions and block height. Documented in the subnet OpenAPI on the same host as existing dashboard surfaces.",
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://zipcode.ai/openapi.json",
+        "https://zipcode.ai/api/dashboard/docs"
+      ],
+      "url": "https://zipcode.ai/api/dashboard/stats/emissions"
     }
   ]
 }


### PR DESCRIPTION
Closes #592

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/zipcode.json`.

## Surface

- Netuid: **46** (Zipcode)
- Kind: **subnet-api**
- Public URL: `https://zipcode.ai/api/dashboard/stats/emissions`
- Source URLs:
  - https://zipcode.ai/openapi.json
  - https://zipcode.ai/api/dashboard/docs
- Provider slug: **zipcode**

## Checklist

- [x] Changes exactly one `registry/subnets/zipcode.json` file (append-only, +19 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, or sensitive data in notes
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint — not a health/liveness probe
- [x] Live probe: `curl -sS https://zipcode.ai/api/dashboard/stats/emissions` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/zipcode.json` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --write registry/subnets/zipcode.json` — passed (`format:check` clean)
- [x] Links tracked issue: **Closes #592**

## Conflict avoidance

Touches only `zipcode.json`. No overlap with open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3560 DownloadCsvButton | No |
| #3556 client version bump | No |
| #3546 readme catalog | `README.md` only |

Merges cleanly after the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)