### PR TITLE
feat(registry): enrich SN55 NIOME — tasks subnet-api surface (#586)

### DIFF
--- a/registry/subnets/niome.json
+++ b/registry/subnets/niome.json
@@ -1,0 +1,40 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "NIOME",
+  "netuid": 55,
+  "schema_version": 1,
+  "slug": "sn-55",
+  "source_repo": "https://github.com/genomesio/subnet-niome",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-55-niome-tasks-api",
+      "kind": "subnet-api",
+      "name": "NIOME tasks API",
+      "notes": "Public no-auth GET /api/tasks on niome-api.genomes.io returning JSON task listings (observed: HTTP 200 with items containing genome_context and input fields). The official genomesio/subnet-niome validator constants set BASE_URL to this host and TASK_URL to /api/tasks.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "niome",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py"
+      ],
+      "url": "https://niome-api.genomes.io/api/tasks"
+    }
+  ],
+  "website_url": "https://niome.genomes.io/"
+}


### PR DESCRIPTION
Closes #586

## Add or update a subnet surface

This PR creates `registry/subnets/niome.json` (SN55 NIOME had no manifest on main) via `subnet:new` and appends one `subnet-api` surface for the public tasks listing endpoint.

## Surface

- **Netuid:** 55 (NIOME) · **Provider slug:** `niome`
- **Kind:** `subnet-api`
- **Public URL:** https://niome-api.genomes.io/api/tasks (verified HTTP 200 JSON, no auth)
- **Source URL (proves the claim):** https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py (`BASE_URL` + `TASK_URL`)

## Checklist

- [x] Changes exactly one `registry/subnets/niome.json` file (`subnet:new` scaffold + one appended surface).
- [x] Generated with `npm run subnet:new` + `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public HTTPS and safe for read-only probes; `source_url` proves the subnet team publishes it.
- [x] Public-safe: no auth-only flows, secrets, or validator internals.
- [x] Does not duplicate an existing Metagraphed surface (new manifest; `niome-api.genomes.io` not in registry).
- [x] Links tracked issue (`Closes #586`).

## Conflict avoidance (open upstream PRs)

| Open PR | Touches | This PR |
|---------|---------|---------|
| #3835 | `gradients.json` | `niome.json` only — no overlap |
| #3833 | `leoma.json` | no overlap |
| #3832 | `iota.json` | no overlap |
| #3831 | `compute-horde.json` | no overlap |
| #3811 | `swap.json` + `taofi.json` | no overlap |

New file `niome.json` only; mergeable after other open registry PRs land without rebase.

## Gate Expectations

Public-safe surface; eligible for automated review after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/niome.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/niome.json`
- [x] `npm run surface:add` dry-run: OK reachable + public-safe

Made with [Cursor](https://cursor.com)