### PR TITLE
feat(ui): add network decentralization scorecard to the status page

### DIFF
--- a/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
@@ -1,0 +1,99 @@
+import { useQuery } from "@tanstack/react-query";
+import type { LucideIcon } from "lucide-react";
+import { Scale, Users, BarChart3, Activity, Percent, Coins, ShieldCheck } from "lucide-react";
+import { chainConcentrationQuery, chainPerformanceQuery } from "@/lib/metagraphed/queries";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { EmptyState } from "@/components/metagraphed/states";
+import {
+  networkDecentralizationModel,
+  type DecentralizationTile,
+} from "@/lib/metagraphed/network-decentralization";
+
+// #3471: network-scope decentralization scorecard — the chain-wide twin of the
+// per-subnet concentration panel. Feeds from the already-shipped-but-unwired
+// chainConcentrationQuery + chainPerformanceQuery (#3609). The data layer is
+// untouched; this only consumes the normalized shape via useQuery and maps it
+// through the pure networkDecentralizationModel helper.
+
+const TILE_ICONS: Record<string, LucideIcon> = {
+  "stake-gini": Scale,
+  "stake-hhi": BarChart3,
+  "stake-nakamoto": Users,
+  "stake-entropy": Activity,
+  "stake-top1": Percent,
+  "emission-gini": Coins,
+  "trust-median": ShieldCheck,
+  "consensus-median": ShieldCheck,
+  "validator-trust-median": ShieldCheck,
+};
+
+function Notice({ children }: { children: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
+      {children}
+    </div>
+  );
+}
+
+function Tile({ tile }: { tile: DecentralizationTile }) {
+  return (
+    <StatTile
+      icon={TILE_ICONS[tile.key]}
+      eyebrow={tile.label}
+      value={tile.value}
+      hint={tile.hint}
+      tone={tile.tone}
+    />
+  );
+}
+
+/**
+ * Chain-wide decentralization scorecard: stake/emission concentration (Gini,
+ * HHI, Nakamoto coefficient, entropy, top-1% share) plus the 0-1 trust /
+ * consensus / validator-trust score spread — the same KPI-tile grid as the
+ * per-subnet concentration panel, at network scope. Fetches both snapshots
+ * once (shared cache) and renders through the pure view-model helper.
+ */
+export function NetworkDecentralizationPanel() {
+  const { data: cRes, isPending: cPending } = useQuery(chainConcentrationQuery());
+  const { data: pRes, isPending: pPending } = useQuery(chainPerformanceQuery());
+
+  const model = networkDecentralizationModel(cRes?.data, pRes?.data);
+
+  if ((cPending || pPending) && !model.hasData) {
+    return <Notice>Loading network decentralization…</Notice>;
+  }
+
+  if (!model.hasData) {
+    return (
+      <EmptyState
+        title="No network decentralization metrics"
+        description="Chain-wide stake- and emission-distribution metrics (Gini, HHI, Nakamoto coefficient, entropy, top-1% share) plus the 0-1 trust/consensus score spread are computed from the metagraph snapshot and will appear here once captured."
+        lastChecked={cRes?.meta?.generated_at ?? pRes?.meta?.generated_at}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Stake & emission concentration — the headline distribution scorecard. */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {model.concentrationTiles.map((tile) => (
+          <Tile key={tile.key} tile={tile} />
+        ))}
+      </div>
+
+      {/* 0-1 trust / consensus / validator-trust score spread. */}
+      <div>
+        <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Trust &amp; consensus score spread
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {model.scoreTiles.map((tile) => (
+            <Tile key={tile.key} tile={tile} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/network-decentralization.test.ts
+++ b/apps/ui/src/lib/metagraphed/network-decentralization.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { networkDecentralizationModel } from "./network-decentralization";
+import type { ChainConcentration, ChainPerformance } from "./types";
+
+function findTile(model: ReturnType<typeof networkDecentralizationModel>, key: string) {
+  return [...model.concentrationTiles, ...model.scoreTiles].find((t) => t.key === key);
+}
+
+const CONCENTRATION: ChainConcentration = {
+  schema_version: 1,
+  subnet_count: 129,
+  neuron_count: 30228,
+  entity_count: 6375,
+  uids_per_entity: 4.74,
+  captured_at: "2026-07-05T08:22:10.382Z",
+  stake: {
+    holders: 8385,
+    total: 337397066,
+    gini: 0.95325,
+    hhi: 0.003325,
+    hhi_normalized: 0.003206,
+    nakamoto_coefficient: 105,
+    top_1pct_share: 0.440809,
+    top_5pct_share: 0.856214,
+    top_10pct_share: 0.970332,
+    top_20pct_share: 0.999098,
+    entropy: 8.986092,
+    entropy_normalized: 0.689456,
+  },
+  emission: {
+    holders: 6191,
+    total: 38493.239,
+    gini: 0.899375,
+    hhi: 0.002802,
+    hhi_normalized: 0.002641,
+    nakamoto_coefficient: 118,
+    top_1pct_share: 0.315999,
+    top_5pct_share: 0.753536,
+    top_10pct_share: 0.877576,
+    top_20pct_share: 0.947895,
+    entropy: 9.426869,
+    entropy_normalized: 0.748404,
+  },
+  entity_stake: null,
+  entity_emission: null,
+  validator_stake: null,
+};
+
+const PERFORMANCE: ChainPerformance = {
+  schema_version: 1,
+  subnet_count: 129,
+  neuron_count: 30228,
+  validator_count: 1540,
+  active_count: 1937,
+  captured_at: "2026-07-05T08:22:10.382Z",
+  incentive: null,
+  dividends: null,
+  trust: { count: 30228, mean: 0, min: 0, max: 0, p10: 0, p25: 0, p50: 0, p75: 0, p90: 0 },
+  consensus: {
+    count: 30228,
+    mean: 0.00425,
+    min: 0,
+    max: 1,
+    p10: 0,
+    p25: 0,
+    p50: 0,
+    p75: 0,
+    p90: 0.001358,
+  },
+  validator_trust: {
+    count: 1540,
+    mean: 0.751977,
+    min: 0,
+    max: 1,
+    p10: 0,
+    p25: 0.659602,
+    p50: 0.999985,
+    p75: 1,
+    p90: 1,
+  },
+};
+
+describe("networkDecentralizationModel", () => {
+  it("maps a populated snapshot to formatted tiles with the right tones", () => {
+    const model = networkDecentralizationModel(CONCENTRATION, PERFORMANCE);
+
+    expect(model.hasData).toBe(true);
+    expect(model.capturedAt).toBe("2026-07-05T08:22:10.382Z");
+    expect(model.concentrationTiles).toHaveLength(6);
+    expect(model.scoreTiles).toHaveLength(3);
+
+    // Stake Gini is high → "down" tone, emission Gini carried in the hint.
+    const stakeGini = findTile(model, "stake-gini");
+    expect(stakeGini?.value).toBe("0.953");
+    expect(stakeGini?.hint).toBe("emission 0.899");
+    expect(stakeGini?.tone).toBe("down");
+
+    // Nakamoto is an integer; 105 entities → resilient → "ok".
+    const nakamoto = findTile(model, "stake-nakamoto");
+    expect(nakamoto?.value).toBe("105");
+    expect(nakamoto?.tone).toBe("ok");
+
+    // Shares render as percentages.
+    const top1 = findTile(model, "stake-top1");
+    expect(top1?.value).toBe("44.1%");
+    expect(top1?.hint).toBe("top 10% 97.0%");
+
+    // Normalized entropy ~0.69 → even-ish → "ok".
+    const entropy = findTile(model, "stake-entropy");
+    expect(entropy?.value).toBe("0.689");
+    expect(entropy?.hint).toBe("8.99 nats");
+    expect(entropy?.tone).toBe("ok");
+
+    // Score spread reads a real zero, not a fallback.
+    const trust = findTile(model, "trust-median");
+    expect(trust?.value).toBe("0.000");
+    expect(trust?.hint).toBe("mean 0.000");
+    const valTrust = findTile(model, "validator-trust-median");
+    expect(valTrust?.value).toBe("1.000");
+  });
+
+  it("returns hasData=false and all '—' values for an empty snapshot", () => {
+    const model = networkDecentralizationModel(null, null);
+
+    expect(model.hasData).toBe(false);
+    expect(model.capturedAt).toBe(null);
+    expect(model.concentrationTiles).toHaveLength(6);
+    expect(model.scoreTiles).toHaveLength(3);
+    // Every tile falls back to the "—" value and a neutral "default" tone.
+    for (const tile of [...model.concentrationTiles, ...model.scoreTiles]) {
+      expect(tile.value).toBe("—");
+      expect(tile.tone).toBe("default");
+    }
+    expect(findTile(model, "stake-gini")?.value).toBe("—");
+    expect(findTile(model, "stake-top1")?.value).toBe("—");
+    expect(findTile(model, "trust-median")?.value).toBe("—");
+    // Missing hints are dropped rather than rendered as "—".
+    expect(findTile(model, "stake-gini")?.hint).toBeUndefined();
+  });
+
+  it("tolerates a missing metric block while other blocks still render", () => {
+    const concentrationNoEmission: ChainConcentration = { ...CONCENTRATION, emission: null };
+    const performanceNoTrust: ChainPerformance = { ...PERFORMANCE, trust: null };
+
+    const model = networkDecentralizationModel(concentrationNoEmission, performanceNoTrust);
+
+    // Stake still resolves → the card stays populated.
+    expect(model.hasData).toBe(true);
+    expect(findTile(model, "stake-gini")?.value).toBe("0.953");
+    // Emission block gone → its Gini tile and the stake-gini emission hint fall back.
+    expect(findTile(model, "emission-gini")?.value).toBe("—");
+    expect(findTile(model, "emission-gini")?.tone).toBe("default");
+    expect(findTile(model, "stake-gini")?.hint).toBeUndefined();
+    // Missing trust block → "—", but consensus/val-trust still render.
+    expect(findTile(model, "trust-median")?.value).toBe("—");
+    expect(findTile(model, "trust-median")?.hint).toBeUndefined();
+    expect(findTile(model, "validator-trust-median")?.value).toBe("1.000");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/network-decentralization.ts
+++ b/apps/ui/src/lib/metagraphed/network-decentralization.ts
@@ -1,0 +1,213 @@
+// #3471: pure view-model for the network-scope decentralization scorecard.
+// Maps the normalized chain concentration (/api/v1/chain/concentration) and
+// performance (/api/v1/chain/performance) snapshots — the chain-wide twin of
+// the per-subnet concentration panel — into StatTile view-models with safe
+// fallbacks for missing / null fields. Kept framework-free so it can be unit
+// tested without React (Codecov gates coverage).
+
+import type {
+  ChainConcentration,
+  ChainPerformance,
+  ConcentrationMetrics,
+  ScoreDistribution,
+} from "@/lib/metagraphed/types";
+
+/** KPI border/icon tone — concentration reads "worse" as it climbs. */
+export type DecentralizationTone = "ok" | "warn" | "down" | "default";
+
+export interface DecentralizationTile {
+  /** Stable key for React lists, icon lookup, and tests. */
+  key: string;
+  /** Uppercase eyebrow shown on the StatTile. */
+  label: string;
+  /** Formatted display value ("—" when the source field is missing). */
+  value: string;
+  /** Optional secondary context line. */
+  hint?: string;
+  /** KPI tone; concentration climbing → warn/down, resilience → ok. */
+  tone: DecentralizationTone;
+}
+
+export interface NetworkDecentralizationModel {
+  /** True once at least one headline metric resolved to a real number. */
+  hasData: boolean;
+  /** Snapshot instant, preferring the concentration capture. */
+  capturedAt: string | null;
+  /** Stake / emission concentration tiles (Gini / HHI / Nakamoto / entropy / top-1%). */
+  concentrationTiles: DecentralizationTile[];
+  /** Trust / consensus / validator-trust score-spread tiles. */
+  scoreTiles: DecentralizationTile[];
+}
+
+function num(v: number | null | undefined): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function numStr(v: number | null | undefined, digits = 3): string {
+  const n = num(v);
+  return n == null ? "—" : n.toFixed(digits);
+}
+
+function pctStr(v: number | null | undefined, digits = 1): string {
+  const n = num(v);
+  return n == null ? "—" : `${(n * 100).toFixed(digits)}%`;
+}
+
+function intStr(v: number | null | undefined): string {
+  const n = num(v);
+  return n == null ? "—" : String(Math.round(n));
+}
+
+// A higher Gini / HHI means more concentration (worse decentralization); a
+// higher Nakamoto coefficient means more resilient; a higher normalized entropy
+// (0-1) means a more even distribution. Map each to a tone so the KPI
+// border/icon reads the right way.
+function giniTone(v: number | null | undefined): DecentralizationTone {
+  const n = num(v);
+  if (n == null) return "default";
+  if (n >= 0.85) return "down";
+  if (n >= 0.6) return "warn";
+  return "ok";
+}
+
+function nakamotoTone(v: number | null | undefined): DecentralizationTone {
+  const n = num(v);
+  if (n == null) return "default";
+  if (n <= 1) return "down";
+  if (n <= 3) return "warn";
+  return "ok";
+}
+
+function entropyTone(v: number | null | undefined): DecentralizationTone {
+  const n = num(v);
+  if (n == null) return "default";
+  if (n >= 0.66) return "ok";
+  if (n >= 0.33) return "warn";
+  return "down";
+}
+
+function shareTone(v: number | null | undefined): DecentralizationTone {
+  const n = num(v);
+  if (n == null) return "default";
+  if (n >= 0.5) return "down";
+  if (n >= 0.25) return "warn";
+  return "ok";
+}
+
+function concentrationTiles(
+  stake: ConcentrationMetrics | null,
+  emission: ConcentrationMetrics | null,
+): DecentralizationTile[] {
+  const emissionGini = num(emission?.gini);
+  const stakeHhiNorm = num(stake?.hhi_normalized);
+  const stakeEntropy = num(stake?.entropy);
+  const stakeTop10 = num(stake?.top_10pct_share);
+  const emissionNakamoto = num(emission?.nakamoto_coefficient);
+  return [
+    {
+      key: "stake-gini",
+      label: "Stake Gini",
+      value: numStr(stake?.gini),
+      hint: emissionGini == null ? undefined : `emission ${emissionGini.toFixed(3)}`,
+      tone: giniTone(stake?.gini),
+    },
+    {
+      key: "stake-hhi",
+      label: "Stake HHI",
+      value: numStr(stake?.hhi),
+      hint: stakeHhiNorm == null ? undefined : `norm ${stakeHhiNorm.toFixed(3)}`,
+      tone: giniTone(stake?.hhi),
+    },
+    {
+      key: "stake-nakamoto",
+      label: "Nakamoto",
+      value: intStr(stake?.nakamoto_coefficient),
+      hint: "entities to 51%",
+      tone: nakamotoTone(stake?.nakamoto_coefficient),
+    },
+    {
+      key: "stake-entropy",
+      label: "Stake entropy",
+      value: numStr(stake?.entropy_normalized),
+      hint: stakeEntropy == null ? undefined : `${stakeEntropy.toFixed(2)} nats`,
+      tone: entropyTone(stake?.entropy_normalized),
+    },
+    {
+      key: "stake-top1",
+      label: "Top 1% stake",
+      value: pctStr(stake?.top_1pct_share),
+      hint: stakeTop10 == null ? undefined : `top 10% ${(stakeTop10 * 100).toFixed(1)}%`,
+      tone: shareTone(stake?.top_1pct_share),
+    },
+    {
+      key: "emission-gini",
+      label: "Emission Gini",
+      value: numStr(emission?.gini),
+      hint: emissionNakamoto == null ? undefined : `Nakamoto ${Math.round(emissionNakamoto)}`,
+      tone: giniTone(emission?.gini),
+    },
+  ];
+}
+
+function scoreTiles(
+  trust: ScoreDistribution | null,
+  consensus: ScoreDistribution | null,
+  validatorTrust: ScoreDistribution | null,
+): DecentralizationTile[] {
+  const trustMean = num(trust?.mean);
+  const consensusMean = num(consensus?.mean);
+  const valTrustP90 = num(validatorTrust?.p90);
+  return [
+    {
+      key: "trust-median",
+      label: "Trust median",
+      value: numStr(trust?.p50),
+      hint: trustMean == null ? undefined : `mean ${trustMean.toFixed(3)}`,
+      tone: "default",
+    },
+    {
+      key: "consensus-median",
+      label: "Consensus median",
+      value: numStr(consensus?.p50),
+      hint: consensusMean == null ? undefined : `mean ${consensusMean.toFixed(3)}`,
+      tone: "default",
+    },
+    {
+      key: "validator-trust-median",
+      label: "Val-trust median",
+      value: numStr(validatorTrust?.p50),
+      hint: valTrustP90 == null ? undefined : `p90 ${valTrustP90.toFixed(3)}`,
+      tone: "default",
+    },
+  ];
+}
+
+/**
+ * Build the network decentralization scorecard view-model. Both inputs are
+ * nullable-by-design (the queries reshape cold-store nulls into `null` metric
+ * blocks); every field falls back to "—" so the tiles always render.
+ */
+export function networkDecentralizationModel(
+  concentration: ChainConcentration | null | undefined,
+  performance: ChainPerformance | null | undefined,
+): NetworkDecentralizationModel {
+  const stake = concentration?.stake ?? null;
+  const emission = concentration?.emission ?? null;
+  const trust = performance?.trust ?? null;
+  const consensus = performance?.consensus ?? null;
+  const validatorTrust = performance?.validator_trust ?? null;
+
+  const hasData =
+    num(stake?.gini) != null ||
+    num(emission?.gini) != null ||
+    num(trust?.p50) != null ||
+    num(consensus?.p50) != null ||
+    num(validatorTrust?.p50) != null;
+
+  return {
+    hasData,
+    capturedAt: concentration?.captured_at ?? performance?.captured_at ?? null,
+    concentrationTiles: concentrationTiles(stake, emission),
+    scoreTiles: scoreTiles(trust, consensus, validatorTrust),
+  };
+}

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -19,6 +19,7 @@ import {
   HealthHistoryDrilldown,
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
+import { NetworkDecentralizationPanel } from "@/components/metagraphed/network-decentralization-panel";
 
 const REFRESH_MS = 60_000;
 const SURFACES_INITIAL = 10;
@@ -79,6 +80,20 @@ function StatusPage() {
           </QueryErrorBoundary>
         </section>
 
+        {/* #3471: network-scope decentralization scorecard — stake &
+            emission concentration (Gini / HHI / Nakamoto / entropy / top-1%)
+            plus the trust/consensus score spread, mirroring the per-subnet
+            concentration panel at chain scope. */}
+        <section>
+          <SectionHeading
+            title="Network decentralization"
+            intro="Chain-wide stake & emission concentration (Gini, HHI, Nakamoto coefficient, entropy, top-1% share) and the trust/consensus score spread, computed across every subnet from the metagraph snapshot."
+          />
+          <QueryErrorBoundary>
+            <NetworkDecentralizationPanel />
+          </QueryErrorBoundary>
+        </section>
+
         {/* #8: operational diagnostics — a per-day probe drill-down and a
             provider verification rollup, both probe-derived. */}
         <section>
@@ -111,6 +126,8 @@ function StatusPage() {
           "/api/v1/incidents",
           "/api/v1/health/history/{date}",
           "/api/v1/source-health",
+          "/api/v1/chain/concentration",
+          "/api/v1/chain/performance",
         ]}
       />
     </AppShell>


### PR DESCRIPTION
Closes #3471
_Supersedes #3757 (closed) — same code, evidence re-captured as constrained thumbnails per @JSONbored's review._

Wires the shipped-but-unused `chainConcentrationQuery` + `chainPerformanceQuery` (#3609) into a network-scope **decentralization scorecard** on `/status`, mirroring the per-subnet concentration panel at chain scope. No data-layer changes — the queries / types / normalizers from #3609 are consumed as-is via `useQuery`.

**Concentration** (`/chain/concentration`): stake Gini, stake HHI, Nakamoto coefficient, stake entropy, top-1% stake share, emission Gini.
**Trust & consensus score spread** (`/chain/performance`): trust / consensus / validator-trust medians, with mean/p90 hints. Network-wide trust & consensus medians are genuinely ~0 in the live snapshot (most neurons carry ~0 trust) — real values, not empty states; validator-trust median is 1.000.

Adds a pure `networkDecentralizationModel()` helper (label/value/hint per tile, safe `—` fallbacks for missing blocks) with a unit test (populated / empty-zero / missing-block).

## Screenshots (live api.metagraph.sh)

_**After** = element screenshot of just the new section (~1200×400); **Before** = viewport-only `/status` at the insertion point (Recent incidents → Probe history), section absent. Every image ≤ ~1000px tall._

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/before-desktop-light.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/after-desktop-light.png"> |
| **Desktop · Dark** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/before-desktop-dark.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/after-desktop-dark.png"> |
| **Tablet · Light** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/before-tablet-light.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/after-tablet-light.png"> |
| **Tablet · Dark** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/before-tablet-dark.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/after-tablet-dark.png"> |
| **Mobile · Light** | <img width="200" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/before-mobile-light.png"> | <img width="200" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/after-mobile-light.png"> |
| **Mobile · Dark** | <img width="200" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/before-mobile-dark.png"> | <img width="200" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/decentralization-shots-v2/after-mobile-dark.png"> |

## Verification
`vite build`, `tsc --noEmit`, `eslint` (0 errors), full `vitest` (430 tests incl. 3 new) all pass; rendered against live api.metagraph.sh.
