### PR TITLE
feat(registry): add SN108 TalkHead /health subnet-api surface

### DIFF
--- a/registry/subnets/talkhead.json
+++ b/registry/subnets/talkhead.json
@@ -12,5 +12,25 @@
   "social": {
     "x": "https://x.com/talkheadai"
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-108-talkhead-health",
+      "kind": "subnet-api",
+      "name": "TalkHead API health",
+      "notes": "Public no-auth GET /health on api.talkhead.ai returning application liveness (observed plain-text response: Healthy). Served on the TalkHead subnet API host documented in the talkhead-subnet repository README for miner and validator submission flows.",
+      "provider": "talkhead",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/talkheadai/talkhead-subnet",
+        "https://www.talkhead.ai/"
+      ],
+      "url": "https://api.talkhead.ai/health"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #580

Adds a public `subnet-api` health surface for SN108 TalkHead at `GET https://api.talkhead.ai/health`, which returns plain-text `Healthy` without authentication. The endpoint is served on the TalkHead subnet API host documented in the talkhead-subnet repository README.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /health` returns 200 on `api.talkhead.ai`
- [x] Single-file append-only change to `registry/subnets/talkhead.json`
- [x] Merge-simulated cleanly after open PRs #3632, #3630, #3629, #3627, #3626, #3618, #3616, #3604, #3594, #3593, #3546

Made with [Cursor](https://cursor.com)