### PR TITLE
fix(client): scope SDK publish dependency install

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -53,11 +53,12 @@ jobs:
       # publish job below never runs npm install/build, so a compromised build
       # dependency can't reach the OIDC token (codex #251).
       #
-      # packages/client is an npm workspace (#3066) with no lockfile of its own,
-      # so the install is now root-scoped (installs apps/ui's tree too) — the
-      # build/pack below still only touches packages/client.
-      - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+      # packages/client is an npm workspace (#3066) with no lockfile of its own.
+      # Keep this publish-build install scoped to the SDK workspace and disable
+      # dependency lifecycle scripts, so unrelated workspaces (for example apps/ui)
+      # cannot affect the tarball that the privileged publish job trusts.
+      - name: Install client dependencies
+        run: npm ci --workspace=packages/client --ignore-scripts --no-audit --no-fund
 
       - name: Build package tarball
         working-directory: packages/client


### PR DESCRIPTION
### Motivation
- Prevent unrelated workspace dependencies and their npm lifecycle scripts from influencing the client SDK tarball produced by the unprivileged publish-build job, reducing the supply-chain trust boundary for `@jsonbored/metagraphed`.

### Description
- Changed the unprivileged `validate` job in `.github/workflows/publish-client.yml` to run a workspace-scoped install for the SDK only by replacing the root `npm ci` with `npm ci --workspace=packages/client --ignore-scripts --no-audit --no-fund` and updating the explanatory comment. 
- Preserved the existing build/pack/upload flow that runs `npm run build` and `npm pack` in `packages/client` so the workflow still produces the same tarball artifact for the privileged publish job to consume. 
- Committed the change with message `fix(client): scope SDK publish dependency install`.

### Testing
- Ran `git diff --check` which succeeded. 
- Ran `npm run validate:workflows` which validated the workflow files successfully. 
- Attempted `npm ci --workspace=packages/client --ignore-scripts --no-audit --no-fund` locally but it was blocked by a registry `403 Forbidden` for `esbuild-0.27.7.tgz`, preventing full dependency installation. 
- Attempted `npm run build --workspace=packages/client` but it failed because the dependency install could not complete (missing `tsup`), so build verification was blocked by the registry failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1f4121cc832c91598169f3155453)