### PR TITLE
refactor(ui): extract shared getNextPageParam helper

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeAccountEvent,
   normalizeExtrinsic,
   normalizeAgentCatalogDetail,
+  getNextPageParam,
 } from "./queries";
 
 // These tests lock the canonical-only reads after #1756 collapsed the redundant
@@ -637,5 +638,17 @@ describe("normalizeProvider", () => {
     );
     expect(out.name).toBe("Acme");
     expect((out as Record<string, unknown>).extra_field).toBe("kept");
+  });
+});
+
+describe("getNextPageParam", () => {
+  it("returns the stashed cursor from infinite-list meta", () => {
+    expect(getNextPageParam({ meta: { _next_cursor: "cursor-abc" } })).toBe("cursor-abc");
+  });
+
+  it("returns undefined when the cursor is null or absent", () => {
+    expect(getNextPageParam({ meta: { _next_cursor: null } })).toBeUndefined();
+    expect(getNextPageParam({ meta: {} })).toBeUndefined();
+    expect(getNextPageParam({})).toBeUndefined();
   });
 });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -3441,6 +3441,12 @@ async function fetchInfinitePage<T>(
   return { ...res, meta, cursorInvalid: v.invalid };
 }
 
+/** Read the validated next cursor stashed on infinite-list meta by fetchInfinitePage. */
+export function getNextPageParam(last: { meta?: Record<string, unknown> }): string | undefined {
+  const nc = last.meta?._next_cursor as string | null | undefined;
+  return nc ?? undefined;
+}
+
 /** Server-driven cursor-paginated subnets. */
 export const subnetsInfiniteQuery = (baseParams: QueryParams = {}, initialCursor = "") =>
   infiniteQueryOptions({
@@ -3456,10 +3462,7 @@ export const subnetsInfiniteQuery = (baseParams: QueryParams = {}, initialCursor
       );
       return { ...page, data: page.data.map(normalizeSubnet) } as typeof page;
     },
-    getNextPageParam: (last) => {
-      const nc = (last.meta as Record<string, unknown>)?._next_cursor as string | null | undefined;
-      return nc ?? undefined;
-    },
+    getNextPageParam,
     staleTime: STALE_MED,
   });
 
@@ -3481,10 +3484,7 @@ export const surfacesInfiniteQuery = (baseParams: QueryParams = {}, initialCurso
       // are populated — same mapping the non-paginated surfacesQuery applies.
       return { ...page, data: page.data.map(normalizeSurface) } as InfinitePage<Surface>;
     },
-    getNextPageParam: (last) => {
-      const nc = (last.meta as Record<string, unknown>)?._next_cursor as string | null | undefined;
-      return nc ?? undefined;
-    },
+    getNextPageParam,
     staleTime: STALE_MED,
   });
 


### PR DESCRIPTION
Closes #3438

## Summary
- Extract `getNextPageParam` to read `_next_cursor` from infinite-list meta.
- Wire both `subnetsInfiniteQuery` and `surfacesInfiniteQuery` through the shared helper.
- Add unit tests for present, null, and missing cursor cases.

Lib-only refactor — no new React components or page wiring.

## Test plan
- [x] `cd apps/ui && npm test`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`

Made with [Cursor](https://cursor.com)