### PR TITLE
feat(ui): add native-TAO transfers leaderboard to explorer (#3475)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-transfers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-transfers.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainTransfersQuery, normalizeChainTransfers } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/transfers",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainTransfersQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainTransfers", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeChainTransfers({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        total_volume_tao: 100,
+        transfer_count: 10,
+        unique_senders: 4,
+        unique_receivers: 6,
+        top_sender_share: 0.8,
+        top_senders: [
+          {
+            address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            volume_tao: 80,
+            transfer_count: 5,
+          },
+        ],
+        top_receivers: [
+          {
+            address: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+            volume_tao: 60,
+            transfer_count: 4,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      total_volume_tao: 100,
+      transfer_count: 10,
+      unique_senders: 4,
+      unique_receivers: 6,
+      top_sender_share: 0.8,
+      top_senders: [
+        {
+          address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+          volume_tao: 80,
+          transfer_count: 5,
+        },
+      ],
+      top_receivers: [
+        {
+          address: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+          volume_tao: 60,
+          transfer_count: 4,
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { unique_senders: "nope" }]) {
+      const card = normalizeChainTransfers(raw);
+      expect(card.unique_senders).toBe(0);
+      expect(card.unique_receivers).toBe(0);
+      expect(card.top_senders).toEqual([]);
+      expect(card.top_receivers).toEqual([]);
+      expect(card.top_sender_share).toBeNull();
+    }
+  });
+
+  it("drops malformed leaderboard rows and coerces a junk share to null", () => {
+    const card = normalizeChainTransfers({
+      top_sender_share: { pct: 1 },
+      top_senders: [
+        { address: "not-ss58" },
+        { address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", volume_tao: 1 },
+      ],
+    });
+    expect(card.top_senders).toHaveLength(1);
+    expect(card.top_sender_share).toBeNull();
+  });
+});
+
+describe("chainTransfersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the card", async () => {
+    resolveWith({
+      window: "7d",
+      unique_senders: 2,
+      top_senders: [
+        {
+          address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+          volume_tao: 3,
+          transfer_count: 1,
+        },
+      ],
+    });
+    const res = await runQuery("7d", 5);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/transfers",
+      expect.objectContaining({ params: { window: "7d", limit: 5 } }),
+    );
+    expect(res.data.unique_senders).toBe(2);
+    expect(res.data.top_senders).toHaveLength(1);
+  });
+
+  it("defaults to the 30d window and limit 25", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/transfers",
+      expect.objectContaining({ params: { window: "30d", limit: 25 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -48,6 +48,8 @@ import type {
   ChainFeePayer,
   ChainTransferPair,
   ChainTransferPairs,
+  ChainTransferParty,
+  ChainTransfers,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -174,6 +176,7 @@ const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
+const MAX_CHAIN_TRANSFER_PARTIES = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -2450,6 +2453,58 @@ export const chainTransferPairsQuery = (
       });
       return {
         data: normalizeChainTransferPairs(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainTransferParty(raw: unknown): ChainTransferParty | null {
+  if (!isRecord(raw)) return null;
+  const address = firstString(raw.address);
+  if (!address || !isValidSs58(address)) return null;
+  return {
+    address: address.trim(),
+    volume_tao: firstFiniteNumber(raw.volume_tao) ?? 0,
+    transfer_count: firstFiniteNumber(raw.transfer_count) ?? 0,
+  };
+}
+
+export function normalizeChainTransfers(raw: unknown): ChainTransfers {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    total_volume_tao: firstFiniteNumber(rec.total_volume_tao) ?? 0,
+    transfer_count: firstFiniteNumber(rec.transfer_count) ?? 0,
+    unique_senders: firstFiniteNumber(rec.unique_senders) ?? 0,
+    unique_receivers: firstFiniteNumber(rec.unique_receivers) ?? 0,
+    top_sender_share: firstFiniteNumber(rec.top_sender_share) ?? null,
+    top_senders: normalizeChainRows(
+      rec.top_senders,
+      MAX_CHAIN_TRANSFER_PARTIES,
+      normalizeChainTransferParty,
+    ),
+    top_receivers: normalizeChainRows(
+      rec.top_receivers,
+      MAX_CHAIN_TRANSFER_PARTIES,
+      normalizeChainTransferParty,
+    ),
+  };
+}
+
+export const chainTransfersQuery = (window = "30d", limit = 25) =>
+  queryOptions({
+    queryKey: k("chain-transfers", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainTransfers>>("/api/v1/chain/transfers", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainTransfers(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1658,6 +1658,32 @@ export interface ChainTransferPairs {
   pairs: ChainTransferPair[];
 }
 
+/** One account on the chain native-TAO transfers leaderboard (#3475). */
+export interface ChainTransferParty {
+  address: string;
+  volume_tao: number;
+  transfer_count: number;
+}
+
+/**
+ * Network-wide native-TAO transfer analytics over a 7d/30d window (#3475), from
+ * GET /api/v1/chain/transfers — total volume/count, distinct senders/receivers,
+ * top senders and receivers by volume, and top-sender concentration share.
+ * Zeroed with empty leaderboards when the store is cold.
+ */
+export interface ChainTransfers {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  total_volume_tao: number;
+  transfer_count: number;
+  unique_senders: number;
+  unique_receivers: number;
+  top_sender_share: number | null;
+  top_senders: ChainTransferParty[];
+  top_receivers: ChainTransferParty[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Activity, Boxes, Coins, Layers, Zap } from "lucide-react";
+import { Activity, ArrowLeftRight, Boxes, Coins, Layers, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -18,10 +18,11 @@ import {
   chainCallsQuery,
   chainFeesQuery,
   chainSignersQuery,
+  chainTransfersQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import type { ChainCalls } from "@/lib/metagraphed/types";
+import type { ChainCalls, ChainTransferParty } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
@@ -35,13 +36,13 @@ export const Route = createFileRoute("/explorer")({
       {
         name: "description",
         content:
-          "Bittensor network at a glance: daily extrinsic/block/event activity, fees, call mix, and the most active accounts — chain-direct analytics.",
+          "Bittensor network at a glance: daily extrinsic/block/event activity, fees, native-TAO transfers, call mix, and the most active accounts — chain-direct analytics.",
       },
       { property: "og:title", content: "Chain explorer — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Bittensor network at a glance: daily activity, fees, call mix, and the most active accounts.",
+          "Bittensor network at a glance: daily activity, fees, native-TAO transfers, call mix, and the most active accounts.",
       },
     ],
   }),
@@ -66,7 +67,7 @@ function ExplorerPage() {
         eyebrow="Explorer"
         live
         title="Chain explorer"
-        description="The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers."
+        description="The Bittensor network at a glance — daily activity, fees, native-TAO transfers, call mix, and the most active accounts, computed live from the chain-direct tiers."
         actions={<ShareButton />}
       />
       <QueryErrorBoundary>
@@ -78,6 +79,7 @@ function ExplorerPage() {
         paths={[
           "/api/v1/chain/activity",
           "/api/v1/chain/fees",
+          "/api/v1/chain/transfers",
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
         ]}
@@ -87,6 +89,62 @@ function ExplorerPage() {
 }
 
 const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+
+function TransferLeaderboard({
+  title,
+  rows,
+  empty,
+}: {
+  title: string;
+  rows: ChainTransferParty[];
+  empty: string;
+}) {
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          {title}
+        </h3>
+        <span className="font-mono text-[11px] text-ink-muted">{rows.length} accounts</span>
+      </div>
+      {rows.length > 0 ? (
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th className={TH}>Account</th>
+              <th className={`${TH} text-right`}>Volume</th>
+              <th className={`${TH} text-right`}>Transfers</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((row) => (
+              <tr key={row.address} className="hover:bg-surface/40">
+                <td className="px-4 py-2 font-mono text-[11px]">
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: row.address }}
+                    className="text-ink-strong hover:text-accent hover:underline"
+                    title={row.address}
+                  >
+                    {shortHash(row.address) ?? row.address}
+                  </Link>
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {fmtTao(row.volume_tao)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {formatNumber(row.transfer_count)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">{empty}</p>
+      )}
+    </div>
+  );
+}
 
 /**
  * One labeled mini-sparkline cell for a daily series. Aligns `days` labels to
@@ -229,6 +287,7 @@ function ExplorerDashboard() {
 
   const activity = useSuspenseQuery(chainActivityQuery(win)).data.data;
   const fees = useSuspenseQuery(chainFeesQuery(win)).data.data;
+  const transfers = useSuspenseQuery(chainTransfersQuery(win, 12)).data.data;
   const calls = useSuspenseQuery(chainCallsQuery(win)).data.data;
   const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
 
@@ -450,6 +509,61 @@ function ExplorerDashboard() {
           )}
         </section>
       </div>
+
+      {/* native-TAO transfers */}
+      <section className="rounded-lg border border-border bg-card p-5">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Native TAO transfers
+          </h2>
+          <span className="font-mono text-[11px] text-ink-muted">
+            Balances.Transfer · {win} window
+          </span>
+        </div>
+        <div className="mb-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <StatTile
+            icon={ArrowLeftRight}
+            eyebrow="Transfer volume"
+            value={fmtTao(transfers.total_volume_tao)}
+            hint={`${win} total`}
+            tone="accent"
+          />
+          <StatTile
+            icon={Activity}
+            eyebrow="Transfers"
+            value={formatNumber(transfers.transfer_count)}
+            hint={`${formatNumber(transfers.unique_senders)} senders · ${formatNumber(transfers.unique_receivers)} receivers`}
+          />
+          <StatTile
+            icon={Layers}
+            eyebrow="Top-sender share"
+            value={
+              transfers.top_sender_share == null
+                ? "—"
+                : `${(transfers.top_sender_share * 100).toFixed(1)}%`
+            }
+            hint="of window volume"
+          />
+          <StatTile
+            icon={Coins}
+            eyebrow="Leaderboard rows"
+            value={formatNumber(transfers.top_senders.length + transfers.top_receivers.length)}
+            hint="top senders + receivers"
+          />
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <TransferLeaderboard
+            title="Top senders"
+            rows={transfers.top_senders}
+            empty="No senders in this window yet."
+          />
+          <TransferLeaderboard
+            title="Top receivers"
+            rows={transfers.top_receivers}
+            empty="No receivers in this window yet."
+          />
+        </div>
+      </section>
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* call mix */}


### PR DESCRIPTION
## Summary
- Add `ChainTransferParty` / `ChainTransfers` types, `normalizeChainTransfers()`, and `chainTransfersQuery()` for GET `/api/v1/chain/transfers`
- Wire the explorer page: volume KPI tiles plus top senders / top receivers leaderboards (respects the 7d/30d window toggle)
- Vitest coverage for the data layer

Completes the full issue scope (data layer + UI), addressing maintainer feedback on #3694.

Closes #3475

## Test plan
- [x] `npx vitest run src/lib/metagraphed/queries.chain-transfers.test.ts`
- [ ] Open `/explorer` and confirm the Native TAO transfers section renders with window toggle