### PR TITLE
feat(registry): add Nepher active tournament IDs API surface (SN49)

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -320,6 +320,25 @@
         "https://docs.nepher.ai/"
       ],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/id"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-active-tournament-ids-api",
+      "kind": "subnet-api",
+      "name": "Nepher active tournament IDs API",
+      "notes": "Public no-auth GET returning the UUIDs of all currently active tournaments (tournament_ids array). Documented in the subnet's own OpenAPI (tournament-api.nepher.ai/openapi.json, path /api/v1/tournaments/active/ids); same host as existing tournament surfaces. Distinct from the singular active/id endpoint and the active-tournaments list.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://docs.nepher.ai/"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/ids"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/nepher-robotics.json`.

Closes #737

## Surface

- Netuid: 49
- Kind: subnet-api
- Public URL: https://tournament-api.nepher.ai/api/v1/tournaments/active/ids
- Source URL (proves the claim): https://tournament-api.nepher.ai/openapi.json
- Provider slug: nepher-robotics

## Checklist

- [x] Changes exactly one `registry/subnets/nepher-robotics.json` file (append-only).
- [x] Generated following `npm run surface:add` conventions — `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #737`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3677 (taostats identity gap-fills) | 18 other subnet manifests | No — `nepher-robotics.json` not in scope |
| #3594, #3546 | release/README | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/nepher-robotics.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/nepher-robotics.json`


Made with [Cursor](https://cursor.com)