### PR TITLE
feat(registry): enrich SN15 ORO — race history API

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -260,6 +260,25 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/v1/public/races/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-races-history-api",
+      "kind": "subnet-api",
+      "name": "ORO race history API",
+      "notes": "Public no-auth GET /v1/public/races/history on api.oroagents.com returning paginated completed and cancelled evaluation races (most recent first). Documented in the subnet OpenAPI on the same host as existing ORO public API surfaces.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/v1/public/races/history"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
Closes #699

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/oro.json`.

## Surface

- Netuid: **15** (ORO)
- Kind: **subnet-api**
- Public URL: `https://api.oroagents.com/v1/public/races/history`
- Source URLs:
  - https://api.oroagents.com/openapi.json
  - https://oroagents.com/
- Provider slug: **oro**

## Checklist

- [x] Changes exactly one `registry/subnets/oro.json` file (append-only, +19 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, or sensitive data in notes
- [x] Does not duplicate an existing Metagraphed surface
- [x] Substantive functional endpoint — not a health/liveness probe
- [x] Live probe: `curl -sS https://api.oroagents.com/v1/public/races/history` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/oro.json` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --write registry/subnets/oro.json` — passed (`format:check` clean)
- [x] Links tracked issue: **Closes #699**

## Conflict avoidance

Touches only `oro.json`. No overlap with open PRs:

| Open PR | Touches registry? |
|---------|-------------------|
| #3585 Actual health | `actual.json` only |
| #3584 lium.io API | `lium-io.json` + provider only |
| #3579 recent-visits tests | No |
| #3546 readme catalog | `README.md` only |

Merges cleanly after the above land without rebase.

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes


Made with [Cursor](https://cursor.com)