### PR TITLE
test(ui): cover useApiBase/useNetwork invalidation helpers

### DIFF
--- a/apps/ui/src/hooks/use-api-base.test.ts
+++ b/apps/ui/src/hooks/use-api-base.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_API_BASE, DEFAULT_NETWORK } from "@/lib/metagraphed/config";
+
+import {
+  isDefaultApiBase,
+  isDefaultChainNetwork,
+  metagraphedQueryInvalidationTarget,
+} from "./use-api-base";
+
+describe("metagraphedQueryInvalidationTarget", () => {
+  it("invalidates the metagraphed query root used by both runtime hooks", () => {
+    expect(metagraphedQueryInvalidationTarget()).toEqual({ queryKey: ["metagraphed"] });
+  });
+});
+
+describe("isDefaultApiBase", () => {
+  it("detects the configured default API base", () => {
+    expect(isDefaultApiBase(DEFAULT_API_BASE)).toBe(true);
+    expect(isDefaultApiBase("https://custom.example")).toBe(false);
+  });
+});
+
+describe("isDefaultChainNetwork", () => {
+  it("detects the configured default chain network", () => {
+    expect(isDefaultChainNetwork(DEFAULT_NETWORK)).toBe(true);
+    expect(isDefaultChainNetwork({ ...DEFAULT_NETWORK, id: "testnet" })).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-api-base.ts
+++ b/apps/ui/src/hooks/use-api-base.ts
@@ -12,6 +12,21 @@ import {
   type ChainNetwork,
 } from "@/lib/metagraphed/config";
 
+/** Query root both runtime hooks invalidate when origin or network changes. */
+export const METAGRAPHED_QUERY_ROOT = ["metagraphed"] as const;
+
+export function metagraphedQueryInvalidationTarget() {
+  return { queryKey: METAGRAPHED_QUERY_ROOT };
+}
+
+export function isDefaultApiBase(base: string): boolean {
+  return base === DEFAULT_API_BASE;
+}
+
+export function isDefaultChainNetwork(network: ChainNetwork): boolean {
+  return network.id === DEFAULT_NETWORK.id;
+}
+
 /**
  * Subscribe to the runtime API base. Returns the current value plus a
  * `change()` helper that persists, broadcasts, and invalidates queries
@@ -26,10 +41,10 @@ export function useApiBase() {
   const change = (next: string) => {
     setApiBase(next);
     // Drop everything; we just changed origins.
-    qc.invalidateQueries({ queryKey: ["metagraphed"] });
+    qc.invalidateQueries(metagraphedQueryInvalidationTarget());
   };
 
-  return { base, change, isDefault: base === DEFAULT_API_BASE };
+  return { base, change, isDefault: isDefaultApiBase(base) };
 }
 
 /**
@@ -45,8 +60,8 @@ export function useNetwork() {
 
   const change = (id: string) => {
     setNetwork(id);
-    qc.invalidateQueries({ queryKey: ["metagraphed"] });
+    qc.invalidateQueries(metagraphedQueryInvalidationTarget());
   };
 
-  return { network, change, isDefault: network.id === DEFAULT_NETWORK.id };
+  return { network, change, isDefault: isDefaultChainNetwork(network) };
 }


### PR DESCRIPTION
## Summary
- Export metagraphedQueryInvalidationTarget, isDefaultApiBase, and isDefaultChainNetwork from use-api-base.ts.
- Add Vitest coverage for the shared invalidation/default helpers used by useApiBase and useNetwork.

Closes #3439

## Test plan
- [x] cd apps/ui && npm test -- use-api-base.test.ts
- [x] npx eslint src/hooks/use-api-base.ts src/hooks/use-api-base.test.ts