### PR TITLE
feat(mcp): add list_search mirroring GET /api/v1/search

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -365,6 +365,11 @@ assert.ok(
   Array.isArray(searchIndexPage.documents),
   "list_search_index must return documents[]",
 );
+const searchPage = await callOk("list_search", { limit: 3 });
+assert.ok(
+  Array.isArray(searchPage.documents),
+  "list_search must return documents[]",
+);
 const sourceSnapshotsPage = await callOk("list_source_snapshots", {
   limit: 3,
   q: "native",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -86,6 +86,12 @@ import {
   loadEvidenceList,
 } from "./evidence-mcp.mjs";
 import {
+  LIST_SEARCH_INSTRUCTIONS,
+  LIST_SEARCH_MCP_TOOL,
+  LIST_SEARCH_OUTPUT_SCHEMA,
+  loadSearchList,
+} from "./search-mcp.mjs";
+import {
   LIST_SEARCH_INDEX_INSTRUCTIONS,
   LIST_SEARCH_INDEX_MCP_TOOL,
   LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
@@ -647,6 +653,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ENRICHMENT_EVIDENCE_INSTRUCTIONS +
   LIST_REVIEW_GAPS_INSTRUCTIONS +
   LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS +
+  LIST_SEARCH_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
@@ -6589,6 +6596,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SEARCH_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadSearchList(ctx, args);
+    },
+  },
+  {
     ...LIST_SEARCH_INDEX_MCP_TOOL,
     async handler(args, ctx) {
       return loadSearchIndexList(ctx, args);
@@ -10318,6 +10331,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       notes: NULLABLE_STRING,
     },
   },
+  list_search: LIST_SEARCH_OUTPUT_SCHEMA,
   list_search_index: LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,

--- a/src/search-mcp.mjs
+++ b/src/search-mcp.mjs
@@ -1,0 +1,186 @@
+// Full search index list loader for MCP parity on GET /api/v1/search.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/search.json artifact (documents include per-row token blobs).
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+
+export const SEARCH_ARTIFACT = "/metagraph/search.json";
+
+const DOCUMENT_SORT_FIELDS = API_QUERY_COLLECTIONS.documents.sort_fields;
+
+export function searchMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw searchMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw searchMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function searchQueryUrl(args) {
+  const url = new URL("https://mcp.internal/search");
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const sort = optionalEnum(args, "sort", DOCUMENT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw searchMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadSearchList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = searchQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, SEARCH_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw searchMcpError("not_found", "Search snapshot unavailable.");
+    }
+    throw searchMcpError(code, `Could not load ${SEARCH_ARTIFACT} (${code}).`);
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw searchMcpError("not_found", "Search snapshot unavailable.");
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "documents", []);
+  if (transformed.error) {
+    throw searchMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.documents) ? data.documents : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    documents: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SEARCH_INSTRUCTIONS =
+  "Use list_search to page the full registry search index (title/slug " +
+  "documents with token blobs; mirrors GET /api/v1/search), or list_search_index " +
+  "for the slim variant without token blobs; ";
+
+export const LIST_SEARCH_MCP_TOOL = {
+  name: "list_search",
+  title: "List search documents",
+  description:
+    "Fetch full search-index documents from the registry: subnet/provider " +
+    "entries with title, slug, kind, netuid, and per-document token blobs " +
+    "for keyword matching. Filter with q, sort with sort + order, project " +
+    "with fields, and page with limit (1-100) / cursor. Prefer list_search_index " +
+    "when token blobs are unnecessary, semantic_search for meaning-based " +
+    "discovery, or search_subnets for quick subnet keyword lookup. Mirrors " +
+    "GET /api/v1/search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      q: {
+        type: "string",
+        description: "Keyword search across title, subtitle, slug, and tokens.",
+      },
+      sort: {
+        type: "string",
+        enum: DOCUMENT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of document fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SEARCH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["documents"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    documents: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -711,6 +711,23 @@ describe("get_contracts — branch coverage", () => {
   });
 });
 
+// ── list_search — full search artifact list ───────────────────────────────
+describe("list_search — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_search", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /search\.json/);
+  });
+});
+
 // ── list_search_index — search index artifact list ────────────────────────
 describe("list_search_index — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13713,6 +13713,63 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
   });
 
+  test("list_search returns filtered document rows with token blobs", async () => {
+    const deps = makeDeps({
+      "/metagraph/search.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        documents: [
+          {
+            id: "subnet-7",
+            kind: "subnet",
+            netuid: 7,
+            slug: "sn-7",
+            title: "Subnet Seven",
+            tokens: ["subnet", "seven"],
+          },
+          {
+            id: "provider-datura",
+            kind: "provider",
+            slug: "datura",
+            title: "Datura",
+            tokens: ["datura"],
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_search",
+      { q: "Subnet", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.documents[0].netuid, 7);
+    assert.deepEqual(out.documents[0].tokens, ["subnet", "seven"]);
+  });
+
+  test("list_search reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_search", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Search snapshot unavailable/,
+    );
+  });
+
+  test("list_search payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_search",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/search.json": {
+        documents: [{ id: "subnet-7", title: "Subnet Seven", tokens: ["x"] }],
+      },
+    });
+    const res = await callTool("list_search", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_search_index returns filtered document rows", async () => {
     const deps = makeDeps({
       "/metagraph/search-index.json": {

--- a/tests/search-mcp.test.mjs
+++ b/tests/search-mcp.test.mjs
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_SEARCH_INSTRUCTIONS,
+  LIST_SEARCH_MCP_TOOL,
+  LIST_SEARCH_OUTPUT_SCHEMA,
+  SEARCH_ARTIFACT,
+  loadSearchList,
+  searchMcpError,
+  searchQueryUrl,
+} from "../src/search-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["full index"],
+  documents: [
+    {
+      id: "subnet-7",
+      kind: "subnet",
+      netuid: 7,
+      slug: "sn-7",
+      title: "Subnet Seven",
+      tokens: ["subnet", "seven"],
+    },
+    {
+      id: "provider-datura",
+      kind: "provider",
+      slug: "datura",
+      title: "Datura",
+      tokens: ["datura", "data"],
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === SEARCH_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("search-mcp", () => {
+  test("searchMcpError is shaped for MCP toolError handling", () => {
+    const err = searchMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("searchQueryUrl validates filters and cursor", () => {
+    const url = searchQueryUrl({
+      q: "subnet",
+      sort: "title",
+      order: "desc",
+      fields: "id,title",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("q"), "subnet");
+    assert.equal(url.searchParams.get("sort"), "title");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("fields"), "id,title");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("searchQueryUrl rejects empty q and invalid sort", () => {
+    assert.throws(
+      () => searchQueryUrl({ q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("searchQueryUrl rejects non-string q and invalid order", () => {
+    assert.throws(
+      () => searchQueryUrl({ q: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("searchQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => searchQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("searchQueryUrl trims and forwards a fields projection", () => {
+    const url = searchQueryUrl({ fields: " id,title " });
+    assert.equal(url.searchParams.get("fields"), "id,title");
+  });
+
+  test("searchQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = searchQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("searchQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = searchQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("searchQueryUrl clamps limit and rejects negative cursor", () => {
+    assert.equal(
+      searchQueryUrl({ limit: 500 }).searchParams.get("limit"),
+      "100",
+    );
+    assert.throws(
+      () => searchQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSearchList returns filtered rows with pagination meta", async () => {
+    const out = await loadSearchList(
+      { env: {}, readArtifact },
+      { q: "Subnet" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.documents[0].netuid, 7);
+    assert.deepEqual(out.documents[0].tokens, ["subnet", "seven"]);
+  });
+
+  test("loadSearchList sorts and pages the collection", async () => {
+    const out = await loadSearchList(
+      { env: {}, readArtifact },
+      { sort: "title", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.documents[0].slug, "sn-7");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSearchList uses an injected readArtifact dep", async () => {
+    const out = await loadSearchList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { documents: [{ id: "solo", tokens: ["solo"] }] },
+        }),
+      },
+    );
+    assert.equal(out.documents[0].id, "solo");
+  });
+
+  test("loadSearchList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSearchList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /search\.json/.test(err.message),
+    );
+  });
+
+  test("loadSearchList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchList({ env: {}, readArtifact }, { fields: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSearchList projects row fields when requested", async () => {
+    const out = await loadSearchList(
+      { env: {}, readArtifact },
+      { fields: "id,title", limit: 1 },
+    );
+    assert.deepEqual(out.documents[0], {
+      id: "subnet-7",
+      title: "Subnet Seven",
+    });
+  });
+
+  test("loadSearchList preserves array notes from the artifact", async () => {
+    const out = await loadSearchList({ env: {}, readArtifact }, {});
+    assert.deepEqual(out.notes, ["full index"]);
+  });
+
+  test("loadSearchList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSearchList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { documents: [{ id: "solo" }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadSearchList treats a non-array documents key as empty", async () => {
+    const out = await loadSearchList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { documents: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.documents, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSearchList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { documents: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSearchList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSearchList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadSearchList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSearchList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SEARCH_MCP_TOOL.name, "list_search");
+    assert.match(LIST_SEARCH_INSTRUCTIONS, /list_search/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_SEARCH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_search", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_search/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_search");
+    assert.ok(tool);
+    assert.equal(tool.title, "List search documents");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `list_search` MCP tool with REST list-query parity via `applyQueryFilters` over the full `/metagraph/search.json` artifact (documents include per-row token blobs; complements the existing slim `list_search_index` tool for `/metagraph/search-index.json`).
- Add `src/search-mcp.mjs` plus 24 unit tests and MCP integration/schema validation coverage; extend `validate-mcp.mjs` cold path.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:mcp`
- [x] `npx vitest run tests/search-mcp.test.mjs`
- [x] MCP integration tests for `list_search` filter/pagination/not_found/outputSchema
