### PR TITLE
fix(chain-yield): coerce D1 numeric-string captured_at to an ISO stamp

### DIFF
--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -64,6 +64,18 @@ function captureStamp(value) {
     return { ms: value, value: new Date(value).toISOString() };
   }
   if (typeof value === "string") {
+    // D1 can surface the INTEGER captured_at (epoch ms) column as a numeric
+    // string. Date.parse("1750000000000") is NaN, so the bare Date.parse path
+    // dropped a valid stamp and emitted captured_at: null. Treat an all-digits
+    // string as epoch ms (and return the ISO form, not the raw digits) — the
+    // same handling the sibling chain/concentration + chain/performance
+    // captureStamp helpers already use.
+    if (/^\d+$/.test(value)) {
+      const ms = Number(value);
+      return Number.isFinite(ms)
+        ? { ms, value: new Date(ms).toISOString() }
+        : null;
+    }
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
   }

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -126,6 +126,16 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("coerces a D1 numeric-string epoch-ms captured_at to an ISO stamp", () => {
+    // D1 can surface the INTEGER captured_at column as a numeric string;
+    // Date.parse("1750000000000") is NaN, so the stamp was previously dropped
+    // and the artifact emitted captured_at: null despite a valid snapshot.
+    const out = buildChainYield([
+      { stake_tao: 1, emission_tao: 0, captured_at: "1750000000000" },
+    ]);
+    assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
+  });
+
   test("coerces numeric-string stake/emission cells from D1", () => {
     const out = buildChainYield([
       {


### PR DESCRIPTION
buildChainYield's `captureStamp` ran `Date.parse("1750000000000")` on a numeric-string epoch-ms `captured_at` (which is `NaN`), so a valid snapshot timestamp was dropped and `/api/v1/chain/yield` (+ its MCP tool) emitted `captured_at: null` whenever D1 surfaced the INTEGER column as a string — diverging from every sibling `chain/*` route. Treat an all-digits string as epoch ms and return the ISO form (mirroring the `chain/concentration` and `chain/performance` `captureStamp` helpers). Adds a numeric-string regression test. No version bump; self-contained.