### PR TITLE
fix(ask): reject invalid Content-Length before reading the body

### DIFF
--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -948,6 +948,48 @@ describe("AI routes through the Worker dispatch", () => {
     assert.equal((await res.json()).error.code, "payload_too_large");
   });
 
+  test("ask rejects invalid Content-Length before parsing", async () => {
+    const env = aiWorkerEnv({
+      AI: { run: () => Promise.reject(new Error("body should not parse")) },
+    });
+    for (const contentLength of ["not-a-number", "-1"]) {
+      const res = await handleRequest(
+        new Request(ASK_URL, {
+          method: "POST",
+          headers: { "content-length": contentLength },
+          body: JSON.stringify({ question: "x" }),
+        }),
+        env,
+        {},
+      );
+      assert.equal(res.status, 400, contentLength);
+      assert.equal(
+        (await res.json()).error.code,
+        "invalid_content_length",
+        contentLength,
+      );
+    }
+  });
+
+  test("ask accepts a finite Content-Length within the cap before parsing", async () => {
+    const payload = { question: "Which subnet does images?" };
+    const body = JSON.stringify(payload);
+    const res = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(new TextEncoder().encode(body).byteLength),
+        },
+        body,
+      }),
+      aiWorkerEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.ok((await res.json()).data.citations.length > 0);
+  });
+
   test("ask rejects oversized streamed bodies while reading", async () => {
     const stream = new ReadableStream({
       start(controller) {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3768,9 +3768,15 @@ function aiClientKey(request, scope) {
 }
 
 async function readBoundedRequestText(request, maxBytes) {
-  const contentLength = Number(request.headers.get("content-length") || 0);
-  if (contentLength > maxBytes) {
-    return { ok: false, text: "" };
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const contentLength = Number(declaredLength);
+    if (!Number.isFinite(contentLength) || contentLength < 0) {
+      return { ok: false, code: "invalid_content_length" };
+    }
+    if (contentLength > maxBytes) {
+      return { ok: false, code: "payload_too_large" };
+    }
   }
 
   if (!request.body) {
@@ -3791,7 +3797,7 @@ async function readBoundedRequestText(request, maxBytes) {
       bytes += chunk.byteLength;
       if (bytes > maxBytes) {
         await reader.cancel();
-        return { ok: false, text: "" };
+        return { ok: false, code: "payload_too_large" };
       }
       text += decoder.decode(chunk, { stream: true });
     }
@@ -3866,6 +3872,13 @@ async function handleAskRequest(request, env) {
       MAX_ASK_BODY_BYTES,
     );
     if (!boundedBody.ok) {
+      if (boundedBody.code === "invalid_content_length") {
+        return errorResponse(
+          "invalid_content_length",
+          "Invalid Content-Length header.",
+          400,
+        );
+      }
       return errorResponse(
         "payload_too_large",
         "Ask request body exceeds the size limit.",


### PR DESCRIPTION

## Summary

- Harden `POST /api/v1/ask` so malformed `Content-Length` values cannot bypass the pre-read body-size guard.
- Mirror the RPC proxy pattern: validate finiteness and non-negativity when the header is present; 400 on invalid, 413 on oversize.

## What changed

- `workers/api.mjs` — validate `Content-Length` in `readBoundedRequestText`; map to `invalid_content_length` in `handleAskRequest`.
- `tests/ai-search.test.mjs` — regression tests for non-numeric and negative headers.

## Registry safety

- [x] No secrets, PATs, wallet data, private URLs, or registry edits.
- [x] No generated artifacts touched.

## Validation

- [x] `npm test -- tests/ai-search.test.mjs -t "ask rejects invalid Content-Length"`
- [x] `npm test -- tests/ai-search.test.mjs -t "ask rejects oversized Content-Length"`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `git diff --check`