### PR TITLE
fix(ui): show daily-rollup freshness on the validators panel

### DIFF
--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -4,6 +4,7 @@ import { subnetValidatorsQuery } from "@/lib/metagraphed/queries";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { FreshnessIndicator } from "@/components/metagraphed/freshness";
 
 const TOP_N = 10;
 
@@ -48,21 +49,33 @@ export function ValidatorsTableLoader({
     );
   }
 
+  const freshness = (
+    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+      Daily rollup
+      <FreshnessIndicator at={meta?.generated_at} />
+    </span>
+  );
+
   return (
     <div className="space-y-4">
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex items-center justify-between">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Validator stake · top {stakeBars.length}
             </span>
-            <span className="font-mono text-[10px] text-ink-muted">
-              peak {taoCompact(stakeBars[0]?.value)} τ
+            <span className="ml-auto flex items-center gap-3">
+              <span className="font-mono text-[10px] text-ink-muted">
+                peak {taoCompact(stakeBars[0]?.value)} τ
+              </span>
+              {freshness}
             </span>
           </div>
           <BarMini data={stakeBars} />
         </div>
-      ) : null}
+      ) : (
+        <div className="flex items-center justify-end">{freshness}</div>
+      )}
 
       <NeuronTable
         netuid={netuid}


### PR DESCRIPTION
## Summary

- `ValidatorsTableLoader`'s loaded (non-empty) view read `meta.generated_at` but only forwarded it to the empty-state `TableState` — a populated validator table gave no signal that the data is a periodic snapshot rather than live.
- Adds a `Daily rollup` label paired with the existing `FreshnessIndicator` (dot + relative time) to the loaded view, visible whether or not the top-stake bar chart renders (`stakeBars.length > 0` or not), matching the empty-state behavior that was already there.
- `FreshnessBadge` (#3370) hasn't merged yet, so this uses `FreshnessIndicator` + a literal "Daily rollup" text label per that issue's fallback guidance — same phrasing precedent as the `hint="UTC daily rollup"` in `account-history-chart.tsx`.

Closes #3380

## What Changed

- `apps/ui/src/components/metagraphed/validators-panel.tsx`: import `FreshnessIndicator`; render a `Daily rollup` + freshness element next to the existing `peak … τ` figure in the stake-bar header, and in its own right-aligned row when there are no stake bars to show. Header row now wraps (`flex-wrap` + `ml-auto`) instead of squeezing on narrow viewports. No changes to `NeuronTable`, `BarMini`, or any backend/API file. The pre-existing empty-state freshness display is untouched.

## Validation

- `npm test --workspace=apps/ui` (461 passed)
- `npm run build --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui` (pre-existing failures in `queries.ts`/`types.ts`, unrelated to this change and present on `main` before this PR)

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/mobile-dark-after.png)<br><sub>after</sub> |