### PR TITLE
feat(registry): enrich SN121 Sundae Bar — coordinator API

### DIFF
--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -64,6 +64,24 @@
         "timeout_ms": 10000
       },
       "notes": "Official Sundae Bar source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-121-sundae-bar-subnet-api",
+      "kind": "subnet-api",
+      "name": "Sundae Bar coordinator API",
+      "notes": "Public no-auth GET on the SN121 coordinator API host documented in the official sb-validator README as API_URL (e.g. https://api.sundaebar.ai/api/v2/validators). Returns JSON liveness (observed: {\"status\":\"ok\"}).",
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/sundae-bar/sb-validator/blob/main/README.md"
+      ],
+      "url": "https://api.sundaebar.ai/api/v2/validators"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #697

## Add or update a subnet surface

This PR appends one community `subnet-api` surface on `registry/subnets/sundae-bar.json`.

## Surface

- Netuid: 121
- Kind: subnet-api
- Public URL: https://api.sundaebar.ai/api/v2/validators
- Source URL (proves the claim): https://github.com/sundae-bar/sb-validator/blob/main/README.md
- Provider slug: sundae-bar

## Checklist

- [x] Changes exactly one `registry/subnets/sundae-bar.json` file (append-only).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, or private URLs.
- [x] Does not duplicate an existing Metagraphed surface (new coordinator host path).
- [x] Links a tracked issue (`Closes #697`).

## Conflict avoidance

| Open upstream PR | Touches `sundae-bar.json`? |
|---|---|
| #3785 Poker44 (merged) | No |
| #3784 stake-transfers UI | No |
| #3781 DownloadCsvButton UI | No |
| #3774 fix(mcp) | No |
| #3771 fix(registry) | No |
| #3770 docs(skill) | No |
| #3749 fix(api) | No |
| #3594 chore: release main | No |
| #3546 docs(readme) | No |

Append-only change at end of `surfaces[]`; mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/sundae-bar.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/sundae-bar.json`


Made with [Cursor](https://cursor.com)