### PR TITLE
feat(ui): add typed data layer for blocks summary (#3488)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { blocksSummaryQuery, normalizeBlocksSummary } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/blocks/summary",
+  });
+}
+
+async function runQuery() {
+  const opts = blocksSummaryQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeBlocksSummary", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeBlocksSummary({
+        schema_version: 1,
+        block_count: 5,
+        first_block: 100,
+        last_block: 110,
+        first_observed_at: "2026-07-01T00:00:00Z",
+        last_observed_at: "2026-07-01T00:02:00Z",
+        distinct_authors: 2,
+        distinct_spec_versions: 2,
+        latest_spec_version: 201,
+        block_time: {
+          count: 3,
+          mean_ms: 12000,
+          min_ms: 12000,
+          max_ms: 12000,
+          p50_ms: 12000,
+          p90_ms: 12000,
+        },
+        throughput: {
+          total_extrinsics: 11,
+          total_events: 42,
+          mean_extrinsics_per_block: 2.2,
+          mean_events_per_block: 8.4,
+          max_extrinsics_in_block: 5,
+        },
+        author_concentration: {
+          holders: 2,
+          total: 4,
+          nakamoto_coefficient: 1,
+        },
+      }),
+    ).toEqual({
+      schema_version: 1,
+      block_count: 5,
+      first_block: 100,
+      last_block: 110,
+      first_observed_at: "2026-07-01T00:00:00Z",
+      last_observed_at: "2026-07-01T00:02:00Z",
+      distinct_authors: 2,
+      distinct_spec_versions: 2,
+      latest_spec_version: 201,
+      block_time: {
+        count: 3,
+        mean_ms: 12000,
+        min_ms: 12000,
+        max_ms: 12000,
+        p50_ms: 12000,
+        p90_ms: 12000,
+      },
+      throughput: {
+        total_extrinsics: 11,
+        total_events: 42,
+        mean_extrinsics_per_block: 2.2,
+        mean_events_per_block: 8.4,
+        max_extrinsics_in_block: 5,
+      },
+      author_concentration: {
+        holders: 2,
+        total: 4,
+        nakamoto_coefficient: 1,
+      },
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { block_count: "nope" }]) {
+      const card = normalizeBlocksSummary(raw);
+      expect(card.block_count).toBe(0);
+      expect(card.block_time).toBeNull();
+      expect(card.throughput).toBeNull();
+      expect(card.author_concentration).toBeNull();
+    }
+  });
+
+  it("nulls block_time when count is below two and drops junk concentration", () => {
+    const card = normalizeBlocksSummary({
+      block_time: { count: 1, mean_ms: 1000 },
+      author_concentration: { holders: 0 },
+    });
+    expect(card.block_time).toBeNull();
+    expect(card.author_concentration).toBeNull();
+  });
+});
+
+describe("blocksSummaryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches /api/v1/blocks/summary and normalizes the card", async () => {
+    resolveWith({ block_count: 3, distinct_authors: 2 });
+    const res = await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/blocks/summary", expect.any(Object));
+    expect(res.data.block_count).toBe(3);
+    expect(res.data.distinct_authors).toBe(2);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -48,6 +48,9 @@ import type {
   ChainFeePayer,
   ChainTransferPair,
   ChainTransferPairs,
+  BlockTimeDistribution,
+  BlocksSummary,
+  BlocksSummaryThroughput,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -2455,6 +2458,63 @@ export const chainTransferPairsQuery = (
       };
     },
     staleTime: STALE_MED,
+  });
+
+function normalizeBlockTimeDistribution(raw: unknown): BlockTimeDistribution | null {
+  if (!isRecord(raw)) return null;
+  const count = firstFiniteNumber(raw.count) ?? 0;
+  if (count < 2) return null;
+  return {
+    count,
+    mean_ms: firstFiniteNumber(raw.mean_ms) ?? null,
+    min_ms: firstFiniteNumber(raw.min_ms) ?? null,
+    max_ms: firstFiniteNumber(raw.max_ms) ?? null,
+    p50_ms: firstFiniteNumber(raw.p50_ms) ?? null,
+    p90_ms: firstFiniteNumber(raw.p90_ms) ?? null,
+  };
+}
+
+function normalizeBlocksSummaryThroughput(raw: unknown): BlocksSummaryThroughput | null {
+  if (!isRecord(raw)) return null;
+  return {
+    total_extrinsics: firstFiniteNumber(raw.total_extrinsics) ?? 0,
+    total_events: firstFiniteNumber(raw.total_events) ?? 0,
+    mean_extrinsics_per_block: firstFiniteNumber(raw.mean_extrinsics_per_block) ?? null,
+    mean_events_per_block: firstFiniteNumber(raw.mean_events_per_block) ?? null,
+    max_extrinsics_in_block: firstFiniteNumber(raw.max_extrinsics_in_block) ?? 0,
+  };
+}
+
+export function normalizeBlocksSummary(raw: unknown): BlocksSummary {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    block_count: firstFiniteNumber(rec.block_count) ?? 0,
+    first_block: firstFiniteNumber(rec.first_block) ?? null,
+    last_block: firstFiniteNumber(rec.last_block) ?? null,
+    first_observed_at: firstString(rec.first_observed_at) ?? null,
+    last_observed_at: firstString(rec.last_observed_at) ?? null,
+    distinct_authors: firstFiniteNumber(rec.distinct_authors) ?? 0,
+    distinct_spec_versions: firstFiniteNumber(rec.distinct_spec_versions) ?? 0,
+    latest_spec_version: firstFiniteNumber(rec.latest_spec_version) ?? null,
+    block_time: normalizeBlockTimeDistribution(rec.block_time),
+    throughput: normalizeBlocksSummaryThroughput(rec.throughput),
+    author_concentration: normalizeConcentrationMetricsOrNull(rec.author_concentration),
+  };
+}
+
+export const blocksSummaryQuery = () =>
+  queryOptions({
+    queryKey: k("blocks-summary"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<BlocksSummary>>("/api/v1/blocks/summary", { signal });
+      return {
+        data: normalizeBlocksSummary(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
   });
 
 const READINESS_COMPONENT_KEYS = [

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1658,6 +1658,45 @@ export interface ChainTransferPairs {
   pairs: ChainTransferPair[];
 }
 
+/** Inter-block interval distribution over consecutive blocks (#3488). */
+export interface BlockTimeDistribution {
+  count: number;
+  mean_ms: number | null;
+  min_ms: number | null;
+  max_ms: number | null;
+  p50_ms: number | null;
+  p90_ms: number | null;
+}
+
+/** Extrinsic/event throughput rollup for the blocks summary window (#3488). */
+export interface BlocksSummaryThroughput {
+  total_extrinsics: number;
+  total_events: number;
+  mean_extrinsics_per_block: number | null;
+  mean_events_per_block: number | null;
+  max_extrinsics_in_block: number;
+}
+
+/**
+ * Block-production analytics over recent blocks (#3488), from
+ * GET /api/v1/blocks/summary — inter-block timing, throughput, author
+ * decentralization, and spec-version spread. Zeroed when the store is cold.
+ */
+export interface BlocksSummary {
+  schema_version: number;
+  block_count: number;
+  first_block: number | null;
+  last_block: number | null;
+  first_observed_at: string | null;
+  last_observed_at: string | null;
+  distinct_authors: number;
+  distinct_spec_versions: number;
+  latest_spec_version: number | null;
+  block_time: BlockTimeDistribution | null;
+  throughput: BlocksSummaryThroughput | null;
+  author_concentration: ConcentrationMetrics | null;
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;


### PR DESCRIPTION
## Summary
- Add BlocksSummary types and normalizeBlocksSummary for GET /api/v1/blocks/summary
- Add blocksSummaryQuery() with defensive coercion for block time, throughput, and author concentration
- Vitest coverage for pass-through, cold/junk degradation, and query wiring

Lib-only data layer — no route/component changes.

Closes #3488

## Test plan
- [x] npx vitest run src/lib/metagraphed/queries.blocks-summary.test.ts