### PR TITLE
fix(ui): wire Download CSV into NeuronTable footer

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
+import { Download } from "lucide-react";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { buildUrl } from "@/lib/metagraphed/client";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
 /**
@@ -111,6 +113,13 @@ export function NeuronTable({
       return (sortValue(a, field) - sortValue(b, field)) * dir;
     });
   }, [rows, field, order]);
+
+  const csvUrl = useMemo(() => {
+    const path = isValidator
+      ? `/api/v1/subnets/${netuid}/validators`
+      : `/api/v1/subnets/${netuid}/metagraph`;
+    return buildUrl(path, { format: "csv" });
+  }, [isValidator, netuid]);
 
   const col = (f: SortField, label: string, align: "left" | "right" = "right") => (
     <th
@@ -244,8 +253,20 @@ export function NeuronTable({
           </tbody>
         </table>
       </div>
-      <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
-        {sorted.length} {sorted.length === 1 ? "neuron" : "neurons"} · subnet {netuid}
+      <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 flex flex-wrap items-center justify-between gap-2 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+        <span>
+          {sorted.length} {sorted.length === 1 ? "neuron" : "neurons"} · subnet {netuid}
+        </span>
+        <a
+          href={csvUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-surface/40 px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider text-ink-muted transition-colors hover:border-ink/30 hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Download className="size-3" aria-hidden />
+          Download CSV
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add a **Download CSV** link to the shared `NeuronTable` footer (Metagraph + Validators tabs on subnet detail)
- URL is built with `buildUrl` so network prefix and API base stay correct on Testnet
- Metagraph variant → `/api/v1/subnets/{netuid}/metagraph?format=csv`; validator variant → `/api/v1/subnets/{netuid}/validators?format=csv`
- Export is the backend’s full unfiltered snapshot (not the in-page “Validators only” filter)
- Closes #3409 · Part of #2542

## Screenshots

| View | Before | After |
|------|--------|-------|
| Subnet detail · Metagraph tab | <img width="1840" height="936" alt="image" src="https://github.com/user-attachments/assets/857e0b61-d5f9-48b1-8f17-dc80158d91b2" /> | <img width="1833" height="940" alt="image" src="https://github.com/user-attachments/assets/d8da798a-5300-4ec2-8b4a-79720d7d42af" /> |
| Subnet detail · Validators tab | <img width="1843" height="934" alt="image" src="https://github.com/user-attachments/assets/a77d5842-df48-4ad6-abb5-166c6059409b" /> |<img width="1831" height="932" alt="image" src="https://github.com/user-attachments/assets/c91c0b61-b2ed-4417-af56-760c380214c0" /> |

## Test plan

- [x] Open a subnet → Metagraph tab → Download CSV opens metagraph CSV (new tab)
- [x] Validators tab → Download CSV opens validators CSV
- [x] Switch to Testnet → link still uses prefixed API base
- [x] `npm run build:client --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
