### PR TITLE
feat(registry): add SN51 lium.io /api/version subnet-api health surface

### DIFF
--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -63,6 +63,23 @@
         "https://lium.io/api/openapi.json"
       ],
       "url": "https://lium.io/api/machines"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-health",
+      "kind": "subnet-api",
+      "name": "Lium API version health",
+      "notes": "Public no-auth GET /version on the Lium Backend API (served at /api/version) returning liveness JSON with started_at and uptime_seconds. Documented as GET /version in the registered OpenAPI spec on the same host as the existing machines subnet-api surface.",
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "schema_url": "https://lium.io/api/openapi.json",
+      "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
+      "url": "https://lium.io/api/version"
     }
   ]
 }


### PR DESCRIPTION
Closes #462

Adds a public `subnet-api` health surface for SN51 lium.io at `GET https://lium.io/api/version`, which returns liveness JSON (`started_at`, `uptime_seconds`) without authentication. The endpoint is documented as `GET /version` in the registered OpenAPI spec on the same host as the existing machines subnet-api surface.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /api/version` returns 200 JSON on `lium.io`
- [x] Single-file append-only change to `registry/subnets/lium-io.json`
- [x] Merge-simulated cleanly after open PRs #3630, #3629, #3627, #3626, #3618, #3616, #3604, #3594, #3593, #3546

Made with [Cursor](https://cursor.com)