### PR TITLE
feat(registry): add SN113 TensorUSD subnet-api health surface

### DIFF
--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -86,6 +86,28 @@
         "timeout_ms": 10000
       },
       "notes": "Official TensorUSD source repository."
+    },
+    {
+      "id": "sn-113-tensorusd-subnet-api",
+      "name": "TensorUSD API health",
+      "kind": "subnet-api",
+      "url": "https://api.tensorusd.com/health",
+      "provider": "tensorusd",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://tensorusd.com/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the TensorUSD (SN113) backend API health (status + component/database connectivity). Hosted on api.tensorusd.com, the API subdomain of the subnet's registered website tensorusd.com."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/tensorusd.json`. Append-only; no other file or field changed.

Closes #710

## Summary

Registers SN113 TensorUSD's public no-auth API endpoint — filling the manifest's own documented gap ("No verified safe public subnet API endpoint yet"). `https://api.tensorusd.com/health` returns live backend health as JSON (`{status:"healthy", components:{database:{connected,state},...}}`), clearly the subnet's real API. The host `api.tensorusd.com` is the API subdomain of the subnet's registered website `tensorusd.com` (same owner), and the subnet's official identity (website + repo + docs) is already maintainer-reviewed on the manifest.

## Surface

- Netuid: 113
- Kind: subnet-api
- Public URL: https://api.tensorusd.com/health
- Source URL (proves the claim): https://tensorusd.com/
- Provider slug: tensorusd

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `auth_required: false`, `public_safe: true`; the API host is the subnet's own registered apex domain.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, or private URLs.
- [x] Not a duplicate — the manifest had no subnet-api surface (gap_notes confirm).
- [x] Links a tracked issue (`Closes #710`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/tensorusd.json` → passed (4 surfaces, 1 file)
- [x] `npm run scan:public-safety` → passed
