### PR TITLE
feat(registry): add NexisGen provider profile (SN70)

### DIFF
--- a/registry/providers/nexisgen.json
+++ b/registry/providers/nexisgen.json
@@ -1,0 +1,13 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/RendixNetwork/nexisgen",
+  "id": "nexisgen",
+  "kind": "subnet-team",
+  "name": "NexisGen",
+  "public_notes": "Subnet 70 (NexisGen) team profile — Bittensor data subnet for validated miner submissions. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+  "schema_version": 1,
+  "social": {
+    "x": "https://x.com/nexisgen_ai"
+  },
+  "website_url": "https://nexisgen.ai/"
+}


### PR DESCRIPTION
## Summary

- Add `registry/providers/nexisgen.json` so SN70 NexisGen surfaces can reference provider slug `nexisgen`.
- Prerequisite for subnet API/OpenAPI enrichment in #579 (provider and surfaces must land in separate PRs per registry review rubric).

## Checklist

- [x] Changes exactly one `registry/providers/nexisgen.json` file.
- [x] `authority: community` provider profile for RendixNetwork/nexisgen (SN70).
- [x] `npm run validate:surface` passes.

## Follow-up

After this merges, a separate append-only PR will add OpenAPI + `/healthz` surfaces to `registry/subnets/nexisgen.json` and close #579.


Made with [Cursor](https://cursor.com)