### PR TITLE
feat(registry): add SN65 TPN lease countries subnet-api

### DIFF
--- a/registry/subnets/tao-private-network.json
+++ b/registry/subnets/tao-private-network.json
@@ -12,5 +12,32 @@
   "social": {
     "x": "https://x.com/tpn_labs"
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tao-private-network-lease-countries-api",
+      "kind": "subnet-api",
+      "name": "TPN federated lease countries API",
+      "notes": "Public no-auth GET /api/lease/countries returning supported worker geographies as ISO codes or human-readable names (format=json&type=code|name). SN65 validators run the federated HTTP API on port 3000; the official taofu-labs/tpn-cli resolves these via a comma-separated validator list (BASE_URLS in tpn.sh, mirrored in sn65-validator-list).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "tao-private-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanksi"
+      },
+      "source_urls": [
+        "https://github.com/taofu-labs/tpn-cli/blob/main/tpn.sh",
+        "https://github.com/taofu-labs/tpn-subnet/blob/main/federated-container/openapi.yaml",
+        "https://github.com/taofu-labs/sn65-validator-list/blob/main/validators.json"
+      ],
+      "url": "http://161.35.91.172:3000/api/lease/countries?format=json&type=code"
+    }
+  ]
 }


### PR DESCRIPTION

## Summary

- Add public `subnet-api` surface: `http://161.35.91.172:3000/api/lease/countries?format=json&type=code`
- Closes #576 for the API half — OpenAPI not submitted: SN65 documents the federated API in [`federated-container/openapi.yaml`](https://github.com/taofu-labs/tpn-subnet/blob/main/federated-container/openapi.yaml) (OpenAPI 3.1 YAML) but does not serve a machine-readable JSON spec at any stable host (`tpn.taofu.xyz/openapi.json` and similar paths return Docusaurus HTML)

Closes #576 

## Surface

- Netuid: 65 (TAO Private Network)
- Kind: `subnet-api`
- URL: validator `/api/lease/countries` (JSON country codes)
- Proof: [`tpn-cli` BASE_URLS + `/api/lease/countries`](https://github.com/taofu-labs/tpn-cli/blob/main/tpn.sh), [`openapi.yaml`](https://github.com/taofu-labs/tpn-subnet/blob/main/federated-container/openapi.yaml), [`sn65-validator-list`](https://github.com/taofu-labs/sn65-validator-list/blob/main/validators.json)
- Provider: `tao-private-network`

## Validation

- [x] `npm run validate:surface -- registry/subnets/tao-private-network.json`
- [x] `npm run scan:public-safety`

