### PR TITLE
feat(registry): enrich SN67 Harnyx — healthz API

### DIFF
--- a/registry/subnets/harnyx.json
+++ b/registry/subnets/harnyx.json
@@ -12,7 +12,24 @@
   "social": {
     "x": "https://x.com/harnyx_ai"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-67-harnyx-healthz-api",
+      "kind": "subnet-api",
+      "name": "Harnyx healthz API",
+      "notes": "Public no-auth GET /healthz on harnyx.ai returning plain-text liveness (observed: ok). Served on the official Harnyx website host linked from the SN67 source repository; the repo documents API flows under docs/api/.",
+      "provider": "harnyx",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": ["https://github.com/harnyx/harnyx", "https://harnyx.ai/"],
+      "url": "https://harnyx.ai/healthz"
+    }
+  ],
   "source_repo": "https://github.com/harnyx/harnyx",
   "website_url": "https://harnyx.ai/",
   "contact": "harnyx@brightmount.co"


### PR DESCRIPTION
Closes #664

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/harnyx.json`.

## Surface

- Netuid: **67** (Harnyx)
- Kind: **subnet-api**
- Public URL: `https://harnyx.ai/healthz`
- Source URLs:
  - https://github.com/harnyx/harnyx
  - https://harnyx.ai/
- Provider slug: **harnyx**

## Checklist

- [x] Changes exactly one `registry/subnets/harnyx.json` file (append-only, +18 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Public-safe: no auth-only/credentialed flows, secrets, or generated artifacts
- [x] Does not duplicate an existing Metagraphed surface
- [x] Links a tracked issue (`Closes #664`)

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/harnyx.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/harnyx.json`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3739, #3737 | UI routes only | registry only |
| #3594 | release manifests | registry only |
| #3546 | `README.md` only | registry only |

Single-file append at end of `surfaces` array — mergeable after other open PRs land without rebase.

Made with [Cursor](https://cursor.com)