### PR TITLE
feat(ui): add ss58 format guidance to the invalid-address empty state

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -108,9 +108,15 @@ function AccountDetail({ ss58 }: { ss58: string }) {
         />
         <EmptyState
           title="Invalid account address"
-          description="Use a valid hotkey or coldkey ss58 address."
+          description="Bittensor addresses start with 5, are 46–49 characters long, and use the base58 alphabet (digits and letters excluding 0, O, I, and l). This value doesn't match — check for a truncated or wrong-chain address."
           action={{ label: "Back to accounts", href: "/accounts" }}
         />
+        <div className="mt-3 flex flex-col items-center gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            Example of a valid address
+          </span>
+          <CopyableCode value="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" truncate={false} />
+        </div>
       </>
     );
   }


### PR DESCRIPTION
## Summary

The `/accounts/<ss58>` invalid-address empty state (in `apps/ui/src/routes/accounts.$ss58.tsx`) only told the visitor to "Use a valid hotkey or coldkey ss58 address" — no hint of what a *valid* address actually looks like. This enriches it with concrete, plain-language format guidance so a mistyped or wrong-chain address in the URL becomes self-correcting.

## Changes

- Rewrites the invalid-branch `EmptyState` description to state the facts already encoded in the `SS58` regex (`apps/ui/src/lib/metagraphed/accounts.ts`): valid addresses **start with 5**, are **46–49 characters**, and use the **base58 alphabet** (excluding `0 O I l`).
- Adds a concrete, copyable **example address** (`5Grwva…KutQY`, the same one already used as the lookup-form placeholder) via the existing `CopyableCode` component.
- Copy/UI only — **no change** to `isValidSs58`, `ss58PathSegment`, or the `SS58` regex. The "Back to accounts" recovery link is preserved. One file changed.

## Screenshots

| Route | Before | After |
| --- | --- | --- |
| `/accounts/<invalid>` | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3400-assets/accounts-invalid-before.png" width="320">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3400-assets/accounts-invalid-before.png)<br><sub>before: generic message, no guidance</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3400-assets/accounts-invalid-after.png" width="320">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3400-assets/accounts-invalid-after.png)<br><sub>after: format facts + copyable example</sub> |

## Testing

Full `ui` gate locally, all green:

- `lint` — 0 errors
- `format:check` — clean
- `typecheck` — clean
- `test` — 461 passed
- `build` — success

Verified live in the dev server at `/accounts/<invalid>` (screenshots above are real renders of the running app).

Closes #3400
