### PR TITLE
feat(registry): add SN126 Poker44 platform health API (#588)

### DIFF
--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "netuid": 126,
+  "name": "Poker44",
+  "slug": "sn-126",
+  "status": "active",
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "social": {
+    "x": "https://x.com/poker44subnet"
+  },
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-health",
+      "kind": "subnet-api",
+      "name": "Poker44 platform health API",
+      "notes": "Public no-auth GET /health on api.poker44.net returning platform liveness JSON (observed: status healthy, database and redis connected). Same host as the internal validator routes configured in the official Poker44-subnet validator neuron.",
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/neurons/validator.py",
+        "https://api.poker44.net/health"
+      ],
+      "url": "https://api.poker44.net/health"
+    }
+  ],
+  "source_repo": "https://github.com/Poker44/Poker44-subnet",
+  "website_url": "https://poker44.net/"
+}


### PR DESCRIPTION
## Summary

- Scaffold `registry/subnets/poker44.json` for SN126 (Poker44)
- Add the public no-auth health endpoint `https://api.poker44.net/health`

Closes #588

## Proof

| Surface | URL | First-party source |
|---------|-----|-------------------|
| Health | `https://api.poker44.net/health` | `Poker44/Poker44-subnet` `neurons/validator.py` configures internal routes on `https://api.poker44.net/...`; live GET `/health` returns JSON (`status: healthy`, database + redis connected) |

**OpenAPI note:** Probed common paths on `api.poker44.net` (`/openapi.json`, `/swagger.json`, `/api/openapi.json`, etc.) — all return `ROUTE_NOT_FOUND`. No machine-readable public OpenAPI is published yet; this PR registers the verified public health API surface.

## Conflict avoidance

| Open PR | File touched | Overlap |
|---------|--------------|---------|
| #3780 (SN60 Bitsec) | `registry/subnets/bitsec-ai.json` | **None** — this PR only touches `registry/subnets/poker44.json` |
| #3779 (SN79 MVTRX) | `registry/subnets/mvtrx.json` | **None** |

## Validation

- [x] `npm run validate:surface -- registry/subnets/poker44.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/poker44.json`
- [x] Confirmed `https://api.poker44.net/health` returns HTTP 200 with healthy JSON


Made with [Cursor](https://cursor.com)