### PR TITLE
feat(ui): extract shared use-refetch-interval hook (visibility-gated polling)

### DIFF
--- a/apps/ui/src/hooks/use-refetch-interval.test.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRefetchInterval } from "./use-refetch-interval";
+
+describe("resolveRefetchInterval", () => {
+  it("polls at the given interval when enabled and the tab is visible", () => {
+    expect(resolveRefetchInterval(30_000, true, true)).toBe(30_000);
+    expect(resolveRefetchInterval(60_000, true, true)).toBe(60_000);
+  });
+
+  it("pauses (false) when polling is disabled, regardless of visibility", () => {
+    expect(resolveRefetchInterval(30_000, false, true)).toBe(false);
+    expect(resolveRefetchInterval(30_000, false, false)).toBe(false);
+  });
+
+  it("pauses (false) while the tab is hidden, even when enabled", () => {
+    expect(resolveRefetchInterval(30_000, true, false)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-refetch-interval.ts
+++ b/apps/ui/src/hooks/use-refetch-interval.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+/**
+ * The effective TanStack Query `refetchInterval`: the numeric interval only
+ * while polling is enabled and the tab is visible, otherwise `false` (Query's
+ * "don't poll"). Pure, so the tab-hidden / paused gating is unit-testable
+ * without mounting a component.
+ */
+export function resolveRefetchInterval(
+  intervalMs: number,
+  enabled: boolean,
+  visible: boolean,
+): number | false {
+  return enabled && visible ? intervalMs : false;
+}
+
+/** Returns true when the document is visible (or true in SSR). */
+export function usePageVisible(): boolean {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const update = () => setVisible(!document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+  return visible;
+}
+
+/**
+ * A refetch interval gated on tab visibility and an `enabled` flag: `intervalMs`
+ * while the tab is visible and polling is enabled, else `false`. Composes
+ * {@link usePageVisible} so callers get the tab-hidden pause for free without
+ * having to wire the visibility listener themselves.
+ */
+export function useRefetchInterval(intervalMs: number, enabled = true): number | false {
+  const visible = usePageVisible();
+  return resolveRefetchInterval(intervalMs, enabled, visible);
+}

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { resolveRefetchInterval, usePageVisible } from "@/hooks/use-refetch-interval";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { RefreshCw, Pause, Play, ChevronDown, ChevronRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -59,24 +60,11 @@ export const Route = createFileRoute("/health")({
   component: HealthPage,
 });
 
-/** Returns true when the document is visible (or true in SSR). */
-function usePageVisible(): boolean {
-  const [visible, setVisible] = useState(true);
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    const update = () => setVisible(!document.hidden);
-    update();
-    document.addEventListener("visibilitychange", update);
-    return () => document.removeEventListener("visibilitychange", update);
-  }, []);
-  return visible;
-}
-
 function HealthPage() {
   const [enabled, setEnabled] = useState(true);
   const [intervalMs, setIntervalMs] = useState(30_000);
   const visible = usePageVisible();
-  const effectiveInterval = enabled && visible ? intervalMs : false;
+  const effectiveInterval = resolveRefetchInterval(intervalMs, enabled, visible);
   // #1117: push a refresh on each registry publish, on top of the poll interval.
   useRegistryEvents();
 

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -20,7 +21,6 @@ import {
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
 
-const REFRESH_MS = 60_000;
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
 // treated as still-ongoing (probe cadence is ~2 min, so ~5 cycles).
@@ -119,7 +119,8 @@ function StatusPage() {
 
 /** Overall verdict banner + status mix, derived from /api/v1/health status counts. */
 function Verdict() {
-  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval: REFRESH_MS });
+  const refetchInterval = useRefetchInterval(60_000);
+  const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval });
   const h = hRes.data;
   const ok = h?.ok ?? 0;
   const warn = h?.warn ?? 0;
@@ -245,9 +246,10 @@ function Kpi({
 function RecentIncidents() {
   const [window, setWindow] = useState<IncidentWindow>("7d");
   const [showAll, setShowAll] = useState(false);
+  const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
     ...globalIncidentsQuery(window),
-    refetchInterval: REFRESH_MS,
+    refetchInterval,
   });
   const ledger = data.data;
   // A surface is still failing ("ongoing") when its most recent downtime event

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -10915,39 +10915,49 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_health_trends aggregates bulk trend rows from D1", async () => {
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind() {
-              return {
-                async all() {
-                  assert.match(sql, /FROM surface_uptime_daily/);
-                  return {
-                    results: [
-                      {
-                        netuid: 7,
-                        date: "2026-06-28",
-                        total: 20,
-                        ok_count: 18,
-                        avg_latency_ms: 42,
-                      },
-                    ],
-                  };
-                },
-              };
-            },
-          };
+    // loadBulkHealthTrends windows rows by `date >= now - Nd`, so a fixed seed
+    // date must be pinned against a fixed `now` — otherwise the 2026-06-28 row
+    // ages out of the 7d window once wall-clock time passes 2026-07-05 and the
+    // test flakes. Freeze the clock like the sibling D1-window tests above.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const env = {
+        METAGRAPH_HEALTH_DB: {
+          prepare(sql) {
+            return {
+              bind() {
+                return {
+                  async all() {
+                    assert.match(sql, /FROM surface_uptime_daily/);
+                    return {
+                      results: [
+                        {
+                          netuid: 7,
+                          date: "2026-06-28",
+                          total: 20,
+                          ok_count: 18,
+                          avg_latency_ms: 42,
+                        },
+                      ],
+                    };
+                  },
+                };
+              },
+            };
+          },
         },
-      },
-    };
-    const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
-    const res = await callTool("get_health_trends", {}, { deps, env });
-    const out = res.body.result.structuredContent;
-    assert.equal(out.observed_at, FRESH_RUN);
-    assert.equal(out.windows["7d"].subnet_count, 1);
-    assert.equal(out.windows["7d"].subnets[0].netuid, 7);
-    assert.equal(out.windows["7d"].subnets[0].samples, 20);
+      };
+      const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
+      const res = await callTool("get_health_trends", {}, { deps, env });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.observed_at, FRESH_RUN);
+      assert.equal(out.windows["7d"].subnet_count, 1);
+      assert.equal(out.windows["7d"].subnets[0].netuid, 7);
+      assert.equal(out.windows["7d"].subnets[0].samples, 20);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("get_chain_calls returns schema-stable empty calls on cold D1", async () => {


### PR DESCRIPTION
## Summary

Extracts the page-visibility-gated polling logic — currently private to `health.tsx` and entirely absent from `status.tsx` — into a shared hook, so both routes compute their TanStack Query `refetchInterval` the same way (dedup, not a new UI surface).

Closes #3371

## What changed

- **New `apps/ui/src/hooks/use-refetch-interval.ts`** (mirrors the `use-delayed-reveal.ts` convention — pure fns + thin hook wrappers):
  - `resolveRefetchInterval(intervalMs, enabled, visible)` — pure: `enabled && visible ? intervalMs : false`.
  - `usePageVisible()` — lifted verbatim from `health.tsx` (`document.hidden` + `visibilitychange`, SSR-safe default `true`).
  - `useRefetchInterval(intervalMs, enabled = true)` — composes `usePageVisible` so callers get the tab-hidden pause for free.
- **New `apps/ui/src/hooks/use-refetch-interval.test.ts`** — unit-tests the pure `resolveRefetchInterval`.
- **`apps/ui/src/routes/health.tsx`** — deletes the private `usePageVisible`; `HealthPage` imports the shared `usePageVisible` (still needed for `AutoRefreshControl`'s `visible` prop) and derives `effectiveInterval` via `resolveRefetchInterval`. `AutoRefreshControl` UI untouched — zero behavior change.
- **`apps/ui/src/routes/status.tsx`** — replaces the hardcoded `REFRESH_MS = 60_000` fed into both `useSuspenseQuery` calls with `useRefetchInterval(60_000)`, so `status.tsx` gains the tab-hidden pause it lacked.

### Also: unblock a red `test` job (pre-existing, unrelated to the hook)

The root `test` job is currently failing on **every** PR because of a time-bomb in `tests/mcp-server.test.mjs > get_health_trends aggregates bulk trend rows from D1`: it seeds a `2026-06-28` uptime row but runs against the real clock, and `loadBulkHealthTrends` windows rows by `date >= now − 7d`. Once wall-clock time passed 2026-07-05 the seed aged out of the 7d window → `subnet_count` 0 → deterministic failure (reproduces on clean `main`; passed earlier the same day). One-line-style fix: freeze the clock to `2026-06-30` with `vi.useFakeTimers()`/`finally { vi.useRealTimers() }`, matching the ~10 sibling D1-window tests in the same file. Production code unchanged. Included here so this PR's own `test` gate goes green.

## Screenshots

Not applicable — a `hooks/`-layer extraction + a test-clock fix, with no presentation/markup change.

## Validation

- [x] `ui` job locally: client build, `lint`+`format:check` (0 errors), `typecheck` (0 errors), `vitest run` (433 pass), `vite build` — all green
- [x] `tests/mcp-server.test.mjs` — 705/705 pass with the clock fix (was 1 failing on `main`)
