### PR TITLE
fix(ui): guard event-kind map lookups

### DIFF
--- a/apps/ui/src/lib/metagraphed/event-kinds.test.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.test.ts
@@ -20,6 +20,12 @@ describe("eventKindCategory", () => {
     expect(eventKindCategory("")).toBe("other");
     expect(eventKindCategory("FutureEventKind")).toBe("other");
   });
+
+  it("treats Object prototype property names as unknown kinds", () => {
+    expect(eventKindCategory("__proto__")).toBe("other");
+    expect(eventKindCategory("constructor")).toBe("other");
+    expect(eventKindCategory("toString")).toBe("other");
+  });
 });
 
 describe("eventKindLabel", () => {
@@ -31,6 +37,12 @@ describe("eventKindLabel", () => {
 
   it("falls back to spaced CamelCase for unknown kinds", () => {
     expect(eventKindLabel("CustomSubnetEvent")).toBe("Custom Subnet Event");
+  });
+
+  it("falls back for Object prototype property names", () => {
+    expect(eventKindLabel("__proto__")).toBe("__proto__");
+    expect(eventKindLabel("constructor")).toBe("Constructor");
+    expect(eventKindLabel("toString")).toBe("To String");
   });
 
   it("returns a stable placeholder for missing kinds", () => {

--- a/apps/ui/src/lib/metagraphed/event-kinds.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.ts
@@ -90,12 +90,14 @@ function fallbackEventKindLabel(kind: string): string {
 
 export function eventKindCategory(kind: string | null | undefined): EventKindCategory {
   if (!kind) return "other";
-  return EVENT_KIND_CATEGORIES[kind] ?? "other";
+  return Object.hasOwn(EVENT_KIND_CATEGORIES, kind) ? EVENT_KIND_CATEGORIES[kind] : "other";
 }
 
 export function eventKindLabel(kind: string | null | undefined): string {
   if (!kind) return "Unknown event";
-  return EVENT_KIND_LABELS[kind] ?? fallbackEventKindLabel(kind);
+  return Object.hasOwn(EVENT_KIND_LABELS, kind)
+    ? EVENT_KIND_LABELS[kind]
+    : fallbackEventKindLabel(kind);
 }
 
 export function eventKindCategoryLabel(category: EventKindCategory): string {


### PR DESCRIPTION
### Motivation
- Unknown or malformed event-kind strings that match `Object.prototype` property names (for example `__proto__`, `constructor`, `toString`) could resolve to inherited values when looked up on plain object maps, causing unexpected non-string returns and possible React render crashes. 
- The helpers in the UI should treat prototype-colliding keys as unknown and use the existing fallback behavior.

### Description
- Replace direct bracket lookups with an own-property guard using `Object.hasOwn(...)` in `apps/ui/src/lib/metagraphed/event-kinds.ts` for both category and label maps so prototype keys fall back correctly. 
- Add regression tests in `apps/ui/src/lib/metagraphed/event-kinds.test.ts` that assert `__proto__`, `constructor`, and `toString` are treated as unknown and use the fallback behavior. 
- Run code formatting on the modified files to satisfy style rules.

### Testing
- Ran the UI unit test for the changed file with `npm --workspace apps/ui test -- --run src/lib/metagraphed/event-kinds.test.ts`, which passed (8 tests). 
- Ran the UI linter with `npm --workspace apps/ui run lint`, which completed with exit code 0 (warnings present but no blocking errors). 
- Ran the UI typecheck with `npm --workspace apps/ui run typecheck`, which failed due to unrelated pre-existing UI type errors in `src/lib/metagraphed/queries.ts` and a missing declaration for `@jsonbored/metagraphed` (these failures are outside the scope of this fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8c03bf78832c8d0f496612124570)