### PR TITLE
feat(registry): enrich SN88 Investing — ratio subnet-api

### DIFF
--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -129,6 +129,24 @@
         "timeout_ms": 10000
       },
       "notes": "Official Investing source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-mobiusfund-subnet-api",
+      "kind": "subnet-api",
+      "name": "Investing ratio API",
+      "notes": "Documented in the official Investing README as api.investing88.ai/ratio. Returns a JSON array describing the asset-class split used for portfolio scoring (e.g. [0.5, 0.5]).",
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/README.md"
+      ],
+      "url": "https://api.investing88.ai/ratio"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #708

## Add or update a subnet surface

This PR appends one community `subnet-api` surface on `registry/subnets/investing.json`.

## Surface

- Netuid: 88
- Kind: subnet-api
- Public URL: https://api.investing88.ai/ratio
- Source URL (proves the claim): https://github.com/mobiusfund/investing/blob/main/README.md
- Provider slug: mobiusfund

## Checklist

- [x] Changes exactly one `registry/subnets/investing.json` file (append-only).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, or private URLs.
- [x] Does not duplicate an existing Metagraphed surface (distinct `subnet-api` kind from existing `data-artifact` at same URL).
- [x] Links a tracked issue (`Closes #708`).

## Conflict avoidance

| Open upstream PR | Touches `investing.json`? |
|---|---|
| #3774 fix(mcp) | No |
| #3771 fix(registry) | No |
| #3770 docs(skill) | No |
| #3749 fix(api) | No |
| #3594 chore: release main | No |
| #3546 docs(readme) | No |

Append-only change at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/investing.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/investing.json`


Made with [Cursor](https://cursor.com)