### PR TITLE
feat(registry): enrich SN44 Score — subnet-api + OpenAPI surfaces

### DIFF
--- a/registry/subnets/score.json
+++ b/registry/subnets/score.json
@@ -1,36 +1,76 @@
 {
-  "schema_version": 1,
-  "netuid": 44,
-  "name": "Score",
-  "slug": "sn-44",
-  "status": "active",
   "categories": [],
+  "contact": "hello@wearescore.com",
   "curation": {
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
+  "name": "Score",
+  "netuid": 44,
+  "schema_version": 1,
+  "slug": "sn-44",
+  "social": {
+    "x": "https://x.com/webuildscore"
+  },
+  "source_repo": "https://github.com/score-technologies/turbovision",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-44-score-source-repo",
-      "name": "Score Vision validator and miner code",
-      "kind": "source-repo",
-      "url": "https://github.com/score-technologies/score-vision",
-      "provider": "score",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-44-score-source-repo",
+      "kind": "source-repo",
+      "name": "Score Vision validator and miner code",
+      "notes": "Current SN44 validator/miner base code, linked as both \"GitHub\" and \"Documentation\" from the official wearescore.com site. Distinct from the legacy turbovision repo.",
+      "provider": "score",
       "public_safe": true,
-      "source_urls": ["https://www.wearescore.com/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Current SN44 validator/miner base code, linked as both \"GitHub\" and \"Documentation\" from the official wearescore.com site. Distinct from the legacy turbovision repo."
+      "source_urls": ["https://www.wearescore.com/"],
+      "url": "https://github.com/score-technologies/score-vision"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-44-score-openapi",
+      "kind": "openapi",
+      "name": "Score Subnet API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Score SN44 backend (title: Score Subnet API). Served publicly at api.scorevision.io; documents challenge/task routes and the no-auth GET /health probe.",
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.scorevision.io/openapi.json",
+      "source_urls": [
+        "https://github.com/score-technologies/score-vision/blob/main/validator/config.py",
+        "https://www.wearescore.com/"
+      ],
+      "url": "https://api.scorevision.io/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-44-score-subnet-api",
+      "kind": "subnet-api",
+      "name": "Score API health",
+      "notes": "Public no-auth GET /health on api.scorevision.io returning backend liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /health in the subnet OpenAPI spec on the same host as the challenge/task routes used by validators.",
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.scorevision.io/openapi.json",
+        "https://github.com/score-technologies/score-vision/blob/main/validator/config.py"
+      ],
+      "url": "https://api.scorevision.io/health"
     }
   ],
-  "social": {
-    "x": "https://x.com/webuildscore"
-  },
-  "contact": "hello@wearescore.com",
-  "source_repo": "https://github.com/score-technologies/turbovision",
   "website_url": "https://www.wearescore.com/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends surface(s) to exactly one subnet's file — `registry/subnets/score.json` (SN44, Score). No other files are touched.

## Summary

Enriches SN44 (Score) with the two callable, verified-live surfaces it was missing per #662:

- **`openapi`** — machine-readable OpenAPI 3.1 schema at `https://api.scorevision.io/openapi.json` (title: Score Subnet API, 14 paths including GET /health).
- **`subnet-api`** — public no-auth health probe at `https://api.scorevision.io/health` (observed: `{"status":"healthy"}`).

Both were fetched live: HTTP 200, `Content-Type: application/json`, no authentication. The official `score-vision` validator config sets `SCORE_VISION_API = "https://api.scorevision.io"`, and the wearescore.com site links the Score console on the same host — independently proving SN44 ownership.

## Surface

- Netuid: 44
- Kind: `subnet-api`, `openapi`
- Public URL: `https://api.scorevision.io/health`, `https://api.scorevision.io/openapi.json`
- Source URL (proves the claim): `https://github.com/score-technologies/score-vision/blob/main/validator/config.py`, `https://api.scorevision.io/openapi.json`
- Provider slug: `score`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file.
- [x] Surfaces carry `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue.

## Validation

- [x] `npm run validate:surface -- registry/subnets/score.json` → passed (3 surfaces, 1 file)
- [x] `npm run scan:public-safety` → passed
- [x] `prettier --check` → clean

Closes #662
