### PR TITLE
feat(registry): enrich SN9 iota — add orchestrator OpenAPI + healthcheck surfaces (#689)

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -105,6 +105,40 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training."
+    },
+    {
+      "id": "sn-9-iota-openapi",
+      "name": "IOTA orchestrator API OpenAPI schema",
+      "kind": "openapi",
+      "url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "provider": "macrocosmos",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "schema_url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "schema_status": "machine-readable",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo."
+    },
+    {
+      "id": "sn-9-iota-healthcheck",
+      "name": "IOTA orchestrator healthcheck",
+      "kind": "subnet-api",
+      "url": "https://iota.api.macrocosmos.ai/healthcheck",
+      "provider": "macrocosmos",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec."
     }
   ],
   "contact": "support@macrocosmos.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Appends two callable surfaces to the one manifest `registry/subnets/iota.json` (SN9 IOTA), append-only. Both are on the subnet's own Macrocosmos orchestrator host `iota.api.macrocosmos.ai` — the SN9 companion to the just-merged SN1 Apex `apex.api.macrocosmos.ai` orchestrator API (#3825). Directly fills two gaps this manifest's own `curation.gap_notes` document: "No verified OpenAPI/Swagger schema yet" and "No verified safe public subnet API endpoint yet."

Closes #689.

## Surface

- **Netuid:** 9 (IOTA) · **Provider slug:** `macrocosmos`
- **Kinds / Public URLs (verified 200, no auth):**
  - `openapi` — https://iota.api.macrocosmos.ai/openapi.json (machine-readable OpenAPI 3.1, FastAPI; miner registration/activation/weight-submission + validator routes)
  - `subnet-api` — https://iota.api.macrocosmos.ai/healthcheck (public liveness, observed `{"status":"healthy"}`)
- **Source URL (proves the claim):** https://iota.api.macrocosmos.ai/openapi.json (the spec on the subnet's own Macrocosmos host documents each route); Macrocosmos operates SN9 per the official IOTA source repo `github.com/macrocosm-os/iota`.

## Checklist

- [x] Changes exactly one `registry/subnets/iota.json` — append-only.
- [x] `authority: community`, `review.state: community-submitted` on each new surface.
- [x] Each `url` is public and read-only-probe safe; `source_url` independently proves the subnet publishes it (spec on `iota.api.macrocosmos.ai`).
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, or private URLs.
- [x] Does not duplicate an existing surface (SN9 had no openapi/subnet-api; mirrors the merged SN1 Apex pattern on the sibling Macrocosmos host).

## Validation

- [x] `npm run validate:surface -- registry/subnets/iota.json` — "Surface validation passed: 6 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — passed.
