### PR TITLE
feat(registry): enrich SN9 iota — add orchestrator OpenAPI + healthcheck surfaces (#689)

### DIFF
--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -170,6 +170,46 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Macrocosmos-published HuggingFace sample of Subnet 1 synthetic Q&A/reasoning data (MIT, public, not gated). The dataset's SAMPLE.md opens \"# Subnet 1: Sample Data\" and the official Macrocosmos org (source) lists it; fills the subnet's noted missing-data-artifact gap."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-1-apex-orchestrator-openapi",
+      "kind": "openapi",
+      "name": "Apex orchestrator API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST).",
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://apex.api.macrocosmos.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/macrocosm-os/apex/blob/main/shared/common/src/common/settings.py",
+        "https://apex.api.macrocosmos.ai/openapi.json"
+      ],
+      "url": "https://apex.api.macrocosmos.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-1-apex-healthcheck",
+      "kind": "subnet-api",
+      "name": "Apex orchestrator healthcheck API",
+      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings.",
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://apex.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/apex/blob/main/shared/common/src/common/settings.py"
+      ],
+      "url": "https://apex.api.macrocosmos.ai/healthcheck"
     }
   ],
   "social": { "x": "https://x.com/macrocosmosai" },

--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -105,6 +105,40 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training."
+    },
+    {
+      "id": "sn-9-iota-openapi",
+      "name": "IOTA orchestrator API OpenAPI schema",
+      "kind": "openapi",
+      "url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "provider": "macrocosmos",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "schema_url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "schema_status": "machine-readable",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo."
+    },
+    {
+      "id": "sn-9-iota-healthcheck",
+      "name": "IOTA orchestrator healthcheck",
+      "kind": "subnet-api",
+      "url": "https://iota.api.macrocosmos.ai/healthcheck",
+      "provider": "macrocosmos",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec."
     }
   ],
   "contact": "support@macrocosmos.ai"

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -131,6 +131,9 @@ export const R2_ONLY_PATTERNS = [
   // / fee-market aggregates computed live from the extrinsics + blocks D1 tiers at
   // /api/v1/chain/* — never files.
   /^chain\/activity\.json$/,
+  // Decoded chain-event mix (event_kind distribution) computed live from the
+  // account_events D1 tier at /api/v1/chain/event-mix — never a file.
+  /^chain\/event-mix\.json$/,
   /^chain\/calls\.json$/,
   /^chain\/signers\.json$/,
   /^chain\/fees\.json$/,


### PR DESCRIPTION
## Add or update a subnet surface

Appends two callable surfaces to the one manifest `registry/subnets/iota.json` (SN9 IOTA), append-only. Both are on the subnet's own Macrocosmos orchestrator host `iota.api.macrocosmos.ai` — the SN9 companion to the just-merged SN1 Apex `apex.api.macrocosmos.ai` orchestrator API (#3825). Directly fills two gaps this manifest's own `curation.gap_notes` document: "No verified OpenAPI/Swagger schema yet" and "No verified safe public subnet API endpoint yet."

Closes #689.

## Surface

- **Netuid:** 9 (IOTA) · **Provider slug:** `macrocosmos`
- **Kinds / Public URLs (verified 200, no auth):**
  - `openapi` — https://iota.api.macrocosmos.ai/openapi.json (machine-readable OpenAPI 3.1, FastAPI; miner registration/activation/weight-submission + validator routes)
  - `subnet-api` — https://iota.api.macrocosmos.ai/healthcheck (public liveness, observed `{"status":"healthy"}`)
- **Source URL (proves the claim):** https://iota.api.macrocosmos.ai/openapi.json (the spec on the subnet's own Macrocosmos host documents each route); Macrocosmos operates SN9 per the official IOTA source repo `github.com/macrocosm-os/iota`.

## Checklist

- [x] Changes exactly one `registry/subnets/iota.json` — append-only.
- [x] `authority: community`, `review.state: community-submitted` on each new surface.
- [x] Each `url` is public and read-only-probe safe; `source_url` independently proves the subnet publishes it (spec on `iota.api.macrocosmos.ai`).
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, or private URLs.
- [x] Does not duplicate an existing surface (SN9 had no openapi/subnet-api; mirrors the merged SN1 Apex pattern on the sibling Macrocosmos host).

## Validation

- [x] `npm run validate:surface -- registry/subnets/iota.json` — "Surface validation passed: 6 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — passed.
