### PR TITLE
feat(registry): enrich SN99 Leoma — add API OpenAPI + public miner-registry surfaces (#587)

### DIFF
--- a/registry/subnets/leoma.json
+++ b/registry/subnets/leoma.json
@@ -34,6 +34,46 @@
         "https://api.leoma.ai/openapi.json"
       ],
       "url": "https://api.leoma.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-openapi",
+      "kind": "openapi",
+      "name": "Leoma API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI schema (title: Leoma API) for the SN99 Leoma validator API on the project's own api.leoma.ai host; documents the public /health liveness route and the /miners/* miner-registry routes. Served from the official RendixNetwork/leoma API.",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.leoma.ai/openapi.json",
+      "source_urls": [
+        "https://api.leoma.ai/openapi.json",
+        "https://github.com/RendixNetwork/leoma"
+      ],
+      "url": "https://api.leoma.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-miners-list",
+      "kind": "subnet-api",
+      "name": "Leoma miner registry",
+      "notes": "Public no-auth GET /miners/list on api.leoma.ai returning the SN99 miner registry (uid, hotkey, ...) as JSON. Documented as GET /miners/list in the subnet OpenAPI spec; the higher-detail /miners/all and /miners/valid require a validator-hotkey header and are intentionally not promoted.",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "source_urls": [
+        "https://api.leoma.ai/openapi.json",
+        "https://github.com/RendixNetwork/leoma"
+      ],
+      "url": "https://api.leoma.ai/miners/list"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends two callable surfaces to the one manifest `registry/subnets/leoma.json` (SN99 Leoma), append-only. Both are on the subnet's own host `api.leoma.ai` (already the host of the registered `/health` surface). Adds the machine-readable OpenAPI schema (the issue's core ask) plus a public miner-registry data endpoint.

Closes #587.

## Surface

- **Netuid:** 99 (Leoma) · **Provider slug:** `leoma`
- **Kinds / Public URLs (verified 200, no auth):**
  - `openapi` — https://api.leoma.ai/openapi.json (machine-readable OpenAPI, title "Leoma API"; documents /health + the /miners/* routes)
  - `subnet-api` — https://api.leoma.ai/miners/list (public miner registry JSON: uid, hotkey, …)
- **Source URL (proves the claim):** https://api.leoma.ai/openapi.json (spec on the subnet's own host documents each route) + the official source repo https://github.com/RendixNetwork/leoma.
- Note: `/miners/all` and `/miners/valid` require a validator-hotkey header (422 without it) and are deliberately **not** promoted — only the no-auth `/miners/list` and `/openapi.json` are registered.

## Checklist

- [x] Changes exactly one `registry/subnets/leoma.json` — append-only.
- [x] `authority: community`, `review.state: community-submitted` on each new surface.
- [x] Each `url` is public and read-only-probe safe; `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, or private URLs.
- [x] Does not duplicate an existing surface (only `/health` was registered; adds `openapi` + `/miners/list`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/leoma.json` — "Surface validation passed: 3 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — passed.
