### PR TITLE
feat(ui): add account teardown activity to account detail page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-axon-removals.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-axon-removals.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountAxonRemovalsQuery, normalizeAccountAxonRemovals } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${SS58}/axon-removals`,
+  });
+}
+
+async function runQuery(ss58: string, window?: string) {
+  const opts = accountAxonRemovalsQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeAccountAxonRemovals", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeAccountAxonRemovals(SS58, {
+        schema_version: 1,
+        address: SS58,
+        window: "30d",
+        total_removals: 5,
+        subnet_count: 2,
+        concentration: 0.68,
+        dominant_netuid: 1,
+        subnets: [
+          {
+            netuid: 1,
+            removals: 4,
+            first_removed_at: "2026-06-01T00:00:00.000Z",
+            last_removed_at: "2026-06-02T00:00:00.000Z",
+          },
+          {
+            netuid: 7,
+            removals: 1,
+            first_removed_at: "2026-06-03T00:00:00.000Z",
+            last_removed_at: "2026-06-03T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_removals: 5,
+      subnet_count: 2,
+      concentration: 0.68,
+      dominant_netuid: 1,
+      subnets: [
+        {
+          netuid: 1,
+          removals: 4,
+          first_removed_at: "2026-06-01T00:00:00.000Z",
+          last_removed_at: "2026-06-02T00:00:00.000Z",
+        },
+        {
+          netuid: 7,
+          removals: 1,
+          first_removed_at: "2026-06-03T00:00:00.000Z",
+          last_removed_at: "2026-06-03T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { total_removals: "nope" }]) {
+      const card = normalizeAccountAxonRemovals(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.total_removals).toBe(0);
+      expect(card.subnet_count).toBe(0);
+      expect(card.concentration).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountAxonRemovalsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ address: SS58, window: "7d", total_removals: 2, subnet_count: 1 });
+    const res = await runQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/axon-removals`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_removals).toBe(2);
+    expect(res.data.subnet_count).toBe(1);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/axon-removals`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -27,6 +27,8 @@ import type {
   HealthHistorySurface,
   SourceHealth,
   SourceHealthProvider,
+  AccountAxonRemovals,
+  AccountAxonRemovalsSubnet,
   AccountBalance,
   AccountDay,
   AccountEvent,
@@ -2170,6 +2172,59 @@ export const accountPortfolioQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountPortfolio>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountAxonRemovalsSubnet(raw: unknown): AccountAxonRemovalsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    removals: firstFiniteNumber(raw.removals) ?? 0,
+    first_removed_at: firstString(raw.first_removed_at) ?? null,
+    last_removed_at: firstString(raw.last_removed_at) ?? null,
+  };
+}
+
+// Per-account axon-removal (teardown) footprint over a 7d/30d/90d window. A flat
+// summary card — total removals + distinct subnets — from the account_events
+// AxonInfoRemoved stream. Every numeric cell coerces defensively: counts fall
+// through to 0 and concentration to null on a cold store or junk.
+export function normalizeAccountAxonRemovals(ss58: string, raw: unknown): AccountAxonRemovals {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountAxonRemovalsSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_removals: firstFiniteNumber(rec.total_removals) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountAxonRemovalsQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-axon-removals", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountAxonRemovals>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/axon-removals`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountAxonRemovals(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -901,6 +901,31 @@ export interface AccountSubnets {
   [key: string]: unknown;
 }
 
+/** Per-subnet AxonInfoRemoved row in /api/v1/accounts/{ss58}/axon-removals. */
+export interface AccountAxonRemovalsSubnet {
+  netuid: number;
+  removals: number;
+  first_removed_at: string | null;
+  last_removed_at: string | null;
+}
+
+/**
+ * One account's axon-removal (teardown) footprint over a 7d/30d/90d window, from
+ * /api/v1/accounts/{ss58}/axon-removals — the account-level companion to
+ * /api/v1/subnets/{netuid}/axon-removals. Zeroed when the account had no
+ * AxonInfoRemoved events in the window.
+ */
+export interface AccountAxonRemovals {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_removals: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountAxonRemovalsSubnet[];
+}
+
 /**
  * One neuron position a wallet holds on a subnet, from
  * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -11,6 +11,7 @@ import {
   Fingerprint,
   Radar,
   Rows3,
+  Unplug,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
@@ -27,6 +28,7 @@ import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import {
+  accountAxonRemovalsQuery,
   accountBalanceQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
@@ -243,6 +245,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       ) : null}
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
+
+      <AccountTeardownActivitySection ss58={ss58} />
 
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
@@ -556,6 +560,82 @@ function AccountTransfersSection({
 function fmtStake(v: number | null | undefined): string {
   if (v == null) return "—";
   return `${formatNumber(v)} τ`;
+}
+
+const KPI_TILE =
+  "rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]";
+
+/**
+ * Axon-removal (teardown) footprint over the trailing 30-day window — a flat
+ * count + distinct-subnet summary from /axon-removals. Non-blocking: while the
+ * dedicated query loads (or if it fails), the section never stalls the page.
+ */
+function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountAxonRemovalsQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="teardown"
+        title="Teardown activity"
+        subtitle="Axon endpoint removals (AxonInfoRemoved) for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="teardown"
+        title="Teardown activity"
+        subtitle="Axon endpoint removals (AxonInfoRemoved) for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load teardown activity"
+          description="The axon-removals tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const removals = card?.total_removals ?? 0;
+  const distinctSubnets = card?.subnet_count ?? 0;
+  if (removals === 0 && distinctSubnets === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="teardown"
+      title="Teardown activity"
+      subtitle="Axon endpoint removals (AxonInfoRemoved) for this account over the trailing 30-day window."
+      tone="accent"
+      info="The account-level companion to subnet axon-removal activity — counts how often this hotkey removed an announced axon endpoint, and on how many distinct subnets."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={Unplug}
+          eyebrow="Removals"
+          tone="accent"
+          value={formatNumber(removals)}
+          hint={`AxonInfoRemoved · ${windowLabel}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Distinct subnets"
+          value={formatNumber(distinctSubnets)}
+          hint="subnets with teardown"
+          className={KPI_TILE}
+        />
+      </div>
+    </SectionAnchor>
+  );
 }
 
 /**


### PR DESCRIPTION
Closes JSONbored/metagraphed#3728

## Summary

Wire GET `/api/v1/accounts/{ss58}/axon-removals` into the account explorer: query helper, types, unit tests, and a **Teardown activity** KPI section on the account detail page (removal count + distinct subnets over the 30-day window). 

## What Changed

- `apps/ui/src/lib/metagraphed/types.ts` — `AccountAxonRemovals`, `AccountAxonRemovalsSubnet`
- `apps/ui/src/lib/metagraphed/queries.ts` — `normalizeAccountAxonRemovals()`, `accountAxonRemovalsQuery(ss58, window = "30d")`
- `apps/ui/src/lib/metagraphed/queries.account-axon-removals.test.ts` — normalization + query tests
- `apps/ui/src/routes/accounts.$ss58.tsx` — `AccountTeardownActivitySection` (`#teardown`) after Subnet footprint; loading / error / hide-when-zero states

## Screenshots

| View | Screenshot |
|------|------------|
| **Before** (`main`) | No Teardown activity section between Subnet footprint and Activity by kind |
| **After** (this PR) | Teardown activity section — Removals **5**, Distinct subnets **2** |
<img width="840" height="149" alt="image" src="https://github.com/user-attachments/assets/89a32632-5e9b-40c7-a8f1-920c04aa6480" />

> Live production API currently returns zero axon-removals for most accounts, so the section hides until indexed data exists. After screenshot captured locally with mocked non-zero axon-removals to show the rendered UI.

## Scope & risk

- **Scope:** UI-only; consumes existing Worker endpoint (no schema/API contract changes).
- **Risk:** Low — non-blocking `useQuery`; section hidden on zero/cold response; error path uses existing `TableState` pattern.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.
      _(None — consumes existing `/api/v1/accounts/{ss58}/axon-removals` endpoint.)_

## Validation

- [x] `npm run validate`

**Also run (UI scope):**

- [x] `cd apps/ui && npm test` (57 files, 437 tests — includes `queries.account-axon-removals.test.ts`)
- [x] `npm run build`
