### PR TITLE
feat(ui): add typed data layer for subnet stake-moves

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-stake-moves.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-stake-moves.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetStakeMoves, subnetStakeMovesQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/stake-moves",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetStakeMovesQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetStakeMoves", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeSubnetStakeMoves(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        distinct_movers: 6,
+        movements: 18,
+        movements_per_mover: 3,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_movers: 6,
+      movements: 18,
+      movements_per_mover: 3,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { distinct_movers: "nope" }]) {
+      const card = normalizeSubnetStakeMoves(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.distinct_movers).toBe(0);
+      expect(card.movements).toBe(0);
+      expect(card.movements_per_mover).toBeNull();
+      expect(card.observed_at).toBeNull();
+    }
+  });
+
+  it("coerces a junk average to null (never NaN)", () => {
+    const card = normalizeSubnetStakeMoves(7, {
+      movements: 4,
+      movements_per_mover: { avg: 1 },
+    });
+    expect(card.movements).toBe(4);
+    expect(card.movements_per_mover).toBeNull();
+  });
+});
+
+describe("subnetStakeMovesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", distinct_movers: 3, movements: 9 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/stake-moves",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.movements).toBe(9);
+    expect(res.data.distinct_movers).toBe(3);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/stake-moves",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -92,6 +92,7 @@ import type {
   SchemaInfo,
   Subnet,
   SubnetAxonRemovals,
+  SubnetStakeMoves,
   SubnetEconomics,
   SubnetHistory,
   SubnetHistoryPoint,
@@ -2943,6 +2944,40 @@ export const subnetAxonRemovalsQuery = (netuid: number, window = "30d") =>
       );
       return {
         data: normalizeSubnetAxonRemovals(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Per-subnet stake-movement (re-delegation) activity over a 7d/30d window. A flat
+// summary card — count/distinct-mover/average — from the account_events
+// StakeMoved stream. Every numeric cell coerces defensively: counts fall through
+// to 0 and the average to null (never NaN) on a cold store or junk.
+export function normalizeSubnetStakeMoves(netuid: number, raw: unknown): SubnetStakeMoves {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_movers: firstFiniteNumber(rec.distinct_movers) ?? 0,
+    movements: firstFiniteNumber(rec.movements) ?? 0,
+    movements_per_mover: firstFiniteNumber(rec.movements_per_mover) ?? null,
+  };
+}
+
+export const subnetStakeMovesQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-stake-moves", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetStakeMoves>>(
+        `/api/v1/subnets/${netuid}/stake-moves`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetStakeMoves(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1158,6 +1158,21 @@ export interface SubnetAxonRemovals {
   removals_per_remover: number | null;
 }
 
+/**
+ * Per-subnet stake-movement (re-delegation) activity over a 7d/30d window, from
+ * /api/v1/subnets/{netuid}/stake-moves — the per-subnet drill-in of chain
+ * stake-moves. Zeroed when the subnet had no StakeMoved events in the window.
+ */
+export interface SubnetStakeMoves {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_movers: number;
+  movements: number;
+  movements_per_mover: number | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;


### PR DESCRIPTION
Closes #3485

Adds the typed data layer for per-subnet stake-movement (re-delegation) activity, consuming \GET /api/v1/subnets/{netuid}/stake-moves\ — the query + response types the subnet economics stake-moves mini-chart needs, split out as its own small tested unit (mirrors #3660 / #3482 axon-removals and #3646 / #3487 identity-history).

## What changed

- **\	ypes.ts\** — \SubnetStakeMoves\ summary card type.
- **\queries.ts\** — \subnetStakeMovesQuery(netuid, window)\ plus exported \
ormalizeSubnetStakeMoves\ with defensive coercion (zeroed cold store, null average never NaN).
- **\queries.subnet-stake-moves.test.ts\** — 5 cases covering pass-through, cold-store degradation, junk average, window param, and 30d default.

## Validation

- [x] \
pm test -- queries.subnet-stake-moves.test.ts\ (5 passed)
- [x] \
px prettier --write\ on touched files