### PR TITLE
fix(ui): add netuid filter dropdown on Surfaces page

### DIFF
--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -17,6 +17,7 @@ export const tableSearchSchema = z.object({
   health: fallback(z.string(), "").default(""),
   kind: fallback(z.string(), "").default(""),
   provider: fallback(z.string(), "").default(""),
+  netuid: fallback(z.string(), "").default(""),
   // #9: agent-catalog capability filters (applied client-side over joined rows).
   serviceKind: fallback(z.string(), "").default(""),
   readiness: fallback(z.string(), "").default(""),

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -60,7 +60,12 @@ function SurfacesPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const filtersActive =
-    !!search.q || !!search.sort || !!search.kind || !!search.provider || !!search.cursor;
+    !!search.q ||
+    !!search.sort ||
+    !!search.kind ||
+    !!search.provider ||
+    !!search.netuid ||
+    !!search.cursor;
   const onReset = () =>
     navigate({
       // Keep page size and view on reset so the chosen layout survives.
@@ -178,6 +183,14 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
       .map((v) => ({ value: v, label: v }));
   }, [all]);
 
+  const netuidOptions = useMemo(() => {
+    const set = new Set<number>();
+    for (const s of all) if (s.netuid != null) set.add(s.netuid);
+    return Array.from(set)
+      .sort((a, b) => a - b)
+      .map((v) => ({ value: String(v), label: String(v) }));
+  }, [all]);
+
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
@@ -199,6 +212,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
       return false;
     if (search.kind && s.kind !== search.kind) return false;
     if (search.provider && (s.provider_slug ?? s.provider) !== search.provider) return false;
+    if (search.netuid && String(s.netuid) !== search.netuid) return false;
     return true;
   });
   const rows = sortBy(
@@ -227,11 +241,17 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
         onChange={(v) => setSearch({ provider: v })}
         options={providerOptions}
       />
+      <SelectFilter
+        label="netuid"
+        value={search.netuid}
+        onChange={(v) => setSearch({ netuid: v })}
+        options={netuidOptions}
+      />
       <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
     </>
   );
 
-  const filtersActive = !!(search.q || search.kind || search.provider);
+  const filtersActive = !!(search.q || search.kind || search.provider || search.netuid);
 
   const emptyNode = (
     <RegistryEmpty
@@ -249,7 +269,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
           ? [
               {
                 label: "Reset filters",
-                onClick: () => setSearch({ q: "", kind: "", provider: "" }),
+                onClick: () => setSearch({ q: "", kind: "", provider: "", netuid: "" }),
                 primary: true,
               },
               { label: "Open API", href: "/api/v1/surfaces", external: true },


### PR DESCRIPTION

## Summary

- Add `netuid` to `tableSearchSchema` and a `SelectFilter` on `/surfaces` alongside kind and provider
- Filter loaded rows client-side (same pattern as kind/provider); free-text search still matches netuid
- Reset filters and empty-state actions clear the new param
- Closes #3421 · Part of #2542

## Screenshots

| Before | After |
|--------|-------|
| <img width="1809" height="933" alt="image" src="https://github.com/user-attachments/assets/a8a2b852-31c5-4d5f-a1a0-dabdb543aba0" /> | <img width="1826" height="936" alt="image" src="https://github.com/user-attachments/assets/7b373ea9-18ab-409b-b7d5-cdaf43fe23b5" /> |


## Test plan

- [x] Open `/surfaces` — three discrete dropdowns: kind, provider, netuid
- [x] Pick a netuid — URL updates, table/grid shows only that subnet's surfaces
- [x] Reset filters clears netuid; hero Reset Filters button toggles correctly
- [x] Free-text search still finds netuid substrings when dropdown is empty
- [x] `npm run build:client --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`