### PR TITLE
feat(registry): add SN95 Actual /api/health subnet-api surface

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -78,6 +78,22 @@
         "timeout_ms": 10000
       },
       "notes": "Public Actual GGUF model registry page. The page is browser-facing and served publicly; account-specific Actual docs redirect to login and are not listed as public docs."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-95-actual-health",
+      "kind": "subnet-api",
+      "name": "Actual API health",
+      "notes": "Public no-auth GET /api/health on actual.inc returning application liveness JSON. Served on the official Actual Computer website host registered in this manifest.",
+      "provider": "actual-computer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": ["https://actual.inc/"],
+      "url": "https://actual.inc/api/health"
     }
   ],
   "contact": "subnet@actual.inc"


### PR DESCRIPTION
Closes #459

Adds a public `subnet-api` health surface for SN95 Actual at `GET https://actual.inc/api/health`, which returns `{"status":"ok"}` without authentication. The endpoint is served on the official Actual Computer website host registered in this manifest.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /api/health` returns 200 JSON on `actual.inc`
- [x] Single-file append-only change to `registry/subnets/actual.json`
- [x] Merge-simulated cleanly after open PRs #3584, #3583, #3579, #3546

Made with [Cursor](https://cursor.com)