### PR TITLE
feat(registry): add Aurelius Central API liveness health surface (SN37)

### DIFF
--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -86,6 +86,25 @@
         "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md"
       ],
       "url": "https://new-collector-api-production.up.railway.app/work-token/designated-address"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-37-aurelius-health-live",
+      "kind": "subnet-api",
+      "name": "Aurelius Central API liveness health",
+      "notes": "Public no-auth GET /health/live returning {\"status\":\"ok\"} for lightweight liveness checks. Documented in the subnet's own OpenAPI (new-collector-api-production.up.railway.app/openapi.json, path /health/live); same host as the existing openapi, docs, /health, and work-token subnet-api surfaces. Distinct from the richer /health endpoint that reports db, db_pool, classifier, and novelty subsystems.",
+      "provider": "aurelius",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://new-collector-api-production.up.railway.app/openapi.json",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md"
+      ],
+      "url": "https://new-collector-api-production.up.railway.app/health/live"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/aurelius.json`.

Closes #582

## Surface

- Netuid: 37
- Kind: subnet-api
- Public URL: https://new-collector-api-production.up.railway.app/health/live
- Source URL (proves the claim): https://new-collector-api-production.up.railway.app/openapi.json
- Provider slug: aurelius

## Checklist

- [x] Changes exactly one `registry/subnets/aurelius.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #582`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3696, #3690 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/aurelius.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/aurelius.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/aurelius.json`


Made with [Cursor](https://cursor.com)