### PR TITLE
feat(registry): add SN60 Bitsec.ai openapi + subnet-api surfaces (#589)

### DIFF
--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -1,0 +1,54 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "Bitsec",
+  "netuid": 60,
+  "schema_version": 1,
+  "slug": "sn-60",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-ai-openapi",
+      "kind": "openapi",
+      "name": "Bitsec.ai FastAPI",
+      "notes": "Machine-readable OpenAPI 3.1 spec (FastAPI, 30 paths) for the SN60 Bitsec.ai public API, also rendered as live Swagger UI (/api/docs) and ReDoc (/api/redoc). Served on the official bitsec.ai domain referenced by the subnet's repo README.",
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://bitsec.ai/api/openapi.json",
+      "source_urls": [
+        "https://github.com/Bitsec-AI/subnet",
+        "https://bitsec.ai/api/docs"
+      ],
+      "url": "https://bitsec.ai/api/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-ai-subnet-api",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai subnet-api",
+      "notes": "Public no-auth JSON endpoint of the SN60 Bitsec.ai API (live subnet analytics: rounds, emissions). Sibling endpoints include /api/agents/top/; the full contract is the openapi surface. Served on the official bitsec.ai domain.",
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://github.com/Bitsec-AI/subnet",
+        "https://bitsec.ai/api/docs"
+      ],
+      "url": "https://bitsec.ai/api/analytics"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #589

Closes **#589** by registering **SN60 Bitsec.ai** and adding its publicly available API surfaces.

This introduces a new registry entry (`registry/subnets/bitsec.json`) and registers both the subnet's public REST API and its OpenAPI specification.

## Surfaces Added

| Kind | URL | Notes |
|------|-----|-------|
| `openapi` | https://bitsec.ai/api/openapi.json | Public OpenAPI 3.1 specification (FastAPI) |
| `subnet-api` | https://bitsec.ai/api/analytics | Public REST endpoint exposing subnet analytics |

## Verification

Both endpoints are publicly accessible without authentication.

### OpenAPI

- https://bitsec.ai/api/openapi.json
- Returns a valid OpenAPI 3.1 JSON document.
- Corresponding documentation is available via:
  - `/api/docs` (Swagger UI)
  - `/api/redoc` (ReDoc)

### Public API

- `GET /api/analytics`
  - Returns live subnet analytics (HTTP 200, JSON)
- Additional public endpoints are available, including:
  - `GET /api/agents/top/`

## Source

Official project resources:

- https://github.com/Bitsec-AI/subnet
- https://bitsec.ai/api/docs

The official subnet repository references the `bitsec.ai` domain, establishing it as the first-party host for the registered API surfaces.

## Registry Safety

- ✅ Public, unauthenticated endpoints only
- ✅ No secrets, tokens, localhost, or private infrastructure
- ✅ `authority: community`
- ✅ `auth_required: false`
- ✅ `public_safe: true`

## Validation

- ✅ `npm run validate:surface -- registry/subnets/bitsec.json`
- ✅ `npm run scan:public-safety`
- ✅ `npm run validate`

Single new registry file. No generated artifacts or schemas were modified.