### PR TITLE
test(ui): cover metric-sources resolveMetric lookup

### DIFF
--- a/apps/ui/src/lib/metagraphed/metric-sources.test.ts
+++ b/apps/ui/src/lib/metagraphed/metric-sources.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { METRIC_SOURCES, resolveMetric, type MetricKey } from "./metric-sources";
+
+const METRIC_KEYS = Object.keys(METRIC_SOURCES) as MetricKey[];
+
+describe("resolveMetric", () => {
+  it("returns the canonical attribution for known metric keys", () => {
+    expect(resolveMetric("health")).toEqual(METRIC_SOURCES.health);
+    expect(resolveMetric("freshness")).toEqual(METRIC_SOURCES.freshness);
+    expect(resolveMetric("latency")).toEqual(METRIC_SOURCES.latency);
+  });
+
+  it("covers every registered metric key", () => {
+    for (const key of METRIC_KEYS) {
+      expect(resolveMetric(key).metric).toBe(METRIC_SOURCES[key].metric);
+    }
+    expect(METRIC_KEYS).toHaveLength(10);
+  });
+
+  it("falls back when the key is missing or unknown", () => {
+    expect(resolveMetric(undefined)).toEqual({
+      metric: "Metric",
+      source: "Registry artifacts",
+      staleness: "Refresh follows upstream artifact cadence.",
+      defaultWindow: undefined,
+    });
+    expect(resolveMetric("not-a-metric" as MetricKey)).toEqual({
+      metric: "Metric",
+      source: "Registry artifacts",
+      staleness: "Refresh follows upstream artifact cadence.",
+      defaultWindow: undefined,
+    });
+  });
+
+  it("merges caller-provided fallback fields", () => {
+    expect(
+      resolveMetric(undefined, {
+        metric: "Custom metric",
+        source: "Custom source",
+        staleness: "Custom staleness",
+        defaultWindow: "7d",
+      }),
+    ).toEqual({
+      metric: "Custom metric",
+      source: "Custom source",
+      staleness: "Custom staleness",
+      defaultWindow: "7d",
+    });
+  });
+});


### PR DESCRIPTION
Closes #3415

## Summary
- Add `metric-sources.test.ts` covering `resolveMetric` for known keys, exhaustive registry coverage, and fallback/override behavior.

Test-only — no new React components or page wiring.

## Test plan
- [x] `cd apps/ui && npm test`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`

Made with [Cursor](https://cursor.com)