### PR TITLE
feat(registry): add Verathos model runtime status data artifact (SN96)

### DIFF
--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -309,6 +309,25 @@
         "https://verathos.ai/docs"
       ],
       "url": "https://api.verathos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-model-status-artifact",
+      "kind": "data-artifact",
+      "name": "Verathos model runtime status",
+      "notes": "Public no-auth JSON snapshot of the currently loaded model configuration and runtime status (preset_id, model_name, quantization label, layer count, max context length). Path is declared in the official OpenAPI spec on verathos.ai. Distinct from the presets catalog and chain-info data artifacts.",
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://verathos.ai/",
+        "https://verathos.ai/openapi.json"
+      ],
+      "url": "https://verathos.ai/api/models/status"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `data-artifact` surface to `registry/subnets/verathos.json`.

Closes #736

## Surface

- Netuid: 96
- Kind: data-artifact
- Public URL: https://verathos.ai/api/models/status
- Source URL (proves the claim): https://verathos.ai/openapi.json
- Provider slug: verathos

## Checklist

- [x] Changes exactly one `registry/subnets/verathos.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #736`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3717 (Beam) | `beam.json` only | No |
| #3716 | src/health-serving | No |
| #3713–#3708 | apps/ui only | No |
| #3594, #3546 | release/README | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/verathos.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/verathos.json`


Made with [Cursor](https://cursor.com)