### PR TITLE
feat(ui): add typed data layer for subnet identity-history

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-identity-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-identity-history.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetIdentityHistoryEntry, subnetIdentityHistoryQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/identity-history",
+  });
+}
+
+// The queryFn is defined on the queryOptions returned by the factory.
+async function runQuery(netuid: number) {
+  const opts = subnetIdentityHistoryQuery(netuid);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetIdentityHistoryEntry", () => {
+  it("passes a well-formed entry through unchanged", () => {
+    const raw = {
+      identity_hash: "0xabc",
+      block_number: 123,
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_name: "Alpha",
+      symbol: "α",
+      description: "d",
+      github_repo: "https://github.com/x/y",
+      subnet_url: "https://x.io",
+      logo_url: "https://x.io/logo.png",
+      discord: "https://discord.gg/x",
+    };
+    expect(normalizeSubnetIdentityHistoryEntry(raw)).toEqual(raw);
+  });
+
+  it("discards a row with no identity_hash (the keyset anchor)", () => {
+    expect(normalizeSubnetIdentityHistoryEntry({ block_number: 1 })).toBeNull();
+    expect(normalizeSubnetIdentityHistoryEntry(null)).toBeNull();
+    expect(normalizeSubnetIdentityHistoryEntry("x")).toBeNull();
+  });
+
+  it("coerces junk cells to null (never NaN or [object Object])", () => {
+    const entry = normalizeSubnetIdentityHistoryEntry({
+      identity_hash: "0xabc",
+      block_number: "not-a-number",
+      observed_at: { x: 1 },
+      subnet_name: 42,
+      description: ["nope"],
+    });
+    expect(entry).not.toBeNull();
+    expect(entry?.block_number).toBeNull();
+    expect(entry?.observed_at).toBeNull();
+    expect(entry?.subnet_name).toBeNull();
+    expect(entry?.description).toBeNull();
+  });
+});
+
+describe("subnetIdentityHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("normalizes the envelope and filters junk entries", async () => {
+    resolveWith({
+      schema_version: 1,
+      netuid: 7,
+      entry_count: 2,
+      entries: [
+        { identity_hash: "0x1", subnet_name: "A" },
+        { block_number: 5 }, // no identity_hash -> dropped
+      ],
+      next_cursor: null,
+    });
+    const res = await runQuery(7);
+    expect(res.data.netuid).toBe(7);
+    expect(res.data.entries).toHaveLength(1);
+    expect(res.data.entries[0]?.identity_hash).toBe("0x1");
+  });
+
+  it("degrades a cold / empty store to a schema-stable zeroed envelope", async () => {
+    resolveWith({});
+    const res = await runQuery(7);
+    expect(res.data.entries).toEqual([]);
+    expect(res.data.entry_count).toBe(0);
+    expect(res.data.netuid).toBe(7);
+    expect(res.data.next_cursor).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -94,6 +94,8 @@ import type {
   SubnetEconomics,
   SubnetHistory,
   SubnetHistoryPoint,
+  SubnetIdentityHistory,
+  SubnetIdentityHistoryEntry,
   SubnetNeuronHistory,
   SubnetNeuronHistoryPoint,
   MetagraphNeuron,
@@ -2786,6 +2788,68 @@ export const subnetHistoryQuery = (netuid: number, window = "90d") =>
         signal,
       });
       return { data: normalizeSubnetHistory(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// One observed on-chain SubnetIdentitiesV3 snapshot (#1647). Operator-controlled
+// untrusted data: every field but the stable `identity_hash` coerces to null on
+// junk, and a row without an identity_hash (the keyset anchor) is discarded.
+export function normalizeSubnetIdentityHistoryEntry(
+  raw: unknown,
+): SubnetIdentityHistoryEntry | null {
+  if (!isRecord(raw)) return null;
+  const identityHash = firstString(raw.identity_hash);
+  if (identityHash == null) return null;
+  return {
+    identity_hash: identityHash,
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+    subnet_name: firstString(raw.subnet_name) ?? null,
+    symbol: firstString(raw.symbol) ?? null,
+    description: firstString(raw.description) ?? null,
+    github_repo: firstString(raw.github_repo) ?? null,
+    subnet_url: firstString(raw.subnet_url) ?? null,
+    logo_url: firstString(raw.logo_url) ?? null,
+    discord: firstString(raw.discord) ?? null,
+  };
+}
+
+const MAX_SUBNET_IDENTITY_HISTORY_ENTRIES = 1000;
+
+function normalizeSubnetIdentityHistory(netuid: number, raw: unknown): SubnetIdentityHistory {
+  const rec = isRecord(raw) ? raw : {};
+  const entries = (Array.isArray(rec.entries) ? rec.entries : [])
+    .map(normalizeSubnetIdentityHistoryEntry)
+    .filter((entry): entry is SubnetIdentityHistoryEntry => entry != null)
+    .slice(0, MAX_SUBNET_IDENTITY_HISTORY_ENTRIES);
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    entry_count: firstFiniteNumber(rec.entry_count) ?? entries.length,
+    entries,
+    limit: firstFiniteNumber(rec.limit) ?? null,
+    offset: firstFiniteNumber(rec.offset) ?? null,
+    next_cursor: firstString(rec.next_cursor) ?? null,
+  };
+}
+
+// #1647: append-only on-chain identity timeline for one subnet (newest first),
+// from the subnet_identity_history D1 tier. No paging params surfaced yet — the
+// default page (limit<=1000) is enough for the profile tab that consumes this.
+export const subnetIdentityHistoryQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-identity-history", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetIdentityHistory>>(
+        `/api/v1/subnets/${netuid}/identity-history`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetIdentityHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1087,6 +1087,35 @@ export interface SubnetHistory {
   points: SubnetHistoryPoint[];
 }
 
+/**
+ * One observed on-chain SubnetIdentitiesV3 snapshot for a subnet (#1647), from
+ * /api/v1/subnets/{netuid}/identity-history. Operator-controlled untrusted data —
+ * every field but the stable `identity_hash` may be null.
+ */
+export interface SubnetIdentityHistoryEntry {
+  identity_hash: string;
+  block_number: number | null;
+  observed_at: string | null;
+  subnet_name: string | null;
+  symbol: string | null;
+  description: string | null;
+  github_repo: string | null;
+  subnet_url: string | null;
+  logo_url: string | null;
+  discord: string | null;
+}
+
+/** Append-only on-chain identity timeline for one subnet (#1647), newest first. */
+export interface SubnetIdentityHistory {
+  schema_version: number;
+  netuid: number;
+  entry_count: number;
+  entries: SubnetIdentityHistoryEntry[];
+  limit: number | null;
+  offset: number | null;
+  next_cursor: string | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;


### PR DESCRIPTION
## Summary

Adds the typed data layer for one subnet's on-chain identity-change history (#1647), consuming the existing `GET /api/v1/subnets/{netuid}/identity-history` endpoint — the query + response types the subnet-profile identity-history tab (#3487) needs, split out as its own small, tested unit (mirrors the data-layer PRs for the account portfolio #3595 and chain decentralization #3609).

Closes #3487

## What changed

- **`apps/ui/src/lib/metagraphed/types.ts`** — `SubnetIdentityHistoryEntry` (one SubnetIdentitiesV3 snapshot: `identity_hash` + nullable name/symbol/description/repo/url/logo/discord/block/observed_at) and `SubnetIdentityHistory` (the paged envelope).
- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetIdentityHistoryQuery(netuid)` (`queryOptions` fetching the endpoint) plus exported `normalizeSubnetIdentityHistoryEntry` and an envelope normalizer. Operator-controlled untrusted data is defensively coerced: junk cells → null (never NaN / `[object Object]`), a row with no `identity_hash` (the keyset anchor) is dropped, and a cold store degrades to a schema-stable zeroed envelope. Capped at 1000 entries.
- **`apps/ui/src/lib/metagraphed/queries.subnet-identity-history.test.ts`** — covers the well-formed pass-through, junk-cell coercion, missing-hash drop, envelope filtering, and cold-store degradation.

## Validation

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm run lint` · `format:check`
- [x] `npm run test` (apps/ui) — 271 passed (incl. the 5 new cases)
