### PR TITLE
feat(ui): surface subnet stake-moves (re-delegation) in the economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -1,6 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { economicsQuery } from "@/lib/metagraphed/queries";
+import { economicsQuery, subnetStakeMovesQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
+import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
+import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
@@ -20,6 +23,46 @@ function Notice({ children }: { children: string }) {
     <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
       {children}
     </div>
+  );
+}
+
+// #3485: re-delegation (StakeMoved) activity for this subnet over the trailing
+// 30-day window, from the already-shipped subnetStakeMovesQuery. The endpoint
+// returns a flat window aggregate (count / distinct movers / avg) rather than a
+// series, so — per the issue — it renders as a single StatTile using the
+// MiniStack + SparkLegend single-snapshot idiom instead of a literal chart. The
+// MiniStack splits the total into unique movers vs repeat moves so the lone
+// aggregate still reads as a composition.
+function StakeMovesTile({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetStakeMovesQuery(netuid));
+  const card = res?.data;
+  const m = stakeMovesTileModel(card);
+  const value = isError ? "—" : isPending && !card ? "…" : formatNumber(m.movements);
+  return (
+    <StatTile
+      eyebrow="Stake moves"
+      tone="accent"
+      value={value}
+      hint={`${m.movers} mover${m.movers === 1 ? "" : "s"}`}
+      chart={
+        <SparkLegend
+          metric="Stake moves"
+          source={`On-chain StakeMoved (re-delegation) events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          windowLabel={card?.window ?? "30d"}
+          updatedAt={card?.observed_at ?? null}
+          staleness="Counts settle as the chain-events indexer catches up; the bar hides when no re-delegations occurred in the window."
+        >
+          <span className="flex w-[72px] items-center gap-1.5">
+            <span className="w-6 text-right font-mono text-[11px] tabular-nums text-ink">
+              {m.perMover != null ? `${m.perMover.toFixed(1)}×` : "—"}
+            </span>
+            <span className="max-w-[56px] flex-1">
+              <MiniStack segments={m.segments} height={6} />
+            </span>
+          </span>
+        </SparkLegend>
+      }
+    />
   );
 }
 
@@ -63,6 +106,7 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         value={e.registration_cost_tao != null ? `${e.registration_cost_tao} τ` : "—"}
         hint={e.registration_allowed === false ? "closed" : "open"}
       />
+      <StakeMovesTile netuid={netuid} />
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/stake-moves-tile.test.ts
+++ b/apps/ui/src/lib/metagraphed/stake-moves-tile.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { stakeMovesTileModel } from "./stake-moves-tile";
+import type { SubnetStakeMoves } from "./types";
+
+function card(p: Partial<SubnetStakeMoves>): SubnetStakeMoves {
+  return {
+    schema_version: 1,
+    netuid: 7,
+    window: "30d",
+    observed_at: null,
+    distinct_movers: 0,
+    movements: 0,
+    movements_per_mover: null,
+    ...p,
+  };
+}
+
+describe("stakeMovesTileModel", () => {
+  it("splits movements into unique movers + repeat moves", () => {
+    const m = stakeMovesTileModel(
+      card({ distinct_movers: 6, movements: 18, movements_per_mover: 3 }),
+    );
+    expect(m.movements).toBe(18);
+    expect(m.movers).toBe(6);
+    expect(m.repeats).toBe(12);
+    expect(m.perMover).toBe(3);
+    expect(m.segments.map((s) => s.value)).toEqual([6, 12]);
+    expect(m.summary).toBe("6 movers, 12 repeat moves");
+  });
+
+  it("degrades an undefined / cold card to a zeroed, empty model", () => {
+    for (const c of [undefined, card({})]) {
+      const m = stakeMovesTileModel(c);
+      expect(m.movements).toBe(0);
+      expect(m.movers).toBe(0);
+      expect(m.repeats).toBe(0);
+      expect(m.perMover).toBeNull();
+      expect(m.segments.every((s) => s.value === 0)).toBe(true);
+      expect(m.summary).toBe("no re-delegations in this window");
+    }
+  });
+
+  it("singularizes a lone mover and never yields a negative repeat count", () => {
+    const one = stakeMovesTileModel(
+      card({ distinct_movers: 1, movements: 1, movements_per_mover: 1 }),
+    );
+    expect(one.repeats).toBe(0);
+    expect(one.summary).toBe("1 mover");
+
+    // junk store where movers > movements must still floor repeats at 0
+    const junk = stakeMovesTileModel(card({ distinct_movers: 9, movements: 4 }));
+    expect(junk.repeats).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stake-moves-tile.ts
+++ b/apps/ui/src/lib/metagraphed/stake-moves-tile.ts
@@ -1,0 +1,46 @@
+import type { SubnetStakeMoves } from "./types";
+
+export interface StakeMovesTileModel {
+  /** Total StakeMoved (re-delegation) events in the window. */
+  movements: number;
+  /** Distinct movers (unique re-delegating hotkeys). */
+  movers: number;
+  /** Repeat moves beyond the first per mover (movements - movers, floored at 0). */
+  repeats: number;
+  /** Average moves per mover, or null on a cold / junk store. */
+  perMover: number | null;
+  /** MiniStack composition: unique movers vs repeat moves. */
+  segments: Array<{ label: string; value: number; color: string }>;
+  /** Short human summary for the SparkLegend tooltip. */
+  summary: string;
+}
+
+/**
+ * #3485: derive the economics-panel stake-moves tile model from the flat
+ * StakeMoved window summary. `movements` is the headline count; the MiniStack
+ * splits it into unique re-delegators (`distinct_movers`) vs repeat moves so a
+ * single-snapshot aggregate still reads as a composition rather than a lone
+ * number. Everything coerces defensively — a cold / undefined card degrades to a
+ * zeroed, empty-bar model, and a junk store where movers exceeds movements can
+ * never produce a negative repeat count.
+ */
+export function stakeMovesTileModel(card: SubnetStakeMoves | undefined): StakeMovesTileModel {
+  const movements = Math.max(0, card?.movements ?? 0);
+  const movers = Math.max(0, card?.distinct_movers ?? 0);
+  const repeats = Math.max(0, movements - movers);
+  const perMover =
+    card?.movements_per_mover != null && Number.isFinite(card.movements_per_mover)
+      ? card.movements_per_mover
+      : null;
+  const segments = [
+    { label: "movers", value: movers, color: "var(--accent)" },
+    { label: "repeat moves", value: repeats, color: "var(--border)" },
+  ];
+  const summary =
+    movements > 0
+      ? `${movers} mover${movers === 1 ? "" : "s"}${
+          repeats > 0 ? `, ${repeats} repeat move${repeats === 1 ? "" : "s"}` : ""
+        }`
+      : "no re-delegations in this window";
+  return { movements, movers, repeats, perMover, segments, summary };
+}


### PR DESCRIPTION
Closes #3485

Wires the already-shipped `subnetStakeMovesQuery` (#3669) into `EconomicsPanel` as a **Stake moves** tile: the trailing-30d `StakeMoved` (re-delegation) count, distinct movers in the hint, and a `MiniStack` + `SparkLegend` single-snapshot breakdown of unique movers vs repeat moves. The endpoint returns a flat window aggregate (not a series), so it uses the codebase's MiniStack idiom rather than a literal chart.

The typed data layer (query / type / normalizer + test) already shipped in #3669 and is untouched here. Adds a pure `stakeMovesTileModel` helper with a unit test.

## Screenshots (subnet 21, live API)

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/before-desktop-light.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/after-desktop-light.png) |
| **Desktop · Dark** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/before-desktop-dark.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/after-desktop-dark.png) |
| **Tablet · Light** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/before-tablet-light.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/after-tablet-light.png) |
| **Tablet · Dark** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/before-tablet-dark.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/after-tablet-dark.png) |
| **Mobile · Light** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/before-mobile-light.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/after-mobile-light.png) |
| **Mobile · Dark** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/before-mobile-dark.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-moves-shots/after-mobile-dark.png) |

## Verification
`npm run build`, `tsc --noEmit`, `eslint` (0 errors), and the full `vitest` suite (428 tests incl. 3 new) all pass; verified against live api.metagraph.sh (subnet 21).
