### PR TITLE
fix(ui): stabilize TimeRange setRange and drop the exhaustive-deps disable

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/time-range-context.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 export type TimeRange = "1h" | "24h" | "7d" | "30d";
 
@@ -44,11 +44,17 @@ export function TimeRangeProvider({
 }) {
   const [internal, setInternal] = useState<TimeRange>(defaultRange);
   const range = value ?? internal;
-  const setRange = (r: TimeRange) => {
-    if (onChange) onChange(r);
-    else setInternal(r);
-  };
-  const ctx = useMemo(() => ({ range, setRange }), [range]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Stable across renders (rebuilds only when `onChange` changes), so the memo
+  // below can depend on it honestly instead of suppressing exhaustive-deps —
+  // which previously let ctx.setRange capture a stale `onChange`.
+  const setRange = useCallback(
+    (r: TimeRange) => {
+      if (onChange) onChange(r);
+      else setInternal(r);
+    },
+    [onChange],
+  );
+  const ctx = useMemo(() => ({ range, setRange }), [range, setRange]);
   return <TimeRangeCtx.Provider value={ctx}>{children}</TimeRangeCtx.Provider>;
 }
 


### PR DESCRIPTION
## Summary

Closes #3460

Revisits and resolves the remaining issue from **#3460** by removing the `react-hooks/exhaustive-deps` suppression in `time-range-context.tsx`.

The suppression masked a legitimate warning rather than a false positive. `TimeRangeProvider` recreated `setRange` on every render while omitting it from the context `useMemo` dependency list, allowing consumers to receive a memoized context value containing a stale `setRange` closure.

This PR stabilizes `setRange` with `useCallback`, updates the memo dependencies accordingly, and removes the unnecessary ESLint suppression.

## Implementation

- Wrapped `setRange` in:

  ```ts
  useCallback(..., [onChange])
  ```

- Updated the context `useMemo` dependencies from:

  ```ts
  [range]
  ```

  to:

  ```ts
  [range, setRange]
  ```

- Removed the `react-hooks/exhaustive-deps` ESLint disable comment.

This preserves the existing context API (`{ range, setRange }`) while ensuring the memoized context always exposes the current callback.

## Rendering Impact

There are **no visual or behavioral UI changes**.

This change only affects callback identity and eliminates the possibility of stale closures within the context provider.

## Validation

All `apps/ui` checks pass:

- ✅ `eslint` (`time-range-context.tsx`) — 0 problems
- ✅ `npm run typecheck --workspace=apps/ui`
- ✅ `npm run format:check --workspace=apps/ui`
- ✅ `npm test --workspace=apps/ui` (417 passing)
- ✅ `npm run build --workspace=apps/ui`
