### PR TITLE
feat(registry): add SN5 Hone subnet-api health surface

### DIFF
--- a/registry/subnets/hone.json
+++ b/registry/subnets/hone.json
@@ -137,6 +137,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Hone source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-5-hone-subnet-api",
+      "kind": "subnet-api",
+      "name": "Hone API health",
+      "notes": "Public no-auth GET /health on api.hone.training returning application liveness JSON (status ok). Served on the Hone subnet API host referenced by the official hone.training dashboard frontend (wss://api.hone.training/ws/dashboard) and documented in the hone source repository README for miner health checks.",
+      "provider": "hone",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://www.hone.training/network",
+        "https://github.com/manifold-inc/hone"
+      ],
+      "url": "https://api.hone.training/health"
     }
   ],
   "contact": "devs@manifold.inc"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/hone.json`. Append-only; no other fields changed.

Closes #713

## Summary

Registers SN5 Hone's public no-auth API health endpoint — filling the manifest's own documented gap ("No verified safe public subnet API endpoint yet"). `https://api.hone.training/health` returns live application liveness as JSON (`{"status":"ok"}`). The endpoint is on the subnet's official API host `api.hone.training`, referenced by the hone.training dashboard frontend (`wss://api.hone.training/ws/dashboard`) and documented in the hone source repository README for miner health checks.

## Surface

- Netuid: 5
- Kind: subnet-api
- Public URL: https://api.hone.training/health
- Source URLs (prove the claim):
  - https://www.hone.training/network
  - https://github.com/manifold-inc/hone
- Provider slug: hone

## Checklist

- [x] Changes exactly one `registry/subnets/hone.json` file: append-only (+19 lines).
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only endpoint on the subnet's official API host.
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs.
- [x] Not a duplicate — the manifest had no subnet-api surface.
- [x] Links a tracked issue (`Closes #713`).

## Validation

- [x] Live probe: `curl -sS https://api.hone.training/health` → HTTP 200 JSON
- [x] `npm run validate:surface -- registry/subnets/hone.json` → passed
- [x] `npm run scan:public-safety` → passed
- [x] `prettier --check registry/subnets/hone.json` → passed

## Conflict avoidance

Touches only `hone.json`. No overlap with open registry PR #3629 (Cacheon SN14).

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes

Made with [Cursor](https://cursor.com)