### PR TITLE
feat(registry): add ORO API deep health surface (SN15)

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -279,6 +279,25 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/v1/public/races/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-health-deep",
+      "kind": "subnet-api",
+      "name": "ORO API deep health",
+      "notes": "Public no-auth GET /health/deep returning deep readiness JSON (status, version) that exercises the SQLAlchemy connection pool. Documented in the subnet's own OpenAPI (api.oroagents.com/openapi.json, path /health/deep); same host as the existing /health and public API surfaces. Distinct from the lightweight /health liveness endpoint.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/health/deep"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/oro.json`.

Closes #699

## Surface

- Netuid: 15
- Kind: subnet-api
- Public URL: https://api.oroagents.com/health/deep
- Source URL (proves the claim): https://api.oroagents.com/openapi.json
- Provider slug: oro

## Checklist

- [x] Changes exactly one `registry/subnets/oro.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #699`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3700 (Leoma) | `leoma.json` only | No |
| #3699 | apps/ui only | No |
| #3594, #3546 | release/README | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/oro.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/oro.json`


Made with [Cursor](https://cursor.com)