### PR TITLE
refactor(ui): centralise health-status colour fallbacks

### DIFF
--- a/apps/ui/src/lib/metagraphed/health-segments.ts
+++ b/apps/ui/src/lib/metagraphed/health-segments.ts
@@ -1,3 +1,5 @@
+import { healthStatusVar, inkMutedVar } from "./health-status-tokens";
+
 // Shared builder for the 4-tier health-status Donut segments (OK / warn / Down / Unknown) used by
 // the /status and /providers pages. Both pages previously inlined the identical array — same order,
 // same CSS-variable colours, same "drop zero-value tiers" filter — which is easy to drift out of
@@ -22,13 +24,13 @@ export function healthStatusSegments(
   options: { warnLabel?: string } = {},
 ): HealthStatusSegment[] {
   return [
-    { label: "OK", value: counts.ok, color: "var(--health-ok, #22c55e)" },
+    { label: "OK", value: counts.ok, color: healthStatusVar("ok") },
     {
       label: options.warnLabel ?? "Degraded",
       value: counts.warn,
-      color: "var(--health-warn, #f59e0b)",
+      color: healthStatusVar("warn"),
     },
-    { label: "Down", value: counts.down, color: "var(--health-down, #ef4444)" },
-    { label: "Unknown", value: counts.unknown, color: "var(--ink-muted, #94a3b8)" },
+    { label: "Down", value: counts.down, color: healthStatusVar("down") },
+    { label: "Unknown", value: counts.unknown, color: inkMutedVar() },
   ].filter((s) => s.value > 0);
 }

--- a/apps/ui/src/lib/metagraphed/health-status-tokens.test.ts
+++ b/apps/ui/src/lib/metagraphed/health-status-tokens.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HEALTH_STATUS_COLOR_FALLBACKS,
+  healthStatusVar,
+  inkMutedVar,
+} from "./health-status-tokens";
+
+describe("healthStatusVar", () => {
+  it("builds canonical var(--health-*, fallback) strings", () => {
+    expect(healthStatusVar("ok")).toBe(`var(--health-ok, ${HEALTH_STATUS_COLOR_FALLBACKS.ok})`);
+    expect(healthStatusVar("warn")).toBe(
+      `var(--health-warn, ${HEALTH_STATUS_COLOR_FALLBACKS.warn})`,
+    );
+    expect(healthStatusVar("down")).toBe(
+      `var(--health-down, ${HEALTH_STATUS_COLOR_FALLBACKS.down})`,
+    );
+  });
+});
+
+describe("inkMutedVar", () => {
+  it("maps the unknown tier to --ink-muted with the shared fallback", () => {
+    expect(inkMutedVar()).toBe(`var(--ink-muted, ${HEALTH_STATUS_COLOR_FALLBACKS.unknown})`);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/health-status-tokens.ts
+++ b/apps/ui/src/lib/metagraphed/health-status-tokens.ts
@@ -1,0 +1,22 @@
+// Canonical hex fallbacks for inline `var(--health-*, …)` usages (#3458). styles.css
+// defines the real tokens in oklch; these literals are only the SSR/chart fallback when a
+// token is unavailable. Centralised here so consumers stop drifting to disagreeing hexes.
+
+export const HEALTH_STATUS_COLOR_FALLBACKS = {
+  ok: "#22c55e",
+  warn: "#f59e0b",
+  down: "#ef4444",
+  unknown: "#94a3b8",
+} as const;
+
+export type HealthStatusColorKey = keyof typeof HEALTH_STATUS_COLOR_FALLBACKS;
+
+/** CSS colour string for one of the three health-state tokens. */
+export function healthStatusVar(key: "ok" | "warn" | "down"): string {
+  return `var(--health-${key}, ${HEALTH_STATUS_COLOR_FALLBACKS[key]})`;
+}
+
+/** Muted/unknown tier colour used by Donut legends (maps to --ink-muted). */
+export function inkMutedVar(): string {
+  return `var(--ink-muted, ${HEALTH_STATUS_COLOR_FALLBACKS.unknown})`;
+}


### PR DESCRIPTION
Closes #3458

Adds `health-status-tokens.ts` with the canonical `var(--health-*, fallback)` helpers and routes `healthStatusSegments` through them so Donut legends stop inlining disagreeing hex literals.

Lib-only change (no component wiring in this PR).


Made with [Cursor](https://cursor.com)