### PR TITLE
fix(ui): fetch subnet Gaps tab from subnet-scoped route

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeExtrinsic,
   normalizeAgentCatalogDetail,
   getNextPageParam,
+  normalizeSubnetGaps,
 } from "./queries";
 
 // These tests lock the canonical-only reads after #1756 collapsed the redundant
@@ -650,5 +651,32 @@ describe("getNextPageParam", () => {
     expect(getNextPageParam({ meta: { _next_cursor: null } })).toBeUndefined();
     expect(getNextPageParam({ meta: {} })).toBeUndefined();
     expect(getNextPageParam({})).toBeUndefined();
+  });
+});
+
+describe("normalizeSubnetGaps (#3348)", () => {
+  it("reads missing_kinds from the subnet gaps priorities row", () => {
+    const out = normalizeSubnetGaps({
+      netuid: 7,
+      priorities: [
+        {
+          netuid: 7,
+          missing_kinds: ["openapi", "docs"],
+          suggested_next_action: "evaluate adapter support",
+        },
+      ],
+      enrichment_queue: [],
+    });
+    expect(out).toMatchObject({
+      netuid: 7,
+      missing_kinds: ["openapi", "docs"],
+      gap_notes: ["evaluate adapter support"],
+      suggested_next_action: "evaluate adapter support",
+    });
+  });
+
+  it("returns null for malformed payloads", () => {
+    expect(normalizeSubnetGaps(null)).toBeNull();
+    expect(normalizeSubnetGaps({ priorities: [] })).toBeNull();
   });
 });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4264,6 +4264,38 @@ export const evidenceQuery = (params?: QueryParams) =>
     staleTime: STALE_LONG,
   });
 
+export type SubnetGapsView = {
+  netuid: number;
+  missing_kinds: string[];
+  gap_notes: string[];
+  suggested_next_action?: string;
+};
+
+/** Normalize GET /api/v1/subnets/{netuid}/gaps for the subnet Gaps tab (#3348). */
+export function normalizeSubnetGaps(raw: unknown): SubnetGapsView | null {
+  if (!isRecord(raw)) return null;
+  const netuid = optionalNumber(raw.netuid);
+  if (netuid == null) return null;
+  const priorities = Array.isArray(raw.priorities) ? raw.priorities : [];
+  const primary = isRecord(priorities[0]) ? priorities[0] : null;
+  const missing_kinds = stringArrayFromUnknown(primary?.missing_kinds);
+  const suggested_next_action = optionalString(primary?.suggested_next_action);
+  const gap_notes = suggested_next_action ? [suggested_next_action] : [];
+  return { netuid, missing_kinds, gap_notes, suggested_next_action };
+}
+
+export const subnetGapsQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-gaps", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/subnets/${netuid}/gaps`, { signal });
+      const data = normalizeSubnetGaps(res.data);
+      if (!data) throw new Error("Invalid subnet gaps response");
+      return { ...res, data };
+    },
+    staleTime: STALE_MED,
+  });
+
 type ChangelogEntry = { id: string; at?: string; title?: string; kind?: string };
 
 function normalizeChangelogEntries(raw: unknown[]): ChangelogEntry[] {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -39,6 +39,7 @@ import {
   subnetHealthQuery,
   subnetCandidatesQuery,
   subnetEventsQuery,
+  subnetGapsQuery,
   fixturesIndexQuery,
   lineageQuery,
   agentCatalogDetailQuery,
@@ -188,16 +189,18 @@ function SubnetDetailPage() {
 
 function ProfileShell({ netuid }: { netuid: number }) {
   const { data: profile, meta } = useSuspenseQuery(subnetProfileQuery(netuid)).data;
+  const { data: gapsResult } = useQuery(subnetGapsQuery(netuid));
+  const subnetGaps = gapsResult?.data;
   const stale = meta?.stale || isStaleFreshness(meta?.generated_at);
   const tab = useActiveTab("overview");
   useHashScroll(tab, SECTION_TO_TAB);
 
-  // Counts shown next to tab labels
+  const gapsCount = subnetGaps?.missing_kinds.length ?? profile?.missing_kinds?.length ?? 0;
   const tabsWithCounts = TABS.map((t) => {
     if (t.id === "surfaces") return { ...t, count: profile?.surface_count };
     if (t.id === "endpoints") return { ...t, count: profile?.endpoint_count };
     if (t.id === "candidates") return { ...t, count: profile?.candidate_count };
-    if (t.id === "gaps") return { ...t, count: (profile?.missing_kinds?.length ?? 0) || undefined };
+    if (t.id === "gaps") return { ...t, count: gapsCount || undefined };
     return { ...t };
   });
 
@@ -258,7 +261,7 @@ function ProfileShell({ netuid }: { netuid: number }) {
           {tab === "endpoints" ? <EndpointsPanel netuid={netuid} /> : null}
           {tab === "schemas" ? <SchemasPanel netuid={netuid} /> : null}
           {tab === "candidates" ? <CandidatesPanel netuid={netuid} /> : null}
-          {tab === "gaps" ? <GapsPanel profile={profile} /> : null}
+          {tab === "gaps" ? <GapsPanel netuid={netuid} /> : null}
           {tab === "evidence" ? (
             <SectionAnchor
               id="evidence"
@@ -300,6 +303,8 @@ function DetailSkeleton() {
 //   8 — Sources & evidence (UI's EvidencePanel, NOT evidence-clusters)
 //   9 — Open incidents (deep-linkable timeline)
 function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetProfile }) {
+  const { data: gapsResult } = useQuery(subnetGapsQuery(netuid));
+  const subnetGaps = gapsResult?.data;
   return (
     <div className="space-y-6">
       {/* 1 — Readiness scorecard: the "can I build on this, where do I start?"
@@ -378,8 +383,10 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         <IncidentTimeline netuid={netuid} />
       </QueryErrorBoundary>
 
-      {(profile?.missing_kinds?.length ?? 0) > 0 || (profile?.gap_notes?.length ?? 0) > 0 ? (
-        <GapsPanel profile={profile} compact />
+      {(subnetGaps?.missing_kinds.length ?? 0) > 0 ||
+      (subnetGaps?.gap_notes.length ?? 0) > 0 ||
+      (profile?.gap_notes?.length ?? 0) > 0 ? (
+        <GapsPanel netuid={netuid} compact />
       ) : null}
     </div>
   );
@@ -910,9 +917,29 @@ function CandidatesPanel({ netuid }: { netuid: number }) {
   );
 }
 
-function GapsPanel({ profile, compact }: { profile?: SubnetProfile; compact?: boolean }) {
-  const missing = profile?.missing_kinds ?? [];
-  const notes = profile?.gap_notes ?? [];
+function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
+  const { data: gapsResult, isLoading, error } = useQuery(subnetGapsQuery(netuid));
+  const gaps = gapsResult?.data;
+  const missing = gaps?.missing_kinds ?? [];
+  const notes = gaps?.gap_notes ?? [];
+  if (isLoading) {
+    return (
+      <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
+        <Skeleton className="h-24 w-full" />
+      </SectionAnchor>
+    );
+  }
+  if (error) {
+    return (
+      <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
+        <EmptyState
+          title="Gaps unavailable"
+          description="The subnet gaps endpoint did not respond."
+          action={RECOVERY.gaps}
+        />
+      </SectionAnchor>
+    );
+  }
   if (missing.length === 0 && notes.length === 0) {
     return (
       <SectionAnchor id="gaps" title="Gaps">
@@ -929,7 +956,7 @@ function GapsPanel({ profile, compact }: { profile?: SubnetProfile; compact?: bo
       id="gaps"
       title={compact ? "Known gaps" : "Gaps"}
       subtitle="Missing resources, profile incompleteness, and curation notes."
-      info="Submit a PR against the public registry to help close any of these gaps."
+      info="GET /api/v1/subnets/{netuid}/gaps"
     >
       <div className="rounded-lg border border-border bg-card p-4 space-y-3">
         {missing.length > 0 ? (
@@ -968,6 +995,7 @@ function ApiPanel({ netuid }: { netuid: number }) {
     { label: "surfaces", path: `/api/v1/subnets/${netuid}/surfaces` },
     { label: "endpoints", path: `/api/v1/subnets/${netuid}/endpoints` },
     { label: "candidates", path: `/api/v1/subnets/${netuid}/candidates` },
+    { label: "gaps", path: `/api/v1/subnets/${netuid}/gaps` },
     { label: "health", path: `/api/v1/subnets/${netuid}/health` },
     { label: "agent-catalog", path: `/api/v1/agent-catalog/${netuid}` },
     { label: "artifact", path: `/metagraph/subnets/${netuid}.json` },


### PR DESCRIPTION
Closes #3348

Re-submits the subnet Gaps tab fix (prior PR #3599 was closed without merge).

## Root cause
GapsPanel read stale `profile.missing_kinds` instead of `GET /api/v1/subnets/{netuid}/gaps`.

## Fix
- Add `subnetGapsQuery` + `normalizeSubnetGaps`
- Wire GapsPanel to the subnet-scoped gaps artifact

## Test plan
- [x] `cd apps/ui && npm test`