### PR TITLE
feat(registry): add SN28 gm /healthz subnet-api surface

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -65,6 +65,22 @@
       },
       "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
       "url": "https://api.saygm.com/v1/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-28-gm-health",
+      "kind": "subnet-api",
+      "name": "gm gateway health",
+      "notes": "Public no-auth GET /healthz on saygm.com returning gateway liveness (observed plain-text response: ok). Served on the same host as the registered OpenAPI spec and website surface.",
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
+      "url": "https://saygm.com/healthz"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #2030

Adds a public `subnet-api` health surface for SN28 gm at `GET https://saygm.com/healthz`, which returns plain-text `ok` without authentication. The endpoint is served on the same host as the registered OpenAPI spec and website surface.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /healthz` returns 200 on `saygm.com`
- [x] Single-file append-only change to `registry/subnets/gm.json`
- [x] Merge-simulated cleanly after open PRs #3572, #3556, #3546

Made with [Cursor](https://cursor.com)