### PR TITLE
fix(mcp): handle leading-zero patch versions in MCP version-sync

### DIFF
--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -104,7 +104,7 @@ jobs:
               .match(/export const MCP_SERVER_VERSION = \"([^\"]+)\"/)[1]
           ")
           IFS='.' read -r maj min pat <<< "$current"
-          next="${maj}.${min}.$((pat + 1))"
+          next="${maj}.${min}.$((10#$pat + 1))"
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "next=$next" >> "$GITHUB_OUTPUT"
 

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -120,8 +120,8 @@ assert.equal(init.body.result.serverInfo.name, "metagraphed");
 // CONTRACT_VERSION, and must match the source constant.
 assert.match(
   init.body.result.serverInfo.version,
-  /^\d+\.\d+\.\d+$/,
-  "serverInfo.version must be SemVer (MCP_SERVER_VERSION), not the date-based CONTRACT_VERSION",
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/,
+  "serverInfo.version must be SemVer without leading-zero numeric identifiers (MCP_SERVER_VERSION), not the date-based CONTRACT_VERSION",
 );
 assert.equal(
   init.body.result.serverInfo.version,


### PR DESCRIPTION
### Motivation
- The MCP version-sync workflow used Bash arithmetic on the patch component which treats numbers with leading zeros as octal and fails for values like `08`/`09`, causing the automation to compute an empty `next` version.
- The existing MCP validator accepted digit-only `X.Y.Z` versions with leading zeros (e.g. `1.78.08`), so malformed versions could pass CI yet later break the scheduled bump workflow.

### Description
- Make the workflow arithmetic robust by forcing base-10 parsing of the patch component in `.github/workflows/sync-mcp-version.yml` (`$((10#$pat + 1))`).
- Tighten the MCP SemVer check in `scripts/validate-mcp.mjs` to reject numeric identifiers with leading zeroes by using a stricter regex and update the assertion message accordingly.

### Testing
- Ran the shell arithmetic sanity check `pat=08; next="1.78.$((10#$pat + 1))"; test "$next" = "1.78.9"` which succeeded.
- Executed a targeted Node snippet validating the new SemVer regex against example versions which passed the intended accept/reject cases.
- Ran `npm run validate:workflows` which succeeded and validated workflow YAMLs.
- Ran `npm run validate:mcp` which failed on an unrelated `search_subnets` `not_found` assertion and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8de16acc832caaa5036f118c8fc4)