### PR TITLE
feat(registry): add Vidaio API readiness health surface (SN85)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -143,6 +143,25 @@
         "https://vidaio.io/"
       ],
       "url": "https://api.vidaio.io/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-85-vidaio-ready",
+      "kind": "subnet-api",
+      "name": "Vidaio API readiness health",
+      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint.",
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.vidaio.io/openapi.json",
+        "https://vidaio.io/"
+      ],
+      "url": "https://api.vidaio.io/ready"
     }
   ],
   "website_url": "https://vidaio.io/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/vidaio.json`.

Closes #703

## Surface

- Netuid: 85
- Kind: subnet-api
- Public URL: https://api.vidaio.io/ready
- Source URL (proves the claim): https://api.vidaio.io/openapi.json
- Provider slug: vidaio

## Checklist

- [x] Changes exactly one `registry/subnets/vidaio.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #703`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3690, #3687 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/vidaio.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/vidaio.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/vidaio.json`


Made with [Cursor](https://cursor.com)