### PR TITLE
feat(registry): enrich SN48 Quantum Compute — health API

### DIFF
--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -66,6 +66,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Quantum Compute source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-48-quantum-compute-health-api",
+      "kind": "subnet-api",
+      "name": "Quantum Compute health API",
+      "notes": "Public no-auth GET /api/health on www.qbittensorlabs.com returning JSON liveness (observed: {\"status\":\"ok\"}). Served on the official qBittensor Labs website host alongside the existing website and source-repo surfaces for SN48.",
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute",
+        "https://www.qbittensorlabs.com/"
+      ],
+      "url": "https://www.qbittensorlabs.com/api/health"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #686

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/quantum-compute.json`.

## Surface

- Netuid: **48** (Quantum Compute)
- Kind: **subnet-api**
- Public URL: `https://www.qbittensorlabs.com/api/health`
- Source URLs:
  - https://github.com/qbittensor-labs/quantum-compute
  - https://www.qbittensorlabs.com/
- Provider slug: **qbittensor-labs**

## Checklist

- [x] Changes exactly one `registry/subnets/quantum-compute.json` file (append-only, +19 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only/credentialed flows, secrets, or generated artifacts
- [x] Does not duplicate an existing Metagraphed surface
- [x] Links a tracked issue (`Closes #686`)

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/quantum-compute.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/quantum-compute.json`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3737 | UI `accounts.$ss58.tsx` | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Made with [Cursor](https://cursor.com)