### PR TITLE
refactor(ui): extract shared healthStatusSegments() for the status + providers donuts

### DIFF
--- a/apps/ui/src/lib/metagraphed/health-segments.test.ts
+++ b/apps/ui/src/lib/metagraphed/health-segments.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { healthStatusSegments } from "./health-segments";
+
+describe("healthStatusSegments", () => {
+  it("builds the four tiers in order with their health CSS-variable colours", () => {
+    const segs = healthStatusSegments({ ok: 4, warn: 3, down: 2, unknown: 1 });
+    expect(segs.map((s) => [s.label, s.value])).toEqual([
+      ["OK", 4],
+      ["Degraded", 3],
+      ["Down", 2],
+      ["Unknown", 1],
+    ]);
+    expect(segs.map((s) => s.color)).toEqual([
+      "var(--health-ok, #22c55e)",
+      "var(--health-warn, #f59e0b)",
+      "var(--health-down, #ef4444)",
+      "var(--ink-muted, #94a3b8)",
+    ]);
+  });
+
+  it("defaults the middle tier's label to 'Degraded' (the /status wording)", () => {
+    const warn = healthStatusSegments({ ok: 1, warn: 1, down: 0, unknown: 0 })[1];
+    expect(warn.label).toBe("Degraded");
+  });
+
+  it("honours a custom warnLabel (the /providers page passes 'Warn')", () => {
+    const segs = healthStatusSegments(
+      { ok: 1, warn: 2, down: 0, unknown: 0 },
+      { warnLabel: "Warn" },
+    );
+    expect(segs.find((s) => s.value === 2)?.label).toBe("Warn");
+  });
+
+  it("drops zero-value tiers so empty segments never render", () => {
+    const segs = healthStatusSegments({ ok: 5, warn: 0, down: 0, unknown: 2 });
+    expect(segs.map((s) => s.label)).toEqual(["OK", "Unknown"]);
+  });
+
+  it("returns an empty array when every tier is zero", () => {
+    expect(healthStatusSegments({ ok: 0, warn: 0, down: 0, unknown: 0 })).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/health-segments.ts
+++ b/apps/ui/src/lib/metagraphed/health-segments.ts
@@ -1,0 +1,34 @@
+// Shared builder for the 4-tier health-status Donut segments (OK / warn / Down / Unknown) used by
+// the /status and /providers pages. Both pages previously inlined the identical array — same order,
+// same CSS-variable colours, same "drop zero-value tiers" filter — which is easy to drift out of
+// sync (#3459). The only per-page difference is the middle tier's label ("Degraded" on /status vs
+// "Warn" on /providers), so that stays a parameter; everything else is centralised here.
+
+export interface HealthStatusCounts {
+  ok: number;
+  warn: number;
+  down: number;
+  unknown: number;
+}
+
+export interface HealthStatusSegment {
+  label: string;
+  value: number;
+  color: string;
+}
+
+export function healthStatusSegments(
+  counts: HealthStatusCounts,
+  options: { warnLabel?: string } = {},
+): HealthStatusSegment[] {
+  return [
+    { label: "OK", value: counts.ok, color: "var(--health-ok, #22c55e)" },
+    {
+      label: options.warnLabel ?? "Degraded",
+      value: counts.warn,
+      color: "var(--health-warn, #f59e0b)",
+    },
+    { label: "Down", value: counts.down, color: "var(--health-down, #ef4444)" },
+    { label: "Unknown", value: counts.unknown, color: "var(--ink-muted, #94a3b8)" },
+  ].filter((s) => s.value > 0);
+}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -13,6 +13,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
 import { providersQuery, endpointsQuery, type ProviderCounts } from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
+import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import { Donut, DonutLegend } from "@/components/metagraphed/charts/donut";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
@@ -564,12 +565,7 @@ function ProviderOverview({
     },
     { ok: 0, warn: 0, down: 0, unknown: 0 },
   );
-  const statusSegs = [
-    { label: "OK", value: endpointStatus.ok, color: "var(--health-ok, #22c55e)" },
-    { label: "Warn", value: endpointStatus.warn, color: "var(--health-warn, #f59e0b)" },
-    { label: "Down", value: endpointStatus.down, color: "var(--health-down, #ef4444)" },
-    { label: "Unknown", value: endpointStatus.unknown, color: "var(--ink-muted, #94a3b8)" },
-  ].filter((s) => s.value > 0);
+  const statusSegs = healthStatusSegments(endpointStatus, { warnLabel: "Warn" });
 
   // Top providers by endpoint count, as a sparkline of counts.
   const topCounts = providers

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -13,6 +13,7 @@ import { Donut, DonutLegend } from "@/components/metagraphed/charts/donut";
 import { AnimatedNumber } from "@/components/metagraphed/animated-number";
 import { healthQuery, globalIncidentsQuery } from "@/lib/metagraphed/queries";
 import { classNames, humaniseSeconds, isStaleFreshness } from "@/lib/metagraphed/format";
+import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import type { GlobalIncidentSurface } from "@/lib/metagraphed/types";
 import {
   HealthHistoryDrilldown,
@@ -153,12 +154,7 @@ function Verdict() {
     down: "border-health-down/40",
   }[verdict.tone];
 
-  const segs = [
-    { label: "OK", value: ok, color: "var(--health-ok, #22c55e)" },
-    { label: "Degraded", value: warn, color: "var(--health-warn, #f59e0b)" },
-    { label: "Down", value: down, color: "var(--health-down, #ef4444)" },
-    { label: "Unknown", value: unknown, color: "var(--ink-muted, #94a3b8)" },
-  ].filter((s) => s.value > 0);
+  const segs = healthStatusSegments({ ok, warn, down, unknown });
   // /api/v1/health carries no real 24h uptime series — this is the share of
   // surfaces healthy in the latest snapshot (ok / total), so label it as such.
   const healthyRatio = total > 0 ? ok / total : null;


### PR DESCRIPTION
Closes #3459.

## What

`/status` and `/providers` each inlined the **identical** 4-tier health Donut segment array — same order (OK / warn / Down / Unknown), same CSS-variable colours, and the same `.filter((s) => s.value > 0)` drop-zero-tiers rule. Two copies of one legend is exactly the kind of thing that drifts out of sync.

This extracts a single pure helper, `healthStatusSegments()`, into `apps/ui/src/lib/metagraphed/`, and swaps both call sites over to it.

## Behaviour-preserving

The only per-page difference was the middle tier's **label** — `"Degraded"` on `/status` vs `"Warn"` on `/providers`. That is now a `warnLabel` option (defaulting to `"Degraded"`), so:

- `/status` calls `healthStatusSegments({ ok, warn, down, unknown })` → renders exactly as before.
- `/providers` calls `healthStatusSegments(endpointStatus, { warnLabel: "Warn" })` → renders exactly as before.

Every colour, order, and the zero-drop filter are unchanged, so the rendered legends are pixel-identical.

## Tests

Adds `health-segments.test.ts` (5 cases): tier order + colours, the default `"Degraded"` label, the custom `"Warn"` label, dropping zero-value tiers, and the all-zero → `[]` case.

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```
