### PR TITLE
fix(ui): keep scroll position when typing in a page search box

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -646,7 +646,11 @@ function AccountEventsSection({
   const hasNext = page?.next_cursor != null || events.length === limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
+    });
 
   // Cold accounts return a schema-stable zero — never error. While loading the
   // first page, defer to the summary-driven sections above rather than flashing.

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -100,7 +100,11 @@ function BlocksTable() {
   const hasNext = rows.length === search.limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
+    });
 
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -393,6 +393,8 @@ function EndpointsTable() {
     navigate({
       search: (prev: Record<string, unknown>) =>
         ({ ...prev, ...patch, ...(resetsPage ? { page: 1 } : {}) }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
       replace: true,
     });
   };

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -107,7 +107,11 @@ function ExtrinsicsTable() {
   const hasNext = rows.length === search.limit;
 
   const setSearch = (patch: Record<string, unknown>) =>
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never });
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
+    });
 
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -456,6 +456,8 @@ function OpenGapsSection() {
   const setSearch = (patch: Partial<typeof search>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
       replace: true,
     });
 

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -304,6 +304,8 @@ function SchemaExplorer() {
     (patch: Partial<typeof search>) =>
       navigate({
         search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+        // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+        resetScroll: false,
         replace: true,
       }),
     [navigate],

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -283,6 +283,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
     });
 
   const onSort = (field: string) =>

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -181,6 +181,8 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
     });
 
   const onSort = (field: string) =>


### PR DESCRIPTION
Closes #3691

On any page with a search box, typing scrolled the page back to the top on every keystroke -- so searching a 2+ character term (e.g. a netuid like "74") meant re-scrolling and re-clicking the input between keystrokes. Reported by a team member on Discord.

**Root cause:** the per-page search/filter handlers call `navigate({ search: ... })` without `resetScroll: false`, so TanStack Router resets scroll to the top on each navigation.

**Fix:** add `resetScroll: false` to those search-navigate calls across the 8 pages with a search box (accounts, blocks, endpoints, extrinsics, gaps, schemas, subnets, surfaces). Filter state still updates; scroll position is preserved.

_Behavioral fix -- no visual-output change, so before/after screenshots would be identical (N/A). Repro: on /subnets, scroll to the table, type into the search box; before this change the page jumps to the top each keystroke, after it stays put._

Verified: `tsc --noEmit` and `eslint` clean.
