### PR TITLE
feat(registry): add SN5 Hone subnet-api health surface

### DIFF
--- a/registry/subnets/hone.json
+++ b/registry/subnets/hone.json
@@ -137,6 +137,28 @@
         "timeout_ms": 10000
       },
       "notes": "Official Hone source repository."
+    },
+    {
+      "id": "sn-5-hone-subnet-api",
+      "name": "Hone API health",
+      "kind": "subnet-api",
+      "url": "https://api.hone.training/health",
+      "provider": "hone",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://www.hone.training/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the Hone (SN5) backend API health as JSON ({\"status\":\"ok\"}). Served on the api.hone.training subdomain of the subnet's registered website hone.training — a live API host distinct from the website-host /health path noted as 404 in this file. Fills the noted missing public-API-endpoint gap."
     }
   ],
   "contact": "devs@manifold.inc"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/hone.json`. Append-only; no other file or field changed.

Closes #713

## Summary

Registers SN5 Hone's public no-auth API endpoint — filling the manifest's own documented gap ("No verified safe public subnet API endpoint yet"). `https://api.hone.training/health` returns live backend health as JSON (`{"status":"ok"}`). It is served on `api.hone.training`, the API subdomain of the subnet's registered website `hone.training` (same owner) — a live API host **distinct from** the website-host `/health` path that this file notes as 404 (the manifest's `baseline_excluded_surface_ids` correctly excludes the dead website-host common paths; this is the real API subdomain).

## Surface

- Netuid: 5
- Kind: subnet-api
- Public URL: https://api.hone.training/health
- Source URL (proves the claim): https://www.hone.training/
- Provider slug: hone

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only endpoint on the subnet's own registered apex domain.
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs.
- [x] Not a duplicate — the manifest had no subnet-api surface; this is the api. subdomain, not the excluded website-host path.
- [x] Links a tracked issue (`Closes #713`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/hone.json` → passed (6 surfaces, 1 file)
- [x] `npm run scan:public-safety` → passed
