### PR TITLE
fix(ui): audit unexplained exhaustive-deps eslint-disables

### DIFF
--- a/apps/ui/src/lib/metagraphed/api-source-context.tsx
+++ b/apps/ui/src/lib/metagraphed/api-source-context.tsx
@@ -86,6 +86,8 @@ export function useRegisterApiSource(paths: string[], artifacts: string[] = []) 
       ...artifacts.map((p) => ({ path: p, artifact: p })),
     ];
     return register(items);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // paths/artifacts omitted on purpose: pathsKey/artifactsKey capture content changes
+    // without re-registering when the parent passes a fresh array identity each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- semantic deps are the keys
   }, [pathsKey, artifactsKey, register]);
 }

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useCallback, useEffect, useMemo } from "react";
 import { fallback } from "@tanstack/zod-adapter";
 import { z } from "zod";
 import { ChevronLeft, FileCode, Copy, Check } from "lucide-react";
@@ -300,11 +300,14 @@ function SchemaExplorer() {
 
   const stale = isStaleFreshness(data.meta?.generated_at);
 
-  const setSearch = (patch: Partial<typeof search>) =>
-    navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
-      replace: true,
-    });
+  const setSearch = useCallback(
+    (patch: Partial<typeof search>) =>
+      navigate({
+        search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+        replace: true,
+      }),
+    [navigate],
+  );
 
   // Esc clears the selected schema on desktop (mobile uses the explicit "back"
   // button inside the viewer). Skips when focus is in an input/textarea so it
@@ -319,8 +322,7 @@ function SchemaExplorer() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [search.open]);
+  }, [search.open, setSearch]);
 
   return (
     <div className="space-y-4">

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -252,12 +252,12 @@ function RecentIncidents() {
   // ends within a few probe cycles of the latest snapshot; everything else is a
   // resolved past event. This separates "what's down right now" from "what's
   // flapped over the window", so the window count never reads as a live outage.
-  const observedMs = ledger?.observed_at ? Date.parse(ledger.observed_at) : Date.now();
-  const isOngoing = (s: GlobalIncidentSurface) => {
-    const latest = s.incidents.reduce((max, i) => Math.max(max, i.ended_at || 0), 0);
-    return latest > 0 && observedMs - latest < ONGOING_MS;
-  };
-  const surfaces = useMemo(() => {
+  const { surfaces, ongoingCount } = useMemo(() => {
+    const observedMs = ledger?.observed_at ? Date.parse(ledger.observed_at) : Date.now();
+    const isOngoing = (s: GlobalIncidentSurface) => {
+      const latest = s.incidents.reduce((max, i) => Math.max(max, i.ended_at || 0), 0);
+      return latest > 0 && observedMs - latest < ONGOING_MS;
+    };
     const list = [...(ledger?.surfaces ?? [])];
     list.sort(
       (a, b) =>
@@ -265,12 +265,10 @@ function RecentIncidents() {
         b.incident_count - a.incident_count ||
         b.downtime_ms - a.downtime_ms,
     );
-    return list;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return { surfaces: list, ongoingCount: list.filter(isOngoing).length };
   }, [ledger]);
   const summary = ledger?.summary;
   const affected = summary?.affected_surface_count ?? surfaces.length;
-  const ongoingCount = surfaces.filter(isOngoing).length;
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
Closes #3461

Audits the three unexplained \eact-hooks/exhaustive-deps\ disables called out in the issue:

- **api-source-context.tsx** — documents why \pathsKey\/\rtifactsKey\ are the semantic deps (disable kept).
- **status.tsx** — hoists \isOngoing\ into the memo so \ledger\ is the sole dep (disable removed).
- **schemas.tsx** — stabilizes \setSearch\ with \useCallback\ and lists it in the Esc-handler effect deps (disable removed).

No visual/UI behavior change intended — hook dependency hygiene only.