### PR TITLE
feat(ui): add homepage recent subnet identity changes widget

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/recent-identity-changes.tsx
@@ -1,0 +1,101 @@
+import { Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Fingerprint, Radio } from "lucide-react";
+import { chainIdentityHistoryQuery } from "@/lib/metagraphed/queries";
+import { TimeAgo } from "@/components/metagraphed/time-ago";
+import { classNames } from "@/lib/metagraphed/format";
+import type { ChainIdentityChange } from "@/lib/metagraphed/types";
+
+function identitySnapshotDetail(change: ChainIdentityChange): string | undefined {
+  if (change.description) return change.description;
+  if (change.subnet_url) return change.subnet_url;
+  if (change.github_repo) return change.github_repo;
+  if (change.discord) return change.discord;
+  if (change.symbol) return `symbol · ${change.symbol}`;
+  return undefined;
+}
+
+function identityTitle(change: ChainIdentityChange): string {
+  const name = change.subnet_name?.trim() || `SN${change.netuid}`;
+  return change.symbol?.trim() ? `${name} · ${change.symbol}` : name;
+}
+
+/**
+ * Homepage feed of the most recent on-chain SubnetIdentitiesV3 changes
+ * network-wide (#3474).
+ */
+export function RecentIdentityChanges({
+  className,
+  limit = 10,
+}: {
+  className?: string;
+  limit?: number;
+}) {
+  const { data: res } = useSuspenseQuery(chainIdentityHistoryQuery(limit));
+  const changes = res.data.changes ?? [];
+
+  return (
+    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            On-chain identity
+          </div>
+          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+            Recent subnet identity changes
+          </h3>
+        </div>
+        <span className="inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted">
+          <Fingerprint className="size-3" aria-hidden />
+          live
+        </span>
+      </div>
+      {changes.length === 0 ? (
+        <div className="flex items-center gap-2 py-6 text-xs text-ink-muted">
+          <Radio className="size-3.5" aria-hidden />
+          No recent identity changes observed.
+        </div>
+      ) : (
+        <ol className="space-y-2.5">
+          {changes.map((change) => {
+            const detail = identitySnapshotDetail(change);
+            return (
+              <li
+                key={`${change.netuid}:${change.identity_hash}`}
+                className="flex items-start gap-2.5 group"
+              >
+                <span
+                  className="mt-0.5 inline-flex size-5 items-center justify-center rounded border border-accent/40 text-accent shrink-0"
+                  aria-hidden
+                >
+                  <Fingerprint className="size-3" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: change.netuid }}
+                    className="text-xs font-medium text-ink-strong truncate block group-hover:text-accent transition-colors"
+                  >
+                    {identityTitle(change)}
+                  </Link>
+                  <div className="flex items-baseline gap-2 mt-0.5 min-w-0">
+                    {detail ? (
+                      <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted truncate">
+                        {detail}
+                      </span>
+                    ) : null}
+                    {change.observed_at ? (
+                      <span className="font-mono text-[10px] text-ink-muted shrink-0">
+                        <TimeAgo at={change.observed_at} />
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.chain-identity-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-identity-history.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainIdentityHistoryQuery, normalizeChainIdentityChange } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/identity-history",
+  });
+}
+
+async function runQuery(limit = 10) {
+  const opts = chainIdentityHistoryQuery(limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainIdentityChange", () => {
+  it("requires identity_hash and a valid netuid", () => {
+    expect(
+      normalizeChainIdentityChange({
+        identity_hash: "0xabc",
+        netuid: 7,
+        subnet_name: "Alpha",
+      }),
+    ).toMatchObject({ identity_hash: "0xabc", netuid: 7, subnet_name: "Alpha" });
+    expect(normalizeChainIdentityChange({ identity_hash: "0xabc" })).toBeNull();
+    expect(normalizeChainIdentityChange({ identity_hash: "0xabc", netuid: -1 })).toBeNull();
+  });
+});
+
+describe("chainIdentityHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("calls the network-wide route and normalizes changes", async () => {
+    resolveWith({
+      schema_version: 1,
+      count: 1,
+      subnet_count: 1,
+      changes: [
+        {
+          identity_hash: "0xabc",
+          netuid: 7,
+          observed_at: "2026-07-01T00:00:00Z",
+          subnet_name: "Alpha",
+          symbol: "α",
+          description: "updated copy",
+        },
+        { netuid: 8 },
+      ],
+    });
+
+    const out = await runQuery(10);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/identity-history", {
+      params: { limit: 10 },
+      signal: expect.any(AbortSignal),
+    });
+    expect(out.data.changes).toHaveLength(1);
+    expect(out.data.changes[0]).toMatchObject({
+      netuid: 7,
+      subnet_name: "Alpha",
+      description: "updated copy",
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.chain-identity-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-identity-history.test.ts
@@ -77,4 +77,14 @@ describe("chainIdentityHistoryQuery", () => {
       description: "updated copy",
     });
   });
+
+  it("clamps the request limit to the API maximum", async () => {
+    resolveWith({ schema_version: 1, count: 0, subnet_count: 0, changes: [] });
+
+    await runQuery(9999);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/identity-history", {
+      params: { limit: 200 },
+      signal: expect.any(AbortSignal),
+    });
+  });
 });

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -46,6 +46,8 @@ import type {
   ChainFees,
   ChainFeeDay,
   ChainFeePayer,
+  ChainIdentityChange,
+  ChainIdentityHistory,
   ChainTransferPair,
   ChainTransferPairs,
   ChainConcentration,
@@ -2927,6 +2929,54 @@ export const subnetIdentityHistoryQuery = (netuid: number) =>
       );
       return {
         data: normalizeSubnetIdentityHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+const MAX_CHAIN_IDENTITY_HISTORY_CHANGES = 200;
+
+export function normalizeChainIdentityChange(raw: unknown): ChainIdentityChange | null {
+  const entry = normalizeSubnetIdentityHistoryEntry(raw);
+  if (!entry) return null;
+  const rec = isRecord(raw) ? raw : {};
+  const netuid = firstFiniteNumber(rec.netuid);
+  if (netuid == null || netuid < 0) return null;
+  return { ...entry, netuid };
+}
+
+function normalizeChainIdentityHistory(raw: unknown): ChainIdentityHistory {
+  const rec = isRecord(raw) ? raw : {};
+  const changes = (Array.isArray(rec.changes) ? rec.changes : [])
+    .map(normalizeChainIdentityChange)
+    .filter((change): change is ChainIdentityChange => change != null)
+    .slice(0, MAX_CHAIN_IDENTITY_HISTORY_CHANGES);
+  const subnetCount = firstFiniteNumber(rec.subnet_count);
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    count: firstFiniteNumber(rec.count) ?? changes.length,
+    subnet_count:
+      subnetCount ??
+      new Set(changes.map((change) => change.netuid)).size,
+    changes,
+  };
+}
+
+// Network-wide subnet identity change feed (#3474) — newest SubnetIdentitiesV3
+// snapshots across every subnet. Distinct from subnetIdentityHistoryQuery, which
+// scopes to one netuid.
+export const chainIdentityHistoryQuery = (limit = 10) =>
+  queryOptions({
+    queryKey: k("chain-identity-history", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainIdentityHistory>>(
+        "/api/v1/chain/identity-history",
+        { params: { limit }, signal },
+      );
+      return {
+        data: normalizeChainIdentityHistory(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -2957,24 +2957,29 @@ function normalizeChainIdentityHistory(raw: unknown): ChainIdentityHistory {
   return {
     schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
     count: firstFiniteNumber(rec.count) ?? changes.length,
-    subnet_count:
-      subnetCount ??
-      new Set(changes.map((change) => change.netuid)).size,
+    subnet_count: subnetCount ?? new Set(changes.map((change) => change.netuid)).size,
     changes,
   };
+}
+
+function clampChainIdentityHistoryLimit(limit: number): number {
+  const n = Math.floor(limit);
+  if (!Number.isFinite(n) || n <= 0) return 10;
+  return Math.min(n, MAX_CHAIN_IDENTITY_HISTORY_CHANGES);
 }
 
 // Network-wide subnet identity change feed (#3474) — newest SubnetIdentitiesV3
 // snapshots across every subnet. Distinct from subnetIdentityHistoryQuery, which
 // scopes to one netuid.
-export const chainIdentityHistoryQuery = (limit = 10) =>
-  queryOptions({
-    queryKey: k("chain-identity-history", limit),
+export const chainIdentityHistoryQuery = (limit = 10) => {
+  const boundedLimit = clampChainIdentityHistoryLimit(limit);
+  return queryOptions({
+    queryKey: k("chain-identity-history", boundedLimit),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Partial<ChainIdentityHistory>>(
-        "/api/v1/chain/identity-history",
-        { params: { limit }, signal },
-      );
+      const res = await apiFetch<Partial<ChainIdentityHistory>>("/api/v1/chain/identity-history", {
+        params: { limit: boundedLimit },
+        signal,
+      });
       return {
         data: normalizeChainIdentityHistory(res.data),
         meta: res.meta,
@@ -2983,6 +2988,7 @@ export const chainIdentityHistoryQuery = (limit = 10) =>
     },
     staleTime: STALE_MED,
   });
+};
 
 // One validator's weight-setting row (#1657). Identified by hotkey or uid — a row
 // with neither is dropped; the count falls through to 0 and share to null on junk.

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1116,6 +1116,19 @@ export interface SubnetIdentityHistory {
   next_cursor: string | null;
 }
 
+/** One network-wide identity change — same snapshot fields plus the owning netuid (#3474). */
+export interface ChainIdentityChange extends SubnetIdentityHistoryEntry {
+  netuid: number;
+}
+
+/** Network-wide subnet identity change feed from /api/v1/chain/identity-history. */
+export interface ChainIdentityHistory {
+  schema_version: number;
+  count: number;
+  subnet_count: number;
+  changes: ChainIdentityChange[];
+}
+
 /**
  * Per-subnet validator weight-setting activity over a 7d/30d window, from
  * /api/v1/subnets/{netuid}/weights — aggregate WeightsSet counts (distinct

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -22,6 +22,7 @@ import { ScrollReveal } from "@/components/metagraphed/scroll-reveal";
 import { CoverageFunnel } from "@/components/metagraphed/analytics/coverage-funnel";
 import { NetworkPulseBand } from "@/components/metagraphed/analytics/network-pulse-band";
 import { WhatChangedFeed } from "@/components/metagraphed/analytics/what-changed-feed";
+import { RecentIdentityChanges } from "@/components/metagraphed/analytics/recent-identity-changes";
 import {
   RegistryScoreHistogram,
   DimensionCoverageHeatmap,
@@ -127,6 +128,11 @@ function OverviewPage() {
                 <Suspense fallback={<Skeleton className="h-64 lg:col-span-12" />}>
                   <div className="lg:col-span-12">
                     <WhatChangedFeed />
+                  </div>
+                </Suspense>
+                <Suspense fallback={<Skeleton className="h-64 lg:col-span-12" />}>
+                  <div className="lg:col-span-12">
+                    <RecentIdentityChanges />
                   </div>
                 </Suspense>
               </div>


### PR DESCRIPTION
## Summary

- Add `chainIdentityHistoryQuery` + `ChainIdentityHistory` types for `GET /api/v1/chain/identity-history`
- New `RecentIdentityChanges` card on the homepage Signal grid (below What changed)
- Each row links to `/subnets/$netuid` with subnet name/symbol, snapshot detail, and `TimeAgo`

- Closes #3474 · Part of #2542
## Screenshots

### Before

<img width="1825" height="934" alt="image" src="https://github.com/user-attachments/assets/04c68773-8207-4d79-accd-7266d0f58bea" />

### After

<img width="1846" height="941" alt="image" src="https://github.com/user-attachments/assets/c7e66208-a855-4fbd-9110-0da3cabcc546" />

## Test plan

- [x] Homepage loads — new card appears under “Recent registry signal”
- [x] Rows show netuid-linked subnet name, snapshot text, and relative timestamp
- [x] Empty API response shows Radio empty-state line (no crash)
- [x] `npm run build:client --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`