### PR TITLE
feat(registry): enrich SN83 CliqueAI — lambda OpenAPI + subnet-api surfaces

### DIFF
--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -1,0 +1,55 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "CliqueAI",
+  "netuid": 83,
+  "schema_version": 1,
+  "slug": "sn-83",
+  "source_repo": "https://github.com/toptensor/CliqueAI",
+  "status": "active",
+  "website_url": "https://cliqueai.toptensor.ai/",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-openapi",
+      "kind": "openapi",
+      "name": "CliqueAI lambda OpenAPI",
+      "notes": "Machine-readable OpenAPI 3.1 spec for the SN83 CliqueAI lambda service (observed: FastAPI title, paths including /graph/lambda and /validator/ip). The official toptensor/CliqueAI client pins LAMBDA_URL to http://lambda.toptensor.ai.",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "http://lambda.toptensor.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py"
+      ],
+      "url": "http://lambda.toptensor.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-subnet-api",
+      "kind": "subnet-api",
+      "name": "CliqueAI validator IP API",
+      "notes": "Public no-auth GET /validator/ip on lambda.toptensor.ai returning a JSON array of validator host IPs (observed: HTTP 200). Documented in the subnet's OpenAPI spec on the same host; CliqueAI/common/base/consts.py sets LAMBDA_URL to http://lambda.toptensor.ai.",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py",
+        "http://lambda.toptensor.ai/openapi.json"
+      ],
+      "url": "http://lambda.toptensor.ai/validator/ip"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #675

## Add or update a subnet surface

This PR scaffolds `registry/subnets/cliqueai.json` (new SN83 manifest) and appends **openapi** + **subnet-api** surfaces.

## Surfaces

| Kind | URL | Proof |
|------|-----|-------|
| **openapi** | `http://lambda.toptensor.ai/openapi.json` | OpenAPI 3.1 FastAPI spec (5 paths); `LAMBDA_URL` in `common/base/consts.py` |
| **subnet-api** | `http://lambda.toptensor.ai/validator/ip` | Public no-auth GET → JSON validator IP list; documented in OpenAPI |

- Netuid: 83
- Provider slug: cliqueai

## Checklist

- [x] Changes exactly one `registry/subnets/cliqueai.json` file (new `subnet:new` scaffold + two surfaces).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] URLs are public and safe for read-only probes; source URLs prove the subnet publishes them.
- [x] Public-safe: no auth-only flows, secrets, or private URLs.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links tracked issue (`Closes #675`).

## Conflict avoidance (open upstream PRs)

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3811 | `swap.json` | new `cliqueai.json` only |
| #3816 | `nova.json` | new `cliqueai.json` only |
| #3805, #3774, #3771, #3770, #3749 | UI/MCP/registry-code | no overlap |
| #3594, #3546 | release/README | no overlap |

New file only — mergeable after other open PRs land without rebase.

## Validation

- [x] `npm run validate:surface -- registry/subnets/cliqueai.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/cliqueai.json`
- [x] `npm run surface:add` dry-run: OK reachable + public-safe; OpenAPI verified (5 paths)


Made with [Cursor](https://cursor.com)