### PR TITLE
fix(contract): allow null subnet yield emissions

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6837,7 +6837,7 @@ export interface components {
             netuid: number;
             neuron_count: number;
             neurons: {
-                emission_tao: number;
+                emission_tao: number | null;
                 hotkey: string | null;
                 /** @enum {string} */
                 role: "validator" | "miner";

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18761,7 +18761,10 @@
               "additionalProperties": false,
               "properties": {
                 "emission_tao": {
-                  "type": "number"
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
                 "hotkey": {
                   "type": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6837,7 +6837,7 @@ export interface components {
             netuid: number;
             neuron_count: number;
             neurons: {
-                emission_tao: number;
+                emission_tao: number | null;
                 hotkey: string | null;
                 /** @enum {string} */
                 role: "validator" | "miner";

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -18739,7 +18739,10 @@
               "additionalProperties": false,
               "properties": {
                 "emission_tao": {
-                  "type": "number"
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
                 "hotkey": {
                   "type": [

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1813,7 +1813,7 @@
                 "hotkey": { "type": ["string", "null"] },
                 "role": { "type": "string", "enum": ["validator", "miner"] },
                 "stake_tao": { "type": "number" },
-                "emission_tao": { "type": "number" },
+                "emission_tao": { "type": ["number", "null"] },
                 "yield": { "type": ["number", "null"] },
                 "vs_median": {
                   "type": ["string", "null"],

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
   buildSubnetYield,
@@ -8,6 +9,13 @@ import {
   loadSubnetYieldHistory,
   YIELD_HISTORY_ROW_CAP,
 } from "../src/subnet-yield.mjs";
+
+const apiComponents = JSON.parse(
+  readFileSync(
+    new URL("../schemas/api-components.schema.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 const CAPTURED = 1717000000000;
 
@@ -215,6 +223,11 @@ describe("buildSubnetYield", () => {
     assert.equal(nullEmission.neuron_count, 1);
     assert.equal(nullEmission.neurons[0].emission_tao, null);
     assert.equal(nullEmission.neurons[0].yield, null);
+
+    const emissionSchema =
+      apiComponents.components.schemas.SubnetYieldArtifact.properties.neurons
+        .items.properties.emission_tao;
+    assert.deepEqual(emissionSchema.type, ["number", "null"]);
 
     const negativeStake = buildSubnetYield(
       [neuron(5, { stake: -1, emission: 2 })],


### PR DESCRIPTION
### Motivation
- The runtime `buildSubnetYield` now emits `neurons[].emission_tao: null` for blank/non-numeric emission cells, which mismatched the published OpenAPI/JSON Schema and generated TypeScript contract that required a numeric `emission_tao`, causing schema validation failures for clients.

### Description
- Relax `SubnetYieldArtifact.neurons[].emission_tao` in the canonical subnet schema to accept `number` or `null` in `schemas/components/05-subnets.schema.json`.
- Regenerate bundled API/OpenAPI and TypeScript contract artifacts so the published contract matches runtime behavior (`public/metagraph/openapi.json`, `schemas/api-components.schema.json`, `public/metagraph/types.d.ts`, `packages/contract/index.d.ts`).
- Add a regression assertion in the subnet-yield tests that checks the generated component schema allows `emission_tao` to be `number | null` (`tests/subnet-yield.test.mjs`).

### Testing
- `npm run build` completed successfully.
- `npx vitest run tests/subnet-yield.test.mjs` ran and all tests passed (33 tests).
- `npm run validate:contract-drift`, `npm run validate:schemas`, `npm run validate:api`, and `npm run validate:openapi` all passed.
- `npm run lint` and `npm run format:check` passed with no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4abcb3bd38832cb252e5f56bb2edea)