### PR TITLE
feat(ui): add raw chain-events browser to explorer page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-events.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-events.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult, QueryParams } from "./client";
+import { apiFetch } from "./client";
+import { chainEventsInfiniteQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain-events",
+  });
+}
+
+async function runPage(params: QueryParams = {}, pageParam = "") {
+  const opts = chainEventsInfiniteQuery(params, pageParam);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    pageParam,
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("chainEventsInfiniteQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches the all-events feed with pallet/method filters and limit", async () => {
+    resolveWith({ count: 0, events: [], next_cursor: null });
+    await runPage({ pallet: "Balances", method: "Transfer", limit: 25 });
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain-events", {
+      params: { pallet: "Balances", method: "Transfer", limit: 25 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("passes cursor pagination on subsequent pages", async () => {
+    resolveWith({ count: 1, events: [], next_cursor: "100.5" });
+    await runPage({ limit: 50 }, "200.3");
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain-events", {
+      params: { limit: 50, cursor: "200.3" },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("normalizes events and reads next_cursor from the data payload", async () => {
+    resolveWith({
+      count: 1,
+      next_cursor: "100.0",
+      events: [
+        {
+          block_number: "101",
+          event_index: "2",
+          pallet: "System",
+          method: "ExtrinsicSuccess",
+          observed_at: "1783313892001",
+        },
+      ],
+    });
+    const page = await runPage();
+    expect(page.data).toHaveLength(1);
+    expect(page.data[0]).toMatchObject({
+      block_number: 101,
+      event_index: 2,
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+      observed_at: new Date(1783313892001).toISOString(),
+    });
+    expect(page.meta?._next_cursor).toBe("100.0");
+  });
+
+  it("degrades a cold / junk store to a schema-stable empty page", async () => {
+    for (const raw of [{}, null, "x", { events: "nope" }]) {
+      resolveWith(raw);
+      const page = await runPage();
+      expect(page.data).toEqual([]);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -64,6 +64,7 @@ import type {
   BlockEvents,
   BlockChainEvents,
   ChainEvent,
+  ChainEventsFeed,
   Coverage,
   BlockExtrinsics,
   CurationLevel,
@@ -1575,6 +1576,24 @@ function normalizeBlockChainEvents(raw: unknown): BlockChainEvents {
     count: coerceFiniteNumber(d.count) ?? rows.length,
     events: rows,
   } satisfies BlockChainEvents;
+}
+
+function normalizeChainEventsFeed(raw: unknown): ChainEventsFeed {
+  const d = isRecord(raw) ? raw : {};
+  const rows = Array.isArray(d.events)
+    ? d.events.flatMap((x) => {
+        const normalized = normalizeChainEvent(x, null);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  const nextCursor = firstString(d.next_cursor);
+  return {
+    ...(d as object),
+    count: coerceFiniteNumber(d.count) ?? rows.length,
+    next_cursor: nextCursor ?? null,
+    next_before: coerceFiniteNumber(d.next_before) ?? null,
+    events: rows,
+  } satisfies ChainEventsFeed;
 }
 
 /** Recent blocks feed — newest first, offset-paginated (limit ≤ 100). */
@@ -4365,6 +4384,49 @@ export function getNextPageParam(last: { meta?: Record<string, unknown> }): stri
   const nc = last.meta?._next_cursor as string | null | undefined;
   return nc ?? undefined;
 }
+
+function validateFeedNextCursor(
+  nextCursor: string | null | undefined,
+  sentCursor: string | undefined,
+): { cursor: string | null; invalid?: boolean } {
+  if (nextCursor === undefined || nextCursor === null) return { cursor: null };
+  const trimmed = nextCursor.trim();
+  if (!trimmed) return { cursor: null };
+  if (sentCursor && trimmed === sentCursor) {
+    if (import.meta.env?.DEV)
+      console.warn("[metagraphed] next_cursor echoes sent cursor; stopping pagination");
+    return { cursor: null, invalid: true };
+  }
+  return { cursor: trimmed };
+}
+
+async function fetchChainEventsInfinitePage(
+  baseParams: QueryParams,
+  pageParam: string,
+  signal?: AbortSignal,
+): Promise<InfinitePage<ChainEvent>> {
+  const params: QueryParams = { ...baseParams, limit: baseParams.limit ?? 50 };
+  if (pageParam) params.cursor = pageParam;
+  const res = await apiFetch<unknown>("/api/v1/chain-events", { params, signal });
+  const feed = normalizeChainEventsFeed(res.data);
+  const v = validateFeedNextCursor(feed.next_cursor, pageParam || undefined);
+  const meta = { ...(res.meta ?? {}), _next_cursor: v.cursor };
+  return { data: feed.events, meta, url: res.url, cursorInvalid: v.invalid };
+}
+
+/** Cursor-paginated all-events feed — newest block/event first. */
+export const chainEventsInfiniteQuery = (baseParams: QueryParams = {}, initialCursor = "") =>
+  infiniteQueryOptions({
+    queryKey: k("chain-events-infinite", baseParams, initialCursor),
+    initialPageParam: initialCursor,
+    queryFn: async ({ pageParam, signal }) =>
+      fetchChainEventsInfinitePage(baseParams, pageParam as string, signal),
+    getNextPageParam,
+    staleTime: STALE_SHORT,
+  });
+
+/** Alias for {@link chainEventsInfiniteQuery} — raw /api/v1/chain-events paginator. */
+export const chainEventsQuery = chainEventsInfiniteQuery;
 
 /** Server-driven cursor-paginated subnets. */
 export const subnetsInfiniteQuery = (baseParams: QueryParams = {}, initialCursor = "") =>

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -839,6 +839,15 @@ export interface BlockChainEvents {
   [key: string]: unknown;
 }
 
+/** Paginated all-events feed from /api/v1/chain-events (Postgres tier). */
+export interface ChainEventsFeed {
+  count: number;
+  events: ChainEvent[];
+  next_cursor?: string | null;
+  next_before?: number | null;
+  [key: string]: unknown;
+}
+
 export interface ExtrinsicCallArg {
   name?: string | null;
   value?: unknown;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1,30 +1,38 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useState } from "react";
+import { useInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useMemo, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Activity, Boxes, Coins, Layers, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { Skeleton } from "@/components/metagraphed/states";
+import { ErrorState, Skeleton } from "@/components/metagraphed/states";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
+import { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
+import { SearchInput } from "@/components/metagraphed/table-controls";
+import { TimeAgo } from "@/components/metagraphed/time-ago";
 import {
   chainActivityQuery,
   chainCallsQuery,
+  chainEventsInfiniteQuery,
   chainFeesQuery,
   chainSignersQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import type { ChainCalls } from "@/lib/metagraphed/types";
+import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
+import type { ChainCalls, ChainEvent } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  pallet: fallback(z.string(), "").default(""),
+  method: fallback(z.string(), "").default(""),
+  events_cursor: fallback(z.string(), "").default(""),
 });
 
 export const Route = createFileRoute("/explorer")({
@@ -74,12 +82,14 @@ function ExplorerPage() {
           <ExplorerDashboard />
         </Suspense>
       </QueryErrorBoundary>
+      <ChainEventsFeedSection />
       <ApiSourceFooter
         paths={[
           "/api/v1/chain/activity",
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
+          "/api/v1/chain-events",
         ]}
       />
     </AppShell>
@@ -516,5 +526,182 @@ function ExplorerDashboard() {
         </section>
       </div>
     </div>
+  );
+}
+
+function ChainEventsFeedSection() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const baseParams = useMemo(
+    () => ({
+      pallet: search.pallet.trim() || undefined,
+      method: search.pallet.trim() && search.method.trim() ? search.method.trim() : undefined,
+      limit: 50,
+    }),
+    [search.pallet, search.method],
+  );
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    error,
+    isPending,
+    isFetching,
+    refetch,
+  } = useInfiniteQuery(chainEventsInfiniteQuery(baseParams, search.events_cursor));
+
+  const setSearch = (patch: Record<string, unknown>) =>
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({ ...prev, ...patch, events_cursor: "" }) as never,
+      resetScroll: false,
+    });
+
+  const pages = data?.pages ?? [];
+  const lastPage = pages[pages.length - 1];
+  const cursorInvalid = !!(lastPage as { cursorInvalid?: boolean } | undefined)?.cursorInvalid;
+  const events = pages.flatMap((p) => (p.data ?? []) as ChainEvent[]);
+  const filtersActive = !!(search.pallet.trim() || search.method.trim());
+
+  const filters = (
+    <>
+      <SearchInput
+        value={search.pallet}
+        onChange={(v) => setSearch({ pallet: v, method: v.trim() ? search.method : "" })}
+        placeholder="Filter by pallet"
+        className="min-w-[140px] flex-none font-mono text-[11px]"
+      />
+      <SearchInput
+        value={search.method}
+        onChange={(v) => setSearch({ method: v })}
+        placeholder={search.pallet.trim() ? "Filter by method" : "Method (requires pallet)"}
+        className="min-w-[140px] flex-none font-mono text-[11px]"
+      />
+    </>
+  );
+
+  const emptyNode = (
+    <p className="font-mono text-[12px] text-ink-muted">
+      {filtersActive
+        ? "No chain events match these filters."
+        : "No chain events indexed yet — the all-events backfill fills this feed."}
+    </p>
+  );
+
+  const table = (
+    <table className="w-full text-left text-sm">
+      <thead className="bg-surface/40">
+        <tr>
+          <th className={TH}>Pallet.method</th>
+          <th className={TH}>Block</th>
+          <th className={`${TH} text-right`}>Observed</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border">
+        {events.map((event) => (
+          <tr
+            key={`${event.block_number}-${event.event_index}`}
+            className="hover:bg-surface/40"
+          >
+            <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+              {extrinsicCall(event.pallet, event.method)}
+            </td>
+            <td className="px-4 py-2.5 font-mono text-[11px]">
+              {event.block_number != null ? (
+                <Link
+                  to="/blocks/$ref"
+                  params={{ ref: String(event.block_number) }}
+                  className="text-ink-strong hover:text-accent hover:underline"
+                >
+                  #{formatNumber(event.block_number)}
+                </Link>
+              ) : (
+                "—"
+              )}
+            </td>
+            <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+              <TimeAgo at={event.observed_at} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  const cards = events.map((event) => (
+    <div
+      key={`${event.block_number}-${event.event_index}-card`}
+      className="rounded border border-border bg-card p-3 min-h-11"
+    >
+      <div className="font-mono text-[11px] text-ink-strong">
+        {extrinsicCall(event.pallet, event.method)}
+      </div>
+      <div className="mt-1 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-muted">
+        {event.block_number != null ? (
+          <Link
+            to="/blocks/$ref"
+            params={{ ref: String(event.block_number) }}
+            className="hover:text-accent hover:underline"
+          >
+            #{formatNumber(event.block_number)}
+          </Link>
+        ) : (
+          <span>—</span>
+        )}
+        <TimeAgo at={event.observed_at} />
+      </div>
+    </div>
+  ));
+
+  return (
+    <section className="mt-10 rounded-lg border border-border bg-card p-5">
+      <div className="mb-4">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Chain events
+        </h2>
+        <p className="mt-1 font-mono text-[11px] text-ink-muted">
+          Browse individual pallet events newest-first — distinct from aggregate activity stats.
+        </p>
+      </div>
+
+      {isPending ? (
+        <Skeleton className="h-56 w-full" />
+      ) : error && !data ? (
+        <ErrorState
+          error={error}
+          context="chain events feed"
+          onRetry={() => {
+            void refetch();
+          }}
+        />
+      ) : (
+        <ListShell
+          filters={filters}
+          table={table}
+          cards={cards}
+          isEmpty={events.length === 0 && !isFetching}
+          empty={emptyNode}
+          isStale={isFetching && !isPending && !isFetchingNextPage}
+          footer={
+            events.length > 0 ? (
+              <LoadMore
+                hasMore={!!hasNextPage}
+                isLoading={isFetchingNextPage}
+                onLoadMore={() => {
+                  void fetchNextPage();
+                }}
+                shown={events.length}
+                error={isFetchNextPageError ? error : null}
+                cursorInvalid={cursorInvalid}
+              />
+            ) : undefined
+          }
+        />
+      )}
+    </section>
   );
 }

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -603,10 +603,7 @@ function ChainEventsFeedSection() {
       </thead>
       <tbody className="divide-y divide-border">
         {events.map((event) => (
-          <tr
-            key={`${event.block_number}-${event.event_index}`}
-            className="hover:bg-surface/40"
-          >
+          <tr key={`${event.block_number}-${event.event_index}`} className="hover:bg-surface/40">
             <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
               {extrinsicCall(event.pallet, event.method)}
             </td>


### PR DESCRIPTION
Closes #3735

## Summary

Adds a raw pallet-event browser to the chain explorer page, wired to `GET /api/v1/chain-events`. This is the paginated individual-event feed.

- `chainEventsInfiniteQuery` / `chainEventsQuery` in `queries.ts` with cursor/limit + pallet/method filters
- `ChainEventsFeedSection` on `/explorer` using `ListShell` + `LoadMore` infinite scroll
- Unit tests for feed normalization and pagination

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-light-before.png)<br><sub>before — no chain-events section</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-light-after.png)<br><sub>after — paginated event table + filters</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-chain-events-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] Open `/explorer` — dashboard loads; chain events section appears below
- [x] Table shows pallet.method, block link, observed timestamp
- [ ] Load more fetches next page via cursor
- [ ] Pallet/method filters narrow results; clearing filters resets list
- [ ] Empty state when no events; error state when data tier unavailable (503)
- [x] Light + dark mode on desktop/tablet/mobile (see screenshot table)

