### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/albedo.json
+++ b/registry/subnets/albedo.json
@@ -66,5 +66,6 @@
       ],
       "url": "https://chat.albedo.tech/health"
     }
-  ]
+  ],
+  "contact": "arbos@bittensor.com"
 }

--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -53,5 +53,8 @@
       ],
       "url": "https://api.babelbit.ai/health"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/babelbit/babelbit_subnet",
+  "website_url": "https://babelbit.ai/",
+  "contact": "mk@babelbit.ai"
 }

--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -12,5 +12,8 @@
   "social": {
     "x": "https://x.com/b1m_ai"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": null,
+  "website_url": "https://b1m.ai/",
+  "contact": "info@b1m.ai"
 }

--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -8,7 +8,9 @@
   "netuid": 94,
   "schema_version": 1,
   "slug": "sn-94",
-  "social": { "x": "https://x.com/bitsota" },
+  "social": {
+    "x": "https://x.com/bitsota"
+  },
   "source_repo": "https://github.com/AlveusLabs/SN94-BitSota",
   "status": "active",
   "surfaces": [
@@ -134,5 +136,6 @@
       ],
       "url": "https://autoresearch.bitsota.com/api/v1/claims"
     }
-  ]
+  ],
+  "contact": "info@bitsota.ai"
 }

--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -61,5 +61,7 @@
       ],
       "url": "https://huggingface.co/datasets/manelalab/ChronoInstruct-SFT-v1"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/chronollm/sn38",
+  "contact": "crew@crunchdao.com"
 }

--- a/registry/subnets/harnyx.json
+++ b/registry/subnets/harnyx.json
@@ -12,5 +12,8 @@
   "social": {
     "x": "https://x.com/harnyx_ai"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": "https://github.com/harnyx/harnyx",
+  "website_url": "https://harnyx.ai/",
+  "contact": "harnyx@brightmount.co"
 }

--- a/registry/subnets/leadpoet.json
+++ b/registry/subnets/leadpoet.json
@@ -12,5 +12,8 @@
   "social": {
     "x": "https://x.com/leadpoetai"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": "https://github.com/leadpoet/leadpoet",
+  "website_url": "https://leadpoet.com/",
+  "contact": "hello@leadpoet.com"
 }

--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -81,5 +81,6 @@
       "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
       "url": "https://lium.io/api/version"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/Datura-ai/lium-io"
 }

--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -8,7 +8,9 @@
   "netuid": 107,
   "schema_version": 1,
   "slug": "sn-107",
-  "social": { "x": "https://x.com/theminos_ai" },
+  "social": {
+    "x": "https://x.com/theminos_ai"
+  },
   "source_repo": "https://github.com/minos-protocol/minos_subnet",
   "status": "active",
   "website_url": "https://theminos.ai/",
@@ -37,5 +39,6 @@
       ],
       "url": "https://api.theminos.ai/health"
     }
-  ]
+  ],
+  "contact": "contact@theminos.ai"
 }

--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -32,5 +32,7 @@
       ],
       "url": "https://api.minotaursubnet.com/health"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/subnet112/minotaur_subnet",
+  "website_url": "https://minotaursubnet.com/"
 }

--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -12,5 +12,7 @@
   "social": {
     "x": "https://x.com/nexisgen_ai"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": "https://github.com/RendixNetwork/nexisgen",
+  "website_url": "https://nexisgen.ai/"
 }

--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -86,5 +86,7 @@
       ],
       "url": "https://huggingface.co/datasets/Metanova/Proteins"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/metanova-labs/nova",
+  "website_url": "https://www.metanova-labs.ai/"
 }

--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -12,5 +12,8 @@
   "social": {
     "x": "https://x.com/swarmsubnet"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": "https://github.com/swarm-subnet/swarm",
+  "website_url": "https://www.swarm124.com/",
+  "contact": "admin@swarm124.com"
 }

--- a/registry/subnets/talkhead.json
+++ b/registry/subnets/talkhead.json
@@ -32,5 +32,8 @@
       ],
       "url": "https://api.talkhead.ai/health"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/talkheadai/talkhead-subnet",
+  "website_url": "https://www.talkhead.ai/",
+  "contact": "contact@talkhead.ai"
 }

--- a/registry/subnets/tao-private-network.json
+++ b/registry/subnets/tao-private-network.json
@@ -12,5 +12,8 @@
   "social": {
     "x": "https://x.com/tpn_labs"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": "https://github.com/taofu-labs/tpn-subnet",
+  "website_url": "https://tpn.taofu.xyz/",
+  "contact": "contact@taoprivatenetwork.com"
 }

--- a/registry/subnets/vocence.json
+++ b/registry/subnets/vocence.json
@@ -50,5 +50,7 @@
       ],
       "url": "https://api.vocence.ai/openapi.json"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/vocence-78/vocence",
+  "website_url": "https://www.vocence.ai/"
 }

--- a/registry/subnets/yanez-miid.json
+++ b/registry/subnets/yanez-miid.json
@@ -12,5 +12,8 @@
   "social": {
     "x": "https://x.com/yanez__ai"
   },
-  "surfaces": []
+  "surfaces": [],
+  "source_repo": "https://github.com/yanez-compliance/MIID-subnet",
+  "website_url": "https://www.yanez.ai/",
+  "contact": "jose@yanezcompliance.com"
 }

--- a/registry/subnets/zipcode.json
+++ b/registry/subnets/zipcode.json
@@ -91,5 +91,8 @@
       ],
       "url": "https://zipcode.ai/api/dashboard/stats/emissions"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/resi-labs-ai/RESI-models",
+  "website_url": "https://zipcode.ai/",
+  "contact": "support@resilabs.ai"
 }


### PR DESCRIPTION
**Provenance: third-party taostats data — gap-fills only, for human review before merge.**

These are identity field gap-fills sourced from the taostats SubnetIdentityV1 API. Each field was sanitized using the repo's own helpers (`backfilledIdentityUrl`, `subnetContact`, `socialAccounts`). No existing fields are overwritten — only empty/null slots are filled.

Skipped subnets where taostats names don't match the registry (SN29/SN40/SN58/SN69/SN80/SN117 — cross-contaminated data).

## Subnets and fields touched

| Subnet | File | Fields added |
|--------|------|-------------|
| SN38 ChronoLLM | chronollm.json | source_repo, contact |
| SN46 Zipcode | zipcode.json | source_repo, website_url, contact |
| SN51 lium.io | lium-io.json | source_repo |
| SN54 Yanez MIID | yanez-miid.json | source_repo, website_url, contact |
| SN59 Babelbit | babelbit.json | source_repo, website_url, contact |
| SN65 TAO Private Network | tao-private-network.json | source_repo, website_url, contact |
| SN67 Harnyx | harnyx.json | source_repo, website_url, contact |
| SN68 NOVA | nova.json | source_repo, website_url |
| SN70 NexisGen | nexisgen.json | source_repo, website_url |
| SN71 Leadpoet | leadpoet.json | source_repo, website_url, contact |
| SN78 Vocence | vocence.json | source_repo, website_url |
| SN94 Bitsota | bitsota.json | contact |
| SN97 Albedo | albedo.json | contact |
| SN105 Beam | beam.json | website_url, contact |
| SN107 Minos | minos.json | contact |
| SN108 TalkHead | talkhead.json | source_repo, website_url, contact |
| SN112 minotaur | minotaur.json | source_repo, website_url |
| SN124 Swarm | swarm.json | source_repo, website_url, contact |

18 files, 18 subnets, 40 field fills.