### PR TITLE
feat(registry): add SN70 NexisGen validation API surfaces (#579)

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -12,7 +12,48 @@
   "social": {
     "x": "https://x.com/nexisgen_ai"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-openapi",
+      "kind": "openapi",
+      "name": "NexisGen Validation API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.x schema for the NexisGen validation API (title: Nexis Validator API). Served publicly at api.nexisgen.ai; documents public GET /healthz and the validator-facing score routes.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.nexisgen.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/RendixNetwork/nexisgen/blob/main/docker/validation-api.env.example#L13",
+        "https://api.nexisgen.ai/openapi.json"
+      ],
+      "url": "https://api.nexisgen.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-healthz",
+      "kind": "subnet-api",
+      "name": "NexisGen validation API health",
+      "notes": "Public no-auth GET /healthz on api.nexisgen.ai returning liveness JSON (observed: {\"status\":\"ok\"}). Documented in the subnet OpenAPI spec on the same host; api.nexisgen.ai is the public validation API fronted by nginx per the official docker env example.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.nexisgen.ai/openapi.json",
+        "https://github.com/RendixNetwork/nexisgen/blob/main/docker/validation-api.env.example#L13"
+      ],
+      "url": "https://api.nexisgen.ai/healthz"
+    }
+  ],
   "source_repo": "https://github.com/RendixNetwork/nexisgen",
   "website_url": "https://nexisgen.ai/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends two community surfaces to `registry/subnets/nexisgen.json`.
Append-only (+42 lines); no existing surfaces or top-level fields modified.

Closes #579

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://api.nexisgen.ai/openapi.json | nexisgen `validation-api.env.example`, live OpenAPI |
| subnet-api | https://api.nexisgen.ai/healthz | live OpenAPI, nexisgen `validation-api.env.example` |

- Netuid: 70
- Provider slug: `nexisgen` (merged in #3722)

First-party proof: the official [nexisgen docker env example](https://github.com/RendixNetwork/nexisgen/blob/main/docker/validation-api.env.example#L13) documents that host nginx terminates TLS for `api.nexisgen.ai`. The subnet `.env.example` sets `NEXIS_VALIDATION_API_URL=https://api.nexisgen.ai/v1/training-scores`. The live OpenAPI on that host documents `GET /healthz` and the validator score routes.

## Canonical manifest

On current `origin/main`, SN70 has one registry file: `registry/subnets/nexisgen.json` (slug `sn-70`). This PR appends to that canonical manifest only — no provider file in this PR.

## Conflict avoidance

| Risk | Mitigation |
|------|------------|
| Two-file PR (provider + subnet) | Provider landed separately in #3722 |
| Phantom duplicate manifest | Only `nexisgen.json` exists for SN70 on main |
| Metadata rewrite / reorder churn | Append-only; top-level fields untouched |

## Checklist

- [x] Changes exactly one `registry/subnets/nexisgen.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `source_urls` independently prove the host.
- [x] `npm run validate:surface -- registry/subnets/nexisgen.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/nexisgen.json`


Made with [Cursor](https://cursor.com)