### PR TITLE
feat(registry): add SN87 Luminar Network /healthz subnet-api surface

### DIFF
--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -218,6 +218,25 @@
       },
       "source_urls": ["https://github.com/Luminar-Network/luminar-sn"],
       "url": "https://github.com/Luminar-Network/luminar-sn"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-87-luminar-health",
+      "kind": "subnet-api",
+      "name": "Luminar Network health",
+      "notes": "Public no-auth GET /healthz on luminar.network returning gateway liveness (observed plain-text response: ok). Served on the official SN87 website host registered in this manifest and linked from the Luminar source repository README.",
+      "provider": "luminar-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/Luminar-Network/luminar-sn",
+        "https://luminar.network/"
+      ],
+      "url": "https://luminar.network/healthz"
     }
   ],
   "website_url": "https://luminar.network/"


### PR DESCRIPTION
Closes #457

Adds a public `subnet-api` health surface for SN87 Luminar Network at `GET https://luminar.network/healthz`, which returns plain-text `ok` without authentication. The endpoint is served on the official website host registered in this manifest and linked from the Luminar source repository README.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /healthz` returns 200 on `luminar.network`
- [x] Single-file append-only change to `registry/subnets/luminar-network.json`
- [x] Merge-simulated cleanly after open PRs #3579, #3578, #3577, #3573, #3546

Made with [Cursor](https://cursor.com)