### PR TITLE
feat(registry): enrich SN88 Investing — PnL subnet-api surface

### DIFF
--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -154,6 +154,31 @@
         "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
       ],
       "url": "https://api.investing88.ai/days"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-investing-pnl-api",
+      "kind": "subnet-api",
+      "name": "Investing PnL API",
+      "notes": "Public no-auth GET /pnl on api.investing88.ai returning JSON miner profit-and-loss records (observed: HTTP 200 JSON array). The official Investing/core/api.py pnl() client fetches this endpoint via API_ROOT; const.py pins API_ROOT to api.investing88.ai.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/api.py",
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
+      ],
+      "url": "https://api.investing88.ai/pnl"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/investing.json` for the SN88 Investing public PnL JSON endpoint.

## Surface

| Field | Value |
|-------|-------|
| Netuid | **88** (Investing) |
| Kind | **subnet-api** |
| URL | `https://api.investing88.ai/pnl` |
| Provider | `mobiusfund` |

Public no-auth GET `/pnl` on `api.investing88.ai` returning JSON miner profit-and-loss records (observed: HTTP 200 JSON array). The official `Investing/core/api.py` `pnl()` client fetches this endpoint via `API_ROOT`; `Investing/core/const.py` pins `API_ROOT` to `api.investing88.ai`.

## Issue linkage

No open SN88 enrich issue currently tracks this addition (`#708` was closed by the merged `/days` subnet-api PR #3814). This follows the contribution guide for surfaces submitted on their own merit when no tracked issue exists (same approach as #3835).

## Checklist

- [x] Changes exactly one `registry/subnets/investing.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`, `submitted_by: jimcody1995`
- [x] Includes `probe` block matching sibling Investing API surfaces
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] Does not duplicate existing surfaces (`/days`, `/ratio`, `/assets` are distinct paths)

## Validation

- [x] `npm run validate:surface -- registry/subnets/investing.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --write registry/subnets/investing.json`

## Conflict avoidance

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3811 | `swap.json`, `taofi.json` | `investing.json` |
| #3831 | `compute-horde.json` | `investing.json` |
| #3832 | `iota.json` | `investing.json` |
| #3833 | `leoma.json` | `investing.json` |
| #3835 | `gradients.json` | `investing.json` |

Merge-simulated clean against all open registry PR branches.


Made with [Cursor](https://cursor.com)