### PR TITLE
feat(registry): enrich SN41 Almanac — API health

### DIFF
--- a/registry/subnets/almanac.json
+++ b/registry/subnets/almanac.json
@@ -1,0 +1,34 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "Almanac",
+  "netuid": 41,
+  "schema_version": 1,
+  "slug": "sn-41",
+  "source_repo": "https://github.com/sportstensor/sn41",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-41-almanac-subnet-api",
+      "kind": "subnet-api",
+      "name": "Almanac API health",
+      "notes": "Public no-auth GET /health on api.almanac.market returning JSON liveness (observed: status healthy with uptime, version, and database/redis checks). The official sportstensor/sn41 trading client sets ALMANAC_API_URL to https://api.almanac.market/api on the same host.",
+      "provider": "almanac",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/sportstensor/sn41/blob/main/api_trading.py"
+      ],
+      "url": "https://api.almanac.market/health"
+    }
+  ],
+  "website_url": "https://almanac.market/"
+}


### PR DESCRIPTION
Closes #668

## Add or update a subnet surface

This PR scaffolds `registry/subnets/almanac.json` (new manifest) with one community `subnet-api` surface, plus debut `registry/providers/almanac.json` for the Almanac team.

## Surface

- Netuid: 41
- Kind: subnet-api
- Public URL: https://api.almanac.market/health
- Source URL (proves the claim): https://github.com/sportstensor/sn41/blob/main/api_trading.py
- Provider slug: almanac

## Checklist

- [x] New subnet scaffold plus surface(s) in `registry/subnets/almanac.json`, plus debut provider `registry/providers/almanac.json`.
- [x] Generated with `npm run surface:add` / `npm run subnet:new` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, or private URLs.
- [x] Does not duplicate an existing Metagraphed surface (new host/path).
- [x] Links a tracked issue (`Closes #668`).

## Conflict avoidance

| Open upstream PR | Touches `almanac.json` subnet? | Touches `providers/almanac.json`? |
|---|---|---|
| #3791 provider profile | No | Yes (same debut provider; identical content — merge one) |
| #3788 UI widget | No | No |
| #3774 fix(mcp) | No | No |
| #3771 fix(registry) | No | No |
| #3770 docs(skill) | No | No |
| #3749 fix(api) | No | No |

Subnet manifest is new; append-only surfaces. UI/MCP/registry-code open PRs do not touch `registry/subnets/almanac.json`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/almanac.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/almanac.json registry/providers/almanac.json`


Made with [Cursor](https://cursor.com)