### PR TITLE
feat(registry): add SN81 Grail Grafana /api/health subnet-api surface

### DIFF
--- a/registry/subnets/grail.json
+++ b/registry/subnets/grail.json
@@ -95,6 +95,25 @@
       "notes": "Public Grafana dashboard linked from the Grail repository."
     },
     {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-81-grail-health",
+      "kind": "subnet-api",
+      "name": "Grail Grafana health",
+      "notes": "Public no-auth GET /api/health on grail-grafana.tplr.ai returning application liveness JSON. Served on the Grail Grafana host registered as a dashboard surface and linked from the Grail source repository README.",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/one-covenant/grail",
+        "https://grail-grafana.tplr.ai/"
+      ],
+      "url": "https://grail-grafana.tplr.ai/api/health"
+    },
+    {
       "id": "sn-81-grail-wandb",
       "name": "Grail W&B dashboard",
       "kind": "dashboard",


### PR DESCRIPTION
Closes #453

Adds a public `subnet-api` health surface for SN81 Grail at `GET https://grail-grafana.tplr.ai/api/health`, which returns application liveness JSON without authentication. The endpoint is served on the Grail Grafana host registered as a dashboard surface and linked from the Grail source repository README.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /api/health` returns 200 JSON on `grail-grafana.tplr.ai`
- [x] Single-file append-only change to `registry/subnets/grail.json`
- [x] Merge-simulated cleanly after open PRs #3630, #3629, #3627, #3626, #3618, #3616, #3604, #3594, #3593, #3546

Made with [Cursor](https://cursor.com)