### PR TITLE
refactor(ui): extract page-visibility polling hook (#3371)

### DIFF
--- a/apps/ui/src/hooks/use-refetch-interval.test.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { computeRefetchInterval } from "./use-refetch-interval";
+
+describe("computeRefetchInterval", () => {
+  it("returns the interval when enabled and the tab is visible", () => {
+    expect(computeRefetchInterval(true, true, 60_000)).toBe(60_000);
+  });
+
+  it("pauses polling when the tab is hidden", () => {
+    expect(computeRefetchInterval(true, false, 60_000)).toBe(false);
+  });
+
+  it("pauses polling when auto-refresh is disabled", () => {
+    expect(computeRefetchInterval(false, true, 30_000)).toBe(false);
+    expect(computeRefetchInterval(false, false, 30_000)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-refetch-interval.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+/** Compute TanStack Query's refetchInterval from enable + tab-visibility gates. */
+export function computeRefetchInterval(
+  enabled: boolean,
+  visible: boolean,
+  intervalMs: number,
+): number | false {
+  return enabled && visible ? intervalMs : false;
+}
+
+/** Returns true when the document is visible (or true in SSR). */
+export function usePageVisible(): boolean {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const update = () => setVisible(!document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+  return visible;
+}
+
+/** Page-visibility-gated refetch interval for useSuspenseQuery / useQuery polling. */
+export function useRefetchInterval(intervalMs: number, enabled = true): number | false {
+  const visible = usePageVisible();
+  return computeRefetchInterval(enabled, visible, intervalMs);
+}

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { usePageVisible, computeRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { RefreshCw, Pause, Play, ChevronDown, ChevronRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -59,24 +60,11 @@ export const Route = createFileRoute("/health")({
   component: HealthPage,
 });
 
-/** Returns true when the document is visible (or true in SSR). */
-function usePageVisible(): boolean {
-  const [visible, setVisible] = useState(true);
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    const update = () => setVisible(!document.hidden);
-    update();
-    document.addEventListener("visibilitychange", update);
-    return () => document.removeEventListener("visibilitychange", update);
-  }, []);
-  return visible;
-}
-
 function HealthPage() {
   const [enabled, setEnabled] = useState(true);
   const [intervalMs, setIntervalMs] = useState(30_000);
   const visible = usePageVisible();
-  const effectiveInterval = enabled && visible ? intervalMs : false;
+  const effectiveInterval = computeRefetchInterval(enabled, visible, intervalMs);
   // #1117: push a refresh on each registry publish, on top of the poll interval.
   useRegistryEvents();
 

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -20,7 +21,6 @@ import {
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
 
-const REFRESH_MS = 60_000;
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
 // treated as still-ongoing (probe cadence is ~2 min, so ~5 cycles).
@@ -119,7 +119,8 @@ function StatusPage() {
 
 /** Overall verdict banner + status mix, derived from /api/v1/health status counts. */
 function Verdict() {
-  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval: REFRESH_MS });
+  const refetchInterval = useRefetchInterval(60_000);
+  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval });
   const h = hRes.data;
   const ok = h?.ok ?? 0;
   const warn = h?.warn ?? 0;
@@ -245,9 +246,10 @@ function Kpi({
 function RecentIncidents() {
   const [window, setWindow] = useState<IncidentWindow>("7d");
   const [showAll, setShowAll] = useState(false);
+  const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
     ...globalIncidentsQuery(window),
-    refetchInterval: REFRESH_MS,
+    refetchInterval,
   });
   const ledger = data.data;
   // A surface is still failing ("ongoing") when its most recent downtime event


### PR DESCRIPTION
## Summary

- Add `usePageVisible`, `useRefetchInterval`, and `computeRefetchInterval` in `apps/ui/src/hooks/use-refetch-interval.ts` with unit tests for the pure interval gate
- Wire `health.tsx` through the shared helpers (replacing the private `usePageVisible` copy) while keeping `AutoRefreshControl` behavior unchanged
- Wire `status.tsx` through `useRefetchInterval(60_000)` so both polling queries pause when the tab is hidden

Closes #3371 · Part of #2542

## Test plan

- [x] `npm test -- use-refetch-interval.test.ts`
- [x] `npm run build --workspace=apps/ui`
- [x] No visual/markup changes — polling plumbing only


Made with [Cursor](https://cursor.com)