### PR TITLE
feat(registry): add SN2 DSperse subnet-api surface (#706)

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -167,6 +167,25 @@
         "https://huggingface.co/inferencelabs"
       ],
       "url": "https://huggingface.co/datasets/inferencelabs/TruthTensor"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-inference-labs-subnet-api",
+      "kind": "subnet-api",
+      "name": "DSperse subnet-api",
+      "notes": "Public no-auth JSON API for SN2 DSperse (Inference Labs): network stats (/stats), validator listing (/validators), and an official Scalar API reference (/docs), all HTTP 200 with no key. Same inferencelabs.com domain as the subnet's registered official website and docs surfaces.",
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://sn2-api.inferencelabs.com/docs",
+        "https://sn2-docs.inferencelabs.com/"
+      ],
+      "url": "https://sn2-api.inferencelabs.com/"
     }
   ],
   "website_url": "https://subnet2.inferencelabs.com/"


### PR DESCRIPTION
## Summary

Closes #706

Closes **#706** by adding a `subnet-api` surface for **SN2 DSperse (Inference Labs)**.

The subnet registry previously included website, documentation, source repository, SDK, and data artifact surfaces, but no callable public API. This PR registers the official public API endpoint exposed by the subnet.

## Surface Added

| Field | Value |
|------|-------|
| Kind | `subnet-api` |
| URL | https://sn2-api.inferencelabs.com |
| Authority | `community` |
| Authentication | `false` |
| Public Safe | `true` |

## Verification

The API is publicly accessible without authentication and exposes live JSON endpoints, including:

| Endpoint | Result |
|----------|--------|
| `GET /stats` | Returns network statistics (HTTP 200) |
| `GET /validators` | Returns validator information (HTTP 200) |
| `GET /docs` | Serves the official Scalar API documentation (HTTP 200) |

## Source

Official documentation and API references:

- https://sn2-api.inferencelabs.com/docs
- https://sn2-docs.inferencelabs.com

The `sn2-api.inferencelabs.com` host is part of the existing official Inference Labs infrastructure already referenced by the subnet manifest alongside:

- `subnet2.inferencelabs.com`
- `sn2-docs.inferencelabs.com`
- `www.inferencelabs.com`

## Registry Safety

- ✅ Public, unauthenticated API
- ✅ No secrets, tokens, localhost, or private infrastructure
- ✅ `authority: community`
- ✅ `auth_required: false`
- ✅ `public_safe: true`

## Validation

- ✅ `npm run validate:surface -- registry/subnets/dsperse.json`
- ✅ `npm run scan:public-safety`
- ✅ `npm run validate` (129 subnets)

Single-file change. No generated artifacts or schemas were modified.