### PR TITLE
feat(registry): add SN127 Astrid Arena API /health subnet-api surface

### DIFF
--- a/registry/subnets/astrid.json
+++ b/registry/subnets/astrid.json
@@ -27,6 +27,26 @@
         "https://github.com/astridintelligence/sn-127/blob/master/README.md"
       ],
       "url": "https://arena-api.astrid.global/public/arena/completed-competitions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-127-astrid-health",
+      "kind": "subnet-api",
+      "name": "Astrid Arena API health",
+      "notes": "Public no-auth GET /health on arena-api.astrid.global returning JSON liveness (observed: {\"status\":\"ok\"}). Served on the SN127 Arena API host documented as ARENA_API_URL in the official astridintelligence/sn-127 README and arena-api.md, on the same host as the registered completed-competitions subnet-api surface.",
+      "provider": "astrid",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/astridintelligence/sn-127/blob/master/README.md",
+        "https://github.com/astridintelligence/sn-127/blob/master/docs/arena-api.md",
+        "https://github.com/astridintelligence/sn-127/blob/master/docs/external-api.md"
+      ],
+      "url": "https://arena-api.astrid.global/health"
     }
   ]
 }


### PR DESCRIPTION
Closes #666

## Summary
- Append `sn-127-astrid-health` subnet-api surface to `registry/subnets/astrid.json` (+19 lines, append-only)
- Registers `GET https://arena-api.astrid.global/health` — live probe returns `{"status":"ok",...}` (no auth)
- Source-backed via `ARENA_API_URL` in the official `astridintelligence/sn-127` README and Arena API docs on the same host

## Conflict avoidance
Merge-simulated clean against all open PRs (#3798, #3797, #3796, #3795, #3793, #3791, #3788, #3774, #3771, #3770, #3749, #3594, #3546). No registry file overlap.

## Test plan
- [x] `npx prettier --write registry/subnets/astrid.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate:surface -- registry/subnets/astrid.json`

Made with [Cursor](https://cursor.com)