### PR TITLE
fix(build): stop local builds from dirtying deploy-owned artifacts

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -89,11 +89,12 @@ contributor.)
 5. **Public-safe only.** No secrets, PATs, wallet/hotkey/coldkey paths, private/localhost URLs, or
    validator-local data anywhere — in files, commits, or PR text. `auth` fields are _placeholders_
    (`Bearer <token>`), never real credentials.
-6. **Link an issue when one exists (optional).** A linked issue is **not required** — a PR with no
-   linked issue is judged on its own merit and is **never** closed for the missing link. When an issue
-   does track the work, reference it (`Closes #<n>` / `Refs #<n>`) in the PR body and the gate verifies
-   the PR against that issue's intent. For surface work, the per-subnet enrichment issues under
-   [epic #427](https://github.com/JSONbored/metagraphed/issues/427) are the natural home to link.
+6. **Link an open issue — required.** Every PR must reference an issue (`Closes #<n>` / `Refs #<n>`)
+   in the PR body, and that issue must be **open/unclosed** at submission time — the gate verifies the
+   PR against that issue's intent, clause by clause. No linked issue, or a linked issue that's already
+   closed, is an automatic close on its own, before content is even scored. For surface work, the
+   per-subnet enrichment issues under [epic #427](https://github.com/JSONbored/metagraphed/issues/427)
+   are the natural home to link — pick one that's still open before you start.
 7. **Schema is the contract — regenerate + commit (Path B).** Editing `schemas/` means
    `npm run build` then committing `openapi.json` + types/clients in the same PR, or
    `validate:contract-drift` fails CI.
@@ -205,8 +206,8 @@ submission lane.)
   `registry/subnets/<slug>.json`.
 - **Commit (Conventional):** `feat(registry): add SN43 Example subnet-api surface (#<issue>)`.
 - **PR body:** fill `.github/pull_request_template.md` honestly — a real Summary, the `url` +
-  `source_url` proof, the validation commands you ran, and **`Closes #<issue>`** if an issue tracks
-  this (optional — not required). No AI attribution.
+  `source_url` proof, the validation commands you ran, and **`Closes #<issue>`** — required, and the
+  issue must still be open. No AI attribution.
 
 ### Phase A5 — Let the gate adjudicate
 
@@ -291,8 +292,8 @@ clean `npm run build` (see the build-gotchas note in `reference.md`).
 
 ### Phase B5 — Commit + PR
 
-Conventional Commit (no AI attribution); `Closes #<issue>` if an issue tracks the work (optional); fill
-the PR template with the validation commands you actually ran. Sync with `main` if it moved
+Conventional Commit (no AI attribution); `Closes #<issue>` — required, and the issue must still be
+open; fill the PR template with the validation commands you actually ran. Sync with `main` if it moved
 (`git fetch upstream && git rebase upstream/main`) — a base conflict closes a contributor PR.
 
 ---
@@ -436,7 +437,7 @@ changed `packages/client/src`.
 ### Phase C4 — Commit + PR
 
 Conventional Commit (e.g. `feat(ui): add validator directory table`), no AI attribution, `Closes
-#<issue>` if one tracks the work (optional). Fill the screenshot table if the change is visual.
+#<issue>` — required, and the issue must still be open. Fill the screenshot table if the change is visual.
 
 ### Phase C5 — Review disposition
 
@@ -461,7 +462,7 @@ confidence — this is a deliberate exception to the normal one-shot autonomous 
       still touches only your one subnet file — see the Path B note below on
       `public/metagraph/r2-manifest.json` / `public/metagraph/schemas/index.json`; the Gittensory Gate's
       registry-review lane rejects a PR that bundles either in with your surface change.
-- [ ] Conventional Commit (no AI attribution); PR template filled; **`Closes #<issue>`** if an issue tracks it (optional).
+- [ ] Conventional Commit (no AI attribution); PR template filled; **`Closes #<issue>`** — required, referencing an issue that's still open.
 
 **Path B (code/schema):**
 
@@ -476,7 +477,7 @@ confidence — this is a deliberate exception to the normal one-shot autonomous 
       itself warns you if either changed.
 - [ ] `git diff --check` clean · `lint` + `format:check` clean · `npm run validate` green ·
       `npm run test:coverage` green · the focused `validate:*` for what you touched green.
-- [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>` if an issue tracks it (optional).
+- [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>` — required, referencing an issue that's still open.
 
 **Path C (frontend):**
 
@@ -488,7 +489,7 @@ confidence — this is a deliberate exception to the normal one-shot autonomous 
 - [ ] `lint` + `format:check` + `typecheck` + `test` + `build` all green (`--workspace=apps/ui`); bundle
       size still under budget.
 - [ ] If `packages/client/src` changed: rebuilt and committed `packages/client/dist`.
-- [ ] Conventional Commit (no AI attribution); `Closes #<issue>` if one tracks it (optional).
+- [ ] Conventional Commit (no AI attribution); `Closes #<issue>` — required, referencing an issue that's still open.
 
 If every box is checked, the PR has the best chance of a one-shot approve-and-merge. If any box can't
 be checked, **keep working — don't push.**

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -199,9 +199,9 @@ posts `Gittensory Gate` + `Gittensory Context` checks and acts on **contributor*
 `url` owner must match the subnet's registered identity, source repo fresh, no prompt-injection in
 fetched or submitted text. Make the `source_url` an _independent_ proof of ownership.
 
-**Linked issues are optional, not a gate.** A PR with **no linked issue** is judged on its own merit —
-the missing link is **never** a fail/close reason (for contributors or maintainers). When an issue
-tracks the work, link it (`Closes #<n>`) and the gate verifies the PR against that issue's intent,
+**Linked issues are required and are a gate.** A PR with **no linked issue**, or one linked to an
+issue that's already **closed**, is auto-closed on that basis alone — before content is even scored.
+Link an **open** issue (`Closes #<n>`) and the gate verifies the PR against that issue's intent,
 clause by clause. (What the gate does with a linked issue is configured in the gittensory system,
 **not** in this repo.)
 
@@ -267,8 +267,8 @@ fix(health-serving): stamp merged RPC endpoint observed_at with sweep time (#161
 
 **PR body:** GitHub pre-fills `.github/pull_request_template.md`. Fill it — don't replace it: a real
 `## Summary`, the `url` + `source_url` proof (Path A) or the validation commands you ran (Path B), and
-**`Closes #<issue>`** when an issue tracks the work (optional — a missing link never fails a PR). No
-local paths, env dumps, or private notes.
+**`Closes #<issue>`** — required, and the issue must still be open (a missing or already-closed link
+fails the PR on its own). No local paths, env dumps, or private notes.
 
 ---
 

--- a/.github/workflows/sync-operational-surfaces.yml
+++ b/.github/workflows/sync-operational-surfaces.yml
@@ -1,0 +1,102 @@
+name: Sync operational surfaces
+
+# operational-surfaces.json (the health-prober's cold-start input list) is the
+# one deliberate DUAL artifact kept committed to git -- purely so the
+# prober's ASSETS read never depends on a live fetch succeeding (see
+# src/artifact-storage.mjs's DUAL_PATTERNS comment). It's excluded from the
+# "Verify committed derived artifacts are fresh" CI gate on purpose, because a
+# one-file community surface PR has no reason to regenerate it -- there's no
+# authority/review gate on that list. That's correct, but it also means
+# nothing was actually keeping the committed copy fresh: it only updated
+# whenever some unrelated PR happened to run `npm run build` and include the
+# diff, which is how it silently drifted (79 -> 96 surfaces observed stale on
+# a clean main checkout, 2026-07-06).
+#
+# This workflow closes that gap the same way sync-mcp-version.yml and
+# sync-client-version.yml already close theirs for other lazily-regenerated
+# files: run the real build on a schedule, and open an auto-PR only when the
+# regenerated file actually differs from what's committed. Batches multiple
+# registry merges into one PR and avoids the noise/races of trying to react
+# to every individual push, matching this repo's existing convention for this
+# exact class of problem.
+on:
+  schedule:
+    - cron: "0 * * * *" # hourly -- this file backs live health-probing, so it warrants a tighter cadence than the day(s)-scale sync-mcp-version/sync-client-version bumps
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-operational-surfaces
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Regenerate operational-surfaces.json if stale
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The real local build -- same code path a contributor or CI runs, so
+      # this can't drift from what "correct" means. scripts/build.mjs's own
+      # deploy-owned-artifact auto-revert (see scripts/lib.mjs
+      # DEPLOY_OWNED_ARTIFACTS) already resets r2-manifest.json and
+      # schemas/index.json, so the only file left that can legitimately
+      # differ afterward is operational-surfaces.json itself.
+      - name: Build
+        run: npm run build
+
+      - name: Check whether operational-surfaces.json changed
+        id: diff
+        run: |
+          if git diff --quiet -- public/metagraph/operational-surfaces.json; then
+            echo "operational-surfaces.json matches main; nothing to sync"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "operational-surfaces.json is stale relative to registry sources"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize the surface-count delta
+        if: steps.diff.outputs.changed == 'true'
+        id: summary
+        run: |
+          before=$(git show HEAD:public/metagraph/operational-surfaces.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).surface_count")
+          after=$(node -p "JSON.parse(require('fs').readFileSync('public/metagraph/operational-surfaces.json','utf8')).surface_count")
+          echo "before=$before" >> "$GITHUB_OUTPUT"
+          echo "after=$after" >> "$GITHUB_OUTPUT"
+
+      - name: Open sync PR (no-op if unchanged)
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-operational-surfaces
+          delete-branch: true
+          add-paths: |
+            public/metagraph/operational-surfaces.json
+          title: "chore(registry): sync operational-surfaces.json (${{ steps.summary.outputs.before }} -> ${{ steps.summary.outputs.after }} surfaces)"
+          commit-message: "chore(registry): sync operational-surfaces.json (${{ steps.summary.outputs.before }} -> ${{ steps.summary.outputs.after }} surfaces)"
+          body: |
+            Auto-regenerates the health-prober's committed cold-start surface list from the current `registry/subnets/*.json` sources. Surface count: `${{ steps.summary.outputs.before }}` -> `${{ steps.summary.outputs.after }}`.
+
+            This file is excluded from the "Verify committed derived artifacts are fresh" CI gate by design (see `src/artifact-storage.mjs`) since a one-file community surface PR has no reason to regenerate it. This workflow is what keeps it from silently drifting instead.
+          labels: |
+            automation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,10 @@ process evolves — edits to those files improve both Claude Code and Codex.
    surface as a different `kind` (that farm is closed — redundant PRs are auto-closed). Adding several
    surfaces for one subnet in one diff is one merge, the way it should be.
 3. **Prove it.** Every surface needs a public `url` **and** a `source_url` that independently proves
-   the subnet publishes it. A linked issue is **optional** — when one tracks the work, reference it
-   (`Closes #<n>`) and the gate verifies the PR against it; a PR with no linked issue is judged on its
-   own merit, never closed for the missing link.
+   the subnet publishes it. A linked issue is **required** — reference it (`Closes #<n>`) and the
+   issue must be **open/unclosed** at the time the PR is submitted; the gate verifies the PR against
+   the linked issue's intent, clause by clause. A PR with no linked issue, or one linked to an issue
+   that's already closed, is auto-closed on that basis alone.
 4. **Schema is the contract; regenerate + commit.** Code/schema changes: edit `schemas/`, run
    `npm run build`, commit the regenerated `openapi.json` + generated types in the same PR, or
    `validate:contract-drift` fails CI. Never hand-edit generated artifacts under `public/`. Do **not**

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 79,
+  "surface_count": 96,
   "surfaces": [
     {
       "auth_required": false,
@@ -173,6 +173,24 @@
       "surface_id": "sn-4-targon-subnet-api",
       "surface_key": "srf-40be5162d95eb737",
       "url": "https://api.targon.com/tha/v2/inventory"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 5,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "hone",
+      "public_safe": true,
+      "subnet_name": "Hone",
+      "subnet_slug": "sn-5",
+      "surface_id": "sn-5-hone-subnet-api",
+      "surface_key": "srf-f943a92bcbeee8ff",
+      "url": "https://api.hone.training/health"
     },
     {
       "auth_required": false,
@@ -432,6 +450,42 @@
       "kind": "subnet-api",
       "netuid": 7,
       "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "sn-7-allways-history-api",
+      "surface_key": "srf-9eafa27eb224284e",
+      "url": "https://api.all-ways.io/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "sn-7-allways-history-state-api",
+      "surface_key": "srf-9a044887ca43513b",
+      "url": "https://api.all-ways.io/history/state"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
         "expect": "any",
         "method": "GET",
         "timeout_ms": 10000
@@ -479,6 +533,24 @@
       "surface_id": "sn-14-cacheon-subnet-api",
       "surface_key": "srf-08ad6da0db95e254",
       "url": "https://api.cacheon.ai/api/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 21,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "adtao",
+      "public_safe": true,
+      "subnet_name": "AdTAO",
+      "subnet_slug": "sn-21",
+      "surface_id": "sn-21-adtao-validator-api",
+      "surface_key": "srf-34b5c51b4e147eef",
+      "url": "https://validator.adtao.io/health"
     },
     {
       "auth_required": false,
@@ -554,6 +626,42 @@
     },
     {
       "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 25,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "Mainframe",
+      "subnet_slug": "sn-25",
+      "surface_id": "sn-25-macrocosm-os-macrobench-benchmark-dataset",
+      "surface_key": "srf-2c94a06dbd4dc428",
+      "url": "https://huggingface.co/datasets/macrocosm-os/macrobench-bittensor-01"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 26,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "perturb",
+      "public_safe": true,
+      "subnet_name": "Perturb",
+      "subnet_slug": "sn-26",
+      "surface_id": "sn-26-perturb-subnet-api",
+      "surface_key": "srf-43db9970eda54936",
+      "url": "https://api.perturbai.io/health"
+    },
+    {
+      "auth_required": false,
       "authority": "official",
       "kind": "data-artifact",
       "netuid": 29,
@@ -569,6 +677,24 @@
       "surface_id": "sn-29-coldint-fineweb-dataset",
       "surface_key": "srf-f51c73d17f954447",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 32,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "its-ai",
+      "public_safe": true,
+      "subnet_name": "ItsAI",
+      "subnet_slug": "sn-32",
+      "surface_id": "sn-32-itsai-subnet-api",
+      "surface_key": "srf-8dcd0daf38042082",
+      "url": "https://api.its-ai.org/api/health"
     },
     {
       "auth_required": false,
@@ -646,6 +772,24 @@
       "auth_required": false,
       "authority": "community",
       "kind": "subnet-api",
+      "netuid": 43,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "subnet_name": "Graphite",
+      "subnet_slug": "sn-43",
+      "surface_id": "sn-43-graphite-miners-stats-api",
+      "surface_key": "srf-ebe9a74d2b26efea",
+      "url": "https://api.graphite-ai.net/api/v1/miners/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
       "netuid": 47,
       "probe": {
         "expect": "json",
@@ -695,6 +839,42 @@
       "surface_id": "sn-49-nepher-robotics-data-artifact",
       "surface_key": "srf-af1fcbae9651114b",
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/list"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 51,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "subnet_name": "lium.io",
+      "subnet_slug": "sn-51",
+      "surface_id": "sn-51-lium-io-machines-api",
+      "surface_key": "srf-f604cb709cccadea",
+      "url": "https://lium.io/api/machines"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 51,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "subnet_name": "lium.io",
+      "subnet_slug": "sn-51",
+      "surface_id": "sn-51-lium-reclaims-api",
+      "surface_key": "srf-e8a0c274374314a5",
+      "url": "https://lium.io/api/reclaims"
     },
     {
       "auth_required": false,
@@ -803,6 +983,24 @@
       "surface_id": "sn-56-gradients-weight-projection-static",
       "surface_key": "srf-5aa367d8193a4a6a",
       "url": "https://api.gradients.io/v1/performance/weight-projection-static"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 57,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "sparket",
+      "public_safe": true,
+      "subnet_name": "Sparket",
+      "subnet_slug": "sn-57",
+      "surface_id": "sn-57-sparket-subnet-api",
+      "surface_key": "srf-8c2c15f893a1216d",
+      "url": "https://sparket.ai/api/v1/health"
     },
     {
       "auth_required": false,
@@ -1040,6 +1238,24 @@
     },
     {
       "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 71,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leadpoet",
+      "public_safe": true,
+      "subnet_name": "Leadpoet",
+      "subnet_slug": "sn-71",
+      "surface_id": "sn-71-leadpoet-health-api",
+      "surface_key": "srf-028d20ae4c3a60fa",
+      "url": "https://leadpoet.com/api/health"
+    },
+    {
+      "auth_required": false,
       "authority": "official",
       "kind": "data-artifact",
       "netuid": 72,
@@ -1257,6 +1473,24 @@
     {
       "auth_required": false,
       "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 88,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "subnet_name": "Investing",
+      "subnet_slug": "sn-88",
+      "surface_id": "sn-88-investing-days-api",
+      "surface_key": "srf-8227eef13bef5b65",
+      "url": "https://api.investing88.ai/days"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
       "kind": "data-artifact",
       "netuid": 88,
       "probe": {
@@ -1271,6 +1505,60 @@
       "surface_id": "sn-88-investing-ratio",
       "surface_key": "srf-e606f94442e24006",
       "url": "https://api.investing88.ai/ratio"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 94,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "subnet_name": "Bitsota",
+      "subnet_slug": "sn-94",
+      "surface_id": "sn-94-bitsota-claims-api",
+      "surface_key": "srf-65479b2cf335c52e",
+      "url": "https://autoresearch.bitsota.com/api/v1/claims"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 94,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "subnet_name": "Bitsota",
+      "subnet_slug": "sn-94",
+      "surface_id": "sn-94-bitsota-dashboard-api",
+      "surface_key": "srf-e2ccfe699d7af82e",
+      "url": "https://autoresearch.bitsota.com/api/v1/dashboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 94,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "subnet_name": "Bitsota",
+      "subnet_slug": "sn-94",
+      "surface_id": "sn-94-bitsota-disclaimer-api",
+      "surface_key": "srf-a477c960fc3c1d2b",
+      "url": "https://autoresearch.bitsota.com/api/v1/disclaimer"
     },
     {
       "auth_required": false,
@@ -1397,6 +1685,24 @@
       "surface_id": "sn-110-website-link-www-green-compute-com-data-artifact-9",
       "surface_key": "srf-ae90870b3452e032",
       "url": "https://www.green-compute.com/models?prefill=meta-llama%2FMeta-Llama-3.1-8B-Instruct"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 113,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorusd",
+      "public_safe": true,
+      "subnet_name": "TensorUSD",
+      "subnet_slug": "sn-113",
+      "surface_id": "sn-113-tensorusd-subnet-api",
+      "surface_key": "srf-af3de99ed4db3abf",
+      "url": "https://api.tensorusd.com/health"
     },
     {
       "auth_required": false,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -58,12 +58,16 @@ console.log(
   }),
 );
 
-warnIfDeployOwnedArtifactsChanged();
+revertDeployOwnedArtifactsIfChanged();
 
-function warnIfDeployOwnedArtifactsChanged() {
+function revertDeployOwnedArtifactsIfChanged() {
   // A real publish run (productionBuild) is expected to update these files —
-  // don't warn in that context. Everywhere else (plain local/CI validate
-  // build), a diff here is the footgun this warning exists to catch.
+  // leave them alone in that context. Everywhere else (plain local/CI validate
+  // build), these two files are inherently non-deterministic build output
+  // (their *_artifact_size_bytes totals sum the live R2-only artifacts, which
+  // legitimately vary build-to-build) — never a signal about YOUR change. A
+  // human manually reverting them before every commit was the actual
+  // recurring papercut, so auto-revert them here instead of just warning.
   if (productionBuild) {
     return;
   }
@@ -76,17 +80,35 @@ function warnIfDeployOwnedArtifactsChanged() {
     return;
   }
   const baseRemote = resolveBaseRemote(process.cwd());
-  console.warn(
+  const revert = spawnSync(
+    "git",
+    ["checkout", `${baseRemote}/main`, "--", ...DEPLOY_OWNED_ARTIFACTS],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  if (revert.status !== 0) {
+    // Fall back to the old warning if the auto-revert itself fails (e.g. no
+    // network access to fetch the base remote's latest main) — don't hide a
+    // dirty working tree silently if we couldn't actually clean it up.
+    console.warn(
+      [
+        "",
+        "warning: build modified deploy-owned artifact(s), and auto-revert failed:",
+        ...DEPLOY_OWNED_ARTIFACTS.map((file) => `  - ${file}`),
+        revert.stderr || "",
+        "Revert them manually before committing:",
+        "",
+        `  git checkout ${baseRemote}/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
+        "",
+      ].join("\n"),
+    );
+    return;
+  }
+  console.log(
     [
       "",
-      "warning: build modified deploy-owned artifact(s):",
+      "note: build produced non-deterministic deploy-owned artifact(s), auto-reverted to",
+      `${baseRemote}/main (see DEPLOY_OWNED_ARTIFACTS in scripts/lib.mjs):`,
       ...DEPLOY_OWNED_ARTIFACTS.map((file) => `  - ${file}`),
-      "These reflect the last real publish, not this local/CI build, and will",
-      "always differ for reasons unrelated to your change (see the",
-      '"Verify committed derived artifacts are fresh" step in',
-      ".github/workflows/validate.yml). Revert them before committing:",
-      "",
-      `  git checkout ${baseRemote}/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
       "",
     ].join("\n"),
   );


### PR DESCRIPTION
## Summary

- `r2-manifest.json` / `schemas/index.json` are inherently non-deterministic build output (they sum live R2-only artifact byte sizes) — a local `npm run build` always left them dirty, requiring a manual `git checkout` before every commit. `scripts/build.mjs` now auto-reverts them for local/CI-validate builds instead of just warning (production publish builds are unaffected).
- New scheduled workflow (`sync-operational-surfaces.yml`) keeps `operational-surfaces.json` — the health-prober's committed cold-start input list, explicitly excluded from the "Verify committed derived artifacts are fresh" CI gate by design — from silently drifting between the occasional PRs that happen to regenerate it. Also regenerates it fresh in this PR (79 → 96 surfaces).
- Updates the linked-issue policy in `CLAUDE.md`/the metagraphed skill from "optional, never a close reason" to "required, must reference an open/unclosed issue," matching the new Gittensory Gate policy.

## Verification

- `npm run build` locally: confirmed `r2-manifest.json`/`schemas/index.json` no longer show as dirty afterward (auto-reverted), run twice to confirm idempotency.
- `npm run lint`, `npx prettier --check`, full `npx vitest run` (228 files / 6414 tests) all green.
- New workflow validated via `actionlint` + this repo's own `scripts/validate-workflows.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts (`operational-surfaces.json`) were produced by repo scripts, not hand-edited.
- [x] No public API/OpenAPI/schema changes.