### PR TITLE
fix(ui): add absolute timestamp tooltip to TimeAgo (#3391)

### DIFF
--- a/apps/ui/src/components/metagraphed/time-ago.test.ts
+++ b/apps/ui/src/components/metagraphed/time-ago.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { timeAgoAbsoluteTitle } from "./time-ago";
+
+describe("timeAgoAbsoluteTitle", () => {
+  it("returns a locale absolute string for usable timestamps", () => {
+    const title = timeAgoAbsoluteTitle("2024-06-15T12:00:00.000Z");
+    expect(title).toBeTruthy();
+    expect(title).toMatch(/\d/);
+  });
+
+  it("returns undefined when at is missing", () => {
+    expect(timeAgoAbsoluteTitle(undefined)).toBeUndefined();
+    expect(timeAgoAbsoluteTitle(null)).toBeUndefined();
+  });
+
+  it("returns undefined for the registry 1970 placeholder", () => {
+    expect(timeAgoAbsoluteTitle("1970-01-01T00:00:00.000Z")).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable values", () => {
+    expect(timeAgoAbsoluteTitle("not-a-date")).toBeUndefined();
+  });
+});

--- a/apps/ui/src/components/metagraphed/time-ago.tsx
+++ b/apps/ui/src/components/metagraphed/time-ago.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
-import { formatRelative } from "@/lib/metagraphed/format";
+import { formatFreshnessAbsolute } from "@/lib/metagraphed/freshness";
+import { formatRelative, isUsableTimestamp } from "@/lib/metagraphed/format";
+
+/** Absolute local-time tooltip for {@link TimeAgo}, gated like the visible relative text. */
+export function timeAgoAbsoluteTitle(at?: string | null): string | undefined {
+  if (!isUsableTimestamp(at)) return undefined;
+  return formatFreshnessAbsolute(at) ?? undefined;
+}
 
 /**
  * Renders a relative timestamp ("2m ago") only after mount.
@@ -19,7 +26,7 @@ export function TimeAgo({
   useEffect(() => setMounted(true), []);
   const text = !at ? fallback : mounted ? formatRelative(at) : "";
   return (
-    <span className={className} suppressHydrationWarning>
+    <span className={className} title={timeAgoAbsoluteTitle(at)} suppressHydrationWarning>
       {text}
     </span>
   );


### PR DESCRIPTION
## Summary

Closes #3391 — every `<TimeAgo>` call site now gets a hover `title` with the absolute local time via the existing `formatFreshnessAbsolute` helper, gated with `isUsableTimestamp` so the 1970 registry placeholder never leaks a bogus date.

## What changed

- `time-ago.tsx`: add `timeAgoAbsoluteTitle` helper and `title` on the rendered `<span>`
- `time-ago.test.ts`: cover usable timestamps, missing `at`, 1970 placeholder, and unparseable values

## Test plan

- [x] `vitest run src/components/metagraphed/time-ago.test.ts`
- [ ] CI green
- [ ] Hover any relative time in the app to confirm absolute tooltip