### PR TITLE
feat(ui): URL-back Providers filters and ShareButton (#3419)

### DIFF
--- a/apps/ui/src/lib/metagraphed/providers-url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/providers-url-state.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { matchesProviderAuthority } from "./providers-url-state";
+import type { Provider } from "./types";
+
+describe("matchesProviderAuthority", () => {
+  const base = { slug: "acme" } satisfies Provider;
+
+  it("passes through when no filter is set", () => {
+    expect(matchesProviderAuthority({ ...base, authority: "community" }, "")).toBe(true);
+  });
+
+  it("matches exact authority values", () => {
+    expect(matchesProviderAuthority({ ...base, authority: "official" }, "official")).toBe(true);
+    expect(matchesProviderAuthority({ ...base, authority: "community" }, "official")).toBe(false);
+  });
+
+  it("treats high as official + provider-claimed", () => {
+    expect(matchesProviderAuthority({ ...base, authority: "official" }, "high")).toBe(true);
+    expect(matchesProviderAuthority({ ...base, authority: "provider-claimed" }, "high")).toBe(true);
+    expect(matchesProviderAuthority({ ...base, authority: "community" }, "high")).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/providers-url-state.ts
+++ b/apps/ui/src/lib/metagraphed/providers-url-state.ts
@@ -1,0 +1,10 @@
+import type { Provider } from "./types";
+
+/** Match a provider against the URL authority filter (including the `high` shortcut). */
+export function matchesProviderAuthority(p: Provider, filter: string): boolean {
+  if (!filter) return true;
+  if (filter === "high") {
+    return p.authority === "official" || p.authority === "provider-claimed";
+  }
+  return p.authority === filter;
+}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Suspense, useEffect, useMemo, type ReactNode } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Globe, Github, BookOpen, Radio, Layers, Network, Search, X } from "lucide-react";
@@ -11,16 +11,28 @@ import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
+import { ShareButton } from "@/components/metagraphed/share-button";
+import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import { providersQuery, endpointsQuery, type ProviderCounts } from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
+import { matchesQuery } from "@/lib/metagraphed/url-state";
+import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
 import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import { Donut, DonutLegend } from "@/components/metagraphed/charts/donut";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import type { Provider } from "@/lib/metagraphed/types";
 
+const providerSortKeys = ["name", "surfaces", "endpoints", "subnets", "updated"] as const;
+type ProviderSortKey = (typeof providerSortKeys)[number];
+
 const providersSearchSchema = z.object({
   view: fallback(z.enum(["grid", "table"]), "grid").default("grid"),
+  q: fallback(z.string(), "").default(""),
+  kind: fallback(z.string(), "").default(""),
+  // `high` is a nav shortcut for official + provider-claimed (see nav-mega-menu-data).
+  authority: fallback(z.string(), "").default(""),
+  sort: fallback(z.enum(providerSortKeys), "name").default("name"),
 });
 
 export const Route = createFileRoute("/providers/")({
@@ -46,6 +58,10 @@ function ProvidersPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const view = search.view ?? "grid";
+  const filtersActive = Boolean(
+    search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
+  );
+  const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
   return (
     <AppShell>
       <PageHero
@@ -54,16 +70,20 @@ function ProvidersPage() {
         title="Providers"
         description="Teams, infra operators, docs registries, and community sources behind public interfaces."
         actions={
-          <ViewModeToggle
-            value={view}
-            options={["table", "grid"]}
-            onChange={(v) =>
-              navigate({
-                search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
-                replace: true,
-              })
-            }
-          />
+          <>
+            <ViewModeToggle
+              value={view}
+              options={["table", "grid"]}
+              onChange={(v) =>
+                navigate({
+                  search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
+                  replace: true,
+                })
+              }
+            />
+            <ResetFiltersButton active={filtersActive} onReset={onReset} />
+            <ShareButton />
+          </>
         }
       />
       <QueryErrorBoundary>
@@ -124,9 +144,15 @@ function authorityTone(a?: string): string {
   }
 }
 
-type SortKey = "name" | "surfaces" | "endpoints" | "subnets";
-
 function ProvidersGrid({ view }: { view: "grid" | "table" }) {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const setSearch = (patch: Record<string, unknown>) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      replace: true,
+    });
+
   const { data: providersRes } = useSuspenseQuery(providersQuery());
   const rows = useMemo(() => (providersRes.data ?? []) as Provider[], [providersRes]);
   // The /api/v1/providers list already carries per-provider tallies
@@ -149,10 +175,10 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
   const generatedAt = providersRes.meta?.generated_at;
   const stale = isStaleFreshness(generatedAt);
 
-  const [q, setQ] = useState("");
-  const [kind, setKind] = useState("");
-  const [authority, setAuthority] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const q = search.q;
+  const kind = search.kind;
+  const authority = search.authority;
+  const sortKey: ProviderSortKey = search.sort ?? "name";
 
   const kinds = useMemo(
     () => Array.from(new Set(rows.map((p) => p.kind).filter(Boolean) as string[])).sort(),
@@ -163,16 +189,17 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
     [rows],
   );
 
+  const authorityOptions = useMemo(() => {
+    const fromRows = authorities.filter((a) => a !== "high");
+    return ["high", ...fromRows];
+  }, [authorities]);
+
   const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
     return rows.filter((p) => {
       if (kind && p.kind !== kind) return false;
-      if (authority && p.authority !== authority) return false;
-      if (!needle) return true;
+      if (!matchesProviderAuthority(p, authority)) return false;
       const host = maskHost(p.website ?? p.homepage) ?? "";
-      return [p.name, p.slug, p.notes, host]
-        .filter(Boolean)
-        .some((v) => String(v).toLowerCase().includes(needle));
+      return matchesQuery([p.name, p.slug, p.notes, host], q);
     });
   }, [rows, q, kind, authority]);
 
@@ -181,6 +208,11 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
     arr.sort((a, b) => {
       if (sortKey === "name")
         return String(a.name ?? a.slug).localeCompare(String(b.name ?? b.slug));
+      if (sortKey === "updated") {
+        const ta = String(a.updated_at ?? "");
+        const tb = String(b.updated_at ?? "");
+        return tb.localeCompare(ta);
+      }
       const ca = counts[a.slug];
       const cb = counts[b.slug];
       const va = (ca?.[sortKey] as number | undefined) ?? 0;
@@ -220,7 +252,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
       />
     );
 
-  const hasFilters = q || kind || authority;
+  const hasFilters = Boolean(q || kind || authority || (sortKey && sortKey !== "name"));
 
   return (
     <div className="space-y-3">
@@ -239,34 +271,35 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
           <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-ink-muted" />
           <input
             value={q}
-            onChange={(e) => setQ(e.target.value)}
+            onChange={(e) => setSearch({ q: e.target.value })}
             placeholder="Search providers, slugs, hosts…"
             className="w-full rounded border border-border bg-card pl-7 pr-2 py-1.5 text-[12px] focus:outline-none focus:border-ink/30"
             aria-label="Search providers"
           />
         </div>
-        <Selector label="Kind" value={kind} onChange={setKind} options={kinds} />
+        <Selector
+          label="Kind"
+          value={kind}
+          onChange={(v) => setSearch({ kind: v })}
+          options={kinds}
+        />
         <Selector
           label="Authority"
           value={authority}
-          onChange={setAuthority}
-          options={authorities}
+          onChange={(v) => setSearch({ authority: v })}
+          options={authorityOptions}
         />
         <Selector
           label="Sort"
           value={sortKey}
-          onChange={(v) => setSortKey(v as SortKey)}
-          options={["name", "surfaces", "endpoints", "subnets"]}
+          onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
+          options={[...providerSortKeys]}
           allowEmpty={false}
         />
         {hasFilters ? (
           <button
             type="button"
-            onClick={() => {
-              setQ("");
-              setKind("");
-              setAuthority("");
-            }}
+            onClick={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
             className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[11px] text-ink-muted hover:text-ink-strong"
           >
             <X className="size-3" /> Clear


### PR DESCRIPTION

## Summary

- Persist Providers toolbar state in the URL (`q`, `kind`, `authority`, `sort`, `view`) via `validateSearch`, matching other list routes
- Honor nav shortcuts: `authority=high` (official + provider-claimed) and `sort=updated` (recently updated)
- Add `ShareButton` and hero-level `ResetFiltersButton` so copied links reproduce the filtered view
- Closes #3418 · Closes #3419 · Part of #2542

## Screenshots

| Before | After |
|--------|-------|
| <img width="1835" height="946" alt="image" src="https://github.com/user-attachments/assets/ffbbe7a6-ab16-4bc1-8ed2-fb950cb0a8af" /> | <img width="1844" height="940" alt="image" src="https://github.com/user-attachments/assets/f2553a9b-86a9-4571-bd44-e14efe2a9aa4" /> |


## Test plan

- [x] Open `/providers` — default grid, no search params beyond optional `view`
- [x] Set search / kind / authority / sort — URL updates, refresh preserves filters
- [x] Nav mega-menu links (`kind=subnet-team`, `authority=high`, `sort=updated`) land on the expected subset
- [x] Share copies full URL; pasted link restores filters + view mode
- [x] Reset filters clears `q`/`kind`/`authority`/`sort` but keeps `view`
- [x] `npm run build:client --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`