### PR TITLE
feat(registry): add SN3 Templar Grafana /api/health subnet-api surface

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -126,6 +126,25 @@
         "timeout_ms": 10000
       },
       "notes": "Public Grafana evaluation dashboard linked from the Templar repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-health",
+      "kind": "subnet-api",
+      "name": "Templar Grafana health",
+      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README.",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/one-covenant/templar",
+        "https://grafana.tplr.ai/"
+      ],
+      "url": "https://grafana.tplr.ai/api/health"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #711

Adds a public `subnet-api` health surface for SN3 Templar at `GET https://grafana.tplr.ai/api/health`, which returns application liveness JSON without authentication. The endpoint is served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /api/health` returns 200 JSON on `grafana.tplr.ai`
- [x] Single-file append-only change to `registry/subnets/templar.json`
- [x] Merge-simulated cleanly after open PRs #3627, #3626, #3618, #3616, #3604, #3594, #3593, #3546

Made with [Cursor](https://cursor.com)