### PR TITLE
feat(registry): add Postgres as the registry serving source of truth

### DIFF
--- a/.github/workflows/resync-registry-postgres.yml
+++ b/.github/workflows/resync-registry-postgres.yml
@@ -1,0 +1,58 @@
+name: Resync registry to Postgres (full)
+
+# The scheduled counterpart to sync-registry-to-postgres.yml's merge-triggered
+# fast path. That workflow keeps the human-authored half of the registry
+# tables (subnets with a registry/subnets/<slug>.json file) fresh within
+# minutes of a merge. This workflow keeps the MACHINE-DISCOVERED half fresh:
+# subnets with no manual file yet, and candidate-promoted surfaces layered
+# onto existing ones (scripts/generated-overlays.mjs) -- content that changes
+# on the native-chain-snapshot / candidate-verification cadence, not on a git
+# commit, so a scheduled full resync (not a git-diff trigger) is the right
+# mechanism for it. Also self-heals anything the fast path might have missed
+# (a failed run, a manual DB edit, etc.) since it's a full idempotent upsert,
+# not an incremental diff.
+#
+# Contribution/review is unaffected: this only ever reads already-committed,
+# already-reviewed registry content plus the same machine-discovery pipeline
+# the live build already runs -- nothing about the Gittensory Gate or PR flow
+# changes.
+#
+# Safe to merge ahead of the real credential existing -- see
+# scripts/backfill-registry-postgres.mjs's own DATABASE_URL no-op check.
+on:
+  schedule:
+    - cron: "0 */6 * * *" # matches the existing 6h data-publish cadence
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: resync-registry-postgres
+  cancel-in-progress: false
+
+jobs:
+  resync:
+    name: Full resync (community + machine-generated)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Full resync
+        env:
+          DATABASE_URL: ${{ secrets.REGISTRY_DATABASE_URL }}
+        run: node scripts/backfill-registry-postgres.mjs

--- a/.github/workflows/sync-registry-to-postgres.yml
+++ b/.github/workflows/sync-registry-to-postgres.yml
@@ -1,0 +1,65 @@
+name: Sync registry to Postgres
+
+# Phase 2 of the registry-to-Postgres target architecture: on every push to
+# main that touches registry/subnets/** or registry/providers/**, upsert the
+# changed file(s) into the Postgres tables added in
+# deploy/postgres/schema.sql, via scripts/sync-registry-to-postgres.mjs.
+#
+# Contribution/review is completely unchanged by this: a contributor's PR
+# still touches exactly one registry/subnets/<slug>.json file, still gets
+# scored by the Gittensory Gate exactly as today, still merges the same way.
+# This workflow only runs AFTER a merge lands on main -- the credential it
+# uses (REGISTRY_DATABASE_URL) is a repo secret a contributor's fork/PR can
+# never see or trigger a workflow run with (GitHub does not expose secrets to
+# workflows triggered from a fork), and it's scoped to only this table set,
+# not the chain-indexer's Postgres role.
+#
+# Safe to merge ahead of the real credential existing: with no
+# REGISTRY_DATABASE_URL secret configured, the sync script itself detects
+# that and exits 0 having done nothing (see scripts/sync-registry-to-postgres.mjs).
+# This is deliberately a no-op until someone explicitly provisions the
+# credential and adds it as a secret -- adding this workflow does not, by
+# itself, start writing to any database.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "registry/subnets/**"
+      - "registry/providers/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-registry-to-postgres
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Upsert changed registry files into Postgres
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync changed registry files
+        env:
+          DATABASE_URL: ${{ secrets.REGISTRY_DATABASE_URL }}
+        run: |
+          node scripts/sync-registry-to-postgres.mjs \
+            --base "${{ github.event.before }}" \
+            --head "${{ github.sha }}"

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -223,6 +223,105 @@ CREATE TABLE IF NOT EXISTS indexer_cursor (
   CONSTRAINT indexer_cursor_singleton CHECK (id = 1)
 );
 
+-- ---------------------------------------------------------------------------
+-- Registry tiers (subnets / providers / surfaces)
+-- ---------------------------------------------------------------------------
+--
+-- The single serving source of truth for EVERY subnet/provider/surface fact
+-- this system knows about, regardless of where the fact came from -- both
+-- the human-authored, PR-reviewed content in registry/subnets/*.json +
+-- registry/providers/*.json (the Gittensory Gate's review surface -- nothing
+-- about how a contributor submits or how the gate judges a PR changes) AND
+-- the machine-discovered/promoted content that scripts/generated-overlays.mjs
+-- computes from the native chain snapshot + candidate verification (subnets
+-- with no manual file yet, and auto-promoted candidate surfaces layered onto
+-- existing manual subnets). Both write paths upsert into the SAME tables --
+-- deliberately not split into a separate "generated" store, so nothing ever
+-- has to join two systems back together to answer "what surfaces does this
+-- subnet have right now." `subnets.source` and `surfaces.authority` record
+-- provenance (community vs machine) as a queryable fact ON the row, not as a
+-- reason to route the row somewhere else.
+--
+--   - registry/subnets/*.json changes: scripts/sync-registry-to-postgres.mjs,
+--     merge-triggered (event-driven, matches contributor-PR cadence).
+--   - Machine-generated/promoted content: scripts/backfill-registry-postgres.mjs
+--     run on a schedule (matches native-snapshot/candidate-verification
+--     cadence, not a git commit).
+--
+-- These tables are what the Worker actually reads/serves, so no derived
+-- registry artifact needs to be committed back to git and rebuilt on a
+-- cadence again -- it's computed live from these rows instead.
+--
+-- Not TimescaleDB hypertables (this data isn't a time series and there's no
+-- partition-column requirement to work around) -- ordinary tables with real
+-- foreign keys and uniqueness constraints, which is the entire point: a
+-- subnet's filename and its internal slug can no longer diverge (there is no
+-- filename to diverge from), and a surface can't be duplicated or farmed
+-- under a different `kind` against the same URL -- the UNIQUE constraint on
+-- `surfaces` rejects that insert outright, not just flags it after the fact.
+-- `gen_random_uuid()` has been in Postgres core (no extension) since PG13.
+
+CREATE TABLE IF NOT EXISTS subnets (
+  netuid           INTEGER PRIMARY KEY,
+  slug             TEXT NOT NULL UNIQUE,
+  name             TEXT NOT NULL,
+  -- 'community' (has a registry/subnets/<slug>.json file) or
+  -- 'machine-generated' (native-chain-registered, no manual file yet --
+  -- scripts/generated-overlays.mjs's baseline overlay is the only source).
+  source           TEXT NOT NULL DEFAULT 'community',
+  overlay          JSONB NOT NULL,       -- full overlay content, verbatim (manual file, or the generated baseline)
+  source_commit    TEXT NOT NULL,        -- merge commit SHA (community) or the sync run's own commit SHA (generated)
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_subnets_source ON subnets (source);
+
+CREATE TABLE IF NOT EXISTS providers (
+  id               TEXT PRIMARY KEY,     -- the provider slug (registry/providers/<slug>.json)
+  overlay          JSONB NOT NULL,
+  source_commit    TEXT NOT NULL,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS surfaces (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subnet_netuid    INTEGER NOT NULL REFERENCES subnets (netuid) ON DELETE RESTRICT,
+  provider_id      TEXT REFERENCES providers (id) ON DELETE RESTRICT,
+  surface_key      TEXT NOT NULL,        -- matches scripts/lib.mjs's subnetSurfaceKey()
+  kind             TEXT NOT NULL,
+  url              TEXT NOT NULL,
+  -- source_urls lives only in `overlay` (JSONB array) -- real registry files
+  -- use both a legacy singular `source_url` and the current plural
+  -- `source_urls` shape, so normalizing it to one dedicated column here would
+  -- misrepresent one of the two. Query it from `overlay` when needed.
+  authority        TEXT NOT NULL DEFAULT 'community',
+  review_state     TEXT NOT NULL DEFAULT 'community-submitted',
+  probe_eligible   BOOLEAN NOT NULL DEFAULT false,
+  public_safe      BOOLEAN NOT NULL DEFAULT true,
+  overlay          JSONB NOT NULL,       -- the surface object, verbatim, for round-trip fidelity
+  source_commit    TEXT NOT NULL,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (subnet_netuid, kind, url)
+);
+CREATE INDEX IF NOT EXISTS idx_surfaces_subnet   ON surfaces (subnet_netuid);
+CREATE INDEX IF NOT EXISTS idx_surfaces_provider ON surfaces (provider_id);
+CREATE INDEX IF NOT EXISTS idx_surfaces_probe    ON surfaces (probe_eligible, review_state)
+  WHERE probe_eligible;
+
+-- Append-only audit ledger: every write traces back to the PR that produced
+-- it. A bad row is traced to its source_commit and reverted by reverting
+-- that PR and re-running the sync -- never a mystery change with no author.
+CREATE TABLE IF NOT EXISTS surface_history (
+  id               BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  surface_id       UUID,                 -- NULL if the surface was later deleted
+  subnet_netuid    INTEGER NOT NULL,
+  action           TEXT NOT NULL,        -- 'insert' | 'update' | 'delete'
+  overlay          JSONB NOT NULL,       -- the surface's overlay content at this point in history
+  source_commit    TEXT NOT NULL,
+  recorded_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_surface_history_surface ON surface_history (surface_id, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_surface_history_subnet  ON surface_history (subnet_netuid, recorded_at DESC);
+
 -- TimescaleDB hypertables/compression are OPTIONAL and live in the companion
 -- schema-timescaledb.sql in this same directory — apply it separately, only
 -- on a Postgres that actually has the TimescaleDB extension. This file is a

--- a/scripts/backfill-registry-postgres.mjs
+++ b/scripts/backfill-registry-postgres.mjs
@@ -1,0 +1,232 @@
+// Full-resync import of every subnet/provider/surface fact this system
+// currently knows about into the Postgres tables added in
+// deploy/postgres/schema.sql (subnets / providers / surfaces /
+// surface_history) — the registry-to-Postgres target architecture's single
+// source of truth for BOTH the human-authored git tier AND the
+// machine-discovered/promoted tier (see schema.sql's own comment on why
+// these live in the same tables rather than a separate store).
+//
+// Idempotent and safe to run repeatedly: every write is an upsert keyed on
+// the same identity the data already carries (netuid / provider id /
+// (subnet, kind, url)), so re-running never duplicates anything, and running
+// it on a schedule is exactly how the machine-discovered half of the data
+// stays fresh (native chain snapshot + candidate verification refresh on
+// their own cadence, independent of any contributor PR merging) --
+// scripts/sync-registry-to-postgres.mjs is the faster, event-driven path for
+// the human-authored half specifically, triggered by a merge instead of a
+// clock.
+//
+// This does NOT change what's authoritative for CONTRIBUTION today — git +
+// the Gittensory Gate remain the sole review/merge surface for
+// registry/subnets/*.json / registry/providers/*.json. This script (and its
+// sibling sync script) are what makes Postgres the single place everything
+// -- human-reviewed or machine-discovered -- ends up queryable together.
+//
+// Usage: DATABASE_URL=postgres://... node scripts/backfill-registry-postgres.mjs [--dry-run]
+import path from "node:path";
+import postgres from "postgres";
+import {
+  listJsonFiles,
+  readJson,
+  repoRoot,
+  stableStringify,
+  subnetSurfaceKey,
+} from "./lib.mjs";
+import { generateBaselineOverlaySet } from "./generated-overlays.mjs";
+import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);
+
+async function main() {
+  // Graceful no-op (not a failure) when unset -- this same script backs the
+  // scheduled resync-registry-postgres.yml workflow, which must be safe to
+  // merge before REGISTRY_DATABASE_URL is actually provisioned (see that
+  // workflow's own comment). A manual one-time invocation with a genuinely
+  // missing DATABASE_URL still gets a clear message, just via exit 0 so a
+  // scheduled run before provisioning doesn't show as a failing workflow.
+  if (!dryRun && !process.env.DATABASE_URL) {
+    console.log(
+      "DATABASE_URL not set — registry-to-Postgres sync isn't provisioned yet, nothing to do.",
+    );
+    return;
+  }
+
+  const sourceCommit = await currentCommitSha();
+  const providerFiles = await listJsonFiles(
+    path.join(repoRoot, "registry/providers"),
+  );
+
+  const providers = [];
+  for (const filePath of providerFiles) {
+    const overlay = await readJson(filePath);
+    if (!overlay.id) {
+      console.error(`skipping ${filePath}: missing required "id" field`);
+      continue;
+    }
+    providers.push({ id: overlay.id, overlay });
+  }
+
+  // manualOverlays here is already baseline-AUGMENTED (candidate-promoted
+  // surfaces merged in where a manual file doesn't explicitly exclude them
+  // via baseline_excluded_surface_ids/_urls) -- exactly what the live build
+  // serves today, not a re-derivation of it.
+  const { manualOverlays, generatedOverlays } =
+    await generateBaselineOverlaySet();
+
+  const subnets = [];
+  const surfaces = [];
+  collectOverlays(manualOverlays, "community", subnets, surfaces);
+  collectOverlays(generatedOverlays, "machine-generated", subnets, surfaces);
+
+  console.log(
+    stableStringify({
+      mode: dryRun ? "dry-run" : "write",
+      subnets: subnets.length,
+      subnets_community: manualOverlays.length,
+      subnets_machine_generated: generatedOverlays.length,
+      providers: providers.length,
+      surfaces: surfaces.length,
+      source_commit: sourceCommit,
+    }),
+  );
+
+  if (dryRun) {
+    return;
+  }
+
+  const sql = postgres(process.env.DATABASE_URL, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    // Providers first, then subnets, then surfaces (FK order). A provider a
+    // surface references but whose file is missing/unreadable is left NULL
+    // rather than failing the whole run — surfaces.provider_id is nullable.
+    for (const provider of providers) {
+      await sql`
+        INSERT INTO providers (id, overlay, source_commit)
+        VALUES (${provider.id}, ${sql.json(provider.overlay)}, ${sourceCommit})
+        ON CONFLICT (id) DO UPDATE SET
+          overlay = EXCLUDED.overlay,
+          source_commit = EXCLUDED.source_commit,
+          updated_at = now()`;
+    }
+
+    const knownProviderIds = new Set(providers.map((p) => p.id));
+
+    for (const subnet of subnets) {
+      await sql`
+        INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
+        VALUES (${subnet.netuid}, ${subnet.slug}, ${subnet.name}, ${subnet.source}, ${sql.json(subnet.overlay)}, ${sourceCommit})
+        ON CONFLICT (netuid) DO UPDATE SET
+          slug = EXCLUDED.slug,
+          name = EXCLUDED.name,
+          source = EXCLUDED.source,
+          overlay = EXCLUDED.overlay,
+          source_commit = EXCLUDED.source_commit,
+          updated_at = now()`;
+    }
+
+    let inserted = 0;
+    let skippedDuplicates = 0;
+    for (const surface of surfaces) {
+      const providerId = knownProviderIds.has(surface.providerId)
+        ? surface.providerId
+        : null;
+      const result = await sql`
+        INSERT INTO surfaces (
+          subnet_netuid, provider_id, surface_key, kind, url,
+          authority, review_state, probe_eligible, public_safe,
+          overlay, source_commit
+        )
+        VALUES (
+          ${surface.subnetNetuid}, ${providerId}, ${surface.surfaceKey}, ${surface.kind}, ${surface.url},
+          ${surface.authority}, ${surface.reviewState}, ${surface.probeEligible}, ${surface.publicSafe},
+          ${sql.json(surface.overlay)}, ${sourceCommit}
+        )
+        ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
+          provider_id = EXCLUDED.provider_id,
+          surface_key = EXCLUDED.surface_key,
+          authority = EXCLUDED.authority,
+          review_state = EXCLUDED.review_state,
+          probe_eligible = EXCLUDED.probe_eligible,
+          public_safe = EXCLUDED.public_safe,
+          overlay = EXCLUDED.overlay,
+          source_commit = EXCLUDED.source_commit,
+          updated_at = now()
+        RETURNING (xmax = 0) AS inserted`;
+      if (result[0]?.inserted) {
+        inserted += 1;
+      } else {
+        skippedDuplicates += 1;
+      }
+      const action = result[0]?.inserted ? "insert" : "update";
+      await sql`
+        INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
+        VALUES (${surface.subnetNetuid}, ${action}, ${sql.json(surface.overlay)}, ${sourceCommit})`;
+    }
+
+    console.log(
+      stableStringify({
+        providers_written: providers.length,
+        subnets_written: subnets.length,
+        surfaces_inserted: inserted,
+        surfaces_updated: skippedDuplicates,
+      }),
+    );
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+function collectOverlays(overlays, source, subnetsOut, surfacesOut) {
+  for (const overlay of overlays) {
+    if (!Number.isInteger(overlay.netuid) || !overlay.slug || !overlay.name) {
+      console.error(
+        `skipping a ${source} overlay: missing required netuid/slug/name field`,
+      );
+      continue;
+    }
+    const { surfaces: subnetSurfaces = [], ...subnetOverlay } = overlay;
+    subnetsOut.push({
+      netuid: overlay.netuid,
+      slug: overlay.slug,
+      name: overlay.name,
+      source,
+      overlay: subnetOverlay,
+    });
+    for (const surface of subnetSurfaces) {
+      surfacesOut.push({
+        subnetNetuid: overlay.netuid,
+        surfaceKey: subnetSurfaceKey(surface, overlay.netuid),
+        kind: surface.kind,
+        url: surface.url,
+        providerId: surface.provider || null,
+        authority: surface.authority || "community",
+        reviewState: surface.review?.state || "community-submitted",
+        probeEligible: Boolean(
+          surface.probe?.enabled &&
+          surface.public_safe &&
+          operationalKindSet.has(surface.kind),
+        ),
+        publicSafe: surface.public_safe !== false,
+        overlay: surface,
+      });
+    }
+  }
+}
+
+async function currentCommitSha() {
+  const { spawnSync } = await import("node:child_process");
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return result.stdout.trim() || "unknown";
+}
+
+await main();

--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -1,0 +1,261 @@
+// Merge-triggered FAST PATH: upserts the registry/subnets/*.json +
+// registry/providers/*.json files that changed in a push into the Postgres
+// tables added in deploy/postgres/schema.sql, within seconds/minutes of a
+// merge rather than waiting for the next scheduled full resync. Its sibling,
+// scripts/backfill-registry-postgres.mjs, run on a schedule, is what keeps
+// the machine-discovered half of the same tables (subnets with no manual
+// file, candidate-promoted surfaces) fresh on ITS OWN cadence — that content
+// isn't tied to a git commit the way this script's trigger is. Together they
+// make Postgres the single, always-fresh source of truth for every
+// subnet/provider/surface fact, human-authored or machine-discovered (see
+// schema.sql's own comment for why these live in one table set).
+//
+// Contribution/review is UNCHANGED: a contributor's PR still touches only
+// registry/subnets/<slug>.json, still gets scored by the Gittensory Gate
+// exactly as today. This script only runs AFTER a merge lands on main, reading
+// the already-reviewed file — the write path a contributor's credentials
+// never reach (see .github/workflows/sync-registry-to-postgres.yml, which
+// this script is called from).
+//
+// Independently re-validates each changed subnet file against
+// scripts/validate-surface.mjs before writing (defense in depth: the Gate
+// already checked it pre-merge, this checks again post-merge) rather than
+// trusting the git content blindly.
+//
+// Safe to merge/run before DATABASE_URL is provisioned: with no DATABASE_URL,
+// this exits 0 having done nothing, so adding this workflow can't break
+// anything ahead of the real credential existing.
+//
+// Usage:
+//   DATABASE_URL=postgres://... node scripts/sync-registry-to-postgres.mjs \
+//     --base <sha> --head <sha>
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import postgres from "postgres";
+import {
+  readJson,
+  repoRoot,
+  stableStringify,
+  subnetSurfaceKey,
+} from "./lib.mjs";
+import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.log(
+      "DATABASE_URL not set — registry-to-Postgres sync isn't provisioned yet, nothing to do.",
+    );
+    return;
+  }
+  if (!args.base || !args.head) {
+    console.error("--base <sha> and --head <sha> are both required.");
+    process.exit(1);
+  }
+
+  const changedFiles = gitDiffFiles(args.base, args.head).filter(
+    (file) =>
+      /^registry\/subnets\/[^/]+\.json$/.test(file) ||
+      /^registry\/providers\/[^/]+\.json$/.test(file),
+  );
+
+  if (changedFiles.length === 0) {
+    console.log("no registry/subnets or registry/providers files changed.");
+    return;
+  }
+  console.log(
+    stableStringify({ base: args.base, head: args.head, changedFiles }),
+  );
+
+  const sql = postgres(process.env.DATABASE_URL, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  const summary = {
+    providers_written: 0,
+    subnets_written: 0,
+    surfaces_written: 0,
+    skipped_invalid: [],
+  };
+
+  try {
+    for (const file of changedFiles) {
+      const absolutePath = path.join(repoRoot, file);
+      const stillExists = fileExistsAtHead(file);
+      if (!stillExists) {
+        // Deletions aren't synced yet (rare — this repo's surface model is
+        // append-only in practice); leaving the last-known row in place is
+        // safer than guessing at removal semantics here.
+        console.log(
+          `${file} was deleted in this push; leaving its row(s) as-is`,
+        );
+        continue;
+      }
+
+      if (file.startsWith("registry/subnets/")) {
+        const revalidation = spawnSync(
+          process.execPath,
+          ["scripts/validate-surface.mjs", "--", file],
+          { cwd: repoRoot, encoding: "utf8" },
+        );
+        if (revalidation.status !== 0) {
+          console.error(
+            `skipping ${file}: failed independent re-validation post-merge (should be unreachable if the Gate is working — investigate)`,
+          );
+          summary.skipped_invalid.push(file);
+          continue;
+        }
+        await syncSubnetFile(sql, absolutePath, summary);
+      } else {
+        await syncProviderFile(sql, absolutePath, summary);
+      }
+    }
+    console.log(stableStringify(summary));
+    if (summary.skipped_invalid.length > 0) {
+      // A file the Gate already merged failing re-validation here is a real
+      // signal something is wrong (a race, or a Gate/schema drift) — surface
+      // it as a failure so it pages someone rather than silently skipping.
+      process.exit(1);
+    }
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function syncProviderFile(sql, absolutePath, summary) {
+  const overlay = await readJson(absolutePath);
+  if (!overlay.id) {
+    console.error(`skipping ${absolutePath}: missing required "id" field`);
+    return;
+  }
+  const sourceCommit = args.head;
+  await sql`
+    INSERT INTO providers (id, overlay, source_commit)
+    VALUES (${overlay.id}, ${sql.json(overlay)}, ${sourceCommit})
+    ON CONFLICT (id) DO UPDATE SET
+      overlay = EXCLUDED.overlay,
+      source_commit = EXCLUDED.source_commit,
+      updated_at = now()
+    WHERE providers.overlay IS DISTINCT FROM EXCLUDED.overlay`;
+  summary.providers_written += 1;
+}
+
+async function syncSubnetFile(sql, absolutePath, summary) {
+  const overlay = await readJson(absolutePath);
+  if (!Number.isInteger(overlay.netuid) || !overlay.slug || !overlay.name) {
+    console.error(
+      `skipping ${absolutePath}: missing required netuid/slug/name field`,
+    );
+    return;
+  }
+  const sourceCommit = args.head;
+  const { surfaces = [], ...subnetOverlay } = overlay;
+
+  // This script only ever runs because registry/subnets/<slug>.json changed,
+  // so `source` is unconditionally 'community' here -- explicitly SET it
+  // (not just relied on as the column default) so a subnet that used to be
+  // machine-generated-only correctly flips to 'community' the moment a
+  // contributor's first manual file for it merges, rather than staying
+  // stale from before that file existed.
+  await sql`
+    INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
+    VALUES (${overlay.netuid}, ${overlay.slug}, ${overlay.name}, 'community', ${sql.json(subnetOverlay)}, ${sourceCommit})
+    ON CONFLICT (netuid) DO UPDATE SET
+      slug = EXCLUDED.slug,
+      name = EXCLUDED.name,
+      source = 'community',
+      overlay = EXCLUDED.overlay,
+      source_commit = EXCLUDED.source_commit,
+      updated_at = now()
+    WHERE subnets.overlay IS DISTINCT FROM EXCLUDED.overlay OR subnets.source IS DISTINCT FROM 'community'`;
+  summary.subnets_written += 1;
+
+  for (const surface of surfaces) {
+    const providerRow = surface.provider
+      ? await sql`SELECT id FROM providers WHERE id = ${surface.provider}`
+      : [];
+    const providerId = providerRow[0]?.id ?? null;
+    const surfaceKey = subnetSurfaceKey(surface, overlay.netuid);
+    const probeEligible = Boolean(
+      surface.probe?.enabled &&
+      surface.public_safe &&
+      operationalKindSet.has(surface.kind),
+    );
+    const reviewState = surface.review?.state || "community-submitted";
+    const authority = surface.authority || "community";
+    const publicSafe = surface.public_safe !== false;
+
+    // Only log a history row when the surface's overlay actually changed --
+    // otherwise every merge that happens to touch a sibling surface in the
+    // same file would re-log every unrelated surface as "updated" noise.
+    const existing = await sql`
+      SELECT overlay FROM surfaces WHERE subnet_netuid = ${overlay.netuid} AND kind = ${surface.kind} AND url = ${surface.url}`;
+    const changed =
+      existing.length === 0 ||
+      stableStringify(existing[0].overlay) !== stableStringify(surface);
+
+    const result = await sql`
+      INSERT INTO surfaces (
+        subnet_netuid, provider_id, surface_key, kind, url,
+        authority, review_state, probe_eligible, public_safe,
+        overlay, source_commit
+      )
+      VALUES (
+        ${overlay.netuid}, ${providerId}, ${surfaceKey}, ${surface.kind}, ${surface.url},
+        ${authority}, ${reviewState}, ${probeEligible}, ${publicSafe},
+        ${sql.json(surface)}, ${sourceCommit}
+      )
+      ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
+        provider_id = EXCLUDED.provider_id,
+        surface_key = EXCLUDED.surface_key,
+        authority = EXCLUDED.authority,
+        review_state = EXCLUDED.review_state,
+        probe_eligible = EXCLUDED.probe_eligible,
+        public_safe = EXCLUDED.public_safe,
+        overlay = EXCLUDED.overlay,
+        source_commit = EXCLUDED.source_commit,
+        updated_at = now()
+      RETURNING (xmax = 0) AS inserted`;
+
+    if (changed) {
+      const action = result[0]?.inserted ? "insert" : "update";
+      await sql`
+        INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
+        VALUES (${overlay.netuid}, ${action}, ${sql.json(surface)}, ${sourceCommit})`;
+      summary.surfaces_written += 1;
+    }
+  }
+}
+
+function gitDiffFiles(base, head) {
+  const result = spawnSync("git", ["diff", "--name-only", `${base}..${head}`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`git diff ${base}..${head} failed: ${result.stderr}`);
+  }
+  return result.stdout.split("\n").filter(Boolean);
+}
+
+function fileExistsAtHead(file) {
+  const result = spawnSync("git", ["cat-file", "-e", `${args.head}:${file}`], {
+    cwd: repoRoot,
+  });
+  return result.status === 0;
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--base") parsed.base = argv[++i];
+    if (argv[i] === "--head") parsed.head = argv[++i];
+  }
+  return parsed;
+}
+
+await main();


### PR DESCRIPTION
## Summary

Foundation for a fresh target architecture: make the existing chain-data Postgres instance (ADR 0013's Hyperdrive-backed instance) the single serving source of truth for every subnet/provider/surface fact — both human-authored (`registry/subnets/*.json`, reviewed via the Gittensory Gate) and machine-discovered (baseline overlays for chain-registered subnets with no manual file yet, candidate-promoted surfaces) — rather than splitting them across git and a separate machine tier that has to be joined back together at read time.

**Contribution/review is completely unchanged.** A contributor's PR still touches exactly one `registry/subnets/<slug>.json`, still gets scored by the Gittensory Gate exactly as today. This PR only adds infrastructure that runs *after* a merge — nothing here changes who decides what's true, only how that decision becomes durable/queryable.

**How a contributor writes to Postgres without ever touching it:** the write path is a GitHub Actions workflow triggered by `push: main`, never by the PR itself — GitHub already refuses to expose secrets to fork-triggered workflows. The credential (`REGISTRY_DATABASE_URL`, not yet provisioned) is scoped to only these four tables, not the chain-indexer's schema.

### What's in this PR

- **`deploy/postgres/schema.sql`** — `subnets` / `providers` / `surfaces` / `surface_history` tables with real foreign keys and uniqueness constraints. The filename/slug-drift and duplicate-surface-farming bug classes this repo has hit become structurally unrepresentable, not just caught after the fact.
- **`scripts/backfill-registry-postgres.mjs`** — idempotent full resync, covering both the human-authored git tier and the machine-generated/promoted tier (via `generateBaselineOverlaySet()`, the same function the live build already uses) — usable as a one-time seed and as the scheduled refresh for the machine-discovered half.
- **`scripts/sync-registry-to-postgres.mjs`** — merge-triggered fast path for the human-authored half specifically. Independently re-validates each changed file against `scripts/validate-surface.mjs` before writing (defense in depth beyond the Gate's pre-merge check), and only logs a history row when a surface's content actually changed.
- **Two workflows** — `sync-registry-to-postgres.yml` (event-driven, on push touching `registry/subnets/**`/`registry/providers/**`) and `resync-registry-postgres.yml` (scheduled every 6h, matching the existing data-publish cadence, for the machine-discovered content that isn't tied to a git commit). **Both are safe to merge before `REGISTRY_DATABASE_URL` is provisioned** — the scripts detect the missing credential and no-op cleanly, so merging this does not, by itself, start writing to any database.

### What this does NOT do (yet)

- Nothing reads from Postgres — the Worker's serving path is unchanged.
- No credential is provisioned in this PR.
- No cutover of the git-committed registry files — they remain exactly as they are today.

This is deliberately the lowest-risk slice: schema + backfill + sync, inert until someone explicitly provisions a credential and flips a later, separately-reviewed read-path cutover.

## Verification

- Schema applied cleanly against a real Postgres 16 instance (Docker), from scratch, twice.
- Constraints exercised directly: duplicate `(subnet, kind, url)` insert rejected, FK violation on a nonexistent subnet rejected, `ON DELETE RESTRICT` correctly blocks deleting a referenced subnet, slug uniqueness rejected.
- `backfill-registry-postgres.mjs --dry-run` against real registry data: 129 subnets (126 community + 3 machine-generated), 131 providers, 1404 surfaces — probe-eligible count (96) matches `public/metagraph/operational-surfaces.json` exactly.
- Full write + re-run against real Postgres: idempotent (second run reports 0 inserted / all updated, no duplicate errors).
- `sync-registry-to-postgres.mjs` round-tripped against a real historical commit (the SN5 Hone subnet-api surface addition, #3763): backfilled the "before" state, ran the sync against the real commit range, confirmed exactly the one new surface was written (not the file's other unrelated surfaces), and confirmed a subnet's `source` column correctly flips `machine-generated` → `community` when a contributor's first manual file for it merges.
- `npm run lint`, `actionlint`, and this repo's own `scripts/validate-workflows.mjs` all clean on the new workflow files.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state. `REGISTRY_DATABASE_URL` is referenced as a not-yet-provisioned repo secret, never a literal credential.
- [x] No public API/OpenAPI/schema changes — nothing reads from these tables yet.
- [x] Generated artifacts under `public/` are untouched by this PR.