### PR TITLE
fix(ui): add focus-visible ring to ProfileTabs and EndpointKindTabs

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -29,7 +29,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             aria-selected={active}
             onClick={() => onChange(k)}
             className={classNames(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -38,7 +38,7 @@ export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defa
                   })
                 }
                 className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
                   isActive
                     ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
                     : "text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
## Summary

The tab `<button>`s in `ProfileTabs` and `EndpointKindTabs` build their `className` via `classNames(...)` with no focus-visible styling, so a keyboard-focused tab renders **no visible ring** — the two outliers in a design system that otherwise uses the existing `.mg-focus-ring` utility (`apps/ui/src/styles.css`, already applied e.g. in `hero-subnet-chips.tsx`). This wires that same utility onto both tab buttons.

Pure styling: **no new CSS**, no markup or logic change — the utility already exists, this only references it. `:focus-visible` means the ring shows on keyboard focus only, not mouse clicks.

## Template Used

Frontend (Path C) — touches `apps/ui/**` only.

## Changes

- `apps/ui/src/components/metagraphed/profile-tabs.tsx` — add `mg-focus-ring` to the tab button's `classNames(...)`
- `apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx` — add `mg-focus-ring` to the tab button's `classNames(...)`

Diff is 2 lines across 2 files; `styles.css` is untouched.

## Screenshots

| Component (route) | Before | After |
| --- | --- | --- |
| `ProfileTabs` — `/subnets/$netuid`, `/providers/$slug` | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-before.png)<br><sub>before: keyboard focus, no ring</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-after.png)<br><sub>after: keyboard focus shows the ring</sub> |
| `EndpointKindTabs` — `/endpoints` | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-before.png)<br><sub>before: keyboard focus, no ring</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-after.png)<br><sub>after: keyboard focus shows the ring</sub> |

<sub>Captured headless with the app's compiled stylesheet; the ring is the exact `.mg-focus-ring:focus-visible` box-shadow (`0 0 0 1px var(--ring), 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent)`).</sub>

## Testing

Ran the full `ui` gate locally, all green:

- `lint` — 0 errors
- `format:check` — clean
- `typecheck` — clean
- `test` — 305 passed
- `build` — success

Closes #3451
