### PR TITLE
feat(registry): add Green Compute billing bonus rates API surface (SN110)

### DIFF
--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -196,6 +196,25 @@
         "https://www.green-compute.com/"
       ],
       "url": "https://api.green-compute.com/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-110-green-compute-billing-bonus-rates-api",
+      "kind": "subnet-api",
+      "name": "Green Compute billing bonus rates API",
+      "notes": "Public no-auth GET returning platform billing bonus rates by payment method (stripe, usdt, usdc, tao, alpha). Documented in the subnet's own OpenAPI (api.green-compute.com/openapi.json, path /platform/billing/bonus-rates); same host as the existing healthz and openapi surfaces.",
+      "provider": "green-compute",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.green-compute.com/openapi.json",
+        "https://www.green-compute.com/"
+      ],
+      "url": "https://api.green-compute.com/platform/billing/bonus-rates"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/green-compute.json`.

## Surface

- Netuid: 110
- Kind: subnet-api
- Public URL: https://api.green-compute.com/platform/billing/bonus-rates
- Source URL (proves the claim): https://api.green-compute.com/openapi.json
- Provider slug: green-compute

## Checklist

- [x] Changes exactly one `registry/subnets/green-compute.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #678`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/green-compute.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3645, #3642 | `registry/subnets/hone.json` | `registry/subnets/green-compute.json` |
| #3629 | `registry/subnets/cacheon.json` | registry only |
| #3644, #3643, #3630, #3627, #3626, #3616, #3604 | UI only | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #678

Made with [Cursor](https://cursor.com)