### PR TITLE
test(ui): cover useEndpointHealth latency classify thresholds

### DIFF
--- a/apps/ui/src/hooks/use-endpoint-health.test.ts
+++ b/apps/ui/src/hooks/use-endpoint-health.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyEndpointLatency } from "./use-endpoint-health";
+
+describe("classifyEndpointLatency", () => {
+  it("returns down when latency is unavailable", () => {
+    expect(classifyEndpointLatency(null)).toBe("down");
+  });
+
+  it("returns ok at or below the slow threshold", () => {
+    expect(classifyEndpointLatency(0)).toBe("ok");
+    expect(classifyEndpointLatency(300)).toBe("ok");
+  });
+
+  it("returns slow above the slow threshold through the bad threshold", () => {
+    expect(classifyEndpointLatency(301)).toBe("slow");
+    expect(classifyEndpointLatency(800)).toBe("slow");
+  });
+
+  it("returns bad above the bad threshold", () => {
+    expect(classifyEndpointLatency(801)).toBe("bad");
+    expect(classifyEndpointLatency(5000)).toBe("bad");
+  });
+});

--- a/apps/ui/src/hooks/use-endpoint-health.ts
+++ b/apps/ui/src/hooks/use-endpoint-health.ts
@@ -13,7 +13,8 @@ const SLOW_MS = 300; // ok → slow (yellow)
 const BAD_MS = 800; // slow → bad (orange)
 const REFRESH_MS = 30_000;
 
-function classify(ms: number | null): EndpointHealth {
+/** Pure latency bucketing for the footer health dot; exported for unit tests. */
+export function classifyEndpointLatency(ms: number | null): EndpointHealth {
   if (ms == null) return "down";
   if (ms > BAD_MS) return "bad";
   if (ms > SLOW_MS) return "slow";
@@ -47,7 +48,7 @@ export function useEndpointHealth(): EndpointHealthState {
 
     async function check() {
       const ms = await pingMs(url, controller.signal);
-      if (active) setState({ status: classify(ms), ms });
+      if (active) setState({ status: classifyEndpointLatency(ms), ms });
     }
 
     setState({ status: "checking", ms: null });


### PR DESCRIPTION
## Summary
- Add Vitest coverage for classifyEndpointLatency ok/slow/bad/down bucket boundaries (300ms / 800ms).
- Export the pure helper from use-endpoint-health.ts for focused unit tests.

Closes #3442

## Test plan
- [x] cd apps/ui && npm test -- use-endpoint-health.test.ts