### PR TITLE
test(ui): cover safeExternalUrl SSRF/private-host barrier

### DIFF
--- a/apps/ui/src/components/metagraphed/external-link.test.ts
+++ b/apps/ui/src/components/metagraphed/external-link.test.ts
@@ -10,7 +10,32 @@ describe("safeExternalUrl", () => {
   it("blocks non-http schemes and credentialed URLs", () => {
     expect(safeExternalUrl("javascript:alert(1)")).toBeUndefined();
     expect(safeExternalUrl("data:text/html,hi")).toBeUndefined();
+    expect(safeExternalUrl("file:///etc/passwd")).toBeUndefined();
     expect(safeExternalUrl("https://user:pass@example.com/")).toBeUndefined();
+    expect(safeExternalUrl("https://user@example.com/")).toBeUndefined();
+  });
+
+  it("returns undefined for missing, empty, or malformed input without throwing", () => {
+    expect(safeExternalUrl(undefined)).toBeUndefined();
+    expect(safeExternalUrl("")).toBeUndefined();
+    expect(safeExternalUrl("   ")).toBeUndefined();
+    expect(() => safeExternalUrl("not a url")).not.toThrow();
+    expect(safeExternalUrl("not a url")).toBeUndefined();
+    expect(() => safeExternalUrl("//evil.com/no-protocol")).not.toThrow();
+    expect(safeExternalUrl("//evil.com/no-protocol")).toBeUndefined();
+    expect(() => safeExternalUrl("http://")).not.toThrow();
+    expect(safeExternalUrl("http://")).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(safeExternalUrl("  https://example.com/  ")).toBe("https://example.com/");
+  });
+
+  it("normalizes hostname case and trailing dot before matching private hosts", () => {
+    expect(safeExternalUrl("http://LOCALHOST/")).toBeUndefined();
+    expect(safeExternalUrl("http://localhost./")).toBeUndefined();
+    expect(safeExternalUrl("http://sub.localhost/")).toBeUndefined();
+    expect(safeExternalUrl("http://EXAMPLE.com/")).toBe("http://example.com/");
   });
 
   it("blocks private, reserved, and local host targets", () => {


### PR DESCRIPTION
## Summary

- Closes #3431
- `safeExternalUrl` in `apps/ui/src/components/metagraphed/external-link.tsx` is a security-relevant SSRF/private-host barrier used by roughly a dozen consumers and had no dedicated coverage for several of its actual branches. Extends the existing `external-link.test.ts` (no new files) to close the gaps: `file:` scheme rejection, credential-only (no password) URLs, missing/empty/whitespace-only input, malformed/unparseable URLs (asserting no throw), href whitespace trimming, and hostname normalization (case-insensitivity and trailing-dot handling) against `localhost`/`.localhost`.
- No production code changed — test-only, non-visual, scoped to a single test file.

## What Changed

- `apps/ui/src/components/metagraphed/external-link.test.ts`: added 3 new `it()` blocks and extended the existing non-http-scheme/credentials block, covering only branches the real `safeExternalUrl` implementation exercises (verified by reading `external-link.tsx` line by line before writing assertions).

## Validation

- `npm test --workspace=apps/ui` (349 tests passed, full suite)
- `npm run typecheck --workspace=apps/ui`
- `npm run lint` / `npm run format:check` (scoped to the changed file)
- `npm run build --workspace=apps/ui`
- `git diff --check`

No visual change — screenshot table not applicable (test-file-only change per the frontend PR contract).