### PR TITLE
feat(registry): add SN57 Sparket subnet-api health surface

### DIFF
--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -69,6 +69,28 @@
         "timeout_ms": 10000
       },
       "notes": "Official Sparket source repository."
+    },
+    {
+      "id": "sn-57-sparket-subnet-api",
+      "name": "Sparket API health",
+      "kind": "subnet-api",
+      "url": "https://sparket.ai/api/v1/health",
+      "provider": "sparket",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://sparket.ai/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the Sparket (SN57) backend API health as JSON (status, db connectivity, version, and sync lag). Served on the subnet's own registered website domain sparket.ai under /api/v1/. Fills the file's noted missing public-API-endpoint gap."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/sparket.json`. Append-only; no other field changed.

Closes #730

## Summary

Registers SN57 Sparket's public no-auth API endpoint — filling the manifest's own documented gap ("No verified safe public subnet API endpoint yet"). `https://sparket.ai/api/v1/health` returns live backend health as JSON (`{status, db_connected, version, last_sync_at, sync_lag_seconds}`). It's served on the subnet's own registered website domain `sparket.ai` under `/api/v1/`, so ownership is direct.

## Surface

- Netuid: 57
- Kind: subnet-api
- Public URL: https://sparket.ai/api/v1/health
- Source URL (proves the claim): https://sparket.ai/
- Provider slug: sparket

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only endpoint on the subnet's own registered domain.
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs.
- [x] Not a duplicate — the manifest had no subnet-api surface.
- [x] Links a tracked issue (`Closes #730`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/sparket.json` → passed
- [x] `npm run scan:public-safety` → passed
