### PR TITLE
feat(registry): add Chutes TAO payment totals API surface (SN64)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -596,6 +596,25 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/fmv"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-tao-payment-totals-api",
+      "kind": "subnet-api",
+      "name": "Chutes TAO payment totals API",
+      "notes": "Public no-auth GET returning aggregate TAO payment totals (today, this_month, total). Documented in the subnet's own OpenAPI (api.chutes.ai/openapi.json, path /payments/summary/tao); same host as the existing pricing, bounties, fmv, and LLM-stats subnet-api surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.chutes.ai/openapi.json",
+        "https://chutes.ai/docs"
+      ],
+      "url": "https://api.chutes.ai/payments/summary/tao"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community subnet-api surface on `registry/subnets/chutes.json`.

## Surface

- Netuid: 64
- Kind: subnet-api
- Public URL: https://api.chutes.ai/payments/summary/tao
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

## Checklist

- [x] Changes exactly one `registry/subnets/chutes.json` file: append-only.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #959`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/chutes.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3629 | `registry/subnets/cacheon.json` | `registry/subnets/chutes.json` |
| #3652 | UI concentration panel | registry only |
| #3627 | UI health-segments | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Closes #959

Made with [Cursor](https://cursor.com)