### PR TITLE
feat(ui): add typed data layer for subnet serving and prometheus

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-prometheus.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-prometheus.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetPrometheus, subnetPrometheusQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/prometheus",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetPrometheusQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetPrometheus", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeSubnetPrometheus(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        distinct_exporters: 3,
+        announcements: 12,
+        announcements_per_exporter: 4,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_exporters: 3,
+      announcements: 12,
+      announcements_per_exporter: 4,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { distinct_exporters: "nope" }]) {
+      const card = normalizeSubnetPrometheus(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.distinct_exporters).toBe(0);
+      expect(card.announcements).toBe(0);
+      expect(card.announcements_per_exporter).toBeNull();
+      expect(card.observed_at).toBeNull();
+    }
+  });
+
+  it("coerces a junk average to null (never NaN)", () => {
+    const card = normalizeSubnetPrometheus(7, {
+      announcements: 1,
+      announcements_per_exporter: { avg: 1 },
+    });
+    expect(card.announcements).toBe(1);
+    expect(card.announcements_per_exporter).toBeNull();
+  });
+});
+
+describe("subnetPrometheusQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", distinct_exporters: 2, announcements: 6 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/prometheus",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.announcements).toBe(6);
+    expect(res.data.distinct_exporters).toBe(2);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/prometheus",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.subnet-serving.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-serving.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetServing, subnetServingQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/serving",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetServingQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetServing", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeSubnetServing(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        distinct_servers: 5,
+        announcements: 20,
+        announcements_per_server: 4,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_servers: 5,
+      announcements: 20,
+      announcements_per_server: 4,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { distinct_servers: "nope" }]) {
+      const card = normalizeSubnetServing(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.distinct_servers).toBe(0);
+      expect(card.announcements).toBe(0);
+      expect(card.announcements_per_server).toBeNull();
+      expect(card.observed_at).toBeNull();
+    }
+  });
+
+  it("coerces a junk average to null (never NaN)", () => {
+    const card = normalizeSubnetServing(7, {
+      announcements: 2,
+      announcements_per_server: { avg: 1 },
+    });
+    expect(card.announcements).toBe(2);
+    expect(card.announcements_per_server).toBeNull();
+  });
+});
+
+describe("subnetServingQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", distinct_servers: 2, announcements: 8 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/serving",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.announcements).toBe(8);
+    expect(res.data.distinct_servers).toBe(2);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/serving",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -93,6 +93,8 @@ import type {
   Subnet,
   SubnetAxonRemovals,
   SubnetStakeMoves,
+  SubnetServing,
+  SubnetPrometheus,
   SubnetEconomics,
   SubnetHistory,
   SubnetHistoryPoint,
@@ -2978,6 +2980,68 @@ export const subnetStakeMovesQuery = (netuid: number, window = "30d") =>
       );
       return {
         data: normalizeSubnetStakeMoves(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Per-subnet axon-serving announcement activity over a 7d/30d window.
+export function normalizeSubnetServing(netuid: number, raw: unknown): SubnetServing {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_servers: firstFiniteNumber(rec.distinct_servers) ?? 0,
+    announcements: firstFiniteNumber(rec.announcements) ?? 0,
+    announcements_per_server: firstFiniteNumber(rec.announcements_per_server) ?? null,
+  };
+}
+
+export const subnetServingQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-serving", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetServing>>(`/api/v1/subnets/${netuid}/serving`, {
+        params: { window },
+        signal,
+      });
+      return {
+        data: normalizeSubnetServing(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Per-subnet Prometheus-endpoint serving activity over a 7d/30d window.
+export function normalizeSubnetPrometheus(netuid: number, raw: unknown): SubnetPrometheus {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_exporters: firstFiniteNumber(rec.distinct_exporters) ?? 0,
+    announcements: firstFiniteNumber(rec.announcements) ?? 0,
+    announcements_per_exporter: firstFiniteNumber(rec.announcements_per_exporter) ?? null,
+  };
+}
+
+export const subnetPrometheusQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-prometheus", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetPrometheus>>(
+        `/api/v1/subnets/${netuid}/prometheus`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetPrometheus(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1173,6 +1173,36 @@ export interface SubnetStakeMoves {
   movements_per_mover: number | null;
 }
 
+/**
+ * Per-subnet axon-serving announcement activity over a 7d/30d window, from
+ * /api/v1/subnets/{netuid}/serving. Zeroed when the subnet had no AxonServed
+ * events in the window.
+ */
+export interface SubnetServing {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_servers: number;
+  announcements: number;
+  announcements_per_server: number | null;
+}
+
+/**
+ * Per-subnet Prometheus-endpoint serving activity over a 7d/30d window, from
+ * /api/v1/subnets/{netuid}/prometheus. Zeroed when the subnet had no
+ * PrometheusServed events in the window.
+ */
+export interface SubnetPrometheus {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_exporters: number;
+  announcements: number;
+  announcements_per_exporter: number | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;


### PR DESCRIPTION
Closes #3481

Adds typed data layers for per-subnet operational endpoint announcement activity:

- **\GET /api/v1/subnets/{netuid}/serving\** — AxonServed announcement card
- **\GET /api/v1/subnets/{netuid}/prometheus\** — PrometheusServed announcement card

Mirrors the merged #3669 / #3485 stake-moves and #3660 / #3482 axon-removals pattern: types + normalize helpers + queryOptions + Vitest coverage. Lib-only (\pps/ui/src/lib/metagraphed/\), no component changes.

## Validation

- [x] \
pm test -- queries.subnet-serving.test.ts queries.subnet-prometheus.test.ts\ (10 passed)
- [x] \
px prettier --write\ on touched files