### PR TITLE
feat(registry): add SN35 OxMarkets Cartha API surfaces (#667)

### DIFF
--- a/registry/subnets/oxmarkets.json
+++ b/registry/subnets/oxmarkets.json
@@ -75,6 +75,46 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Source repository for the 0xMarkets documentation; README states the project is \"built on the Cartha Subnet (SN35)\". Distinct from the cartha-validator repo at the top level."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-35-oxmarkets-openapi",
+      "kind": "openapi",
+      "name": "Cartha Verifier API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Cartha Verifier API (title: Cartha Verifier). Served publicly at api.cartha.finance; documents SN35 OxMarkets/Cartha miner verification, pool, and lock routes plus the no-auth GET /health probe.",
+      "provider": "oxmarkets",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.cartha.finance/openapi.json",
+      "source_urls": [
+        "https://github.com/General-Tao-Ventures/cartha-principal-miner-template/blob/main/README.md",
+        "https://api.cartha.finance/openapi.json"
+      ],
+      "url": "https://api.cartha.finance/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-35-oxmarkets-health",
+      "kind": "subnet-api",
+      "name": "Cartha Verifier API health",
+      "notes": "Public no-auth GET /health on api.cartha.finance returning liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /health in the subnet OpenAPI spec; api.cartha.finance is the default VERIFIER_URL configured in the official Cartha principal miner template.",
+      "provider": "oxmarkets",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.cartha.finance/openapi.json",
+        "https://github.com/General-Tao-Ventures/cartha-principal-miner-template/blob/main/README.md"
+      ],
+      "url": "https://api.cartha.finance/health"
     }
   ],
   "contact": "contact@0xmarkets.io",


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends two community surfaces to `registry/subnets/oxmarkets.json`.
Append-only (+40 lines); no existing surfaces or top-level fields modified.

Closes #667

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://api.cartha.finance/openapi.json | cartha principal miner template README, live OpenAPI |
| subnet-api | https://api.cartha.finance/health | live OpenAPI, cartha principal miner template README |

- Netuid: 35 (OxMarkets / Cartha)
- Provider slug: `oxmarkets`

First-party proof: the official [cartha-principal-miner-template README](https://github.com/General-Tao-Ventures/cartha-principal-miner-template/blob/main/README.md) sets `VERIFIER_URL` default to `https://api.cartha.finance`. The live OpenAPI 3.1 spec on that host documents `GET /health` and the Cartha verifier routes for SN35.

## Canonical manifest

On current `origin/main`, SN35 has one registry file: `registry/subnets/oxmarkets.json` (slug `sn-35`). This PR appends to that canonical manifest only.

## Conflict avoidance

| Risk | Mitigation |
|------|------------|
| Two-file PR | Single `registry/subnets/oxmarkets.json` change only |
| Metadata rewrite / reorder churn | Append-only; existing four surfaces untouched |
| Weak source proof | `VERIFIER_URL` in official miner template + live OpenAPI |

## Checklist

- [x] Changes exactly one `registry/subnets/oxmarkets.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `source_urls` independently prove the host.
- [x] `npm run validate:surface -- registry/subnets/oxmarkets.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/oxmarkets.json`


Made with [Cursor](https://cursor.com)