### PR TITLE
feat(registry): enrich SN21 AdTAO — add validator API + OpenAPI schema surfaces

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -65,6 +65,59 @@
         "timeout_ms": 10000
       },
       "notes": "Official AdTAO source repository."
+    },
+    {
+      "id": "sn-21-adtao-validator-openapi",
+      "name": "AdTAO SN21 Validator OpenAPI schema",
+      "kind": "openapi",
+      "url": "https://validator.adtao.io/openapi.json",
+      "provider": "adtao",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "schema_status": "machine-readable",
+      "schema_url": "https://validator.adtao.io/openapi.json",
+      "source_urls": [
+        "https://github.com/ippcteam/SN21-adtao",
+        "https://validator.adtao.io/openapi.json"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"SN21 Validator\", version 0.1.0) served by the official AdTAO validator API on the operator's validator.adtao.io host. Documents the public epoch/episode, prediction, commitment, verification, scores, and training routes plus /health. Unauthenticated GET returns the full paths object."
+    },
+    {
+      "id": "sn-21-adtao-validator-api",
+      "name": "AdTAO SN21 Validator API",
+      "kind": "subnet-api",
+      "url": "https://validator.adtao.io/health",
+      "provider": "adtao",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "schema_url": "https://validator.adtao.io/openapi.json",
+      "source_urls": [
+        "https://github.com/ippcteam/SN21-adtao",
+        "https://validator.adtao.io/"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Official public AdTAO (SN21) validator API on the operator's validator.adtao.io host. An unauthenticated GET on /health returns live JSON service status (service, current epoch label, episodes loaded, submission window, deadline). The /v1/epochs routes are described in the linked OpenAPI schema."
     }
   ],
   "social": { "x": "https://x.com/ppcrebel" },


### PR DESCRIPTION
Closes #693

## Summary

SN21 **AdTAO**'s registry file notes it has no verified public subnet API endpoint or OpenAPI schema yet. The operator (AdTAO / ippcteam — site adtao.io, repo github.com/ippcteam/SN21-adtao) runs its official validator API on the operator-owned `validator.adtao.io` host, so this enriches the subnet with those surfaces (exactly what #693 asks for).

## Surfaces added

**OpenAPI schema** — https://validator.adtao.io/openapi.json
- Verified 200, machine-readable OpenAPI 3.1.0, info.title = "SN21 Validator", info.version = 0.1.0, real paths object (/health, /v1/epochs/{epoch_id}/episodes, .../predictions, .../commitment, .../verification, .../scores, /v1/registration-status). No auth required to retrieve the schema.

**Public API** — https://validator.adtao.io/health
- Verified 200, no-auth JSON service status: `{"status":"ok","service":"sn21-validator","current_epoch":"WR-2026-W27-PUB-E1","episodes_loaded":179,"submission_open":true,"deadline_utc":"2026-07-06T05:00:00+00:00"}`. No wallet/key material in the body.

Both hosts are on the operator's own `adtao.io` domain (validator subdomain) and are net-new (the file previously had only website + source-repo). Provider `adtao` is already registered.

## Validation
- validate:surface passes (560 surfaces across 118 files)
- scan:public-safety passes
- prettier clean; both endpoints re-fetched 200 during review
