### PR TITLE
feat(registry): add Nepher tournaments list API surface (SN49)

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -282,6 +282,25 @@
         "https://docs.nepher.ai/"
       ],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/current-block"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-tournaments-list-api",
+      "kind": "subnet-api",
+      "name": "Nepher tournaments list API",
+      "notes": "Public no-auth GET returning the full tournament catalog with task names, versions, stages, contest windows, and repository links. Documented in the subnet's own OpenAPI (tournament-api.nepher.ai/openapi.json, path /api/v1/tournaments/list); same host as existing tournament surfaces. Distinct from the active-tournaments list and current-block endpoints.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://docs.nepher.ai/"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/list"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/nepher-robotics.json`.

## Surface

- Netuid: 49
- Kind: subnet-api
- Public URL: https://tournament-api.nepher.ai/api/v1/tournaments/list
- Source URL (proves the claim): https://tournament-api.nepher.ai/openapi.json
- Provider slug: nepher-robotics

## Checklist

- [x] Changes exactly one `registry/subnets/nepher-robotics.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #916`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/nepher-robotics.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3605 | UI validators route | registry only |
| #3604 | UI Gaps tab | registry only |
| #3602 | UI compare-selection tests | registry only |
| #3594 | release manifests | `registry/subnets/nepher-robotics.json` |
| #3593 | UI table-controls | registry only |
| #3579 | UI recent-visits tests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #916

Made with [Cursor](https://cursor.com)