### PR TITLE
feat(registry): add Handshake58 directory providers API surface (SN58)

### DIFF
--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -306,6 +306,25 @@
         "https://handshake58.com/skill.md"
       ],
       "url": "https://handshake58.com/api/validator/registry"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-58-handshake58-directory-providers-api",
+      "kind": "subnet-api",
+      "name": "Handshake58 directory providers API",
+      "notes": "Public no-auth GET returning the Handshake58 marketplace provider directory (provider names, API URLs, descriptions, and on-chain addresses). Documented in the subnet's own OpenAPI (handshake58.com/openapi.json, path /api/directory/providers); same host as existing subnet-api surfaces. Distinct from the /api/mcp/providers and validator registry endpoints.",
+      "provider": "handshake58",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://handshake58.com/openapi.json",
+        "https://handshake58.com/skill.md"
+      ],
+      "url": "https://handshake58.com/api/directory/providers"
     }
   ],
   "website_url": "https://handshake58.com"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/handshake58.json`.

## Surface

- Netuid: 58
- Kind: subnet-api
- Public URL: https://handshake58.com/api/directory/providers
- Source URL (proves the claim): https://handshake58.com/openapi.json
- Provider slug: handshake58

## Checklist

- [x] Changes exactly one `registry/subnets/handshake58.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #721`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/handshake58.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3617 | UI useCopy tests | registry only |
| #3616 | UI chain-yield | registry only |
| #3612 | UI transfer-pairs | registry only |
| #3604 | UI Gaps tab | registry only |
| #3602 | UI compare-selection tests | registry only |
| #3594 | release manifests | `registry/subnets/handshake58.json` |
| #3593 | UI table-controls | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #721

Made with [Cursor](https://cursor.com)