### PR TITLE
feat(registry): add SN117 BrainPlay /api/health subnet-api surface

### DIFF
--- a/registry/subnets/brainplay.json
+++ b/registry/subnets/brainplay.json
@@ -72,6 +72,25 @@
         "timeout_ms": 10000
       },
       "notes": "Public BrainPlay app URL from repository homepage metadata."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-117-brainplay-health",
+      "kind": "subnet-api",
+      "name": "BrainPlay API health",
+      "notes": "Public no-auth GET /api/health on play.shiftlayer.ai returning application liveness JSON. Served on the BrainPlay public app host declared as the GitHub repository homepage and registered website surface.",
+      "provider": "shiftlayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/shiftlayer-llc/brainplay-subnet",
+        "https://play.shiftlayer.ai/"
+      ],
+      "url": "https://play.shiftlayer.ai/api/health"
     }
   ]
 }


### PR DESCRIPTION
Closes #704

Adds a public `subnet-api` health surface for SN117 BrainPlay at `GET https://play.shiftlayer.ai/api/health`, which returns `{"status":"ok"}` without authentication. The endpoint is served on the same host as the registered website surface and GitHub repository homepage (`shiftlayer-llc/brainplay-subnet`).

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /api/health` returns 200 JSON on `play.shiftlayer.ai`
- [x] Single-file append-only change to `registry/subnets/brainplay.json`

Made with [Cursor](https://cursor.com)