### PR TITLE
test(ui): cover validateNextCursor pagination guard

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeAgentCatalogDetail,
   getNextPageParam,
   normalizeSubnetGaps,
+  validateNextCursor,
 } from "./queries";
 
 // These tests lock the canonical-only reads after #1756 collapsed the redundant
@@ -678,5 +679,63 @@ describe("normalizeSubnetGaps (#3348)", () => {
   it("returns null for malformed payloads", () => {
     expect(normalizeSubnetGaps(null)).toBeNull();
     expect(normalizeSubnetGaps({ priorities: [] })).toBeNull();
+  });
+});
+
+describe("validateNextCursor", () => {
+  it("returns null when next_cursor is absent, null, blank, or whitespace-only", () => {
+    expect(validateNextCursor({}, undefined)).toEqual({ cursor: null });
+    expect(validateNextCursor({ pagination: { next_cursor: null } }, undefined)).toEqual({
+      cursor: null,
+    });
+    expect(validateNextCursor({ pagination: { next_cursor: "" } }, undefined)).toEqual({
+      cursor: null,
+    });
+    expect(validateNextCursor({ pagination: { next_cursor: "   " } }, undefined)).toEqual({
+      cursor: null,
+    });
+  });
+
+  it("trims string cursors and reads pagination.next_cursor or meta.next_cursor", () => {
+    expect(
+      validateNextCursor({ pagination: { next_cursor: "  cursor-abc  " } }, undefined),
+    ).toEqual({ cursor: "cursor-abc" });
+    expect(validateNextCursor({ next_cursor: "legacy-cursor" }, undefined)).toEqual({
+      cursor: "legacy-cursor",
+    });
+  });
+
+  it("coerces finite numeric cursors to strings", () => {
+    expect(validateNextCursor({ pagination: { next_cursor: 42 } }, undefined)).toEqual({
+      cursor: "42",
+    });
+  });
+
+  it("stops pagination when the API echoes the sent cursor", () => {
+    expect(
+      validateNextCursor({ pagination: { next_cursor: "same-cursor" } }, "same-cursor"),
+    ).toEqual({ cursor: null, invalid: true });
+    expect(validateNextCursor({ pagination: { next_cursor: 99 } }, "99")).toEqual({
+      cursor: null,
+      invalid: true,
+    });
+  });
+
+  it("marks unexpected cursor shapes invalid", () => {
+    expect(
+      validateNextCursor(
+        { pagination: { next_cursor: { bad: true } } } as unknown as Parameters<
+          typeof validateNextCursor
+        >[0],
+        undefined,
+      ),
+    ).toEqual({
+      cursor: null,
+      invalid: true,
+    });
+    expect(validateNextCursor({ pagination: { next_cursor: Number.NaN } }, undefined)).toEqual({
+      cursor: null,
+      invalid: true,
+    });
   });
 });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -3560,7 +3560,7 @@ export const subnetCandidatesQuery = (netuid: number) =>
  *   { cursor: null }   — explicit end of list
  *   { invalid: true }  — API returned something but we can't trust it
  */
-function validateNextCursor(
+export function validateNextCursor(
   meta: ApiResult<unknown>["meta"],
   sentCursor: string | undefined,
 ): { cursor: string | null; invalid?: boolean } {


### PR DESCRIPTION
Closes #3462

Adds unit tests for `validateNextCursor` covering blank/null cursors, trim behavior, legacy `meta.next_cursor`, numeric coercion, echo detection, and malformed shapes. Exports the helper so tests can import it directly.

Rebased on latest `main` and fixes the CI typecheck failure by casting the malformed-cursor fixture through `unknown`.


Made with [Cursor](https://cursor.com)