### PR TITLE
feat(registry): enrich SN15 ORO — current race API

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -241,6 +241,25 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/v1/public/suites/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-races-current-api",
+      "kind": "subnet-api",
+      "name": "ORO current race API",
+      "notes": "Public no-auth GET /v1/public/races/current on api.oroagents.com returning the active evaluation race for the current suite. Documented in the subnet OpenAPI on the same host as existing ORO public API surfaces.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/v1/public/races/current"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
Closes #699

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/oro.json`.

## Surface

- Netuid: **15** (ORO)
- Kind: **subnet-api**
- Public URL: `https://api.oroagents.com/v1/public/races/current`
- Source URLs:
  - https://api.oroagents.com/openapi.json
  - https://oroagents.com/
- Provider slug: **oro**

## Checklist

- [x] Changes exactly one `registry/subnets/oro.json` file (append-only, +19 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, or sensitive data in notes
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint — not a health/liveness probe
- [x] Live probe: `curl -sS https://api.oroagents.com/v1/public/races/current` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/oro.json` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --write registry/subnets/oro.json` — passed (`format:check` clean)
- [x] Links tracked issue: **Closes #699**

## Conflict avoidance

Touches only `oro.json`. No overlap with open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3571 BrainPlay health | `brainplay.json` only |
| #3570 Verathos subnet-config | `verathos.json` only |
| #3569 Vidaio health | `vidaio.json` only |
| #3556 client version bump | No |
| #3546 readme catalog | `README.md` only |

Merges cleanly after the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)