### PR TITLE
feat(registry): enrich SN79 MVTRX — exchange health API

### DIFF
--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -82,6 +82,22 @@
         "timeout_ms": 10000
       },
       "notes": "Official MVTRX source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-79-taos-im-subnet-api",
+      "kind": "subnet-api",
+      "name": "MVTRX exchange health API",
+      "notes": "Public no-auth GET /health on mvtrx.exchange returning JSON liveness for the TAOS IM trading host (observed: {\"status\":\"ok\",\"mode\":\"host\",\"network\":\"mainnet\"}). The official SN79 README links mvtrx.exchange as the project exchange.",
+      "provider": "taos-im",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
+      "url": "https://mvtrx.exchange/health"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #684

## Add or update a subnet surface

This PR appends one community `subnet-api` surface on `registry/subnets/mvtrx.json`.

## Surface

- Netuid: 79
- Kind: subnet-api
- Public URL: https://mvtrx.exchange/health
- Source URL (proves the claim): https://github.com/taos-im/sn-79/blob/main/README.md
- Provider slug: taos-im

## Checklist

- [x] Changes exactly one `registry/subnets/mvtrx.json` file (append-only).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, or private URLs.
- [x] Does not duplicate an existing Metagraphed surface (new host/path not present in registry).
- [x] Links a tracked issue (`Closes #684`).

## Conflict avoidance

| Open upstream PR | Touches `mvtrx.json`? |
|---|---|
| #3774 fix(mcp) | No |
| #3771 fix(registry) | No |
| #3770 docs(skill) | No |
| #3749 fix(api) | No |
| #3594 chore: release main | No |
| #3546 docs(readme) | No |

Append-only change at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/mvtrx.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/mvtrx.json`


Made with [Cursor](https://cursor.com)