### PR TITLE
test(ui): cover useRegistryEvents skip-first-snapshot logic

### DIFF
--- a/apps/ui/src/hooks/use-registry-events.test.ts
+++ b/apps/ui/src/hooks/use-registry-events.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createRegistrySnapshotHandler } from "./use-registry-events";
+
+describe("createRegistrySnapshotHandler", () => {
+  it("skips the first snapshot replayed on connect", () => {
+    const invalidate = vi.fn();
+    const onSnapshot = createRegistrySnapshotHandler(invalidate);
+
+    onSnapshot();
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it("invalidates on every snapshot after the connect replay", () => {
+    const invalidate = vi.fn();
+    const onSnapshot = createRegistrySnapshotHandler(invalidate);
+
+    onSnapshot();
+    onSnapshot();
+    onSnapshot();
+
+    expect(invalidate).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts fresh when a new handler is created on reconnect", () => {
+    const invalidate = vi.fn();
+    const first = createRegistrySnapshotHandler(invalidate);
+    first();
+    first();
+    expect(invalidate).toHaveBeenCalledTimes(1);
+
+    const second = createRegistrySnapshotHandler(invalidate);
+    second();
+    second();
+
+    expect(invalidate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/ui/src/hooks/use-registry-events.ts
+++ b/apps/ui/src/hooks/use-registry-events.ts
@@ -2,6 +2,18 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { getApiBase, getNetwork, onApiBaseChange, onNetworkChange } from "@/lib/metagraphed/config";
 
+/** Pure connect-replay guard; exported for unit tests. */
+export function createRegistrySnapshotHandler(invalidate: () => void): () => void {
+  let primed = false;
+  return () => {
+    if (!primed) {
+      primed = true;
+      return;
+    }
+    invalidate();
+  };
+}
+
 /**
  * #1117: subscribe to the registry publish feed (`GET /api/v1/events`, SSE) and
  * invalidate active queries on each `snapshot` event, so views update on publish
@@ -24,7 +36,6 @@ export function useRegistryEvents() {
     if (typeof window === "undefined" || typeof EventSource === "undefined") return;
 
     let es: EventSource | null = null;
-    let primed = false;
 
     const teardown = () => {
       es?.close();
@@ -35,22 +46,15 @@ export function useRegistryEvents() {
       teardown();
       // The publish feed is mainnet-only; on testnet, polling remains the path.
       if (getNetwork().id !== "mainnet") return;
-      primed = false;
       try {
         es = new EventSource(`${getApiBase()}/api/v1/events`);
       } catch {
         es = null;
         return;
       }
-      const onSnapshot = () => {
-        // Skip the snapshot replayed on connect (the route already has it); every
-        // later event is a real publish worth refreshing for.
-        if (!primed) {
-          primed = true;
-          return;
-        }
+      const onSnapshot = createRegistrySnapshotHandler(() => {
         qc.invalidateQueries({ queryKey: ["metagraphed"] });
-      };
+      });
       es.addEventListener("snapshot", onSnapshot);
       // Some proxies deliver SSE as unnamed `message` events — cover both.
       es.onmessage = onSnapshot;


### PR DESCRIPTION
## Summary
- Extract createRegistrySnapshotHandler and add Vitest coverage for the skip-first-connect-replay guard.
- Locks behavior: first SSE snapshot is ignored, later snapshots invalidate the metagraphed query cache.

Closes #3441

## Test plan
- [x] cd apps/ui && npm test -- use-registry-events.test.ts