### PR TITLE
feat(ui): add typed data layer for subnet weight-setters leaderboard

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-weight-setters.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-weight-setters.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetWeightSetter, subnetWeightSettersQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/weights/setters",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetWeightSettersQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetWeightSetter", () => {
+  it("passes a well-formed setter row through", () => {
+    const raw = {
+      hotkey: "5Grw",
+      uid: 3,
+      weight_sets: 12,
+      share: 0.4,
+      first_set_at: "2026-07-01T00:00:00Z",
+      last_set_at: "2026-07-02T00:00:00Z",
+    };
+    expect(normalizeSubnetWeightSetter(raw)).toEqual(raw);
+  });
+
+  it("keeps a uid-only row and coerces junk cells to null / 0", () => {
+    const setter = normalizeSubnetWeightSetter({
+      hotkey: 42,
+      uid: 9,
+      weight_sets: "nope",
+      share: { x: 1 },
+    });
+    expect(setter).not.toBeNull();
+    expect(setter?.hotkey).toBeNull();
+    expect(setter?.uid).toBe(9);
+    expect(setter?.weight_sets).toBe(0);
+    expect(setter?.share).toBeNull();
+  });
+
+  it("drops a row with neither hotkey nor uid", () => {
+    expect(normalizeSubnetWeightSetter({ weight_sets: 5 })).toBeNull();
+    expect(normalizeSubnetWeightSetter(null)).toBeNull();
+    expect(normalizeSubnetWeightSetter("x")).toBeNull();
+  });
+});
+
+describe("subnetWeightSettersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and filters junk setters", async () => {
+    resolveWith({
+      netuid: 7,
+      window: "7d",
+      distinct_setters: 1,
+      setters: [
+        { hotkey: "5Grw", uid: 1, weight_sets: 4 },
+        { weight_sets: 9 }, // no hotkey/uid -> dropped
+      ],
+    });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/weights/setters",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.setters).toHaveLength(1);
+    expect(res.data.setters[0]?.hotkey).toBe("5Grw");
+  });
+
+  it("defaults to 30d and degrades a cold store to a zeroed leaderboard", async () => {
+    resolveWith({});
+    const res = await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/weights/setters",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+    expect(res.data.setters).toEqual([]);
+    expect(res.data.setter_count).toBe(0);
+    expect(res.data.netuid).toBe(7);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -96,6 +96,8 @@ import type {
   SubnetHistory,
   SubnetHistoryPoint,
   SubnetIdentityHistory,
+  SubnetWeightSetter,
+  SubnetWeightSetters,
   SubnetIdentityHistoryEntry,
   SubnetNeuronHistory,
   SubnetNeuronHistoryPoint,
@@ -2848,6 +2850,62 @@ export const subnetIdentityHistoryQuery = (netuid: number) =>
       );
       return {
         data: normalizeSubnetIdentityHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// One validator's weight-setting row (#1657). Identified by hotkey or uid — a row
+// with neither is dropped; the count falls through to 0 and share to null on junk.
+export function normalizeSubnetWeightSetter(raw: unknown): SubnetWeightSetter | null {
+  if (!isRecord(raw)) return null;
+  const hotkey = firstString(raw.hotkey) ?? null;
+  const uid = firstFiniteNumber(raw.uid) ?? null;
+  if (hotkey == null && uid == null) return null;
+  return {
+    hotkey,
+    uid,
+    weight_sets: firstFiniteNumber(raw.weight_sets) ?? 0,
+    share: firstFiniteNumber(raw.share) ?? null,
+    first_set_at: firstString(raw.first_set_at) ?? null,
+    last_set_at: firstString(raw.last_set_at) ?? null,
+  };
+}
+
+const MAX_SUBNET_WEIGHT_SETTERS = 256;
+
+function normalizeSubnetWeightSetters(netuid: number, raw: unknown): SubnetWeightSetters {
+  const rec = isRecord(raw) ? raw : {};
+  const setters = (Array.isArray(rec.setters) ? rec.setters : [])
+    .map(normalizeSubnetWeightSetter)
+    .filter((setter): setter is SubnetWeightSetter => setter != null)
+    .slice(0, MAX_SUBNET_WEIGHT_SETTERS);
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_setters: firstFiniteNumber(rec.distinct_setters) ?? 0,
+    weight_sets: firstFiniteNumber(rec.weight_sets) ?? 0,
+    setter_count: firstFiniteNumber(rec.setter_count) ?? setters.length,
+    setters,
+  };
+}
+
+// #1657: per-subnet weight-setters leaderboard over a 7d/30d window — the
+// individual validators behind the subnet's WeightsSet activity, newest first.
+export const subnetWeightSettersQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-weight-setters", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetWeightSetters>>(
+        `/api/v1/subnets/${netuid}/weights/setters`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetWeightSetters(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1116,6 +1116,32 @@ export interface SubnetIdentityHistory {
   next_cursor: string | null;
 }
 
+/** One validator's weight-setting activity for a subnet over the window (#1657). */
+export interface SubnetWeightSetter {
+  hotkey: string | null;
+  uid: number | null;
+  weight_sets: number;
+  share: number | null;
+  first_set_at: string | null;
+  last_set_at: string | null;
+}
+
+/**
+ * Per-subnet weight-setters leaderboard over a 7d/30d window (#1657), from
+ * /api/v1/subnets/{netuid}/weights/setters — the individual validators behind the
+ * subnet's WeightsSet activity, ranked by weight-set count. Zeroed when cold.
+ */
+export interface SubnetWeightSetters {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_setters: number;
+  weight_sets: number;
+  setter_count: number;
+  setters: SubnetWeightSetter[];
+}
+
 /**
  * Per-subnet axon-removal (teardown) activity over a 7d/30d window (#1657), from
  * /api/v1/subnets/{netuid}/axon-removals — the removal-side complement of the


### PR DESCRIPTION
## Summary

Adds the typed data layer for the per-subnet weight-setters leaderboard (#1657), consuming the existing `GET /api/v1/subnets/{netuid}/weights/setters` endpoint — the query + types the subnet validators panel (#3480) needs to rank the individual validators behind the subnet's WeightsSet activity. Split out as its own small, tested unit (same pattern as identity-history #3487, axon-removals #3482, account-portfolio #3595).

Closes #3480

## What changed

- **`apps/ui/src/lib/metagraphed/types.ts`** — `SubnetWeightSetter` (one validator: `hotkey`/`uid`/`weight_sets`/`share`/`first_set_at`/`last_set_at`) and `SubnetWeightSetters` (the window envelope: `distinct_setters`, `weight_sets`, `setter_count`, `setters[]`).
- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetWeightSettersQuery(netuid, window)` (`?window=7d|30d`, default 30d) + exported `normalizeSubnetWeightSetter`. Defensive: a setter row identified by `hotkey` or `uid` (neither → dropped), junk cells coerce to null / count to 0, capped at 256, cold store → zeroed leaderboard.
- **`apps/ui/src/lib/metagraphed/queries.subnet-weight-setters.test.ts`** — well-formed pass-through, uid-only + junk coercion, missing-identity drop, envelope filtering, and window-param wiring (7d + default 30d).

## Validation

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm run lint` · `format:check`
- [x] `npm run test` — 5 new cases pass
