### PR TITLE
feat(registry): add Nepher active tournament ID API surface (SN49)

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -301,6 +301,25 @@
         "https://docs.nepher.ai/"
       ],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/list"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-active-tournament-id-api",
+      "kind": "subnet-api",
+      "name": "Nepher active tournament ID API",
+      "notes": "Public no-auth GET returning the UUID of the currently active tournament. Documented in the subnet's own OpenAPI (tournament-api.nepher.ai/openapi.json, path /api/v1/tournaments/active/id); same host as existing tournament surfaces. Distinct from the tournaments list, active-tournaments list, and current-block endpoints.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://docs.nepher.ai/"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/id"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/nepher-robotics.json`.

## Surface

- Netuid: 49
- Kind: subnet-api
- Public URL: https://tournament-api.nepher.ai/api/v1/tournaments/active/id
- Source URL (proves the claim): https://tournament-api.nepher.ai/openapi.json
- Provider slug: nepher-robotics

## Checklist

- [x] Changes exactly one `registry/subnets/nepher-robotics.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #962`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/nepher-robotics.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3629 | `registry/subnets/cacheon.json` | `registry/subnets/nepher-robotics.json` |
| #3630, #3627, #3626, #3616, #3604 | UI only | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #962

Made with [Cursor](https://cursor.com)