### PR TITLE
feat(registry): add SN54 Yanez MIID openapi + subnet-api surfaces (#663)

### DIFF
--- a/registry/providers/yanez-compliance.json
+++ b/registry/providers/yanez-compliance.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "yanez-compliance",
+  "kind": "subnet-team",
+  "name": "Yanez Compliance",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://yanez.ai/"
+}

--- a/registry/subnets/yanez-miid.json
+++ b/registry/subnets/yanez-miid.json
@@ -1,19 +1,60 @@
 {
-  "schema_version": 1,
-  "netuid": 54,
-  "name": "Yanez MIID",
-  "slug": "sn-54",
-  "status": "active",
   "categories": [],
+  "contact": "jose@yanezcompliance.com",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "Yanez MIID",
+  "netuid": 54,
+  "schema_version": 1,
+  "slug": "sn-54",
   "social": {
     "x": "https://x.com/yanez__ai"
   },
-  "surfaces": [],
   "source_repo": "https://github.com/yanez-compliance/MIID-subnet",
-  "website_url": "https://www.yanez.ai/",
-  "contact": "jose@yanezcompliance.com"
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-54-yanez-compliance-openapi",
+      "kind": "openapi",
+      "name": "Yanez MIID Miner Stats API",
+      "notes": "Machine-readable OpenAPI 3.1 spec for the SN54 Yanez MIID public Miner Stats API. The yanezcompliance.net host matches the subnet's registered source-repo org (yanez-compliance) and contact domain, and powers the official leaderboard dashboard linked from the repo README.",
+      "provider": "yanez-compliance",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://miners-stats.yanezcompliance.net/openapi.json",
+      "source_urls": [
+        "https://github.com/yanez-compliance/MIID-subnet",
+        "https://tao-ui-dashboard.yanez.ai/"
+      ],
+      "url": "https://miners-stats.yanezcompliance.net/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-54-yanez-compliance-subnet-api",
+      "kind": "subnet-api",
+      "name": "Yanez MIID subnet-api",
+      "notes": "Public no-auth JSON endpoint of the SN54 Yanez MIID Miner Stats API (latest per-miner quality/similarity scores). Sibling endpoints: /miners and /miners/{miner_uid}; the full contract is the openapi surface. Powers the subnet's official leaderboard dashboard.",
+      "provider": "yanez-compliance",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://github.com/yanez-compliance/MIID-subnet",
+        "https://tao-ui-dashboard.yanez.ai/"
+      ],
+      "url": "https://miners-stats.yanezcompliance.net/miners_stats"
+    }
+  ],
+  "website_url": "https://www.yanez.ai/"
 }


### PR DESCRIPTION
## Summary

Closes **#663** by adding the public API surfaces for **SN54 Yanez MIID**.

This PR registers both the public REST API and the OpenAPI specification requested in #663. Since Yanez did not yet have a provider profile in the registry, it also introduces the initial `registry/providers/yanez-compliance.json` entry alongside the subnet surfaces.

## Surfaces Added

| Kind | URL | Notes |
|------|-----|-------|
| `openapi` | https://miners-stats.yanezcompliance.net/openapi.json | Public OpenAPI 3.1 specification for the Miner Stats API |
| `subnet-api` | https://miners-stats.yanezcompliance.net/miners_stats | Public REST endpoint exposing per-miner quality and similarity metrics |

## Verification

Both endpoints are publicly accessible without authentication.

### OpenAPI

- https://miners-stats.yanezcompliance.net/openapi.json
- Returns a valid OpenAPI 3.1 JSON document (HTTP 200).

### Public API

- `GET /miners_stats`
  - Returns the latest miner quality and similarity scores (HTTP 200, JSON).
- Additional public endpoints include:
  - `GET /miners`
  - `GET /miners/{miner_uid}`

## Source

Official project resources:

- https://github.com/yanez-compliance/MIID-subnet
- https://tao-ui-dashboard.yanez.ai

The official subnet repository belongs to the `yanez-compliance` organization, and the subnet's published contact domain (`@yanezcompliance.com`) aligns with the API host `yanezcompliance.net`, establishing it as the project's first-party infrastructure. The official dashboard referenced in the repository is powered by the same API.

## Registry Safety

- ✅ Public, unauthenticated endpoints only
- ✅ No secrets, tokens, localhost, or private infrastructure
- ✅ `authority: community`
- ✅ `auth_required: false`
- ✅ `public_safe: true`

## Validation

- ✅ `npm run validate:surface -- registry/subnets/yanez-miid.json`
- ✅ `npm run scan:public-safety`
- ✅ `npm run validate`

This PR adds two registry files:

- `registry/subnets/yanez-miid.json`
- `registry/providers/yanez-compliance.json`

No generated artifacts or schemas were modified.

Closes #663