### PR TITLE
feat(ui): add reusable polling interval hook for live freshness queries

### DIFF
--- a/apps/ui/src/hooks/use-polling-interval.test.ts
+++ b/apps/ui/src/hooks/use-polling-interval.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_POLLING_INTERVAL_MS,
+  STATUS_POLLING_INTERVAL_MS,
+  resolveRefetchInterval,
+} from "./use-polling-interval";
+
+describe("resolveRefetchInterval", () => {
+  it("returns the interval when polling is enabled and the tab is visible", () => {
+    expect(resolveRefetchInterval(true, true, DEFAULT_POLLING_INTERVAL_MS)).toBe(30_000);
+    expect(resolveRefetchInterval(true, true, STATUS_POLLING_INTERVAL_MS)).toBe(60_000);
+  });
+
+  it("pauses polling when disabled, hidden, or interval is non-positive", () => {
+    expect(resolveRefetchInterval(false, true, 30_000)).toBe(false);
+    expect(resolveRefetchInterval(true, false, 30_000)).toBe(false);
+    expect(resolveRefetchInterval(true, true, 0)).toBe(false);
+    expect(resolveRefetchInterval(true, true, -1)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-polling-interval.ts
+++ b/apps/ui/src/hooks/use-polling-interval.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+/** Default auto-refresh cadence on /health (30s). */
+export const DEFAULT_POLLING_INTERVAL_MS = 30_000;
+
+/** Fixed poll cadence on /status (60s). */
+export const STATUS_POLLING_INTERVAL_MS = 60_000;
+
+/**
+ * TanStack Query `refetchInterval` value: `false` pauses polling when the tab
+ * is hidden or the user has paused refresh.
+ */
+export function resolveRefetchInterval(
+  enabled: boolean,
+  visible: boolean,
+  intervalMs: number,
+): number | false {
+  if (!enabled || !visible || intervalMs <= 0) return false;
+  return intervalMs;
+}
+
+/** Returns true when the document is visible (or true during SSR). */
+export function usePageVisible(): boolean {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const update = () => setVisible(!document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+  return visible;
+}
+
+/**
+ * Reusable poll interval for live freshness / health queries. Pauses when the
+ * tab is hidden or `enabled` is false; returns a ms value suitable for
+ * TanStack Query's `refetchInterval`.
+ */
+export function usePollingInterval({
+  enabled = true,
+  intervalMs = DEFAULT_POLLING_INTERVAL_MS,
+}: {
+  enabled?: boolean;
+  intervalMs?: number;
+} = {}): number | false {
+  const visible = usePageVisible();
+  return resolveRefetchInterval(enabled, visible, intervalMs);
+}


### PR DESCRIPTION
Closes #3371

Adds `usePollingInterval` (+ `usePageVisible`, `resolveRefetchInterval`) under `apps/ui/src/hooks/` with unit tests for the pure interval resolver. Call sites in `health.tsx` / `status.tsx` can migrate off their inlined `refetchInterval` logic in a follow-up.


Made with [Cursor](https://cursor.com)