### PR TITLE
feat(ui): add typed data layer for subnet axon-removals

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-axon-removals.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-axon-removals.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetAxonRemovals, subnetAxonRemovalsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/axon-removals",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetAxonRemovalsQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetAxonRemovals", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeSubnetAxonRemovals(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        distinct_removers: 4,
+        removals: 9,
+        removals_per_remover: 2.25,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_removers: 4,
+      removals: 9,
+      removals_per_remover: 2.25,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { distinct_removers: "nope" }]) {
+      const card = normalizeSubnetAxonRemovals(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.distinct_removers).toBe(0);
+      expect(card.removals).toBe(0);
+      expect(card.removals_per_remover).toBeNull();
+      expect(card.observed_at).toBeNull();
+    }
+  });
+
+  it("coerces a junk average to null (never NaN)", () => {
+    const card = normalizeSubnetAxonRemovals(7, {
+      removals: 3,
+      removals_per_remover: { avg: 1 },
+    });
+    expect(card.removals).toBe(3);
+    expect(card.removals_per_remover).toBeNull();
+  });
+});
+
+describe("subnetAxonRemovalsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", distinct_removers: 2, removals: 5 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/axon-removals",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.removals).toBe(5);
+    expect(res.data.distinct_removers).toBe(2);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/axon-removals",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -91,6 +91,7 @@ import type {
   RpcUsage,
   SchemaInfo,
   Subnet,
+  SubnetAxonRemovals,
   SubnetEconomics,
   SubnetHistory,
   SubnetHistoryPoint,
@@ -2847,6 +2848,40 @@ export const subnetIdentityHistoryQuery = (netuid: number) =>
       );
       return {
         data: normalizeSubnetIdentityHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #1657: per-subnet axon-removal (teardown) activity over a 7d/30d window. A flat
+// summary card — count/distinct-remover/average — from the account_events
+// AxonInfoRemoved stream. Every numeric cell coerces defensively: counts fall
+// through to 0 and the average to null (never NaN) on a cold store or junk.
+export function normalizeSubnetAxonRemovals(netuid: number, raw: unknown): SubnetAxonRemovals {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_removers: firstFiniteNumber(rec.distinct_removers) ?? 0,
+    removals: firstFiniteNumber(rec.removals) ?? 0,
+    removals_per_remover: firstFiniteNumber(rec.removals_per_remover) ?? null,
+  };
+}
+
+export const subnetAxonRemovalsQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-axon-removals", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetAxonRemovals>>(
+        `/api/v1/subnets/${netuid}/axon-removals`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetAxonRemovals(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1116,6 +1116,22 @@ export interface SubnetIdentityHistory {
   next_cursor: string | null;
 }
 
+/**
+ * Per-subnet axon-removal (teardown) activity over a 7d/30d window (#1657), from
+ * /api/v1/subnets/{netuid}/axon-removals — the removal-side complement of the
+ * AxonServed announcement activity in /subnets/{netuid}/serving. Zeroed when the
+ * subnet had no AxonInfoRemoved events in the window.
+ */
+export interface SubnetAxonRemovals {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_removers: number;
+  removals: number;
+  removals_per_remover: number | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;


### PR DESCRIPTION
## Summary

Adds the typed data layer for per-subnet axon-removal (teardown) activity (#1657), consuming the existing `GET /api/v1/subnets/{netuid}/axon-removals` endpoint — the query + type the subnet operational panel (#3482) needs to show teardown activity alongside the AxonServed announcement cadence. Split out as its own small, tested unit (same pattern as the identity-history #3487, account-portfolio #3595, and decentralization #3609 data-layer PRs).

Closes #3482

## What changed

- **`apps/ui/src/lib/metagraphed/types.ts`** — `SubnetAxonRemovals` (flat window card: `distinct_removers`, `removals`, `removals_per_remover`, plus `window`/`observed_at`/`netuid`).
- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetAxonRemovalsQuery(netuid, window)` (`queryOptions`, `?window=7d|30d`, default 30d) + exported `normalizeSubnetAxonRemovals`. Defensive: counts fall through to 0, the average coerces to null (never NaN) on a cold store or a junk cell.
- **`apps/ui/src/lib/metagraphed/queries.subnet-axon-removals.test.ts`** — well-formed pass-through, cold/junk-store degradation, junk-average coercion, and the window-param wiring (7d + default 30d).

## Validation

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm run lint` · `format:check`
- [x] `npm run test` — 5 new cases pass
