### PR TITLE
fix(test): derive get_health_trends sample day from current date so it stays in the 7d window

### DIFF
--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -10915,6 +10915,11 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_health_trends aggregates bulk trend rows from D1", async () => {
+    // #NNNN: derive the sample day from the current date so the row always
+    // lands inside the 7d window (a hard-coded date ages out and fails).
+    const recentDay = new Date(Date.now() - 2 * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
     const env = {
       METAGRAPH_HEALTH_DB: {
         prepare(sql) {
@@ -10927,7 +10932,7 @@ describe("MCP economics + metagraph data tools", () => {
                     results: [
                       {
                         netuid: 7,
-                        date: "2026-06-28",
+                        date: recentDay,
                         total: 20,
                         ok_count: 18,
                         avg_latency_ms: 42,


### PR DESCRIPTION
The test `get_health_trends aggregates bulk trend rows from D1` fails 100% on `main`, which blocks CI on every open PR.

The mock `surface_uptime_daily` row hard-codes `date: "2026-06-28"`. `buildBulkHealthTrends` keeps only rows with `date >= (now − 7d)` for the 7d window, so once the current date passed 2026-07-05 the row aged out and `windows["7d"].subnet_count` became `0` instead of the asserted `1`.

This derives the sample day from the current date (2 days ago) so it always lands inside the 7d window — the same relative-to-now approach the file already uses for `FRESH_RUN`. No production code changes.

**Verified:** `vitest run tests/mcp-server.test.mjs` → **705 passed** (previously 704 passed / 1 failed).