### PR TITLE
feat(ui): add typed data layer for chain transfer-pairs (#3476)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-transfer-pairs.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-transfer-pairs.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainTransferPairsQuery, normalizeChainTransferPairs } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/transfer-pairs",
+  });
+}
+
+async function runQuery(window?: string, limit?: number, sort?: "volume" | "count") {
+  const opts = chainTransferPairsQuery(window, limit, sort);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainTransferPairs", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeChainTransferPairs({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        sort: "count",
+        total_volume_tao: 100,
+        transfer_count: 10,
+        unique_pairs: 4,
+        pair_count: 1,
+        top_pair_share: 0.8,
+        pairs: [
+          {
+            from: "5Sa",
+            to: "5Rx",
+            volume_tao: 80,
+            transfer_count: 5,
+            last_block: 8454388,
+            last_observed_at: "2026-07-03T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      sort: "count",
+      total_volume_tao: 100,
+      transfer_count: 10,
+      unique_pairs: 4,
+      pair_count: 1,
+      top_pair_share: 0.8,
+      pairs: [
+        {
+          from: "5Sa",
+          to: "5Rx",
+          volume_tao: 80,
+          transfer_count: 5,
+          last_block: 8454388,
+          last_observed_at: "2026-07-03T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { unique_pairs: "nope" }]) {
+      const card = normalizeChainTransferPairs(raw);
+      expect(card.unique_pairs).toBe(0);
+      expect(card.pair_count).toBe(0);
+      expect(card.pairs).toEqual([]);
+      expect(card.top_pair_share).toBeNull();
+      expect(card.sort).toBe("volume");
+    }
+  });
+
+  it("drops malformed pair rows and coerces a junk share to null", () => {
+    const card = normalizeChainTransferPairs({
+      top_pair_share: { pct: 1 },
+      pairs: [{ from: "5Sa" }, { to: "5Rx" }, { from: "5Sa", to: "5Rx", volume_tao: 1 }],
+    });
+    expect(card.pairs).toHaveLength(1);
+    expect(card.pairs[0]?.from).toBe("5Sa");
+    expect(card.top_pair_share).toBeNull();
+  });
+});
+
+describe("chainTransferPairsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window, limit, and sort params and normalizes the card", async () => {
+    resolveWith({
+      window: "7d",
+      sort: "count",
+      unique_pairs: 2,
+      pairs: [{ from: "5Sa", to: "5Rx", volume_tao: 3, transfer_count: 1 }],
+    });
+    const res = await runQuery("7d", 5, "count");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/transfer-pairs",
+      expect.objectContaining({ params: { window: "7d", limit: 5, sort: "count" } }),
+    );
+    expect(res.data.unique_pairs).toBe(2);
+    expect(res.data.pairs).toHaveLength(1);
+  });
+
+  it("defaults to the 30d window, limit 25, and volume sort", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/transfer-pairs",
+      expect.objectContaining({ params: { window: "30d", limit: 25, sort: "volume" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -46,6 +46,8 @@ import type {
   ChainFees,
   ChainFeeDay,
   ChainFeePayer,
+  ChainTransferPair,
+  ChainTransferPairs,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -169,6 +171,7 @@ const MAX_CHAIN_CALLS = 12;
 const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
+const MAX_CHAIN_TRANSFER_PAIRS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -2390,6 +2393,66 @@ export const chainFeesQuery = (window: ChainWindow = "7d") =>
       } as ApiResult<ChainFees>;
     },
     staleTime: STALE_SHORT,
+  });
+
+function normalizeChainTransferPair(raw: unknown): ChainTransferPair | null {
+  if (!isRecord(raw)) return null;
+  const from = firstString(raw.from);
+  const to = firstString(raw.to);
+  if (!from || !to) return null;
+  return {
+    from,
+    to,
+    volume_tao: firstFiniteNumber(raw.volume_tao) ?? 0,
+    transfer_count: firstFiniteNumber(raw.transfer_count) ?? 0,
+    last_block: firstFiniteNumber(raw.last_block) ?? null,
+    last_observed_at: firstString(raw.last_observed_at) ?? null,
+  };
+}
+
+function normalizeChainTransferPairSort(raw: unknown): "volume" | "count" {
+  return raw === "count" ? "count" : "volume";
+}
+
+// #3476: network-wide directed native-TAO transfer-pair corridors over a 7d/30d
+// window — the data layer for a sender→receiver flow/sankey view on the explorer.
+// Every numeric cell coerces defensively: counts fall through to 0, shares/averages
+// to null (never NaN), and malformed pair rows are dropped on a cold store or junk.
+export function normalizeChainTransferPairs(raw: unknown): ChainTransferPairs {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    sort: normalizeChainTransferPairSort(rec.sort),
+    total_volume_tao: firstFiniteNumber(rec.total_volume_tao) ?? 0,
+    transfer_count: firstFiniteNumber(rec.transfer_count) ?? 0,
+    unique_pairs: firstFiniteNumber(rec.unique_pairs) ?? 0,
+    pair_count: firstFiniteNumber(rec.pair_count) ?? 0,
+    top_pair_share: firstFiniteNumber(rec.top_pair_share) ?? null,
+    pairs: normalizeChainRows(rec.pairs, MAX_CHAIN_TRANSFER_PAIRS, normalizeChainTransferPair),
+  };
+}
+
+export const chainTransferPairsQuery = (
+  window = "30d",
+  limit = 25,
+  sort: "volume" | "count" = "volume",
+) =>
+  queryOptions({
+    queryKey: k("chain-transfer-pairs", window, limit, sort),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainTransferPairs>>("/api/v1/chain/transfer-pairs", {
+        params: { window, limit, sort },
+        signal,
+      });
+      return {
+        data: normalizeChainTransferPairs(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
   });
 
 const READINESS_COMPONENT_KEYS = [

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1599,6 +1599,35 @@ export interface ChainFees {
   top_fee_payers: ChainFeePayer[];
 }
 
+/** One directed sender→receiver pair on the chain transfer-pairs leaderboard (#3476). */
+export interface ChainTransferPair {
+  from: string;
+  to: string;
+  volume_tao: number;
+  transfer_count: number;
+  last_block: number | null;
+  last_observed_at: string | null;
+}
+
+/**
+ * Network-wide directed native-TAO transfer-pair analytics over a 7d/30d window
+ * (#3476), from GET /api/v1/chain/transfer-pairs — top sender→receiver corridors
+ * ranked by volume or count, plus window rollup (unique pairs, top-pair share).
+ * Zeroed with an empty pairs list when the store is cold.
+ */
+export interface ChainTransferPairs {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  sort: "volume" | "count";
+  total_volume_tao: number;
+  transfer_count: number;
+  unique_pairs: number;
+  pair_count: number;
+  top_pair_share: number | null;
+  pairs: ChainTransferPair[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;


### PR DESCRIPTION
## Summary
- Add `ChainTransferPair` / `ChainTransferPairs` types and `normalizeChainTransferPairs()` for GET `/api/v1/chain/transfer-pairs`
- Add `chainTransferPairsQuery(window, limit, sort)` with defensive coercion (cold store → zeroed card, malformed pair rows dropped)
- Vitest coverage for pass-through, cold/junk degradation, param wiring, and 30d defaults

Lib-only data layer in `apps/ui/src/lib/metagraphed/` — no route/component changes.

Closes #3476

## Test plan
- [x] `npx vitest run src/lib/metagraphed/queries.chain-transfer-pairs.test.ts`