### PR TITLE
feat(registry): add Lium reclaims API surface (SN51)

### DIFF
--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -80,6 +80,29 @@
       "schema_url": "https://lium.io/api/openapi.json",
       "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
       "url": "https://lium.io/api/version"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-reclaims-api",
+      "kind": "subnet-api",
+      "name": "Lium reclaims API",
+      "notes": "Public no-auth GET /reclaims on the Lium Backend API (served at /api/reclaims) returning a JSON array of collateral reclaims with status, expiration, executor_id, and collateral_amount for the SN51 lium.io compute marketplace. Documented in the registered OpenAPI spec on the same host as the existing machines and version subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "schema_url": "https://lium.io/api/openapi.json",
+      "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
+      "url": "https://lium.io/api/reclaims"
     }
   ],
   "source_repo": "https://github.com/Datura-ai/lium-io"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/lium-io.json`.

Closes #462

## Surface

- Netuid: 51
- Kind: subnet-api
- Public URL: https://lium.io/api/reclaims
- Source URL (proves the claim): https://lium.io/api/openapi.json
- Provider slug: lium

## Checklist

- [x] Changes exactly one `registry/subnets/lium-io.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #462`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3685, #3684, #3683 | apps/ui, workflow | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/lium-io.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/lium-io.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/lium-io.json`


Made with [Cursor](https://cursor.com)