### PR TITLE
feat(registry): add SN60 Bitsec API surfaces (#589)

### DIFF
--- a/registry/subnets/bitsec-ai.json
+++ b/registry/subnets/bitsec-ai.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "netuid": 60,
+  "name": "Bitsec.ai",
+  "slug": "sn-60",
+  "status": "active",
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-openapi",
+      "kind": "openapi",
+      "name": "Bitsec API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Bitsec platform API (title: FastAPI). Served publicly at bitsec.ai/api; documents agent submission, jobs, analytics, and other SN60 Bitsec routes.",
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://bitsec.ai/api/openapi.json",
+      "source_urls": [
+        "https://github.com/Bitsec-AI/sandbox/blob/main/config.py#L12",
+        "https://bitsec.ai/api/openapi.json"
+      ],
+      "url": "https://bitsec.ai/api/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-stats",
+      "kind": "subnet-api",
+      "name": "Bitsec jobs stats API",
+      "notes": "Public no-auth GET /api/jobs/stats on bitsec.ai returning platform stats JSON (observed: agents_created_1w, real_vulns_found, daily_prize_pool). Documented as GET /jobs/stats in the subnet OpenAPI spec; bitsec.ai is the platform_url configured in the official Bitsec sandbox config.",
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://bitsec.ai/api/openapi.json",
+        "https://github.com/Bitsec-AI/sandbox/blob/main/config.py#L12"
+      ],
+      "url": "https://bitsec.ai/api/jobs/stats"
+    }
+  ],
+  "source_repo": "https://github.com/Bitsec-AI/sandbox",
+  "website_url": "https://bitsec.ai/"
+}


### PR DESCRIPTION
## Add or update a subnet surface

This PR debuts `registry/subnets/bitsec-ai.json` with two community surfaces for SN60 Bitsec.ai.
Single-file change only; provider `bitsec-ai` already exists on main (#840).

Closes #589

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://bitsec.ai/api/openapi.json | Bitsec sandbox `config.py`, live OpenAPI |
| subnet-api | https://bitsec.ai/api/jobs/stats | live OpenAPI, Bitsec sandbox `config.py` |

- Netuid: 60
- Provider slug: `bitsec-ai`

First-party proof: the official [Bitsec sandbox config](https://github.com/Bitsec-AI/sandbox/blob/main/config.py#L12) sets `platform_url = "https://bitsec.ai/"`. The live OpenAPI 3.1 spec at `bitsec.ai/api/openapi.json` documents `GET /jobs/stats` and the other platform routes.

## Canonical manifest

SN60 had no curated overlay on `origin/main` yet. This PR adds the canonical `registry/subnets/bitsec-ai.json` manifest only.

## Conflict avoidance

| Risk | Mitigation |
|------|------------|
| Two-file PR | Single `registry/subnets/bitsec-ai.json` only |
| Provider debut in same PR | Provider merged separately in #840 |
| Weak source proof | `platform_url` in official sandbox config + live OpenAPI |

## Checklist

- [x] Changes exactly one `registry/subnets/bitsec-ai.json` file.
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `source_urls` independently prove the host.
- [x] `npm run validate:surface -- registry/subnets/bitsec-ai.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/bitsec-ai.json`


Made with [Cursor](https://cursor.com)