### PR TITLE
feat(registry): add SN61 RedTeam /healthz subnet-api surface

### DIFF
--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -107,6 +107,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official RedTeam source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-61-redteam-health",
+      "kind": "subnet-api",
+      "name": "RedTeam dashboard health",
+      "notes": "Public no-auth GET /healthz on dashboard.theredteam.io returning gateway liveness (observed plain-text response: ok). Served on the official RedTeam dashboard host registered in this manifest and linked from the RedTeam source repository README.",
+      "provider": "redteam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/RedTeamSubnet/RedTeam",
+        "https://dashboard.theredteam.io/"
+      ],
+      "url": "https://dashboard.theredteam.io/healthz"
     }
   ],
   "contact": "oscar@theredteam.io"


### PR DESCRIPTION
Closes #716

Adds a public `subnet-api` health surface for SN61 RedTeam at `GET https://dashboard.theredteam.io/healthz`, which returns plain-text `ok` without authentication. The endpoint is served on the official RedTeam dashboard host registered in this manifest and linked from the RedTeam source repository README.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /healthz` returns 200 on `dashboard.theredteam.io`
- [x] Single-file append-only change to `registry/subnets/redteam.json`
- [x] Merge-simulated cleanly after open PRs #3589, #3586, #3579, #3546

Made with [Cursor](https://cursor.com)