### PR TITLE
fix(ui): drop stale exhaustive-deps disable in time-range context

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/time-range-context.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 export type TimeRange = "1h" | "24h" | "7d" | "30d";
 
@@ -44,11 +44,14 @@ export function TimeRangeProvider({
 }) {
   const [internal, setInternal] = useState<TimeRange>(defaultRange);
   const range = value ?? internal;
-  const setRange = (r: TimeRange) => {
-    if (onChange) onChange(r);
-    else setInternal(r);
-  };
-  const ctx = useMemo(() => ({ range, setRange }), [range]); // eslint-disable-line react-hooks/exhaustive-deps
+  const setRange = useCallback(
+    (r: TimeRange) => {
+      if (onChange) onChange(r);
+      else setInternal(r);
+    },
+    [onChange],
+  );
+  const ctx = useMemo(() => ({ range, setRange }), [range, setRange]);
   return <TimeRangeCtx.Provider value={ctx}>{children}</TimeRangeCtx.Provider>;
 }
 


### PR DESCRIPTION
## Summary

Closes #3460

The `TimeRangeProvider` memoized its context value while suppressing
`react-hooks/exhaustive-deps` because `setRange` was recreated every render.
Wrap `setRange` in `useCallback` (keyed on `onChange`) so the provider memo
deps are complete and the eslint disable can be removed.

## What changed

- `setRange` → stable `useCallback` when `onChange` is unchanged.
- `useMemo` context deps now `[range, setRange]` with no suppression.

## Validation

- `npx eslint src/components/metagraphed/analytics/time-range-context.tsx` — clean (exhaustive-deps satisfied)
- root `format:check` — clean


Made with [Cursor](https://cursor.com)