### PR TITLE
feat(registry): add SN105 Beam OpenAPI + health surfaces

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -12,7 +12,48 @@
   "social": {
     "x": "https://x.com/b1m_ai"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-openapi",
+      "kind": "openapi",
+      "name": "BeamCore API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.0 schema for the BeamCore control-plane HTTP API (title: BeamCore API). Served publicly at beamcore.b1m.ai; documents orchestrator, worker, validator, and health routes for SN105 Beam.",
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://beamcore.b1m.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/Beam-Network/beam/blob/main/README.md",
+        "https://beamcore.b1m.ai/openapi.json"
+      ],
+      "url": "https://beamcore.b1m.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-health",
+      "kind": "subnet-api",
+      "name": "BeamCore API health",
+      "notes": "Public no-auth GET /health on beamcore.b1m.ai returning control-plane liveness JSON (ok, db, schema, metagraph sync). Documented in the subnet OpenAPI spec on the same host; beamcore.b1m.ai is the CORE_SERVER_URL configured in the official Beam README.",
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://beamcore.b1m.ai/openapi.json",
+        "https://github.com/Beam-Network/beam/blob/main/README.md"
+      ],
+      "url": "https://beamcore.b1m.ai/health"
+    }
+  ],
   "source_repo": null,
   "website_url": "https://b1m.ai/",
   "contact": "info@b1m.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends two community surfaces to `registry/subnets/beam.json`.
Append-only; no other fields changed.

Closes #670

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://beamcore.b1m.ai/openapi.json | Beam README (`CORE_SERVER_URL`), live OpenAPI |
| subnet-api | https://beamcore.b1m.ai/health | OpenAPI spec, Beam README |

- Netuid: 105
- Provider slug: beam

First-party proof: the official [Beam README](https://github.com/Beam-Network/beam/blob/main/README.md) documents `CORE_SERVER_URL=https://beamcore.b1m.ai` as the BeamCore control-plane API host. The live OpenAPI 3.0 spec on that host documents `GET /health` and the orchestrator/validator routes.

## Checklist

- [x] Changes exactly one `registry/subnets/beam.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #670`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3713, #3712, #3711, #3708, #3705 | apps/ui only | No |
| #3710 | `aurelius.json` only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/beam.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] Live: `curl -sS https://beamcore.b1m.ai/health` → HTTP 200 JSON
- [x] Live: `curl -sS https://beamcore.b1m.ai/openapi.json` → HTTP 200 OpenAPI 3.0
- [x] `npm run validate:surface -- registry/subnets/beam.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/beam.json`

Made with [Cursor](https://cursor.com)