### PR TITLE
feat(sn-18): add Zeus BOREAS Edge API readiness surface

### DIFF
--- a/registry/subnets/zeus.json
+++ b/registry/subnets/zeus.json
@@ -68,6 +68,25 @@
         "https://docs.zeussubnet.com/docs/introduction"
       ],
       "url": "https://api.zeussubnet.com/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-ready",
+      "kind": "subnet-api",
+      "name": "Zeus BOREAS Edge API readiness",
+      "notes": "Public no-auth readiness probe for the Zeus BOREAS Edge API; GET /v1/ready reports service readiness per the machine-readable OpenAPI spec on the same host as the existing /v1/meta and /v1/health subnet-api surfaces.",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.zeussubnet.com/openapi.json",
+        "https://docs.zeussubnet.com/docs/introduction"
+      ],
+      "url": "https://api.zeussubnet.com/v1/ready"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Summary

Adds the public, no-auth `GET /v1/ready` endpoint of the Zeus (SN18) **BOREAS Edge API** as a `subnet-api` surface.

## Provenance

- **URL:** https://api.zeussubnet.com/v1/ready — returns `200` with no authentication.
- **source_urls:** the same machine-readable OpenAPI spec (`https://api.zeussubnet.com/openapi.json`) and docs (`https://docs.zeussubnet.com/docs/introduction`) that already back the accepted `/v1/meta` and `/v1/health` surfaces on this host.
- It is a distinct endpoint and signal from the existing surfaces (readiness vs. liveness), not a re-title.

## Checks

- `validate:surface` passes (579 surfaces / 118 files)
- `validate:schemas`, `validate:private-boundary`, `validate:intake` pass
- One focused change: appends a single surface to `registry/subnets/zeus.json`, nothing else
- `authority: community`, `review.state: community-submitted`