### PR TITLE
feat(registry): add Aurelius work-token designated address API (SN37)

### DIFF
--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -67,6 +67,25 @@
         "submitted_by": "kiannidev"
       },
       "notes": "Public no-auth GET returning Central API health (status, db, db_pool, classifier, novelty). Documented in the subnet's own OpenAPI (new-collector-api-production.up.railway.app/openapi.json, path /health); same host as the existing openapi + docs surfaces. The official README documents this production host as the finney/mainnet api_url and recommends curl against /health for connectivity checks."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-37-aurelius-work-token-designated-address",
+      "kind": "subnet-api",
+      "name": "Aurelius work-token designated address API",
+      "notes": "Public no-auth GET returning the Central API work-token designated receiving address. Documented in the subnet's own OpenAPI (new-collector-api-production.up.railway.app/openapi.json, path /work-token/designated-address); same host as the existing openapi, docs, and /health subnet-api surfaces. The official README documents this production host as the finney/mainnet api_url.",
+      "provider": "aurelius",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://new-collector-api-production.up.railway.app/openapi.json",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md"
+      ],
+      "url": "https://new-collector-api-production.up.railway.app/work-token/designated-address"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/aurelius.json`.

## Surface

- Netuid: 37
- Kind: subnet-api
- Public URL: https://new-collector-api-production.up.railway.app/work-token/designated-address
- Source URL (proves the claim): https://new-collector-api-production.up.railway.app/openapi.json
- Provider slug: aurelius

## Checklist

- [x] Changes exactly one `registry/subnets/aurelius.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #582`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/aurelius.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3594 | release manifests | `registry/subnets/aurelius.json` |
| #3593 | UI table-controls | registry only |
| #3579 | UI recent-visits tests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #582

Made with [Cursor](https://cursor.com)