### PR TITLE
feat(registry): add Chutes TAO fair market value API surface (SN64)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -577,6 +577,25 @@
       },
       "source_urls": ["https://chutes.ai/", "https://chutes.ai/docs"],
       "url": "https://chutes.ai/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-fmv-api",
+      "kind": "subnet-api",
+      "name": "Chutes TAO fair market value API",
+      "notes": "Public no-auth GET returning the platform TAO fair market value used for pricing calculations. Documented in the subnet's own OpenAPI (api.chutes.ai/openapi.json, path /fmv); same host as the existing pricing, bounties, and LLM-stats subnet-api surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.chutes.ai/openapi.json",
+        "https://chutes.ai/docs"
+      ],
+      "url": "https://api.chutes.ai/fmv"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/chutes.json`.

## Surface

- Netuid: 64
- Kind: subnet-api
- Public URL: https://api.chutes.ai/fmv
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

## Checklist

- [x] Changes exactly one `registry/subnets/chutes.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #907`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/chutes.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3649 | `registry/subnets/bitcast.json` | `registry/subnets/chutes.json` |
| #3642 | `registry/subnets/hone.json` | registry only |
| #3629 | `registry/subnets/cacheon.json` | registry only |
| #3648, #3627, #3626, #3604 | UI only | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #907

Made with [Cursor](https://cursor.com)