### PR TITLE
feat(ui): add typed data layer for chain yield endpoint

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-yield.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-yield.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainYieldQuery, normalizeChainYield, normalizeYieldDistributionOrNull } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/yield",
+  });
+}
+
+async function runChainYieldQuery() {
+  const opts = chainYieldQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeYieldDistributionOrNull", () => {
+  it("normalizes percentile fields with a required count", () => {
+    expect(
+      normalizeYieldDistributionOrNull({
+        count: 3,
+        mean: 0.05,
+        median: 0.04,
+        min: 0.01,
+        max: 0.09,
+        p10: 0.02,
+        p90: 0.08,
+      }),
+    ).toEqual({
+      count: 3,
+      mean: 0.05,
+      median: 0.04,
+      min: 0.01,
+      max: 0.09,
+      p10: 0.02,
+      p25: null,
+      p75: null,
+      p90: 0.08,
+    });
+  });
+
+  it("returns null for cold-store null and zero-count distributions", () => {
+    expect(normalizeYieldDistributionOrNull(null)).toBeNull();
+    expect(normalizeYieldDistributionOrNull({ count: 0 })).toBeNull();
+    expect(normalizeYieldDistributionOrNull({})).toBeNull();
+  });
+});
+
+describe("normalizeChainYield", () => {
+  it("maps network yield aggregates and role splits", () => {
+    expect(
+      normalizeChainYield({
+        schema_version: 1,
+        subnet_count: 2,
+        neuron_count: 3,
+        validator_count: 2,
+        miner_count: 1,
+        captured_at: "2026-06-27T00:00:00Z",
+        total_stake_tao: 1100,
+        total_emission_tao: 60,
+        network_yield: 0.054545,
+        validator_yield: 0.05,
+        miner_yield: 0.1,
+        distribution: {
+          count: 3,
+          mean: 0.05,
+          median: 0.05,
+          min: 0.04,
+          max: 0.06,
+        },
+      }),
+    ).toMatchObject({
+      schema_version: 1,
+      subnet_count: 2,
+      neuron_count: 3,
+      network_yield: 0.054545,
+      validator_yield: 0.05,
+      miner_yield: 0.1,
+      distribution: { count: 3, mean: 0.05, median: 0.05 },
+    });
+  });
+
+  it("falls back to schema-stable null blocks on a cold body", () => {
+    expect(
+      normalizeChainYield({
+        schema_version: 1,
+        subnet_count: 0,
+        neuron_count: 0,
+        captured_at: null,
+        network_yield: null,
+        validator_yield: null,
+        miner_yield: null,
+        distribution: null,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      subnet_count: 0,
+      neuron_count: 0,
+      validator_count: undefined,
+      miner_count: undefined,
+      captured_at: null,
+      total_stake_tao: undefined,
+      total_emission_tao: undefined,
+      network_yield: null,
+      validator_yield: null,
+      miner_yield: null,
+      distribution: null,
+    });
+  });
+});
+
+describe("chainYieldQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches and normalizes the network yield artifact", async () => {
+    resolveWith({
+      schema_version: 1,
+      subnet_count: 1,
+      neuron_count: 2,
+      captured_at: "2026-01-01T00:00:00Z",
+      network_yield: 0.05,
+      validator_yield: 0.04,
+      miner_yield: null,
+      distribution: { count: 2, mean: 0.05, median: 0.05 },
+    });
+
+    const result = await runChainYieldQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/yield", {
+      signal: expect.any(AbortSignal),
+    });
+    expect(result.data.network_yield).toBe(0.05);
+    expect(result.data.distribution).toMatchObject({ count: 2, mean: 0.05 });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -48,6 +48,8 @@ import type {
   ChainFeePayer,
   ChainConcentration,
   ChainPerformance,
+  ChainYield,
+  YieldDistribution,
   ChainSigners,
   ChainSignerEntry,
   Extrinsic,
@@ -3064,6 +3066,42 @@ export function normalizeChainPerformance(raw: unknown): ChainPerformance {
   };
 }
 
+export function normalizeYieldDistributionOrNull(raw: unknown): YieldDistribution | null {
+  if (raw == null) return null;
+  if (!isPlainRecord(raw)) return null;
+  const count = coerceFiniteNumber(raw.count);
+  if (count == null || count === 0) return null;
+  return {
+    count,
+    mean: coerceFiniteNumber(raw.mean) ?? null,
+    median: coerceFiniteNumber(raw.median) ?? null,
+    min: coerceFiniteNumber(raw.min) ?? null,
+    max: coerceFiniteNumber(raw.max) ?? null,
+    p10: coerceFiniteNumber(raw.p10) ?? null,
+    p25: coerceFiniteNumber(raw.p25) ?? null,
+    p75: coerceFiniteNumber(raw.p75) ?? null,
+    p90: coerceFiniteNumber(raw.p90) ?? null,
+  };
+}
+
+export function normalizeChainYield(raw: unknown): ChainYield {
+  const d = isPlainRecord(raw) ? raw : {};
+  return {
+    schema_version: coerceFiniteNumber(d.schema_version) ?? 1,
+    subnet_count: coerceFiniteNumber(d.subnet_count) ?? 0,
+    neuron_count: coerceFiniteNumber(d.neuron_count) ?? 0,
+    validator_count: coerceFiniteNumber(d.validator_count),
+    miner_count: coerceFiniteNumber(d.miner_count),
+    captured_at: coerceString(d.captured_at) ?? null,
+    total_stake_tao: coerceFiniteNumber(d.total_stake_tao),
+    total_emission_tao: coerceFiniteNumber(d.total_emission_tao),
+    network_yield: coerceFiniteNumber(d.network_yield) ?? null,
+    validator_yield: coerceFiniteNumber(d.validator_yield) ?? null,
+    miner_yield: coerceFiniteNumber(d.miner_yield) ?? null,
+    distribution: normalizeYieldDistributionOrNull(d.distribution),
+  };
+}
+
 function normalizeSubnetConcentration(netuid: number, raw: unknown): SubnetConcentration {
   const d = isPlainRecord(raw) ? raw : {};
   return {
@@ -3262,6 +3300,21 @@ export const chainPerformanceQuery = () =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainPerformance>;
+    },
+    staleTime: STALE_MED,
+  });
+
+/** Network-wide emission-yield aggregate (return rate + validator/miner split). */
+export const chainYieldQuery = () =>
+  queryOptions({
+    queryKey: k("chain-yield"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainYield>>("/api/v1/chain/yield", { signal });
+      return {
+        data: normalizeChainYield(res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainYield>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1436,6 +1436,35 @@ export interface ChainPerformance {
   validator_trust: ScoreDistribution | null;
 }
 
+/** Per-neuron emission/stake return spread from chain yield artifacts. */
+export interface YieldDistribution {
+  count: number;
+  mean?: number | null;
+  median?: number | null;
+  min?: number | null;
+  max?: number | null;
+  p10?: number | null;
+  p25?: number | null;
+  p75?: number | null;
+  p90?: number | null;
+}
+
+/** Network-wide emission yield from GET /api/v1/chain/yield. */
+export interface ChainYield {
+  schema_version: number;
+  subnet_count: number;
+  neuron_count: number;
+  validator_count?: number;
+  miner_count?: number;
+  captured_at: string | null;
+  total_stake_tao?: number;
+  total_emission_tao?: number;
+  network_yield: number | null;
+  validator_yield: number | null;
+  miner_yield: number | null;
+  distribution: YieldDistribution | null;
+}
+
 /* ===================== Theme C: registry & network-health depth ===================== */
 
 /**


### PR DESCRIPTION
## Summary

Closes #3472

Adds the `apps/ui` typed-client **data layer** for the live
`GET /api/v1/chain/yield` endpoint. **No rendered/visual change** —
confined to `apps/ui/src/lib/**` plus tests. Companion to the merged
chain decentralization data layer (#3609 / #3471).

## What changed

- `chainYieldQuery` for the network-wide emission-yield artifact.
- `normalizeChainYield` + `normalizeYieldDistributionOrNull` with the
  cold-store null contract (`network_yield`, role yields, and
  `distribution` stay null when empty).
- Adds `ChainYield` and `YieldDistribution` types (`count` required on
  normalized distributions).
- Tests cover distribution null-when-empty, cold-body fallback, and query
  response shaping.

## Validation

- `npx vitest run src/lib/metagraphed/queries.chain-yield.test.ts` — 5 passed
- `npx eslint` on changed files — clean
- root `format:check` — clean


Made with [Cursor](https://cursor.com)