### PR TITLE
feat(ui): add network decentralization scorecard to /status

### DIFF
--- a/apps/ui/src/components/metagraphed/network-decentralization-scorecard.tsx
+++ b/apps/ui/src/components/metagraphed/network-decentralization-scorecard.tsx
@@ -1,0 +1,124 @@
+import { useQuery } from "@tanstack/react-query";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { chainConcentrationQuery, chainPerformanceQuery } from "@/lib/metagraphed/queries";
+import {
+  concentrationTone,
+  decentralizationScore,
+  fmtCount,
+  fmtPct,
+  fmtRatio,
+  gradeFor,
+  scoreSpread,
+} from "@/lib/metagraphed/decentralization";
+
+function Notice({ children }: { children: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * #3471: a network-wide decentralization scorecard. Folds the stake/emission
+ * concentration lenses (Gini / HHI / Nakamoto / top-share) from
+ * /api/v1/chain/concentration and the trust/consensus score spread from
+ * /api/v1/chain/performance into a single composite grade plus a StatTile grid.
+ * Mirrors the economics-panel shape: its own loading / empty / error notices
+ * rather than a Suspense fence, so a slow or absent performance snapshot never
+ * blanks the concentration tiles.
+ */
+export function NetworkDecentralizationScorecard() {
+  const concentration = useQuery(chainConcentrationQuery());
+  const performance = useQuery(chainPerformanceQuery());
+
+  if (concentration.isPending || performance.isPending) {
+    return <Notice>Loading network decentralization metrics…</Notice>;
+  }
+  if (concentration.isError && performance.isError) {
+    return <Notice>Network decentralization metrics are temporarily unavailable.</Notice>;
+  }
+
+  const c = concentration.data?.data;
+  const p = performance.data?.data;
+  const stake = c?.stake ?? null;
+  const emission = c?.emission ?? null;
+
+  if (!stake && !emission && !p?.trust && !p?.consensus) {
+    return <Notice>No network decentralization data has been captured yet.</Notice>;
+  }
+
+  const score = decentralizationScore(stake, emission);
+  const grade = score != null ? gradeFor(score) : null;
+  const trustSpread = scoreSpread(p?.trust);
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatTile
+        eyebrow="Decentralization"
+        tone={grade?.tone ?? "default"}
+        value={score != null ? String(score) : "—"}
+        hint={grade ? `grade ${grade.letter} · 0–100` : "composite"}
+      />
+      <StatTile
+        eyebrow="Stake Gini"
+        tone={concentrationTone(stake?.gini)}
+        value={fmtRatio(stake?.gini)}
+        hint="0 even · 1 concentrated"
+      />
+      <StatTile
+        eyebrow="Stake HHI"
+        tone={concentrationTone(stake?.hhi_normalized)}
+        value={fmtRatio(stake?.hhi_normalized)}
+        hint="normalized"
+      />
+      <StatTile
+        eyebrow="Nakamoto (stake)"
+        value={fmtCount(stake?.nakamoto_coefficient)}
+        hint="entities to 51%"
+      />
+      <StatTile
+        eyebrow="Top-1% stake"
+        tone={concentrationTone(stake?.top_1pct_share)}
+        value={fmtPct(stake?.top_1pct_share)}
+        hint="held by the top 1%"
+      />
+      <StatTile
+        eyebrow="Emission Gini"
+        tone={concentrationTone(emission?.gini)}
+        value={fmtRatio(emission?.gini)}
+        hint="reward balance"
+      />
+      <StatTile
+        eyebrow="Nakamoto (emission)"
+        value={fmtCount(emission?.nakamoto_coefficient)}
+        hint="entities to 51%"
+      />
+      <StatTile
+        eyebrow="Stake entropy"
+        value={fmtRatio(stake?.entropy_normalized)}
+        hint="normalized · 1 = uniform"
+      />
+      <StatTile
+        eyebrow="Trust spread"
+        value={trustSpread != null ? fmtRatio(trustSpread, 2) : "—"}
+        hint={p?.trust?.mean != null ? `mean ${fmtRatio(p.trust.mean, 2)}` : "p90 − p10"}
+      />
+      <StatTile
+        eyebrow="Consensus (mean)"
+        value={fmtRatio(p?.consensus?.mean, 2)}
+        hint="0–1 network consensus"
+      />
+      <StatTile
+        eyebrow="Validators"
+        value={fmtCount(p?.validator_count)}
+        hint={c?.entity_count != null ? `${fmtCount(c.entity_count)} entities` : "in scope"}
+      />
+      <StatTile
+        eyebrow="Neurons"
+        value={fmtCount(c?.neuron_count)}
+        hint={c?.subnet_count != null ? `${fmtCount(c.subnet_count)} subnets` : "network-wide"}
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/decentralization.test.ts
+++ b/apps/ui/src/lib/metagraphed/decentralization.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  concentrationTone,
+  decentralizationScore,
+  fmtCount,
+  fmtPct,
+  fmtRatio,
+  gradeFor,
+  scoreSpread,
+} from "./decentralization";
+
+describe("concentrationTone", () => {
+  it("maps low concentration to ok, mid to warn, high to down", () => {
+    expect(concentrationTone(0.2)).toBe("ok");
+    expect(concentrationTone(0.5)).toBe("warn");
+    expect(concentrationTone(0.9)).toBe("down");
+  });
+  it("falls back to default on nullish / non-finite input", () => {
+    expect(concentrationTone(null)).toBe("default");
+    expect(concentrationTone(undefined)).toBe("default");
+    expect(concentrationTone(Number.NaN)).toBe("default");
+  });
+});
+
+describe("scoreSpread", () => {
+  it("returns p90 − p10 when both percentiles are present", () => {
+    expect(scoreSpread({ p10: 0.2, p90: 0.8 })).toBeCloseTo(0.6);
+  });
+  it("returns null when a percentile is missing or the distribution is absent", () => {
+    expect(scoreSpread({ p10: 0.2 })).toBeNull();
+    expect(scoreSpread({ p90: 0.8 })).toBeNull();
+    expect(scoreSpread(null)).toBeNull();
+    expect(scoreSpread(undefined)).toBeNull();
+  });
+});
+
+describe("decentralizationScore", () => {
+  it("scores a perfectly even distribution at 100", () => {
+    const even = { gini: 0, hhi_normalized: 0, top_1pct_share: 0 };
+    expect(decentralizationScore(even, even)).toBe(100);
+  });
+  it("scores a fully concentrated distribution at 0", () => {
+    const concentrated = { gini: 1, hhi_normalized: 1, top_1pct_share: 1 };
+    expect(decentralizationScore(concentrated, concentrated)).toBe(0);
+  });
+  it("blends a Nakamoto breadth term normalized by holder count", () => {
+    // gini 0.5 → balance 0.5; nakamoto 20 of 100 holders → 20/(100*0.2) = 1.
+    expect(decentralizationScore({ gini: 0.5, nakamoto_coefficient: 20, holders: 100 }, null)).toBe(
+      75,
+    );
+  });
+  it("ignores a Nakamoto term with no holder base", () => {
+    expect(decentralizationScore({ gini: 0.4, nakamoto_coefficient: 5 }, null)).toBe(60);
+  });
+  it("returns null when no lens carries a usable metric", () => {
+    expect(decentralizationScore(null, null)).toBeNull();
+    expect(decentralizationScore({}, {})).toBeNull();
+    expect(decentralizationScore({ gini: Number.NaN }, undefined)).toBeNull();
+  });
+});
+
+describe("gradeFor", () => {
+  it("maps score bands to letter grades", () => {
+    expect(gradeFor(90).letter).toBe("A");
+    expect(gradeFor(70).letter).toBe("B");
+    expect(gradeFor(55).letter).toBe("C");
+    expect(gradeFor(40).letter).toBe("D");
+    expect(gradeFor(10).letter).toBe("F");
+  });
+  it("pairs a health tone with each grade", () => {
+    expect(gradeFor(90).tone).toBe("ok");
+    expect(gradeFor(55).tone).toBe("warn");
+    expect(gradeFor(10).tone).toBe("down");
+  });
+});
+
+describe("formatters", () => {
+  it("formats ratios at fixed precision and dashes on nullish", () => {
+    expect(fmtRatio(0.4237)).toBe("0.424");
+    expect(fmtRatio(0.5, 2)).toBe("0.50");
+    expect(fmtRatio(null)).toBe("—");
+    expect(fmtRatio(Number.NaN)).toBe("—");
+  });
+  it("formats 0–1 shares as percentages", () => {
+    expect(fmtPct(0.153)).toBe("15.3%");
+    expect(fmtPct(undefined)).toBe("—");
+  });
+  it("formats counts with separators and dashes on nullish", () => {
+    expect(fmtCount(1234)).toBe("1,234");
+    expect(fmtCount(0)).toBe("0");
+    expect(fmtCount(null)).toBe("—");
+    expect(fmtCount(Number.NaN)).toBe("—");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/decentralization.ts
+++ b/apps/ui/src/lib/metagraphed/decentralization.ts
@@ -1,0 +1,79 @@
+import type { ConcentrationMetrics, ScoreDistribution } from "@/lib/metagraphed/types";
+
+// #3471: pure derivation logic behind the network decentralization scorecard.
+// Kept in a plain module (not the .tsx) so the composite-score algorithm and its
+// formatters are unit-testable and don't trip react-refresh's component-only rule.
+
+export type DecentralizationTone = "default" | "ok" | "warn" | "down";
+
+/** Gini / HHI / top-share are 0–1 where lower = more decentralized → map to a tone. */
+export function concentrationTone(v?: number | null): DecentralizationTone {
+  if (v == null || !Number.isFinite(v)) return "default";
+  if (v < 0.4) return "ok";
+  if (v < 0.7) return "warn";
+  return "down";
+}
+
+/** Percentile band width (p90 − p10) of a 0–1 score, or null when unavailable. */
+export function scoreSpread(d?: ScoreDistribution | null): number | null {
+  if (!d || d.p90 == null || d.p10 == null || !Number.isFinite(d.p90) || !Number.isFinite(d.p10)) {
+    return null;
+  }
+  return d.p90 - d.p10;
+}
+
+/**
+ * Composite 0–100 decentralization score. Averages the "balance" (1 − metric) of
+ * every available concentration lens across the stake + emission distributions,
+ * plus a Nakamoto breadth term normalized against the holder count. Higher = more
+ * decentralized. Returns null when no lens carries a usable metric.
+ */
+export function decentralizationScore(
+  stake: ConcentrationMetrics | null | undefined,
+  emission: ConcentrationMetrics | null | undefined,
+): number | null {
+  const parts: number[] = [];
+  const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+  const addBalance = (v?: number | null) => {
+    if (v != null && Number.isFinite(v)) parts.push(clamp01(1 - v));
+  };
+  const addBreadth = (m?: ConcentrationMetrics | null) => {
+    if (m?.nakamoto_coefficient != null && m.holders && m.holders > 0) {
+      // In a well-distributed network, reaching 51% takes ~20% of the holders.
+      parts.push(clamp01(m.nakamoto_coefficient / (m.holders * 0.2)));
+    }
+  };
+  for (const m of [stake, emission]) {
+    if (!m) continue;
+    addBalance(m.gini);
+    addBalance(m.hhi_normalized);
+    addBalance(m.top_1pct_share);
+    addBreadth(m);
+  }
+  if (parts.length === 0) return null;
+  return Math.round((parts.reduce((a, b) => a + b, 0) / parts.length) * 100);
+}
+
+/** Letter grade + tone for a 0–100 decentralization score. */
+export function gradeFor(score: number): { letter: string; tone: DecentralizationTone } {
+  if (score >= 80) return { letter: "A", tone: "ok" };
+  if (score >= 65) return { letter: "B", tone: "ok" };
+  if (score >= 50) return { letter: "C", tone: "warn" };
+  if (score >= 35) return { letter: "D", tone: "warn" };
+  return { letter: "F", tone: "down" };
+}
+
+/** Fixed-precision ratio (e.g. Gini/HHI/entropy); em-dash on nullish/non-finite. */
+export function fmtRatio(v?: number | null, dp = 3): string {
+  return v == null || !Number.isFinite(v) ? "—" : v.toFixed(dp);
+}
+
+/** A 0–1 share rendered as a percentage; em-dash on nullish/non-finite. */
+export function fmtPct(v?: number | null): string {
+  return v == null || !Number.isFinite(v) ? "—" : `${(v * 100).toFixed(1)}%`;
+}
+
+/** A count with thousands separators; em-dash on nullish/non-finite. */
+export function fmtCount(v?: number | null): string {
+  return v == null || !Number.isFinite(v) ? "—" : Math.round(v).toLocaleString("en-US");
+}

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -8,6 +8,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { SectionHeading } from "@/components/metagraphed/section-heading";
+import { NetworkDecentralizationScorecard } from "@/components/metagraphed/network-decentralization-scorecard";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { Donut, DonutLegend } from "@/components/metagraphed/charts/donut";
 import { AnimatedNumber } from "@/components/metagraphed/animated-number";
@@ -70,6 +71,19 @@ function StatusPage() {
             <Verdict />
           </Suspense>
         </QueryErrorBoundary>
+        {/* #3471: network-wide decentralization scorecard — stake/emission
+            concentration (Gini/HHI/Nakamoto) + trust/consensus score spread,
+            folded into a composite grade. Its own loading/empty/error states. */}
+        <section>
+          <SectionHeading
+            title="Network decentralization"
+            intro="Stake & emission concentration (Gini / HHI / Nakamoto) and the trust/consensus score spread, folded into a single composite grade."
+          />
+          <QueryErrorBoundary>
+            <NetworkDecentralizationScorecard />
+          </QueryErrorBoundary>
+        </section>
+
         <section>
           <SectionHeading title="Recent incidents" />
           <QueryErrorBoundary>
@@ -109,6 +123,8 @@ function StatusPage() {
         paths={[
           "/api/v1/health",
           "/api/v1/incidents",
+          "/api/v1/chain/concentration",
+          "/api/v1/chain/performance",
           "/api/v1/health/history/{date}",
           "/api/v1/source-health",
         ]}


### PR DESCRIPTION
## Summary

Closes #3471

Adds a **Network decentralization** scorecard to the `/status` page.

The scorecard combines data from the existing:

- `/api/v1/chain/concentration`
- `/api/v1/chain/performance`

endpoints into a single structural health view, presenting an overall decentralization grade alongside stake, emission, and network-distribution metrics.

This complements the existing operational status summary by surfacing how evenly stake, emission, trust, and validator participation are distributed across the network.

## Implementation

### Derivation Logic

Added:

- `apps/ui/src/lib/metagraphed/decentralization.ts`

Provides pure, reusable utilities for:

- `decentralizationScore(stake, emission)`
  - Computes a 0–100 composite score using available stake and emission concentration metrics.
  - Combines:
    - Gini
    - HHI
    - Top-share
    - Nakamoto coefficient (normalized by holder count)
- `gradeFor()`
  - Maps the composite score to an A–F grade and corresponding tone.
- `concentrationTone()`
  - Returns health color thresholds for concentration metrics.
- `scoreSpread()`
  - Computes percentile spread (`p90 - p10`).
- Null-safe formatting helpers:
  - `fmtRatio`
  - `fmtPct`
  - `fmtCount`

Keeping the scoring logic outside the React component allows independent unit testing and avoids React Fast Refresh lint warnings.

### Component

Added:

- `apps/ui/src/components/metagraphed/network-decentralization-scorecard.tsx`

The component:

- Fetches both concentration and performance data via `useQuery`.
- Handles loading, empty, and error states independently so one endpoint failing does not prevent rendering available metrics.
- Displays:
  - Overall decentralization grade
  - Stake Gini
  - Stake HHI
  - Stake Nakamoto
  - Stake Top Share
  - Stake Entropy
  - Emission Gini
  - Emission Nakamoto
  - Trust score spread
  - Consensus mean
  - Validator count
  - Neuron count

### Status Page

Updated:

- `apps/ui/src/routes/status.tsx`

Changes:

- Adds the Network decentralization section beneath the existing status verdict.
- Includes the chain concentration and chain performance endpoints in the API source footer.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1538" height="917" alt="before" src="https://github.com/user-attachments/assets/7a30cee4-cc66-4135-a2bf-a48c0c6f95e2" /> | <img width="1578" height="948" alt="after" src="https://github.com/user-attachments/assets/e6ada392-bb42-445c-98aa-e3876203c55e" /> |

## Validation

All relevant checks pass:

- ✅ `npm run typecheck -w apps/ui`
- ✅ `npx vitest run src/lib/metagraphed/decentralization.test.ts` (14/14 passing)
- ✅ `npm run lint` (changed files)
- ✅ `npm run build -w apps/ui`

## Notes

The scorecard consumes existing backend endpoints and introduces **no API or schema changes**. All calculations are performed client-side using the data already exposed by the chain concentration and performance APIs.

