### PR TITLE
feat(registry): enrich SN71 Leadpoet — health API

### DIFF
--- a/registry/subnets/leadpoet.json
+++ b/registry/subnets/leadpoet.json
@@ -12,7 +12,33 @@
   "social": {
     "x": "https://x.com/leadpoetai"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-71-leadpoet-health-api",
+      "kind": "subnet-api",
+      "name": "Leadpoet web health API",
+      "notes": "Public no-auth GET /api/health on leadpoet.com returning JSON liveness (observed: {\"status\":\"ok\",\"service\":\"leadpoet-web\",...}). Documented in the subnet's own OpenAPI (leadpoet.com/api/openapi.json, path /api/health); same host as the official Leadpoet website linked from the SN71 source repository README.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leadpoet",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://leadpoet.com/api/openapi.json",
+        "https://github.com/leadpoet/leadpoet"
+      ],
+      "url": "https://leadpoet.com/api/health"
+    }
+  ],
   "source_repo": "https://github.com/leadpoet/leadpoet",
   "website_url": "https://leadpoet.com/",
   "contact": "hello@leadpoet.com"


### PR DESCRIPTION
Closes #673

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/leadpoet.json`.

## Surface

- Netuid: **71** (Leadpoet)
- Kind: **subnet-api**
- Public URL: `https://leadpoet.com/api/health`
- Source URLs:
  - https://leadpoet.com/api/openapi.json
  - https://github.com/leadpoet/leadpoet
- Provider slug: **leadpoet**

## Checklist

- [x] Changes exactly one `registry/subnets/leadpoet.json` file (append-only, +27 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only/credentialed flows, secrets, or generated artifacts
- [x] Does not duplicate an existing Metagraphed surface
- [x] Links a tracked issue (`Closes #673`)

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/leadpoet.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/leadpoet.json`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3720 | `registry/subnets/score.json` | `registry/subnets/leadpoet.json` |
| #3713 | UI only | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Made with [Cursor](https://cursor.com)