### PR TITLE
feat(registry): add Bitcast API readiness health surface (SN93)

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -162,6 +162,25 @@
         "https://bitcast-api.bitcast.network/docs"
       ],
       "url": "https://bitcast-api.bitcast.network/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-api-health-ready",
+      "kind": "subnet-api",
+      "name": "Bitcast API readiness health",
+      "notes": "Public no-auth GET /health/ready on bitcast-api.bitcast.network returning API readiness JSON (status, app_name, version, database connectivity). Documented in the subnet OpenAPI spec on the same host as the existing openapi surface. Distinct from the creator-portal /api/health endpoint on creator.bitcast.network.",
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://bitcast-api.bitcast.network/openapi.json",
+        "https://bitcast-api.bitcast.network/docs"
+      ],
+      "url": "https://bitcast-api.bitcast.network/health/ready"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/bitcast.json`.

Closes #574

## Surface

- Netuid: 93
- Kind: subnet-api
- Public URL: https://bitcast-api.bitcast.network/health/ready
- Source URL (proves the claim): https://bitcast-api.bitcast.network/openapi.json
- Provider slug: bitcast-network

## Checklist

- [x] Changes exactly one `registry/subnets/bitcast.json` file (append-only).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #574`).

## Conflict avoidance

| Open PR | File touched | Conflict? |
|---------|--------------|-----------|
| #3666, #3665, #3664, #3663, #3652 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/bitcast.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Gate Expectations

Public-safe community subnet-api on a documented OpenAPI path; eligible for automated gate review after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitcast.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/bitcast.json`


Made with [Cursor](https://cursor.com)