### PR TITLE
feat(ui): surface subnet stake-transfers in the economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { economicsQuery, subnetStakeMovesQuery } from "@/lib/metagraphed/queries";
+import {
+  economicsQuery,
+  subnetStakeMovesQuery,
+  subnetStakeTransfersQuery,
+} from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
+import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
@@ -66,6 +71,42 @@ function StakeMovesTile({ netuid }: { netuid: number }) {
   );
 }
 
+// #3484: between-accounts stake-transfer (StakeTransferred) activity for this
+// subnet over the trailing 30-day window, from subnetStakeTransfersQuery. Same
+// flat-window / MiniStack + SparkLegend single-snapshot idiom as StakeMovesTile.
+function StakeTransfersTile({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetStakeTransfersQuery(netuid));
+  const card = res?.data;
+  const m = stakeTransfersTileModel(card);
+  const value = isError ? "—" : isPending && !card ? "…" : formatNumber(m.transfers);
+  return (
+    <StatTile
+      eyebrow="Stake transfers"
+      tone="accent"
+      value={value}
+      hint={`${m.senders} sender${m.senders === 1 ? "" : "s"}`}
+      chart={
+        <SparkLegend
+          metric="Stake transfers"
+          source={`On-chain StakeTransferred (transfer_stake) events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          windowLabel={card?.window ?? "30d"}
+          updatedAt={card?.observed_at ?? null}
+          staleness="Counts settle as the chain-events indexer catches up; the bar hides when no stake transfers occurred in the window."
+        >
+          <span className="flex w-[72px] items-center gap-1.5">
+            <span className="w-6 text-right font-mono text-[11px] tabular-nums text-ink">
+              {m.perSender != null ? `${m.perSender.toFixed(1)}×` : "—"}
+            </span>
+            <span className="max-w-[56px] flex-1">
+              <MiniStack segments={m.segments} height={6} />
+            </span>
+          </span>
+        </SparkLegend>
+      }
+    />
+  );
+}
+
 export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
@@ -107,6 +148,7 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         hint={e.registration_allowed === false ? "closed" : "open"}
       />
       <StakeMovesTile netuid={netuid} />
+      <StakeTransfersTile netuid={netuid} />
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { stakeTransfersTileModel } from "./stake-transfers-tile";
+import type { SubnetStakeTransfers } from "./types";
+
+function card(p: Partial<SubnetStakeTransfers>): SubnetStakeTransfers {
+  return {
+    schema_version: 1,
+    netuid: 7,
+    window: "30d",
+    observed_at: null,
+    distinct_senders: 0,
+    transfers: 0,
+    transfers_per_sender: null,
+    ...p,
+  };
+}
+
+describe("stakeTransfersTileModel", () => {
+  it("splits transfers into unique senders + repeat transfers", () => {
+    const m = stakeTransfersTileModel(
+      card({ distinct_senders: 6, transfers: 18, transfers_per_sender: 3 }),
+    );
+    expect(m.transfers).toBe(18);
+    expect(m.senders).toBe(6);
+    expect(m.repeats).toBe(12);
+    expect(m.perSender).toBe(3);
+    expect(m.segments.map((s) => s.value)).toEqual([6, 12]);
+    expect(m.summary).toBe("6 senders, 12 repeat transfers");
+  });
+
+  it("degrades an undefined / cold card to a zeroed, empty model", () => {
+    for (const c of [undefined, card({})]) {
+      const m = stakeTransfersTileModel(c);
+      expect(m.transfers).toBe(0);
+      expect(m.senders).toBe(0);
+      expect(m.repeats).toBe(0);
+      expect(m.perSender).toBeNull();
+      expect(m.segments.every((s) => s.value === 0)).toBe(true);
+      expect(m.summary).toBe("no stake transfers in this window");
+    }
+  });
+
+  it("singularizes a lone sender and never yields a negative repeat count", () => {
+    const one = stakeTransfersTileModel(
+      card({ distinct_senders: 1, transfers: 1, transfers_per_sender: 1 }),
+    );
+    expect(one.repeats).toBe(0);
+    expect(one.summary).toBe("1 sender");
+
+    const junk = stakeTransfersTileModel(card({ distinct_senders: 9, transfers: 4 }));
+    expect(junk.repeats).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
@@ -1,0 +1,48 @@
+import type { SubnetStakeTransfers } from "./types";
+
+export interface StakeTransfersTileModel {
+  /** Total StakeTransferred events in the window. */
+  transfers: number;
+  /** Distinct sending accounts. */
+  senders: number;
+  /** Repeat transfers beyond the first per sender (transfers - senders, floored at 0). */
+  repeats: number;
+  /** Average transfers per sender, or null on a cold / junk store. */
+  perSender: number | null;
+  /** MiniStack composition: unique senders vs repeat transfers. */
+  segments: Array<{ label: string; value: number; color: string }>;
+  /** Short human summary for the SparkLegend tooltip. */
+  summary: string;
+}
+
+/**
+ * #3484: derive the economics-panel stake-transfers tile model from the flat
+ * StakeTransferred window summary. `transfers` is the headline count; the MiniStack
+ * splits it into unique senders (`distinct_senders`) vs repeat transfers so a
+ * single-snapshot aggregate still reads as a composition rather than a lone
+ * number. Everything coerces defensively — a cold / undefined card degrades to a
+ * zeroed, empty-bar model, and a junk store where senders exceeds transfers can
+ * never produce a negative repeat count.
+ */
+export function stakeTransfersTileModel(
+  card: SubnetStakeTransfers | undefined,
+): StakeTransfersTileModel {
+  const transfers = Math.max(0, card?.transfers ?? 0);
+  const senders = Math.max(0, card?.distinct_senders ?? 0);
+  const repeats = Math.max(0, transfers - senders);
+  const perSender =
+    card?.transfers_per_sender != null && Number.isFinite(card.transfers_per_sender)
+      ? card.transfers_per_sender
+      : null;
+  const segments = [
+    { label: "senders", value: senders, color: "var(--accent)" },
+    { label: "repeat transfers", value: repeats, color: "var(--border)" },
+  ];
+  const summary =
+    transfers > 0
+      ? `${senders} sender${senders === 1 ? "" : "s"}${
+          repeats > 0 ? `, ${repeats} repeat transfer${repeats === 1 ? "" : "s"}` : ""
+        }`
+      : "no stake transfers in this window";
+  return { transfers, senders, repeats, perSender, segments, summary };
+}


### PR DESCRIPTION
Closes #3484

## Summary

Wires per-subnet **stake-transfer** activity into the subnet economics panel as a **Stake transfers** tile, matching the existing **Stake moves** tile (#3753 / #3485) and the typed query layer (#3666).

## What changed

- **`lib/metagraphed/stake-transfers-tile.ts`** — `stakeTransfersTileModel()` derives MiniStack segments + summary from `SubnetStakeTransfers`.
- **`lib/metagraphed/stake-transfers-tile.test.ts`** — 3 unit tests.
- **`components/metagraphed/economics-panel.tsx`** — `StakeTransfersTile` calls `subnetStakeTransfersQuery` via `useQuery` and renders count + distinct senders with MiniStack/SparkLegend.

## Gates run locally

- `vitest run src/lib/metagraphed/stake-transfers-tile.test.ts` — 3/3
