### PR TITLE
feat(registry): add SN44 Score OpenAPI + health surfaces

### DIFF
--- a/registry/subnets/score.json
+++ b/registry/subnets/score.json
@@ -25,6 +25,46 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Current SN44 validator/miner base code, linked as both \"GitHub\" and \"Documentation\" from the official wearescore.com site. Distinct from the legacy turbovision repo."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-44-score-openapi",
+      "kind": "openapi",
+      "name": "Score Subnet API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Score SN44 backend (title: Score Subnet API). Served publicly at api.scorevision.io; documents challenge/task routes and the no-auth GET /health probe.",
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.scorevision.io/openapi.json",
+      "source_urls": [
+        "https://github.com/score-technologies/score-vision/blob/main/validator/config.py",
+        "https://api.scorevision.io/openapi.json"
+      ],
+      "url": "https://api.scorevision.io/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-44-score-subnet-api",
+      "kind": "subnet-api",
+      "name": "Score API health",
+      "notes": "Public no-auth GET /health on api.scorevision.io returning backend liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /health in the subnet OpenAPI spec; api.scorevision.io is the SCORE_VISION_API host configured in the score-vision validator source.",
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.scorevision.io/openapi.json",
+        "https://github.com/score-technologies/score-vision/blob/main/validator/config.py"
+      ],
+      "url": "https://api.scorevision.io/health"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends two community surfaces to exactly one subnet manifest —
`registry/subnets/score.json`. Append-only (+40 lines); no existing surfaces or top-level fields modified.

Closes #662

## Summary

Registers SN44 Score's public API host with both requested gap fills:

1. **OpenAPI** — `https://api.scorevision.io/openapi.json` (OpenAPI 3.1, title "Score Subnet API", 14 paths)
2. **subnet-api health** — `https://api.scorevision.io/health` → `{"status":"healthy"}`

First-party proof:
- `score-vision` validator source sets `SCORE_VISION_API = "https://api.scorevision.io"` in `validator/config.py`
- The live OpenAPI spec on that host documents `GET /health` and the challenge/task routes

## Canonical manifest

On current `origin/main`, SN44 has **one** registry file: `registry/subnets/score.json` (`git ls-tree origin/main registry/subnets/ | grep score`). There is no separate `sn-44.json`. This PR appends to the existing canonical manifest without rewriting metadata.

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://api.scorevision.io/openapi.json | config.py, openapi.json |
| subnet-api | https://api.scorevision.io/health | openapi.json, config.py |

Provider slug: **score**

## Checklist

- [x] Changes exactly one `registry/subnets/score.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] `source_urls` independently name the public host/path (config.py + OpenAPI spec).
- [x] Public-safe: no auth-only flows, secrets, or private URLs.
- [x] Not a duplicate — manifest had no openapi or subnet-api surfaces.
- [x] Links tracked issue (`Closes #662`).

## Validation

- [x] Live: `curl -sS https://api.scorevision.io/health` → HTTP 200 JSON
- [x] Live: `curl -sS https://api.scorevision.io/openapi.json` → HTTP 200 OpenAPI 3.1
- [x] `npm run validate:surface -- registry/subnets/score.json` → passed
- [x] `npm run scan:public-safety` → passed
- [x] `prettier --check registry/subnets/score.json` → passed

## Test plan

- [ ] CI: `test`, `checks`, `validate:surface`, `scan:public-safety`
- [ ] codecov/patch and codecov/project green
- [ ] Gittensory review passes

Made with [Cursor](https://cursor.com)