### PR TITLE
feat(registry): add SN64 Chutes /api/health subnet-api surface

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -561,6 +561,22 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/ping"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-health",
+      "kind": "subnet-api",
+      "name": "Chutes website health",
+      "notes": "Public no-auth GET /api/health on chutes.ai returning application liveness JSON. Served on the official Chutes website host registered in this manifest.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": ["https://chutes.ai/", "https://chutes.ai/docs"],
+      "url": "https://chutes.ai/api/health"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
Closes #688

Adds a public `subnet-api` health surface for SN64 Chutes at `GET https://chutes.ai/api/health`, which returns application liveness JSON without authentication. The endpoint is served on the official Chutes website host registered in this manifest.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /api/health` returns 200 JSON on `chutes.ai`
- [x] Single-file append-only change to `registry/subnets/chutes.json`
- [x] Merge-simulated cleanly after open PRs #3587, #3586, #3579, #3546

Made with [Cursor](https://cursor.com)