### PR TITLE
feat(registry): add SN112 Minotaur API health subnet-api surface

### DIFF
--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -12,5 +12,25 @@
   "social": {
     "x": "https://x.com/minotaursubnet"
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-health",
+      "kind": "subnet-api",
+      "name": "Minotaur API health",
+      "notes": "Public no-auth GET /health on api.minotaursubnet.com returning application liveness JSON (observed: {\"status\":\"ok\",\"service\":\"app-intents-api\"}). Documented as the production API health probe in the official minotaur_subnet check_validator.sh script and served on the SN112 API host listed in docs/operator/network-reference.md.",
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/main/docs/operator/network-reference.md",
+        "https://github.com/subnet112/minotaur_subnet/blob/main/scripts/check_validator.sh"
+      ],
+      "url": "https://api.minotaursubnet.com/health"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #585

Adds a public `subnet-api` health surface for SN112 Minotaur at `GET https://api.minotaursubnet.com/health`, which returns liveness JSON (`status`, `service`, and operational checks) without authentication. The production API host is documented in the official minotaur_subnet network reference, and `/health` is the documented API health probe in `scripts/check_validator.sh`.

## Test plan
- [x] `npm run scan:public-safety`
- [x] Verified live `GET /health` returns 200 JSON on `api.minotaursubnet.com`
- [x] Single-file append-only change to `registry/subnets/minotaur.json`
- [x] Merge-simulated cleanly after open PRs #3652, #3629, #3627, #3604, #3594, #3593

Made with [Cursor](https://cursor.com)