### PR TITLE
feat(registry): add SN41 Almanac API health surface

### DIFF
--- a/registry/providers/almanac.json
+++ b/registry/providers/almanac.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/sportstensor/sn41",
+  "id": "almanac",
+  "kind": "subnet-team",
+  "name": "Almanac",
+  "public_notes": "Subnet 41 (Almanac) team profile — incentivized market intelligence via Sportstensor prediction markets. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+  "schema_version": 1,
+  "website_url": "https://almanac.market/"
+}

--- a/registry/subnets/almanac.json
+++ b/registry/subnets/almanac.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "netuid": 41,
+  "name": "Almanac",
+  "slug": "sn-41",
+  "status": "active",
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-41-almanac-health",
+      "kind": "subnet-api",
+      "name": "Almanac API health",
+      "notes": "Public no-auth GET /health on api.almanac.market returning JSON liveness (observed: status healthy, database and redis connected, websocket state). Same host as ALMANAC_API_URL (https://api.almanac.market/api) in the official sportstensor/sn41 api_trading.py trading client. No machine-readable OpenAPI URL found on this host yet (common /openapi.json paths return 404).",
+      "provider": "almanac",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://github.com/sportstensor/sn41/blob/main/api_trading.py",
+        "https://api.almanac.market/health"
+      ],
+      "url": "https://api.almanac.market/health"
+    }
+  ],
+  "source_repo": "https://github.com/sportstensor/sn41",
+  "website_url": "https://almanac.market/"
+}


### PR DESCRIPTION
Closes #668

## Summary
Debut `registry/subnets/almanac.json` with one public **subnet-api** health surface for **Subnet 41 — Almanac** (`api.almanac.market/health`).

## Surface
- Netuid: **41** (Almanac)
- Kind: **subnet-api**
- Public URL: `https://api.almanac.market/health`
- Source URLs:
  - https://github.com/sportstensor/sn41/blob/main/api_trading.py
  - https://api.almanac.market/health
- Provider slug: **almanac** (debut in #3791 — must merge first)

## Proof
The official `sportstensor/sn41` trading client sets `ALMANAC_API_URL = "https://api.almanac.market/api"`. Live GET `/health` returns JSON (`status: healthy`, database/redis/websocket subsystems).

## OpenAPI gap
No machine-readable OpenAPI on `api.almanac.market` yet (`/openapi.json` → 404). This PR documents the verified health endpoint; OpenAPI can be appended when published.

## Checklist
- [x] Changes exactly one `registry/subnets/almanac.json` file (subnet debut)
- [x] `authority: community`, `review.state: community-submitted`, `submitted_by: bohdansolovie`
- [x] Public URL safe for read-only probes; source URLs prove the host
- [x] Does not duplicate an existing Metagraphed surface
- [x] Links tracked issue (`Closes #668`)

## Validation
- [x] `npm run validate:surface -- registry/subnets/almanac.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/almanac.json`

## Dependency
Merge **#3791** (Almanac provider profile) before this PR so CI provider validation passes.

## Conflict avoidance
| PR | Touches | This PR |
|----|---------|---------|
| #3780 (closed, unmerged) | `bitsec-ai.json` | `almanac.json` |
| #3785 (merged) | `poker44.json` | `almanac.json` |
| #3779 (open) | `mvtrx.json` | `almanac.json` |


Made with [Cursor](https://cursor.com)