### PR TITLE
test(ui): cover useCopy truncation and clipboard fallback helpers

### DIFF
--- a/apps/ui/src/hooks/use-copy.test.ts
+++ b/apps/ui/src/hooks/use-copy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  copyErrorDescription,
+  copySuccessTitle,
+  shouldUseNavigatorClipboard,
+  truncateCopyPreview,
+} from "./use-copy";
+
+describe("truncateCopyPreview", () => {
+  it("returns short values unchanged", () => {
+    expect(truncateCopyPreview("abc")).toBe("abc");
+    expect(truncateCopyPreview("x".repeat(64))).toBe("x".repeat(64));
+  });
+
+  it("truncates values longer than the default max with an ellipsis", () => {
+    const value = "y".repeat(65);
+    expect(truncateCopyPreview(value)).toBe("y".repeat(64) + "…");
+  });
+
+  it("honors a custom max length", () => {
+    expect(truncateCopyPreview("abcdef", 3)).toBe("abc…");
+  });
+});
+
+describe("copySuccessTitle", () => {
+  it("uses the label when provided", () => {
+    expect(copySuccessTitle("endpoint url")).toBe("Copied endpoint url");
+  });
+
+  it("falls back to the generic title", () => {
+    expect(copySuccessTitle()).toBe("Copied to clipboard");
+  });
+});
+
+describe("copyErrorDescription", () => {
+  it("returns the Error message when available", () => {
+    expect(copyErrorDescription(new Error("denied"))).toBe("denied");
+  });
+
+  it("falls back for non-Error values", () => {
+    expect(copyErrorDescription("nope")).toBe("Clipboard unavailable");
+  });
+});
+
+describe("shouldUseNavigatorClipboard", () => {
+  it("prefers the async clipboard API when present", () => {
+    expect(shouldUseNavigatorClipboard({ clipboard: {} } as Navigator)).toBe(true);
+  });
+
+  it("falls back when navigator or clipboard is missing", () => {
+    expect(shouldUseNavigatorClipboard(undefined)).toBe(false);
+    expect(shouldUseNavigatorClipboard({} as Navigator)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-copy.ts
+++ b/apps/ui/src/hooks/use-copy.ts
@@ -9,6 +9,23 @@ interface CopyOpts {
   toastOnSuccess?: boolean;
 }
 
+/** Truncates long copied values for toast previews. */
+export function truncateCopyPreview(value: string, max = 64): string {
+  return value.length > max ? value.slice(0, max) + "…" : value;
+}
+
+export function copySuccessTitle(label?: string): string {
+  return label ? `Copied ${label}` : "Copied to clipboard";
+}
+
+export function copyErrorDescription(err: unknown): string {
+  return err instanceof Error ? err.message : "Clipboard unavailable";
+}
+
+export function shouldUseNavigatorClipboard(navigatorValue: Navigator | undefined): boolean {
+  return typeof navigatorValue !== "undefined" && !!navigatorValue.clipboard;
+}
+
 /**
  * Shared copy hook used by every "copy this URL/value" interaction.
  * Returns `copied` (truthy for ~1.4s after success) so callers can swap an
@@ -23,7 +40,7 @@ export function useCopy(opts: CopyOpts = {}) {
     async (value: string) => {
       if (!value) return false;
       try {
-        if (typeof navigator !== "undefined" && navigator.clipboard) {
+        if (shouldUseNavigatorClipboard(typeof navigator !== "undefined" ? navigator : undefined)) {
           await navigator.clipboard.writeText(value);
         } else if (typeof document !== "undefined") {
           // Fallback for older browsers / SSR-safe access pattern.
@@ -38,8 +55,8 @@ export function useCopy(opts: CopyOpts = {}) {
         }
         setCopied(true);
         if (toastOnSuccess) {
-          toast.success(label ? `Copied ${label}` : "Copied to clipboard", {
-            description: value.length > 64 ? value.slice(0, 64) + "…" : value,
+          toast.success(copySuccessTitle(label), {
+            description: truncateCopyPreview(value),
             duration: 1800,
           });
         }
@@ -48,7 +65,7 @@ export function useCopy(opts: CopyOpts = {}) {
         return true;
       } catch (err) {
         toast.error("Copy failed", {
-          description: err instanceof Error ? err.message : "Clipboard unavailable",
+          description: copyErrorDescription(err),
         });
         return false;
       }


### PR DESCRIPTION
## Summary
- Export pure useCopy helpers for toast preview truncation, success/error copy, and clipboard API selection.
- Add Vitest coverage for the shared copy hook helpers.

Closes #3443

## Test plan
- [x] cd apps/ui && npm test -- use-copy.test.ts
- [x] npx eslint src/hooks/use-copy.ts src/hooks/use-copy.test.ts