### PR TITLE
fix(ui): give SearchInput an accessible name (aria-label)

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -69,6 +69,9 @@ export function SearchInput({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder ?? "Search…"}
+      // Give the control an accessible name (a placeholder is not one for assistive tech); mirrors
+      // the aria-labelled sibling controls (SortButton, PageSizeSelect) in this file.
+      aria-label={placeholder ?? "Search"}
       className="flex-1 min-w-[180px] rounded border border-border bg-paper px-2.5 py-1.5 text-sm placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
     />
   );


### PR DESCRIPTION
Closes #3429.

## What

The shared `SearchInput` (table toolbar search box) rendered a bare `<input>` with only a `placeholder` — which is **not** an accessible name for assistive technology — unlike every sibling control in the same file (`SortButton`, `PageSizeSelect`) which are `aria-label`led. This affects the search box on the surfaces, subnets, and extrinsics table pages.

## How

Adds `aria-label={placeholder ?? "Search"}` to the input, so the accessible name mirrors the visible placeholder (or a sensible default when none is passed). No visual or behavioral change — accessibility-only, 1 file, +3 lines.