### PR TITLE
test(ui): cover theme bootstrap/runtime sync invariants

### DIFF
--- a/apps/ui/src/lib/theme.test.ts
+++ b/apps/ui/src/lib/theme.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  THEME_BOOTSTRAP_SCRIPT,
+  THEME_STORAGE_KEY,
+  bootstrapTheme,
+  normalizeThemeChoice,
+  resolveTheme,
+} from "./theme";
+
+describe("normalizeThemeChoice", () => {
+  it.each([
+    ["light", "light"],
+    ["dark", "dark"],
+    ["system", "system"],
+    [null, "system"],
+    [undefined, "system"],
+    ["", "system"],
+    ["auto", "system"],
+  ] as const)("maps %s to %s", (input, expected) => {
+    expect(normalizeThemeChoice(input)).toBe(expected);
+  });
+});
+
+describe("resolveTheme", () => {
+  it.each([
+    ["light", false, "light"],
+    ["light", true, "light"],
+    ["dark", false, "dark"],
+    ["system", false, "light"],
+    ["system", true, "dark"],
+  ] as const)("resolves %s with prefersDark=%s to %s", (choice, prefersDark, expected) => {
+    expect(resolveTheme(choice, prefersDark)).toBe(expected);
+  });
+});
+
+describe("bootstrapTheme", () => {
+  it.each([
+    ["light", false, "light"],
+    ["light", true, "light"],
+    ["dark", false, "dark"],
+    ["dark", true, "dark"],
+    ["system", false, "light"],
+    ["system", true, "dark"],
+    [null, false, "light"],
+    [null, true, "dark"],
+    ["auto", false, "light"],
+    ["auto", true, "dark"],
+  ] as const)("bootstrap stored=%s prefersDark=%s -> %s", (stored, prefersDark, expected) => {
+    expect(bootstrapTheme(stored, prefersDark)).toBe(expected);
+  });
+
+  it("stays in sync with normalizeThemeChoice + resolveTheme", () => {
+    const storedValues = ["light", "dark", "system", null, "invalid"] as const;
+    for (const stored of storedValues) {
+      for (const prefersDark of [false, true]) {
+        const choice = stored === "light" || stored === "dark" ? stored : ("system" as const);
+        expect(bootstrapTheme(stored, prefersDark)).toBe(resolveTheme(choice, prefersDark));
+      }
+    }
+  });
+});
+
+describe("THEME_BOOTSTRAP_SCRIPT", () => {
+  it("reads the same storage key as runtime theme state", () => {
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain(THEME_STORAGE_KEY);
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain('localStorage.getItem("mg-theme")');
+  });
+
+  it("applies dark class and dataset.theme like resolveTheme", () => {
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain('r.classList.add("dark")');
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain('r.classList.remove("dark")');
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain('r.dataset.theme = dark ? "dark" : "light"');
+    expect(THEME_BOOTSTRAP_SCRIPT).toContain('matchMedia("(prefers-color-scheme: dark)")');
+  });
+});

--- a/apps/ui/src/lib/theme.ts
+++ b/apps/ui/src/lib/theme.ts
@@ -1,7 +1,27 @@
 import { useEffect, useState, useCallback } from "react";
 
 export type ThemeChoice = "light" | "dark" | "system";
-const STORAGE_KEY = "mg-theme";
+export const THEME_STORAGE_KEY = "mg-theme";
+
+/** Normalizes a stored/local value to a valid theme choice. */
+export function normalizeThemeChoice(value: string | null | undefined): ThemeChoice {
+  return value === "light" || value === "dark" || value === "system" ? value : "system";
+}
+
+/** Resolves the document theme from a choice and the current system preference. */
+export function resolveTheme(choice: ThemeChoice, prefersDark: boolean): ResolvedTheme {
+  return choice === "system" ? (prefersDark ? "dark" : "light") : choice;
+}
+
+/** Mirrors the pre-hydration bootstrap IIFE for drift tests. */
+export function bootstrapTheme(stored: string | null, prefersDark: boolean): ResolvedTheme {
+  let choice = stored;
+  if (choice !== "light" && choice !== "dark") choice = "system";
+  const dark = choice === "dark" || (choice === "system" && prefersDark);
+  return dark ? "dark" : "light";
+}
+
+const STORAGE_KEY = THEME_STORAGE_KEY;
 
 /** Resolved mode (what the document actually shows). */
 export type ResolvedTheme = "light" | "dark";
@@ -14,8 +34,7 @@ function systemPrefersDark(): boolean {
 function readChoice(): ThemeChoice {
   if (typeof window === "undefined") return "system";
   try {
-    const v = window.localStorage.getItem(STORAGE_KEY);
-    return v === "light" || v === "dark" || v === "system" ? v : "system";
+    return normalizeThemeChoice(window.localStorage.getItem(STORAGE_KEY));
   } catch {
     return "system";
   }
@@ -23,8 +42,7 @@ function readChoice(): ThemeChoice {
 
 function apply(choice: ThemeChoice): ResolvedTheme {
   if (typeof document === "undefined") return "light";
-  const resolved: ResolvedTheme =
-    choice === "system" ? (systemPrefersDark() ? "dark" : "light") : choice;
+  const resolved = resolveTheme(choice, systemPrefersDark());
   const root = document.documentElement;
   root.classList.toggle("dark", resolved === "dark");
   root.dataset.theme = resolved;


### PR DESCRIPTION
## Summary
- Export pure theme helpers and add Vitest coverage for bootstrap/runtime sync.

Closes #3445

## Test plan
- [x] cd apps/ui && npm test -- theme.test.ts
- [x] npx eslint src/lib/theme.ts src/lib/theme.test.ts