### PR TITLE
docs(ui): justify exhaustive-deps eslint disables

### DIFF
--- a/apps/ui/src/lib/metagraphed/api-source-context.tsx
+++ b/apps/ui/src/lib/metagraphed/api-source-context.tsx
@@ -86,6 +86,7 @@ export function useRegisterApiSource(paths: string[], artifacts: string[] = []) 
       ...artifacts.map((p) => ({ path: p, artifact: p })),
     ];
     return register(items);
+    // paths/artifacts omitted: pathsKey/artifactsKey serialise them so fresh array literals do not re-register every render (#3461).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathsKey, artifactsKey, register]);
 }

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -319,6 +319,7 @@ function SchemaExplorer() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
+    // setSearch omitted: TanStack Router setter is stable; only search.open should rebind Escape (#3461).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search.open]);
 

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -262,6 +262,7 @@ function RecentIncidents() {
         b.downtime_ms - a.downtime_ms,
     );
     return list;
+    // isOngoing omitted: closes over ledger.observed_at in the same render; ledger already triggers recompute (#3461).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ledger]);
   const summary = ledger?.summary;


### PR DESCRIPTION
Closes #3461

Adds the missing justification comments for the three `react-hooks/exhaustive-deps` suppressions in `api-source-context.tsx`, `status.tsx`, and `schemas.tsx`. No runtime behaviour changes.


Made with [Cursor](https://cursor.com)