### PR TITLE
feat(registry): add SN127 Astrid subnet-api surface (#666)

### DIFF
--- a/registry/subnets/astrid.json
+++ b/registry/subnets/astrid.json
@@ -1,0 +1,32 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "Astrid",
+  "netuid": 127,
+  "schema_version": 1,
+  "slug": "sn-127",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-127-astrid-subnet-api",
+      "kind": "subnet-api",
+      "name": "Astrid Arena API",
+      "notes": "Public no-auth REST API for SN127 Astrid's trading Arena (arena-api.astrid.global) exposing completed competitions, trades, and execution runs; GET /public/arena/completed-competitions returns JSON with no authentication. Documented in the official astridintelligence/sn-127 README.",
+      "provider": "astrid",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://github.com/astridintelligence/sn-127/blob/master/README.md"
+      ],
+      "url": "https://arena-api.astrid.global/public/arena/completed-competitions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #666

Adds the publicly documented API surface for **SN127 Astrid** to `registry/subnets/astrid.json`.

Astrid provides a hosted, unauthenticated REST API for its Arena trading platform, documented in the official `astridintelligence/sn-127` repository. This PR registers the public endpoint so it can be discovered through the registry.

## Surface Added

| Kind | URL | Notes |
|------|-----|-------|
| `subnet-api` | https://arena-api.astrid.global/public/arena/completed-competitions | Public REST endpoint returning completed competition data as JSON |

## Source

Official project documentation:

- https://github.com/astridintelligence/sn-127/blob/master/README.md

The README documents the public Arena API hosted at `arena-api.astrid.global`.

## Registry Safety

- ✅ Public, unauthenticated endpoint only
- ✅ No secrets, tokens, localhost, or private infrastructure
- ✅ `authority: community`
- ✅ `review.state: community-submitted`
- ✅ `public_safe: true`

## Validation

- ✅ `npm run validate:surface -- registry/subnets/astrid.json`
- ✅ `npm run scan:public-safety`