### PR TITLE
feat(registry): add SN41 Almanac provider profile

### DIFF
--- a/registry/providers/almanac.json
+++ b/registry/providers/almanac.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/sportstensor/sn41",
+  "id": "almanac",
+  "kind": "subnet-team",
+  "name": "Almanac",
+  "public_notes": "Subnet 41 (Almanac) team profile — incentivized market intelligence via Sportstensor prediction markets. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+  "schema_version": 1,
+  "website_url": "https://almanac.market/"
+}


### PR DESCRIPTION
## Summary
Adds the community provider profile for **Subnet 41 — Almanac** (`almanac`), required before surfacing the public API on `registry/subnets/almanac.json`.

## Changes
- New `registry/providers/almanac.json` only (provider debut; no surfaces in this PR)

## Checklist
- [x] Changes exactly one `registry/providers/almanac.json` file
- [x] `authority: community`
- [x] Identity from on-chain SubnetIdentitiesV3 + official `sportstensor/sn41` source repo
- [x] `npx prettier --check registry/providers/almanac.json`
- [x] `node scripts/validate-schemas.mjs`

## Follow-up
A separate surface PR (`Closes #668`) will add `registry/subnets/almanac.json` with the live `api.almanac.market/health` subnet-api surface after this provider profile merges.

## Conflict avoidance
| Open PR | Touches | This PR |
|---------|---------|---------|
| #3780 (closed) | `bitsec-ai.json` | `providers/almanac.json` |
| #3785 (merged) | `poker44.json` | providers only |


Made with [Cursor](https://cursor.com)