### PR TITLE
feat(ui): add typed data layer for per-subnet stake-transfers

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-stake-transfers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-stake-transfers.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetStakeTransfers, subnetStakeTransfersQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/stake-transfers",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetStakeTransfersQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetStakeTransfers", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeSubnetStakeTransfers(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        distinct_senders: 2,
+        transfers: 3,
+        transfers_per_sender: 1.5,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_senders: 2,
+      transfers: 3,
+      transfers_per_sender: 1.5,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { distinct_senders: "nope" }]) {
+      const card = normalizeSubnetStakeTransfers(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.distinct_senders).toBe(0);
+      expect(card.transfers).toBe(0);
+      expect(card.transfers_per_sender).toBeNull();
+      expect(card.observed_at).toBeNull();
+    }
+  });
+
+  it("coerces a junk average to null (never NaN)", () => {
+    const card = normalizeSubnetStakeTransfers(7, {
+      transfers: 3,
+      transfers_per_sender: { avg: 1 },
+    });
+    expect(card.transfers).toBe(3);
+    expect(card.transfers_per_sender).toBeNull();
+  });
+
+  it("falls back to the passed netuid when the payload omits it", () => {
+    const card = normalizeSubnetStakeTransfers(12, { transfers: 1, distinct_senders: 1 });
+    expect(card.netuid).toBe(12);
+  });
+});
+
+describe("subnetStakeTransfersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", distinct_senders: 2, transfers: 5 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/stake-transfers",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.transfers).toBe(5);
+    expect(res.data.distinct_senders).toBe(2);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/stake-transfers",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -99,6 +99,7 @@ import type {
   SubnetIdentityHistoryEntry,
   SubnetNeuronHistory,
   SubnetNeuronHistoryPoint,
+  SubnetStakeTransfers,
   MetagraphNeuron,
   SubnetMetagraph,
   SubnetValidators,
@@ -2882,6 +2883,40 @@ export const subnetAxonRemovalsQuery = (netuid: number, window = "30d") =>
       );
       return {
         data: normalizeSubnetAxonRemovals(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3484: per-subnet stake-transfer activity over a 7d/30d window. A flat summary
+// card — StakeTransferred event count/distinct-sender/average — from the
+// account_events transfer_stake stream. Every numeric cell coerces defensively:
+// counts fall through to 0 and the average to null (never NaN) on a cold store or junk.
+export function normalizeSubnetStakeTransfers(netuid: number, raw: unknown): SubnetStakeTransfers {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_senders: firstFiniteNumber(rec.distinct_senders) ?? 0,
+    transfers: firstFiniteNumber(rec.transfers) ?? 0,
+    transfers_per_sender: firstFiniteNumber(rec.transfers_per_sender) ?? null,
+  };
+}
+
+export const subnetStakeTransfersQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-stake-transfers", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetStakeTransfers>>(
+        `/api/v1/subnets/${netuid}/stake-transfers`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetStakeTransfers(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1132,6 +1132,24 @@ export interface SubnetAxonRemovals {
   removals_per_remover: number | null;
 }
 
+/**
+ * Per-subnet stake-transfer activity over a 7d/30d window (#3484), from
+ * /api/v1/subnets/{netuid}/stake-transfers — the per-subnet drill-in of
+ * /api/v1/chain/stake-transfers and the between-accounts sibling of
+ * /subnets/{netuid}/stake-moves (transfer_stake relocates staked alpha between
+ * accounts on the same hotkey; origin leg only). Zeroed when the subnet had no
+ * StakeTransferred events in the window.
+ */
+export interface SubnetStakeTransfers {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_senders: number;
+  transfers: number;
+  transfers_per_sender: number | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;


### PR DESCRIPTION
Closes #3484.

## Summary

Adds the typed data layer for per-subnet **stake-transfer** activity, consuming the existing `GET /api/v1/subnets/{netuid}/stake-transfers` endpoint — the query + type the subnet economics area needs to render a stake-transfers mini-chart. Split out as its own small, tested unit, matching the axon-removals (#3660), identity-history (#3487), and decentralization (#3609) data-layer PRs.

`transfer_stake` relocates staked alpha between accounts on the same hotkey (origin leg only) — distinct from the already-flagged stake-flow route and the re-delegation `stake-moves` sibling.

## What changed

- **`types.ts`** — `SubnetStakeTransfers` (flat window card: `distinct_senders` / `transfers` / `transfers_per_sender` + `window` / `observed_at`), mirroring the backend `SubnetStakeTransfersArtifact` schema.
- **`queries.ts`** — `subnetStakeTransfersQuery(netuid, window = "30d")` (TanStack `queryOptions`, `STALE_MED`) + an exported `normalizeSubnetStakeTransfers()` that coerces every numeric cell defensively — counts fall through to `0`, the average to `null` (never `NaN`) — so a cold/absent store yields a schema-stable zeroed card.
- **`queries.subnet-stake-transfers.test.ts`** — 6 tests: well-formed passthrough, cold/junk degradation, junk-average → null, netuid fallback, window param forwarding, and the 30d default.

Pure `lib/metagraphed` data layer — no route/component wiring in this PR.

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```
