### PR TITLE
feat(ui): wire Download CSV on Surfaces and Endpoints pages

### DIFF
--- a/apps/ui/src/components/metagraphed/download-csv-button.test.ts
+++ b/apps/ui/src/components/metagraphed/download-csv-button.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildCsvDownloadUrl } from "./download-csv-button";
+
+describe("buildCsvDownloadUrl", () => {
+  it("appends format=csv to a bare path URL", () => {
+    expect(buildCsvDownloadUrl("https://api.metagraph.sh/api/v1/surfaces")).toBe(
+      "https://api.metagraph.sh/api/v1/surfaces?format=csv",
+    );
+  });
+
+  it("preserves existing query params", () => {
+    expect(
+      buildCsvDownloadUrl(
+        "https://api.metagraph.sh/api/v1/surfaces?q=openapi&kind=api&sort=name&order=asc",
+      ),
+    ).toBe(
+      "https://api.metagraph.sh/api/v1/surfaces?q=openapi&kind=api&sort=name&order=asc&format=csv",
+    );
+  });
+
+  it("overwrites an existing format param with csv", () => {
+    expect(buildCsvDownloadUrl("https://api.metagraph.sh/api/v1/endpoints?format=json")).toBe(
+      "https://api.metagraph.sh/api/v1/endpoints?format=csv",
+    );
+  });
+});

--- a/apps/ui/src/components/metagraphed/download-csv-button.tsx
+++ b/apps/ui/src/components/metagraphed/download-csv-button.tsx
@@ -1,0 +1,42 @@
+import { Download } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+interface Props {
+  /** API list endpoint URL (with any filter/sort query params), excluding `format=csv`. */
+  url: string;
+  /** Optional hint only — the server sets the filename via Content-Disposition. */
+  filename?: string;
+  label?: string;
+  className?: string;
+}
+
+/** Append `format=csv` to an API URL, preserving existing query params. */
+export function buildCsvDownloadUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("format", "csv");
+  return parsed.toString();
+}
+
+export function DownloadCsvButton({ url, label = "Download CSV", className }: Props) {
+  const exportUrl = buildCsvDownloadUrl(url);
+
+  const onClick = () => {
+    window.location.href = exportUrl;
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={classNames(
+        "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      <Download className="size-3 text-ink-muted" aria-hidden />
+      {label}
+    </button>
+  );
+}

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -30,8 +30,10 @@ import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-sc
 import { ExternalLink } from "@/components/metagraphed/external-link";
 import { EndpointKindTabs } from "@/components/metagraphed/endpoint-kind-tabs";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { ProxyHero, ProxyUsagePanel } from "@/components/metagraphed/rpc-proxy";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { useScrolled } from "@/hooks/use-scrolled";
 import {
   endpointsQuery,
@@ -524,6 +526,10 @@ function EndpointsTable() {
     search.region ||
     search.eligibility;
 
+  // The table filters client-side over the full fetched list; the CSV export
+  // hits the backend route directly (full endpoint snapshot, no client filters).
+  const endpointsCsvUrl = buildUrl("/api/v1/endpoints");
+
   function toggleSort(k: SortKey) {
     if (search.sort === k) {
       setSearch({ order: search.order === "asc" ? "desc" : "asc" });
@@ -630,6 +636,7 @@ function EndpointsTable() {
         >
           <X className="size-3" /> Reset filters
         </button>
+        <DownloadCsvButton url={endpointsCsvUrl} />
         <button
           type="button"
           onClick={() => {

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -13,6 +13,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { SectionHeading } from "@/components/metagraphed/section-heading";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { ShareButton } from "@/components/metagraphed/share-button";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
@@ -32,6 +33,7 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
 import { surfacesInfiniteQuery, providersQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { matchesQuery, sortBy, tableSearchSchema } from "@/lib/metagraphed/url-state";
 import type { Surface, Provider, Subnet } from "@/lib/metagraphed/types";
 
@@ -73,6 +75,13 @@ function SurfacesPage() {
       replace: true,
     });
   const viewMode: "table" | "grid" = search.view === "grid" ? "grid" : "table";
+  const surfacesCsvUrl = buildUrl("/api/v1/surfaces", {
+    q: search.q || undefined,
+    sort: search.sort || undefined,
+    order: search.sort ? search.order : undefined,
+    kind: search.kind || undefined,
+    provider: search.provider || undefined,
+  });
   return (
     <AppShell>
       <TimeRangeProvider defaultRange="7d">
@@ -95,6 +104,7 @@ function SurfacesPage() {
                 }
               />
               <ResetFiltersButton active={filtersActive} onReset={onReset} />
+              <DownloadCsvButton url={surfacesCsvUrl} />
               <ShareButton />
             </>
           }


### PR DESCRIPTION
## Summary

- Add shared `DownloadCsvButton` (+ `buildCsvDownloadUrl`) and wire it into the Surfaces page hero and Endpoints sticky toolbar
- **Surfaces:** export URL mirrors active server filters (`q`, `sort`, `order`, `kind`, `provider`) — same params as `SurfacesTable`'s `baseParams`, without pagination cursor/limit
- **Endpoints:** export downloads the **full unfiltered** `/api/v1/endpoints` snapshot from the API; the page applies search, category, region, eligibility, and callable-only filters **client-side**, so those are not reflected in the CSV (documented here intentionally)
- URLs built via `buildUrl` for correct API base + network prefix on Testnet
- Closes #3408 · Part of #2542

## Screenshots

| View | Before | After |
|------|--------|-------|
| `/surfaces` page hero | <img width="1843" height="928" alt="image" src="https://github.com/user-attachments/assets/76f3f9fa-a06d-4002-944b-adeb8910b12f" /> | <img width="1830" height="937" alt="image" src="https://github.com/user-attachments/assets/74e922a8-d3e3-4f2d-b5b1-d47d162f65b4" /> |
| `/endpoints` toolbar | <img width="1829" height="931" alt="image" src="https://github.com/user-attachments/assets/c8155e90-1a68-40db-b6dd-c48fbfa50ee8" /> | <img width="1842" height="937" alt="image" src="https://github.com/user-attachments/assets/39cba3da-36c7-49d5-a6fa-45af62a4a2b4" /> |

## Test plan

- [ ] `/surfaces` — Download CSV with filters active exports matching filtered set
- [ ] `/endpoints` — Download CSV fetches full backend endpoint list (may differ from filtered table)
- [ ] Testnet network selector — both links use prefixed API base
- [ ] `npm run test --workspace=apps/ui -- download-csv-button`
- [ ] `npm run lint --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui`
