### PR TITLE
test(ui): cover ApiSourceProvider path deduplication logic

### DIFF
--- a/apps/ui/src/lib/metagraphed/api-source-context.test.ts
+++ b/apps/ui/src/lib/metagraphed/api-source-context.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { dedupeApiSources, type ApiSource } from "./api-source-context";
+
+describe("dedupeApiSources", () => {
+  it("returns an empty list for no registrations", () => {
+    expect(dedupeApiSources([])).toEqual([]);
+  });
+
+  it("keeps the first registration for duplicate paths across groups", () => {
+    const first: ApiSource = { path: "/api/v1/health", label: "first" };
+    const second: ApiSource = { path: "/api/v1/health", label: "second" };
+    const groups = [
+      [first, { path: "/api/v1/coverage" }],
+      [second, { path: "/api/v1/subnets" }],
+    ];
+
+    expect(dedupeApiSources(groups)).toEqual([
+      first,
+      { path: "/api/v1/coverage" },
+      { path: "/api/v1/subnets" },
+    ]);
+  });
+
+  it("skips duplicate paths within the same registration group", () => {
+    const groups = [[{ path: "/api/v1/events" }, { path: "/api/v1/events", artifact: "dup" }]];
+
+    expect(dedupeApiSources(groups)).toEqual([{ path: "/api/v1/events" }]);
+  });
+
+  it("preserves registration order across groups", () => {
+    const groups = [[{ path: "/a" }, { path: "/b" }], [{ path: "/c" }]];
+
+    expect(dedupeApiSources(groups).map((s) => s.path)).toEqual(["/a", "/b", "/c"]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/api-source-context.tsx
+++ b/apps/ui/src/lib/metagraphed/api-source-context.tsx
@@ -14,6 +14,20 @@ export interface ApiSource {
   label?: string;
 }
 
+/** Merges registered source groups with first-wins path deduplication. */
+export function dedupeApiSources(groups: Iterable<ApiSource[]>): ApiSource[] {
+  const out: ApiSource[] = [];
+  const seen = new Set<string>();
+  for (const arr of groups) {
+    for (const s of arr) {
+      if (seen.has(s.path)) continue;
+      seen.add(s.path);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
 interface Ctx {
   sources: ApiSource[];
   register: (s: ApiSource[]) => () => void;
@@ -44,18 +58,7 @@ export function ApiSourceProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const sources = useMemo(() => {
-    const out: ApiSource[] = [];
-    const seen = new Set<string>();
-    for (const arr of registry.values()) {
-      for (const s of arr) {
-        if (seen.has(s.path)) continue;
-        seen.add(s.path);
-        out.push(s);
-      }
-    }
-    return out;
-  }, [registry]);
+  const sources = useMemo(() => dedupeApiSources(registry.values()), [registry]);
 
   const value = useMemo<Ctx>(
     () => ({ sources, register, isOpen, setOpen, open: () => setOpen(true) }),


### PR DESCRIPTION
## Summary
- Extract dedupeApiSources from ApiSourceProvider and add Vitest coverage for first-wins path deduplication.

Closes #3444

## Test plan
- [x] cd apps/ui && npm test -- api-source-context.test.ts
- [x] npx eslint src/lib/metagraphed/api-source-context.tsx src/lib/metagraphed/api-source-context.test.ts