### PR TITLE
feat(registry): enrich SN2 DSperse — network stats subnet-api surface

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -167,6 +167,24 @@
         "https://huggingface.co/inferencelabs"
       ],
       "url": "https://huggingface.co/datasets/inferencelabs/TruthTensor"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-inference-labs-subnet-api",
+      "kind": "subnet-api",
+      "name": "DSperse network stats API",
+      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host.",
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/inference-labs-inc/subnet-2/blob/main/crates/sn2-types/src/constants.rs"
+      ],
+      "url": "https://sn2-api.inferencelabs.com/stats"
     }
   ],
   "website_url": "https://subnet2.inferencelabs.com/"


### PR DESCRIPTION
Closes #706

## Add or update a subnet surface

This PR appends one `subnet-api` surface on `registry/subnets/dsperse.json`.

## Surface

- Netuid: 2
- Kind: subnet-api
- Public URL: https://sn2-api.inferencelabs.com/stats
- Source URL (proves the claim): https://github.com/inference-labs-inc/subnet-2/blob/main/crates/sn2-types/src/constants.rs (`DEFAULT_API_URL = "https://sn2-api.inferencelabs.com"`)
- Provider slug: inference-labs

## Checklist

- [x] Changes exactly one `registry/subnets/dsperse.json` file (append-only).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, private URLs, or validator internals.
- [x] Does not duplicate an existing Metagraphed surface (distinct `/stats` path; no prior `sn2-api.inferencelabs.com` URL in registry).
- [x] Links tracked issue (`Closes #706`).

## Conflict avoidance (open upstream PRs)

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3806 | `investing.json` | `dsperse.json` only — no overlap |
| #3805, #3804 | UI only | no overlap |
| #3774, #3771, #3770, #3749 | MCP/registry-code/API | no overlap |
| #3594, #3546 | release/README | no overlap |

Append-only change to `dsperse.json`; mergeable after other open PRs land without rebase.

## Gate Expectations

Public-safe surface; eligible for automated review after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/dsperse.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/dsperse.json`
- [x] `npm run surface:add` dry-run: OK reachable + public-safe


Made with [Cursor](https://cursor.com)