### PR TITLE
feat(ui): add typed data layer for subnet yield history

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-yield-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-yield-history.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetYieldHistory, subnetYieldHistoryQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/yield/history",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetYieldHistoryQuery(netuid, window as "7d" | "30d" | "90d" | undefined);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetYieldHistory", () => {
+  it("passes a well-formed series through", () => {
+    expect(
+      normalizeSubnetYieldHistory(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        point_count: 2,
+        points: [
+          {
+            snapshot_date: "2026-07-01",
+            neuron_count: 64,
+            validator_count: 8,
+            yield_count: 60,
+            subnet_yield: 0.012,
+            mean_yield: 0.011,
+            median_yield: 0.0105,
+            p25_yield: 0.008,
+            p75_yield: 0.013,
+            p90_yield: 0.015,
+          },
+          {
+            snapshot_date: "2026-07-02",
+            neuron_count: 64,
+            validator_count: 8,
+            yield_count: 58,
+            subnet_yield: null,
+            mean_yield: null,
+            median_yield: null,
+            p25_yield: null,
+            p75_yield: null,
+            p90_yield: null,
+          },
+        ],
+      }),
+    ).toEqual({
+      netuid: 7,
+      window: "30d",
+      point_count: 2,
+      points: [
+        {
+          snapshot_date: "2026-07-01",
+          neuron_count: 64,
+          validator_count: 8,
+          yield_count: 60,
+          subnet_yield: 0.012,
+          mean_yield: 0.011,
+          median_yield: 0.0105,
+          p25_yield: 0.008,
+          p75_yield: 0.013,
+          p90_yield: 0.015,
+        },
+        {
+          snapshot_date: "2026-07-02",
+          neuron_count: 64,
+          validator_count: 8,
+          yield_count: 58,
+          subnet_yield: null,
+          mean_yield: null,
+          median_yield: null,
+          p25_yield: null,
+          p75_yield: null,
+          p90_yield: null,
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to an empty series", () => {
+    for (const raw of [{}, null, "x", { points: "nope" }]) {
+      const series = normalizeSubnetYieldHistory(7, raw);
+      expect(series.netuid).toBe(7);
+      expect(series.points).toEqual([]);
+      expect(series.point_count).toBe(0);
+    }
+  });
+
+  it("drops malformed points and coerces junk yield cells to null", () => {
+    const series = normalizeSubnetYieldHistory(7, {
+      points: [
+        { snapshot_date: "2026-07-01", median_yield: { x: 1 } },
+        { snapshot_date: "2026-07-02", mean_yield: 0.02, p90_yield: "bad" },
+      ],
+    });
+    expect(series.points).toHaveLength(2);
+    expect(series.points[0]?.median_yield).toBeNull();
+    expect(series.points[1]?.mean_yield).toBe(0.02);
+    expect(series.points[1]?.p90_yield).toBeNull();
+  });
+
+  it("falls back to the requested netuid when the payload omits it", () => {
+    expect(normalizeSubnetYieldHistory(12, { points: [] }).netuid).toBe(12);
+  });
+});
+
+describe("subnetYieldHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the series", async () => {
+    resolveWith({
+      netuid: 7,
+      window: "7d",
+      points: [{ snapshot_date: "2026-07-01", mean_yield: 0.01 }],
+    });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/yield/history",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.points).toHaveLength(1);
+    expect(res.data.points[0]?.mean_yield).toBe(0.01);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({ points: [] });
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/yield/history",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -126,6 +126,8 @@ import type {
   SubnetPerformance,
   PerformanceHistoryPoint,
   SubnetPerformanceHistory,
+  YieldHistoryPoint,
+  SubnetYieldHistory,
   SubnetProfile,
   Surface,
   SurfaceLatencyPercentiles,
@@ -3829,6 +3831,63 @@ export const subnetPerformanceHistoryQuery = (
         meta: res.meta,
         url: res.url,
       } as ApiResult<SubnetPerformanceHistory>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeYieldHistoryPoint(raw: unknown): YieldHistoryPoint | undefined {
+  if (!isRecord(raw)) return undefined;
+  const snapshotDate = coerceString(raw.snapshot_date);
+  if (!snapshotDate) return undefined;
+  const nullableNum = (v: unknown): number | null => coerceFiniteNumber(v) ?? null;
+  return {
+    ...(raw as object),
+    snapshot_date: snapshotDate,
+    neuron_count: coerceFiniteNumber(raw.neuron_count),
+    validator_count: coerceFiniteNumber(raw.validator_count),
+    yield_count: coerceFiniteNumber(raw.yield_count),
+    subnet_yield: nullableNum(raw.subnet_yield),
+    mean_yield: nullableNum(raw.mean_yield),
+    median_yield: nullableNum(raw.median_yield),
+    p25_yield: nullableNum(raw.p25_yield),
+    p75_yield: nullableNum(raw.p75_yield),
+    p90_yield: nullableNum(raw.p90_yield),
+  };
+}
+
+export function normalizeSubnetYieldHistory(netuid: number, raw: unknown): SubnetYieldHistory {
+  const d = isRecord(raw) ? raw : {};
+  const points = Array.isArray(d.points)
+    ? d.points.slice(-MAX_HISTORY_POINTS).flatMap((point) => {
+        const normalized = normalizeYieldHistoryPoint(point);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+    window: coerceString(d.window),
+    point_count: coerceFiniteNumber(d.point_count) ?? points.length,
+    points,
+  };
+}
+
+/** Daily emission-yield distribution drift (subnet return + per-UID yield percentiles). */
+export const subnetYieldHistoryQuery = (
+  netuid: number,
+  window: "7d" | "30d" | "90d" = "30d",
+) =>
+  queryOptions({
+    queryKey: k("subnet-yield-history", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetYieldHistory>>(
+        `/api/v1/subnets/${netuid}/yield/history`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetYieldHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetYieldHistory>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -3872,10 +3872,7 @@ export function normalizeSubnetYieldHistory(netuid: number, raw: unknown): Subne
 }
 
 /** Daily emission-yield distribution drift (subnet return + per-UID yield percentiles). */
-export const subnetYieldHistoryQuery = (
-  netuid: number,
-  window: "7d" | "30d" | "90d" = "30d",
-) =>
+export const subnetYieldHistoryQuery = (netuid: number, window: "7d" | "30d" | "90d" = "30d") =>
   queryOptions({
     queryKey: k("subnet-yield-history", netuid, window),
     queryFn: async ({ signal }) => {

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1502,6 +1502,29 @@ export interface SubnetPerformanceHistory {
   points: PerformanceHistoryPoint[];
 }
 
+/** One daily yield-history point from /yield/history. */
+export interface YieldHistoryPoint {
+  snapshot_date: string;
+  neuron_count?: number;
+  validator_count?: number;
+  yield_count?: number;
+  subnet_yield?: number | null;
+  mean_yield?: number | null;
+  median_yield?: number | null;
+  p25_yield?: number | null;
+  p75_yield?: number | null;
+  p90_yield?: number | null;
+  [key: string]: unknown;
+}
+
+/** Emission-yield distribution drift from /api/v1/subnets/{netuid}/yield/history. */
+export interface SubnetYieldHistory {
+  netuid: number;
+  window?: string;
+  point_count?: number;
+  points: YieldHistoryPoint[];
+}
+
 // --- Compile-time contract enforcement ---------------------------------------
 //
 // These are type-only assertions (zero runtime cost). They tie this file's UI


### PR DESCRIPTION
Part of #3478 — add the typed data layer for per-subnet **yield/history**, consuming `GET /api/v1/subnets/{netuid}/yield/history`. Split out as its own small, tested unit (same pattern as performance/history and the other subnet activity data layers).

The return-rate twin of `/performance/history`: daily subnet-wide emission yield plus mean/median/p25/p75/p90 of per-UID yields — not reconstructable from stake+emission totals in `/history`.

## What changed

- **`types.ts`** — `YieldHistoryPoint` + `SubnetYieldHistory` mirroring `SubnetYieldHistoryArtifact`.
- **`queries.ts`** — `subnetYieldHistoryQuery(netuid, window = "30d")` + exported `normalizeSubnetYieldHistory()` with defensive numeric coercion (counts → `0`, yield cells → `null`, never `NaN`).
- **`queries.subnet-yield-history.test.ts`** — 6 tests: passthrough, cold/junk empty series, malformed-point drop + junk yield coercion, netuid fallback, window forwarding, 30d default.

Pure `lib/metagraphed` data layer — no route/component wiring in this PR.

## Gates run green locally

- `vitest run src/lib/metagraphed/queries.subnet-yield-history.test.ts` — 6/6
- `npm run scan:public-safety`
- `eslint` + `prettier --check` on touched files
