### PR TITLE
feat(mcp): filter and paginate list_schemas

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -6577,15 +6577,68 @@ export const MCP_TOOLS = [
       "Fetch the index of captured OpenAPI/Swagger schema snapshots across " +
       "subnets: which surfaces publish a machine-readable schema, its hash, and " +
       "drift status (new/unchanged/changed). Use it to discover which surfaces " +
-      "have a schema, then fetch one with get_api_schema. Mirrors " +
-      "GET /api/v1/schemas.",
+      "have a schema, then fetch one with get_api_schema. Optionally filter by " +
+      "netuid/status/drift_status and page with limit/offset — the full index " +
+      "can be large. Mirrors GET /api/v1/schemas.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        status: {
+          type: "string",
+          description:
+            "Capture status, e.g. 'captured', 'not-captured', or " +
+            "'pending-snapshot'.",
+        },
+        drift_status: {
+          type: "string",
+          enum: ["new", "unchanged", "changed", "not-captured"],
+          description:
+            "Whether the captured schema's hash changed since last snapshot.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max entries to return. Omit for the full index.",
+          minimum: 1,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset into the (filtered) list. Default 0.",
+          minimum: 0,
+        },
+      },
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
-      return loadArtifactData(ctx, "/metagraph/schemas/index.json");
+    async handler(args, ctx) {
+      const netuid = optionalNonNegativeInt(args, "netuid");
+      const status = optionalString(args, "status");
+      const driftStatus = optionalEnum(args, "drift_status", [
+        "new",
+        "unchanged",
+        "changed",
+        "not-captured",
+      ]);
+      const limit = optionalPositiveInt(args, "limit");
+      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const data = await loadArtifactData(ctx, "/metagraph/schemas/index.json");
+      const all = Array.isArray(data.schemas) ? data.schemas : [];
+      const filtered = all.filter(
+        (s) =>
+          (netuid === null || s.netuid === netuid) &&
+          (status === null || s.status === status) &&
+          (driftStatus === null || s.drift_status === driftStatus),
+      );
+      const page =
+        limit === null
+          ? filtered.slice(offset)
+          : filtered.slice(offset, offset + limit);
+      return {
+        ...data,
+        schemas: page,
+        total: filtered.length,
+        returned: page.length,
+        offset,
+      };
     },
   },
   {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13713,6 +13713,106 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
   });
 
+  test("list_schemas rejects an unexpected argument", async () => {
+    const res = await callTool("list_schemas", { bogus: 1 });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  function schemasDeps() {
+    return makeDeps({
+      "/metagraph/schemas/index.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        schemas: [
+          {
+            netuid: 6,
+            surface_id: "6:openapi:numinous",
+            status: "captured",
+            drift_status: "new",
+          },
+          {
+            netuid: 6,
+            surface_id: "6:subnet-api:numinous",
+            status: "pending-snapshot",
+            drift_status: "not-captured",
+          },
+          {
+            netuid: 7,
+            surface_id: "7:openapi:allways",
+            status: "captured",
+            drift_status: "changed",
+          },
+        ],
+      },
+    });
+  }
+
+  test("list_schemas filters by netuid, status, and drift_status", async () => {
+    const deps = schemasDeps();
+    const byNetuid = (await callTool("list_schemas", { netuid: 7 }, { deps }))
+      .body.result.structuredContent;
+    assert.equal(byNetuid.total, 1);
+    assert.equal(byNetuid.schemas[0].surface_id, "7:openapi:allways");
+
+    const byStatus = (
+      await callTool("list_schemas", { status: "captured" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byStatus.total, 2);
+
+    const byDrift = (
+      await callTool("list_schemas", { drift_status: "changed" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byDrift.total, 1);
+    assert.equal(byDrift.schemas[0].netuid, 7);
+  });
+
+  test("list_schemas combines filters (AND) and reports total vs returned", async () => {
+    const deps = schemasDeps();
+    const res = await callTool(
+      "list_schemas",
+      { netuid: 6, status: "captured" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.schemas[0].drift_status, "new");
+  });
+
+  test("list_schemas paginates the filtered list with limit/offset", async () => {
+    const deps = schemasDeps();
+    const res = await callTool(
+      "list_schemas",
+      { limit: 1, offset: 1 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 1);
+    assert.equal(out.offset, 1);
+    assert.equal(out.schemas[0].surface_id, "6:subnet-api:numinous");
+  });
+
+  test("list_schemas rejects an unknown drift_status enum value", async () => {
+    const deps = schemasDeps();
+    const res = await callTool(
+      "list_schemas",
+      { drift_status: "not-a-status" },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("list_schemas is schema-stable when the artifact has no schemas array", async () => {
+    const deps = makeDeps({
+      "/metagraph/schemas/index.json": { generated_at: "2026-01-01T00:00:00Z" },
+    });
+    const res = await callTool("list_schemas", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.schemas, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
+  });
+
   test("list_search_index returns filtered document rows", async () => {
     const deps = makeDeps({
       "/metagraph/search-index.json": {


### PR DESCRIPTION
## Summary

`list_schemas` returns the entire captured-schema index across all subnets with no way to narrow or page it — unlike most other `list_*` MCP tools (following the same pattern already merged for `list_candidates`/`list_endpoints`/`list_providers`/`list_surfaces`).

Adds optional `netuid` / `status` / `drift_status` filters plus `limit`/`offset` pagination over the filtered result. `drift_status` is validated against its known values (`new`/`unchanged`/`changed`/`not-captured`, per `scripts/snapshot-openapi.mjs`); `status` is a free-text filter since the capture-status values aren't a single exported enum (`captured`, `not-captured`, `pending-snapshot`, `ui-only-or-undiscovered`, `not-snapshotted`, etc.).

**Omitting every arg keeps the response backward compatible** — `schemas` is unchanged; `total`/`returned`/`offset` are simply added.

Per the current `MCP_SERVER_VERSION` policy (the post-merge `sync-mcp-version` workflow bumps it automatically), this PR does **not** touch the version constant or `server.json`. Independent of #3723 (`list_profile_completeness`) — different tool, no file overlap.

## Changes
- `src/mcp-server.mjs`: filter + pagination logic on `list_schemas`'s handler; inputSchema gains the 5 new optional args.
- `tests/mcp-server.test.mjs`: per-field filters, combined (AND) filtering, limit/offset pagination, invalid drift_status rejection, unexpected-argument rejection, missing-array schema-stability (branch-coverage complete, verified locally with no partial branches in the touched region before push).

MCP-only change — no REST/contract/OpenAPI files touched, no server-card regen needed.

## Validation
- `node scripts/validate-mcp.mjs` (150 tools, version consistency) — green
- `npx vitest run tests/mcp-server.test.mjs` — 711 passed; new lines fully covered (statement + branch)
- `npm run lint`, `npm run format:check` — clean