### PR TITLE
feat(registry): add SN56 Gradients latest-tournament-details subnet-api surface

### DIFF
--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -274,6 +274,25 @@
         "https://www.gradients.io/"
       ],
       "url": "https://api.gradients.io/tournament/fees"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-latest-tournament-details",
+      "kind": "subnet-api",
+      "name": "Gradients latest tournament details",
+      "notes": "Public no-auth GET returning the most recently completed text/image/environment tournament results (winner hotkey, participants, final standings). Documented in the subnet's own OpenAPI (api.gradients.io/openapi.json, path /tournament/latest/details); same host as the existing performance, network-status, healthz, and tournament-fees subnet-api surfaces.",
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://api.gradients.io/openapi.json",
+        "https://www.gradients.io/"
+      ],
+      "url": "https://api.gradients.io/tournament/latest/details"
     }
   ],
   "website_url": "https://www.gradients.io/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/gradients.json` (no other file, pure append matching the file's existing key order/format).

## Surface

- Netuid: 56
- Kind: subnet-api
- Public URL: https://api.gradients.io/tournament/latest/details
- Source URL (proves the claim): https://api.gradients.io/openapi.json (the subnet's own machine-readable OpenAPI schema — `GET /tournament/latest/details`, operationId `get_latest_tournaments_details_tournament_latest_details_get`, no `security` requirement), plus https://www.gradients.io/ (official site linking the `api.gradients.io` host, already the registered `source_repo`/website provider for SN56)
- Provider slug: gradients (already registered)

This is a read-only, no-auth GET returning the most recently completed text/image/environment tournament results (winner hotkey, participant standings). It's on the same host (`api.gradients.io`) and documented in the same OpenAPI spec as the four `subnet-api` surfaces already merged for this subnet (`network-status`, `healthz`, `tournament-fees`, `latest-tournament-weights`), so it follows an established, previously-accepted pattern for this file.

No open issue specifically tracks this addition (the only open SN56 issue, #1274, is about an SSE stream — a different surface), so this is submitted on its own merit per the contribution guide.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Generated to match the existing file's format — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove the subnet's own team publishes/operates this API.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (checked all existing SN56 `subnet-api` entries — this path is not registered).

## Gate Expectations

Public-safe surface, minimal single-surface append, consistent with sibling surfaces already merged on this same file/host.

## Validation

- [x] `npm run validate:surface -- registry/subnets/gradients.json` — passed (13 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed