### PR TITLE
feat(registry): add SN5 Hone API health subnet-api surface

### DIFF
--- a/registry/subnets/hone.json
+++ b/registry/subnets/hone.json
@@ -137,6 +137,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Hone source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-5-hone-health",
+      "kind": "subnet-api",
+      "name": "Hone API health",
+      "notes": "Public no-auth GET /health on api.hone.training returning application liveness JSON (observed: {\"status\":\"ok\"}). Served on the Hone API subdomain of the official SN5 website host registered in this manifest; the official hone repository defines a no-auth GET /health route on the sandbox-runner load balancer service.",
+      "provider": "hone",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/manifold-inc/hone/blob/main/sandbox_runner/lb/load_balancer.py",
+        "https://www.hone.training/"
+      ],
+      "url": "https://api.hone.training/health"
     }
   ],
   "contact": "devs@manifold.inc"


### PR DESCRIPTION
Closes #713

Adds a public `subnet-api` health surface for SN5 Hone at `GET https://api.hone.training/health`, which returns liveness JSON (`{"status":"ok"}`) without authentication. The endpoint is served on the Hone API subdomain of the official SN5 website host registered in this manifest; the official hone repository defines a no-auth GET /health route on the sandbox-runner load balancer service.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /health` returns 200 JSON on `api.hone.training`
- [x] Single-file append-only change to `registry/subnets/hone.json`
- [x] Merge-simulated cleanly after open PRs #3637, #3630, #3629, #3627, #3626, #3618, #3616, #3604, #3594, #3593

Made with [Cursor](https://cursor.com)