### PR TITLE
feat(registry): add Nepher active tournament API surface (SN49)

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -339,6 +339,25 @@
         "https://docs.nepher.ai/"
       ],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/ids"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-active-tournament-api",
+      "kind": "subnet-api",
+      "name": "Nepher active tournament API",
+      "notes": "Public no-auth GET returning the single newest active tournament with task name, version, stage, contest windows, and repository links. Documented in the subnet's own OpenAPI (tournament-api.nepher.ai/openapi.json, path /api/v1/tournaments/active); same host as existing tournament surfaces. Distinct from the active/id, active/ids, and active/list endpoints.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://docs.nepher.ai/"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/nepher-robotics.json`.

Closes #916

## Surface

- Netuid: 49
- Kind: subnet-api
- Public URL: https://tournament-api.nepher.ai/api/v1/tournaments/active
- Source URL (proves the claim): https://tournament-api.nepher.ai/openapi.json
- Provider slug: nepher-robotics

## Checklist

- [x] Changes exactly one `registry/subnets/nepher-robotics.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #916`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3713, #3712, #3711, #3708, #3705 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/nepher-robotics.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/nepher-robotics.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/nepher-robotics.json`


Made with [Cursor](https://cursor.com)