### PR TITLE
feat(registry): add SN55 NIOME backend API surfaces

### DIFF
--- a/registry/subnets/niome.json
+++ b/registry/subnets/niome.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "netuid": 55,
+  "name": "NIOME",
+  "slug": "sn-55",
+  "status": "active",
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-55-niome-miner-scores-api",
+      "kind": "subnet-api",
+      "name": "NIOME miner scores API",
+      "notes": "Public no-auth GET /api/miner_scores on niome-api.genomes.io returning paginated miner score records (observed: items with final_score, f1_score, miner_hotkey, task_id, validator_uid). Same host as MINER_SCORE_URL in the official subnet-niome constants; consumed by the NIOME leaderboard frontend (Access-Control-Allow-Origin: niome-leaderboard.genomes.io). No machine-readable OpenAPI URL found on this host yet (conventional /openapi.json paths return 404).",
+      "provider": "niome",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py",
+        "https://niome-api.genomes.io/api/miner_scores"
+      ],
+      "url": "https://niome-api.genomes.io/api/miner_scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-55-niome-tasks-catalog-api",
+      "kind": "subnet-api",
+      "name": "NIOME tasks catalog API",
+      "notes": "Public no-auth GET /api/tasks on niome-api.genomes.io returning paginated genomic task catalog JSON (observed: items with id, created_at, content.genome_context). Documented backend route in the official subnet-niome constants as TASK_URL; validators POST signed requests to the same path to allocate tasks. Distinct from the miner-scores leaderboard endpoint.",
+      "provider": "niome",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py",
+        "https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/validator/forward.py",
+        "https://niome-api.genomes.io/api/tasks"
+      ],
+      "url": "https://niome-api.genomes.io/api/tasks"
+    }
+  ],
+  "source_repo": "https://github.com/genomesio/subnet-niome",
+  "website_url": "https://niome.genomes.io/"
+}


### PR DESCRIPTION
Closes #586

## Summary
Debut `registry/subnets/niome.json` with two public **subnet-api** surfaces on the NIOME SN55 backend at `niome-api.genomes.io`.

## Surfaces
| Kind | URL | Proof |
|------|-----|-------|
| **subnet-api** | `https://niome-api.genomes.io/api/miner_scores` | Public paginated miner score leaderboard JSON |
| **subnet-api** | `https://niome-api.genomes.io/api/tasks` | Public paginated genomic task catalog JSON |

## Proof
- `BASE_URL = "https://niome-api.genomes.io"` with `MINER_SCORE_URL` and `TASK_URL` in [niome_subnet/utils/constants.py](https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py)
- Validators POST signed task requests to `TASK_URL` in [niome_subnet/validator/forward.py](https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/validator/forward.py)
- Live GET endpoints return JSON without authentication

## OpenAPI gap
`niome.genomes.io` is a static site (no machine-readable OpenAPI). `niome-api.genomes.io` serves the live backend but conventional `/openapi.json`, `/swagger.json`, and `/docs` paths all return 404. This PR documents the verified public GET APIs; an **openapi** surface can be appended when the team publishes a machine-readable schema.

## Checklist
- [x] Changes exactly one `registry/subnets/niome.json` file
- [x] `authority: community`, `review.state: community-submitted`, `submitted_by: bohdansolovie`
- [x] Provider slug **niome** (already on main)
- [x] Links tracked issue (`Closes #586`)

## Validation
- [x] `npm run validate:surface -- registry/subnets/niome.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/niome.json`


Made with [Cursor](https://cursor.com)