### PR TITLE
feat(registry): add Bitsota research claims API surface (SN94)

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -108,6 +108,25 @@
         "https://bitsota.ai/docs/autoresearch-backend-routes"
       ],
       "url": "https://autoresearch.bitsota.com/api/v1/dashboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-claims-api",
+      "kind": "subnet-api",
+      "name": "Bitsota research claims API",
+      "notes": "Public no-auth GET returning research task claims with task IDs, status, descriptions, and participation metadata. Documented in the subnet's own OpenAPI (autoresearch.bitsota.com/openapi.json, path /api/v1/claims); same host as the existing tasks, dashboard, and idea-rewards surfaces.",
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://autoresearch.bitsota.com/openapi.json",
+        "https://bitsota.ai/docs/autoresearch-backend-routes"
+      ],
+      "url": "https://autoresearch.bitsota.com/api/v1/claims"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/bitsota.json`.

## Surface

- Netuid: 94
- Kind: subnet-api
- Public URL: https://autoresearch.bitsota.com/api/v1/claims
- Source URL (proves the claim): https://autoresearch.bitsota.com/openapi.json
- Provider slug: alveus-labs

## Checklist

- [x] Changes exactly one `registry/subnets/bitsota.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #591`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitsota.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3636 | `registry/subnets/lium-io.json` | `registry/subnets/bitsota.json` |
| #3629 | `registry/subnets/cacheon.json` | registry only |
| #3618 | `registry/subnets/handshake58.json` | registry only |
| #3630, #3627, #3626, #3616, #3604 | UI only | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #591

Made with [Cursor](https://cursor.com)