### PR TITLE
feat(ui): add account weight-setting activity to account detail page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-weight-setters.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-weight-setters.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountWeightSettersQuery, normalizeAccountWeightSetters } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${SS58}/weight-setters`,
+  });
+}
+
+async function runQuery(ss58: string, window?: string) {
+  const opts = accountWeightSettersQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeAccountWeightSetters", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeAccountWeightSetters(SS58, {
+        schema_version: 1,
+        address: SS58,
+        window: "30d",
+        total_weight_sets: 12,
+        subnet_count: 2,
+        concentration: 0.5,
+        dominant_netuid: 1,
+        subnets: [
+          {
+            netuid: 1,
+            weight_sets: 8,
+            first_set_at: "2026-06-01T00:00:00.000Z",
+            last_set_at: "2026-06-15T00:00:00.000Z",
+          },
+          {
+            netuid: 7,
+            weight_sets: 4,
+            first_set_at: "2026-06-20T00:00:00.000Z",
+            last_set_at: "2026-06-20T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_weight_sets: 12,
+      subnet_count: 2,
+      concentration: 0.5,
+      dominant_netuid: 1,
+      subnets: [
+        {
+          netuid: 1,
+          weight_sets: 8,
+          first_set_at: "2026-06-01T00:00:00.000Z",
+          last_set_at: "2026-06-15T00:00:00.000Z",
+        },
+        {
+          netuid: 7,
+          weight_sets: 4,
+          first_set_at: "2026-06-20T00:00:00.000Z",
+          last_set_at: "2026-06-20T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { total_weight_sets: "nope" }]) {
+      const card = normalizeAccountWeightSetters(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.total_weight_sets).toBe(0);
+      expect(card.subnet_count).toBe(0);
+      expect(card.concentration).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountWeightSettersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ address: SS58, window: "7d", total_weight_sets: 3, subnet_count: 1 });
+    const res = await runQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/weight-setters`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_weight_sets).toBe(3);
+    expect(res.data.subnet_count).toBe(1);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/weight-setters`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -29,6 +29,8 @@ import type {
   SourceHealthProvider,
   AccountAxonRemovals,
   AccountAxonRemovalsSubnet,
+  AccountWeightSetters,
+  AccountWeightSettersSubnet,
   AccountBalance,
   AccountDay,
   AccountEvent,
@@ -2284,6 +2286,59 @@ export const accountAxonRemovalsQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountAxonRemovals(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountWeightSettersSubnet(raw: unknown): AccountWeightSettersSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    weight_sets: firstFiniteNumber(raw.weight_sets) ?? 0,
+    first_set_at: firstString(raw.first_set_at) ?? null,
+    last_set_at: firstString(raw.last_set_at) ?? null,
+  };
+}
+
+// Per-account weight-setting (WeightsSet) footprint over a 7d/30d window — total
+// weight sets + per-subnet breakdown from the account_events stream. Every
+// numeric cell coerces defensively: counts fall through to 0 and concentration
+// to null on a cold store or junk.
+export function normalizeAccountWeightSetters(ss58: string, raw: unknown): AccountWeightSetters {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountWeightSettersSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_weight_sets: firstFiniteNumber(rec.total_weight_sets) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountWeightSettersQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-weight-setters", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountWeightSetters>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/weight-setters`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountWeightSetters(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -951,6 +951,31 @@ export interface AccountAxonRemovals {
   subnets: AccountAxonRemovalsSubnet[];
 }
 
+/** Per-subnet WeightsSet row in /api/v1/accounts/{ss58}/weight-setters. */
+export interface AccountWeightSettersSubnet {
+  netuid: number;
+  weight_sets: number;
+  first_set_at: string | null;
+  last_set_at: string | null;
+}
+
+/**
+ * One account's (validator's) weight-setting footprint over a 7d/30d window, from
+ * /api/v1/accounts/{ss58}/weight-setters — the account-level companion to
+ * /api/v1/subnets/{netuid}/weights/setters. Zeroed when the account had no
+ * WeightsSet events in the window.
+ */
+export interface AccountWeightSetters {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_weight_sets: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountWeightSettersSubnet[];
+}
+
 /**
  * One neuron position a wallet holds on a subnet, from
  * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -11,6 +11,7 @@ import {
   Fingerprint,
   Radar,
   Rows3,
+  Scale,
   Unplug,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -29,6 +30,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountWeightSettersQuery,
   accountBalanceQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
@@ -247,6 +249,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
       <AccountTeardownActivitySection ss58={ss58} />
+
+      <AccountWeightSettingSection ss58={ss58} />
 
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
@@ -634,6 +638,120 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
           className={KPI_TILE}
         />
       </div>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Validator weight-setting (WeightsSet) footprint over the trailing 30-day
+ * window — KPI summary + per-subnet breakdown from /weight-setters. Unlike
+ * teardown, always renders: zero activity shows an empty state (typical for
+ * non-validator hotkeys), not a hidden section or an error.
+ */
+function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountWeightSettersQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+  const subnets = card?.subnets ?? [];
+  const totalSets = card?.total_weight_sets ?? 0;
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="weight-setting"
+        title="Weight-setting activity"
+        subtitle="Validator WeightsSet events for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="weight-setting"
+        title="Weight-setting activity"
+        subtitle="Validator WeightsSet events for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load weight-setting activity"
+          description="The weight-setters tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  return (
+    <SectionAnchor
+      id="weight-setting"
+      title="Weight-setting activity"
+      subtitle="Validator WeightsSet events for this account over the trailing 30-day window — per-subnet breakdown when this hotkey submits weights."
+      tone="accent"
+      info="The account-level companion to subnet weight-setter leaderboards — keyed on the validator hotkey submitting its weight vector."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      {totalSets === 0 && subnets.length === 0 ? (
+        <TableState
+          variant="empty"
+          title="No weight-setting activity"
+          description="This account has not submitted WeightsSet events in the trailing window — typical for non-validator hotkeys or coldkey-only addresses."
+        />
+      ) : (
+        <>
+          <div className="mb-5 grid max-w-2xl gap-4 sm:grid-cols-2">
+            <StatTile
+              icon={Scale}
+              eyebrow="Weight sets"
+              tone="accent"
+              value={formatNumber(totalSets)}
+              hint={`WeightsSet · ${windowLabel}`}
+              className={KPI_TILE}
+            />
+            <StatTile
+              icon={Boxes}
+              eyebrow="Distinct subnets"
+              value={formatNumber(card?.subnet_count ?? subnets.length)}
+              hint="subnets with weight sets"
+              className={KPI_TILE}
+            />
+          </div>
+          <DataPanel>
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50">
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Weight sets</th>
+                  <th className={`${TH} text-right`}>Last set</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {subnets.map((row) => (
+                  <tr key={row.netuid} className="hover:bg-surface/30">
+                    <td className="px-5 py-4 font-mono text-[12px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: row.netuid }}
+                        className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
+                      >
+                        SN{row.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                      {formatNumber(row.weight_sets)}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
+                      <TimeAgo at={row.last_set_at ?? undefined} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </DataPanel>
+        </>
+      )}
     </SectionAnchor>
   );
 }


### PR DESCRIPTION
Closes #3731

## Summary

Wire GET `/api/v1/accounts/{ss58}/weight-setters` into the account explorer: query helper, types, unit tests, and a **Weight-setting activity** section on the account detail page — KPI summary plus per-subnet WeightsSet breakdown for validator hotkeys. Unlike teardown, zero activity renders an explicit empty state (typical for non-validators), not a hidden section.

## What Changed

- `apps/ui/src/lib/metagraphed/types.ts` — `AccountWeightSetters`, `AccountWeightSettersSubnet`
- `apps/ui/src/lib/metagraphed/queries.ts` — `normalizeAccountWeightSetters()`, `accountWeightSettersQuery(ss58, window = "30d")`
- `apps/ui/src/lib/metagraphed/queries.account-weight-setters.test.ts` — normalization + query tests
- `apps/ui/src/routes/accounts.$ss58.tsx` — `AccountWeightSettingSection` (`#weight-setting`) after Teardown activity; loading / error / empty / per-subnet table states

## Screenshots

### `/accounts/$ss58` — desktop light 
<img width="1767" height="773" alt="image" src="https://github.com/user-attachments/assets/0e9435b5-cf20-4594-b7a9-9a6b291204f7" />

### `/accounts/$ss58` — desktop dark
<img width="1391" height="867" alt="image" src="https://github.com/user-attachments/assets/e0ea133c-cc85-4496-9fed-d063f4ab656a" />

### `/accounts/$ss58` — mobile
<img width="391" height="823" alt="image" src="https://github.com/user-attachments/assets/5bd888ee-ad26-493e-9627-5ca13f08123c" />


> Empty state is visible on production API (zeroed response). Populate the table/KPI row with mocked non-zero data locally if needed for the active-validator screenshot.

## Scope & risk

- **Scope:** UI-only; consumes existing Worker endpoint (no schema/API contract changes).
- **Risk:** Low — non-blocking `useQuery`; zero activity uses `TableState` empty (not error); error path uses existing retry pattern.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.
      _(None — consumes existing `/api/v1/accounts/{ss58}/weight-setters` endpoint.)_

## Validation

- [x] `npm run validate`
- [x] `cd apps/ui && npm test` (includes `queries.account-weight-setters.test.ts`)
- [x] `npm run build`
