### PR TITLE
refactor(ui): centralize health-status color fallbacks in a shared token helper

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -9,6 +9,7 @@ import { BrandIcon } from "./brand-icon";
 import { safeExternalUrl } from "./external-link";
 import { Sparkline } from "./charts/sparkline";
 import { useCopy } from "@/hooks/use-copy";
+import { healthColorVar } from "@/lib/health-tokens";
 import { classNames } from "@/lib/metagraphed/format";
 import {
   endpointCategory,
@@ -414,10 +415,10 @@ function HeaderHint({ label, hint }: { label: string; hint: string }) {
 
 function healthColor(state?: HealthState | string): string {
   const s = (state ?? "unknown") as string;
-  if (s === "ok") return "var(--health-ok, #16a34a)";
-  if (s === "warn" || s === "degraded") return "var(--health-warn, #d97706)";
-  if (s === "down" || s === "offline") return "var(--health-down, #dc2626)";
-  return "var(--health-unknown, #94a3b8)";
+  if (s === "ok") return healthColorVar("ok");
+  if (s === "warn" || s === "degraded") return healthColorVar("warn");
+  if (s === "down" || s === "offline") return healthColorVar("down");
+  return healthColorVar("unknown");
 }
 
 /**

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
 
@@ -87,14 +88,14 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
             <HistoryRow
               label="Validators"
               series={series.validators}
-              color="var(--health-ok, #4ade80)"
+              color={healthColorVar("ok")}
             />
           ) : null}
           {series.stake.length > 0 ? (
             <HistoryRow
               label="Total stake"
               series={series.stake}
-              color="var(--health-warn, #fbbf24)"
+              color={healthColorVar("warn")}
               format={taoStr}
             />
           ) : null}

--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -5,10 +5,11 @@ import { Coins } from "lucide-react";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { economicsQuery, subnetsQuery, subnetTrajectoryQuery } from "@/lib/metagraphed/queries";
+import { healthColorVar } from "@/lib/health-tokens";
 import type { Subnet } from "@/lib/metagraphed/types";
 
-const UP = "var(--health-ok, #4ade80)";
-const DOWN = "var(--health-down, #ef4444)";
+const UP = healthColorVar("ok");
+const DOWN = healthColorVar("down");
 const FLAT = "var(--ink-muted, #8a8f98)";
 
 function priceStr(v?: number) {

--- a/apps/ui/src/lib/health-tokens.test.ts
+++ b/apps/ui/src/lib/health-tokens.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { HEALTH_TOKEN_FALLBACK, healthColorVar, type HealthTone } from "./health-tokens";
+
+describe("healthColorVar", () => {
+  it("returns the canonical var() with the one agreed fallback per tier", () => {
+    expect(healthColorVar("ok")).toBe("var(--health-ok, #22c55e)");
+    expect(healthColorVar("warn")).toBe("var(--health-warn, #f59e0b)");
+    expect(healthColorVar("down")).toBe("var(--health-down, #ef4444)");
+    expect(healthColorVar("unknown")).toBe("var(--health-unknown, #94a3b8)");
+  });
+
+  it("always references the same token name it falls back for", () => {
+    const tones: HealthTone[] = ["ok", "warn", "down", "unknown"];
+    for (const tone of tones) {
+      expect(healthColorVar(tone)).toBe(`var(--health-${tone}, ${HEALTH_TOKEN_FALLBACK[tone]})`);
+    }
+  });
+});

--- a/apps/ui/src/lib/health-tokens.ts
+++ b/apps/ui/src/lib/health-tokens.ts
@@ -1,0 +1,25 @@
+// Single source of truth for the health-status color CSS custom properties.
+// styles.css (and the runtime palette in health-palette.ts) owns the real token
+// values; a `var(--health-*, <fallback>)` reference only uses the fallback hex on
+// the vanishingly rare occasion the token is absent — it is otherwise inert.
+//
+// Consumers (endpoint-list, subnet-history-chart, subnet-price-ticker,
+// health-segments, …) each previously re-declared their OWN fallback hex for the
+// same token, and those hexes disagreed (#3458): `--health-ok` was written as
+// `#16a34a`, `#4ade80`, and `#22c55e` across files. This centralizes one agreed
+// fallback per tier so they can never drift again.
+
+export type HealthTone = "ok" | "warn" | "down" | "unknown";
+
+/** The one agreed fallback hex per health tier (Tailwind 500 / slate-400). */
+export const HEALTH_TOKEN_FALLBACK: Record<HealthTone, string> = {
+  ok: "#22c55e",
+  warn: "#f59e0b",
+  down: "#ef4444",
+  unknown: "#94a3b8",
+};
+
+/** `var(--health-<tone>, <fallback>)` — the canonical color reference for a tier. */
+export function healthColorVar(tone: HealthTone): string {
+  return `var(--health-${tone}, ${HEALTH_TOKEN_FALLBACK[tone]})`;
+}

--- a/apps/ui/src/lib/metagraphed/health-segments.ts
+++ b/apps/ui/src/lib/metagraphed/health-segments.ts
@@ -4,6 +4,8 @@
 // sync (#3459). The only per-page difference is the middle tier's label ("Degraded" on /status vs
 // "Warn" on /providers), so that stays a parameter; everything else is centralised here.
 
+import { healthColorVar } from "@/lib/health-tokens";
+
 export interface HealthStatusCounts {
   ok: number;
   warn: number;
@@ -22,13 +24,13 @@ export function healthStatusSegments(
   options: { warnLabel?: string } = {},
 ): HealthStatusSegment[] {
   return [
-    { label: "OK", value: counts.ok, color: "var(--health-ok, #22c55e)" },
+    { label: "OK", value: counts.ok, color: healthColorVar("ok") },
     {
       label: options.warnLabel ?? "Degraded",
       value: counts.warn,
-      color: "var(--health-warn, #f59e0b)",
+      color: healthColorVar("warn"),
     },
-    { label: "Down", value: counts.down, color: "var(--health-down, #ef4444)" },
+    { label: "Down", value: counts.down, color: healthColorVar("down") },
     { label: "Unknown", value: counts.unknown, color: "var(--ink-muted, #94a3b8)" },
   ].filter((s) => s.value > 0);
 }


### PR DESCRIPTION
## Summary

Closes #3458

Adds `lib/health-tokens.ts` as the single source of truth for health color CSS variables and fallback values.

Previously, multiple files independently declared `var(--health-*, fallback)` with inconsistent fallback colors despite `styles.css` already defining a canonical token for each health state. This PR centralizes those definitions and updates existing consumers to use a shared helper.

**No visual change is expected.** The fallback colors are never used during normal rendering because the corresponding CSS variables are always defined.

## What Changed

### New shared helper

Added:

- `lib/health-tokens.ts`

Exports:

- `healthColorVar(tone)`
- `HEALTH_TOKEN_FALLBACK`

This provides a single canonical mapping for:

- `ok`
- `warn`
- `down`
- `unknown`

using the existing Tailwind-500 palette.

### Updated consumers

Replaced inline `var(--health-*, fallback)` declarations with `healthColorVar(...)` in:

- `endpoint-list.tsx`
- `subnet-history-chart.tsx`
- `subnet-price-ticker.tsx`
- `health-segments.ts`

This removes duplicated fallback values and keeps all health color references consistent.

## Rendering Impact

There is **no rendered or behavioral change**.

The fallback hex values are effectively inert because:

- `styles.css` always defines the `--health-*` CSS variables.
- Runtime palette overrides continue to be supplied by `health-palette.ts`.

As a result, every `var(--health-*, fallback)` resolves to the CSS variable rather than the fallback color.

This PR only:

- centralizes fallback definitions
- removes duplicated constants
- introduces a shared helper

Accordingly, no before/after screenshots are applicable.

## Tests

- Added `health-tokens.test.ts`.
- Existing `health-segments.test.ts` remains unchanged, as the helper produces the same CSS variable strings previously asserted.

## Validation

All `apps/ui` checks pass:

- ✅ `npm run lint --workspace=apps/ui`
- ✅ `npm run format:check --workspace=apps/ui`
- ✅ `npm run typecheck --workspace=apps/ui`
- ✅ `npm test --workspace=apps/ui` (health suite: 27 passing)
- ✅ `npm run build --workspace=apps/ui`
