### PR TITLE
feat(ui): add a stake-transfers tile to the subnet economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -1,10 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { economicsQuery, subnetStakeMovesQuery } from "@/lib/metagraphed/queries";
+import {
+  economicsQuery,
+  subnetStakeMovesQuery,
+  subnetStakeTransfersQuery,
+} from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
 // validators, volume) from the previously-unused /api/v1/economics. The artifact
@@ -70,6 +75,12 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
 
+  // #3484: recent stake-transfer (transfer_stake) activity for this subnet, from
+  // the already-shipped-but-unwired subnetStakeTransfersQuery. Folded into a tile
+  // view-model with safe fallbacks so it renders even on a cold/empty store.
+  const { data: transfers } = useQuery(subnetStakeTransfersQuery(netuid));
+  const xfer = stakeTransfersTileModel(transfers?.data);
+
   if (isPending && !e) return <Notice>Loading economics…</Notice>;
   if (!e) return <Notice>No on-chain economic data for this subnet.</Notice>;
 
@@ -107,6 +118,7 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         hint={e.registration_allowed === false ? "closed" : "open"}
       />
       <StakeMovesTile netuid={netuid} />
+      <StatTile eyebrow={xfer.eyebrow} tone={xfer.tone} value={xfer.value} hint={xfer.hint} />
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { stakeTransfersTileModel } from "./stake-transfers-tile";
+import type { SubnetStakeTransfers } from "./types";
+
+function card(partial: Partial<SubnetStakeTransfers>): SubnetStakeTransfers {
+  return {
+    schema_version: 1,
+    netuid: 7,
+    window: "30d",
+    observed_at: null,
+    distinct_senders: 0,
+    transfers: 0,
+    transfers_per_sender: null,
+    ...partial,
+  };
+}
+
+describe("stakeTransfersTileModel", () => {
+  it("summarizes a populated card", () => {
+    const m = stakeTransfersTileModel(
+      card({ distinct_senders: 6, transfers: 28, transfers_per_sender: 4.67 }),
+    );
+    expect(m.eyebrow).toBe("Stake transfers");
+    expect(m.value).toBe("28");
+    expect(m.hint).toBe("6 senders · 4.7/sender");
+    expect(m.tone).toBe("accent");
+    expect(m.hasActivity).toBe(true);
+  });
+
+  it("shows an idle tile for a zeroed (cold-store) card", () => {
+    const m = stakeTransfersTileModel(card({}));
+    expect(m.value).toBe("0");
+    expect(m.hint).toBe("no transfers");
+    expect(m.tone).toBe("default");
+    expect(m.hasActivity).toBe(false);
+  });
+
+  it("falls back safely when the card is missing", () => {
+    const m = stakeTransfersTileModel(undefined);
+    expect(m.value).toBe("0");
+    expect(m.hint).toBe("no transfers");
+    expect(m.hasActivity).toBe(false);
+  });
+
+  it("singularizes a lone sender and omits a null average", () => {
+    const m = stakeTransfersTileModel(
+      card({ distinct_senders: 1, transfers: 2, transfers_per_sender: null }),
+    );
+    expect(m.hint).toBe("1 sender");
+    expect(m.hasActivity).toBe(true);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
@@ -1,0 +1,42 @@
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { SubnetStakeTransfers } from "@/lib/metagraphed/types";
+
+// #3484: view-model for the economics-panel stake-transfers StatTile. Consumes the
+// already-shipped subnetStakeTransfersQuery card (transfer_stake activity over the
+// window) and folds it into display strings. Kept pure + framework-free so the
+// count/sender/average formatting and the idle vs. active states are unit-tested
+// without rendering; the component just spreads the result onto <StatTile />.
+
+export interface StakeTransfersTileModel {
+  eyebrow: string;
+  value: string;
+  hint: string;
+  tone: "default" | "accent";
+  hasActivity: boolean;
+}
+
+/**
+ * Fold a normalized SubnetStakeTransfers card into a StatTile view-model.
+ * Missing / cold / junk cards degrade to a stable zeroed "no transfers" tile
+ * (never NaN, never a thrown), so the tile renders regardless of store state.
+ */
+export function stakeTransfersTileModel(
+  card?: SubnetStakeTransfers | null,
+): StakeTransfersTileModel {
+  const transfers = card && Number.isFinite(card.transfers) ? card.transfers : 0;
+  const senders = card && Number.isFinite(card.distinct_senders) ? card.distinct_senders : 0;
+  const perSender = card?.transfers_per_sender;
+  const hasActivity = transfers > 0;
+
+  const senderLabel = `${formatNumber(senders)} ${senders === 1 ? "sender" : "senders"}`;
+  const avgLabel =
+    perSender != null && Number.isFinite(perSender) ? ` · ${perSender.toFixed(1)}/sender` : "";
+
+  return {
+    eyebrow: "Stake transfers",
+    value: formatNumber(transfers),
+    hint: hasActivity ? `${senderLabel}${avgLabel}` : "no transfers",
+    tone: hasActivity ? "accent" : "default",
+    hasActivity,
+  };
+}


### PR DESCRIPTION
Closes #3484

Wires the shipped-but-unused `subnetStakeTransfersQuery` (#3666) into the subnet **Economics** panel as a **Stake transfers** tile: the trailing-30d transfer-stake count, with distinct senders and the per-sender average in the hint. Complements the recently merged stake-moves tile in the same panel — no data-layer changes (the query / type / normalizer from #3666 are consumed as-is via `useQuery`).

Adds a pure `stakeTransfersTileModel()` helper with safe fallbacks (singularizes "1 sender", omits the average when null, "no transfers" at zero) and a unit test (populated / empty-zero / missing).

## Screenshots (subnet 21, live API)

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/before-desktop-light.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/after-desktop-light.png) |
| **Desktop · Dark** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/before-desktop-dark.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/after-desktop-dark.png) |
| **Tablet · Light** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/before-tablet-light.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/after-tablet-light.png) |
| **Tablet · Dark** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/before-tablet-dark.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/after-tablet-dark.png) |
| **Mobile · Light** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/before-mobile-light.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/after-mobile-light.png) |
| **Mobile · Dark** | ![b](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/before-mobile-dark.png) | ![a](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots/after-mobile-dark.png) |

## Verification
`tsc --noEmit`, `eslint` (0 errors), `vitest` (new tile tests pass), and `vite build` all green; verified against live api.metagraph.sh (subnet 21: 28 transfers / 6 senders / 4.7 per sender).
