### PR TITLE
feat(registry): enrich SN88 Investing — days-active subnet-api

### DIFF
--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -129,6 +129,31 @@
         "timeout_ms": 10000
       },
       "notes": "Official Investing source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-investing-days-api",
+      "kind": "subnet-api",
+      "name": "Investing days-active API",
+      "notes": "Public no-auth GET /days on api.investing88.ai returning JSON miner days-active records (observed: HTTP 200 JSON array). The official Investing/core/api.py client fetches this endpoint via API_ROOT; const.py pins API_ROOT to api.investing88.ai.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/api.py",
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
+      ],
+      "url": "https://api.investing88.ai/days"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #708

## Summary

Appends one `subnet-api` surface on `registry/subnets/investing.json` for the SN88 Investing public days-active JSON endpoint.

## Surface

| Field | Value |
|-------|-------|
| Netuid | **88** (Investing) |
| Kind | **subnet-api** |
| URL | `https://api.investing88.ai/days` |
| Provider | **mobiusfund** |
| Probe | `GET` → `expect: json` (live HTTP 200 JSON array) |

## Source evidence

- `Investing/core/api.py` — official client `days()` calls `GET {API_ROOT}/days`
- `Investing/core/const.py` — `API_ROOT = 'http://api.investing88.ai'`

Distinct from the existing `data-artifact` surfaces (`/assets`, `/ratio`); this registers the subnet's days-active API contract as `subnet-api`.

## Checklist

- [x] Changes exactly one `registry/subnets/investing.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Includes `probe` block matching sibling surfaces (`enabled`, `method`, `expect`, `timeout_ms`)
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] `public_safe: true`, `auth_required: false`
- [x] No overlap with open PR paths (`swap.json`, `tao-private-network.json`)
- [x] Links tracked open issue (`Closes #708`)

## Validation

- [x] `npm run validate:surface -- registry/subnets/investing.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --write registry/subnets/investing.json`

## Conflict avoidance

Merge-simulated clean against all currently open PR branches; single-file append at end of `surfaces` array.

Made with [Cursor](https://cursor.com)