### PR TITLE
fix(ui): add focus-visible ring to ProfileTabs and EndpointKindTabs

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -29,7 +29,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             aria-selected={active}
             onClick={() => onChange(k)}
             className={classNames(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -38,7 +38,7 @@ export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defa
                   })
                 }
                 className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
                   isActive
                     ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
                     : "text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/components/metagraphed/tab-focus-ring.test.ts
+++ b/apps/ui/src/components/metagraphed/tab-focus-ring.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// ProfileTabs reads URL state via router hooks; stub them so the component
+// can be rendered in isolation (no RouterProvider needed for a markup check).
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => () => {},
+  useSearch: () => ({}),
+}));
+
+import { EndpointKindTabs } from "./endpoint-kind-tabs";
+import { ProfileTabs } from "./profile-tabs";
+
+// Guards the accessibility fix (#3451): both tab strips must keep the shared
+// `mg-focus-ring` utility so keyboard focus stays visible. A refactor that
+// drops the class from either component's classNames() call fails here.
+describe("tab focus ring", () => {
+  it("EndpointKindTabs button carries mg-focus-ring", () => {
+    const html = renderToStaticMarkup(
+      createElement(EndpointKindTabs, {
+        value: "all",
+        counts: { all: 3, api: 2 },
+        onChange: () => {},
+      }),
+    );
+    expect(html).toContain("mg-focus-ring");
+  });
+
+  it("ProfileTabs button carries mg-focus-ring", () => {
+    const html = renderToStaticMarkup(
+      createElement(ProfileTabs, {
+        tabs: [{ id: "overview", label: "Overview" }],
+        defaultTab: "overview",
+      }),
+    );
+    expect(html).toContain("mg-focus-ring");
+  });
+});


### PR DESCRIPTION
## Summary

The tab `<button>`s in `ProfileTabs` and `EndpointKindTabs` build their `className` via `classNames(...)` with no focus-visible styling, so a keyboard-focused tab renders **no visible ring** — the two outliers in a design system that otherwise uses the existing `.mg-focus-ring` utility (`apps/ui/src/styles.css`, already applied e.g. in `hero-subnet-chips.tsx`). This wires that same utility onto both tab buttons.

Pure styling: **no new CSS**, no markup or logic change — the utility already exists, this only references it. `:focus-visible` means the ring shows on keyboard focus only, not mouse clicks.

## Template Used

Frontend (Path C) — touches `apps/ui/**` only.

## Changes

- `apps/ui/src/components/metagraphed/profile-tabs.tsx` — add `mg-focus-ring` to the tab button's `classNames(...)`
- `apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx` — add `mg-focus-ring` to the tab button's `classNames(...)`

Diff is 2 lines across 2 files; `styles.css` is untouched.

## Screenshots

| Component (route) | Before | After |
| --- | --- | --- |
| `ProfileTabs` — `/subnets/$netuid`, `/providers/$slug` | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-before.png)<br><sub>before: keyboard focus, no ring</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/profile-tabs-after.png)<br><sub>after: keyboard focus shows the ring</sub> |
| `EndpointKindTabs` — `/endpoints` | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-before.png)<br><sub>before: keyboard focus, no ring</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3451-assets/endpoint-kind-tabs-after.png)<br><sub>after: keyboard focus shows the ring</sub> |

<sub>Captured headless with the app's compiled stylesheet; the ring is the exact `.mg-focus-ring:focus-visible` box-shadow (`0 0 0 1px var(--ring), 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent)`).</sub>

## Testing

Ran the full `ui` gate locally, all green:

- `lint` — 0 errors
- `format:check` — clean
- `typecheck` — clean
- `test` — 444 passed (adds `tab-focus-ring.test.ts`)
- `build` — success

Closes #3451


## Addressing review feedback

- **Test evidence** — added `apps/ui/src/components/metagraphed/tab-focus-ring.test.ts`: a dependency-free regression check (`react-dom/server` + `createElement`, no jsdom / no new deps, matching the repo's colocated `.test.ts` pattern) that renders both components and asserts each button keeps `mg-focus-ring`. A refactor dropping the class from either `classNames(...)` now fails CI instead of silently removing the focus indicator.
- **`:focus-visible` confirmed** — `.mg-focus-ring` in `apps/ui/src/styles.css` is defined with `:focus-visible` (not `:focus`), so the ring shows on keyboard focus only, not mouse clicks — as described above.