### PR TITLE
feat(ui): extract shared use-refetch-interval hook (visibility-gated polling)

### DIFF
--- a/apps/ui/src/hooks/use-refetch-interval.test.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRefetchInterval } from "./use-refetch-interval";
+
+describe("resolveRefetchInterval", () => {
+  it("polls at the given interval when enabled and the tab is visible", () => {
+    expect(resolveRefetchInterval(30_000, true, true)).toBe(30_000);
+    expect(resolveRefetchInterval(60_000, true, true)).toBe(60_000);
+  });
+
+  it("pauses (false) when polling is disabled, regardless of visibility", () => {
+    expect(resolveRefetchInterval(30_000, false, true)).toBe(false);
+    expect(resolveRefetchInterval(30_000, false, false)).toBe(false);
+  });
+
+  it("pauses (false) while the tab is hidden, even when enabled", () => {
+    expect(resolveRefetchInterval(30_000, true, false)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-refetch-interval.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+/**
+ * The effective TanStack Query `refetchInterval`: the numeric interval only
+ * while polling is enabled and the tab is visible, otherwise `false` (Query's
+ * "don't poll"). Pure, so the tab-hidden / paused gating is unit-testable
+ * without mounting a component.
+ */
+export function resolveRefetchInterval(
+  intervalMs: number,
+  enabled: boolean,
+  visible: boolean,
+): number | false {
+  return enabled && visible ? intervalMs : false;
+}
+
+/** Returns true when the document is visible (or true in SSR). */
+export function usePageVisible(): boolean {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const update = () => setVisible(!document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+  return visible;
+}
+
+/**
+ * A refetch interval gated on tab visibility and an `enabled` flag: `intervalMs`
+ * while the tab is visible and polling is enabled, else `false`. Composes
+ * {@link usePageVisible} so callers get the tab-hidden pause for free without
+ * having to wire the visibility listener themselves.
+ */
+export function useRefetchInterval(intervalMs: number, enabled = true): number | false {
+  const visible = usePageVisible();
+  return resolveRefetchInterval(intervalMs, enabled, visible);
+}

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { resolveRefetchInterval, usePageVisible } from "@/hooks/use-refetch-interval";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { RefreshCw, Pause, Play, ChevronDown, ChevronRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -59,24 +60,11 @@ export const Route = createFileRoute("/health")({
   component: HealthPage,
 });
 
-/** Returns true when the document is visible (or true in SSR). */
-function usePageVisible(): boolean {
-  const [visible, setVisible] = useState(true);
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    const update = () => setVisible(!document.hidden);
-    update();
-    document.addEventListener("visibilitychange", update);
-    return () => document.removeEventListener("visibilitychange", update);
-  }, []);
-  return visible;
-}
-
 function HealthPage() {
   const [enabled, setEnabled] = useState(true);
   const [intervalMs, setIntervalMs] = useState(30_000);
   const visible = usePageVisible();
-  const effectiveInterval = enabled && visible ? intervalMs : false;
+  const effectiveInterval = resolveRefetchInterval(intervalMs, enabled, visible);
   // #1117: push a refresh on each registry publish, on top of the poll interval.
   useRegistryEvents();
 

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -20,7 +21,6 @@ import {
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
 
-const REFRESH_MS = 60_000;
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
 // treated as still-ongoing (probe cadence is ~2 min, so ~5 cycles).
@@ -119,7 +119,8 @@ function StatusPage() {
 
 /** Overall verdict banner + status mix, derived from /api/v1/health status counts. */
 function Verdict() {
-  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval: REFRESH_MS });
+  const refetchInterval = useRefetchInterval(60_000);
+  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval });
   const h = hRes.data;
   const ok = h?.ok ?? 0;
   const warn = h?.warn ?? 0;
@@ -245,9 +246,10 @@ function Kpi({
 function RecentIncidents() {
   const [window, setWindow] = useState<IncidentWindow>("7d");
   const [showAll, setShowAll] = useState(false);
+  const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
     ...globalIncidentsQuery(window),
-    refetchInterval: REFRESH_MS,
+    refetchInterval,
   });
   const ledger = data.data;
   // A surface is still failing ("ongoing") when its most recent downtime event


### PR DESCRIPTION
## Summary

Extracts the page-visibility-gated polling logic — currently private to `health.tsx` and entirely absent from `status.tsx` — into a shared hook, so both routes compute their TanStack Query `refetchInterval` the same way (dedup, not a new UI surface).

Closes #3371

## What changed

- **New `apps/ui/src/hooks/use-refetch-interval.ts`** (mirrors the `use-delayed-reveal.ts` convention — pure fns + thin hook wrappers):
  - `resolveRefetchInterval(intervalMs, enabled, visible)` — pure: `enabled && visible ? intervalMs : false`.
  - `usePageVisible()` — lifted verbatim from `health.tsx` (`document.hidden` + `visibilitychange`, SSR-safe default `true`).
  - `useRefetchInterval(intervalMs, enabled = true)` — composes `usePageVisible` so callers get the tab-hidden pause for free.
- **New `apps/ui/src/hooks/use-refetch-interval.test.ts`** — unit-tests the pure `resolveRefetchInterval` (visible+enabled → interval; disabled → false; tab hidden → false).
- **`apps/ui/src/routes/health.tsx`** — deletes the private `usePageVisible`; `HealthPage` now imports the shared `usePageVisible` (still needed for `AutoRefreshControl`'s `visible` prop) and derives `effectiveInterval` via `resolveRefetchInterval`. `AutoRefreshControl` and its interval-picker/pause/play UI are untouched — zero behavior change.
- **`apps/ui/src/routes/status.tsx`** — replaces the hardcoded `REFRESH_MS = 60_000` fed into both `useSuspenseQuery` calls with `useRefetchInterval(60_000)`, so `status.tsx` gains the same tab-hidden pause `health.tsx` already had (previously it polled every 60s regardless of tab state).

Net: one hook, one behavior, two call sites reusing it — no regression on `health.tsx`, a net-new visibility pause on `status.tsx`.

## Screenshots

Not applicable — this is a `hooks/`-layer extraction with **no presentation/markup change** (per the issue's own note for `apps/ui/src/hooks/**`-only changes).

## Validation

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm run lint` — exit 0 (0 errors) · `format:check`
- [x] `npm run test` — new pure-logic tests pass; no other route/component touched
