### PR TITLE
fix(api): resolve account weight-setters by uid fallback

### DIFF
--- a/src/account-weight-setters.mjs
+++ b/src/account-weight-setters.mjs
@@ -118,10 +118,11 @@ export function buildAccountWeightSetters(rows, address, { window } = {}) {
 
 // One account's weight-setting footprint — reads its WeightsSet events from account_events over the
 // window (observed_at >= now - windowDays, epoch ms), grouped per subnet, shaped with
-// buildAccountWeightSetters. The (hotkey) prefix of idx_account_events_hotkey seeks just this
-// account's events; event_kind/observed_at are residual filters on that bounded seek. Returns
-// { data, generatedAt } where generatedAt is the newest weight-set's observed_at as an ISO string
-// (string|null per the envelope contract). Cold/absent D1 -> zeroed card + null.
+// buildAccountWeightSetters. WeightsSet ingestion can omit hotkey and store only (netuid, uid),
+// so fall back through the latest neurons snapshot for those hotkey-less rows instead of silently
+// dropping the validator's activity. Returns { data, generatedAt } where generatedAt is the newest
+// weight-set's observed_at as an ISO string (string|null per the envelope contract). Cold/absent
+// D1 -> zeroed card + null.
 export async function loadAccountWeightSetters(
   d1,
   address,
@@ -132,11 +133,14 @@ export async function loadAccountWeightSetters(
     ACCOUNT_WEIGHT_SETTERS_WINDOWS[DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW];
   const cutoff = Date.now() - days * DAY_MS;
   const rows = await d1(
-    "SELECT netuid, COUNT(*) AS weight_sets, MIN(observed_at) AS first_observed, " +
-      "MAX(observed_at) AS last_observed " +
-      "FROM account_events INDEXED BY idx_account_events_hotkey " +
-      "WHERE hotkey = ? AND event_kind = ? AND observed_at >= ? GROUP BY netuid",
-    [address, WEIGHTS_EVENT_KIND, cutoff],
+    "SELECT e.netuid, COUNT(*) AS weight_sets, MIN(e.observed_at) AS first_observed, " +
+      "MAX(e.observed_at) AS last_observed " +
+      "FROM account_events e " +
+      "LEFT JOIN neurons n ON e.netuid = n.netuid AND e.uid = n.uid " +
+      "AND (e.hotkey IS NULL OR e.hotkey = '') " +
+      "WHERE e.event_kind = ? AND e.observed_at >= ? " +
+      "AND (e.hotkey = ? OR n.hotkey = ?) GROUP BY e.netuid",
+    [WEIGHTS_EVENT_KIND, cutoff, address, address],
   );
   let latestObserved = null;
   for (const row of Array.isArray(rows) ? rows : []) {

--- a/tests/account-weight-setters.test.mjs
+++ b/tests/account-weight-setters.test.mjs
@@ -144,7 +144,7 @@ describe("buildAccountWeightSetters", () => {
 });
 
 describe("loadAccountWeightSetters", () => {
-  test("seeks the hotkey index for WeightsSet over the window and shapes it", async () => {
+  test("queries direct and uid-resolved WeightsSet rows over the window and shapes them", async () => {
     let captured;
     const d1 = async (sql, params) => {
       captured = { sql, params };
@@ -159,17 +159,112 @@ describe("loadAccountWeightSetters", () => {
     const { data, generatedAt } = await loadAccountWeightSetters(d1, ADDR, {
       windowLabel: "7d",
     });
+    assert.match(captured.sql, /FROM account_events e/);
     assert.match(
       captured.sql,
-      /FROM account_events INDEXED BY idx_account_events_hotkey/,
+      /LEFT JOIN neurons n ON e\.netuid = n\.netuid AND e\.uid = n\.uid/,
     );
-    assert.match(captured.sql, /WHERE hotkey = \? AND event_kind = \?/);
-    assert.match(captured.sql, /GROUP BY netuid/);
-    assert.equal(captured.params[0], ADDR);
-    assert.equal(captured.params[1], WEIGHTS_EVENT_KIND);
-    assert.equal(typeof captured.params[2], "number"); // epoch-ms cutoff
+    assert.match(captured.sql, /e\.hotkey = \? OR n\.hotkey = \?/);
+    assert.match(captured.sql, /GROUP BY e\.netuid/);
+    assert.equal(captured.params[0], WEIGHTS_EVENT_KIND);
+    assert.equal(typeof captured.params[1], "number"); // epoch-ms cutoff
+    assert.equal(captured.params[2], ADDR);
+    assert.equal(captured.params[3], ADDR);
     assert.equal(data.total_weight_sets, 5);
     assert.equal(generatedAt, new Date(1_700_500_000_000).toISOString());
+  });
+
+  test("counts hotkey-less WeightsSet rows by resolving netuid and uid through neurons", async () => {
+    const now = Date.now();
+    const events = [
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        hotkey: null,
+        netuid: 7,
+        uid: 3,
+        observed_at: now - 4_000,
+      },
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        hotkey: "",
+        netuid: 7,
+        uid: 3,
+        observed_at: now - 3_000,
+      },
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        hotkey: null,
+        netuid: 9,
+        uid: 4,
+        observed_at: now - 2_000,
+      },
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        hotkey: null,
+        netuid: 8,
+        uid: 5,
+        observed_at: now - 1_000,
+      },
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        hotkey: ADDR,
+        netuid: 11,
+        uid: null,
+        observed_at: now,
+      },
+    ];
+    const neurons = [
+      { netuid: 7, uid: 3, hotkey: ADDR },
+      { netuid: 9, uid: 4, hotkey: ADDR },
+      { netuid: 8, uid: 5, hotkey: "5DifferentHotkey" },
+    ];
+    const d1 = async (sql, params) => {
+      const [kind, cutoff, directHotkey, resolvedHotkey] = params;
+      assert.equal(kind, WEIGHTS_EVENT_KIND);
+      const grouped = events
+        .filter(
+          (event) => event.event_kind === kind && event.observed_at >= cutoff,
+        )
+        .filter((event) => {
+          if (event.hotkey === directHotkey) return true;
+          if (event.hotkey != null && event.hotkey !== "") return false;
+          return neurons.some(
+            (n) =>
+              n.netuid === event.netuid &&
+              n.uid === event.uid &&
+              n.hotkey === resolvedHotkey,
+          );
+        })
+        .reduce((acc, event) => {
+          const row = acc.get(event.netuid) ?? {
+            netuid: event.netuid,
+            weight_sets: 0,
+            first_observed: event.observed_at,
+            last_observed: event.observed_at,
+          };
+          row.weight_sets += 1;
+          row.first_observed = Math.min(row.first_observed, event.observed_at);
+          row.last_observed = Math.max(row.last_observed, event.observed_at);
+          acc.set(event.netuid, row);
+          return acc;
+        }, new Map());
+      return Array.from(grouped.values());
+    };
+
+    const { data, generatedAt } = await loadAccountWeightSetters(d1, ADDR, {
+      windowLabel: "30d",
+    });
+
+    assert.equal(data.total_weight_sets, 4);
+    assert.deepEqual(
+      data.subnets.map((s) => [s.netuid, s.weight_sets]),
+      [
+        [7, 2],
+        [9, 1],
+        [11, 1],
+      ],
+    );
+    assert.equal(generatedAt, new Date(now).toISOString());
   });
 
   test("an unknown window label falls back to the default window days", async () => {
@@ -181,7 +276,7 @@ describe("loadAccountWeightSetters", () => {
     await loadAccountWeightSetters(d1, ADDR, { windowLabel: "bogus" });
     // 7d default cutoff = now - 7d; assert it's within a day of that.
     const expected = Date.now() - 7 * 24 * 60 * 60 * 1000;
-    assert.ok(Math.abs(captured.params[2] - expected) < 24 * 60 * 60 * 1000);
+    assert.ok(Math.abs(captured.params[1] - expected) < 24 * 60 * 60 * 1000);
   });
 
   test("a cold store (no rows) yields a zeroed card + null generatedAt", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4226,10 +4226,10 @@ describe("MCP stake-flow and movers economics tools", () => {
               return {
                 async all() {
                   if (
-                    /idx_account_events_hotkey/.test(sql) &&
+                    /FROM account_events e/.test(sql) &&
                     /AS weight_sets/.test(sql) &&
                     /first_observed/.test(sql) &&
-                    params[1] === "WeightsSet"
+                    params[0] === "WeightsSet"
                   ) {
                     return { results: rows };
                   }


### PR DESCRIPTION
### Motivation

- The account `/api/v1/accounts/{ss58}/weight-setters` loader filtered `WeightsSet` rows by `hotkey` only, which missed ingestion rows that record only `(netuid, uid)` and therefore returned empty/incorrect per-account activity.

### Description

- Change `loadAccountWeightSetters` to LEFT JOIN `neurons` and count rows where `e.hotkey = ? OR n.hotkey = ?`, resolving hotkey-less `WeightsSet` events via `(netuid, uid)` so they attribute to the correct account (`src/account-weight-setters.mjs`).
- Adjusted the query parameter ordering to `(event_kind, cutoff, address, address)` to match the revised SQL predicate.
- Added a regression test that validates counting of direct-hotkey rows and hotkey-less rows resolved through `neurons`, and updated the query-shape assertions (`tests/account-weight-setters.test.mjs`).

### Testing

- Ran `npm run lint` and `npm run format:check`, both passed.
- Ran `npm test -- --run tests/account-weight-setters.test.mjs tests/subnet-weight-setters.test.mjs`, all tests passed.
- Ran `npm run build && npm run validate:api`, the build completed and `validate:api` passed.
- Local checks (`git diff --check`) showed no lint/format errors after fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a90312570832c86c9144bc6dcc41e)