### PR TITLE
feat(ui): add registration/deregistration counters to the subnet masthead

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -27,7 +27,9 @@ import {
 } from "@/components/metagraphed/charts/stat-with-spark";
 import {
   subnetEndpointsQuery,
+  subnetDeregistrationsQuery,
   subnetHealthPercentilesQuery,
+  subnetRegistrationsQuery,
   subnetTrajectoryQuery,
   subnetUptimeQuery,
 } from "@/lib/metagraphed/queries";
@@ -168,6 +170,10 @@ export function SubnetMasthead({
   const { data: uptimeRes } = useQuery(subnetUptimeQuery(netuid));
   const { data: endpointsRes } = useQuery(subnetEndpointsQuery(netuid));
   const { data: pctRes } = useQuery(subnetHealthPercentilesQuery(netuid));
+  const { data: regRes } = useQuery(subnetRegistrationsQuery(netuid));
+  const { data: deregRes } = useQuery(subnetDeregistrationsQuery(netuid));
+  const reg = regRes?.data;
+  const dereg = deregRes?.data;
 
   // Subnet-wide daily uptime % + median latency, meaned across tracked surfaces.
   const trendWindowKey = uptimeRes?.data?.window ?? "90d";
@@ -407,6 +413,22 @@ export function SubnetMasthead({
           hint="Native chain id"
           full="Native Bittensor metagraph identifier"
           updatedAt={generatedAt}
+        />
+        <StatWithSpark
+          label="Registrations"
+          value={formatNumber(reg?.registrations)}
+          hint={`${formatNumber(reg?.distinct_registrants ?? 0)} registrants`}
+          full="Neuron-registration events on this subnet over the trailing 30-day window."
+          updatedAt={reg?.observed_at ?? null}
+          windowLabel={reg?.window ?? "30d"}
+        />
+        <StatWithSpark
+          label="Deregistrations"
+          value={formatNumber(dereg?.deregistrations)}
+          hint={`${formatNumber(dereg?.distinct_deregistered_hotkeys ?? 0)} hotkeys`}
+          full="Neuron-deregistration (eviction) events on this subnet over the trailing 30-day window."
+          updatedAt={dereg?.observed_at ?? null}
+          windowLabel={dereg?.window ?? "30d"}
         />
         <StatWithSpark
           label="Participants"


### PR DESCRIPTION
Closes #3483

Wires the shipped-but-unused `subnetRegistrationsQuery` + `subnetDeregistrationsQuery` (#3682) into `SubnetMasthead` as two event-volume counters in the stat spine, alongside the existing Netuid / Participants / Endpoints tiles. Each shows the trailing-30d event count with the distinct-actor count in the hint (registrants / hotkeys). No data-layer changes — the queries / types from #3682 are consumed as-is via `useQuery`, matching the masthead's existing `StatWithSpark` convention (loading → `formatNumber`'s no-data state; a cold subnet degrades to `0`).

## Screenshots (subnet 4, live api.metagraph.sh)

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/before-desktop-light.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/after-desktop-light.png"> |
| **Desktop · Dark** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/before-desktop-dark.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/after-desktop-dark.png"> |
| **Tablet · Light** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/before-tablet-light.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/after-tablet-light.png"> |
| **Tablet · Dark** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/before-tablet-dark.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/after-tablet-dark.png"> |
| **Mobile · Light** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/before-mobile-light.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/after-mobile-light.png"> |
| **Mobile · Dark** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/before-mobile-dark.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/masthead-reg-dereg-shots/after-mobile-dark.png"> |

## Verification
`tsc --noEmit`, `eslint` (0 errors), and `vite build` all pass; rendered against live api.metagraph.sh (SN4: 12 registrations / 12 registrants, 0 deregistrations in the 30d window).
