### PR TITLE
feat(registry): add Cacheon evaluation records API surface (SN14)

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -262,6 +262,25 @@
         "https://cacheon.ai/docs/miners/api-contract"
       ],
       "url": "https://api.cacheon.ai/api/leader/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-evaluations-api",
+      "kind": "subnet-api",
+      "name": "Cacheon evaluation records API",
+      "notes": "Public no-auth GET returning all evaluation records with challenger UID, scores, speed improvement, image metadata, and commit blocks. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/evaluations); same host as the existing /api/status, /api/leader, /api/rounds, and /api/leader/history subnet-api surfaces.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/evaluations"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/cacheon.json`.

## Surface

- Netuid: 14
- Kind: subnet-api
- Public URL: https://api.cacheon.ai/api/evaluations
- Source URL (proves the claim): https://api.cacheon.ai/openapi.json
- Provider slug: cacheon

## Checklist

- [x] Changes exactly one `registry/subnets/cacheon.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #1276`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/cacheon.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3618 | `registry/subnets/handshake58.json` | `registry/subnets/cacheon.json` |
| #3627 | UI health-segments | registry only |
| #3626 | UI health-colors | registry only |
| #3616 | UI chain-yield | registry only |
| #3604 | UI Gaps tab | registry only |
| #3594 | release manifests | registry only |
| #3593 | UI table-controls | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #1276

Made with [Cursor](https://cursor.com)