### PR TITLE
fix(health): coerce D1 numeric-string cells on the live-health fallback path

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1306,8 +1306,12 @@ export async function loadReliabilityAggregate({
 // on one corrupt last_checked/last_ok cell. Range-guard via getTime() and drop
 // to null, preserving the existing non-finite -> null behavior.
 function isoFromMs(ms) {
-  if (!Number.isFinite(ms)) return null;
-  const date = new Date(ms);
+  // D1 can surface an INTEGER epoch-ms column as a numeric string, so coerce
+  // before the finite guard. Guard null explicitly first: Number(null) === 0
+  // would otherwise turn an absent timestamp into 1970-01-01.
+  const n = ms == null ? Number.NaN : Number(ms);
+  if (!Number.isFinite(n)) return null;
+  const date = new Date(n);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
@@ -1321,8 +1325,11 @@ function liveFromD1Rows(rows) {
     url: r.url,
     status: normalizeProbeStatus(r.status),
     classification: r.classification,
-    latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
-    status_code: Number.isInteger(r.status_code) ? r.status_code : null,
+    // D1 often returns INTEGER/REAL cells as numeric strings; coerce (null-safe)
+    // so a live surface's status_code/latency are not dropped to null on the
+    // D1-fallback path (mirrors formatTrajectory's roundInt handling above).
+    latency_ms: toFiniteOrNull(r.latency_ms),
+    status_code: toFiniteOrNull(r.status_code),
     last_checked: isoFromMs(r.last_checked),
     last_ok: isoFromMs(r.last_ok),
   }));

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1335,6 +1335,38 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.match(live.surfaces[0].last_checked, /^20\d\d-/);
   });
 
+  test("coerces D1 numeric-string cells on the fallback path (status_code/latency/timestamps)", async () => {
+    // D1 can return INTEGER/REAL columns as numeric strings; a bare
+    // Number.isInteger/Number.isFinite guard would drop status_code/latency to
+    // null and (via isoFromMs) null out last_checked/last_ok too.
+    const db = d1With([
+      {
+        surface_id: "7:subnet-api:x",
+        surface_key: "srf-stringcells000",
+        netuid: 7,
+        kind: "subnet-api",
+        provider: "x",
+        url: "https://x",
+        status: "ok",
+        classification: "up",
+        latency_ms: "10",
+        status_code: "200",
+        last_checked: "1700000000000",
+        last_ok: "1699000000000",
+      },
+    ]);
+    const live = await resolveLiveHealth({
+      readHealthKv: async () => null,
+      env: {},
+      db,
+      now: () => 1_700_000_600_000,
+    });
+    assert.equal(live.surfaces[0].status_code, 200);
+    assert.equal(live.surfaces[0].latency_ms, 10);
+    assert.match(live.surfaces[0].last_checked, /^20\d\d-/);
+    assert.match(live.surfaces[0].last_ok, /^20\d\d-/);
+  });
+
   test("D1 fallback survives an out-of-range last_checked/last_ok (no RangeError)", async () => {
     // A finite but out-of-range epoch-ms (beyond the ±8.64e15 JS Date limit)
     // would make new Date().toISOString() throw a RangeError and 500 the live


### PR DESCRIPTION
`liveFromD1Rows` maps `surface_status` D1 rows on the KV-cold fallback path but guarded `status_code` with `Number.isInteger`, `latency_ms` with `Number.isFinite`, and ran `isoFromMs` (a `Number.isFinite` gate) on `last_checked`/`last_ok`. D1 commonly surfaces INTEGER/REAL columns as **numeric strings**, so a surface that genuinely returned HTTP 200 was served as `status_code: null`, and the nulled `last_checked` cascaded to a null `last_run_at`/`generated_at` for the whole snapshot. Coerce via the file's own `toFiniteOrNull` and make `isoFromMs` coerce (null-safe) first — mirroring `formatTrajectory`'s `roundInt` handling. Adds a string-cell regression test. No version bump; self-contained; 141 health-serving tests pass.