### PR TITLE
feat(ui): add reward-distribution tab to the subnet concentration panel

### DIFF
--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { Suspense, useMemo, useState, type ReactNode } from "react";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Scale, Users, BarChart3 } from "lucide-react";
 import {
   subnetConcentrationQuery,
   subnetConcentrationHistoryQuery,
+  subnetPerformanceQuery,
+  subnetPerformanceHistoryQuery,
 } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
@@ -11,7 +13,11 @@ import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { TableState } from "@/components/metagraphed/table-state";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
-import type { ConcentrationMetrics, ConcentrationHistoryPoint } from "@/lib/metagraphed/types";
+import type {
+  ConcentrationMetrics,
+  ConcentrationHistoryPoint,
+  PerformanceHistoryPoint,
+} from "@/lib/metagraphed/types";
 
 type Win = "7d" | "30d" | "90d";
 const WINDOWS: Win[] = ["7d", "30d", "90d"];
@@ -293,6 +299,235 @@ function DriftRow({
       <span className="w-20 shrink-0 text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
         {last != null ? format(last) : "—"}
       </span>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* #3477: reward-distribution tab — the reward-flow twin of the panel above.  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Reward distribution for one subnet — the reward-flow twin of {@link
+ * ConcentrationLoader}. /performance is the SAME Gini / Nakamoto / HHI / top-
+ * share scorecard as /concentration, computed over incentive + dividends
+ * instead of stake + emission, plus the 0-1 trust / consensus / validator-trust
+ * score spread. Reuses the same KPI tiles, share bars, and drift sparklines.
+ */
+function PerformanceLoader({ netuid }: { netuid: number }) {
+  const { data } = useSuspenseQuery(subnetPerformanceQuery(netuid));
+  const meta = data.meta;
+  const p = data.data;
+  const incentive = p.incentive;
+  const dividends = p.dividends;
+
+  const hasMetrics = Boolean(incentive?.gini != null || dividends?.gini != null);
+  if (!hasMetrics) {
+    return (
+      <TableState
+        variant="empty"
+        title="No reward-distribution metrics"
+        description="Incentive- and dividend-distribution metrics (Gini, HHI, Nakamoto coefficient) plus the 0-1 trust/consensus score spread are computed from the metagraph snapshot and will appear here once captured."
+        generatedAt={meta?.generated_at}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* KPI tiles — incentive-weighted (the headline reward distribution). */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StatTile
+          icon={Scale}
+          eyebrow="Incentive Gini"
+          value={numStr(incentive?.gini)}
+          hint={dividends?.gini != null ? `dividends ${numStr(dividends.gini)}` : undefined}
+          tone={giniTone(incentive?.gini)}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Nakamoto"
+          value={incentive?.nakamoto_coefficient ?? "—"}
+          hint="miners to 51%"
+          tone={nakamotoTone(incentive?.nakamoto_coefficient)}
+        />
+        <StatTile
+          icon={BarChart3}
+          eyebrow="Incentive HHI"
+          value={numStr(incentive?.hhi)}
+          hint={
+            incentive?.hhi_normalized != null
+              ? `norm ${numStr(incentive.hhi_normalized)}`
+              : undefined
+          }
+          tone={giniTone(incentive?.hhi)}
+        />
+      </div>
+
+      {/* Top-percentile reward share — incentive vs dividends side by side. */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <SharePanel title="Incentive to top %" metrics={incentive} accent="var(--accent)" />
+        <SharePanel title="Dividends to top %" metrics={dividends} accent="var(--health-warn)" />
+      </div>
+
+      {/* Score spread — 0-1 trust / consensus / validator-trust medians. */}
+      <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Fact label="Trust median" value={numStr(p.trust?.p50)} />
+        <Fact label="Consensus median" value={numStr(p.consensus?.p50)} />
+        <Fact label="Val-trust median" value={numStr(p.validator_trust?.p50)} />
+        <Fact label="Active neurons" value={p.active_count ?? p.neuron_count ?? "—"} />
+      </div>
+
+      {/* Reward-Gini drift over a window. */}
+      <RewardDriftCard netuid={netuid} />
+    </div>
+  );
+}
+
+function RewardDriftCard({ netuid }: { netuid: number }) {
+  const [win, setWin] = useState<Win>("30d");
+  const { data: res, isLoading } = useQuery(subnetPerformanceHistoryQuery(netuid, win));
+  const points = useMemo<PerformanceHistoryPoint[]>(
+    () => res?.data?.points ?? [],
+    [res?.data?.points],
+  );
+
+  const series = useMemo(() => {
+    // History points arrive newest-first; reverse so the sparkline reads L→R in
+    // time. Null metrics (early window) are filtered per-series, not per-point.
+    const ordered = [...points].reverse();
+    const pick = (key: keyof PerformanceHistoryPoint) =>
+      ordered
+        .map((point) => point[key])
+        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    return {
+      incentiveGini: pick("incentive_gini"),
+      dividendsGini: pick("dividends_gini"),
+      incentiveTop10: pick("incentive_top_10pct_share"),
+      dividendsTop10: pick("dividends_top_10pct_share"),
+    };
+  }, [points]);
+
+  const hasData =
+    series.incentiveGini.length +
+      series.dividendsGini.length +
+      series.incentiveTop10.length +
+      series.dividendsTop10.length >
+    0;
+
+  const toggle = (
+    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          onClick={() => setWin(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Reward drift
+        </span>
+        {toggle}
+      </div>
+      {isLoading ? (
+        <Skeleton className="h-28 w-full" />
+      ) : !hasData ? (
+        <EmptyState
+          title="No reward-drift history"
+          description="Daily reward-distribution snapshots will appear here once enough chain history has accumulated."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          {series.incentiveGini.length > 0 ? (
+            <DriftRow
+              label="Incentive Gini"
+              series={series.incentiveGini}
+              color="var(--health-warn)"
+              format={(v) => v.toFixed(3)}
+            />
+          ) : null}
+          {series.dividendsGini.length > 0 ? (
+            <DriftRow
+              label="Dividends Gini"
+              series={series.dividendsGini}
+              color="var(--accent)"
+              format={(v) => v.toFixed(3)}
+            />
+          ) : null}
+          {series.incentiveTop10.length > 0 ? (
+            <DriftRow
+              label="Incentive top 10%"
+              series={series.incentiveTop10}
+              color="var(--chart-1)"
+              format={(v) => `${(v * 100).toFixed(1)}%`}
+            />
+          ) : null}
+          {series.dividendsTop10.length > 0 ? (
+            <DriftRow
+              label="Dividends top 10%"
+              series={series.dividendsTop10}
+              color="var(--chart-3)"
+              format={(v) => `${(v * 100).toFixed(1)}%`}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type DistView = "distribution" | "rewards";
+
+/**
+ * The subnet concentration panel with a stake/emission ↔ rewards tab toggle
+ * (#3477). "Stake & emission" is the existing {@link ConcentrationLoader};
+ * "Rewards" is the reward-flow {@link PerformanceLoader}. The toggle sits
+ * outside the Suspense boundary so it stays interactive while the selected
+ * view's snapshot loads.
+ */
+export function DistributionPanel({ netuid }: { netuid: number }) {
+  const [view, setView] = useState<DistView>("distribution");
+  const tabs: { id: DistView; label: string }[] = [
+    { id: "distribution", label: "Stake & emission" },
+    { id: "rewards", label: "Rewards" },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setView(t.id)}
+            className={classNames(
+              "px-3 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+              view === t.id ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+        {view === "distribution" ? (
+          <ConcentrationLoader netuid={netuid} />
+        ) : (
+          <PerformanceLoader netuid={netuid} />
+        )}
+      </Suspense>
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -109,6 +109,9 @@ import type {
   SubnetConcentration,
   ConcentrationHistoryPoint,
   SubnetConcentrationHistory,
+  SubnetPerformance,
+  PerformanceHistoryPoint,
+  SubnetPerformanceHistory,
   SubnetProfile,
   Surface,
   SurfaceLatencyPercentiles,
@@ -3251,6 +3254,125 @@ export const chainPerformanceQuery = () =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainPerformance>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3477: reward-distribution + score-spread for one subnet — the reward-flow
+// twin of the stake/emission concentration above. /performance reuses the same
+// ConcentrationMetrics scorecard (Gini/HHI/Nakamoto/top-share) over incentive +
+// dividends, and adds the 0-1 trust/consensus/validator_trust score spread.
+function normalizeScoreDistribution(raw: unknown): ScoreDistribution | undefined {
+  if (!isRecord(raw)) return undefined;
+  const nullableNum = (v: unknown): number | null => coerceFiniteNumber(v) ?? null;
+  return {
+    count: coerceFiniteNumber(raw.count),
+    mean: nullableNum(raw.mean),
+    min: nullableNum(raw.min),
+    max: nullableNum(raw.max),
+    p10: nullableNum(raw.p10),
+    p25: nullableNum(raw.p25),
+    p50: nullableNum(raw.p50),
+    p75: nullableNum(raw.p75),
+    p90: nullableNum(raw.p90),
+  };
+}
+
+function normalizeSubnetPerformance(netuid: number, raw: unknown): SubnetPerformance {
+  const d = isRecord(raw) ? raw : {};
+  return {
+    netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+    neuron_count: coerceFiniteNumber(d.neuron_count),
+    active_count: coerceFiniteNumber(d.active_count),
+    validator_count: coerceFiniteNumber(d.validator_count),
+    captured_at: coerceString(d.captured_at),
+    incentive: normalizeConcentrationMetrics(d.incentive),
+    dividends: normalizeConcentrationMetrics(d.dividends),
+    trust: normalizeScoreDistribution(d.trust),
+    consensus: normalizeScoreDistribution(d.consensus),
+    validator_trust: normalizeScoreDistribution(d.validator_trust),
+  };
+}
+
+function normalizePerformanceHistoryPoint(raw: unknown): PerformanceHistoryPoint | undefined {
+  if (!isRecord(raw)) return undefined;
+  const snapshotDate = coerceString(raw.snapshot_date);
+  if (!snapshotDate) return undefined;
+  // Nullable-by-design: the early window has no reward metrics yet — keep null
+  // (not undefined) so the chart can render a gap rather than dropping the day.
+  const nullableNum = (v: unknown): number | null => coerceFiniteNumber(v) ?? null;
+  return {
+    ...(raw as object),
+    snapshot_date: snapshotDate,
+    neuron_count: coerceFiniteNumber(raw.neuron_count),
+    active_count: coerceFiniteNumber(raw.active_count),
+    validator_count: coerceFiniteNumber(raw.validator_count),
+    incentive_gini: nullableNum(raw.incentive_gini),
+    incentive_nakamoto_coefficient: nullableNum(raw.incentive_nakamoto_coefficient),
+    incentive_top_10pct_share: nullableNum(raw.incentive_top_10pct_share),
+    dividends_gini: nullableNum(raw.dividends_gini),
+    dividends_nakamoto_coefficient: nullableNum(raw.dividends_nakamoto_coefficient),
+    dividends_top_10pct_share: nullableNum(raw.dividends_top_10pct_share),
+    trust_mean: nullableNum(raw.trust_mean),
+    trust_median: nullableNum(raw.trust_median),
+    consensus_mean: nullableNum(raw.consensus_mean),
+    consensus_median: nullableNum(raw.consensus_median),
+    validator_trust_mean: nullableNum(raw.validator_trust_mean),
+    validator_trust_median: nullableNum(raw.validator_trust_median),
+  };
+}
+
+function normalizeSubnetPerformanceHistory(netuid: number, raw: unknown): SubnetPerformanceHistory {
+  const d = isRecord(raw) ? raw : {};
+  const points = Array.isArray(d.points)
+    ? d.points.slice(-MAX_HISTORY_POINTS).flatMap((point) => {
+        const normalized = normalizePerformanceHistoryPoint(point);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+    window: coerceString(d.window),
+    point_count: coerceFiniteNumber(d.point_count) ?? points.length,
+    points,
+  };
+}
+
+/** Reward-distribution scorecard (incentive/dividends concentration + trust/consensus spread). */
+export const subnetPerformanceQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-performance", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetPerformance>>(
+        `/api/v1/subnets/${netuid}/performance`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetPerformance(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetPerformance>;
+    },
+    staleTime: STALE_MED,
+  });
+
+/** Daily reward-flow drift (incentive/dividends Gini/Nakamoto/top-10%, trust/consensus mean/median). */
+export const subnetPerformanceHistoryQuery = (
+  netuid: number,
+  window: "7d" | "30d" | "90d" = "30d",
+) =>
+  queryOptions({
+    queryKey: k("subnet-performance-history", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetPerformanceHistory>>(
+        `/api/v1/subnets/${netuid}/performance/history`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetPerformanceHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetPerformanceHistory>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1279,6 +1279,49 @@ export interface SubnetConcentrationHistory {
   points: ConcentrationHistoryPoint[];
 }
 
+/** Reward-distribution & score-spread metrics from /api/v1/subnets/{netuid}/performance. */
+export interface SubnetPerformance {
+  netuid: number;
+  neuron_count?: number;
+  active_count?: number;
+  validator_count?: number;
+  captured_at?: string;
+  incentive?: ConcentrationMetrics;
+  dividends?: ConcentrationMetrics;
+  trust?: ScoreDistribution;
+  consensus?: ScoreDistribution;
+  validator_trust?: ScoreDistribution;
+}
+
+/** One daily performance-history point from /performance/history. */
+export interface PerformanceHistoryPoint {
+  snapshot_date: string;
+  neuron_count?: number;
+  active_count?: number;
+  validator_count?: number;
+  incentive_gini?: number | null;
+  incentive_nakamoto_coefficient?: number | null;
+  incentive_top_10pct_share?: number | null;
+  dividends_gini?: number | null;
+  dividends_nakamoto_coefficient?: number | null;
+  dividends_top_10pct_share?: number | null;
+  trust_mean?: number | null;
+  trust_median?: number | null;
+  consensus_mean?: number | null;
+  consensus_median?: number | null;
+  validator_trust_mean?: number | null;
+  validator_trust_median?: number | null;
+  [key: string]: unknown;
+}
+
+/** Reward-flow drift from /api/v1/subnets/{netuid}/performance/history. */
+export interface SubnetPerformanceHistory {
+  netuid: number;
+  window?: string;
+  point_count?: number;
+  points: PerformanceHistoryPoint[];
+}
+
 // --- Compile-time contract enforcement ---------------------------------------
 //
 // These are type-only assertions (zero runtime cost). They tie this file's UI

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -28,7 +28,7 @@ import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-s
 import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-chart";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
-import { ConcentrationLoader } from "@/components/metagraphed/concentration-panel";
+import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
 import { NeuronDetailCard } from "@/components/metagraphed/neuron-detail-card";
 import { NeuronHistoryChart } from "@/components/metagraphed/neuron-history-chart";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
@@ -805,14 +805,12 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
       <SectionAnchor
         id="concentration"
         title="Concentration"
-        subtitle="Stake- and emission-distribution metrics: Gini, HHI, Nakamoto coefficient, and top-percentile shares with daily drift."
-        info="GET /api/v1/subnets/{netuid}/concentration and /concentration/history — how concentrated stake and emission are across neurons."
+        subtitle="Stake, emission, and reward distribution: Gini, HHI, Nakamoto coefficient, and top-percentile shares with daily drift."
+        info="GET /api/v1/subnets/{netuid}/concentration and /performance (plus their /history) — how concentrated stake, emission, and rewards (incentive/dividends) are across neurons."
         tone="muted"
       >
         <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-            <ConcentrationLoader netuid={netuid} />
-          </Suspense>
+          <DistributionPanel netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
     </div>


### PR DESCRIPTION
Closes #3477

Wires the previously-unconsumed `GET /api/v1/subnets/{netuid}/performance` (+ `/history`) into a "Rewards" tab alongside the existing stake/emission concentration view on the subnet profile page.

`/performance` is the reward-flow twin of `/concentration`: it returns the same Gini / HHI / Nakamoto / top-percentile-share scorecard computed over incentive + dividends instead of stake + emission, plus the 0-1 trust / consensus / validator-trust score spread.

## Screenshots
Desktop and mobile, before/after the Concentration section (rendered against live `api.metagraph.sh` data).

**Desktop**

| Before | After (Rewards tab) |
|---|---|
| ![before-desktop](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/reward-tab-screenshots/before-desktop.png) | ![after-desktop](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/reward-tab-screenshots/after-desktop.png) |

**Mobile**

| Before | After (Rewards tab) |
|---|---|
| ![before-mobile](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/reward-tab-screenshots/before-mobile.png) | ![after-mobile](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/reward-tab-screenshots/after-mobile.png) |

## What changed
- `types.ts`: `SubnetPerformance`, `PerformanceHistoryPoint`, `SubnetPerformanceHistory` (mirror the concentration types; incentive/dividends reuse `ConcentrationMetrics`; trust/consensus reuse the shared `ScoreDistribution`).
- `queries.ts`: `subnetPerformanceQuery` + `subnetPerformanceHistoryQuery` with null-safe normalizers mirroring the concentration normalizers.
- `concentration-panel.tsx`: `PerformanceLoader` + `RewardDriftCard` reuse the shared `StatTile` / `SharePanel` / `DriftRow` primitives; `DistributionPanel` adds the Stake & emission <-> Rewards toggle.
- `subnets.$netuid.tsx`: mounts `DistributionPanel` in the Concentration section.

No new endpoints or contract changes -- consumes existing routes only.

## Verification
typecheck, lint (0 errors), prettier --check, 346 UI tests, and the production build all pass.
