### PR TITLE
feat(registry): enrich SN51 lium.io — add public API + OpenAPI schema surfaces

### DIFF
--- a/registry/providers/lium.json
+++ b/registry/providers/lium.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "id": "lium",
+  "name": "lium.io",
+  "kind": "subnet-team",
+  "website_url": "https://lium.io/",
+  "docs_url": "https://docs.lium.io/",
+  "github_url": "https://github.com/Datura-ai/lium-io",
+  "authority": "official",
+  "notes": "Provider entry for lium.io SN51, the GPU-compute marketplace operator — website, Lium Backend API OpenAPI schema, and public machines API."
+}

--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -12,5 +12,57 @@
   "social": {
     "x": "https://x.com/lium_io"
   },
-  "surfaces": []
+  "website_url": "https://lium.io/",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-io-openapi",
+      "kind": "openapi",
+      "name": "Lium Backend API OpenAPI schema",
+      "notes": "Public machine-readable OpenAPI 3.1.0 document for the Lium Backend API (title \"Lium Backend API\", version 1.0.0) powering the SN51 lium.io GPU-compute marketplace. Fetched 200 with a real paths object (e.g. GET /machines, /executors, /volumes, /version). No auth required to retrieve the schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://lium.io/api/openapi.json",
+      "source_urls": ["https://lium.io/", "https://lium.io/api/openapi.json"],
+      "url": "https://lium.io/api/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-io-machines-api",
+      "kind": "subnet-api",
+      "name": "Lium machines API",
+      "notes": "Public no-auth GET /api/machines on lium.io returning a JSON array of available GPU machine types with live pricing and utilization (name, price, rental_rate, total_gpu_count, per-epoch cost estimates) for the SN51 lium.io compute marketplace. Verified 200 application/json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "schema_url": "https://lium.io/api/openapi.json",
+      "source_urls": [
+        "https://lium.io/api/machines",
+        "https://lium.io/api/openapi.json"
+      ],
+      "url": "https://lium.io/api/machines"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #462

## Summary

SN51 **lium.io** was a bare community-seeded stub (empty surfaces). lium.io — the GPU-compute marketplace operator (X @lium_io, repo Datura-ai/lium-io) — serves a live, public Lium Backend API, so this enriches the subnet with its OpenAPI schema and a public API endpoint (exactly what #462 asks for).

## Surfaces added

**OpenAPI schema** — https://lium.io/api/openapi.json
- Verified 200, machine-readable OpenAPI 3.1.0, info.title = "Lium Backend API", info.version = 1.0.0, real paths object (e.g. GET /machines, /executors, /volumes, /version). No auth required to retrieve the schema.

**Public API** — https://lium.io/api/machines
- Verified 200, public no-auth JSON array of available GPU machine types with live pricing/utilization (name, price, rental_rate, total_gpu_count, per-epoch cost estimates). No wallet/key material in the body.

The machine-injected website surface is left to the build pipeline (validate flags it as auto-promoted); this PR adds only the machine-undiscoverable openapi + subnet-api surfaces, plus the operator's website_url and a new registry/providers/lium.json provider entry.

## Validation
- validate:surface passes (560 surfaces across 118 files)
- scan:public-safety passes
- prettier clean; both endpoints re-fetched 200 during review
