### PR TITLE
feat(ui): add a stake-transfers mini-chart tile to the subnet economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -1,10 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { economicsQuery, subnetStakeMovesQuery } from "@/lib/metagraphed/queries";
+import {
+  economicsQuery,
+  subnetStakeMovesQuery,
+  subnetStakeTransfersQuery,
+} from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
 // validators, volume) from the previously-unused /api/v1/economics. The artifact
@@ -66,6 +71,45 @@ function StakeMovesTile({ netuid }: { netuid: number }) {
   );
 }
 
+// #3484: recent stake-transfer activity for a subnet, 30-day window, from the
+// already-shipped subnetStakeTransfersQuery. Like the sibling stake-moves tile,
+// the endpoint returns a flat window aggregate (count / distinct senders / avg)
+// rather than a series, so it renders as a single StatTile using the MiniStack +
+// SparkLegend single-snapshot idiom. The MiniStack splits the total into unique
+// senders vs repeat transfers so the lone aggregate still reads as a composition.
+function StakeTransfersTile({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetStakeTransfersQuery(netuid));
+  const card = res?.data;
+  const m = stakeTransfersTileModel(card);
+  const value = isError ? "—" : isPending && !card ? "…" : formatNumber(m.transfers);
+  return (
+    <StatTile
+      eyebrow="Stake transfers"
+      tone="accent"
+      value={value}
+      hint={`${m.senders} sender${m.senders === 1 ? "" : "s"}`}
+      chart={
+        <SparkLegend
+          metric="Stake transfers"
+          source={`On-chain stake-transfer events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          windowLabel={card?.window ?? "30d"}
+          updatedAt={card?.observed_at ?? null}
+          staleness="Counts settle as the chain-events indexer catches up; the bar hides when no transfers occurred in the window."
+        >
+          <span className="flex w-[72px] items-center gap-1.5">
+            <span className="w-6 text-right font-mono text-[11px] tabular-nums text-ink">
+              {m.perSender != null ? `${m.perSender.toFixed(1)}×` : "—"}
+            </span>
+            <span className="max-w-[56px] flex-1">
+              <MiniStack segments={m.segments} height={6} />
+            </span>
+          </span>
+        </SparkLegend>
+      }
+    />
+  );
+}
+
 export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
@@ -107,6 +151,7 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         hint={e.registration_allowed === false ? "closed" : "open"}
       />
       <StakeMovesTile netuid={netuid} />
+      <StakeTransfersTile netuid={netuid} />
     </div>
   );
 }

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { stakeTransfersTileModel } from "./stake-transfers-tile";
+import type { SubnetStakeTransfers } from "./types";
+
+function card(p: Partial<SubnetStakeTransfers>): SubnetStakeTransfers {
+  return {
+    schema_version: 1,
+    netuid: 7,
+    window: "30d",
+    observed_at: null,
+    distinct_senders: 0,
+    transfers: 0,
+    transfers_per_sender: null,
+    ...p,
+  };
+}
+
+describe("stakeTransfersTileModel", () => {
+  it("splits transfers into unique senders + repeat transfers", () => {
+    const m = stakeTransfersTileModel(
+      card({ distinct_senders: 6, transfers: 18, transfers_per_sender: 3 }),
+    );
+    expect(m.transfers).toBe(18);
+    expect(m.senders).toBe(6);
+    expect(m.repeats).toBe(12);
+    expect(m.perSender).toBe(3);
+    expect(m.segments.map((s) => s.value)).toEqual([6, 12]);
+    expect(m.summary).toBe("6 senders, 12 repeat transfers");
+  });
+
+  it("degrades an undefined / cold card to a zeroed, empty model", () => {
+    for (const c of [undefined, card({})]) {
+      const m = stakeTransfersTileModel(c);
+      expect(m.transfers).toBe(0);
+      expect(m.senders).toBe(0);
+      expect(m.repeats).toBe(0);
+      expect(m.perSender).toBeNull();
+      expect(m.segments.every((s) => s.value === 0)).toBe(true);
+      expect(m.summary).toBe("no transfers in this window");
+    }
+  });
+
+  it("singularizes a lone sender and never yields a negative repeat count", () => {
+    const one = stakeTransfersTileModel(
+      card({ distinct_senders: 1, transfers: 1, transfers_per_sender: 1 }),
+    );
+    expect(one.repeats).toBe(0);
+    expect(one.summary).toBe("1 sender");
+
+    const junk = stakeTransfersTileModel(card({ distinct_senders: 9, transfers: 4 }));
+    expect(junk.repeats).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
+++ b/apps/ui/src/lib/metagraphed/stake-transfers-tile.ts
@@ -1,0 +1,48 @@
+import type { SubnetStakeTransfers } from "./types";
+
+export interface StakeTransfersTileModel {
+  /** Total stake-transfer events in the window. */
+  transfers: number;
+  /** Distinct senders (unique transferring hotkeys). */
+  senders: number;
+  /** Repeat transfers beyond the first per sender (transfers - senders, floored at 0). */
+  repeats: number;
+  /** Average transfers per sender, or null on a cold / junk store. */
+  perSender: number | null;
+  /** MiniStack composition: unique senders vs repeat transfers. */
+  segments: Array<{ label: string; value: number; color: string }>;
+  /** Short human summary for the SparkLegend tooltip. */
+  summary: string;
+}
+
+/**
+ * #3484: derive the economics-panel stake-transfers tile model from the flat
+ * stake-transfer window summary. `transfers` is the headline count; the MiniStack
+ * splits it into unique senders (`distinct_senders`) vs repeat transfers so a
+ * single-snapshot aggregate still reads as a composition rather than a lone
+ * number. Everything coerces defensively — a cold / undefined card degrades to a
+ * zeroed, empty-bar model, and a junk store where senders exceeds transfers can
+ * never produce a negative repeat count.
+ */
+export function stakeTransfersTileModel(
+  card: SubnetStakeTransfers | undefined,
+): StakeTransfersTileModel {
+  const transfers = Math.max(0, card?.transfers ?? 0);
+  const senders = Math.max(0, card?.distinct_senders ?? 0);
+  const repeats = Math.max(0, transfers - senders);
+  const perSender =
+    card?.transfers_per_sender != null && Number.isFinite(card.transfers_per_sender)
+      ? card.transfers_per_sender
+      : null;
+  const segments = [
+    { label: "senders", value: senders, color: "var(--accent)" },
+    { label: "repeat transfers", value: repeats, color: "var(--border)" },
+  ];
+  const summary =
+    transfers > 0
+      ? `${senders} sender${senders === 1 ? "" : "s"}${
+          repeats > 0 ? `, ${repeats} repeat transfer${repeats === 1 ? "" : "s"}` : ""
+        }`
+      : "no transfers in this window";
+  return { transfers, senders, repeats, perSender, segments, summary };
+}


### PR DESCRIPTION
Closes #3484
_Supersedes #3772 (auto-closed on the now-fixed CI) — reworked so the tile is a proper **mini-chart** per the review, and rebased onto latest main._

Wires the shipped-but-unused `subnetStakeTransfersQuery` (#3666) into the subnet **Economics** panel as a **Stake transfers** tile. Mirrors the sibling stake-moves tile (#3485) in the same panel: the endpoint returns a flat window aggregate (count / distinct senders / avg) rather than a series, so the tile renders via the **MiniStack + SparkLegend** single-snapshot idiom — the MiniStack splits the total into unique senders vs repeat transfers, with the per-sender multiplier — instead of a bare stat. No data-layer changes (the query / type / normalizer from #3666 are consumed as-is via `useQuery`).

Adds a pure `stakeTransfersTileModel()` helper (senders / repeats / perSender / segments / summary, with safe fallbacks) and a unit test (populated / cold-zero / lone-sender + junk-store).

## Screenshots (subnet 21, live api.metagraph.sh) — economics panel, constrained thumbnails

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/before-desktop-light.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/after-desktop-light.png"> |
| **Desktop · Dark** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/before-desktop-dark.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/after-desktop-dark.png"> |
| **Tablet · Light** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/before-tablet-light.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/after-tablet-light.png"> |
| **Tablet · Dark** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/before-tablet-dark.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/after-tablet-dark.png"> |
| **Mobile · Light** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/before-mobile-light.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/after-mobile-light.png"> |
| **Mobile · Dark** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/before-mobile-dark.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stake-transfers-shots-v2/after-mobile-dark.png"> |

## Verification
`tsc --noEmit`, `eslint` (0 errors), the full apps/ui `vitest` suite (433 tests incl. the new tile test), and `vite build` all pass. _(The one failing check on the superseded #3765 was an unrelated backend D1 `mcp-server` test — `get_health_trends` — this branch changes only 3 UI files and is rebased onto latest main.)_
