### PR TITLE
feat(registry): enrich SN7 Allways — network history state API

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -337,6 +337,31 @@
         "https://api.all-ways.io/swagger"
       ],
       "url": "https://api.all-ways.io/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-7-allways-history-state-api",
+      "kind": "subnet-api",
+      "name": "Allways network history state API",
+      "notes": "Public no-auth GET /history/state on api.all-ways.io returning time-series active node counts and in-flight swap concurrency per bucket. Documented in the subnet OpenAPI (api.all-ways.io/swagger-json, path /history/state); same host as existing Allways subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/history/state"
     }
   ],
   "website_url": "https://all-ways.io/"


### PR DESCRIPTION
Closes #573

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/allways.json`.

## Surface

- Netuid: **7** (Allways)
- Kind: **subnet-api**
- Public URL: `https://api.all-ways.io/history/state`
- Source URLs:
  - https://api.all-ways.io/swagger-json
  - https://api.all-ways.io/swagger
- Provider slug: **allways**

## Checklist

- [x] Changes exactly one `registry/subnets/allways.json` file (append-only, +25 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, or sensitive data in notes
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint — not a health/liveness probe
- [x] Live probe: `curl -sS https://api.all-ways.io/history/state` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/allways.json` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --write registry/subnets/allways.json` — passed (`format:check` clean)
- [x] Links tracked issue: **Closes #573**

## Conflict avoidance

Touches only `allways.json`. No overlap with open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3581 Luminar health | `luminar-network.json` only |
| #3580 TensorUSD health | `tensorusd.json` only |
| #3579 recent-visits tests | No |
| #3546 readme catalog | `README.md` only |

Merges cleanly after the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)