### PR TITLE
feat(registry): add SN26 Perturb subnet-api health surface

### DIFF
--- a/registry/subnets/perturb.json
+++ b/registry/subnets/perturb.json
@@ -9,7 +9,30 @@
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "id": "sn-26-perturb-subnet-api",
+      "name": "Perturb API health",
+      "kind": "subnet-api",
+      "url": "https://api.perturbai.io/health",
+      "provider": "perturb",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://www.perturbai.io/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the Perturb (SN26) backend API health as JSON (status + server timestamp). Hosted on api.perturbai.io, the API subdomain of the subnet's registered website perturbai.io."
+    }
+  ],
   "social": {
     "x": "https://x.com/perturbaix"
   },


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/perturb.json`. Append-only; no other file or field changed.

Closes #583

## Summary

Registers SN26 Perturb's public no-auth API endpoint. `https://api.perturbai.io/health` returns live backend health as JSON (`{status:"ok", timestamp}`). The host `api.perturbai.io` is the API subdomain of the subnet's registered website `perturbai.io` (same owner), matching the subnet's on-chain identity.

## Surface

- Netuid: 26
- Kind: subnet-api
- Public URL: https://api.perturbai.io/health
- Source URL (proves the claim): https://www.perturbai.io/
- Provider slug: perturb

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only (first surface on the manifest).
- [x] `authority: community` + `review.state: community-submitted`.
- [x] The `url` is public, no-auth, safe for read-only probes; the API host is the subnet's own registered apex domain.
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs.
- [x] Not a duplicate — the manifest had no surfaces.
- [x] Links a tracked issue (`Closes #583`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/perturb.json` → passed
- [x] `npm run scan:public-safety` → passed
