### PR TITLE
feat(registry): add SN44 Score OpenAPI + health surfaces

### DIFF
--- a/registry/subnets/score.json
+++ b/registry/subnets/score.json
@@ -25,6 +25,46 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Current SN44 validator/miner base code, linked as both \"GitHub\" and \"Documentation\" from the official wearescore.com site. Distinct from the legacy turbovision repo."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-44-score-openapi",
+      "kind": "openapi",
+      "name": "Score Subnet API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Score SN44 backend (title: Score Subnet API). Served publicly at api.scorevision.io; documents challenge/task routes and the no-auth GET /health probe.",
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.scorevision.io/openapi.json",
+      "source_urls": [
+        "https://github.com/score-technologies/score-vision/blob/main/validator/config.py",
+        "https://api.scorevision.io/openapi.json"
+      ],
+      "url": "https://api.scorevision.io/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-44-score-subnet-api",
+      "kind": "subnet-api",
+      "name": "Score API health",
+      "notes": "Public no-auth GET /health on api.scorevision.io returning backend liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /health in the subnet OpenAPI spec; api.scorevision.io is the SCORE_VISION_API host configured in the score-vision validator source.",
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.scorevision.io/openapi.json",
+        "https://github.com/score-technologies/score-vision/blob/main/validator/config.py"
+      ],
+      "url": "https://api.scorevision.io/health"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends two community surfaces to `registry/subnets/score.json`.
Append-only (+40 lines); no existing surfaces or top-level fields modified.

Closes #662

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://api.scorevision.io/openapi.json | score-vision `config.py`, live OpenAPI |
| subnet-api | https://api.scorevision.io/health | OpenAPI spec, score-vision `config.py` |

- Netuid: 44
- Provider slug: score

First-party proof: the official [score-vision validator config](https://github.com/score-technologies/score-vision/blob/main/validator/config.py) sets `SCORE_VISION_API = "https://api.scorevision.io"`. The live OpenAPI 3.1 spec on that host documents `GET /health` and the challenge/task routes.

## Canonical manifest

On current `origin/main`, SN44 has one registry file: `registry/subnets/score.json` (slug `sn-44`). This PR appends to that canonical manifest only.

## Checklist

- [x] Changes exactly one `registry/subnets/score.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #662`).

## Conflict avoidance

| Open PR | Files touched | Conflict? |
|---------|---------------|-----------|
| #3719, #3718 | UI / `verathos.json` | No |
| #3713 | apps/ui only | No |
| #3594, #3546 | release/README | No |
| (none) | `registry/subnets/score.json` | No |

Append-only at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] Live: `curl -sS https://api.scorevision.io/health` → HTTP 200 JSON
- [x] Live: `curl -sS https://api.scorevision.io/openapi.json` → HTTP 200 OpenAPI 3.1
- [x] `npm run validate:surface -- registry/subnets/score.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/score.json`

Made with [Cursor](https://cursor.com)