### PR TITLE
feat(registry): add SN32 ItsAI subnet-api health surface

### DIFF
--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -112,6 +112,28 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "ItsAI API repository in the team's It-s-AI org; its README describes a FastAPI app that queries miners in \"Subnet32: It's AI\". Distinct from the registered llm-detection repo."
+    },
+    {
+      "id": "sn-32-itsai-subnet-api",
+      "name": "ItsAI API health",
+      "kind": "subnet-api",
+      "url": "https://api.its-ai.org/api/health",
+      "provider": "its-ai",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://its-ai.org/en", "https://docs.its-ai.org/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the ItsAI (SN32) content-detection API health as JSON. Hosted on api.its-ai.org, the API subdomain of the registered website its-ai.org; the API is documented at docs.its-ai.org and implemented in the team's It-s-AI/api FastAPI repo. Fills the file's noted missing public-API-endpoint gap."
     }
   ],
   "social": { "x": "https://x.com/ai_detection" },


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/itsai.json`. Append-only; no other field changed.

Closes #694

## Summary

Registers SN32 ItsAI's public no-auth API endpoint — filling the manifest's own documented gap ("No verified safe public subnet API endpoint yet"). `https://api.its-ai.org/api/health` returns live API health as JSON. The host `api.its-ai.org` is the API subdomain of the subnet's registered website `its-ai.org`; the API is documented at `docs.its-ai.org` ("AI content detection API") and implemented in the team's `It-s-AI/api` FastAPI repo (both already on this manifest) — so ownership and publication are independently established.

## Surface

- Netuid: 32
- Kind: subnet-api
- Public URL: https://api.its-ai.org/api/health
- Source URL (proves the claim): https://its-ai.org/en + https://docs.its-ai.org/
- Provider slug: its-ai

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only endpoint on the subnet's own registered apex domain.
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs.
- [x] Not a duplicate — the manifest had no subnet-api surface.
- [x] Links a tracked issue (`Closes #694`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/itsai.json` → passed
- [x] `npm run scan:public-safety` → passed
