### PR TITLE
feat(ui): surface account weight-setting activity

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-weight-setters.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-weight-setters.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountWeightSettersQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${SS58}/weight-setters`,
+  });
+}
+
+async function runQuery(ss58: string, window?: string) {
+  const opts = accountWeightSettersQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountWeightSettersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and filters junk subnet rows", async () => {
+    resolveWith({
+      address: SS58,
+      window: "7d",
+      total_weight_sets: 4,
+      subnet_count: 1,
+      concentration: 1,
+      dominant_netuid: 12,
+      subnets: [
+        {
+          netuid: 12,
+          weight_sets: 4,
+          first_set_at: "2026-07-01T00:00:00Z",
+          last_set_at: "2026-07-02T00:00:00Z",
+        },
+        { weight_sets: 9 }, // no netuid -> dropped
+      ],
+    });
+    const res = await runQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/weight-setters`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.subnets).toHaveLength(1);
+    expect(res.data.subnets[0]).toEqual({
+      netuid: 12,
+      weight_sets: 4,
+      first_set_at: "2026-07-01T00:00:00Z",
+      last_set_at: "2026-07-02T00:00:00Z",
+    });
+  });
+
+  it("defaults to 30d and degrades a cold store to a zeroed, empty-subnet card", async () => {
+    resolveWith({});
+    const res = await runQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/weight-setters`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+    expect(res.data.subnets).toEqual([]);
+    expect(res.data.subnet_count).toBe(0);
+    expect(res.data.total_weight_sets).toBe(0);
+    expect(res.data.dominant_netuid).toBeNull();
+    expect(res.data.address).toBe(SS58);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -36,6 +36,8 @@ import type {
   AccountRegistration,
   AccountSubnets,
   AccountSummary,
+  AccountWeightSetterSubnet,
+  AccountWeightSetters,
   PortfolioConcentration,
   PortfolioPosition,
   Block,
@@ -2170,6 +2172,61 @@ export const accountPortfolioQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountPortfolio>;
+    },
+    staleTime: STALE_MED,
+  });
+
+const MAX_ACCOUNT_WEIGHT_SETTER_SUBNETS = 256;
+
+function normalizeAccountWeightSetterSubnet(raw: unknown): AccountWeightSetterSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    weight_sets: firstFiniteNumber(raw.weight_sets) ?? 0,
+    first_set_at: firstString(raw.first_set_at) ?? null,
+    last_set_at: firstString(raw.last_set_at) ?? null,
+  };
+}
+
+function normalizeAccountWeightSetters(ss58: string, raw: unknown): AccountWeightSetters {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = (Array.isArray(rec.subnets) ? rec.subnets : [])
+    .slice(0, MAX_ACCOUNT_WEIGHT_SETTER_SUBNETS)
+    .flatMap((row) => {
+      const normalized = normalizeAccountWeightSetterSubnet(row);
+      return normalized ? [normalized] : [];
+    });
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_weight_sets: firstFiniteNumber(rec.total_weight_sets) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+// #3731: one account's (validator's) per-subnet WeightsSet footprint over a
+// 7d/30d window — the account-level twin of subnetWeightSettersQuery. A
+// non-validator or inactive-validator account degrades to a zeroed, empty-subnet
+// card rather than an error.
+export const accountWeightSettersQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-weight-setters", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/weight-setters`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountWeightSetters(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountWeightSetters>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1158,6 +1158,31 @@ export interface SubnetWeightSetters {
   setters: SubnetWeightSetter[];
 }
 
+/** One subnet's WeightsSet footprint within an account's weight-setters card (#3731). */
+export interface AccountWeightSetterSubnet {
+  netuid: number;
+  weight_sets: number;
+  first_set_at: string | null;
+  last_set_at: string | null;
+}
+
+/**
+ * One account's (validator's) per-subnet WeightsSet footprint over a 7d/30d
+ * window (#3731), from /api/v1/accounts/{ss58}/weight-setters — the account-level
+ * twin of SubnetWeightSetters. Zeroed when the account set no weights in the
+ * window (a non-validator account, or a validator outside its active subnets).
+ */
+export interface AccountWeightSetters {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_weight_sets: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountWeightSetterSubnet[];
+}
+
 /**
  * Per-subnet axon-removal (teardown) activity over a 7d/30d window (#1657), from
  * /api/v1/subnets/{netuid}/axon-removals — the removal-side complement of the

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -33,6 +33,7 @@ import {
   accountQuery,
   accountSubnetsQuery,
   accountTransfersQuery,
+  accountWeightSettersQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -244,6 +245,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
+      <AccountWeightSettersSection ss58={ss58} />
+
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
           id="kinds"
@@ -301,6 +304,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
+            { label: "weight-setters", path: `/api/v1/accounts/${sourceRef}/weight-setters` },
           ]}
         />
       </SectionAnchor>
@@ -311,6 +315,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/history`,
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
+          `/api/v1/accounts/${sourceRef}/weight-setters`,
         ]}
       />
     </>
@@ -654,6 +659,103 @@ function AccountFootprintSection({
           </tbody>
         </table>
       </DataPanel>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Account-level weight-setting activity (#3731) — the per-subnet WeightsSet
+ * footprint over the last 30 days, the account-level twin of the subnet-level
+ * weight-setters leaderboard (#3480). Only relevant for validator accounts;
+ * non-validator (or currently-inactive-validator) accounts legitimately have
+ * zero rows, so a cold result renders an empty state rather than being hidden
+ * or treated as an error.
+ */
+function AccountWeightSettersSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountWeightSettersQuery(ss58));
+  const data = result.data?.data;
+  const subnets = data?.subnets ?? [];
+
+  if (result.isPending) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="weight-setters"
+        title="Weight-setting activity"
+        subtitle="Per-subnet WeightsSet footprint for this account over the last 30 days — relevant for validators."
+      />
+    );
+  }
+
+  return (
+    <SectionAnchor
+      id="weight-setters"
+      title="Weight-setting activity"
+      subtitle="Per-subnet WeightsSet footprint for this account over the last 30 days — relevant for validators."
+      tone="accent"
+      right={
+        subnets.length > 0 ? (
+          <SectionBadge>{formatNumber(subnets.length)} subnets</SectionBadge>
+        ) : undefined
+      }
+    >
+      {subnets.length === 0 ? (
+        <TableState
+          variant="empty"
+          title="No weight-setting activity"
+          description="This account hasn't set weights on any subnet in the last 30 days. Expected for non-validator accounts, or a validator outside its active subnets."
+          error={result.error}
+        />
+      ) : (
+        <>
+          <div className="mb-5 rounded-2xl border border-border/80 bg-card/95 px-5 py-4 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]">
+            <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              weight sets by subnet
+            </div>
+            <BarMini
+              data={subnets
+                .slice(0, 12)
+                .map((s) => ({ label: `SN${s.netuid}`, value: s.weight_sets }))}
+              showValue
+            />
+          </div>
+          <DataPanel>
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50">
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Weight sets</th>
+                  <th className={TH}>First set</th>
+                  <th className={TH}>Last set</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {subnets.map((s) => (
+                  <tr key={s.netuid} className="hover:bg-surface/30">
+                    <td className="px-5 py-4 font-mono text-[12px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: s.netuid }}
+                        className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
+                      >
+                        SN{s.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                      {formatNumber(s.weight_sets)}
+                    </td>
+                    <td className="px-5 py-4 font-mono text-[11px] text-ink-muted">
+                      {s.first_set_at ? <TimeAgo at={s.first_set_at} /> : "—"}
+                    </td>
+                    <td className="px-5 py-4 font-mono text-[11px] text-ink-muted">
+                      {s.last_set_at ? <TimeAgo at={s.last_set_at} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </DataPanel>
+        </>
+      )}
     </SectionAnchor>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a "Weight-setting activity" section to the account detail page (`/accounts/{ss58}`) surfacing an account's per-subnet `WeightsSet` footprint over the last 30 days — the account-level twin of the subnet-level weight-setters leaderboard (#3480).
- New `accountWeightSettersQuery(ss58, window = "30d")` in `apps/ui/src/lib/metagraphed/queries.ts` calling `GET /api/v1/accounts/{ss58}/weight-setters`, consumed via `useQuery` in `apps/ui/src/routes/accounts.$ss58.tsx` in the same PR.
- Renders a per-subnet bar chart + table (subnet, weight sets, first/last set) when the account has weight-setting rows, and degrades to a "No weight-setting activity" empty state (not an error) for non-validator accounts or validators with no recent weight-setting rows.

## Screenshots

**TODO (pending manual add):** this is a visual change to `apps/ui/**`, so it needs a before/after screenshot table per the contribution guide. I generated local captures during verification but was not able to embed them (no external hosting authorized in this session). Adding the table here before review:

| Page / Feature | Before | After |
| --- | --- | --- |
| `/accounts/{ss58}` — no weight-setting activity | _pending_ | _pending_ |
| `/accounts/{ss58}` — populated weight-setting activity | _pending_ | _pending_ |

## Validation

- `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui` (2 pre-existing errors unrelated to this change remain; no new errors introduced)
- `npm test --workspace=apps/ui` (435 passed, including new `queries.account-weight-setters.test.ts`)
- `npm run build --workspace=apps/ui`
- Verified against the live API (`https://api.metagraph.sh`) in a local dev server: a real account renders the empty state correctly; a mocked response renders the per-subnet chart + table correctly.

Closes #3731
