### PR TITLE
feat(ui): add typed data layer for chain transfers (#3475)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-transfers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-transfers.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainTransfersQuery, normalizeChainTransfers } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/transfers",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainTransfersQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainTransfers", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeChainTransfers({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        total_volume_tao: 100,
+        transfer_count: 10,
+        unique_senders: 4,
+        unique_receivers: 6,
+        top_sender_share: 0.8,
+        top_senders: [
+          {
+            address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            volume_tao: 80,
+            transfer_count: 5,
+          },
+        ],
+        top_receivers: [
+          {
+            address: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+            volume_tao: 60,
+            transfer_count: 4,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      total_volume_tao: 100,
+      transfer_count: 10,
+      unique_senders: 4,
+      unique_receivers: 6,
+      top_sender_share: 0.8,
+      top_senders: [
+        {
+          address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+          volume_tao: 80,
+          transfer_count: 5,
+        },
+      ],
+      top_receivers: [
+        {
+          address: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+          volume_tao: 60,
+          transfer_count: 4,
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { unique_senders: "nope" }]) {
+      const card = normalizeChainTransfers(raw);
+      expect(card.unique_senders).toBe(0);
+      expect(card.unique_receivers).toBe(0);
+      expect(card.top_senders).toEqual([]);
+      expect(card.top_receivers).toEqual([]);
+      expect(card.top_sender_share).toBeNull();
+    }
+  });
+
+  it("drops malformed leaderboard rows and coerces a junk share to null", () => {
+    const card = normalizeChainTransfers({
+      top_sender_share: { pct: 1 },
+      top_senders: [
+        { address: "not-ss58" },
+        { address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", volume_tao: 1 },
+      ],
+    });
+    expect(card.top_senders).toHaveLength(1);
+    expect(card.top_sender_share).toBeNull();
+  });
+});
+
+describe("chainTransfersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the card", async () => {
+    resolveWith({
+      window: "7d",
+      unique_senders: 2,
+      top_senders: [
+        {
+          address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+          volume_tao: 3,
+          transfer_count: 1,
+        },
+      ],
+    });
+    const res = await runQuery("7d", 5);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/transfers",
+      expect.objectContaining({ params: { window: "7d", limit: 5 } }),
+    );
+    expect(res.data.unique_senders).toBe(2);
+    expect(res.data.top_senders).toHaveLength(1);
+  });
+
+  it("defaults to the 30d window and limit 25", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/transfers",
+      expect.objectContaining({ params: { window: "30d", limit: 25 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -46,6 +46,8 @@ import type {
   ChainFees,
   ChainFeeDay,
   ChainFeePayer,
+  ChainTransferParty,
+  ChainTransfers,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -169,6 +171,7 @@ const MAX_CHAIN_CALLS = 12;
 const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
+const MAX_CHAIN_TRANSFER_PARTIES = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -2390,6 +2393,62 @@ export const chainFeesQuery = (window: ChainWindow = "7d") =>
       } as ApiResult<ChainFees>;
     },
     staleTime: STALE_SHORT,
+  });
+
+function normalizeChainTransferParty(raw: unknown): ChainTransferParty | null {
+  if (!isRecord(raw)) return null;
+  const address = firstString(raw.address);
+  if (!address || !isValidSs58(address)) return null;
+  return {
+    address: address.trim(),
+    volume_tao: firstFiniteNumber(raw.volume_tao) ?? 0,
+    transfer_count: firstFiniteNumber(raw.transfer_count) ?? 0,
+  };
+}
+
+// #3475: network-wide native-TAO transfer leaderboard over a 7d/30d window — the
+// data layer for the explorer transfers panel. Every numeric cell coerces
+// defensively: counts fall through to 0, concentration share to null (never NaN),
+// and malformed leaderboard rows are dropped on a cold store or junk payload.
+export function normalizeChainTransfers(raw: unknown): ChainTransfers {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    total_volume_tao: firstFiniteNumber(rec.total_volume_tao) ?? 0,
+    transfer_count: firstFiniteNumber(rec.transfer_count) ?? 0,
+    unique_senders: firstFiniteNumber(rec.unique_senders) ?? 0,
+    unique_receivers: firstFiniteNumber(rec.unique_receivers) ?? 0,
+    top_sender_share: firstFiniteNumber(rec.top_sender_share) ?? null,
+    top_senders: normalizeChainRows(
+      rec.top_senders,
+      MAX_CHAIN_TRANSFER_PARTIES,
+      normalizeChainTransferParty,
+    ),
+    top_receivers: normalizeChainRows(
+      rec.top_receivers,
+      MAX_CHAIN_TRANSFER_PARTIES,
+      normalizeChainTransferParty,
+    ),
+  };
+}
+
+export const chainTransfersQuery = (window = "30d", limit = 25) =>
+  queryOptions({
+    queryKey: k("chain-transfers", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainTransfers>>("/api/v1/chain/transfers", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainTransfers(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
   });
 
 const READINESS_COMPONENT_KEYS = [

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1599,6 +1599,32 @@ export interface ChainFees {
   top_fee_payers: ChainFeePayer[];
 }
 
+/** One account on the chain native-TAO transfers leaderboard (#3475). */
+export interface ChainTransferParty {
+  address: string;
+  volume_tao: number;
+  transfer_count: number;
+}
+
+/**
+ * Network-wide native-TAO transfer analytics over a 7d/30d window (#3475), from
+ * GET /api/v1/chain/transfers — total volume/count, distinct senders/receivers,
+ * top senders and receivers by volume, and top-sender concentration share.
+ * Zeroed with empty leaderboards when the store is cold.
+ */
+export interface ChainTransfers {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  total_volume_tao: number;
+  transfer_count: number;
+  unique_senders: number;
+  unique_receivers: number;
+  top_sender_share: number | null;
+  top_senders: ChainTransferParty[];
+  top_receivers: ChainTransferParty[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;


### PR DESCRIPTION
## Summary
- Add `ChainTransferParty` / `ChainTransfers` types and `normalizeChainTransfers()` for GET `/api/v1/chain/transfers`
- Add `chainTransfersQuery(window, limit)` with defensive coercion (cold store -> zeroed card, invalid SS58 rows dropped)
- Vitest coverage for pass-through, cold/junk degradation, param wiring, and 30d defaults

Lib-only data layer in `apps/ui/src/lib/metagraphed/` — no route/component changes.

Closes #3475

## Test plan
- [x] `npx vitest run src/lib/metagraphed/queries.chain-transfers.test.ts`