### PR TITLE
feat(ui): add typed data layer for chain transfer-pairs endpoint

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-transfer-pairs.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-transfer-pairs.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  chainTransferPairsQuery,
+  normalizeChainTransferPair,
+  normalizeChainTransferPairs,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+const CHARLIE = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/transfer-pairs",
+  });
+}
+
+async function runQuery(
+  params: { window?: "7d" | "30d"; limit?: number; sort?: "volume" | "count" } = {},
+) {
+  const opts = chainTransferPairsQuery(params);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainTransferPair", () => {
+  it("accepts a well-formed directed pair", () => {
+    expect(
+      normalizeChainTransferPair({
+        from: ALICE,
+        to: BOB,
+        volume_tao: 80,
+        transfer_count: 5,
+        last_block: 5_000_000,
+        last_observed_at: "2026-06-01T00:00:00.000Z",
+      }),
+    ).toEqual({
+      from: ALICE,
+      to: BOB,
+      volume_tao: 80,
+      transfer_count: 5,
+      last_block: 5_000_000,
+      last_observed_at: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("drops malformed rows, self-transfers, and invalid ss58 addresses", () => {
+    expect(normalizeChainTransferPair(null)).toBeNull();
+    expect(
+      normalizeChainTransferPair({
+        from: ALICE,
+        to: ALICE,
+        volume_tao: 10,
+        transfer_count: 1,
+      }),
+    ).toBeNull();
+    expect(
+      normalizeChainTransferPair({
+        from: "not-ss58",
+        to: BOB,
+        volume_tao: 10,
+        transfer_count: 1,
+      }),
+    ).toBeNull();
+    expect(
+      normalizeChainTransferPair({
+        from: ALICE,
+        to: BOB,
+        volume_tao: { bad: true },
+        transfer_count: 1,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeChainTransferPairs", () => {
+  it("maps the leaderboard card and filters bad pair rows", () => {
+    const out = normalizeChainTransferPairs({
+      schema_version: 1,
+      window: "7d",
+      sort: "count",
+      observed_at: "2026-07-03T00:00:00.000Z",
+      total_volume_tao: 100,
+      transfer_count: 12,
+      unique_pairs: 5,
+      pair_count: 2,
+      top_pair_share: 0.55,
+      pairs: [
+        {
+          from: ALICE,
+          to: BOB,
+          volume_tao: 20,
+          transfer_count: 4,
+          last_block: 100,
+          last_observed_at: "2026-07-03T00:00:00.000Z",
+        },
+        {
+          from: BOB,
+          to: CHARLIE,
+          volume_tao: 55,
+          transfer_count: 2,
+          last_block: 99,
+          last_observed_at: "2026-07-03T00:00:00.000Z",
+        },
+        { from: ALICE, to: ALICE, volume_tao: 99, transfer_count: 9 },
+      ],
+    });
+    expect(out).toMatchObject({
+      schema_version: 1,
+      window: "7d",
+      sort: "count",
+      total_volume_tao: 100,
+      transfer_count: 12,
+      unique_pairs: 5,
+      pair_count: 2,
+      top_pair_share: 0.55,
+    });
+    expect(out.pairs).toHaveLength(2);
+  });
+
+  it("falls back to a schema-stable cold card", () => {
+    expect(normalizeChainTransferPairs({})).toEqual({
+      schema_version: 1,
+      window: null,
+      sort: "volume",
+      observed_at: null,
+      total_volume_tao: 0,
+      transfer_count: 0,
+      unique_pairs: 0,
+      pair_count: 0,
+      top_pair_share: null,
+      pairs: [],
+    });
+  });
+
+  it("caps the pair list at 100 rows", () => {
+    const pairs = Array.from({ length: 120 }, (_, i) => ({
+      from: ALICE,
+      to: BOB,
+      volume_tao: i + 1,
+      transfer_count: 1,
+    }));
+    expect(normalizeChainTransferPairs({ pairs }).pairs).toHaveLength(100);
+  });
+});
+
+describe("chainTransferPairsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches with window/limit/sort params and normalizes the response", async () => {
+    resolveWith({
+      schema_version: 1,
+      window: "30d",
+      sort: "volume",
+      observed_at: "2026-07-03T00:00:00.000Z",
+      total_volume_tao: 250,
+      transfer_count: 30,
+      unique_pairs: 3,
+      pair_count: 1,
+      top_pair_share: 0.6,
+      pairs: [{ from: ALICE, to: BOB, volume_tao: 150, transfer_count: 10 }],
+    });
+
+    const result = await runQuery({ window: "30d", limit: 10, sort: "volume" });
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/transfer-pairs", {
+      params: { window: "30d", limit: 10, sort: "volume" },
+      signal: expect.any(AbortSignal),
+    });
+    expect(result.data.pairs).toHaveLength(1);
+    expect(result.data.pairs[0]).toMatchObject({
+      from: ALICE,
+      to: BOB,
+      volume_tao: 150,
+      transfer_count: 10,
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -46,6 +46,9 @@ import type {
   ChainFees,
   ChainFeeDay,
   ChainFeePayer,
+  ChainTransferPair,
+  ChainTransferPairs,
+  ChainTransferPairSort,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -156,6 +159,7 @@ const MAX_CHAIN_CALLS = 12;
 const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
+const MAX_CHAIN_TRANSFER_PAIRS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -2269,6 +2273,52 @@ function normalizeChainFeePayer(raw: unknown): ChainFeePayer | null {
   };
 }
 
+export function normalizeChainTransferPair(raw: unknown): ChainTransferPair | null {
+  if (!isRecord(raw)) return null;
+  const from = firstString(raw.from);
+  const to = firstString(raw.to);
+  const volumeTao = coerceFiniteNumber(raw.volume_tao);
+  const transferCount = coerceFiniteNumber(raw.transfer_count);
+  if (
+    !from ||
+    !to ||
+    !isValidSs58(from) ||
+    !isValidSs58(to) ||
+    from === to ||
+    volumeTao == null ||
+    transferCount == null
+  ) {
+    return null;
+  }
+  return {
+    from: from.trim(),
+    to: to.trim(),
+    volume_tao: volumeTao,
+    transfer_count: transferCount,
+    last_block: coerceFiniteNumber(raw.last_block) ?? null,
+    last_observed_at: firstString(raw.last_observed_at) ?? null,
+  };
+}
+
+export function normalizeChainTransferPairs(raw: unknown): ChainTransferPairs {
+  const d = isRecord(raw) ? raw : {};
+  const sortRaw = firstString(d.sort);
+  const sort: ChainTransferPairSort = sortRaw === "count" ? "count" : "volume";
+  const pairs = normalizeChainRows(d.pairs, MAX_CHAIN_TRANSFER_PAIRS, normalizeChainTransferPair);
+  return {
+    schema_version: coerceFiniteNumber(d.schema_version) ?? 1,
+    window: firstString(d.window) ?? null,
+    sort,
+    observed_at: firstString(d.observed_at) ?? null,
+    total_volume_tao: coerceFiniteNumber(d.total_volume_tao) ?? 0,
+    transfer_count: coerceFiniteNumber(d.transfer_count) ?? 0,
+    unique_pairs: coerceFiniteNumber(d.unique_pairs) ?? 0,
+    pair_count: coerceFiniteNumber(d.pair_count) ?? pairs.length,
+    top_pair_share: coerceFiniteNumber(d.top_pair_share) ?? null,
+    pairs,
+  };
+}
+
 function normalizeChainRows<T>(
   raw: unknown,
   max: number,
@@ -2380,6 +2430,32 @@ export const chainFeesQuery = (window: ChainWindow = "7d") =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainFees>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+/** Directed sender→receiver transfer corridors (flow/sankey data source). */
+export const chainTransferPairsQuery = ({
+  window = "7d",
+  limit = 25,
+  sort = "volume",
+}: {
+  window?: ChainWindow;
+  limit?: number;
+  sort?: ChainTransferPairSort;
+} = {}) =>
+  queryOptions({
+    queryKey: k("chain-transfer-pairs", window, sort, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainTransferPairs>>("/api/v1/chain/transfer-pairs", {
+        params: { window, limit, sort },
+        signal,
+      });
+      return {
+        data: normalizeChainTransferPairs(res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainTransferPairs>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1406,6 +1406,32 @@ export interface ChainFees {
   top_fee_payers: ChainFeePayer[];
 }
 
+/** One directed sender→receiver corridor from GET /api/v1/chain/transfer-pairs. */
+export interface ChainTransferPair {
+  from: string;
+  to: string;
+  volume_tao: number;
+  transfer_count: number;
+  last_block: number | null;
+  last_observed_at: string | null;
+}
+
+export type ChainTransferPairSort = "volume" | "count";
+
+/** Network-wide transfer-pair leaderboard from GET /api/v1/chain/transfer-pairs. */
+export interface ChainTransferPairs {
+  schema_version: number;
+  window: string | null;
+  sort: ChainTransferPairSort;
+  observed_at: string | null;
+  total_volume_tao: number;
+  transfer_count: number;
+  unique_pairs: number;
+  pair_count: number;
+  top_pair_share: number | null;
+  pairs: ChainTransferPair[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;


### PR DESCRIPTION
## Summary

Closes #3476

Adds the `apps/ui` typed-client **data layer** for the live
`GET /api/v1/chain/transfer-pairs` endpoint. **No rendered/visual change** —
confined to `apps/ui/src/lib/**` plus tests. This is the reusable data-layer
foundation for the explorer transfer-pairs flow view.

## What changed

- `chainTransferPairsQuery` accepts `window` (7d/30d), `limit`, and `sort` (volume/count).
- `normalizeChainTransferPairs` + `normalizeChainTransferPair` coerce the leaderboard card and drop malformed/self-transfer rows; pair list capped at 100.
- Adds `ChainTransferPair`, `ChainTransferPairs`, and `ChainTransferPairSort` types.
- Tests cover pair validation, cold-body fallback, cap, and query param wiring.

## Validation

- `npx vitest run src/lib/metagraphed/queries.chain-transfer-pairs.test.ts` — 6 passed
- `npx eslint` on changed files — clean
- root `format:check` — clean


Made with [Cursor](https://cursor.com)