### PR TITLE
feat(registry): add Aurelius Central API readiness health surface (SN37)

### DIFF
--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -105,6 +105,25 @@
         "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md"
       ],
       "url": "https://new-collector-api-production.up.railway.app/health/live"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-37-aurelius-health-ready",
+      "kind": "subnet-api",
+      "name": "Aurelius Central API readiness health",
+      "notes": "Public no-auth GET /health/ready returning readiness JSON (status, db, db_pool, classifier, novelty). Documented in the subnet's own OpenAPI (new-collector-api-production.up.railway.app/openapi.json, path /health/ready); same host as the existing openapi, docs, /health, /health/live, and work-token subnet-api surfaces. Distinct from the lightweight /health/live liveness endpoint.",
+      "provider": "aurelius",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://new-collector-api-production.up.railway.app/openapi.json",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md"
+      ],
+      "url": "https://new-collector-api-production.up.railway.app/health/ready"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/aurelius.json`.

Closes #582

## Surface

- Netuid: 37
- Kind: subnet-api
- Public URL: https://new-collector-api-production.up.railway.app/health/ready
- Source URL (proves the claim): https://new-collector-api-production.up.railway.app/openapi.json
- Provider slug: aurelius

## Checklist

- [x] Changes exactly one `registry/subnets/aurelius.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #582`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3709, #3708, #3705 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/aurelius.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/aurelius.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/aurelius.json`


Made with [Cursor](https://cursor.com)