### PR TITLE
feat(registry): add SN65 TAO Private Network openapi + subnet-api surfaces (#576)

### DIFF
--- a/registry/providers/taofu-labs.json
+++ b/registry/providers/taofu-labs.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "taofu-labs",
+  "kind": "subnet-team",
+  "name": "Taofu Labs",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://tpn.taofu.xyz/"
+}

--- a/registry/subnets/tao-private-network.json
+++ b/registry/subnets/tao-private-network.json
@@ -1,19 +1,60 @@
 {
-  "schema_version": 1,
-  "netuid": 65,
-  "name": "TAO Private Network",
-  "slug": "sn-65",
-  "status": "active",
   "categories": [],
+  "contact": "contact@taoprivatenetwork.com",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "TAO Private Network",
+  "netuid": 65,
+  "schema_version": 1,
+  "slug": "sn-65",
   "social": {
     "x": "https://x.com/tpn_labs"
   },
-  "surfaces": [],
   "source_repo": "https://github.com/taofu-labs/tpn-subnet",
-  "website_url": "https://tpn.taofu.xyz/",
-  "contact": "contact@taoprivatenetwork.com"
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-taofu-labs-openapi",
+      "kind": "openapi",
+      "name": "TAO Private Network TPN API",
+      "notes": "Machine-readable OpenAPI 3.0 spec (TPN API v1.1.0, 13 paths) for SN65 TAO Private Network. The api.taoprivatenetwork.com host matches the subnet's registered contact domain, and its no-auth endpoints are documented at /docs.",
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.taoprivatenetwork.com/api-docs/openapi.json",
+      "source_urls": [
+        "https://github.com/taofu-labs/tpn-subnet",
+        "https://api.taoprivatenetwork.com/docs/getting-started/"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-taofu-labs-subnet-api",
+      "kind": "subnet-api",
+      "name": "TAO Private Network subnet-api",
+      "notes": "Public no-auth JSON endpoint (canonical health check → {\"message\":\"OK!\"}) of the SN65 TAO Private Network API; /api/v1/version is a sibling. The full contract is the openapi surface. Served on api.taoprivatenetwork.com, the subnet's registered contact domain.",
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://github.com/taofu-labs/tpn-subnet",
+        "https://api.taoprivatenetwork.com/docs/getting-started/"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/health"
+    }
+  ],
+  "website_url": "https://tpn.taofu.xyz/"
 }


### PR DESCRIPTION
## Summary

Closes #576

Closes **#576** by adding the public API surfaces for **SN65 TAO Private Network**.

This PR registers both the public REST API and the OpenAPI specification requested in #576. Since TAO Private Network did not yet have a provider profile in the registry, it also introduces the initial `registry/providers/taofu-labs.json` entry alongside the subnet surfaces.

## Surfaces Added

| Kind | URL | Notes |
|------|-----|-------|
| `openapi` | https://api.taoprivatenetwork.com/api-docs/openapi.json | Public OpenAPI 3.0 specification for the TPN API |
| `subnet-api` | https://api.taoprivatenetwork.com/api/v1/health | Public REST health endpoint |

## Verification

Both endpoints are publicly accessible without authentication.

### OpenAPI

- https://api.taoprivatenetwork.com/api-docs/openapi.json
- Returns a valid OpenAPI 3.0 JSON document (HTTP 200).

### Public API

- `GET /api/v1/health`
  - Returns the canonical health response (`{"message":"OK!"}`) with HTTP 200.
- Additional public endpoint:
  - `GET /api/v1/version`

## Source

Official project resources:

- https://github.com/taofu-labs/tpn-subnet
- https://api.taoprivatenetwork.com/docs/getting-started

The official subnet repository and API documentation reference the `taoprivatenetwork.com` domain. The API host also matches the subnet's published contact address (`contact@taoprivatenetwork.com`), establishing it as the project's first-party infrastructure.

## Registry Safety

- ✅ Public, unauthenticated endpoints only
- ✅ No secrets, tokens, localhost, or private infrastructure
- ✅ `authority: community`
- ✅ `auth_required: false`
- ✅ `public_safe: true`

## Validation

- ✅ `npm run validate:surface -- registry/subnets/tao-private-network.json`
- ✅ `npm run scan:public-safety`
- ✅ `npm run validate`

This PR adds two registry files:

- `registry/subnets/tao-private-network.json`
- `registry/providers/taofu-labs.json`

No generated artifacts or schemas were modified.