### PR TITLE
feat(registry): add Bitsota disclaimer API surface (SN94)

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -135,6 +135,31 @@
         "https://bitsota.ai/docs/autoresearch-backend-routes"
       ],
       "url": "https://autoresearch.bitsota.com/api/v1/claims"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-disclaimer-api",
+      "kind": "subnet-api",
+      "name": "Bitsota disclaimer API",
+      "notes": "Public no-auth GET returning the Bitsota no-reward-guarantee disclaimer payload (code, version, title, summary, must_display, url). Documented in the subnet's own OpenAPI (autoresearch.bitsota.com/openapi.json, path /api/v1/disclaimer); same host as the existing tasks, dashboard, and claims surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://autoresearch.bitsota.com/openapi.json",
+        "https://bitsota.ai/docs/autoresearch-backend-routes"
+      ],
+      "url": "https://autoresearch.bitsota.com/api/v1/disclaimer"
     }
   ],
   "contact": "info@bitsota.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/bitsota.json`.

Closes #591

## Surface

- Netuid: 94
- Kind: subnet-api
- Public URL: https://autoresearch.bitsota.com/api/v1/disclaimer
- Source URL (proves the claim): https://autoresearch.bitsota.com/openapi.json
- Provider slug: alveus-labs

## Checklist

- [x] Changes exactly one `registry/subnets/bitsota.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #591`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3688 (NexisGen) | `nexisgen.json`, provider only | No |
| #3687, #3684 | apps/ui, workflow | No |
| #3594, #3546 | release/README | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitsota.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/bitsota.json`


Made with [Cursor](https://cursor.com)