### PR TITLE
feat(registry): add Gradients tournament fees API surface (SN56)

### DIFF
--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -255,6 +255,25 @@
         "https://www.gradients.io/"
       ],
       "url": "https://api.gradients.io/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-tournament-fees-api",
+      "kind": "subnet-api",
+      "name": "Gradients tournament fees API",
+      "notes": "Public no-auth GET returning participation fee amounts (in rao) for text, image, and environment tournaments. Documented in the subnet's own OpenAPI (api.gradients.io/openapi.json, path /tournament/fees); same host as the existing network-status and healthz subnet-api surfaces.",
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.gradients.io/openapi.json",
+        "https://www.gradients.io/"
+      ],
+      "url": "https://api.gradients.io/tournament/fees"
     }
   ],
   "website_url": "https://www.gradients.io/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/gradients.json`.

## Surface

- Netuid: 56
- Kind: subnet-api
- Public URL: https://api.gradients.io/tournament/fees
- Source URL (proves the claim): https://api.gradients.io/openapi.json
- Provider slug: gradients

## Checklist

- [x] Changes exactly one `registry/subnets/gradients.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #677`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/gradients.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3613 | UI theme tests | registry only |
| #3612 | UI transfer-pairs | registry only |
| #3605 | UI validators route | registry only |
| #3604 | UI Gaps tab | registry only |
| #3602 | UI compare-selection tests | registry only |
| #3594 | release manifests | `registry/subnets/gradients.json` |
| #3593 | UI table-controls | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #677

Made with [Cursor](https://cursor.com)