### PR TITLE
feat(ui): add per-UID emission-yield tab to the subnet profile page

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -1,0 +1,319 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Percent, Activity, Users, ArrowUpRight, ArrowDownRight, Minus } from "lucide-react";
+import { subnetYieldQuery, subnetYieldHistoryQuery } from "@/lib/metagraphed/queries";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { BarMini } from "@/components/metagraphed/charts/bar-mini";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { TableState } from "@/components/metagraphed/table-state";
+import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { classNames } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { SubnetYieldNeuron, YieldHistoryPoint } from "@/lib/metagraphed/types";
+
+type Win = "7d" | "30d" | "90d";
+const WINDOWS: Win[] = ["7d", "30d", "90d"];
+const TOP_N = 15;
+
+// Yield is an emission/stake return rate — tiny fractions (~1e-5..1e-1). Render
+// as a percentage with adaptive precision; null/non-finite collapses to em-dash.
+function fmtYield(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "0%";
+  const pct = v * 100;
+  if (Math.abs(pct) >= 1) return `${pct.toFixed(2)}%`;
+  if (Math.abs(pct) >= 0.001) return `${pct.toFixed(4)}%`;
+  return `${pct.toExponential(2)}%`;
+}
+
+function Fact({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        {label}
+      </div>
+      <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong leading-none">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function VsMedian({ vs }: { vs: SubnetYieldNeuron["vs_median"] }) {
+  if (vs === "above")
+    return (
+      <span className="inline-flex items-center gap-0.5 text-health-ok" title="above median">
+        <ArrowUpRight className="size-3" aria-hidden />
+        <span className="sr-only">above median</span>
+      </span>
+    );
+  if (vs === "below")
+    return (
+      <span className="inline-flex items-center gap-0.5 text-ink-muted" title="below median">
+        <ArrowDownRight className="size-3" aria-hidden />
+        <span className="sr-only">below median</span>
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center gap-0.5 text-ink-subtle-text" title="at median">
+      <Minus className="size-3" aria-hidden />
+      <span className="sr-only">at median</span>
+    </span>
+  );
+}
+
+/**
+ * Per-UID emission yield for one subnet — the return-rate twin of the
+ * Concentration panel. Distribution summary (subnet aggregate, mean, median,
+ * p25/p75/p90), a validator/miner split, the ranked per-UID leaderboard (top
+ * yielders), and the daily yield-distribution drift. Mirrors the concentration/
+ * metagraph render primitives (StatTile / BarMini / Sparkline / table).
+ */
+export function YieldLoader({ netuid }: { netuid: number }) {
+  const { data } = useSuspenseQuery(subnetYieldQuery(netuid));
+  const meta = data.meta;
+  const y = data.data;
+  const neurons = y.neurons;
+
+  const hasData = neurons.length > 0 || y.subnet_yield != null;
+  if (!hasData) {
+    return (
+      <TableState
+        variant="empty"
+        title="No yield data"
+        description="Per-UID emission yield (emission ÷ stake) is computed live from the neuron snapshot and will appear here once the subnet has stake and emission on-chain."
+        generatedAt={meta?.generated_at}
+      />
+    );
+  }
+
+  // The API ranks high→low already; re-sort defensively (null yields sink).
+  // Plain const (not useMemo) — this runs after the early return above, so a
+  // hook here would violate the rules of hooks.
+  const ranked = [...neurons]
+    .sort((a, b) => (b.yield ?? Number.NEGATIVE_INFINITY) - (a.yield ?? Number.NEGATIVE_INFINITY))
+    .slice(0, TOP_N);
+
+  const splitBars = [
+    { label: "Validators", value: y.validator_count ?? 0, color: "var(--accent)" },
+    { label: "Miners", value: y.miner_count ?? 0, color: "var(--chart-1)" },
+  ].filter((b) => b.value > 0);
+
+  return (
+    <div className="space-y-4">
+      {/* KPI tiles — the headline return + central tendency. */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StatTile
+          icon={Percent}
+          eyebrow="Subnet yield"
+          value={fmtYield(y.subnet_yield)}
+          hint="emission ÷ stake"
+          tone="accent"
+        />
+        <StatTile
+          icon={Activity}
+          eyebrow="Median yield"
+          value={fmtYield(y.median_yield)}
+          hint={y.mean_yield != null ? `mean ${fmtYield(y.mean_yield)}` : undefined}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Validators / miners"
+          value={`${y.validator_count ?? "—"} / ${y.miner_count ?? "—"}`}
+          hint={`${y.neuron_count ?? neurons.length} UIDs`}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {/* Validator vs miner split. */}
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Validator / miner split
+          </div>
+          {splitBars.length ? (
+            <BarMini data={splitBars} />
+          ) : (
+            <p className="font-mono text-[11px] text-ink-muted">Not enough data yet.</p>
+          )}
+        </div>
+
+        {/* Yield percentile spread. */}
+        <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Fact label="p25" value={fmtYield(y.p25_yield)} />
+          <Fact label="Median" value={fmtYield(y.median_yield)} />
+          <Fact label="p75" value={fmtYield(y.p75_yield)} />
+          <Fact label="p90" value={fmtYield(y.p90_yield)} />
+        </div>
+      </div>
+
+      {/* Per-UID yield leaderboard (top yielders). */}
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+              <tr>
+                <th className="px-3 py-2.5 text-left">UID</th>
+                <th className="px-3 py-2.5 text-left">Hotkey</th>
+                <th className="px-3 py-2.5 text-left">Role</th>
+                <th className="px-3 py-2.5 text-right">Stake τ</th>
+                <th className="px-3 py-2.5 text-right">Emission τ</th>
+                <th className="px-3 py-2.5 text-right">Yield</th>
+                <th className="px-3 py-2.5 text-center">vs median</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ranked.map((n) => (
+                <tr key={n.uid} className="mg-row-hover border-t border-border/60">
+                  <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
+                    {n.uid}
+                  </td>
+                  <td className="px-3 py-2.5 font-mono text-[11px]">
+                    {n.hotkey ? (
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: n.hotkey }}
+                        className="text-ink-muted hover:text-ink hover:underline"
+                        title={n.hotkey}
+                      >
+                        {shortHash(n.hotkey) ?? n.hotkey}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5">
+                    {n.role === "validator" ? (
+                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                        Validator
+                      </span>
+                    ) : (
+                      <span className="font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                        Miner
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                    {taoCompact(n.stake_tao)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                    {taoCompact(n.emission_tao)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                    {fmtYield(n.yield)}
+                  </td>
+                  <td className="px-3 py-2.5 text-center">
+                    <VsMedian vs={n.vs_median} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          top {ranked.length} of {neurons.length} by yield · subnet {netuid}
+        </div>
+      </div>
+
+      {/* Daily yield-distribution drift. */}
+      <YieldDriftCard netuid={netuid} />
+    </div>
+  );
+}
+
+function YieldDriftCard({ netuid }: { netuid: number }) {
+  const [win, setWin] = useState<Win>("30d");
+  const { data: res, isLoading } = useQuery(subnetYieldHistoryQuery(netuid, win));
+  const points = useMemo<YieldHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
+
+  const series = useMemo(() => {
+    // History points arrive newest-first; reverse so the sparkline reads L→R in
+    // time. Null metrics (early window) are filtered per-series, not per-point.
+    const ordered = [...points].reverse();
+    const pick = (key: keyof YieldHistoryPoint) =>
+      ordered
+        .map((point) => point[key])
+        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    return {
+      subnet: pick("subnet_yield"),
+      median: pick("median_yield"),
+      p90: pick("p90_yield"),
+    };
+  }, [points]);
+
+  const hasData = series.subnet.length + series.median.length + series.p90.length > 0;
+
+  const toggle = (
+    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          onClick={() => setWin(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Yield drift
+        </span>
+        {toggle}
+      </div>
+      {isLoading ? (
+        <Skeleton className="h-28 w-full" />
+      ) : !hasData ? (
+        <EmptyState
+          title="No yield history"
+          description="Daily yield-distribution snapshots will appear here once enough chain history has accumulated."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          {series.subnet.length > 0 ? (
+            <DriftRow label="Subnet yield" series={series.subnet} color="var(--accent)" />
+          ) : null}
+          {series.median.length > 0 ? (
+            <DriftRow label="Median yield" series={series.median} color="var(--chart-1)" />
+          ) : null}
+          {series.p90.length > 0 ? (
+            <DriftRow label="p90 yield" series={series.p90} color="var(--health-warn)" />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DriftRow({ label, series, color }: { label: string; series: number[]; color: string }) {
+  const last = series[series.length - 1];
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
+        {label}
+      </span>
+      <div className="flex-1 min-w-0">
+        <Sparkline
+          values={series}
+          color={color}
+          width={220}
+          height={28}
+          formatValue={fmtYield}
+          ariaLabel={label}
+        />
+      </div>
+      <span className="w-20 shrink-0 text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
+        {last != null ? fmtYield(last) : "—"}
+      </span>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-yield.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-yield.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { subnetYieldQuery, subnetYieldHistoryQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/1/yield",
+  });
+}
+
+async function runYieldQuery(netuid = 1) {
+  const opts = subnetYieldQuery(netuid);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+async function runYieldHistoryQuery(netuid = 1, window: "7d" | "30d" | "90d" = "30d") {
+  const opts = subnetYieldHistoryQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+beforeEach(() => {
+  mockedApiFetch.mockReset();
+});
+
+describe("subnetYieldQuery", () => {
+  it("normalizes the distribution summary and per-UID rows", async () => {
+    resolveWith({
+      netuid: 1,
+      captured_at: "2026-07-05T00:00:00.000Z",
+      block_number: 8555404,
+      neuron_count: 3,
+      validator_count: 1,
+      miner_count: 2,
+      total_stake_tao: 100,
+      total_emission_tao: 2,
+      subnet_yield: 0.00003,
+      mean_yield: 0.004,
+      median_yield: 0.000016,
+      p25_yield: 0,
+      p75_yield: 0.0000164,
+      p90_yield: 0.0164,
+      neurons: [
+        {
+          uid: 176,
+          hotkey: "5CGSG3UgtPPoJ5QkMzM4BrqFQ4BwHjxRuAZRnzQs4Ek8DMgo",
+          role: "miner",
+          stake_tao: 19.53,
+          emission_tao: 1.15,
+          yield: 0.0589,
+          vs_median: "above",
+        },
+        {
+          uid: 4,
+          hotkey: null,
+          role: "validator",
+          stake_tao: 50,
+          emission_tao: 0.5,
+          yield: null,
+          vs_median: null,
+        },
+      ],
+    });
+
+    const res = await runYieldQuery(1);
+    expect(res.data.netuid).toBe(1);
+    expect(res.data.subnet_yield).toBe(0.00003);
+    expect(res.data.median_yield).toBe(0.000016);
+    expect(res.data.validator_count).toBe(1);
+    expect(res.data.miner_count).toBe(2);
+    expect(res.data.neurons).toHaveLength(2);
+    expect(res.data.neurons[0]).toMatchObject({
+      uid: 176,
+      role: "miner",
+      stake_tao: 19.53,
+      yield: 0.0589,
+      vs_median: "above",
+    });
+    // null-safe: missing hotkey → null, null yield preserved, unknown vs → null.
+    expect(res.data.neurons[1]).toMatchObject({
+      uid: 4,
+      hotkey: null,
+      role: "validator",
+      yield: null,
+      vs_median: null,
+    });
+  });
+
+  it("drops malformed neuron rows and coerces an unknown role to miner", async () => {
+    resolveWith({
+      netuid: 1,
+      neurons: [
+        { uid: 7, role: "weird", stake_tao: 1, emission_tao: 0.1, yield: 0.1, vs_median: "below" },
+        { hotkey: "no-uid" },
+        null,
+        42,
+      ],
+    });
+
+    const res = await runYieldQuery(1);
+    expect(res.data.neurons).toHaveLength(1);
+    expect(res.data.neurons[0]).toMatchObject({ uid: 7, role: "miner", vs_median: "below" });
+  });
+
+  it("returns a schema-stable empty shape for a cold subnet", async () => {
+    resolveWith({});
+    const res = await runYieldQuery(9);
+    expect(res.data.netuid).toBe(9);
+    expect(res.data.neurons).toEqual([]);
+    expect(res.data.subnet_yield).toBeNull();
+    expect(res.data.median_yield).toBeNull();
+  });
+});
+
+describe("subnetYieldHistoryQuery", () => {
+  it("normalizes points and drops entries without a snapshot_date", async () => {
+    resolveWith({
+      netuid: 1,
+      window: "30d",
+      point_count: 2,
+      points: [
+        {
+          snapshot_date: "2026-07-04",
+          neuron_count: 256,
+          validator_count: 9,
+          yield_count: 23,
+          subnet_yield: 0.0000323,
+          mean_yield: 0.0077,
+          median_yield: 0.0000159,
+          p25_yield: 0,
+          p75_yield: 0.0000164,
+          p90_yield: 0.0164,
+        },
+        { neuron_count: 100 },
+      ],
+    });
+
+    const res = await runYieldHistoryQuery(1, "30d");
+    expect(res.data.netuid).toBe(1);
+    expect(res.data.window).toBe("30d");
+    expect(res.data.points).toHaveLength(1);
+    expect(res.data.points[0]).toMatchObject({
+      snapshot_date: "2026-07-04",
+      subnet_yield: 0.0000323,
+      median_yield: 0.0000159,
+      yield_count: 23,
+    });
+  });
+
+  it("returns an empty series for a cold subnet", async () => {
+    resolveWith({ netuid: 5 });
+    const res = await runYieldHistoryQuery(5, "7d");
+    expect(res.data.points).toEqual([]);
+    expect(res.data.point_count).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -126,6 +126,10 @@ import type {
   SubnetPerformance,
   PerformanceHistoryPoint,
   SubnetPerformanceHistory,
+  SubnetYield,
+  SubnetYieldNeuron,
+  YieldHistoryPoint,
+  SubnetYieldHistory,
   SubnetProfile,
   Surface,
   SurfaceLatencyPercentiles,
@@ -3829,6 +3833,125 @@ export const subnetPerformanceHistoryQuery = (
         meta: res.meta,
         url: res.url,
       } as ApiResult<SubnetPerformanceHistory>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3478: per-UID emission yield (emission/stake return) for one subnet — the
+// return-rate twin of /concentration + /performance. A distribution summary
+// (subnet aggregate, mean, p25/median/p75/p90), a validator/miner split, and the
+// per-UID ranked rows, plus the daily distribution trend from /yield/history.
+function normalizeSubnetYieldNeuron(raw: unknown): SubnetYieldNeuron | undefined {
+  if (!isRecord(raw)) return undefined;
+  const uid = coerceFiniteNumber(raw.uid);
+  if (uid == null) return undefined;
+  const vs = raw.vs_median;
+  return {
+    uid,
+    hotkey: coerceString(raw.hotkey) ?? null,
+    role: raw.role === "validator" ? "validator" : "miner",
+    stake_tao: coerceFiniteNumber(raw.stake_tao) ?? 0,
+    emission_tao: coerceFiniteNumber(raw.emission_tao) ?? 0,
+    yield: coerceFiniteNumber(raw.yield) ?? null,
+    vs_median: vs === "above" || vs === "below" || vs === "at" ? vs : null,
+  };
+}
+
+function normalizeSubnetYield(netuid: number, raw: unknown): SubnetYield {
+  const d = isRecord(raw) ? raw : {};
+  const nullableNum = (v: unknown): number | null => coerceFiniteNumber(v) ?? null;
+  const neurons = Array.isArray(d.neurons)
+    ? d.neurons.slice(0, MAX_NEURON_ROWS).flatMap((n) => {
+        const normalized = normalizeSubnetYieldNeuron(n);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+    captured_at: coerceString(d.captured_at),
+    block_number: coerceFiniteNumber(d.block_number),
+    neuron_count: coerceFiniteNumber(d.neuron_count) ?? neurons.length,
+    validator_count: coerceFiniteNumber(d.validator_count),
+    miner_count: coerceFiniteNumber(d.miner_count),
+    total_stake_tao: coerceFiniteNumber(d.total_stake_tao),
+    total_emission_tao: coerceFiniteNumber(d.total_emission_tao),
+    subnet_yield: nullableNum(d.subnet_yield),
+    mean_yield: nullableNum(d.mean_yield),
+    median_yield: nullableNum(d.median_yield),
+    p25_yield: nullableNum(d.p25_yield),
+    p75_yield: nullableNum(d.p75_yield),
+    p90_yield: nullableNum(d.p90_yield),
+    neurons,
+  };
+}
+
+function normalizeYieldHistoryPoint(raw: unknown): YieldHistoryPoint | undefined {
+  if (!isRecord(raw)) return undefined;
+  const snapshotDate = coerceString(raw.snapshot_date);
+  if (!snapshotDate) return undefined;
+  const nullableNum = (v: unknown): number | null => coerceFiniteNumber(v) ?? null;
+  return {
+    ...(raw as object),
+    snapshot_date: snapshotDate,
+    neuron_count: coerceFiniteNumber(raw.neuron_count),
+    validator_count: coerceFiniteNumber(raw.validator_count),
+    yield_count: coerceFiniteNumber(raw.yield_count),
+    subnet_yield: nullableNum(raw.subnet_yield),
+    mean_yield: nullableNum(raw.mean_yield),
+    median_yield: nullableNum(raw.median_yield),
+    p25_yield: nullableNum(raw.p25_yield),
+    p75_yield: nullableNum(raw.p75_yield),
+    p90_yield: nullableNum(raw.p90_yield),
+  };
+}
+
+function normalizeSubnetYieldHistory(netuid: number, raw: unknown): SubnetYieldHistory {
+  const d = isRecord(raw) ? raw : {};
+  const points = Array.isArray(d.points)
+    ? d.points.slice(-MAX_HISTORY_POINTS).flatMap((point) => {
+        const normalized = normalizeYieldHistoryPoint(point);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+    window: coerceString(d.window),
+    point_count: coerceFiniteNumber(d.point_count) ?? points.length,
+    points,
+  };
+}
+
+/** Per-UID emission-yield snapshot (distribution summary, validator/miner split, ranked rows). */
+export const subnetYieldQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-yield", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetYield>>(`/api/v1/subnets/${netuid}/yield`, {
+        signal,
+      });
+      return {
+        data: normalizeSubnetYield(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetYield>;
+    },
+    staleTime: STALE_MED,
+  });
+
+/** Daily emission-yield distribution drift (subnet/mean/median/percentile yields). */
+export const subnetYieldHistoryQuery = (netuid: number, window: "7d" | "30d" | "90d" = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-yield-history", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetYieldHistory>>(
+        `/api/v1/subnets/${netuid}/yield/history`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetYieldHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetYieldHistory>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1502,6 +1502,59 @@ export interface SubnetPerformanceHistory {
   points: PerformanceHistoryPoint[];
 }
 
+/** One per-UID emission-yield row from /api/v1/subnets/{netuid}/yield. */
+export interface SubnetYieldNeuron {
+  uid: number;
+  hotkey: string | null;
+  role: "validator" | "miner";
+  stake_tao: number;
+  emission_tao: number;
+  yield: number | null;
+  vs_median: "above" | "below" | "at" | null;
+}
+
+/** Per-UID emission-yield snapshot from /api/v1/subnets/{netuid}/yield. */
+export interface SubnetYield {
+  netuid: number;
+  captured_at?: string;
+  block_number?: number;
+  neuron_count?: number;
+  validator_count?: number;
+  miner_count?: number;
+  total_stake_tao?: number;
+  total_emission_tao?: number;
+  subnet_yield?: number | null;
+  mean_yield?: number | null;
+  median_yield?: number | null;
+  p25_yield?: number | null;
+  p75_yield?: number | null;
+  p90_yield?: number | null;
+  neurons: SubnetYieldNeuron[];
+}
+
+/** One daily yield-distribution point from /yield/history. */
+export interface YieldHistoryPoint {
+  snapshot_date: string;
+  neuron_count?: number;
+  validator_count?: number;
+  yield_count?: number;
+  subnet_yield?: number | null;
+  mean_yield?: number | null;
+  median_yield?: number | null;
+  p25_yield?: number | null;
+  p75_yield?: number | null;
+  p90_yield?: number | null;
+  [key: string]: unknown;
+}
+
+/** Emission-yield drift from /api/v1/subnets/{netuid}/yield/history. */
+export interface SubnetYieldHistory {
+  netuid: number;
+  window?: string;
+  point_count?: number;
+  points: YieldHistoryPoint[];
+}
+
 // --- Compile-time contract enforcement ---------------------------------------
 //
 // These are type-only assertions (zero runtime cost). They tie this file's UI

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -29,6 +29,7 @@ import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-char
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
+import { YieldLoader } from "@/components/metagraphed/yield-panel";
 import { NeuronDetailCard } from "@/components/metagraphed/neuron-detail-card";
 import { NeuronHistoryChart } from "@/components/metagraphed/neuron-history-chart";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
@@ -163,6 +164,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   metagraph: "metagraph",
   neuron: "metagraph",
   concentration: "metagraph",
+  yield: "metagraph",
   validators: "validators",
   services: "services",
   "agent-readiness": "services",
@@ -818,6 +820,19 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
       >
         <QueryErrorBoundary>
           <DistributionPanel netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="yield"
+        title="Yield"
+        subtitle="Per-UID emission yield (emission ÷ stake return rate): distribution summary, validator/miner split, and the ranked neuron leaderboard with daily drift."
+        info="GET /api/v1/subnets/{netuid}/yield and /yield/history — the return-rate twin of concentration, computed per-UID from the live neuron snapshot."
+      >
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+            <YieldLoader netuid={netuid} />
+          </Suspense>
         </QueryErrorBoundary>
       </SectionAnchor>
     </div>


### PR DESCRIPTION
Closes #3478

Wires the previously-unconsumed `GET /api/v1/subnets/{netuid}/yield` (+ `/history`) into a **Yield** section on the subnet profile page -- the return-rate twin of the existing Concentration panel. No new endpoint; it surfaces existing live data.

## What it shows
- Distribution summary KPIs: subnet aggregate yield, median (+ mean), validator/miner counts.
- Validator/miner split bar and the yield percentile spread (p25 / median / p75 / p90).
- Ranked per-UID leaderboard (top yielders) -- role badge, stake, emission, yield %, and an above/below-median indicator; hotkeys link to their account pages.
- Daily yield drift (subnet / median / p90) with a 7d/30d/90d window toggle.

Mirrors the Concentration/Performance normalizer + query + render pattern and reuses the shared `StatTile` / `BarMini` / `Sparkline` / neuron-table primitives. The contract documents `/yield/history` as "the return-rate twin of /concentration/history."

## Files
- `types.ts`: `SubnetYield`, `SubnetYieldNeuron`, `YieldHistoryPoint`, `SubnetYieldHistory`
- `queries.ts`: `subnetYieldQuery` + `subnetYieldHistoryQuery` with null-safe normalizers
- `yield-panel.tsx`: `YieldLoader` (new)
- `subnets.$netuid.tsx`: mounts the Yield section in the Metagraph tab (+ deep-link registration)
- `queries.subnet-yield.test.ts`: normalizer coverage (snapshot + history)

## Verification
`tsc --noEmit`, ESLint (0 errors), Prettier, and the full vitest suite (388 tests incl. 5 new) all pass; verified against live `api.metagraph.sh` (subnet 1).

## Screenshots

**Desktop (1280x900)** -- Before / After

![before desktop](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/subnet-yield-screenshots/before-desktop.png)
![after desktop](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/subnet-yield-screenshots/after-desktop.png)

**Mobile (390x844)** -- Before / After

![before mobile](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/subnet-yield-screenshots/before-mobile.png)
![after mobile](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/subnet-yield-screenshots/after-mobile.png)

_BEFORE = `upstream/main`: the Metagraph tab ended at Concentration -- no Yield section. AFTER: the new Yield section (per-UID emission yield) added right below it._
