### PR TITLE
refactor(ui): centralize health status inline color tokens

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -9,6 +9,7 @@ import { BrandIcon } from "./brand-icon";
 import { safeExternalUrl } from "./external-link";
 import { Sparkline } from "./charts/sparkline";
 import { useCopy } from "@/hooks/use-copy";
+import { HEALTH_COLOR, healthStateInlineColor } from "@/lib/metagraphed/health-colors";
 import { classNames } from "@/lib/metagraphed/format";
 import {
   endpointCategory,
@@ -413,11 +414,7 @@ function HeaderHint({ label, hint }: { label: string; hint: string }) {
 }
 
 function healthColor(state?: HealthState | string): string {
-  const s = (state ?? "unknown") as string;
-  if (s === "ok") return "var(--health-ok, #16a34a)";
-  if (s === "warn" || s === "degraded") return "var(--health-warn, #d97706)";
-  if (s === "down" || s === "offline") return "var(--health-down, #dc2626)";
-  return "var(--health-unknown, #94a3b8)";
+  return healthStateInlineColor(state);
 }
 
 /**

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -4,6 +4,7 @@ import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { HEALTH_COLOR } from "@/lib/metagraphed/health-colors";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
 
 // Lowercase windows, mirroring the /history API + the inline toggle conventions
@@ -84,17 +85,13 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
             <HistoryRow label="Neurons" series={series.neurons} color="var(--accent, #7aa2ff)" />
           ) : null}
           {series.validators.length > 0 ? (
-            <HistoryRow
-              label="Validators"
-              series={series.validators}
-              color="var(--health-ok, #4ade80)"
-            />
+            <HistoryRow label="Validators" series={series.validators} color={HEALTH_COLOR.ok} />
           ) : null}
           {series.stake.length > 0 ? (
             <HistoryRow
               label="Total stake"
               series={series.stake}
-              color="var(--health-warn, #fbbf24)"
+              color={HEALTH_COLOR.warn}
               format={taoStr}
             />
           ) : null}

--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -5,11 +5,12 @@ import { Coins } from "lucide-react";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { economicsQuery, subnetsQuery, subnetTrajectoryQuery } from "@/lib/metagraphed/queries";
+import { HEALTH_COLOR } from "@/lib/metagraphed/health-colors";
 import type { Subnet } from "@/lib/metagraphed/types";
 
-const UP = "var(--health-ok, #4ade80)";
-const DOWN = "var(--health-down, #ef4444)";
-const FLAT = "var(--ink-muted, #8a8f98)";
+const UP = HEALTH_COLOR.ok;
+const DOWN = HEALTH_COLOR.down;
+const FLAT = "var(--ink-muted)";
 
 function priceStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";

--- a/apps/ui/src/lib/metagraphed/health-colors.test.ts
+++ b/apps/ui/src/lib/metagraphed/health-colors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { HEALTH_COLOR, healthStateInlineColor } from "./health-colors";
+
+describe("HEALTH_COLOR", () => {
+  it("references the shared CSS tokens without per-file hex fallbacks", () => {
+    expect(HEALTH_COLOR.ok).toBe("var(--health-ok)");
+    expect(HEALTH_COLOR.warn).toBe("var(--health-warn)");
+    expect(HEALTH_COLOR.down).toBe("var(--health-down)");
+    expect(HEALTH_COLOR.unknown).toBe("var(--health-unknown)");
+  });
+});
+
+describe("healthStateInlineColor", () => {
+  it.each([
+    ["ok", HEALTH_COLOR.ok],
+    ["warn", HEALTH_COLOR.warn],
+    ["degraded", HEALTH_COLOR.warn],
+    ["down", HEALTH_COLOR.down],
+    ["offline", HEALTH_COLOR.down],
+    ["unknown", HEALTH_COLOR.unknown],
+    [undefined, HEALTH_COLOR.unknown],
+  ] as const)("maps %s to the canonical token", (state, expected) => {
+    expect(healthStateInlineColor(state)).toBe(expected);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/health-colors.ts
+++ b/apps/ui/src/lib/metagraphed/health-colors.ts
@@ -1,0 +1,17 @@
+/** Canonical inline health color tokens (defined in styles.css). */
+export const HEALTH_COLOR = {
+  ok: "var(--health-ok)",
+  warn: "var(--health-warn)",
+  down: "var(--health-down)",
+  unknown: "var(--health-unknown)",
+} as const;
+
+export const INK_MUTED_COLOR = "var(--ink-muted)";
+
+export function healthStateInlineColor(state?: string): string {
+  const s = state ?? "unknown";
+  if (s === "ok") return HEALTH_COLOR.ok;
+  if (s === "warn" || s === "degraded") return HEALTH_COLOR.warn;
+  if (s === "down" || s === "offline") return HEALTH_COLOR.down;
+  return HEALTH_COLOR.unknown;
+}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -13,6 +13,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
 import { providersQuery, endpointsQuery, type ProviderCounts } from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
+import { HEALTH_COLOR, INK_MUTED_COLOR } from "@/lib/metagraphed/health-colors";
 import { Donut, DonutLegend } from "@/components/metagraphed/charts/donut";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
@@ -565,10 +566,10 @@ function ProviderOverview({
     { ok: 0, warn: 0, down: 0, unknown: 0 },
   );
   const statusSegs = [
-    { label: "OK", value: endpointStatus.ok, color: "var(--health-ok, #22c55e)" },
-    { label: "Warn", value: endpointStatus.warn, color: "var(--health-warn, #f59e0b)" },
-    { label: "Down", value: endpointStatus.down, color: "var(--health-down, #ef4444)" },
-    { label: "Unknown", value: endpointStatus.unknown, color: "var(--ink-muted, #94a3b8)" },
+    { label: "OK", value: endpointStatus.ok, color: HEALTH_COLOR.ok },
+    { label: "Warn", value: endpointStatus.warn, color: HEALTH_COLOR.warn },
+    { label: "Down", value: endpointStatus.down, color: HEALTH_COLOR.down },
+    { label: "Unknown", value: endpointStatus.unknown, color: INK_MUTED_COLOR },
   ].filter((s) => s.value > 0);
 
   // Top providers by endpoint count, as a sparkline of counts.

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -13,6 +13,7 @@ import { Donut, DonutLegend } from "@/components/metagraphed/charts/donut";
 import { AnimatedNumber } from "@/components/metagraphed/animated-number";
 import { healthQuery, globalIncidentsQuery } from "@/lib/metagraphed/queries";
 import { classNames, humaniseSeconds, isStaleFreshness } from "@/lib/metagraphed/format";
+import { HEALTH_COLOR, INK_MUTED_COLOR } from "@/lib/metagraphed/health-colors";
 import type { GlobalIncidentSurface } from "@/lib/metagraphed/types";
 import {
   HealthHistoryDrilldown,
@@ -154,10 +155,10 @@ function Verdict() {
   }[verdict.tone];
 
   const segs = [
-    { label: "OK", value: ok, color: "var(--health-ok, #22c55e)" },
-    { label: "Degraded", value: warn, color: "var(--health-warn, #f59e0b)" },
-    { label: "Down", value: down, color: "var(--health-down, #ef4444)" },
-    { label: "Unknown", value: unknown, color: "var(--ink-muted, #94a3b8)" },
+    { label: "OK", value: ok, color: HEALTH_COLOR.ok },
+    { label: "Degraded", value: warn, color: HEALTH_COLOR.warn },
+    { label: "Down", value: down, color: HEALTH_COLOR.down },
+    { label: "Unknown", value: unknown, color: INK_MUTED_COLOR },
   ].filter((s) => s.value > 0);
   // /api/v1/health carries no real 24h uptime series — this is the share of
   // surfaces healthy in the latest snapshot (ok / total), so label it as such.


### PR DESCRIPTION
## Summary
- Add shared HEALTH_COLOR tokens and healthStateInlineColor helper.
- Replace disagreeing per-file hex fallbacks in donut/chart call sites with canonical CSS vars from styles.css.

Closes #3458

## Test plan
- [x] cd apps/ui && npm test -- health-colors.test.ts
- [x] npx eslint on touched files