### PR TITLE
fix(api): bound account weight-setter lookups

### DIFF
--- a/migrations/0035_account_events_uid_weight_setters_index.sql
+++ b/migrations/0035_account_events_uid_weight_setters_index.sql
@@ -1,0 +1,6 @@
+-- Account weight-setter lookups can recover hotkey-less WeightsSet events by
+-- resolving the account's current (netuid, uid) rows through neurons. Keep that
+-- fallback account-bounded instead of scanning the public 7d/30d network-wide
+-- WeightsSet window for each requested account.
+CREATE INDEX IF NOT EXISTS idx_account_events_netuid_uid_kind_observed
+  ON account_events (netuid, uid, event_kind, observed_at);

--- a/src/account-weight-setters.mjs
+++ b/src/account-weight-setters.mjs
@@ -120,9 +120,11 @@ export function buildAccountWeightSetters(rows, address, { window } = {}) {
 // window (observed_at >= now - windowDays, epoch ms), grouped per subnet, shaped with
 // buildAccountWeightSetters. WeightsSet ingestion can omit hotkey and store only (netuid, uid),
 // so fall back through the latest neurons snapshot for those hotkey-less rows instead of silently
-// dropping the validator's activity. Returns { data, generatedAt } where generatedAt is the newest
-// weight-set's observed_at as an ISO string (string|null per the envelope contract). Cold/absent
-// D1 -> zeroed card + null.
+// dropping the validator's activity. Keep the direct hotkey branch pinned to the hotkey index and
+// the uid fallback pinned to (netuid, uid, event_kind, observed_at); a single OR across account_events
+// and neurons makes SQLite scan the whole recent WeightsSet window for each public account lookup.
+// Returns { data, generatedAt } where generatedAt is the newest weight-set's observed_at as an ISO
+// string (string|null per the envelope contract). Cold/absent D1 -> zeroed card + null.
 export async function loadAccountWeightSetters(
   d1,
   address,
@@ -133,14 +135,20 @@ export async function loadAccountWeightSetters(
     ACCOUNT_WEIGHT_SETTERS_WINDOWS[DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW];
   const cutoff = Date.now() - days * DAY_MS;
   const rows = await d1(
-    "SELECT e.netuid, COUNT(*) AS weight_sets, MIN(e.observed_at) AS first_observed, " +
-      "MAX(e.observed_at) AS last_observed " +
-      "FROM account_events e " +
-      "LEFT JOIN neurons n ON e.netuid = n.netuid AND e.uid = n.uid " +
-      "AND (e.hotkey IS NULL OR e.hotkey = '') " +
-      "WHERE e.event_kind = ? AND e.observed_at >= ? " +
-      "AND (e.hotkey = ? OR n.hotkey = ?) GROUP BY e.netuid",
-    [WEIGHTS_EVENT_KIND, cutoff, address, address],
+    "SELECT netuid, COUNT(*) AS weight_sets, MIN(observed_at) AS first_observed, " +
+      "MAX(observed_at) AS last_observed FROM (" +
+      "SELECT netuid, observed_at " +
+      "FROM account_events INDEXED BY idx_account_events_hotkey " +
+      "WHERE hotkey = ? AND event_kind = ? AND observed_at >= ? " +
+      "UNION ALL " +
+      "SELECT e.netuid, e.observed_at " +
+      "FROM neurons n INDEXED BY idx_neurons_hotkey " +
+      "JOIN account_events e INDEXED BY idx_account_events_netuid_uid_kind_observed " +
+      "ON e.netuid = n.netuid AND e.uid = n.uid " +
+      "WHERE n.hotkey = ? AND e.event_kind = ? AND e.observed_at >= ? " +
+      "AND (e.hotkey IS NULL OR e.hotkey = '')" +
+      ") GROUP BY netuid",
+    [address, WEIGHTS_EVENT_KIND, cutoff, address, WEIGHTS_EVENT_KIND, cutoff],
   );
   let latestObserved = null;
   for (const row of Array.isArray(rows) ? rows : []) {

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -37,6 +37,14 @@ function dbWith({
                   return { results: activity ? [activity] : [] };
                 if (/COUNT\(\*\) AS c\b/.test(sql))
                   return { results: agg ? [agg] : [] };
+                // Account weight-setters (#3842): the query is one UNION ALL
+                // combining a `FROM account_events` seek with a `FROM neurons
+                // ... JOIN account_events` fallback, so it textually matches
+                // BOTH the `FROM neurons` and `FROM account_events` checks
+                // below -- match its unique `AS weight_sets` alias first so
+                // it resolves to the `events` fixture, not `registrations`.
+                if (/AS weight_sets/.test(sql))
+                  return { results: events || [] };
                 if (/FROM neurons/.test(sql))
                   return { results: registrations || [] };
                 if (/FROM extrinsics/.test(sql))

--- a/tests/account-weight-setters.test.mjs
+++ b/tests/account-weight-setters.test.mjs
@@ -159,17 +159,23 @@ describe("loadAccountWeightSetters", () => {
     const { data, generatedAt } = await loadAccountWeightSetters(d1, ADDR, {
       windowLabel: "7d",
     });
-    assert.match(captured.sql, /FROM account_events e/);
     assert.match(
       captured.sql,
-      /LEFT JOIN neurons n ON e\.netuid = n\.netuid AND e\.uid = n\.uid/,
+      /FROM account_events INDEXED BY idx_account_events_hotkey/,
     );
-    assert.match(captured.sql, /e\.hotkey = \? OR n\.hotkey = \?/);
-    assert.match(captured.sql, /GROUP BY e\.netuid/);
-    assert.equal(captured.params[0], WEIGHTS_EVENT_KIND);
-    assert.equal(typeof captured.params[1], "number"); // epoch-ms cutoff
-    assert.equal(captured.params[2], ADDR);
+    assert.match(captured.sql, /FROM neurons n INDEXED BY idx_neurons_hotkey/);
+    assert.match(
+      captured.sql,
+      /JOIN account_events e INDEXED BY idx_account_events_netuid_uid_kind_observed/,
+    );
+    assert.doesNotMatch(captured.sql, /e\.hotkey = \? OR n\.hotkey = \?/);
+    assert.match(captured.sql, /GROUP BY netuid/);
+    assert.equal(captured.params[0], ADDR);
+    assert.equal(captured.params[1], WEIGHTS_EVENT_KIND);
+    assert.equal(typeof captured.params[2], "number"); // epoch-ms cutoff
     assert.equal(captured.params[3], ADDR);
+    assert.equal(captured.params[4], WEIGHTS_EVENT_KIND);
+    assert.equal(typeof captured.params[5], "number"); // epoch-ms cutoff
     assert.equal(data.total_weight_sets, 5);
     assert.equal(generatedAt, new Date(1_700_500_000_000).toISOString());
   });
@@ -219,8 +225,19 @@ describe("loadAccountWeightSetters", () => {
       { netuid: 8, uid: 5, hotkey: "5DifferentHotkey" },
     ];
     const d1 = async (sql, params) => {
-      const [kind, cutoff, directHotkey, resolvedHotkey] = params;
-      assert.equal(kind, WEIGHTS_EVENT_KIND);
+      const [
+        directHotkey,
+        directKind,
+        directCutoff,
+        resolvedHotkey,
+        resolvedKind,
+        resolvedCutoff,
+      ] = params;
+      assert.equal(directKind, WEIGHTS_EVENT_KIND);
+      assert.equal(resolvedKind, WEIGHTS_EVENT_KIND);
+      assert.equal(directCutoff, resolvedCutoff);
+      const kind = directKind;
+      const cutoff = directCutoff;
       const grouped = events
         .filter(
           (event) => event.event_kind === kind && event.observed_at >= cutoff,
@@ -276,7 +293,8 @@ describe("loadAccountWeightSetters", () => {
     await loadAccountWeightSetters(d1, ADDR, { windowLabel: "bogus" });
     // 7d default cutoff = now - 7d; assert it's within a day of that.
     const expected = Date.now() - 7 * 24 * 60 * 60 * 1000;
-    assert.ok(Math.abs(captured.params[1] - expected) < 24 * 60 * 60 * 1000);
+    assert.ok(Math.abs(captured.params[2] - expected) < 24 * 60 * 60 * 1000);
+    assert.ok(Math.abs(captured.params[5] - expected) < 24 * 60 * 60 * 1000);
   });
 
   test("a cold store (no rows) yields a zeroed card + null generatedAt", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4226,10 +4226,12 @@ describe("MCP stake-flow and movers economics tools", () => {
               return {
                 async all() {
                   if (
-                    /FROM account_events e/.test(sql) &&
+                    /idx_account_events_hotkey/.test(sql) &&
+                    /idx_account_events_netuid_uid_kind_observed/.test(sql) &&
                     /AS weight_sets/.test(sql) &&
                     /first_observed/.test(sql) &&
-                    params[0] === "WeightsSet"
+                    params[1] === "WeightsSet" &&
+                    params[4] === "WeightsSet"
                   ) {
                     return { results: rows };
                   }


### PR DESCRIPTION
### Motivation
- The account-level weight-setters lookup was changed to a join+OR predicate that forces SQLite to scan the recent network-wide `WeightsSet` window, enabling unauthenticated cost-amplification for per-account queries.
- The intent of this change is to restore an account-bounded read pattern so single-account requests cannot trigger broad D1 scans and to preserve uid-fallback semantics for hotkey-less rows.

### Description
- Split `loadAccountWeightSetters` into two bounded branches: a direct hotkey seek using `FROM account_events INDEXED BY idx_account_events_hotkey` and a uid-fallback that joins `neurons` to `account_events` via an account-bounded `JOIN`/`UNION ALL` subquery; this avoids the cross-table `OR` predicate that caused full-window scans (`src/account-weight-setters.mjs`).
- Add a D1 migration to create an index `idx_account_events_netuid_uid_kind_observed` on `(netuid, uid, event_kind, observed_at)` so the uid-fallback path is index-satisfiable and remains bounded (`migrations/0035_account_events_uid_weight_setters_index.sql`).
- Update unit/regression tests to assert the new indexed query shape, parameter ordering, and absence of the vulnerable `e.hotkey = ? OR n.hotkey = ?` pattern (`tests/account-weight-setters.test.mjs`).
- Update the MCP D1 mock expectations so the tool-level tests validate the new query hint usage and parameter positions (`tests/mcp-server.test.mjs`).

### Testing
- Ran the focused loader unit tests with `npm test -- tests/account-weight-setters.test.mjs -t loadAccountWeightSetters`, which passed.
- Ran the targeted MCP tests for the account tool with `npm test -- tests/mcp-server.test.mjs -t get_account_weight_setters`, which passed.
- Validated the new migration with `npm run validate:migrations`, which succeeded.
- A broader `npm test` run limited to the two related test files passed for account weight-setter coverage, while a wider run of the full MCP suite encountered one unrelated local artifact fixture failure; the modified account weight-setter tests themselves are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b77827c90832c954cea4e40d8b515)