### PR TITLE
test(ui): cover useDelayedReveal when/delayMs branch logic

### DIFF
--- a/apps/ui/src/hooks/use-delayed-reveal.test.ts
+++ b/apps/ui/src/hooks/use-delayed-reveal.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInitialDelayedReveal, shouldDelayReveal } from "./use-delayed-reveal";
+
+describe("resolveInitialDelayedReveal", () => {
+  it("stays hidden when the reveal gate is off", () => {
+    expect(resolveInitialDelayedReveal(false, 120)).toBe(false);
+    expect(resolveInitialDelayedReveal(false, 0)).toBe(false);
+  });
+
+  it("reveals immediately when delay is zero or negative", () => {
+    expect(resolveInitialDelayedReveal(true, 0)).toBe(true);
+    expect(resolveInitialDelayedReveal(true, -1)).toBe(true);
+  });
+
+  it("starts hidden when a positive delay is configured", () => {
+    expect(resolveInitialDelayedReveal(true, 120)).toBe(false);
+  });
+});
+
+describe("shouldDelayReveal", () => {
+  it("arms a timer only for positive delays while the gate is on", () => {
+    expect(shouldDelayReveal(true, 120)).toBe(true);
+    expect(shouldDelayReveal(true, 1)).toBe(true);
+  });
+
+  it("skips the timer when the gate is off or delay is non-positive", () => {
+    expect(shouldDelayReveal(false, 120)).toBe(false);
+    expect(shouldDelayReveal(true, 0)).toBe(false);
+    expect(shouldDelayReveal(true, -5)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-delayed-reveal.ts
+++ b/apps/ui/src/hooks/use-delayed-reveal.ts
@@ -1,5 +1,17 @@
 import { useEffect, useState } from "react";
 
+/** Initial revealed state before any timer fires. */
+export function resolveInitialDelayedReveal(when: boolean, delayMs: number): boolean {
+  if (!when) return false;
+  if (delayMs <= 0) return true;
+  return false;
+}
+
+/** Whether the hook should arm a timeout instead of resolving immediately. */
+export function shouldDelayReveal(when: boolean, delayMs: number): boolean {
+  return when && delayMs > 0;
+}
+
 /**
  * Returns `true` after `delayMs` has elapsed since mount. SSR-safe.
  *
@@ -10,12 +22,8 @@ import { useEffect, useState } from "react";
 export function useDelayedReveal(delayMs = 120, when = true): boolean {
   const [revealed, setRevealed] = useState(false);
   useEffect(() => {
-    if (!when) {
-      setRevealed(false);
-      return;
-    }
-    if (delayMs <= 0) {
-      setRevealed(true);
+    if (!shouldDelayReveal(when, delayMs)) {
+      setRevealed(resolveInitialDelayedReveal(when, delayMs));
       return;
     }
     const t = window.setTimeout(() => setRevealed(true), delayMs);


### PR DESCRIPTION
## Summary
- Export resolveInitialDelayedReveal and shouldDelayReveal helpers from use-delayed-reveal.ts.
- Add Vitest coverage for when/delayMs branch logic.

Closes #3450

## Test plan
- [x] cd apps/ui && npm test -- use-delayed-reveal.test.ts
- [x] npx eslint src/hooks/use-delayed-reveal.ts src/hooks/use-delayed-reveal.test.ts