### PR TITLE
feat(ui): add cross-subnet neuron portfolio to the account page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-portfolio.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-portfolio.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  accountPortfolioQuery,
+  normalizePortfolioConcentration,
+  normalizePortfolioPosition,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 addresses (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+const CHARLIE = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/accounts/x/portfolio",
+  });
+}
+
+// The queryFn is defined on the queryOptions returned by the factory.
+async function runQuery(ss58: string) {
+  const opts = accountPortfolioQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizePortfolioPosition", () => {
+  it("coerces a well-formed position and passes yield through unchanged", () => {
+    expect(
+      normalizePortfolioPosition({
+        netuid: 7,
+        uid: 42,
+        role: "validator",
+        active: true,
+        stake_tao: 1250.5,
+        emission_tao: 3.2,
+        rank: 0.9,
+        trust: 0.8,
+        incentive: 0.5,
+        dividends: 0.4,
+        yield: 0.00256,
+      }),
+    ).toEqual({
+      netuid: 7,
+      uid: 42,
+      role: "validator",
+      active: true,
+      stake_tao: 1250.5,
+      emission_tao: 3.2,
+      rank: 0.9,
+      trust: 0.8,
+      incentive: 0.5,
+      dividends: 0.4,
+      yield: 0.00256,
+    });
+  });
+
+  it("nulls object/string economic cells and rejects an unknown role", () => {
+    // Numeric-looking strings are not finite numbers to the strict coercer — they
+    // drop to null rather than render as `[object Object]` or NaN.
+    expect(
+      normalizePortfolioPosition({
+        netuid: 3,
+        uid: { attacker: true },
+        role: "overlord",
+        stake_tao: { attacker: true },
+        emission_tao: "1.5",
+        yield: null,
+      }),
+    ).toEqual({
+      netuid: 3,
+      uid: null,
+      role: null,
+      active: undefined,
+      stake_tao: null,
+      emission_tao: null,
+      rank: null,
+      trust: null,
+      incentive: null,
+      dividends: null,
+      yield: null,
+    });
+  });
+
+  it("keeps the miner role and a zero-stake null yield", () => {
+    const position = normalizePortfolioPosition({
+      netuid: 0,
+      uid: 1,
+      role: "miner",
+      active: false,
+      stake_tao: 0,
+      emission_tao: 0,
+      yield: null,
+    });
+    expect(position?.role).toBe("miner");
+    expect(position?.active).toBe(false);
+    expect(position?.yield).toBeNull();
+  });
+
+  it("drops a row with no numeric netuid or a non-object input", () => {
+    expect(normalizePortfolioPosition({ netuid: "abc", uid: 1 })).toBeNull();
+    expect(normalizePortfolioPosition(null)).toBeNull();
+    expect(normalizePortfolioPosition("nope")).toBeNull();
+  });
+});
+
+describe("normalizePortfolioConcentration", () => {
+  it("keeps finite lenses, nulls a junk typed cell, and passes extra fields through", () => {
+    expect(
+      normalizePortfolioConcentration({
+        holders: 5,
+        gini: { attacker: true }, // junk in a typed cell → null (never rendered raw)
+        hhi_normalized: 0.31,
+        nakamoto_coefficient: 2,
+        total: 1000, // an un-typed lens field passes through untouched
+      }),
+    ).toEqual({
+      holders: 5,
+      gini: null,
+      hhi_normalized: 0.31,
+      nakamoto_coefficient: 2,
+      total: 1000,
+    });
+  });
+
+  it("returns null for a null / non-object distribution (cold wallet)", () => {
+    expect(normalizePortfolioConcentration(null)).toBeNull();
+    expect(normalizePortfolioConcentration(undefined)).toBeNull();
+    expect(normalizePortfolioConcentration(42)).toBeNull();
+  });
+
+  it("returns null for an empty, all-null, or zero-holder distribution", () => {
+    // The cold/empty-distribution contract: an object that carries no real
+    // concentration signal must not become a non-null card.
+    expect(normalizePortfolioConcentration({})).toBeNull();
+    expect(
+      normalizePortfolioConcentration({
+        holders: null,
+        gini: null,
+        hhi_normalized: null,
+        nakamoto_coefficient: null,
+      }),
+    ).toBeNull();
+    // Zero holders is an empty distribution even if other cells are present.
+    expect(
+      normalizePortfolioConcentration({
+        holders: 0,
+        gini: 0,
+        hhi_normalized: 0,
+        nakamoto_coefficient: 3,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("accountPortfolioQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("requests the ss58 portfolio path and shapes the envelope", async () => {
+    resolveWith({
+      ss58: "5Server",
+      captured_at: "2026-07-05T00:00:00Z",
+      subnet_count: 2,
+      position_count: 2,
+      validator_count: 1,
+      miner_count: 1,
+      total_stake_tao: 100,
+      total_emission_tao: 4,
+      overall_yield: 0.04,
+      stake_concentration: { holders: 2, gini: 0.5, hhi_normalized: 0.6, nakamoto_coefficient: 1 },
+      positions: [
+        { netuid: 1, uid: 10, role: "validator", stake_tao: 90, emission_tao: 3, yield: 0.033 },
+        { role: "miner", uid: 5 }, // no numeric netuid → dropped
+      ],
+    });
+
+    const result = await runQuery(ALICE);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(`/api/v1/accounts/${ALICE}/portfolio`, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(result.data.ss58).toBe("5Server");
+    expect(result.data.captured_at).toBe("2026-07-05T00:00:00Z");
+    expect(result.data.positions).toHaveLength(1);
+    expect(result.data.positions[0]).toMatchObject({ netuid: 1, role: "validator", yield: 0.033 });
+    expect(result.data.stake_concentration).toEqual({
+      holders: 2,
+      gini: 0.5,
+      hhi_normalized: 0.6,
+      nakamoto_coefficient: 1,
+    });
+  });
+
+  it("falls back to safe defaults when the body is a non-object (cold/absent)", async () => {
+    resolveWith(null);
+
+    const result = await runQuery(BOB);
+
+    expect(result.data.ss58).toBe(BOB);
+    expect(result.data.positions).toEqual([]);
+    expect(result.data.subnet_count).toBe(0);
+    expect(result.data.position_count).toBe(0);
+    expect(result.data.validator_count).toBe(0);
+    expect(result.data.total_stake_tao).toBeNull();
+    expect(result.data.overall_yield).toBeNull();
+    expect(result.data.stake_concentration).toBeNull();
+  });
+
+  it("caps the position list defensively", async () => {
+    resolveWith({
+      positions: Array.from({ length: 300 }, (_, i) => ({
+        netuid: i,
+        uid: i,
+        role: "miner",
+        stake_tao: 1,
+        emission_tao: 0,
+        yield: 0,
+      })),
+    });
+
+    const result = await runQuery(CHARLIE);
+
+    expect(result.data.positions).toHaveLength(256);
+    // subnet_count/position_count fall back to the (capped) rendered length.
+    expect(result.data.position_count).toBe(256);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -32,9 +32,12 @@ import type {
   AccountEvent,
   AccountEventsPage,
   AccountHistory,
+  AccountPortfolio,
   AccountRegistration,
   AccountSubnets,
   AccountSummary,
+  PortfolioConcentration,
+  PortfolioPosition,
   Block,
   ChainActivity,
   ChainActivityDay,
@@ -142,6 +145,7 @@ const MAX_EXTRINSIC_VALUE_DEPTH = 8;
 const MAX_EXTRINSIC_COLLECTION_ENTRIES = 64;
 const MAX_EXTRINSIC_STRING_LENGTH = 2_000;
 const MAX_ACCOUNT_REGISTRATIONS = 100;
+const MAX_ACCOUNT_POSITIONS = 256;
 const MAX_ACCOUNT_HISTORY_DAYS = 180;
 const MAX_ACCOUNT_DAY_EVENT_KINDS = 32;
 const MAX_CHAIN_ACTIVITY_DAYS = 31;
@@ -1749,6 +1753,51 @@ function normalizeAccountRegistration(raw: unknown): AccountRegistration | null 
   return registration.netuid != null || registration.uid != null ? registration : null;
 }
 
+// One cross-subnet neuron position. Strict on render fields — object/junk economic
+// cells coerce to null (never NaN or `[object Object]`), an unknown role drops to
+// null, and a row with no numeric netuid is discarded.
+export function normalizePortfolioPosition(raw: unknown): PortfolioPosition | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  const role = firstString(raw.role);
+  return {
+    ...(raw as object),
+    netuid,
+    uid: firstFiniteNumber(raw.uid) ?? null,
+    role: role === "validator" || role === "miner" ? role : null,
+    active: booleanValue(raw.active),
+    stake_tao: firstFiniteNumber(raw.stake_tao) ?? null,
+    emission_tao: firstFiniteNumber(raw.emission_tao) ?? null,
+    rank: firstFiniteNumber(raw.rank) ?? null,
+    trust: firstFiniteNumber(raw.trust) ?? null,
+    incentive: firstFiniteNumber(raw.incentive) ?? null,
+    dividends: firstFiniteNumber(raw.dividends) ?? null,
+    yield: firstFiniteNumber(raw.yield) ?? null,
+  };
+}
+
+// The portfolio's stake-concentration lens.
+export function normalizePortfolioConcentration(raw: unknown): PortfolioConcentration | null {
+  if (!isRecord(raw)) return null;
+  const holders = firstFiniteNumber(raw.holders) ?? null;
+  const gini = firstFiniteNumber(raw.gini) ?? null;
+  const hhi_normalized = firstFiniteNumber(raw.hhi_normalized) ?? null;
+  const nakamoto_coefficient = firstFiniteNumber(raw.nakamoto_coefficient) ?? null;
+  // Cold / empty distribution: a zero-holder object, or one with no populated
+  // lens fields (e.g. `{}` or all-null), is not a real concentration card — the
+  // backend emits null there, and so do we (the ConcentrationMetrics
+  // null-when-empty contract). Guards a malformed body from rendering a non-null
+  // card built entirely from nulls.
+  if (
+    holders === 0 ||
+    (holders == null && gini == null && hhi_normalized == null && nakamoto_coefficient == null)
+  ) {
+    return null;
+  }
+  return { ...(raw as object), holders, gini, hhi_normalized, nakamoto_coefficient };
+}
+
 function accountEventString(value: unknown): string | undefined {
   if (typeof value === "string") return value.trim() ? value : undefined;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
@@ -2063,6 +2112,44 @@ export const accountSubnetsQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountSubnets>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// The economics-rich companion to accountSubnetsQuery — every neuron position
+// under this hotkey with stake/emission/yield, plus wallet aggregates. A cold
+// wallet returns an empty positions[].
+export const accountPortfolioQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-portfolio", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/portfolio`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const positions = Array.isArray(d.positions)
+        ? d.positions.slice(0, MAX_ACCOUNT_POSITIONS).flatMap((position) => {
+            const normalized = normalizePortfolioPosition(position);
+            return normalized ? [normalized] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          captured_at: firstString(d.captured_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? positions.length,
+          position_count: firstFiniteNumber(d.position_count) ?? positions.length,
+          validator_count: firstFiniteNumber(d.validator_count) ?? 0,
+          miner_count: firstFiniteNumber(d.miner_count) ?? 0,
+          total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? null,
+          total_emission_tao: firstFiniteNumber(d.total_emission_tao) ?? null,
+          overall_yield: firstFiniteNumber(d.overall_yield) ?? null,
+          stake_concentration: normalizePortfolioConcentration(d.stake_concentration),
+          positions,
+        } as AccountPortfolio,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountPortfolio>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -901,6 +901,61 @@ export interface AccountSubnets {
   [key: string]: unknown;
 }
 
+/**
+ * One neuron position a wallet holds on a subnet, from
+ * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.
+ * Score cells are null when absent; `yield` is null with zero stake.
+ */
+export interface PortfolioPosition {
+  netuid: number;
+  uid: number | null;
+  role: "validator" | "miner" | null;
+  active?: boolean;
+  stake_tao: number | null;
+  emission_tao: number | null;
+  rank: number | null;
+  trust: number | null;
+  incentive: number | null;
+  dividends: number | null;
+  /** Emission-per-stake return (a fraction; null with zero stake). */
+  yield: number | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Stake-concentration lens over a wallet's per-subnet stake (Gini / normalized
+ * HHI / Nakamoto coefficient), from the portfolio's `stake_concentration`. Null
+ * when the wallet holds no stake (a cold or all-zero distribution).
+ */
+export interface PortfolioConcentration {
+  holders: number | null;
+  gini: number | null;
+  hhi_normalized: number | null;
+  nakamoto_coefficient: number | null;
+  [key: string]: unknown;
+}
+
+/**
+ * A wallet's cross-subnet neuron portfolio from /api/v1/accounts/{ss58}/portfolio:
+ * every position's economics + yield plus wallet-level aggregates (totals, role
+ * counts, overall return, stake concentration). Richer than the registrations-only
+ * AccountSubnets footprint.
+ */
+export interface AccountPortfolio {
+  ss58: string;
+  captured_at?: string | null;
+  subnet_count: number;
+  position_count: number;
+  validator_count: number;
+  miner_count: number;
+  total_stake_tao: number | null;
+  total_emission_tao: number | null;
+  overall_yield: number | null;
+  stake_concentration: PortfolioConcentration | null;
+  positions: PortfolioPosition[];
+  [key: string]: unknown;
+}
+
 /** Cross-subnet activity summary for one account from /api/v1/accounts/{ss58}. */
 export interface AccountSummary {
   ss58: string;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -30,6 +30,7 @@ import {
   accountBalanceQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
+  accountPortfolioQuery,
   accountQuery,
   accountSubnetsQuery,
   accountTransfersQuery,
@@ -121,6 +122,12 @@ function fmtTao(v: number): string {
   if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
   if (v >= 1) return `${v.toFixed(2)} τ`;
   return `${v.toFixed(4)} τ`;
+}
+
+// Render an emission/stake yield ratio (a fraction) as a percentage.
+function fmtPct(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(2)}%`;
 }
 
 function ValidAccountDetail({ ss58 }: { ss58: string }) {
@@ -242,6 +249,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
+      <AccountPortfolioSection ss58={ss58} />
+
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
           id="kinds"
@@ -299,6 +308,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
+            { label: "portfolio", path: `/api/v1/accounts/${sourceRef}/portfolio` },
           ]}
         />
       </SectionAnchor>
@@ -309,6 +319,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/history`,
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
+          `/api/v1/accounts/${sourceRef}/portfolio`,
         ]}
       />
     </>
@@ -604,6 +615,114 @@ function AccountFootprintSection({
                       idle
                     </span>
                   )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </DataPanel>
+    </SectionAnchor>
+  );
+}
+
+// Cross-subnet neuron portfolio — the /portfolio economics companion to the
+// footprint above. Non-blocking; stays hidden for a cold wallet (no positions)
+// so it never renders an empty shell or stalls the page.
+function AccountPortfolioSection({ ss58 }: { ss58: string }) {
+  const portfolio = useQuery(accountPortfolioQuery(ss58)).data?.data;
+  const positions = portfolio?.positions ?? [];
+  if (positions.length === 0) return null;
+
+  const concentration = portfolio?.stake_concentration ?? null;
+
+  return (
+    <SectionAnchor
+      id="portfolio"
+      title="Neuron portfolio"
+      subtitle="Cross-subnet neuron positions with per-position stake, emission, and yield — the economics view behind the registration footprint."
+      tone="accent"
+      info="Yield is emission per stake for each position (null with zero stake). Neuron-registration analytics, not wallet PnL."
+      right={<SectionBadge tone="accent">{formatNumber(positions.length)} positions</SectionBadge>}
+    >
+      <div className="mb-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <StatTile
+          eyebrow="Positions"
+          tone="accent"
+          value={formatNumber(portfolio?.position_count ?? positions.length)}
+          hint={`${formatNumber(portfolio?.subnet_count ?? positions.length)} subnets`}
+        />
+        <StatTile
+          eyebrow="Roles"
+          value={`${formatNumber(portfolio?.validator_count ?? 0)} / ${formatNumber(
+            portfolio?.miner_count ?? 0,
+          )}`}
+          hint="validators / miners"
+        />
+        <StatTile
+          eyebrow="Overall yield"
+          value={fmtPct(portfolio?.overall_yield)}
+          hint="emission / stake"
+        />
+        <StatTile eyebrow="Total stake" value={fmtTao(portfolio?.total_stake_tao ?? 0)} />
+        <StatTile eyebrow="Total emission" value={fmtTao(portfolio?.total_emission_tao ?? 0)} />
+        <StatTile
+          eyebrow="Stake concentration"
+          value={concentration?.gini != null ? concentration.gini.toFixed(3) : "—"}
+          hint={
+            concentration?.nakamoto_coefficient != null
+              ? `Gini · Nakamoto ${formatNumber(concentration.nakamoto_coefficient)}`
+              : "Gini across subnets"
+          }
+        />
+      </div>
+      <DataPanel>
+        <table className="w-full text-left text-sm">
+          <thead className="bg-surface/50">
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={TH}>Role</th>
+              <th className={`${TH} text-right`}>UID</th>
+              <th className={`${TH} text-right`}>Stake</th>
+              <th className={`${TH} text-right`}>Emission</th>
+              <th className={`${TH} text-right`}>Yield</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {positions.map((p) => (
+              <tr key={`${p.netuid}-${p.uid}`} className="hover:bg-surface/30">
+                <td className="px-5 py-4 font-mono text-[12px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: p.netuid }}
+                    className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
+                  >
+                    SN{p.netuid}
+                  </Link>
+                </td>
+                <td className="px-5 py-4 font-mono text-[11px]">
+                  {p.role === "validator" ? (
+                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+                      validator
+                    </span>
+                  ) : p.role === "miner" ? (
+                    <span className="inline-flex rounded-full bg-surface px-2 py-0.5 text-ink-muted">
+                      miner
+                    </span>
+                  ) : (
+                    <span className="text-ink-muted">—</span>
+                  )}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {p.uid != null ? formatNumber(p.uid) : "—"}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {fmtStake(p.stake_tao)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {fmtStake(p.emission_tao)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {fmtPct(p.yield)}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary

Closes #3491

Adds a **Neuron portfolio** section to the account page (`/accounts/$ss58`), backed by a new typed `accountPortfolioQuery` over the existing `GET /api/v1/accounts/{ss58}/portfolio` endpoint.

The new section displays per-neuron **stake, emission, and yield**, together with wallet-level aggregates including position count, subnet count, validator vs. miner split, total stake, total emission, overall return, and stake concentration. This complements the existing registration view with portfolio-level analytics.

## Scope Note

This PR intentionally targets `apps/ui`.

A previous automated review suggested this work belonged in `metagraphed-ui`, but that repository has since been archived following the UI consolidation into this monorepo.

Specifically:

- `JSONbored/metagraphed-ui` is archived (read-only).
- The frontend now lives under `apps/ui/` as an npm workspace following the monorepo consolidation (#3063 / #3190).
- Issue **#3491** was created after that migration and targets the account page implemented in `apps/ui/src/routes/accounts.$ss58.tsx`.

Accordingly, `apps/ui` is the intended location for this feature.

## Implementation

### Data Layer

- Added `accountPortfolioQuery`, following the existing `accountSubnetsQuery` pattern.
- Added strict normalization for:
  - `PortfolioPosition`
  - `PortfolioConcentration`

Normalization rules include:

- invalid economic values → `null`
- unknown roles → `null`
- rows without a numeric `netuid` → discarded
- portfolio size capped at **256** positions
- cold, empty, or zero-holder concentration → `null`

### UI

- Added a **Neuron portfolio** section to `/accounts/$ss58`.
- Displays:
  - wallet summary metrics
  - validator/miner split
  - stake concentration
  - per-position portfolio table
- Uses existing shared UI components (`StatTile`, `SectionAnchor`, `DataPanel`).
- Portfolio data is fetched independently, so failures do not block page rendering.
- The section remains hidden for wallets without portfolio positions.
- Adds the `/portfolio` endpoint to the API snippet and source footer.

## Screenshots

| Page / Feature | Before (`main`) | After (this PR) |
|----------------|-----------------|-----------------|
| `/accounts/{ss58}` — Neuron portfolio | *(account page without portfolio section)* | *(Neuron portfolio section showing summary metrics and per-position table)* |

<img width="1607" height="947" alt="Screenshot_1" src="https://github.com/user-attachments/assets/5e4800a5-6d54-449a-a6d0-21592c62cd5d" />


## Validation

All `apps/ui` checks pass:

- ✅ `npm run lint --workspace=apps/ui`
- ✅ `npm run format:check --workspace=apps/ui`
- ✅ `npm run typecheck --workspace=apps/ui`
- ✅ `npm test --workspace=apps/ui` (249 passing)
- ✅ `npm run build --workspace=apps/ui`