### PR TITLE
fix(ui): drop exhaustive-deps disable in TimeRangeProvider

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/time-range-context.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 export type TimeRange = "1h" | "24h" | "7d" | "30d";
 
@@ -44,11 +44,14 @@ export function TimeRangeProvider({
 }) {
   const [internal, setInternal] = useState<TimeRange>(defaultRange);
   const range = value ?? internal;
-  const setRange = (r: TimeRange) => {
-    if (onChange) onChange(r);
-    else setInternal(r);
-  };
-  const ctx = useMemo(() => ({ range, setRange }), [range]); // eslint-disable-line react-hooks/exhaustive-deps
+  const setRange = useCallback(
+    (r: TimeRange) => {
+      if (onChange) onChange(r);
+      else setInternal(r);
+    },
+    [onChange],
+  );
+  const ctx = useMemo(() => ({ range, setRange }), [range, setRange]);
   return <TimeRangeCtx.Provider value={ctx}>{children}</TimeRangeCtx.Provider>;
 }
 


### PR DESCRIPTION
Closes #3460

Removes the `react-hooks/exhaustive-deps` suppression in `time-range-context.tsx` by wrapping `setRange` in `useCallback` and listing it in the provider `useMemo` deps.


Made with [Cursor](https://cursor.com)