### PR TITLE
feat(ui): add typed data layer for subnet weights activity

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-weights.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-weights.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetWeights, subnetWeightsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/weights",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetWeightsQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetWeights", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeSubnetWeights(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        distinct_setters: 8,
+        weight_sets: 24,
+        sets_per_setter: 3,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      distinct_setters: 8,
+      weight_sets: 24,
+      sets_per_setter: 3,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { distinct_setters: "nope" }]) {
+      const card = normalizeSubnetWeights(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.distinct_setters).toBe(0);
+      expect(card.weight_sets).toBe(0);
+      expect(card.sets_per_setter).toBeNull();
+      expect(card.observed_at).toBeNull();
+    }
+  });
+
+  it("coerces a junk average to null (never NaN)", () => {
+    const card = normalizeSubnetWeights(7, {
+      weight_sets: 5,
+      sets_per_setter: { avg: 1 },
+    });
+    expect(card.weight_sets).toBe(5);
+    expect(card.sets_per_setter).toBeNull();
+  });
+});
+
+describe("subnetWeightsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", distinct_setters: 4, weight_sets: 12 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/weights",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.weight_sets).toBe(12);
+    expect(res.data.distinct_setters).toBe(4);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/weights",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -101,6 +101,7 @@ import type {
   SubnetIdentityHistory,
   SubnetWeightSetter,
   SubnetWeightSetters,
+  SubnetWeights,
   SubnetIdentityHistoryEntry,
   SubnetNeuronHistory,
   SubnetNeuronHistoryPoint,
@@ -3042,6 +3043,37 @@ export const subnetPrometheusQuery = (netuid: number, window = "30d") =>
       );
       return {
         data: normalizeSubnetPrometheus(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Per-subnet aggregate weight-setting activity over a 7d/30d window.
+export function normalizeSubnetWeights(netuid: number, raw: unknown): SubnetWeights {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_setters: firstFiniteNumber(rec.distinct_setters) ?? 0,
+    weight_sets: firstFiniteNumber(rec.weight_sets) ?? 0,
+    sets_per_setter: firstFiniteNumber(rec.sets_per_setter) ?? null,
+  };
+}
+
+export const subnetWeightsQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-weights", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetWeights>>(`/api/v1/subnets/${netuid}/weights`, {
+        params: { window },
+        signal,
+      });
+      return {
+        data: normalizeSubnetWeights(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1116,6 +1116,22 @@ export interface SubnetIdentityHistory {
   next_cursor: string | null;
 }
 
+/**
+ * Per-subnet validator weight-setting activity over a 7d/30d window, from
+ * /api/v1/subnets/{netuid}/weights — aggregate WeightsSet counts (distinct
+ * setters, total sets, average). Zeroed when the subnet had no WeightsSet
+ * events in the window. Setter-level drill-in lives at /weights/setters.
+ */
+export interface SubnetWeights {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_setters: number;
+  weight_sets: number;
+  sets_per_setter: number | null;
+}
+
 /** One validator's weight-setting activity for a subnet over the window (#1657). */
 export interface SubnetWeightSetter {
   hotkey: string | null;


### PR DESCRIPTION
Closes #3479

Adds the typed data layer for per-subnet aggregate weight-setting activity at \GET /api/v1/subnets/{netuid}/weights\ — distinct from the existing \/weights/setters\ leaderboard layer (#3480 / #3665).

- **\	ypes.ts\** — \SubnetWeights\ summary card (distinct_setters, weight_sets, sets_per_setter).
- **\queries.ts\** — \subnetWeightsQuery(netuid, window)\ + exported \
ormalizeSubnetWeights\.
- **\queries.subnet-weights.test.ts\** — 5 cases (pass-through, cold store, junk average, window param, 30d default).

Lib-only (\pps/ui/src/lib/metagraphed/\), mirrors #3669 / #3675 data-layer PRs.

## Validation

- [x] \
pm test -- queries.subnet-weights.test.ts\ (5 passed)
- [x] \
px prettier --write\ on touched files