### PR TITLE
feat(registry): add Cacheon leader overtake history API surface (SN14)

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -243,6 +243,25 @@
         "https://cacheon.ai/docs/miners/api-contract"
       ],
       "url": "https://api.cacheon.ai/api/rounds"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-leader-history-api",
+      "kind": "subnet-api",
+      "name": "Cacheon leader overtake history API",
+      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/leader/history"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/cacheon.json`.

## Surface

- Netuid: 14
- Kind: subnet-api
- Public URL: https://api.cacheon.ai/api/leader/history
- Source URL (proves the claim): https://api.cacheon.ai/openapi.json
- Provider slug: cacheon

## Checklist

- [x] Changes exactly one `registry/subnets/cacheon.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #913`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/cacheon.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3604 | UI Gaps tab | registry only |
| #3603 | UI Evidence tab | registry only |
| #3602 | UI compare-selection tests | registry only |
| #3594 | release manifests | `registry/subnets/cacheon.json` |
| #3593 | UI table-controls | registry only |
| #3579 | UI recent-visits tests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #913

Made with [Cursor](https://cursor.com)