### PR TITLE
fix(ui): preserve scroll position on search/filter navigation

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -646,7 +646,10 @@ function AccountEventsSection({
   const hasNext = page?.next_cursor != null || events.length === limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      resetScroll: false,
+    });
 
   // Cold accounts return a schema-stable zero — never error. While loading the
   // first page, defer to the summary-driven sections above rather than flashing.

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -100,7 +100,10 @@ function BlocksTable() {
   const hasNext = rows.length === search.limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      resetScroll: false,
+    });
 
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -394,6 +394,7 @@ function EndpointsTable() {
       search: (prev: Record<string, unknown>) =>
         ({ ...prev, ...patch, ...(resetsPage ? { page: 1 } : {}) }) as never,
       replace: true,
+      resetScroll: false,
     });
   };
 
@@ -536,6 +537,7 @@ function EndpointsTable() {
     navigate({
       search: { pageSize: search.pageSize, view: search.view } as never,
       replace: true,
+      resetScroll: false,
     });
 
   if (rows.length === 0)

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -251,7 +251,7 @@ function ExplorerDashboard() {
           <button
             key={w}
             type="button"
-            onClick={() => navigate({ search: { window: w } })}
+            onClick={() => navigate({ search: { window: w }, resetScroll: false })}
             className={
               w === win
                 ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -107,7 +107,10 @@ function ExtrinsicsTable() {
   const hasNext = rows.length === search.limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      resetScroll: false,
+    });
 
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -457,6 +457,7 @@ function OpenGapsSection() {
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
       replace: true,
+      resetScroll: false,
     });
 
   const missingSet = useMemo<Set<string>>(
@@ -540,7 +541,7 @@ function OpenGapsSection() {
       {hasFilters ? (
         <button
           type="button"
-          onClick={() => navigate({ search: {} as never, replace: true })}
+          onClick={() => navigate({ search: {} as never, replace: true, resetScroll: false })}
           className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong"
         >
           <X className="size-3" /> Clear

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -161,6 +161,7 @@ function SchemaDriftDetailHost() {
           navigate({
             search: (p: Record<string, unknown>) => ({ ...p, driftDetail: "" }) as never,
             replace: true,
+            resetScroll: false,
           });
         }
       }}
@@ -168,6 +169,7 @@ function SchemaDriftDetailHost() {
         navigate({
           search: (p: Record<string, unknown>) => ({ ...p, driftDetail: "", open: id }) as never,
           replace: true,
+          resetScroll: false,
         })
       }
     />
@@ -305,6 +307,7 @@ function SchemaExplorer() {
       navigate({
         search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
         replace: true,
+        resetScroll: false,
       }),
     [navigate],
   );
@@ -451,6 +454,7 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                 navigate({
                   search: (p: Record<string, unknown>) => ({ ...p, open: "" }) as never,
                   replace: true,
+                  resetScroll: false,
                 })
               }
               className="lg:hidden inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong mb-2"

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -107,11 +107,13 @@ function SubnetsPage() {
     navigate({
       search: { limit: search.limit, view: search.view } as never,
       replace: true,
+      resetScroll: false,
     });
   const setView = (v: ViewMode) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
       replace: true,
+      resetScroll: false,
     });
   const isMobile = useIsMobile();
   const effectiveDensity: Density =
@@ -124,6 +126,7 @@ function SubnetsPage() {
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
       replace: true,
+      resetScroll: false,
     });
   return (
     <AppShell>
@@ -283,6 +286,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      resetScroll: false,
     });
 
   const onSort = (field: string) =>
@@ -294,6 +298,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           order: prev.sort === field && prev.order === "asc" ? "desc" : "asc",
           cursor: "",
         }) as never,
+      resetScroll: false,
     });
 
   const filtersActive = !!(

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -66,6 +66,7 @@ function SurfacesPage() {
       // Keep page size and view on reset so the chosen layout survives.
       search: { limit: search.limit, view: search.view } as never,
       replace: true,
+      resetScroll: false,
     });
   const viewMode: "table" | "grid" = search.view === "grid" ? "grid" : "table";
   return (
@@ -86,6 +87,7 @@ function SurfacesPage() {
                   navigate({
                     search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
                     replace: true,
+                    resetScroll: false,
                   })
                 }
               />
@@ -181,6 +183,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      resetScroll: false,
     });
 
   const onSort = (field: string) =>
@@ -192,6 +195,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
           order: prev.sort === field && prev.order === "asc" ? "desc" : "asc",
           cursor: "",
         }) as never,
+      resetScroll: false,
     });
 
   const filtered = all.filter((s) => {


### PR DESCRIPTION
Closes #3691 — stop page search/filter keystrokes from jumping scroll to the top.

TanStack Router's `navigate()` defaults `resetScroll: true`, so every in-place search-param update (typing in `SearchInput`, toggling filters, sorting, paginating) was resetting scroll to `(0, 0)`. On long index pages like `/subnets`, that made multi-character searches unusable.

## What changed

Pass `resetScroll: false` on filter/search/sort/pagination `navigate()` calls that only mutate URL search params (real page-to-page links keep the default).

**Pages updated (as scoped in #3691):**
- `subnets.index.tsx` — search, filters, sort, view/density toggles, reset
- `surfaces.tsx` — search, filters, sort, view toggle, reset
- `extrinsics.index.tsx` — search fields, filters, pagination
- `blocks.index.tsx` — page size / offset pagination
- `gaps.tsx` — search, filters, sort, clear
- `schemas.tsx` — schema search, drift filter, panel selection
- `endpoints.tsx` — search, filters, sort, reset
- `accounts.$ss58.tsx` — event feed filters / pagination
- `explorer.tsx` — window toggle

## Test plan

- [ ] On `/subnets`, scroll down, type a 2+ digit netuid in the search box — page stays scrolled in place
- [ ] Same on `/surfaces` and `/extrinsics`
- [ ] Clicking a row link to a detail page still scrolls to top as expected
