### PR TITLE
test(ui): cover health-palette readId and cssFor resolution

### DIFF
--- a/apps/ui/src/lib/health-palette.test.ts
+++ b/apps/ui/src/lib/health-palette.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { cssFor, HEALTH_PALETTES, readId } from "./health-palette";
+
+describe("cssFor", () => {
+  it("maps each palette to light :root and dark .dark health variables", () => {
+    for (const palette of HEALTH_PALETTES) {
+      const css = cssFor(palette);
+      expect(css).toBe(
+        `:root{--health-ok:${palette.light.ok};--health-warn:${palette.light.warn};--health-down:${palette.light.down};--health-unknown:${palette.light.unknown};}` +
+          `.dark{--health-ok:${palette.dark.ok};--health-warn:${palette.dark.warn};--health-down:${palette.dark.down};--health-unknown:${palette.dark.unknown};}`,
+      );
+    }
+  });
+});
+
+describe("readId", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the default palette during SSR when window is absent", () => {
+    expect(readId()).toBe("traffic-light");
+  });
+
+  it("returns the default palette when localStorage is empty", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => null) },
+    });
+    expect(readId()).toBe("traffic-light");
+  });
+
+  it("restores a valid persisted palette id", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => "colorblind-safe") },
+    });
+    expect(readId()).toBe("colorblind-safe");
+  });
+
+  it("falls back to the default palette for unknown stored values", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => "not-a-real-palette") },
+    });
+    expect(readId()).toBe("traffic-light");
+  });
+
+  it("resolves every registered palette id from storage", () => {
+    for (const palette of HEALTH_PALETTES) {
+      vi.stubGlobal("window", {
+        localStorage: { getItem: vi.fn(() => palette.id) },
+      });
+      expect(readId()).toBe(palette.id);
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/apps/ui/src/lib/health-palette.ts
+++ b/apps/ui/src/lib/health-palette.ts
@@ -102,13 +102,13 @@ const STORAGE_KEY = "mg-health-palette";
 const STYLE_ID = "mg-health-palette-style";
 const DEFAULT_ID: HealthPaletteId = "traffic-light";
 
-function readId(): HealthPaletteId {
+export function readId(): HealthPaletteId {
   if (typeof window === "undefined") return DEFAULT_ID;
   const v = window.localStorage.getItem(STORAGE_KEY);
   return (HEALTH_PALETTES.find((p) => p.id === v)?.id ?? DEFAULT_ID) as HealthPaletteId;
 }
 
-function cssFor(p: HealthPaletteDef): string {
+export function cssFor(p: HealthPaletteDef): string {
   return (
     `:root{--health-ok:${p.light.ok};--health-warn:${p.light.warn};--health-down:${p.light.down};--health-unknown:${p.light.unknown};}` +
     `.dark{--health-ok:${p.dark.ok};--health-warn:${p.dark.warn};--health-down:${p.dark.down};--health-unknown:${p.dark.unknown};}`


### PR DESCRIPTION
Closes #3446

## Summary
- Export `readId` and `cssFor` from `lib/health-palette.ts` so palette resolution is unit-testable.
- Add tests for CSS variable mapping across all palettes and localStorage-backed palette id resolution (valid, empty, unknown, SSR).

Test-only / lib-only — no new React components or page wiring.

## Test plan
- [x] `cd apps/ui && npm run lint`
- [x] `cd apps/ui && npm test`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`

Made with [Cursor](https://cursor.com)