### PR TITLE
feat(registry): add SN45 Talisman coordination API surfaces (#692)

### DIFF
--- a/registry/subnets/talisman-ai.json
+++ b/registry/subnets/talisman-ai.json
@@ -64,6 +64,46 @@
         "timeout_ms": 10000
       },
       "notes": "Official Talisman AI source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-talisman-openapi",
+      "kind": "openapi",
+      "name": "Talisman coordination API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema for the Talisman SN45 coordination API (title: Alpharidge AI API). Served publicly at api.alpharidge.ai; documents validator/miner coordination routes and the no-auth GET /health probe.",
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.alpharidge.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/Team-Rizzo/talisman-ai/blob/main/README.md#L153",
+        "https://api.alpharidge.ai/openapi.json"
+      ],
+      "url": "https://api.alpharidge.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-talisman-health",
+      "kind": "subnet-api",
+      "name": "Talisman coordination API health",
+      "notes": "Public no-auth GET /health on api.alpharidge.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /health in the subnet OpenAPI spec; api.alpharidge.ai is the default MINER_API_URL configured in the official talisman-ai README for SN45 validators and miners.",
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.alpharidge.ai/openapi.json",
+        "https://github.com/Team-Rizzo/talisman-ai/blob/main/README.md#L153"
+      ],
+      "url": "https://api.alpharidge.ai/health"
     }
   ],
   "social": { "x": "https://x.com/wearetalisman" },


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends two community surfaces to `registry/subnets/talisman-ai.json`.
Append-only (+40 lines); no existing surfaces or top-level fields modified.

Closes #692

## Surfaces

| Kind | Public URL | Source URLs |
|------|------------|-------------|
| openapi | https://api.alpharidge.ai/openapi.json | talisman-ai README, live OpenAPI |
| subnet-api | https://api.alpharidge.ai/health | live OpenAPI, talisman-ai README |

- Netuid: 45 (Talisman AI)
- Provider slug: `talisman-ai`

First-party proof: the official [talisman-ai README](https://github.com/Team-Rizzo/talisman-ai/blob/main/README.md#L153) pre-fills `MINER_API_URL` to `https://api.alpharidge.ai` for SN45 validators and miners. The live OpenAPI 3.1 spec on that host documents `GET /health` and the coordination routes.

## Canonical manifest

On current `origin/main`, SN45 has one registry file: `registry/subnets/talisman-ai.json` (slug `sn-45`). This PR appends to that canonical manifest only.

## Conflict avoidance

| Risk | Mitigation |
|------|------------|
| Overlap with open PR #3780 (SN60 Bitsec) | Different file (`talisman-ai.json` vs `bitsec-ai.json`) and different netuid |
| Metadata rewrite / reorder churn | Append-only; existing website + source-repo surfaces untouched |
| Weak source proof | `MINER_API_URL` in official talisman-ai README + live OpenAPI |

## Checklist

- [x] Changes exactly one `registry/subnets/talisman-ai.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `source_urls` independently prove the host.
- [x] `npm run validate:surface -- registry/subnets/talisman-ai.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/talisman-ai.json`


Made with [Cursor](https://cursor.com)