### PR TITLE
fix(ui): reuse durationLabel in IncidentTimeline

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-timeline.test.ts
+++ b/apps/ui/src/components/metagraphed/incident-timeline.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { subnetIncidentDurationText } from "./incident-timeline";
+
+describe("subnetIncidentDurationText", () => {
+  it("returns null when started_at is missing", () => {
+    expect(subnetIncidentDurationText(null, "2024-01-01T00:01:00.000Z")).toBeNull();
+    expect(subnetIncidentDurationText(undefined, "2024-01-01T00:01:00.000Z")).toBeNull();
+    expect(subnetIncidentDurationText("", "2024-01-01T00:01:00.000Z")).toBeNull();
+  });
+
+  it("returns null for unparseable started_at (no bare em dash in the row)", () => {
+    expect(subnetIncidentDurationText("nonsense", "2024-01-01T00:01:00.000Z")).toBeNull();
+  });
+
+  it("labels a resolved incident from ISO start/end", () => {
+    expect(
+      subnetIncidentDurationText("2024-01-01T00:00:00.000Z", "2024-01-01T00:01:30.000Z"),
+    ).toBe("1m 30s");
+  });
+
+  it("returns live elapsed text for open incidents (ended_at omitted)", () => {
+    const start = new Date(Date.now() - 2000).toISOString();
+    expect(subnetIncidentDurationText(start, null)).toMatch(/^\d+s$/);
+    expect(subnetIncidentDurationText(start, undefined)).toMatch(/^\d+s$/);
+  });
+});

--- a/apps/ui/src/components/metagraphed/incident-timeline.test.ts
+++ b/apps/ui/src/components/metagraphed/incident-timeline.test.ts
@@ -13,9 +13,9 @@ describe("subnetIncidentDurationText", () => {
   });
 
   it("labels a resolved incident from ISO start/end", () => {
-    expect(
-      subnetIncidentDurationText("2024-01-01T00:00:00.000Z", "2024-01-01T00:01:30.000Z"),
-    ).toBe("1m 30s");
+    expect(subnetIncidentDurationText("2024-01-01T00:00:00.000Z", "2024-01-01T00:01:30.000Z")).toBe(
+      "1m 30s",
+    );
   });
 
   it("returns live elapsed text for open incidents (ended_at omitted)", () => {

--- a/apps/ui/src/components/metagraphed/incident-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/incident-timeline.tsx
@@ -4,21 +4,12 @@ import { subnetHealthIncidentsQuery, flattenSurfaceIncidents } from "@/lib/metag
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
-import { classNames } from "@/lib/metagraphed/format";
+import { classNames, durationLabel } from "@/lib/metagraphed/format";
 
 function severityIcon(sev?: string) {
   if (sev === "high") return <AlertOctagon className="size-3.5 text-health-down" />;
   if (sev === "medium") return <AlertTriangle className="size-3.5 text-health-warn" />;
   return <Info className="size-3.5 text-ink-muted" />;
-}
-
-function fmtDuration(ms?: number) {
-  if (ms == null || !Number.isFinite(ms) || ms <= 0) return null;
-  const seconds = ms / 1000;
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
-  if (seconds < 86400) return `${(seconds / 3600).toFixed(1)}h`;
-  return `${(seconds / 86400).toFixed(1)}d`;
 }
 
 /** Trim the "sn-<netuid>-" / "community-sn-<netuid>-" prefix from a surface id. */
@@ -47,12 +38,6 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
       ) : (
         <ol className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
           {incidents.slice(0, 12).map((inc, i) => {
-            const duration = fmtDuration(
-              inc.duration_ms ??
-                (inc.ended_at && inc.started_at
-                  ? new Date(inc.ended_at).getTime() - new Date(inc.started_at).getTime()
-                  : undefined),
-            );
             const open = !inc.ended_at;
             return (
               <li
@@ -70,7 +55,9 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
                         started <TimeAgo at={inc.started_at} />
                       </span>
                     ) : null}
-                    {duration ? <span>· {duration}</span> : null}
+                    {inc.started_at ? (
+                      <span>· {durationLabel(inc.started_at, inc.ended_at)}</span>
+                    ) : null}
                     {inc.failed_samples != null ? <span>· {inc.failed_samples} failed</span> : null}
                   </div>
                 </div>

--- a/apps/ui/src/components/metagraphed/incident-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/incident-timeline.tsx
@@ -17,6 +17,20 @@ function shortSurfaceId(id: string, netuid: number): string {
   return id.replace(new RegExp(`^(community-)?sn-${netuid}-`), "");
 }
 
+/**
+ * #3427: duration segment for subnet incident rows — omit when `started_at` is
+ * absent or unparseable; open incidents (`ended_at` null) use live elapsed time
+ * via `durationLabel`, matching `IncidentCard`.
+ */
+export function subnetIncidentDurationText(
+  startedAt?: string | null,
+  endedAt?: string | null,
+): string | null {
+  if (!startedAt) return null;
+  const label = durationLabel(startedAt, endedAt);
+  return label === "—" ? null : label;
+}
+
 export function IncidentTimeline({ netuid }: { netuid: number }) {
   const { data, isLoading } = useQuery(subnetHealthIncidentsQuery(netuid));
   const incidents = flattenSurfaceIncidents(data?.data ?? []);
@@ -39,6 +53,7 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
         <ol className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
           {incidents.slice(0, 12).map((inc, i) => {
             const open = !inc.ended_at;
+            const duration = subnetIncidentDurationText(inc.started_at, inc.ended_at);
             return (
               <li
                 key={`${inc.surface_id}-${inc.started_at ?? i}`}
@@ -55,9 +70,7 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
                         started <TimeAgo at={inc.started_at} />
                       </span>
                     ) : null}
-                    {inc.started_at ? (
-                      <span>· {durationLabel(inc.started_at, inc.ended_at)}</span>
-                    ) : null}
+                    {duration ? <span>· {duration}</span> : null}
                     {inc.failed_samples != null ? <span>· {inc.failed_samples} failed</span> : null}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Closes #3427

Removes the duplicate `fmtDuration` helper in `incident-timeline.tsx` and uses `subnetIncidentDurationText()` (wraps shared `durationLabel`) for incident row durations, matching `IncidentCard`. Open incidents show live elapsed time when `started_at` is present; rows without a usable start omit the duration segment.

## Test plan

- [x] `vitest run src/components/metagraphed/incident-timeline.test.ts` — 4/4
- [x] `vitest run src/lib/metagraphed/format.test.ts` — covers `durationLabel` core cases
- [ ] Manual: subnet incident history shows `· {duration}` for resolved and open incidents with `started_at`