### PR TITLE
test(ui): cover search-history recent queries + palette state

### DIFF
--- a/apps/ui/src/lib/metagraphed/search-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/search-history.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  loadRecent,
+  pushRecent,
+  clearRecent,
+  loadPaletteState,
+  savePaletteState,
+  SUGGESTED_QUERIES,
+} from "./search-history";
+
+const RECENT_KEY = "mg.search.recent";
+const STATE_KEY = "mg.search.state.v1";
+
+// A Map-backed localStorage on a stub `window`. search-history reads `window` fresh on every call
+// (no module-level cache), so a per-test stub is enough — no vi.resetModules needed. Node's default
+// (no window) covers the SSR paths.
+function stubWindow(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  });
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("recent queries (loadRecent / pushRecent / clearRecent)", () => {
+  it("pushRecent prepends most-recent-first and loadRecent reads it back", () => {
+    stubWindow();
+    pushRecent("bittensor");
+    pushRecent("rpc");
+    expect(loadRecent()).toEqual(["rpc", "bittensor"]);
+  });
+
+  it("trims and ignores empty / whitespace-only queries", () => {
+    const store = stubWindow();
+    pushRecent("  spaced  ");
+    pushRecent("   ");
+    pushRecent("");
+    expect(loadRecent()).toEqual(["spaced"]);
+    expect(store.has(RECENT_KEY)).toBe(true);
+  });
+
+  it("de-duplicates case-insensitively, moving an existing entry to the front", () => {
+    stubWindow();
+    pushRecent("Alpha");
+    pushRecent("beta");
+    pushRecent("ALPHA");
+    expect(loadRecent()).toEqual(["ALPHA", "beta"]);
+  });
+
+  it("caps the list at 5 (drops the oldest)", () => {
+    stubWindow();
+    for (const q of ["a", "b", "c", "d", "e", "f"]) pushRecent(q);
+    expect(loadRecent()).toEqual(["f", "e", "d", "c", "b"]);
+  });
+
+  it("loadRecent filters non-strings and caps a longer persisted array", () => {
+    stubWindow({
+      [RECENT_KEY]: JSON.stringify(["a", 1, null, "b", "c", "d", "e", "f"]),
+    });
+    expect(loadRecent()).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("loadRecent tolerates malformed / non-array storage, returning []", () => {
+    stubWindow({ [RECENT_KEY]: "{not json" });
+    expect(loadRecent()).toEqual([]);
+    stubWindow({ [RECENT_KEY]: JSON.stringify({ not: "an array" }) });
+    expect(loadRecent()).toEqual([]);
+  });
+
+  it("clearRecent removes the persisted list", () => {
+    const store = stubWindow({ [RECENT_KEY]: JSON.stringify(["a", "b"]) });
+    clearRecent();
+    expect(store.has(RECENT_KEY)).toBe(false);
+    expect(loadRecent()).toEqual([]);
+  });
+});
+
+describe("palette state (loadPaletteState / savePaletteState)", () => {
+  it("round-trips a full state", () => {
+    stubWindow();
+    savePaletteState({ q: "rpc", scope: "endpoints" });
+    expect(loadPaletteState()).toEqual({ q: "rpc", scope: "endpoints" });
+  });
+
+  it("defaults missing fields (q -> '', scope -> 'all')", () => {
+    stubWindow({ [STATE_KEY]: JSON.stringify({ q: "only-q" }) });
+    expect(loadPaletteState()).toEqual({ q: "only-q", scope: "all" });
+    stubWindow({ [STATE_KEY]: JSON.stringify({ scope: "subnets" }) });
+    expect(loadPaletteState()).toEqual({ q: "", scope: "subnets" });
+  });
+
+  it("returns null when nothing is persisted or the value is malformed", () => {
+    stubWindow();
+    expect(loadPaletteState()).toBeNull();
+    stubWindow({ [STATE_KEY]: "{broken" });
+    expect(loadPaletteState()).toBeNull();
+  });
+});
+
+describe("SSR safety (no window)", () => {
+  it("reads default to empty/null and writes are no-ops without throwing", () => {
+    // No window stubbed → node's `window` is undefined.
+    expect(loadRecent()).toEqual([]);
+    expect(loadPaletteState()).toBeNull();
+    expect(() => pushRecent("x")).not.toThrow();
+    expect(() => clearRecent()).not.toThrow();
+    expect(() => savePaletteState({ q: "x", scope: "all" })).not.toThrow();
+  });
+});
+
+describe("SUGGESTED_QUERIES", () => {
+  it("is a non-empty list of trimmed strings", () => {
+    expect(SUGGESTED_QUERIES.length).toBeGreaterThan(0);
+    for (const q of SUGGESTED_QUERIES) {
+      expect(typeof q).toBe("string");
+      expect(q).toBe(q.trim());
+      expect(q.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds unit coverage for `lib/metagraphed/search-history.ts` — the recent-query history and persisted command-palette state (both localStorage-backed) that the ⌘K palette and nav omnibox rely on, previously untested.

Part of #2542 (Phase-1 pure-module coverage).

## How

Test-only — no production change. Stubs a Map-backed `localStorage` on a fake `window` per case (the module reads `window` fresh each call, so no `resetModules` is needed); the SSR paths run with node's default `window === undefined`.

Covers:
- **loadRecent / pushRecent / clearRecent** — most-recent-first ordering, whitespace trim + empty-query rejection, case-insensitive de-dup (moves an existing entry to the front), the 5-item cap (oldest dropped), non-string filtering, and malformed / non-array JSON tolerance.
- **loadPaletteState / savePaletteState** — full round-trip, per-field defaults (`q → ""`, `scope → "all"`), and `null` on missing/malformed storage.
- **SSR safety** — reads default to empty/null and writes are no-ops without throwing when there's no `window`.
- **SUGGESTED_QUERIES** — sanity (non-empty, trimmed strings).

12 tests pass locally (`vitest run src/lib/metagraphed/search-history.test.ts`).