### PR TITLE
feat(registry): enrich SN10 Swap — add TaoFi API + OpenAPI schema surfaces

### DIFF
--- a/registry/providers/taofi.json
+++ b/registry/providers/taofi.json
@@ -7,6 +7,6 @@
   "docs_url": "https://docs.taofi.com/",
   "github_url": "https://github.com/Swap-Subnet/swap-subnet",
   "authority": "official",
-  "public_notes": "Provider profile for Swap / SN10 through TaoFi. Public surfaces include the TaoFi pool page, docs, and source repository.",
-  "notes": "No safe public subnet API, OpenAPI schema, SSE stream, or standalone data artifact has been verified yet."
+  "public_notes": "Provider profile for Swap / SN10 through TaoFi. Public surfaces include the TaoFi pool page, docs, source repository, the public TaoFi swap API (taofi-api.web.app), and its machine-readable OpenAPI 3.0.4 schema (taofi-doc.web.app/openapi.yaml).",
+  "notes": "Public TaoFi swap API and its OpenAPI schema are verified live. No safe public SSE stream or standalone static data artifact has been verified yet."
 }

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -99,6 +99,59 @@
         "timeout_ms": 10000
       },
       "notes": "Official Swap subnet source repository."
+    },
+    {
+      "id": "sn-10-taofi-openapi",
+      "name": "TaoFi API OpenAPI schema",
+      "kind": "openapi",
+      "url": "https://taofi-doc.web.app/openapi.yaml",
+      "provider": "taofi",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "schema_status": "machine-readable",
+      "schema_url": "https://taofi-doc.web.app/openapi.yaml",
+      "source_urls": [
+        "https://docs.taofi.com/",
+        "https://taofi-doc.web.app/openapi.yaml"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Official TaoFi (SN10 Swap) OpenAPI 3.0.4 schema (title \"TaoFi - OpenAPI 3.0\", servers host https://taofi-api.web.app/) served behind the public Swagger UI at taofi-doc.web.app. Documents the swap/bridge quote-and-call endpoints (getBuyQuote, getSellQuote, getBalance, getNativeTaoQuote, etc.); no authentication scheme is defined. The taofi-api.web.app host is referenced in TaoFi's own repository (TaoFi-0x/taofi-swap)."
+    },
+    {
+      "id": "sn-10-taofi-api",
+      "name": "TaoFi swap API",
+      "kind": "subnet-api",
+      "url": "https://taofi-api.web.app/",
+      "provider": "taofi",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "schema_url": "https://taofi-doc.web.app/openapi.yaml",
+      "source_urls": [
+        "https://docs.taofi.com/",
+        "https://taofi-doc.web.app/openapi.yaml"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public unauthenticated TaoFi (SN10 Swap) API — the servers host declared in the TaoFi OpenAPI schema. POST endpoints return live swap/bridge quotes and transaction call data (verified: getBuyQuote returned an HTTP 200 JSON quote). Documented at taofi-doc.web.app."
     }
   ]
 }


### PR DESCRIPTION
Closes #719

## Summary

SN10 Swap's registry file notes it has **no verified public subnet API endpoint or OpenAPI schema yet**. TaoFi — the subnet operator (provider `taofi`, docs `docs.taofi.com`, repo `Swap-Subnet/swap-subnet`) — serves its official swap/bridge API and a machine-readable OpenAPI schema, so this fills both gaps.

## Surfaces added

**OpenAPI schema** — https://taofi-doc.web.app/openapi.yaml
- Verified 200, OpenAPI **3.0.4**, `info.title` = "TaoFi - OpenAPI 3.0", `servers` host `https://taofi-api.web.app/`, real `paths` object: `/getBuyQuote`, `/getBuyCall`, `/getSellQuote`, `/getSellCall`, `/getRefundCall`, `/getBalance`, `/getNativeTaoQuote`, `/getNativeTaoCall`. No `security`/auth scheme defined (public). Served behind the public Swagger UI at `taofi-doc.web.app`.

**Public API** — https://taofi-api.web.app/
- The `servers` host declared in the schema. Unauthenticated POST endpoints return live data — verified `POST /getBuyQuote` → HTTP 200 JSON quote (`{"message":"Success","priceImpact":...,"expectedAlphaAmount":...}`). GET on a POST route returns 405 (server live, not auth-gated).

## Operator match

The OpenAPI is titled **"TaoFi"** and carries **`subnetuid: 10`** (= SN10 Swap), and the `taofi-api.web.app` host is referenced in **TaoFi's own GitHub org** (`TaoFi-0x/taofi-swap`, e.g. `hardhat/tasks/whitelist.ts`, `test/bittensor/SwapAndBridgeAndCall.spec.ts`). Both hosts are TaoFi's own Firebase deploys, distinct from the excluded generic `www.taofi.com` paths.

## Non-duplication

Neither `taofi-doc.web.app` nor `taofi-api.web.app` appears in any existing surface of `swap.json` (which held only pool/docs/source-repo). Provider `taofi` is already registered.

## Validation
- `validate:surface` passes (632 surfaces across 126 files)
- `scan:public-safety` passes
- prettier clean; both endpoints re-fetched 200 during review
