### PR TITLE
feat(registry): add SN68 NOVA score-share OpenAPI and molecules API

### DIFF
--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -85,6 +85,47 @@
         "https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/utils/challenge.py#L37"
       ],
       "url": "https://huggingface.co/datasets/Metanova/Proteins"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-68-nova-score-share-openapi",
+      "kind": "openapi",
+      "name": "NOVA Boltz score sharing API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.x schema for the NOVA SN68 validator score-sharing service (title: Boltz score sharing API). Served publicly at vali-score-share-api.metanova-labs.ai; documents molecule and nanobody score-share routes used by validators to average non-deterministic model results.",
+      "provider": "nova",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://vali-score-share-api.metanova-labs.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/metanova-labs/nova/blob/main/neurons/validator/validator.py",
+        "https://github.com/metanova-labs/nova/blob/main/docs/VALIDATOR.md",
+        "https://vali-score-share-api.metanova-labs.ai/openapi.json"
+      ],
+      "url": "https://vali-score-share-api.metanova-labs.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-68-nova-score-share-molecules",
+      "kind": "subnet-api",
+      "name": "NOVA score-share molecules catalog API",
+      "notes": "Public no-auth GET /api/v1/molecules on vali-score-share-api.metanova-labs.ai returning paginated molecule score-share records (items with name, epoch, target_averages). Documented as GET /api/v1/molecules in the subnet OpenAPI spec; same host as SCORE_SHARE_API_URL in the official nova validator docs and validator.py.",
+      "provider": "nova",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://vali-score-share-api.metanova-labs.ai/openapi.json",
+        "https://github.com/metanova-labs/nova/blob/main/docs/VALIDATOR.md"
+      ],
+      "url": "https://vali-score-share-api.metanova-labs.ai/api/v1/molecules"
     }
   ],
   "source_repo": "https://github.com/metanova-labs/nova",


### PR DESCRIPTION
Closes #578

## Summary
Append **openapi** + **subnet-api** surfaces to `registry/subnets/nova.json` for the NOVA SN68 validator score-sharing service at `vali-score-share-api.metanova-labs.ai`.

## Surfaces
| Kind | URL | Proof |
|------|-----|-------|
| **openapi** | `https://vali-score-share-api.metanova-labs.ai/openapi.json` | Boltz score sharing API (OpenAPI 3.x, machine-readable) |
| **subnet-api** | `https://vali-score-share-api.metanova-labs.ai/api/v1/molecules` | Public no-auth GET catalog documented in the OpenAPI spec |

## Proof
- `SCORE_SHARE_API_URL="https://vali-score-share-api.metanova-labs.ai"` in [docs/VALIDATOR.md](https://github.com/metanova-labs/nova/blob/main/docs/VALIDATOR.md)
- Default host in [neurons/validator/validator.py](https://github.com/metanova-labs/nova/blob/main/neurons/validator/validator.py) (`os.environ.get('SCORE_SHARE_API_URL', ...)`)
- Live GET `/api/v1/molecules` returns JSON (`items` with `name`, `epoch`, `target_averages`)

## Checklist
- [x] Changes exactly one `registry/subnets/nova.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`, `submitted_by: bohdansolovie`
- [x] Public URLs safe for read-only probes; source URLs prove the subnet publishes them
- [x] Does not duplicate existing surfaces
- [x] Links tracked issue (`Closes #578`)

## Validation
- [x] `npm run validate:surface -- registry/subnets/nova.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/nova.json`

## Conflict avoidance
| PR | Touches | This PR |
|----|---------|---------|
| #3780 (closed) | `bitsec-ai.json` | `nova.json` |


Made with [Cursor](https://cursor.com)