### PR TITLE
feat(ui): add stake-transfers tile model for economics panel

### DIFF
--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { stakeTransfersTileModel } from "./stake-transfers-tile";
+import type { SubnetStakeTransfers } from "./types";
+
+function card(p: Partial<SubnetStakeTransfers>): SubnetStakeTransfers {
+  return {
+    schema_version: 1,
+    netuid: 7,
+    window: "30d",
+    observed_at: null,
+    distinct_senders: 0,
+    transfers: 0,
+    transfers_per_sender: null,
+    ...p,
+  };
+}
+
+describe("stakeTransfersTileModel", () => {
+  it("splits transfers into unique senders + repeat transfers", () => {
+    const m = stakeTransfersTileModel(
+      card({ distinct_senders: 6, transfers: 18, transfers_per_sender: 3 }),
+    );
+    expect(m.transfers).toBe(18);
+    expect(m.senders).toBe(6);
+    expect(m.repeats).toBe(12);
+    expect(m.perSender).toBe(3);
+    expect(m.segments.map((s) => s.value)).toEqual([6, 12]);
+    expect(m.summary).toBe("6 senders, 12 repeat transfers");
+  });
+
+  it("degrades an undefined / cold card to a zeroed, empty model", () => {
+    for (const c of [undefined, card({})]) {
+      const m = stakeTransfersTileModel(c);
+      expect(m.transfers).toBe(0);
+      expect(m.senders).toBe(0);
+      expect(m.repeats).toBe(0);
+      expect(m.perSender).toBeNull();
+      expect(m.segments.every((s) => s.value === 0)).toBe(true);
+      expect(m.summary).toBe("no stake transfers in this window");
+    }
+  });
+
+  it("singularizes a lone sender and never yields a negative repeat count", () => {
+    const one = stakeTransfersTileModel(
+      card({ distinct_senders: 1, transfers: 1, transfers_per_sender: 1 }),
+    );
+    expect(one.repeats).toBe(0);
+    expect(one.summary).toBe("1 sender");
+
+    const junk = stakeTransfersTileModel(card({ distinct_senders: 9, transfers: 4 }));
+    expect(junk.repeats).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
@@ -1,0 +1,48 @@
+import type { SubnetStakeTransfers } from "./types";
+
+export interface StakeTransfersTileModel {
+  /** Total StakeTransferred events in the window. */
+  transfers: number;
+  /** Distinct sending accounts. */
+  senders: number;
+  /** Repeat transfers beyond the first per sender (transfers - senders, floored at 0). */
+  repeats: number;
+  /** Average transfers per sender, or null on a cold / junk store. */
+  perSender: number | null;
+  /** MiniStack composition: unique senders vs repeat transfers. */
+  segments: Array<{ label: string; value: number; color: string }>;
+  /** Short human summary for the SparkLegend tooltip. */
+  summary: string;
+}
+
+/**
+ * #3484: derive the economics-panel stake-transfers tile model from the flat
+ * StakeTransferred window summary. `transfers` is the headline count; the MiniStack
+ * splits it into unique senders (`distinct_senders`) vs repeat transfers so a
+ * single-snapshot aggregate still reads as a composition rather than a lone
+ * number. Everything coerces defensively — a cold / undefined card degrades to a
+ * zeroed, empty-bar model, and a junk store where senders exceeds transfers can
+ * never produce a negative repeat count.
+ */
+export function stakeTransfersTileModel(
+  card: SubnetStakeTransfers | undefined,
+): StakeTransfersTileModel {
+  const transfers = Math.max(0, card?.transfers ?? 0);
+  const senders = Math.max(0, card?.distinct_senders ?? 0);
+  const repeats = Math.max(0, transfers - senders);
+  const perSender =
+    card?.transfers_per_sender != null && Number.isFinite(card.transfers_per_sender)
+      ? card.transfers_per_sender
+      : null;
+  const segments = [
+    { label: "senders", value: senders, color: "var(--accent)" },
+    { label: "repeat transfers", value: repeats, color: "var(--border)" },
+  ];
+  const summary =
+    transfers > 0
+      ? `${senders} sender${senders === 1 ? "" : "s"}${
+          repeats > 0 ? `, ${repeats} repeat transfer${repeats === 1 ? "" : "s"}` : ""
+        }`
+      : "no stake transfers in this window";
+  return { transfers, senders, repeats, perSender, segments, summary };
+}


### PR DESCRIPTION
## Summary

Adds `stakeTransfersTileModel()` — a pure lib presenter that turns the flat `SubnetStakeTransfers` window card into MiniStack segments + summary text for the economics panel, mirroring the already-shipped `stakeMovesTileModel` pattern (#3753).

Contributes to #3484 — economics-panel wiring is a separate follow-up; `subnetStakeTransfersQuery` already landed in #3666.

## What changed

- **`lib/metagraphed/stake-transfers-tile.ts`** — headline transfer count, unique senders vs repeat transfers split, defensive cold/junk degradation.
- **`lib/metagraphed/stake-transfers-tile.test.ts`** — 3 tests (composition, cold card, singular/junk guard).

Pure `apps/ui/src/lib/**` — no routes, components, or visual changes.

## Gates run locally

- `vitest run src/lib/metagraphed/stake-transfers-tile.test.ts` — 3/3
