### PR TITLE
feat(registry): add SN77 Liquidity subnet-api surface (#674)

### DIFF
--- a/registry/subnets/liquidity.json
+++ b/registry/subnets/liquidity.json
@@ -1,0 +1,32 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "Liquidity",
+  "netuid": 77,
+  "schema_version": 1,
+  "slug": "sn-77",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-77-liquidity-subnet-api",
+      "kind": "subnet-api",
+      "name": "Liquidity API",
+      "notes": "Public no-auth REST API for SN77 Liquidity (77.creativebuilds.io) exposing Uniswap V3 pool voting, positions, weights, miners, and holders; the /pools endpoint returns JSON with no authentication. Documented in the official creativebuilds/sn77 README.",
+      "provider": "liquidity",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://github.com/creativebuilds/sn77/blob/master/README.md"
+      ],
+      "url": "https://77.creativebuilds.io/pools"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #674

Enriches **SN77 Liquidity** with its public API surface. The official
`creativebuilds/sn77` README documents a hosted, unauthenticated REST API at
`77.creativebuilds.io` — Uniswap V3 pool voting, positions, weights, miners, and
holders. `GET /pools` returns JSON with no authentication (verified live).

| Kind | URL | Proof |
|------|-----|-------|
| `subnet-api` | https://77.creativebuilds.io/pools | public no-auth GET → `200 application/json` (`{"success":true,"pools":[…]}`) |

**Source URL:** https://github.com/creativebuilds/sn77/blob/master/README.md
(README's "API Endpoints" section documents `/pools`, `/weights`, `/allMiners`, etc.)

## Registry Safety
- Real public, no-auth URL; no secrets/private/localhost.
- `authority: community`, `review.state: community-submitted`, `public_safe: true`.
- No health/verification set by hand.

## Validation
- `npm run validate:surface -- registry/subnets/liquidity.json` — passed
- `npm run scan:public-safety` — passed

## Template Used
- Subnet surface (`surface.md`)