### PR TITLE
fix(ui): preserve scroll when updating table search filters

### DIFF
--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { joinHealth, matchesQuery, sortBy, paginate } from "./url-state";
+import { joinHealth, matchesQuery, sortBy, paginate, TABLE_FILTER_NAV_OPTS } from "./url-state";
 
 describe("matchesQuery", () => {
   it("matches everything for an empty needle", () => {
@@ -115,5 +115,11 @@ describe("paginate", () => {
 
   it("returns an empty slice past the end", () => {
     expect(paginate(rows, 4, 3)).toEqual([]);
+  });
+});
+
+describe("TABLE_FILTER_NAV_OPTS", () => {
+  it("opts table filter navigations out of TanStack Router scroll reset (#3691)", () => {
+    expect(TABLE_FILTER_NAV_OPTS).toEqual({ resetScroll: false });
   });
 });

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -78,3 +78,6 @@ export function joinHealth<
     return h ? { ...s, health: h.health, updated_at: s.updated_at ?? h.last_checked } : s;
   });
 }
+
+/** TanStack Router scrolls to (0,0) on every navigate by default; table filter setters opt out (#3691). */
+export const TABLE_FILTER_NAV_OPTS = { resetScroll: false } as const;

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
+import { TABLE_FILTER_NAV_OPTS } from "@/lib/metagraphed/url-state";
 import { extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -107,7 +108,10 @@ function ExtrinsicsTable() {
   const hasNext = rows.length === search.limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      ...TABLE_FILTER_NAV_OPTS,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+    });
 
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -40,7 +40,13 @@ import {
   agentCatalogMapQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
-import { joinHealth, matchesQuery, sortBy, tableSearchSchema } from "@/lib/metagraphed/url-state";
+import {
+  joinHealth,
+  matchesQuery,
+  sortBy,
+  TABLE_FILTER_NAV_OPTS,
+  tableSearchSchema,
+} from "@/lib/metagraphed/url-state";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { AgentCatalogSummary, Subnet } from "@/lib/metagraphed/types";
 
@@ -282,11 +288,13 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
+      ...TABLE_FILTER_NAV_OPTS,
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
     });
 
   const onSort = (field: string) =>
     navigate({
+      ...TABLE_FILTER_NAV_OPTS,
       search: (prev: { sort?: string; order?: "asc" | "desc" }) =>
         ({
           ...prev,

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -32,7 +32,12 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
 import { surfacesInfiniteQuery, providersQuery, subnetsQuery } from "@/lib/metagraphed/queries";
-import { matchesQuery, sortBy, tableSearchSchema } from "@/lib/metagraphed/url-state";
+import {
+  matchesQuery,
+  sortBy,
+  TABLE_FILTER_NAV_OPTS,
+  tableSearchSchema,
+} from "@/lib/metagraphed/url-state";
 import type { Surface, Provider, Subnet } from "@/lib/metagraphed/types";
 
 export const Route = createFileRoute("/surfaces")({
@@ -180,11 +185,13 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
+      ...TABLE_FILTER_NAV_OPTS,
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
     });
 
   const onSort = (field: string) =>
     navigate({
+      ...TABLE_FILTER_NAV_OPTS,
       search: (prev: { sort?: string; order?: "asc" | "desc" }) =>
         ({
           ...prev,


### PR DESCRIPTION
Closes #3691

Typing into table search boxes was scrolling the page to the top on every keystroke because `navigate()` defaults `resetScroll: true`.

- Adds `TABLE_FILTER_NAV_OPTS` in `url-state.ts` for filter/sort navigations
- Applies it to `setSearch` / `onSort` on `/subnets`, `/surfaces`, and `/extrinsics` (the three confirmed repro pages)


Made with [Cursor](https://cursor.com)