### PR TITLE
feat(registry): add Bitcast API database health surface (SN93)

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -181,6 +181,25 @@
         "https://bitcast-api.bitcast.network/docs"
       ],
       "url": "https://bitcast-api.bitcast.network/health/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-api-health-database",
+      "kind": "subnet-api",
+      "name": "Bitcast API database health",
+      "notes": "Public no-auth GET /health/database on bitcast-api.bitcast.network returning database connectivity and pool status JSON. Documented in the subnet OpenAPI spec on the same host as the existing openapi and /health/ready surfaces. Distinct from the /health and /health/ready endpoints and the creator-portal /api/health endpoint on creator.bitcast.network.",
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://bitcast-api.bitcast.network/openapi.json",
+        "https://bitcast-api.bitcast.network/docs"
+      ],
+      "url": "https://bitcast-api.bitcast.network/health/database"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/bitcast.json`.

Closes #574

## Surface

- Netuid: 93
- Kind: subnet-api
- Public URL: https://bitcast-api.bitcast.network/health/database
- Source URL (proves the claim): https://bitcast-api.bitcast.network/openapi.json
- Provider slug: bitcast-network

## Checklist

- [x] Changes exactly one `registry/subnets/bitcast.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #574`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3705, #3704, #3703, #3701, #3699 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/bitcast.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitcast.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/bitcast.json`


Made with [Cursor](https://cursor.com)