### PR TITLE
test(ui): cover safeExternalUrl SSRF barrier in lib

### DIFF
--- a/apps/ui/src/components/metagraphed/external-link.tsx
+++ b/apps/ui/src/components/metagraphed/external-link.tsx
@@ -1,5 +1,8 @@
 import { ExternalLink as ExternalIcon, Lock, AlertTriangle } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
+import { safeExternalUrl } from "@/lib/metagraphed/external-url";
+
+export { safeExternalUrl } from "@/lib/metagraphed/external-url";
 
 interface Props {
   href: string;
@@ -7,85 +10,6 @@ interface Props {
   authRequired?: boolean;
   publicSafe?: boolean;
   className?: string;
-}
-
-const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
-
-function isBlockedIpv4(hostname: string): boolean {
-  const parts = hostname.split(".");
-  if (parts.length !== 4) return false;
-  const octets = parts.map((part) => {
-    if (!/^\d{1,3}$/.test(part)) return null;
-    const value = Number(part);
-    return value >= 0 && value <= 255 ? value : null;
-  });
-  if (octets.some((value) => value === null)) return false;
-  const [a, b, c] = octets as [number, number, number, number];
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 0) ||
-    (a === 192 && b === 168) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    (a === 198 && b === 51 && c === 100) ||
-    (a === 203 && b === 0 && c === 113) ||
-    a >= 224
-  );
-}
-
-function isBlockedIpv6(hostname: string): boolean {
-  if (!hostname.includes(":")) return false;
-  return (
-    hostname === "" ||
-    hostname === "::" ||
-    hostname === "::1" ||
-    hostname.startsWith("fc") ||
-    hostname.startsWith("fd") ||
-    hostname.startsWith("fe8") ||
-    hostname.startsWith("fe9") ||
-    hostname.startsWith("fea") ||
-    hostname.startsWith("feb") ||
-    hostname.startsWith("ff") ||
-    hostname.startsWith("::ffff:")
-  );
-}
-
-function isPrivateHostname(hostname: string) {
-  const normalized = hostname
-    .trim()
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "")
-    .replace(/\.$/, "");
-  if (
-    normalized === "localhost" ||
-    normalized.endsWith(".localhost") ||
-    normalized.endsWith(".local")
-  ) {
-    return true;
-  }
-  return isBlockedIpv4(normalized) || isBlockedIpv6(normalized);
-}
-
-export function safeExternalUrl(href?: string) {
-  if (!href) return undefined;
-  try {
-    const url = new URL(href.trim());
-    if (
-      !SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) ||
-      url.username ||
-      url.password ||
-      isPrivateHostname(url.hostname)
-    ) {
-      return undefined;
-    }
-    return url.href;
-  } catch {
-    return undefined;
-  }
 }
 
 export function ExternalLink({

--- a/apps/ui/src/lib/metagraphed/external-url.test.ts
+++ b/apps/ui/src/lib/metagraphed/external-url.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { safeExternalUrl } from "./external-link";
+import { safeExternalUrl } from "./external-url";
 
 describe("safeExternalUrl", () => {
+  it("returns undefined for missing or blank input", () => {
+    expect(safeExternalUrl(undefined)).toBeUndefined();
+    expect(safeExternalUrl("")).toBeUndefined();
+    expect(safeExternalUrl("   ")).toBeUndefined();
+  });
+
   it("allows ordinary public http(s) URLs", () => {
     expect(safeExternalUrl("https://example.com/path?q=1")).toBe("https://example.com/path?q=1");
     expect(safeExternalUrl("http://docs.example.com/")).toBe("http://docs.example.com/");
+    expect(safeExternalUrl("  https://example.com/  ")).toBe("https://example.com/");
+    expect(safeExternalUrl("https://8.8.8.8/dns")).toBe("https://8.8.8.8/dns");
   });
 
   it("blocks non-http schemes and credentialed URLs", () => {
     expect(safeExternalUrl("javascript:alert(1)")).toBeUndefined();
     expect(safeExternalUrl("data:text/html,hi")).toBeUndefined();
+    expect(safeExternalUrl("file:///etc/passwd")).toBeUndefined();
     expect(safeExternalUrl("https://user:pass@example.com/")).toBeUndefined();
+    expect(safeExternalUrl("https://user@example.com/")).toBeUndefined();
   });
 
   it("blocks private, reserved, and local host targets", () => {
@@ -39,5 +49,10 @@ describe("safeExternalUrl", () => {
     for (const href of unsafe) {
       expect(safeExternalUrl(href), href).toBeUndefined();
     }
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(safeExternalUrl("not-a-url")).toBeUndefined();
+    expect(safeExternalUrl("://missing-scheme")).toBeUndefined();
   });
 });

--- a/apps/ui/src/lib/metagraphed/external-url.ts
+++ b/apps/ui/src/lib/metagraphed/external-url.ts
@@ -1,0 +1,79 @@
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
+
+function isBlockedIpv4(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    return value >= 0 && value <= 255 ? value : null;
+  });
+  if (octets.some((value) => value === null)) return false;
+  const [a, b, c] = octets as [number, number, number, number];
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function isBlockedIpv6(hostname: string): boolean {
+  if (!hostname.includes(":")) return false;
+  return (
+    hostname === "" ||
+    hostname === "::" ||
+    hostname === "::1" ||
+    hostname.startsWith("fc") ||
+    hostname.startsWith("fd") ||
+    hostname.startsWith("fe8") ||
+    hostname.startsWith("fe9") ||
+    hostname.startsWith("fea") ||
+    hostname.startsWith("feb") ||
+    hostname.startsWith("ff") ||
+    hostname.startsWith("::ffff:")
+  );
+}
+
+function isPrivateHostname(hostname: string) {
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
+  if (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized.endsWith(".local")
+  ) {
+    return true;
+  }
+  return isBlockedIpv4(normalized) || isBlockedIpv6(normalized);
+}
+
+/** SSRF/private-host barrier for user-supplied external hrefs. */
+export function safeExternalUrl(href?: string) {
+  if (!href) return undefined;
+  try {
+    const url = new URL(href.trim());
+    if (
+      !SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) ||
+      url.username ||
+      url.password ||
+      isPrivateHostname(url.hostname)
+    ) {
+      return undefined;
+    }
+    return url.href;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Closes #3431

Moves the `safeExternalUrl` SSRF/private-host barrier into `apps/ui/src/lib/metagraphed/external-url.ts` and adds focused Vitest coverage there. The component re-exports the helper so existing import paths stay stable.


Made with [Cursor](https://cursor.com)