### PR TITLE
feat(registry): enrich SN88 Investing — PnL subnet-api surface

### DIFF
--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -129,6 +129,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Investing source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-investing-pnl-api",
+      "kind": "subnet-api",
+      "name": "Investing PnL API",
+      "notes": "Public no-auth GET /pnl on api.investing88.ai returning JSON miner PnL records (observed: HTTP 200 JSON array). The official Investing/core/api.py client fetches this endpoint via API_ROOT and the const.py module pins API_ROOT to api.investing88.ai.",
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/api.py",
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
+      ],
+      "url": "https://api.investing88.ai/pnl"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #708

## Summary

Appends one `subnet-api` surface on `registry/subnets/investing.json` for the SN88 Investing public PnL JSON endpoint.

## Surface

| Field | Value |
|-------|-------|
| Netuid | **88** (Investing) |
| Kind | **subnet-api** |
| URL | `https://api.investing88.ai/pnl` |
| Provider | **mobiusfund** |
| Live probe | `GET` → HTTP 200 JSON array of miner PnL records |

## Source evidence

- `Investing/core/api.py` — official client calls `GET {API_ROOT}/pnl`
- `Investing/core/const.py` — `API_ROOT = 'http://api.investing88.ai'`

## Checklist

- [x] Changes exactly one `registry/subnets/investing.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] `public_safe: true`, `auth_required: false`
- [x] No overlap with open PR file paths (`dsperse.json`, `almanac.json`, `bitsec.json`)
- [x] Links tracked open issue (`Closes #708`)

## Validation

- [x] `npm run validate:surface -- registry/subnets/investing.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --write registry/subnets/investing.json`

## Conflict avoidance

Merge-simulated clean against all currently open PR branches; single-file append at end of `surfaces` array.

Made with [Cursor](https://cursor.com)