### PR TITLE
fix(ui): router-level notFound for invalid block and extrinsic refs

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
 import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
@@ -18,6 +18,10 @@ import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraph
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/blocks/$ref")({
+  parseParams: ({ ref }) => {
+    if (!isValidBlockRef(ref)) throw notFound();
+    return { ref };
+  },
   // Prime the shared cache so head() can title the page with the real block
   // number. Non-fatal: any failure falls back to the ref-only copy and the
   // page's own useSuspenseQuery still drives the not-found/empty path.
@@ -47,6 +51,20 @@ export const Route = createFileRoute("/blocks/$ref")({
     };
   },
   component: BlockDetailPage,
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Invalid block reference"
+        description="Block references must be a decimal block number or a 0x-prefixed hex hash."
+      />
+      <EmptyState
+        title="Invalid block reference"
+        description="Use a decimal block number or a 0x-prefixed hexadecimal block hash."
+        action={{ label: "Back to blocks", href: "/blocks" }}
+      />
+    </AppShell>
+  ),
 });
 
 function BlockDetailPage() {
@@ -55,32 +73,11 @@ function BlockDetailPage() {
     <AppShell>
       <QueryErrorBoundary>
         <Suspense fallback={<DetailSkeleton />}>
-          <BlockDetail refValue={ref} />
+          <ValidBlockDetail refValue={ref} />
         </Suspense>
       </QueryErrorBoundary>
     </AppShell>
   );
-}
-
-function BlockDetail({ refValue }: { refValue: string }) {
-  if (!isValidBlockRef(refValue)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid block reference"
-          description="Block references must be a decimal block number or a 0x-prefixed hex hash."
-        />
-        <EmptyState
-          title="Invalid block reference"
-          description="Use a decimal block number or a 0x-prefixed hexadecimal block hash."
-          action={{ label: "Back to blocks", href: "/blocks" }}
-        />
-      </>
-    );
-  }
-
-  return <ValidBlockDetail refValue={refValue} />;
 }
 
 function ValidBlockDetail({ refValue }: { refValue: string }) {

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
 import { Boxes, Clock, FileText } from "lucide-react";
@@ -22,6 +22,10 @@ import {
 } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/extrinsics/$hash")({
+  parseParams: ({ hash }) => {
+    if (!isValidExtrinsicHash(hash)) throw notFound();
+    return { hash };
+  },
   // Prime the shared cache so head() can title with the call name. Non-fatal:
   // any failure falls back to the hash-only copy and the page's own
   // useSuspenseQuery still drives the not-found/empty path.
@@ -53,6 +57,20 @@ export const Route = createFileRoute("/extrinsics/$hash")({
     };
   },
   component: ExtrinsicDetailPage,
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Invalid extrinsic reference"
+        description="Extrinsic references must be a 0x-prefixed hexadecimal hash."
+      />
+      <EmptyState
+        title="Invalid extrinsic reference"
+        description="Use a 0x-prefixed hexadecimal extrinsic hash."
+        action={{ label: "Back to extrinsics", href: "/extrinsics" }}
+      />
+    </AppShell>
+  ),
 });
 
 function ExtrinsicDetailPage() {
@@ -61,31 +79,11 @@ function ExtrinsicDetailPage() {
     <AppShell>
       <QueryErrorBoundary>
         <Suspense fallback={<DetailSkeleton />}>
-          <ExtrinsicDetail hash={hash} />
+          <ValidExtrinsicDetail hash={hash} />
         </Suspense>
       </QueryErrorBoundary>
     </AppShell>
   );
-}
-
-function ExtrinsicDetail({ hash }: { hash: string }) {
-  if (!isValidExtrinsicHash(hash)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid extrinsic reference"
-          description="Extrinsic references must be a 0x-prefixed hexadecimal hash."
-        />
-        <EmptyState
-          title="Invalid extrinsic reference"
-          description="Use a 0x-prefixed hexadecimal extrinsic hash."
-          action={{ label: "Back to extrinsics", href: "/extrinsics" }}
-        />
-      </>
-    );
-  }
-  return <ValidExtrinsicDetail hash={hash} />;
 }
 
 function ValidExtrinsicDetail({ hash }: { hash: string }) {


### PR DESCRIPTION

## Summary

- Add `parseParams` + `notFound()` guards on `/blocks/$ref` and `/extrinsics/$hash` using existing `isValidBlockRef` / `isValidExtrinsicHash`
- Add route-level `notFoundComponent` (AppShell + invalid-ref copy + back link) on both routes
- Remove dead in-component validation branches; detail pages call `Valid*` components directly

- Closes #3422 · Part of #2542

## Test plan

- [x] Visit `/blocks/not-a-ref` — invalid block reference notFound UI, link to `/blocks`
- [x] Visit `/extrinsics/not-a-hash` — invalid extrinsic reference notFound UI, link to `/extrinsics`
- [x] Visit a valid but unindexed block/extrinsic — existing “not yet indexed” path unchanged
- [x] `npm run build:client --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
