### PR TITLE
feat(ui): extract visibility-gated refetch interval hook (#3371)

### DIFF
--- a/apps/ui/src/hooks/use-refetch-interval.test.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRefetchInterval } from "./use-refetch-interval";
+
+describe("resolveRefetchInterval", () => {
+  it("returns the interval when polling is enabled and the tab is visible", () => {
+    expect(resolveRefetchInterval(true, true, 30_000)).toBe(30_000);
+    expect(resolveRefetchInterval(true, true, 60_000)).toBe(60_000);
+  });
+
+  it("pauses polling when disabled, hidden, or interval is non-positive", () => {
+    expect(resolveRefetchInterval(false, true, 30_000)).toBe(false);
+    expect(resolveRefetchInterval(true, false, 30_000)).toBe(false);
+    expect(resolveRefetchInterval(true, true, 0)).toBe(false);
+    expect(resolveRefetchInterval(true, true, -1)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-refetch-interval.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+/**
+ * TanStack Query `refetchInterval` value: `false` pauses polling when the tab
+ * is hidden or the user has paused refresh.
+ */
+export function resolveRefetchInterval(
+  enabled: boolean,
+  visible: boolean,
+  intervalMs: number,
+): number | false {
+  if (!enabled || !visible || intervalMs <= 0) return false;
+  return intervalMs;
+}
+
+/** Returns true when the document is visible (or true during SSR). */
+export function usePageVisible(): boolean {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const update = () => setVisible(!document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+  return visible;
+}
+
+/**
+ * Visibility- and enable-gated poll interval for live freshness queries.
+ * Returns a ms value suitable for TanStack Query's `refetchInterval`, or
+ * `false` when polling should pause.
+ */
+export function useRefetchInterval(intervalMs: number, enabled = true): number | false {
+  const visible = usePageVisible();
+  return resolveRefetchInterval(enabled, visible, intervalMs);
+}

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { usePageVisible, resolveRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { RefreshCw, Pause, Play, ChevronDown, ChevronRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -59,24 +60,11 @@ export const Route = createFileRoute("/health")({
   component: HealthPage,
 });
 
-/** Returns true when the document is visible (or true in SSR). */
-function usePageVisible(): boolean {
-  const [visible, setVisible] = useState(true);
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    const update = () => setVisible(!document.hidden);
-    update();
-    document.addEventListener("visibilitychange", update);
-    return () => document.removeEventListener("visibilitychange", update);
-  }, []);
-  return visible;
-}
-
 function HealthPage() {
   const [enabled, setEnabled] = useState(true);
   const [intervalMs, setIntervalMs] = useState(30_000);
   const visible = usePageVisible();
-  const effectiveInterval = enabled && visible ? intervalMs : false;
+  const effectiveInterval = resolveRefetchInterval(enabled, visible, intervalMs);
   // #1117: push a refresh on each registry publish, on top of the poll interval.
   useRegistryEvents();
 

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -20,7 +21,6 @@ import {
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
 
-const REFRESH_MS = 60_000;
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
 // treated as still-ongoing (probe cadence is ~2 min, so ~5 cycles).
@@ -119,7 +119,8 @@ function StatusPage() {
 
 /** Overall verdict banner + status mix, derived from /api/v1/health status counts. */
 function Verdict() {
-  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval: REFRESH_MS });
+  const refetchInterval = useRefetchInterval(60_000);
+  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval });
   const h = hRes.data;
   const ok = h?.ok ?? 0;
   const warn = h?.warn ?? 0;
@@ -245,9 +246,10 @@ function Kpi({
 function RecentIncidents() {
   const [window, setWindow] = useState<IncidentWindow>("7d");
   const [showAll, setShowAll] = useState(false);
+  const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
     ...globalIncidentsQuery(window),
-    refetchInterval: REFRESH_MS,
+    refetchInterval,
   });
   const ledger = data.data;
   // A surface is still failing ("ongoing") when its most recent downtime event


### PR DESCRIPTION
## Summary
- Add `use-refetch-interval.ts` with `usePageVisible`, `useRefetchInterval`, and testable `resolveRefetchInterval` pure helper
- Lift page-visibility logic out of `health.tsx`; keep AutoRefreshControl and enabled/intervalMs state unchanged
- Wire `/status` Verdict and RecentIncidents through `useRefetchInterval(60_000)` so polling pauses when the tab is hidden

Closes #3371

## Test plan
- [x] `npm test -- use-refetch-interval.test.ts` passes locally
- [ ] CI validate + codecov green
- [ ] Confirm no `manual-review` label (hooks-layer extraction per issue scope)


Made with [Cursor](https://cursor.com)