### PR TITLE
feat(registry): add SN93 Bitcast OpenAPI surface

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -135,6 +135,33 @@
         "https://creator.bitcast.network/briefs"
       ],
       "url": "https://creator.bitcast.network/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-network-openapi",
+      "kind": "openapi",
+      "name": "Bitcast API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Bitcast API gateway (bitcast-api.bitcast.network). The spec and Swagger UI at /docs are publicly fetchable; most documented endpoints require API-key auth, but the schema itself is no-auth.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanksi"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://bitcast-api.bitcast.network/openapi.json",
+      "source_urls": [
+        "https://github.com/bitcast-network/bitcast/blob/main/bitcast/validator/utils/config.py",
+        "https://bitcast-api.bitcast.network/docs"
+      ],
+      "url": "https://bitcast-api.bitcast.network/openapi.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Register Bitcast's machine-readable OpenAPI 3.1 schema at `https://bitcast-api.bitcast.network/openapi.json`.
- Completes the remaining gap from #574; public `subnet-api` surfaces (`creator.bitcast.network/api/briefs` and `/api/health`) are already on `main`.

Closes #574 

## Surface

- Netuid: 93 (Bitcast)
- Kind: `openapi`
- Public URL: `https://bitcast-api.bitcast.network/openapi.json`
- Source URL (proves the claim):
  - `https://github.com/bitcast-network/bitcast/blob/main/bitcast/validator/utils/config.py` — `BITCAST_API_URL` defaults to `https://bitcast-api.bitcast.network`
  - `https://bitcast-api.bitcast.network/docs` — FastAPI Swagger UI loading `/openapi.json`
- Provider slug: `bitcast-network`

## Checklist

- [x] Changes exactly one `registry/subnets/bitcast.json` file (append-only).
- [x] Generated with `npm run surface:add`, then hand-tuned name/notes/probe; lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and resolves as OpenAPI JSON (147 paths, title "Bitcast API"); `source_urls` prove SN93 ownership.
- [x] Public-safe: spec and Swagger UI are no-auth; no secrets, wallet data, or generated artifacts in the diff.
- [x] Does not duplicate an existing surface (`stats.bitcast.network/*` paths return HTML, not machine-readable OpenAPI).
- [x] Links tracked issue (`Closes #574`).

## Gate Expectations

Public-safe `openapi` surface — eligible for auto-review. Most API endpoints documented in the spec require API-key auth, but the schema URL itself is publicly fetchable (`auth_required: false`, `public_safe: true`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitcast.json`
- [x] `npm run scan:public-safety`
- [x] Pre-push gate (25/25 local gates, `--skip-tests`)
