### PR TITLE
feat(mcp): filter and paginate list_profile_completeness

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -6401,18 +6401,113 @@ export const MCP_TOOLS = [
       "Fetch the contributor review queue of subnet profile-completeness gaps: " +
       "which subnets have incomplete public-safe profiles (missing identity, " +
       "native name, confidence, or promotion signals) and are worth profile " +
-      "enrichment. Use it to find high-value profile contributions. Mirrors " +
+      "enrichment. Use it to find high-value profile contributions. Optionally " +
+      "filter by netuid/profile_level/confidence/identity_level/" +
+      "native_name_quality/identity_promotion_kind and page with limit/offset " +
+      "— the full queue can be large. Mirrors " +
       "GET /api/v1/review/profile-completeness.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        profile_level: {
+          type: "string",
+          enum: QUERY_ENUMS.profileLevel,
+          description: "Profile depth, e.g. 'directory-only' or 'operational'.",
+        },
+        confidence: {
+          type: "string",
+          enum: ["low", "medium", "high"],
+          description: "Identity confidence tier.",
+        },
+        identity_level: {
+          type: "string",
+          enum: ["none", "directory", "partial", "complete"],
+          description: "How complete the subnet's identity evidence is.",
+        },
+        native_name_quality: {
+          type: "string",
+          enum: ["chain", "placeholder", "empty"],
+          description: "Quality of the on-chain native name signal.",
+        },
+        identity_promotion_kind: {
+          type: "string",
+          enum: QUERY_ENUMS.surfaceKind,
+          description:
+            "Only subnets that still need identity promotion for this " +
+            "surface kind (checks the row's identity_promotion_kinds list).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max rows to return. Omit for the full queue.",
+          minimum: 1,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset into the (filtered) list. Default 0.",
+          minimum: 0,
+        },
+      },
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
-      return loadArtifactData(
+    async handler(args, ctx) {
+      const netuid = optionalNonNegativeInt(args, "netuid");
+      const profileLevel = optionalEnum(
+        args,
+        "profile_level",
+        QUERY_ENUMS.profileLevel,
+      );
+      const confidence = optionalEnum(args, "confidence", [
+        "low",
+        "medium",
+        "high",
+      ]);
+      const identityLevel = optionalEnum(args, "identity_level", [
+        "none",
+        "directory",
+        "partial",
+        "complete",
+      ]);
+      const nativeNameQuality = optionalEnum(args, "native_name_quality", [
+        "chain",
+        "placeholder",
+        "empty",
+      ]);
+      const identityPromotionKind = optionalEnum(
+        args,
+        "identity_promotion_kind",
+        QUERY_ENUMS.surfaceKind,
+      );
+      const limit = optionalPositiveInt(args, "limit");
+      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const data = await loadArtifactData(
         ctx,
         "/metagraph/review/profile-completeness.json",
       );
+      const all = Array.isArray(data.profiles) ? data.profiles : [];
+      const filtered = all.filter(
+        (p) =>
+          (netuid === null || p.netuid === netuid) &&
+          (profileLevel === null || p.profile_level === profileLevel) &&
+          (confidence === null || p.confidence === confidence) &&
+          (identityLevel === null || p.identity_level === identityLevel) &&
+          (nativeNameQuality === null ||
+            p.native_name_quality === nativeNameQuality) &&
+          (identityPromotionKind === null ||
+            (Array.isArray(p.identity_promotion_kinds) &&
+              p.identity_promotion_kinds.includes(identityPromotionKind))),
+      );
+      const page =
+        limit === null
+          ? filtered.slice(offset)
+          : filtered.slice(offset, offset + limit);
+      return {
+        ...data,
+        profiles: page,
+        total: filtered.length,
+        returned: page.length,
+        offset,
+      };
     },
   },
   {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14654,6 +14654,179 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
+  function profileCompletenessDeps() {
+    return makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        profiles: [
+          {
+            netuid: 7,
+            name: "Allways",
+            profile_level: "directory-only",
+            confidence: "low",
+            identity_level: "none",
+            native_name_quality: "empty",
+            identity_promotion_kinds: ["openapi", "docs"],
+          },
+          {
+            netuid: 12,
+            name: "Compute",
+            profile_level: "operational",
+            confidence: "high",
+            identity_level: "complete",
+            native_name_quality: "chain",
+            identity_promotion_kinds: [],
+          },
+          {
+            netuid: 64,
+            name: "Chutes",
+            profile_level: "directory-only",
+            confidence: "medium",
+            identity_level: "partial",
+            native_name_quality: "placeholder",
+            identity_promotion_kinds: ["subnet-api"],
+          },
+        ],
+      },
+    });
+  }
+
+  test("list_profile_completeness returns the review queue artifact", async () => {
+    const deps = profileCompletenessDeps();
+    const res = await callTool("list_profile_completeness", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
+  });
+
+  test("list_profile_completeness filters by netuid, profile_level, confidence, identity_level, and native_name_quality", async () => {
+    const deps = profileCompletenessDeps();
+    const byNetuid = (
+      await callTool("list_profile_completeness", { netuid: 12 }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byNetuid.total, 1);
+    assert.equal(byNetuid.profiles[0].name, "Compute");
+
+    const byLevel = (
+      await callTool(
+        "list_profile_completeness",
+        { profile_level: "directory-only" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byLevel.total, 2);
+
+    const byConfidence = (
+      await callTool(
+        "list_profile_completeness",
+        { confidence: "high" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byConfidence.total, 1);
+    assert.equal(byConfidence.profiles[0].netuid, 12);
+
+    const byIdentity = (
+      await callTool(
+        "list_profile_completeness",
+        { identity_level: "partial" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byIdentity.total, 1);
+    assert.equal(byIdentity.profiles[0].netuid, 64);
+
+    const byNameQuality = (
+      await callTool(
+        "list_profile_completeness",
+        { native_name_quality: "placeholder" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.equal(byNameQuality.total, 1);
+    assert.equal(byNameQuality.profiles[0].netuid, 64);
+  });
+
+  test("list_profile_completeness filters by identity_promotion_kind (array membership)", async () => {
+    const deps = profileCompletenessDeps();
+    const res = await callTool(
+      "list_profile_completeness",
+      { identity_promotion_kind: "docs" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.profiles[0].netuid, 7);
+  });
+
+  test("list_profile_completeness combines filters (AND) and reports total vs returned", async () => {
+    const deps = profileCompletenessDeps();
+    const res = await callTool(
+      "list_profile_completeness",
+      { profile_level: "directory-only", confidence: "medium" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.profiles[0].netuid, 64);
+  });
+
+  test("list_profile_completeness paginates the filtered list with limit/offset", async () => {
+    const deps = profileCompletenessDeps();
+    const res = await callTool(
+      "list_profile_completeness",
+      { limit: 1, offset: 1 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 1);
+    assert.equal(out.offset, 1);
+    assert.equal(out.profiles[0].netuid, 12);
+  });
+
+  test("list_profile_completeness rejects an unknown enum value for each enum arg", async () => {
+    const deps = profileCompletenessDeps();
+    for (const args of [
+      { profile_level: "not-a-level" },
+      { confidence: "not-a-confidence" },
+      { identity_level: "not-a-level" },
+      { native_name_quality: "not-a-quality" },
+      { identity_promotion_kind: "not-a-kind" },
+    ]) {
+      const res = await callTool("list_profile_completeness", args, { deps });
+      assert.equal(
+        res.body.result.isError,
+        true,
+        `expected isError for ${JSON.stringify(args)}`,
+      );
+    }
+  });
+
+  test("list_profile_completeness rejects an unexpected argument", async () => {
+    const deps = profileCompletenessDeps();
+    const res = await callTool(
+      "list_profile_completeness",
+      { bogus: 1 },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("list_profile_completeness is schema-stable when the artifact has no profiles array", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+      },
+    });
+    const res = await callTool("list_profile_completeness", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.profiles, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
+  });
+
   test("get_subnet_endpoints returns one subnet's endpoints artifact", async () => {
     const deps = makeDeps({
       "/metagraph/endpoints/5.json": {


### PR DESCRIPTION
## Summary

`list_profile_completeness` returns the entire contributor review queue with no way to narrow or page it — unlike most other `list_*` MCP tools (following the same pattern already merged for `list_candidates`/`list_endpoints`/`list_providers`/`list_surfaces`).

Adds optional `netuid` / `profile_level` / `confidence` / `identity_level` / `native_name_quality` filters (validated against the same enums the REST `profile-completeness` query collection uses in `src/contracts.mjs`) plus `identity_promotion_kind` — an array-membership check against each row's `identity_promotion_kinds` list (a subnet can need promotion on multiple surface kinds at once) — and `limit`/`offset` pagination.

**Omitting every arg keeps the response backward compatible** — `profiles` is unchanged; `total`/`returned`/`offset` are simply added.

Per the current `MCP_SERVER_VERSION` policy (the post-merge `sync-mcp-version` workflow bumps it automatically), this PR does **not** touch the version constant or `server.json`.

## Changes
- `src/mcp-server.mjs`: filter + pagination logic on `list_profile_completeness`'s handler (including the array-membership `identity_promotion_kind` check); inputSchema gains the 7 new optional args.
- `tests/mcp-server.test.mjs`: per-field filters (including the array-membership case), combined (AND) filtering, limit/offset pagination, invalid-enum rejection for every enum arg, unexpected-argument rejection, missing-array schema-stability (branch-coverage complete, verified locally with no partial branches in the touched region before push).

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed.

## Validation
- `node scripts/validate-mcp.mjs` (150 tools, version consistency) — green
- `npx vitest run tests/mcp-server.test.mjs` — 713 passed; new lines fully covered (statement + branch)
- `npm run lint`, `npm run format:check` — clean