### PR TITLE
feat(sn-18): add Zeus BOREAS Edge API readiness surface

### DIFF
--- a/registry/subnets/zeus.json
+++ b/registry/subnets/zeus.json
@@ -68,6 +68,25 @@
         "https://docs.zeussubnet.com/docs/introduction"
       ],
       "url": "https://api.zeussubnet.com/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-ready",
+      "kind": "subnet-api",
+      "name": "Zeus BOREAS Edge API readiness",
+      "notes": "Public no-auth readiness probe for the Zeus BOREAS Edge API; GET /v1/ready reports service readiness per the machine-readable OpenAPI spec on the same host as the existing /v1/meta and /v1/health subnet-api surfaces.",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.zeussubnet.com/openapi.json",
+        "https://docs.zeussubnet.com/docs/introduction"
+      ],
+      "url": "https://api.zeussubnet.com/v1/ready"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Summary

Adds the public, no-auth `GET /v1/ready` endpoint of the Zeus (SN18) BOREAS Edge API as a `subnet-api` surface.

## Why it's safe to merge

- **Official & documented** — `/v1/ready` is a path in Zeus's own machine-readable OpenAPI spec (`https://api.zeussubnet.com/openapi.json`), alongside the already-registered `/v1/meta` and `/v1/health`.
- **Same host, sibling pattern** — it lives on the same `api.zeussubnet.com` host as the existing meta/health surfaces in `zeus.json`.
- **Public & no auth** — returns HTTP 200 with a plain service-readiness status; `auth_required: false`, `public_safe: true`.
- **Unique** — the URL is not registered by any other surface or subnet (no duplication).

## Change

Single additive entry in `registry/subnets/zeus.json` (19 lines). No generated artifacts touched.
