### PR TITLE
feat(registry): add SN17 404-GEN portal health subnet-api

### DIFF
--- a/registry/subnets/404-gen.json
+++ b/registry/subnets/404-gen.json
@@ -49,6 +49,25 @@
       },
       "source_urls": ["https://huggingface.co/404-Gen"],
       "url": "https://huggingface.co/datasets/404-Gen/404mini"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-17-404-gen-health",
+      "kind": "subnet-api",
+      "name": "404—GEN portal health",
+      "notes": "Public no-auth GET /api/health on gen.404.xyz returning portal liveness JSON (observed: {\"status\":\"ok\",\"time\":\"...\"}). Same host where users obtain gateway API keys (gen.404.xyz/account); gateway client docs in 404-Repo/gateway-rs reference this portal.",
+      "provider": "404-gen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanksi"
+      },
+      "source_urls": [
+        "https://github.com/404-Repo/gateway-rs/blob/main/docs/api/client_api.md",
+        "https://gen.404.xyz/api/health"
+      ],
+      "url": "https://gen.404.xyz/api/health"
     }
   ],
   "website_url": "https://www.404.xyz/"


### PR DESCRIPTION
## Summary

- Add public `subnet-api` surface: `https://gen.404.xyz/api/health`
- Refs #575 — OpenAPI half not submitted: no machine-readable spec found (`gen.404.xyz/api/openapi.json` is empty; gateway API at `api-eu.404.xyz` requires `x-api-key`)

Closes #575

## Surface

- Netuid: 17 (404—GEN)
- Kind: `subnet-api`
- URL: `https://gen.404.xyz/api/health`
- Source: [gateway-rs client_api.md](https://github.com/404-Repo/gateway-rs/blob/main/docs/api/client_api.md), live health endpoint
- Provider: `404-gen`

## Validation

- [x] `npm run validate:surface -- registry/subnets/404-gen.json`
- [x] `npm run scan:public-safety`