### PR TITLE
feat(registry): add SN12 Compute Horde subnet-api surface (#726)

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -113,6 +113,25 @@
         "submitted_by": "devmixa702"
       },
       "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository."
+    },
+    {
+      "id": "sn-12-compute-horde-subnet-api",
+      "name": "Compute Horde subnet-api",
+      "kind": "subnet-api",
+      "url": "https://facilitator.computehorde.io/auth/nonce",
+      "provider": "compute-horde",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py",
+        "https://sdk.computehorde.io/"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/compute-horde.json` (no other file, no reformatting of unrelated content).

## Surface

- Netuid: 12
- Kind: subnet-api
- Public URL: https://facilitator.computehorde.io/auth/nonce
- Source URL (proves the claim): https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py (defines `DEFAULT_FACILITATOR_URL = "https://facilitator.computehorde.io/"` in ComputeHorde's own official SDK, the source repo already registered for SN12), plus https://sdk.computehorde.io/ (the project's official SDK reference docs, linked from the SDK README)
- Provider slug: compute-horde (already registered)

SN12 Compute Horde's Facilitator API (the base URL used by default in the official `compute_horde_sdk` Python client) has no public root page, so this surface points at `/auth/nonce`, the API's live no-auth endpoint (returns `200` with a JSON nonce payload). The authenticated job endpoints (`/api/v1/jobs/`) sit behind bittensor-hotkey-signed auth obtained via this nonce + `/auth/login`, confirmed live (`401 Authentication credentials were not provided`).

Closes #726

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (pure 19-line insertion, no unrelated reformatting).
- [x] Generated to match the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove the subnet's own team publishes/operates this API.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (SN12 had no `subnet-api` surface before this PR).
- [x] Links a tracked issue (`Closes #726`).

## Gate Expectations

Public-safe surface, minimal single-surface append.

## Validation

- [x] `npm run validate:surface -- registry/subnets/compute-horde.json` — passed (5 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed