### PR TITLE
fix(ui): fetch subnet Evidence tab from subnet-scoped route

### DIFF
--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -49,8 +49,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
     queryFn: async ({ pageParam, signal }) => {
       const params: Record<string, string | number> = { limit: pageSize };
       if (pageParam != null) params.cursor = pageParam;
-      const path =
-        netuid != null ? `/api/v1/subnets/${netuid}/evidence` : "/api/v1/evidence";
+      const path = netuid != null ? `/api/v1/subnets/${netuid}/evidence` : "/api/v1/evidence";
       const res = await apiFetch<unknown>(path, { params, signal });
       const items = parseEvidenceListPayload(res.data);
       return { items, meta: res.meta as ApiMeta };

--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/metagraphed/client";
-import { metagraphedQueryKey } from "@/lib/metagraphed/queries";
+import { metagraphedQueryKey, parseEvidenceListPayload } from "@/lib/metagraphed/queries";
 import { ExternalLink } from "./external-link";
 import { HoverPreview } from "./hover-preview";
 import { EmptyState, Skeleton } from "./states";
@@ -30,9 +30,11 @@ function nextEvidenceCursor(meta?: ApiMeta): string | number | undefined {
 /**
  * Grouped evidence/source panel.
  *
- * Uses cursor-based pagination (?limit=&cursor=) against /api/v1/evidence and
- * exposes a "Load more" control that walks the next cursor returned in API
- * metadata. The panel also supports a source-type filter and group sort.
+ * Uses cursor-based pagination (?limit=&cursor=) against the canonical route:
+ * GET /api/v1/subnets/{netuid}/evidence when scoped to a subnet, otherwise the
+ * network-wide GET /api/v1/evidence ledger. Exposes a "Load more" control that
+ * walks the next cursor returned in API metadata, plus source-type filter and
+ * group sort.
  */
 export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
   const [sourceFilter, setSourceFilter] = useState<string>("");
@@ -47,16 +49,10 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
     queryFn: async ({ pageParam, signal }) => {
       const params: Record<string, string | number> = { limit: pageSize };
       if (pageParam != null) params.cursor = pageParam;
-      if (netuid != null) params.netuid = netuid;
-      const res = await apiFetch<unknown>("/api/v1/evidence", { params, signal });
-      const raw = res.data as unknown;
-      let items: EvidenceItem[] = [];
-      if (Array.isArray(raw)) items = raw as EvidenceItem[];
-      else if (raw && typeof raw === "object") {
-        const obj = raw as Record<string, unknown>;
-        const candidate = obj.evidence ?? obj.entries ?? obj.items;
-        if (Array.isArray(candidate)) items = candidate as EvidenceItem[];
-      }
+      const path =
+        netuid != null ? `/api/v1/subnets/${netuid}/evidence` : "/api/v1/evidence";
+      const res = await apiFetch<unknown>(path, { params, signal });
+      const items = parseEvidenceListPayload(res.data);
       return { items, meta: res.meta as ApiMeta };
     },
     getNextPageParam: (last) => nextEvidenceCursor(last.meta),

--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -12,6 +12,8 @@ import {
   normalizeAccountEvent,
   normalizeExtrinsic,
   normalizeAgentCatalogDetail,
+  normalizeEvidenceClaim,
+  parseEvidenceListPayload,
 } from "./queries";
 
 // These tests lock the canonical-only reads after #1756 collapsed the redundant
@@ -637,5 +639,55 @@ describe("normalizeProvider", () => {
     );
     expect(out.name).toBe("Acme");
     expect((out as Record<string, unknown>).extra_field).toBe("kept");
+  });
+});
+
+describe("subnet evidence helpers (#3347)", () => {
+  it("normalizeEvidenceClaim maps a claim row to a render item", () => {
+    const out = normalizeEvidenceClaim(
+      {
+        subject: "candidate:sn-7-website",
+        source_type: "website",
+        source_url: "https://example.com",
+        claim: "Example claim",
+        support_summary: "Summary",
+        verified_at: "2026-06-01T00:00:00.000Z",
+      },
+      7,
+    );
+    expect(out).toMatchObject({
+      id: "candidate:sn-7-website",
+      netuid: 7,
+      source: "website",
+      url: "https://example.com",
+      note: "Example claim",
+      recorded_at: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("parseEvidenceListPayload reads claims from the subnet-scoped envelope", () => {
+    const items = parseEvidenceListPayload({
+      netuid: 7,
+      claims: [
+        {
+          subject: "a",
+          source_type: "docs",
+          source_url: "https://a.test",
+          claim: "A",
+          support_summary: "A",
+        },
+      ],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe("a");
+    expect(items[0]?.netuid).toBe(7);
+  });
+
+  it("parseEvidenceListPayload still reads the network-wide evidence array", () => {
+    const items = parseEvidenceListPayload({
+      evidence: [{ id: "e1", source: "docs", url: "https://e.test" }],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe("e1");
   });
 });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4177,6 +4177,40 @@ export const evidenceQuery = (params?: QueryParams) =>
     staleTime: STALE_LONG,
   });
 
+/** Map a subnet-scoped evidence claim (GET /api/v1/subnets/{netuid}/evidence) to a render row. */
+export function normalizeEvidenceClaim(raw: unknown, netuid?: number): EvidenceItem | null {
+  if (!isRecord(raw)) return null;
+  const subject = optionalString(raw.subject)?.trim();
+  if (!subject) return null;
+  return {
+    id: subject,
+    netuid,
+    source: optionalString(raw.source_type),
+    url: optionalString(raw.source_url),
+    recorded_at: optionalString(raw.verified_at),
+    note: optionalString(raw.claim) ?? optionalString(raw.support_summary),
+  };
+}
+
+export function parseEvidenceListPayload(raw: unknown): EvidenceItem[] {
+  if (Array.isArray(raw)) return raw as EvidenceItem[];
+  if (!isRecord(raw)) return [];
+  for (const key of ["evidence", "entries", "items", "claims"] as const) {
+    const candidate = raw[key];
+    if (Array.isArray(candidate)) {
+      if (key === "claims") {
+        const netuid = optionalNumber(raw.netuid);
+        return candidate.flatMap((row) => {
+          const item = normalizeEvidenceClaim(row, netuid);
+          return item ? [item] : [];
+        });
+      }
+      return candidate as EvidenceItem[];
+    }
+  }
+  return [];
+}
+
 type ChangelogEntry = { id: string; at?: string; title?: string; kind?: string };
 
 function normalizeChangelogEntries(raw: unknown[]): ChangelogEntry[] {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -264,7 +264,7 @@ function ProfileShell({ netuid }: { netuid: number }) {
               id="evidence"
               title="Evidence & sources"
               subtitle="Every claim should be traceable."
-              info="Source URLs and timestamps for verified registry entries."
+              info="GET /api/v1/subnets/{netuid}/evidence"
             >
               <EvidencePanel netuid={netuid} />
             </SectionAnchor>
@@ -367,7 +367,7 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         id="evidence"
         title="Sources & evidence"
         subtitle="Primary links and recorded evidence backing this profile."
-        info="GET /api/v1/evidence"
+        info="GET /api/v1/subnets/{netuid}/evidence"
         tone="muted"
       >
         <EvidencePanel netuid={netuid} />


### PR DESCRIPTION
Closes #3347

## Summary

The subnet **Evidence** tab was calling the network-wide ledger (`GET /api/v1/evidence?netuid=…`) instead of the canonical per-subnet artifact route (`GET /api/v1/subnets/{netuid}/evidence`). That returned the wrong collection shape and could omit subnet-scoped claims.

## Root cause

`EvidencePanel` always hit `/api/v1/evidence` and passed `netuid` as a query param. The public contract defines a dedicated subnet route whose payload is `data.claims[]`, not the global `evidence[]` ledger.

## Fix

- When `netuid` is provided, fetch `/api/v1/subnets/{netuid}/evidence`.
- Map `claims[]` into the existing render model via `normalizeEvidenceClaim` / `parseEvidenceListPayload`.
- Update subnet page API hints to document the correct route.

## Impact

Subnet evidence tabs now show the same claims the API/MCP subnet route serves — restoring data correctness for operators reviewing registry provenance.

## Risks / tradeoffs

- Global surfaces page (`<EvidencePanel />` without `netuid`) is unchanged and still uses `/api/v1/evidence`.

## Test plan

- [x] `cd apps/ui && npm test`
- [x] Added unit tests for claim parsing helpers
