### PR TITLE
feat(ui): add typed data layer for subnet registrations + deregistrations

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-registrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-registrations.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  normalizeSubnetDeregistrations,
+  normalizeSubnetRegistrations,
+  subnetDeregistrationsQuery,
+  subnetRegistrationsQuery,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
+// options object; each call site keeps its own precise data type).
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+describe("normalizeSubnetRegistrations", () => {
+  it("passes a well-formed card through", () => {
+    const raw = {
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_registrants: 3,
+      registrations: 8,
+      registrations_per_registrant: 2.6667,
+    };
+    expect(normalizeSubnetRegistrations(7, raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk to a zeroed card (average null, never NaN)", () => {
+    for (const raw of [{}, null, { registrations: "nope" }]) {
+      const card = normalizeSubnetRegistrations(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.registrations).toBe(0);
+      expect(card.distinct_registrants).toBe(0);
+      expect(card.registrations_per_registrant).toBeNull();
+    }
+  });
+});
+
+describe("normalizeSubnetDeregistrations", () => {
+  it("passes a well-formed card through", () => {
+    const raw = {
+      schema_version: 1,
+      netuid: 7,
+      window: "7d",
+      observed_at: null,
+      distinct_deregistered_hotkeys: 2,
+      deregistrations: 5,
+      deregistrations_per_hotkey: 2.5,
+    };
+    expect(normalizeSubnetDeregistrations(7, raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk to a zeroed card", () => {
+    const card = normalizeSubnetDeregistrations(7, {
+      deregistrations_per_hotkey: { x: 1 },
+    });
+    expect(card.deregistrations).toBe(0);
+    expect(card.distinct_deregistered_hotkeys).toBe(0);
+    expect(card.deregistrations_per_hotkey).toBeNull();
+  });
+});
+
+describe("registration/deregistration queries", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("registrations: hits its route with the window param", async () => {
+    resolveWith({ netuid: 7, registrations: 4 });
+    const res = await runQuery(subnetRegistrationsQuery(7, "7d"));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/registrations",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.registrations).toBe(4);
+  });
+
+  it("deregistrations: defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(subnetDeregistrationsQuery(7));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/deregistrations",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -92,6 +92,7 @@ import type {
   SchemaInfo,
   Subnet,
   SubnetAxonRemovals,
+  SubnetDeregistrations,
   SubnetStakeMoves,
   SubnetServing,
   SubnetPrometheus,
@@ -105,6 +106,7 @@ import type {
   SubnetNeuronHistory,
   SubnetNeuronHistoryPoint,
   SubnetStakeTransfers,
+  SubnetRegistrations,
   MetagraphNeuron,
   SubnetMetagraph,
   SubnetValidators,
@@ -3077,6 +3079,74 @@ export const subnetPrometheusQuery = (netuid: number, window = "30d") =>
       );
       return {
         data: normalizeSubnetPrometheus(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #1657: per-subnet neuron-registration event volume over a 7d/30d window. A flat
+// summary card from the account_events NeuronRegistered stream; counts fall
+// through to 0 and the average to null (never NaN) on a cold store or junk cell.
+export function normalizeSubnetRegistrations(netuid: number, raw: unknown): SubnetRegistrations {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_registrants: firstFiniteNumber(rec.distinct_registrants) ?? 0,
+    registrations: firstFiniteNumber(rec.registrations) ?? 0,
+    registrations_per_registrant: firstFiniteNumber(rec.registrations_per_registrant) ?? null,
+  };
+}
+
+export const subnetRegistrationsQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-registrations", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetRegistrations>>(
+        `/api/v1/subnets/${netuid}/registrations`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetRegistrations(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #1657: per-subnet neuron-deregistration (eviction) event volume over a 7d/30d
+// window — the eviction-side complement of the registrations card above.
+export function normalizeSubnetDeregistrations(
+  netuid: number,
+  raw: unknown,
+): SubnetDeregistrations {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_deregistered_hotkeys: firstFiniteNumber(rec.distinct_deregistered_hotkeys) ?? 0,
+    deregistrations: firstFiniteNumber(rec.deregistrations) ?? 0,
+    deregistrations_per_hotkey: firstFiniteNumber(rec.deregistrations_per_hotkey) ?? null,
+  };
+}
+
+export const subnetDeregistrationsQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-deregistrations", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetDeregistrations>>(
+        `/api/v1/subnets/${netuid}/deregistrations`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetDeregistrations(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1221,6 +1221,36 @@ export interface SubnetPrometheus {
   announcements_per_exporter: number | null;
 }
 
+/**
+ * Per-subnet neuron-registration event volume over a 7d/30d window (#1657), from
+ * /api/v1/subnets/{netuid}/registrations — raw NeuronRegistered activity, distinct
+ * from the turnover snapshot-diff. Zeroed when the subnet had none in the window.
+ */
+export interface SubnetRegistrations {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number | null;
+}
+
+/**
+ * Per-subnet neuron-deregistration (eviction) event volume over a 7d/30d window
+ * (#1657), from /api/v1/subnets/{netuid}/deregistrations — the eviction-side
+ * complement of {@link SubnetRegistrations}. Zeroed when cold.
+ */
+export interface SubnetDeregistrations {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_deregistered_hotkeys: number;
+  deregistrations: number;
+  deregistrations_per_hotkey: number | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;


### PR DESCRIPTION
## Summary

Adds the typed data layer for per-subnet registration and deregistration event volume (#1657), consuming the existing `GET /api/v1/subnets/{netuid}/registrations` and `/deregistrations` endpoints — the queries + types the subnet masthead (#3483) needs for raw event-volume counters (distinct from the turnover snapshot-diff already shown). Same small, tested pattern as identity-history #3487, axon-removals #3482, weight-setters #3480.

Rebased on fresh main (supersedes #3672, which the gate auto-closed for a base conflict after the stake-moves data layer merged; resolved cleanly here — kept both).

Closes #3483

## What changed

- **`apps/ui/src/lib/metagraphed/types.ts`** — `SubnetRegistrations` (`distinct_registrants`, `registrations`, `registrations_per_registrant`) and `SubnetDeregistrations` (`distinct_deregistered_hotkeys`, `deregistrations`, `deregistrations_per_hotkey`), each with window/observed_at/netuid.
- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetRegistrationsQuery` / `subnetDeregistrationsQuery` (`?window=7d|30d`, default 30d) + exported `normalizeSubnetRegistrations` / `normalizeSubnetDeregistrations`. Defensive: counts → 0, averages → null (never NaN) on a cold store or junk cell.
- **`apps/ui/src/lib/metagraphed/queries.subnet-registrations.test.ts`** — well-formed pass-through, cold/junk degradation, and window-param wiring for both routes.

## Validation

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm run lint` · `format:check`
- [x] `npm run test` — 6 new cases pass (and the merged stake-moves suite still green)
