### PR TITLE
feat(registry): move registry Postgres to its own DB, drop Tailscale for a Worker relay

### DIFF
--- a/.github/workflows/resync-registry-postgres.yml
+++ b/.github/workflows/resync-registry-postgres.yml
@@ -18,7 +18,11 @@ name: Resync registry to Postgres (full)
 # changes.
 #
 # Safe to merge ahead of the real credential existing -- see
-# scripts/backfill-registry-postgres.mjs's own DATABASE_URL no-op check.
+# scripts/backfill-registry-postgres.mjs's own REGISTRY_SYNC_SECRET no-op
+# check. There is no Tailscale, SSH, or direct network path from this
+# workflow to the database at all: the script POSTs to the registry-sync
+# Worker over HTTPS (see workers/registry-sync-api.mjs); this job only ever
+# needs the shared secret and the public endpoint.
 on:
   schedule:
     - cron: "0 */6 * * *" # matches the existing 6h data-publish cadence
@@ -54,5 +58,5 @@ jobs:
 
       - name: Full resync
         env:
-          DATABASE_URL: ${{ secrets.REGISTRY_DATABASE_URL }}
+          REGISTRY_SYNC_SECRET: ${{ secrets.REGISTRY_SYNC_SECRET }}
         run: node scripts/backfill-registry-postgres.mjs

--- a/.github/workflows/sync-registry-to-postgres.yml
+++ b/.github/workflows/sync-registry-to-postgres.yml
@@ -2,24 +2,34 @@ name: Sync registry to Postgres
 
 # Phase 2 of the registry-to-Postgres target architecture: on every push to
 # main that touches registry/subnets/** or registry/providers/**, upsert the
-# changed file(s) into the Postgres tables added in
-# deploy/postgres/schema.sql, via scripts/sync-registry-to-postgres.mjs.
+# changed file(s) into the registry Postgres instance (see
+# deploy/postgres/registry-schema.sql), via
+# scripts/sync-registry-to-postgres.mjs.
 #
 # Contribution/review is completely unchanged by this: a contributor's PR
 # still touches exactly one registry/subnets/<slug>.json file, still gets
 # scored by the Gittensory Gate exactly as today, still merges the same way.
-# This workflow only runs AFTER a merge lands on main -- the credential it
-# uses (REGISTRY_DATABASE_URL) is a repo secret a contributor's fork/PR can
-# never see or trigger a workflow run with (GitHub does not expose secrets to
-# workflows triggered from a fork), and it's scoped to only this table set,
-# not the chain-indexer's Postgres role.
+# This workflow only runs AFTER a merge lands on main -- a contributor's
+# fork/PR can never see these secrets or trigger a workflow run with them
+# (GitHub does not expose secrets to workflows triggered from a fork).
+#
+# The database is a dedicated, separate Postgres instance (not the
+# chain-indexer's), bound to 127.0.0.1 on its host and reachable only via a
+# Cloudflare Tunnel + Workers VPC Service + Hyperdrive -- the exact same path
+# already used for reads. This job never touches that path directly: it POSTs
+# the changed rows to the registry-sync Worker over HTTPS (see
+# workers/registry-sync-api.mjs, reached at /api/v1/internal/registry-sync),
+# authenticated by a single shared secret. There is no Tailscale, SSH, or any
+# other direct network route from CI to the database -- the runner only ever
+# needs the secret and the public HTTPS endpoint.
 #
 # Safe to merge ahead of the real credential existing: with no
-# REGISTRY_DATABASE_URL secret configured, the sync script itself detects
-# that and exits 0 having done nothing (see scripts/sync-registry-to-postgres.mjs).
-# This is deliberately a no-op until someone explicitly provisions the
-# credential and adds it as a secret -- adding this workflow does not, by
-# itself, start writing to any database.
+# REGISTRY_SYNC_SECRET configured, the sync script detects that and exits
+# cleanly having done nothing (see scripts/sync-registry-to-postgres.mjs).
+# This is deliberately a no-op until someone explicitly provisions the secret
+# on both the Worker (`wrangler secret put REGISTRY_SYNC_SECRET`) and this
+# repo (`gh secret set REGISTRY_SYNC_SECRET`) -- adding this workflow does
+# not, by itself, start writing to any database.
 on:
   push:
     branches: [main]
@@ -58,7 +68,7 @@ jobs:
 
       - name: Sync changed registry files
         env:
-          DATABASE_URL: ${{ secrets.REGISTRY_DATABASE_URL }}
+          REGISTRY_SYNC_SECRET: ${{ secrets.REGISTRY_SYNC_SECRET }}
         run: |
           node scripts/sync-registry-to-postgres.mjs \
             --base "${{ github.event.before }}" \

--- a/deploy/postgres/registry-schema.sql
+++ b/deploy/postgres/registry-schema.sql
@@ -1,0 +1,108 @@
+-- metagraphed-registry — target Postgres schema for the registry serving DB
+--
+-- Applies to a DEDICATED, SEPARATE Postgres instance from schema.sql's chain
+-- sink (different container, different port, different credentials,
+-- different host resources) -- deliberately not the same database. The
+-- chain-indexer's Postgres holds blocks/extrinsics/neurons at a completely
+-- different scale (hundreds of GB, growing) and operational tempo (written
+-- continuously by the indexer) from this one (a few thousand rows, written
+-- on contributor-PR-merge cadence). Keeping them fully independent means
+-- either can be restarted, backed up, or migrated without touching the
+-- other, and a chain-indexer incident can't take the registry down with it.
+--
+-- The single serving source of truth for EVERY subnet/provider/surface fact
+-- this system knows about, regardless of where the fact came from -- both
+-- the human-authored, PR-reviewed content in registry/subnets/*.json +
+-- registry/providers/*.json (the Gittensory Gate's review surface -- nothing
+-- about how a contributor submits or how the gate judges a PR changes) AND
+-- the machine-discovered/promoted content that scripts/generated-overlays.mjs
+-- computes from the native chain snapshot + candidate verification (subnets
+-- with no manual file yet, and auto-promoted candidate surfaces layered onto
+-- existing manual subnets). Both write paths upsert into the SAME tables --
+-- deliberately not split into a separate "generated" store, so nothing ever
+-- has to join two systems back together to answer "what surfaces does this
+-- subnet have right now." `subnets.source` and `surfaces.authority` record
+-- provenance (community vs machine) as a queryable fact ON the row, not as a
+-- reason to route the row somewhere else.
+--
+--   - registry/subnets/*.json changes: scripts/sync-registry-to-postgres.mjs,
+--     merge-triggered (event-driven, matches contributor-PR cadence).
+--   - Machine-generated/promoted content: scripts/backfill-registry-postgres.mjs
+--     run on a schedule (matches native-snapshot/candidate-verification
+--     cadence, not a git commit).
+--
+-- These tables are what the Worker actually reads/serves (once the read-path
+-- cutover happens -- not yet wired), so no derived registry artifact needs
+-- to be committed back to git and rebuilt on a cadence again -- it's
+-- computed live from these rows instead.
+--
+-- Not TimescaleDB hypertables (this data isn't a time series and there's no
+-- partition-column requirement to work around) -- ordinary tables with real
+-- foreign keys and uniqueness constraints, which is the entire point: a
+-- subnet's filename and its internal slug can no longer diverge (there is no
+-- filename to diverge from), and a surface can't be duplicated or farmed
+-- under a different `kind` against the same URL -- the UNIQUE constraint on
+-- `surfaces` rejects that insert outright, not just flags it after the fact.
+-- `gen_random_uuid()` has been in Postgres core (no extension) since PG13.
+-- Portable vanilla Postgres -- no extensions required.
+
+CREATE TABLE IF NOT EXISTS subnets (
+  netuid           INTEGER PRIMARY KEY,
+  slug             TEXT NOT NULL UNIQUE,
+  name             TEXT NOT NULL,
+  -- 'community' (has a registry/subnets/<slug>.json file) or
+  -- 'machine-generated' (native-chain-registered, no manual file yet --
+  -- scripts/generated-overlays.mjs's baseline overlay is the only source).
+  source           TEXT NOT NULL DEFAULT 'community',
+  overlay          JSONB NOT NULL,       -- full overlay content, verbatim (manual file, or the generated baseline)
+  source_commit    TEXT NOT NULL,        -- merge commit SHA (community) or the sync run's own commit SHA (generated)
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_subnets_source ON subnets (source);
+
+CREATE TABLE IF NOT EXISTS providers (
+  id               TEXT PRIMARY KEY,     -- the provider slug (registry/providers/<slug>.json)
+  overlay          JSONB NOT NULL,
+  source_commit    TEXT NOT NULL,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS surfaces (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subnet_netuid    INTEGER NOT NULL REFERENCES subnets (netuid) ON DELETE RESTRICT,
+  provider_id      TEXT REFERENCES providers (id) ON DELETE RESTRICT,
+  surface_key      TEXT NOT NULL,        -- matches scripts/lib.mjs's subnetSurfaceKey()
+  kind             TEXT NOT NULL,
+  url              TEXT NOT NULL,
+  -- source_urls lives only in `overlay` (JSONB array) -- real registry files
+  -- use both a legacy singular `source_url` and the current plural
+  -- `source_urls` shape, so normalizing it to one dedicated column here would
+  -- misrepresent one of the two. Query it from `overlay` when needed.
+  authority        TEXT NOT NULL DEFAULT 'community',
+  review_state     TEXT NOT NULL DEFAULT 'community-submitted',
+  probe_eligible   BOOLEAN NOT NULL DEFAULT false,
+  public_safe      BOOLEAN NOT NULL DEFAULT true,
+  overlay          JSONB NOT NULL,       -- the surface object, verbatim, for round-trip fidelity
+  source_commit    TEXT NOT NULL,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (subnet_netuid, kind, url)
+);
+CREATE INDEX IF NOT EXISTS idx_surfaces_subnet   ON surfaces (subnet_netuid);
+CREATE INDEX IF NOT EXISTS idx_surfaces_provider ON surfaces (provider_id);
+CREATE INDEX IF NOT EXISTS idx_surfaces_probe    ON surfaces (probe_eligible, review_state)
+  WHERE probe_eligible;
+
+-- Append-only audit ledger: every write traces back to the PR that produced
+-- it. A bad row is traced to its source_commit and reverted by reverting
+-- that PR and re-running the sync -- never a mystery change with no author.
+CREATE TABLE IF NOT EXISTS surface_history (
+  id               BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  surface_id       UUID,                 -- NULL if the surface was later deleted
+  subnet_netuid    INTEGER NOT NULL,
+  action           TEXT NOT NULL,        -- 'insert' | 'update' | 'delete'
+  overlay          JSONB NOT NULL,       -- the surface's overlay content at this point in history
+  source_commit    TEXT NOT NULL,
+  recorded_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_surface_history_surface ON surface_history (surface_id, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_surface_history_subnet  ON surface_history (subnet_netuid, recorded_at DESC);

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -223,106 +223,15 @@ CREATE TABLE IF NOT EXISTS indexer_cursor (
   CONSTRAINT indexer_cursor_singleton CHECK (id = 1)
 );
 
--- ---------------------------------------------------------------------------
--- Registry tiers (subnets / providers / surfaces)
--- ---------------------------------------------------------------------------
---
--- The single serving source of truth for EVERY subnet/provider/surface fact
--- this system knows about, regardless of where the fact came from -- both
--- the human-authored, PR-reviewed content in registry/subnets/*.json +
--- registry/providers/*.json (the Gittensory Gate's review surface -- nothing
--- about how a contributor submits or how the gate judges a PR changes) AND
--- the machine-discovered/promoted content that scripts/generated-overlays.mjs
--- computes from the native chain snapshot + candidate verification (subnets
--- with no manual file yet, and auto-promoted candidate surfaces layered onto
--- existing manual subnets). Both write paths upsert into the SAME tables --
--- deliberately not split into a separate "generated" store, so nothing ever
--- has to join two systems back together to answer "what surfaces does this
--- subnet have right now." `subnets.source` and `surfaces.authority` record
--- provenance (community vs machine) as a queryable fact ON the row, not as a
--- reason to route the row somewhere else.
---
---   - registry/subnets/*.json changes: scripts/sync-registry-to-postgres.mjs,
---     merge-triggered (event-driven, matches contributor-PR cadence).
---   - Machine-generated/promoted content: scripts/backfill-registry-postgres.mjs
---     run on a schedule (matches native-snapshot/candidate-verification
---     cadence, not a git commit).
---
--- These tables are what the Worker actually reads/serves, so no derived
--- registry artifact needs to be committed back to git and rebuilt on a
--- cadence again -- it's computed live from these rows instead.
---
--- Not TimescaleDB hypertables (this data isn't a time series and there's no
--- partition-column requirement to work around) -- ordinary tables with real
--- foreign keys and uniqueness constraints, which is the entire point: a
--- subnet's filename and its internal slug can no longer diverge (there is no
--- filename to diverge from), and a surface can't be duplicated or farmed
--- under a different `kind` against the same URL -- the UNIQUE constraint on
--- `surfaces` rejects that insert outright, not just flags it after the fact.
--- `gen_random_uuid()` has been in Postgres core (no extension) since PG13.
-
-CREATE TABLE IF NOT EXISTS subnets (
-  netuid           INTEGER PRIMARY KEY,
-  slug             TEXT NOT NULL UNIQUE,
-  name             TEXT NOT NULL,
-  -- 'community' (has a registry/subnets/<slug>.json file) or
-  -- 'machine-generated' (native-chain-registered, no manual file yet --
-  -- scripts/generated-overlays.mjs's baseline overlay is the only source).
-  source           TEXT NOT NULL DEFAULT 'community',
-  overlay          JSONB NOT NULL,       -- full overlay content, verbatim (manual file, or the generated baseline)
-  source_commit    TEXT NOT NULL,        -- merge commit SHA (community) or the sync run's own commit SHA (generated)
-  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-CREATE INDEX IF NOT EXISTS idx_subnets_source ON subnets (source);
-
-CREATE TABLE IF NOT EXISTS providers (
-  id               TEXT PRIMARY KEY,     -- the provider slug (registry/providers/<slug>.json)
-  overlay          JSONB NOT NULL,
-  source_commit    TEXT NOT NULL,
-  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS surfaces (
-  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  subnet_netuid    INTEGER NOT NULL REFERENCES subnets (netuid) ON DELETE RESTRICT,
-  provider_id      TEXT REFERENCES providers (id) ON DELETE RESTRICT,
-  surface_key      TEXT NOT NULL,        -- matches scripts/lib.mjs's subnetSurfaceKey()
-  kind             TEXT NOT NULL,
-  url              TEXT NOT NULL,
-  -- source_urls lives only in `overlay` (JSONB array) -- real registry files
-  -- use both a legacy singular `source_url` and the current plural
-  -- `source_urls` shape, so normalizing it to one dedicated column here would
-  -- misrepresent one of the two. Query it from `overlay` when needed.
-  authority        TEXT NOT NULL DEFAULT 'community',
-  review_state     TEXT NOT NULL DEFAULT 'community-submitted',
-  probe_eligible   BOOLEAN NOT NULL DEFAULT false,
-  public_safe      BOOLEAN NOT NULL DEFAULT true,
-  overlay          JSONB NOT NULL,       -- the surface object, verbatim, for round-trip fidelity
-  source_commit    TEXT NOT NULL,
-  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
-  UNIQUE (subnet_netuid, kind, url)
-);
-CREATE INDEX IF NOT EXISTS idx_surfaces_subnet   ON surfaces (subnet_netuid);
-CREATE INDEX IF NOT EXISTS idx_surfaces_provider ON surfaces (provider_id);
-CREATE INDEX IF NOT EXISTS idx_surfaces_probe    ON surfaces (probe_eligible, review_state)
-  WHERE probe_eligible;
-
--- Append-only audit ledger: every write traces back to the PR that produced
--- it. A bad row is traced to its source_commit and reverted by reverting
--- that PR and re-running the sync -- never a mystery change with no author.
-CREATE TABLE IF NOT EXISTS surface_history (
-  id               BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-  surface_id       UUID,                 -- NULL if the surface was later deleted
-  subnet_netuid    INTEGER NOT NULL,
-  action           TEXT NOT NULL,        -- 'insert' | 'update' | 'delete'
-  overlay          JSONB NOT NULL,       -- the surface's overlay content at this point in history
-  source_commit    TEXT NOT NULL,
-  recorded_at      TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-CREATE INDEX IF NOT EXISTS idx_surface_history_surface ON surface_history (surface_id, recorded_at DESC);
-CREATE INDEX IF NOT EXISTS idx_surface_history_subnet  ON surface_history (subnet_netuid, recorded_at DESC);
-
 -- TimescaleDB hypertables/compression are OPTIONAL and live in the companion
 -- schema-timescaledb.sql in this same directory — apply it separately, only
 -- on a Postgres that actually has the TimescaleDB extension. This file is a
 -- complete, working schema on its own (plain tables, no extensions needed).
+--
+-- The registry (subnets/providers/surfaces) tables live in the SEPARATE
+-- registry-schema.sql in this same directory, applied to a dedicated
+-- registry Postgres instance -- not this one. Two logically and physically
+-- independent databases (different container, different port, different
+-- credentials, different host resources), so either can be restarted,
+-- backed up, or migrated without touching the other. See registry-schema.sql
+-- for why.

--- a/scripts/backfill-registry-postgres.mjs
+++ b/scripts/backfill-registry-postgres.mjs
@@ -1,10 +1,11 @@
 // Full-resync import of every subnet/provider/surface fact this system
-// currently knows about into the Postgres tables added in
-// deploy/postgres/schema.sql (subnets / providers / surfaces /
-// surface_history) — the registry-to-Postgres target architecture's single
-// source of truth for BOTH the human-authored git tier AND the
-// machine-discovered/promoted tier (see schema.sql's own comment on why
-// these live in the same tables rather than a separate store).
+// currently knows about into the registry Postgres instance (subnets /
+// providers / surfaces / surface_history — see
+// deploy/postgres/registry-schema.sql) — the registry-to-Postgres target
+// architecture's single source of truth for BOTH the human-authored git tier
+// AND the machine-discovered/promoted tier (see that schema file's own
+// comment on why these live in the same tables rather than a separate
+// store).
 //
 // Idempotent and safe to run repeatedly: every write is an upsert keyed on
 // the same identity the data already carries (netuid / provider id /
@@ -22,11 +23,17 @@
 // sibling sync script) are what makes Postgres the single place everything
 // -- human-reviewed or machine-discovered -- ends up queryable together.
 //
-// Usage: DATABASE_URL=postgres://... node scripts/backfill-registry-postgres.mjs [--dry-run]
+// There is no Tailscale, SSH, or direct network path from CI to the database
+// at all: this script POSTs to the registry-sync Worker over HTTPS in
+// row-count-bounded chunks (see workers/registry-sync-api.mjs), never opens
+// a DB connection itself.
+//
+// Usage: REGISTRY_SYNC_SECRET=... node scripts/backfill-registry-postgres.mjs [--dry-run]
 import path from "node:path";
-import postgres from "postgres";
 import {
+  chunkRows,
   listJsonFiles,
+  postRegistrySync,
   readJson,
   repoRoot,
   stableStringify,
@@ -42,13 +49,14 @@ const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);
 async function main() {
   // Graceful no-op (not a failure) when unset -- this same script backs the
   // scheduled resync-registry-postgres.yml workflow, which must be safe to
-  // merge before REGISTRY_DATABASE_URL is actually provisioned (see that
+  // merge before REGISTRY_SYNC_SECRET is actually provisioned (see that
   // workflow's own comment). A manual one-time invocation with a genuinely
-  // missing DATABASE_URL still gets a clear message, just via exit 0 so a
-  // scheduled run before provisioning doesn't show as a failing workflow.
-  if (!dryRun && !process.env.DATABASE_URL) {
+  // missing REGISTRY_SYNC_SECRET still gets a clear message, just via exit 0
+  // so a scheduled run before provisioning doesn't show as a failing
+  // workflow.
+  if (!dryRun && !process.env.REGISTRY_SYNC_SECRET) {
     console.log(
-      "DATABASE_URL not set — registry-to-Postgres sync isn't provisioned yet, nothing to do.",
+      "REGISTRY_SYNC_SECRET not set — registry-to-Postgres sync isn't provisioned yet, nothing to do.",
     );
     return;
   }
@@ -65,7 +73,7 @@ async function main() {
       console.error(`skipping ${filePath}: missing required "id" field`);
       continue;
     }
-    providers.push({ id: overlay.id, overlay });
+    providers.push({ id: overlay.id, overlay, source_commit: sourceCommit });
   }
 
   // manualOverlays here is already baseline-AUGMENTED (candidate-promoted
@@ -77,8 +85,14 @@ async function main() {
 
   const subnets = [];
   const surfaces = [];
-  collectOverlays(manualOverlays, "community", subnets, surfaces);
-  collectOverlays(generatedOverlays, "machine-generated", subnets, surfaces);
+  collectOverlays(manualOverlays, "community", sourceCommit, subnets, surfaces);
+  collectOverlays(
+    generatedOverlays,
+    "machine-generated",
+    sourceCommit,
+    subnets,
+    surfaces,
+  );
 
   console.log(
     stableStringify({
@@ -96,94 +110,37 @@ async function main() {
     return;
   }
 
-  const sql = postgres(process.env.DATABASE_URL, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
+  const summary = {
+    providers_written: 0,
+    subnets_written: 0,
+    surfaces_written: 0,
+  };
 
-  try {
-    // Providers first, then subnets, then surfaces (FK order). A provider a
-    // surface references but whose file is missing/unreadable is left NULL
-    // rather than failing the whole run — surfaces.provider_id is nullable.
-    for (const provider of providers) {
-      await sql`
-        INSERT INTO providers (id, overlay, source_commit)
-        VALUES (${provider.id}, ${sql.json(provider.overlay)}, ${sourceCommit})
-        ON CONFLICT (id) DO UPDATE SET
-          overlay = EXCLUDED.overlay,
-          source_commit = EXCLUDED.source_commit,
-          updated_at = now()`;
-    }
-
-    const knownProviderIds = new Set(providers.map((p) => p.id));
-
-    for (const subnet of subnets) {
-      await sql`
-        INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
-        VALUES (${subnet.netuid}, ${subnet.slug}, ${subnet.name}, ${subnet.source}, ${sql.json(subnet.overlay)}, ${sourceCommit})
-        ON CONFLICT (netuid) DO UPDATE SET
-          slug = EXCLUDED.slug,
-          name = EXCLUDED.name,
-          source = EXCLUDED.source,
-          overlay = EXCLUDED.overlay,
-          source_commit = EXCLUDED.source_commit,
-          updated_at = now()`;
-    }
-
-    let inserted = 0;
-    let skippedDuplicates = 0;
-    for (const surface of surfaces) {
-      const providerId = knownProviderIds.has(surface.providerId)
-        ? surface.providerId
-        : null;
-      const result = await sql`
-        INSERT INTO surfaces (
-          subnet_netuid, provider_id, surface_key, kind, url,
-          authority, review_state, probe_eligible, public_safe,
-          overlay, source_commit
-        )
-        VALUES (
-          ${surface.subnetNetuid}, ${providerId}, ${surface.surfaceKey}, ${surface.kind}, ${surface.url},
-          ${surface.authority}, ${surface.reviewState}, ${surface.probeEligible}, ${surface.publicSafe},
-          ${sql.json(surface.overlay)}, ${sourceCommit}
-        )
-        ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
-          provider_id = EXCLUDED.provider_id,
-          surface_key = EXCLUDED.surface_key,
-          authority = EXCLUDED.authority,
-          review_state = EXCLUDED.review_state,
-          probe_eligible = EXCLUDED.probe_eligible,
-          public_safe = EXCLUDED.public_safe,
-          overlay = EXCLUDED.overlay,
-          source_commit = EXCLUDED.source_commit,
-          updated_at = now()
-        RETURNING (xmax = 0) AS inserted`;
-      if (result[0]?.inserted) {
-        inserted += 1;
-      } else {
-        skippedDuplicates += 1;
-      }
-      const action = result[0]?.inserted ? "insert" : "update";
-      await sql`
-        INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
-        VALUES (${surface.subnetNetuid}, ${action}, ${sql.json(surface.overlay)}, ${sourceCommit})`;
-    }
-
-    console.log(
-      stableStringify({
-        providers_written: providers.length,
-        subnets_written: subnets.length,
-        surfaces_inserted: inserted,
-        surfaces_updated: skippedDuplicates,
-      }),
-    );
-  } finally {
-    await sql.end({ timeout: 5 });
+  // Providers + subnets are small (low hundreds) -- one request each is
+  // plenty. Surfaces are the largest set by far, so they're chunked to stay
+  // under the Worker's rows-per-kind cap regardless of how large the
+  // registry grows.
+  if (providers.length || subnets.length) {
+    const result = await postRegistrySync({ providers, subnets });
+    summary.providers_written += result?.providers_written ?? 0;
+    summary.subnets_written += result?.subnets_written ?? 0;
   }
+  for (const chunk of chunkRows(surfaces)) {
+    if (!chunk.length) continue;
+    const result = await postRegistrySync({ surfaces: chunk });
+    summary.surfaces_written += result?.surfaces_written ?? 0;
+  }
+
+  console.log(stableStringify(summary));
 }
 
-function collectOverlays(overlays, source, subnetsOut, surfacesOut) {
+function collectOverlays(
+  overlays,
+  source,
+  sourceCommit,
+  subnetsOut,
+  surfacesOut,
+) {
   for (const overlay of overlays) {
     if (!Number.isInteger(overlay.netuid) || !overlay.slug || !overlay.name) {
       console.error(
@@ -198,23 +155,25 @@ function collectOverlays(overlays, source, subnetsOut, surfacesOut) {
       name: overlay.name,
       source,
       overlay: subnetOverlay,
+      source_commit: sourceCommit,
     });
     for (const surface of subnetSurfaces) {
       surfacesOut.push({
-        subnetNetuid: overlay.netuid,
-        surfaceKey: subnetSurfaceKey(surface, overlay.netuid),
+        subnet_netuid: overlay.netuid,
+        surface_key: subnetSurfaceKey(surface, overlay.netuid),
         kind: surface.kind,
         url: surface.url,
-        providerId: surface.provider || null,
+        provider_id: surface.provider || null,
         authority: surface.authority || "community",
-        reviewState: surface.review?.state || "community-submitted",
-        probeEligible: Boolean(
+        review_state: surface.review?.state || "community-submitted",
+        probe_eligible: Boolean(
           surface.probe?.enabled &&
           surface.public_safe &&
           operationalKindSet.has(surface.kind),
         ),
-        publicSafe: surface.public_safe !== false,
+        public_safe: surface.public_safe !== false,
         overlay: surface,
+        source_commit: sourceCommit,
       });
     }
   }

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -812,6 +812,63 @@ export function sortValue(value) {
   return value;
 }
 
+export const REGISTRY_SYNC_DEFAULT_URL =
+  "https://api.metagraph.sh/api/v1/internal/registry-sync";
+// Stay comfortably under workers/registry-sync-api.mjs's own 4 MiB body /
+// 5,000-rows-per-kind caps -- these are call-site chunk sizes, not the
+// server's actual limit, so a caller can safely batch well below them.
+export const REGISTRY_SYNC_MAX_BODY_BYTES = 3_500_000;
+export const REGISTRY_SYNC_MAX_ROWS_PER_KIND = 2_000;
+
+// Shared POST client for scripts/sync-registry-to-postgres.mjs (merge-
+// triggered) and scripts/backfill-registry-postgres.mjs (scheduled full
+// resync) -- both send {providers, subnets, surfaces} row arrays to the
+// registry-sync Worker over HTTPS instead of touching Postgres directly (see
+// workers/registry-sync-api.mjs). Returns null when REGISTRY_SYNC_SECRET
+// isn't set, so callers can no-op gracefully before the secret is
+// provisioned; throws on any transport/auth/validation failure so a real
+// misconfiguration fails the run loudly instead of silently doing nothing.
+export async function postRegistrySync(payload) {
+  const secret = process.env.REGISTRY_SYNC_SECRET;
+  if (!secret) {
+    return null;
+  }
+  const endpoint = process.env.REGISTRY_SYNC_URL || REGISTRY_SYNC_DEFAULT_URL;
+  const body = JSON.stringify(payload);
+  if (new TextEncoder().encode(body).length > REGISTRY_SYNC_MAX_BODY_BYTES) {
+    throw new Error(
+      `registry-sync payload of ${body.length} bytes exceeds the ${REGISTRY_SYNC_MAX_BODY_BYTES}-byte chunk budget -- split it further before calling postRegistrySync`,
+    );
+  }
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-registry-sync-token": secret,
+    },
+    body,
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(
+      `registry-sync request to ${endpoint} failed (${response.status}): ${json.error || response.statusText}`,
+    );
+  }
+  return json;
+}
+
+// Splits `rows` into chunks of at most `maxRows` each -- used to keep every
+// individual postRegistrySync() call under the server's rows-per-kind cap
+// when a caller (namely the full backfill) has more rows than fit in one
+// request. Always returns at least one (possibly empty) chunk.
+export function chunkRows(rows, maxRows = REGISTRY_SYNC_MAX_ROWS_PER_KIND) {
+  const chunks = [];
+  for (let i = 0; i < rows.length; i += maxRows) {
+    chunks.push(rows.slice(i, i + maxRows));
+  }
+  return chunks.length ? chunks : [[]];
+}
+
 const schemaGeneratedTimestampKeys = new Set(["x-generated-at", "x-timestamp"]);
 const schemaDroppedContentKeys = new Set([
   "description",

--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -1,38 +1,43 @@
 // Merge-triggered FAST PATH: upserts the registry/subnets/*.json +
-// registry/providers/*.json files that changed in a push into the Postgres
-// tables added in deploy/postgres/schema.sql, within seconds/minutes of a
-// merge rather than waiting for the next scheduled full resync. Its sibling,
+// registry/providers/*.json files that changed in a push into the registry
+// Postgres instance, within seconds/minutes of a merge rather than waiting
+// for the next scheduled full resync. Its sibling,
 // scripts/backfill-registry-postgres.mjs, run on a schedule, is what keeps
 // the machine-discovered half of the same tables (subnets with no manual
 // file, candidate-promoted surfaces) fresh on ITS OWN cadence — that content
 // isn't tied to a git commit the way this script's trigger is. Together they
 // make Postgres the single, always-fresh source of truth for every
 // subnet/provider/surface fact, human-authored or machine-discovered (see
-// schema.sql's own comment for why these live in one table set).
+// deploy/postgres/registry-schema.sql's own comment for why these live in
+// one table set).
 //
 // Contribution/review is UNCHANGED: a contributor's PR still touches only
 // registry/subnets/<slug>.json, still gets scored by the Gittensory Gate
 // exactly as today. This script only runs AFTER a merge lands on main, reading
 // the already-reviewed file — the write path a contributor's credentials
-// never reach (see .github/workflows/sync-registry-to-postgres.yml, which
-// this script is called from).
+// never reach. There is no Tailscale, SSH, or direct network path from CI to
+// the database at all: this script POSTs to the registry-sync Worker over
+// HTTPS (see workers/registry-sync-api.mjs and
+// .github/workflows/sync-registry-to-postgres.yml, which this script is
+// called from); the database itself stays exactly as private as it already
+// was.
 //
 // Independently re-validates each changed subnet file against
-// scripts/validate-surface.mjs before writing (defense in depth: the Gate
+// scripts/validate-surface.mjs before sending it (defense in depth: the Gate
 // already checked it pre-merge, this checks again post-merge) rather than
 // trusting the git content blindly.
 //
-// Safe to merge/run before DATABASE_URL is provisioned: with no DATABASE_URL,
-// this exits 0 having done nothing, so adding this workflow can't break
-// anything ahead of the real credential existing.
+// Safe to merge/run before REGISTRY_SYNC_SECRET is provisioned: with no
+// REGISTRY_SYNC_SECRET, this exits 0 having done nothing, so adding this
+// workflow can't break anything ahead of the real credential existing.
 //
 // Usage:
-//   DATABASE_URL=postgres://... node scripts/sync-registry-to-postgres.mjs \
+//   REGISTRY_SYNC_SECRET=... node scripts/sync-registry-to-postgres.mjs \
 //     --base <sha> --head <sha>
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import postgres from "postgres";
 import {
+  postRegistrySync,
   readJson,
   repoRoot,
   stableStringify,
@@ -44,9 +49,9 @@ const args = parseArgs(process.argv.slice(2));
 const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);
 
 async function main() {
-  if (!process.env.DATABASE_URL) {
+  if (!process.env.REGISTRY_SYNC_SECRET) {
     console.log(
-      "DATABASE_URL not set — registry-to-Postgres sync isn't provisioned yet, nothing to do.",
+      "REGISTRY_SYNC_SECRET not set — registry-to-Postgres sync isn't provisioned yet, nothing to do.",
     );
     return;
   }
@@ -69,82 +74,74 @@ async function main() {
     stableStringify({ base: args.base, head: args.head, changedFiles }),
   );
 
-  const sql = postgres(process.env.DATABASE_URL, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
+  const providers = [];
+  const subnets = [];
+  const surfaces = [];
+  const skippedInvalid = [];
+
+  for (const file of changedFiles) {
+    const stillExists = fileExistsAtHead(file);
+    if (!stillExists) {
+      // Deletions aren't synced yet (rare — this repo's surface model is
+      // append-only in practice); leaving the last-known row in place is
+      // safer than guessing at removal semantics here.
+      console.log(`${file} was deleted in this push; leaving its row(s) as-is`);
+      continue;
+    }
+    const absolutePath = path.join(repoRoot, file);
+
+    if (file.startsWith("registry/subnets/")) {
+      const revalidation = spawnSync(
+        process.execPath,
+        ["scripts/validate-surface.mjs", "--", file],
+        { cwd: repoRoot, encoding: "utf8" },
+      );
+      if (revalidation.status !== 0) {
+        console.error(
+          `skipping ${file}: failed independent re-validation post-merge (should be unreachable if the Gate is working — investigate)`,
+        );
+        skippedInvalid.push(file);
+        continue;
+      }
+      await collectSubnetFile(absolutePath, subnets, surfaces);
+    } else {
+      await collectProviderFile(absolutePath, providers);
+    }
+  }
 
   const summary = {
     providers_written: 0,
     subnets_written: 0,
     surfaces_written: 0,
-    skipped_invalid: [],
+    skipped_invalid: skippedInvalid,
   };
 
-  try {
-    for (const file of changedFiles) {
-      const absolutePath = path.join(repoRoot, file);
-      const stillExists = fileExistsAtHead(file);
-      if (!stillExists) {
-        // Deletions aren't synced yet (rare — this repo's surface model is
-        // append-only in practice); leaving the last-known row in place is
-        // safer than guessing at removal semantics here.
-        console.log(
-          `${file} was deleted in this push; leaving its row(s) as-is`,
-        );
-        continue;
-      }
+  if (providers.length || subnets.length || surfaces.length) {
+    const result = await postRegistrySync({ providers, subnets, surfaces });
+    summary.providers_written = result?.providers_written ?? 0;
+    summary.subnets_written = result?.subnets_written ?? 0;
+    summary.surfaces_written = result?.surfaces_written ?? 0;
+  }
 
-      if (file.startsWith("registry/subnets/")) {
-        const revalidation = spawnSync(
-          process.execPath,
-          ["scripts/validate-surface.mjs", "--", file],
-          { cwd: repoRoot, encoding: "utf8" },
-        );
-        if (revalidation.status !== 0) {
-          console.error(
-            `skipping ${file}: failed independent re-validation post-merge (should be unreachable if the Gate is working — investigate)`,
-          );
-          summary.skipped_invalid.push(file);
-          continue;
-        }
-        await syncSubnetFile(sql, absolutePath, summary);
-      } else {
-        await syncProviderFile(sql, absolutePath, summary);
-      }
-    }
-    console.log(stableStringify(summary));
-    if (summary.skipped_invalid.length > 0) {
-      // A file the Gate already merged failing re-validation here is a real
-      // signal something is wrong (a race, or a Gate/schema drift) — surface
-      // it as a failure so it pages someone rather than silently skipping.
-      process.exit(1);
-    }
-  } finally {
-    await sql.end({ timeout: 5 });
+  console.log(stableStringify(summary));
+  if (skippedInvalid.length > 0) {
+    // A file the Gate already merged failing re-validation here is a real
+    // signal something is wrong (a race, or a Gate/schema drift) — surface
+    // it as a failure so it pages someone rather than silently skipping.
+    process.exit(1);
   }
 }
 
-async function syncProviderFile(sql, absolutePath, summary) {
+async function collectProviderFile(absolutePath, providersOut) {
   const overlay = await readJson(absolutePath);
   if (!overlay.id) {
     console.error(`skipping ${absolutePath}: missing required "id" field`);
     return;
   }
-  const sourceCommit = args.head;
-  await sql`
-    INSERT INTO providers (id, overlay, source_commit)
-    VALUES (${overlay.id}, ${sql.json(overlay)}, ${sourceCommit})
-    ON CONFLICT (id) DO UPDATE SET
-      overlay = EXCLUDED.overlay,
-      source_commit = EXCLUDED.source_commit,
-      updated_at = now()
-    WHERE providers.overlay IS DISTINCT FROM EXCLUDED.overlay`;
-  summary.providers_written += 1;
+  providersOut.push({ id: overlay.id, overlay, source_commit: args.head });
 }
 
-async function syncSubnetFile(sql, absolutePath, summary) {
+async function collectSubnetFile(absolutePath, subnetsOut, surfacesOut) {
   const overlay = await readJson(absolutePath);
   if (!Number.isInteger(overlay.netuid) || !overlay.slug || !overlay.name) {
     console.error(
@@ -152,82 +149,40 @@ async function syncSubnetFile(sql, absolutePath, summary) {
     );
     return;
   }
-  const sourceCommit = args.head;
   const { surfaces = [], ...subnetOverlay } = overlay;
 
   // This script only ever runs because registry/subnets/<slug>.json changed,
-  // so `source` is unconditionally 'community' here -- explicitly SET it
-  // (not just relied on as the column default) so a subnet that used to be
-  // machine-generated-only correctly flips to 'community' the moment a
+  // so `source` is unconditionally 'community' here — a subnet that used to
+  // be machine-generated-only correctly flips to 'community' the moment a
   // contributor's first manual file for it merges, rather than staying
   // stale from before that file existed.
-  await sql`
-    INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
-    VALUES (${overlay.netuid}, ${overlay.slug}, ${overlay.name}, 'community', ${sql.json(subnetOverlay)}, ${sourceCommit})
-    ON CONFLICT (netuid) DO UPDATE SET
-      slug = EXCLUDED.slug,
-      name = EXCLUDED.name,
-      source = 'community',
-      overlay = EXCLUDED.overlay,
-      source_commit = EXCLUDED.source_commit,
-      updated_at = now()
-    WHERE subnets.overlay IS DISTINCT FROM EXCLUDED.overlay OR subnets.source IS DISTINCT FROM 'community'`;
-  summary.subnets_written += 1;
+  subnetsOut.push({
+    netuid: overlay.netuid,
+    slug: overlay.slug,
+    name: overlay.name,
+    source: "community",
+    overlay: subnetOverlay,
+    source_commit: args.head,
+  });
 
   for (const surface of surfaces) {
-    const providerRow = surface.provider
-      ? await sql`SELECT id FROM providers WHERE id = ${surface.provider}`
-      : [];
-    const providerId = providerRow[0]?.id ?? null;
-    const surfaceKey = subnetSurfaceKey(surface, overlay.netuid);
-    const probeEligible = Boolean(
-      surface.probe?.enabled &&
-      surface.public_safe &&
-      operationalKindSet.has(surface.kind),
-    );
-    const reviewState = surface.review?.state || "community-submitted";
-    const authority = surface.authority || "community";
-    const publicSafe = surface.public_safe !== false;
-
-    // Only log a history row when the surface's overlay actually changed --
-    // otherwise every merge that happens to touch a sibling surface in the
-    // same file would re-log every unrelated surface as "updated" noise.
-    const existing = await sql`
-      SELECT overlay FROM surfaces WHERE subnet_netuid = ${overlay.netuid} AND kind = ${surface.kind} AND url = ${surface.url}`;
-    const changed =
-      existing.length === 0 ||
-      stableStringify(existing[0].overlay) !== stableStringify(surface);
-
-    const result = await sql`
-      INSERT INTO surfaces (
-        subnet_netuid, provider_id, surface_key, kind, url,
-        authority, review_state, probe_eligible, public_safe,
-        overlay, source_commit
-      )
-      VALUES (
-        ${overlay.netuid}, ${providerId}, ${surfaceKey}, ${surface.kind}, ${surface.url},
-        ${authority}, ${reviewState}, ${probeEligible}, ${publicSafe},
-        ${sql.json(surface)}, ${sourceCommit}
-      )
-      ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
-        provider_id = EXCLUDED.provider_id,
-        surface_key = EXCLUDED.surface_key,
-        authority = EXCLUDED.authority,
-        review_state = EXCLUDED.review_state,
-        probe_eligible = EXCLUDED.probe_eligible,
-        public_safe = EXCLUDED.public_safe,
-        overlay = EXCLUDED.overlay,
-        source_commit = EXCLUDED.source_commit,
-        updated_at = now()
-      RETURNING (xmax = 0) AS inserted`;
-
-    if (changed) {
-      const action = result[0]?.inserted ? "insert" : "update";
-      await sql`
-        INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
-        VALUES (${overlay.netuid}, ${action}, ${sql.json(surface)}, ${sourceCommit})`;
-      summary.surfaces_written += 1;
-    }
+    surfacesOut.push({
+      subnet_netuid: overlay.netuid,
+      provider_id: surface.provider || null,
+      surface_key: subnetSurfaceKey(surface, overlay.netuid),
+      kind: surface.kind,
+      url: surface.url,
+      authority: surface.authority || "community",
+      review_state: surface.review?.state || "community-submitted",
+      probe_eligible: Boolean(
+        surface.probe?.enabled &&
+        surface.public_safe &&
+        operationalKindSet.has(surface.kind),
+      ),
+      public_safe: surface.public_safe !== false,
+      overlay: surface,
+      source_commit: args.head,
+    });
   }
 }
 

--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -1,0 +1,271 @@
+// Unit tests for the registry-sync Worker (workers/registry-sync-api.mjs). postgres.js
+// is mocked so the auth/validation/upsert routing is tested with no real DB — the live
+// Hyperdrive path is validated separately.
+import { beforeEach, expect, test, vi } from "vitest";
+
+const sqlCalls = vi.hoisted(() => []);
+const surfaceResult = vi.hoisted(() => ({ current: [{ inserted: true }] }));
+const failure = vi.hoisted(() => ({ error: null }));
+
+vi.mock("postgres", () => ({
+  default: () => {
+    const sql = (strings, ...values) => {
+      const text = Array.from(strings).join("?");
+      sqlCalls.push({ text, values });
+      if (failure.error && /INSERT INTO providers/.test(text)) {
+        return Promise.reject(failure.error);
+      }
+      if (/INSERT INTO surfaces/.test(text)) {
+        return Promise.resolve(surfaceResult.current);
+      }
+      return Promise.resolve([]);
+    };
+    sql.json = (value) => value;
+    sql.end = () => Promise.resolve();
+    return sql;
+  },
+}));
+
+const { default: worker } = await import("../workers/registry-sync-api.mjs");
+
+const SECRET = "test-registry-sync-secret";
+
+function post(body, { secret, method = "POST", raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret) headers["x-registry-sync-token"] = secret;
+  const init = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = raw !== undefined ? raw : JSON.stringify(body ?? {});
+  }
+  return new Request("https://registry-sync.internal/", init);
+}
+
+function baseEnv(overrides = {}) {
+  return {
+    REGISTRY_SYNC_SECRET: SECRET,
+    HYPERDRIVE: { connectionString: "postgres://mock" },
+    ...overrides,
+  };
+}
+
+const provider = () => ({
+  id: "acme",
+  overlay: { id: "acme", name: "Acme" },
+  source_commit: "abc123",
+});
+
+const subnet = () => ({
+  netuid: 8,
+  slug: "taoshi",
+  name: "Taoshi",
+  source: "community",
+  overlay: { netuid: 8, slug: "taoshi", name: "Taoshi" },
+  source_commit: "abc123",
+});
+
+const surface = () => ({
+  subnet_netuid: 8,
+  provider_id: "acme",
+  surface_key: "sn-8-example",
+  kind: "docs",
+  url: "https://example.com/docs",
+  overlay: { kind: "docs", url: "https://example.com/docs" },
+  source_commit: "abc123",
+});
+
+beforeEach(() => {
+  sqlCalls.length = 0;
+  surfaceResult.current = [{ inserted: true }];
+  failure.error = null;
+});
+
+test("rejects non-POST (405)", async () => {
+  const res = await worker.fetch(post(null, { method: "GET" }), baseEnv(), {});
+  expect(res.status).toBe(405);
+});
+
+test("is disabled (503) when REGISTRY_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    {},
+  );
+  expect(res.status).toBe(503);
+});
+
+test("rejects a missing or wrong token (401)", async () => {
+  const env = baseEnv();
+  const wrong = await worker.fetch(
+    post({ providers: [provider()] }, { secret: "wrong" }),
+    env,
+    {},
+  );
+  expect(wrong.status).toBe(401);
+  const missing = await worker.fetch(
+    post({ providers: [provider()] }),
+    env,
+    {},
+  );
+  expect(missing.status).toBe(401);
+});
+
+test("returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    { REGISTRY_SYNC_SECRET: SECRET },
+    {},
+  );
+  expect(res.status).toBe(503);
+});
+
+test("rejects a body over the byte cap (413)", async () => {
+  const res = await worker.fetch(
+    post(null, { secret: SECRET, raw: "x".repeat(5_000_000) }),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(413);
+});
+
+test("rejects malformed JSON (400)", async () => {
+  const res = await worker.fetch(
+    post(null, { secret: SECRET, raw: "{not json" }),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(400);
+});
+
+test("rejects more than the rows-per-kind cap (413)", async () => {
+  const many = Array.from({ length: 5001 }, (_, i) => ({
+    ...subnet(),
+    netuid: i,
+  }));
+  const res = await worker.fetch(
+    post({ subnets: many }, { secret: SECRET }),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(413);
+});
+
+test("rejects a non-object row (400)", async () => {
+  const res = await worker.fetch(
+    post({ providers: ["not-an-object"] }, { secret: SECRET }),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(400);
+});
+
+test("rejects an empty payload with no rows of any kind (400)", async () => {
+  const res = await worker.fetch(post({}, { secret: SECRET }), baseEnv(), {});
+  expect(res.status).toBe(400);
+});
+
+test("upserts providers + subnets + surfaces and reports written counts", async () => {
+  const res = await worker.fetch(
+    post(
+      { providers: [provider()], subnets: [subnet()], surfaces: [surface()] },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({
+    ok: true,
+    providers_written: 1,
+    subnets_written: 1,
+    surfaces_written: 1,
+  });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).toMatch(/INSERT INTO providers/);
+  expect(text).toMatch(/INSERT INTO subnets/);
+  expect(text).toMatch(/INSERT INTO surfaces/);
+  expect(text).toMatch(/INSERT INTO surface_history/);
+});
+
+test("skips rows missing required fields without failing the request", async () => {
+  const res = await worker.fetch(
+    post(
+      {
+        providers: [{ id: "acme" }], // missing overlay/source_commit
+        subnets: [{ netuid: 8 }], // missing slug/name/overlay/source_commit
+        surfaces: [{ subnet_netuid: 8 }], // missing surface_key/kind/url/overlay/source_commit
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({
+    providers_written: 0,
+    subnets_written: 0,
+    surfaces_written: 0,
+  });
+});
+
+test("defaults subnet source and surface provider_id when omitted", async () => {
+  const { source: _source, ...subnetWithoutSource } = subnet();
+  const { provider_id: _providerId, ...surfaceWithoutProvider } = surface();
+  const res = await worker.fetch(
+    post(
+      { subnets: [subnetWithoutSource], surfaces: [surfaceWithoutProvider] },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(200);
+  const subnetCall = sqlCalls.find((c) => /INSERT INTO subnets/.test(c.text));
+  expect(subnetCall.values).toContain("community");
+  const surfaceCall = sqlCalls.find((c) => /INSERT INTO surfaces/.test(c.text));
+  expect(surfaceCall.values).toContain(null);
+});
+
+test("does not log surface_history when the surface upsert is a no-op", async () => {
+  // WHERE surfaces.overlay IS DISTINCT FROM EXCLUDED.overlay yields zero
+  // RETURNING rows when the overlay is unchanged -- no history entry, no
+  // surfaces_written increment.
+  surfaceResult.current = [];
+  const res = await worker.fetch(
+    post({ surfaces: [surface()] }, { secret: SECRET }),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces_written).toBe(0);
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).not.toMatch(/INSERT INTO surface_history/);
+});
+
+test("records an update action in surface_history when the row already existed", async () => {
+  surfaceResult.current = [{ inserted: false }];
+  await worker.fetch(
+    post({ surfaces: [surface()] }, { secret: SECRET }),
+    baseEnv(),
+    {},
+  );
+  // The action is bound as a value, not embedded in the SQL text -- assert it
+  // was passed to the surface_history insert as "update", not "insert".
+  const historyCall = sqlCalls.find((c) =>
+    /INSERT INTO surface_history/.test(c.text),
+  );
+  expect(historyCall.values).toContain("update");
+});
+
+test("maps a DB failure to a clean 502 instead of throwing", async () => {
+  failure.error = new Error("connection reset");
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    baseEnv(),
+    {},
+  );
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});

--- a/tests/registry-sync-client.test.mjs
+++ b/tests/registry-sync-client.test.mjs
@@ -1,0 +1,109 @@
+// Unit tests for scripts/lib.mjs's registry-sync HTTP client helpers
+// (postRegistrySync, chunkRows) -- the shared POST client
+// scripts/sync-registry-to-postgres.mjs and scripts/backfill-registry-postgres.mjs
+// both call instead of touching Postgres directly.
+import assert from "node:assert/strict";
+import { afterEach, test } from "vitest";
+import {
+  REGISTRY_SYNC_DEFAULT_URL,
+  REGISTRY_SYNC_MAX_BODY_BYTES,
+  chunkRows,
+  postRegistrySync,
+} from "../scripts/lib.mjs";
+
+const originalFetch = globalThis.fetch;
+const originalSecret = process.env.REGISTRY_SYNC_SECRET;
+const originalUrl = process.env.REGISTRY_SYNC_URL;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalSecret === undefined) delete process.env.REGISTRY_SYNC_SECRET;
+  else process.env.REGISTRY_SYNC_SECRET = originalSecret;
+  if (originalUrl === undefined) delete process.env.REGISTRY_SYNC_URL;
+  else process.env.REGISTRY_SYNC_URL = originalUrl;
+});
+
+test("postRegistrySync no-ops (returns null) when REGISTRY_SYNC_SECRET is unset", async () => {
+  delete process.env.REGISTRY_SYNC_SECRET;
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return { ok: true, json: async () => ({}) };
+  };
+  const result = await postRegistrySync({ providers: [] });
+  assert.equal(result, null);
+  assert.equal(called, false);
+});
+
+test("postRegistrySync POSTs to the default URL with the secret header", async () => {
+  process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
+  delete process.env.REGISTRY_SYNC_URL;
+  let seenUrl;
+  let seenInit;
+  globalThis.fetch = async (url, init) => {
+    seenUrl = url;
+    seenInit = init;
+    return { ok: true, json: async () => ({ ok: true, providers_written: 1 }) };
+  };
+  const result = await postRegistrySync({ providers: [{ id: "acme" }] });
+  assert.equal(seenUrl, REGISTRY_SYNC_DEFAULT_URL);
+  assert.equal(seenInit.method, "POST");
+  assert.equal(seenInit.headers["x-registry-sync-token"], "s3cr3t");
+  assert.deepEqual(JSON.parse(seenInit.body), { providers: [{ id: "acme" }] });
+  assert.deepEqual(result, { ok: true, providers_written: 1 });
+});
+
+test("postRegistrySync honors REGISTRY_SYNC_URL when set", async () => {
+  process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
+  process.env.REGISTRY_SYNC_URL = "https://staging.example.com/registry-sync";
+  let seenUrl;
+  globalThis.fetch = async (url) => {
+    seenUrl = url;
+    return { ok: true, json: async () => ({}) };
+  };
+  await postRegistrySync({ subnets: [] });
+  assert.equal(seenUrl, "https://staging.example.com/registry-sync");
+});
+
+test("postRegistrySync throws with the response status + error on failure", async () => {
+  process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 401,
+    statusText: "Unauthorized",
+    json: async () => ({ error: "provide a valid token" }),
+  });
+  await assert.rejects(
+    postRegistrySync({ providers: [] }),
+    /failed \(401\): provide a valid token/,
+  );
+});
+
+test("postRegistrySync throws before sending when the payload exceeds the byte budget", async () => {
+  process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return { ok: true, json: async () => ({}) };
+  };
+  const bigOverlay = "x".repeat(REGISTRY_SYNC_MAX_BODY_BYTES + 1);
+  await assert.rejects(
+    postRegistrySync({ subnets: [{ overlay: bigOverlay }] }),
+    /exceeds the \d+-byte chunk budget/,
+  );
+  assert.equal(called, false);
+});
+
+test("chunkRows splits rows into groups of at most maxRows", () => {
+  const rows = Array.from({ length: 5 }, (_, i) => i);
+  const chunks = chunkRows(rows, 2);
+  assert.deepEqual(chunks, [[0, 1], [2, 3], [4]]);
+});
+
+test("chunkRows returns a single empty chunk for an empty input", () => {
+  assert.deepEqual(chunkRows([], 100), [[]]);
+});
+
+test("chunkRows returns one chunk when rows fit within maxRows", () => {
+  assert.deepEqual(chunkRows([1, 2, 3], 10), [[1, 2, 3]]);
+});

--- a/tests/registry-sync-client.test.mjs
+++ b/tests/registry-sync-client.test.mjs
@@ -79,6 +79,31 @@ test("postRegistrySync throws with the response status + error on failure", asyn
   );
 });
 
+test("postRegistrySync falls back to statusText when the error body has no message", async () => {
+  process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 502,
+    statusText: "Bad Gateway",
+    json: async () => ({}),
+  });
+  await assert.rejects(
+    postRegistrySync({ providers: [] }),
+    /failed \(502\): Bad Gateway/,
+  );
+});
+
+test("postRegistrySync tolerates an unreadable response body", async () => {
+  process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError("Unexpected end of JSON input");
+    },
+  });
+  assert.deepEqual(await postRegistrySync({ providers: [] }), {});
+});
+
 test("postRegistrySync throws before sending when the payload exceeds the byte budget", async () => {
   process.env.REGISTRY_SYNC_SECRET = "s3cr3t";
   let called = false;

--- a/tests/registry-sync-proxy.test.mjs
+++ b/tests/registry-sync-proxy.test.mjs
@@ -1,0 +1,104 @@
+// Unit tests for the /api/v1/internal/registry-sync proxy (workers/api.mjs's
+// handleRegistrySyncProxy), which forwards to the dedicated registry-sync
+// Worker via the REGISTRY_SYNC_API service binding. The downstream Worker
+// itself is covered by tests/registry-sync-api.test.mjs.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+
+function post(body, { method = "POST" } = {}) {
+  return new Request("https://api.metagraph.sh/api/v1/internal/registry-sync", {
+    method,
+    headers: { "content-type": "application/json" },
+    body:
+      method === "GET" || method === "HEAD"
+        ? undefined
+        : JSON.stringify(body ?? {}),
+  });
+}
+
+test("rejects non-POST before reaching the binding (405)", async () => {
+  let calls = 0;
+  const res = await handleRequest(
+    post(null, { method: "GET" }),
+    {
+      REGISTRY_SYNC_API: {
+        fetch() {
+          calls += 1;
+          return new Response("{}", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 405);
+  assert.equal(calls, 0);
+});
+
+test("returns 503 when REGISTRY_SYNC_API is not bound", async () => {
+  const res = await handleRequest(post({ providers: [] }), {}, {});
+  assert.equal(res.status, 503);
+});
+
+test("forwards the request to REGISTRY_SYNC_API and relays its response body + status", async () => {
+  let receivedToken;
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/internal/registry-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-registry-sync-token": "shared-secret",
+      },
+      body: JSON.stringify({ providers: [{ id: "acme" }] }),
+    }),
+    {
+      REGISTRY_SYNC_API: {
+        fetch(req) {
+          receivedToken = req.headers.get("x-registry-sync-token");
+          return new Response(
+            JSON.stringify({ ok: true, providers_written: 1 }),
+            { status: 200 },
+          );
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedToken, "shared-secret");
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { ok: true, providers_written: 1 });
+});
+
+test("relays a non-2xx upstream status (e.g. 401) unchanged", async () => {
+  const res = await handleRequest(
+    post({ providers: [] }),
+    {
+      REGISTRY_SYNC_API: {
+        fetch() {
+          return new Response(JSON.stringify({ error: "unauthorized" }), {
+            status: 401,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.deepEqual(await res.json(), { error: "unauthorized" });
+});
+
+test("returns 502 when the upstream response body is unreadable", async () => {
+  const res = await handleRequest(
+    post({ providers: [] }),
+    {
+      REGISTRY_SYNC_API: {
+        fetch() {
+          return new Response("not json", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal((await res.json()).error.code, "registry_sync_unavailable");
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1020,6 +1020,42 @@ async function handleChainEventsProxy(request, env, url) {
   );
 }
 
+// Proxies POST /api/v1/internal/registry-sync to the dedicated registry-sync
+// Worker (REGISTRY_SYNC_API service binding), the sole write path into the
+// registry Postgres instance. This function forwards the request as-is
+// (including the x-registry-sync-token header) -- the shared-secret check
+// happens once, downstream in workers/registry-sync-api.mjs, which is the
+// only place the secret needs to be provisioned. There is no bypass path
+// here to defend against: REGISTRY_SYNC_API has no public routes of its own,
+// so this route is the only way to reach it.
+async function handleRegistrySyncProxy(request, env) {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", "Only POST is supported.", 405);
+  }
+  if (!env.REGISTRY_SYNC_API) {
+    return errorResponse(
+      "registry_sync_unavailable",
+      "The registry-sync tier is not bound to this deployment.",
+      503,
+    );
+  }
+  const upstream = await env.REGISTRY_SYNC_API.fetch(request);
+  let body;
+  try {
+    body = await upstream.json();
+  } catch {
+    return errorResponse(
+      "registry_sync_unavailable",
+      "The registry-sync tier returned an unreadable response.",
+      502,
+    );
+  }
+  return new Response(JSON.stringify(body), {
+    status: upstream.status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
 export async function handleRequest(request, env = {}, ctx = {}) {
   let url = new URL(request.url);
 
@@ -1114,6 +1150,16 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   }
   if (url.pathname === "/api/v1/internal/backfill-economics") {
     return handleEconomicsBackfill(request, env);
+  }
+  // The only write path into the registry Postgres instance (a dedicated,
+  // separate database from the chain-indexer's) -- GitHub Actions calls this
+  // over HTTPS from the registry-sync workflows, never touches Postgres
+  // directly. Proxies to the dedicated registry-sync Worker (wrangler.registry.jsonc),
+  // which owns the postgres.js driver + this database's own Hyperdrive
+  // binding, keeping this Worker's bundle lean the same way DATA_API does
+  // for the chain-data tier.
+  if (url.pathname === "/api/v1/internal/registry-sync") {
+    return handleRegistrySyncProxy(request, env);
   }
 
   // GraphQL read-only query layer over existing artifacts (issue #751). Runs

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -1,0 +1,191 @@
+// metagraphed registry-sync Worker — the ONLY write path into the registry
+// Postgres instance (a dedicated, separate database from the chain-indexer's
+// -- see deploy/postgres/registry-schema.sql). Kept SEPARATE from the main
+// api.mjs Worker and from workers/data-api.mjs (which is READ-ONLY by design
+// for chain data) for the same bundle-budget reason ADR 0013 already split
+// data-api.mjs out: the postgres.js driver shouldn't grow every Worker that
+// merely proxies to it.
+//
+// Reached only via the main Worker's REGISTRY_SYNC_API service binding (no
+// public routes of its own) -- see workers/api.mjs's handleRegistrySyncProxy,
+// which forwards the request here unchanged. This Worker's shared-secret
+// check below is the only auth gate in the whole path.
+//
+// This is the write path scripts/sync-registry-to-postgres.mjs (merge-
+// triggered) and scripts/backfill-registry-postgres.mjs (scheduled full
+// resync) call over HTTPS from GitHub Actions -- there is no Tailscale, SSH,
+// or direct network path from CI to the database at all. GitHub Actions
+// only ever needs a REGISTRY_SYNC_SECRET value and the public HTTPS
+// endpoint; the database itself stays exactly as private as it already was
+// (bound to 127.0.0.1 on its host, reachable only via the Cloudflare Tunnel
+// + Workers VPC Service + Hyperdrive path already proven for reads).
+import postgres from "postgres";
+import { timingSafeEqual } from "../src/webhooks.mjs";
+
+const TOKEN_HEADER = "x-registry-sync-token";
+const MAX_BODY_BYTES = 4_194_304; // 4 MiB -- the full registry is ~1.5k surfaces, comfortably under this
+const MAX_ROWS_PER_KIND = 5_000;
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function isValidRow(row) {
+  return row && typeof row === "object" && !Array.isArray(row);
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return json({ error: "method not allowed" }, 405);
+    }
+    if (!env.REGISTRY_SYNC_SECRET) {
+      return json(
+        { error: "registry sync is not provisioned on this deployment" },
+        503,
+      );
+    }
+    const provided = request.headers.get(TOKEN_HEADER) || "";
+    if (!provided || !timingSafeEqual(provided, env.REGISTRY_SYNC_SECRET)) {
+      return json({ error: `provide a valid ${TOKEN_HEADER} header` }, 401);
+    }
+    if (!env.HYPERDRIVE?.connectionString) {
+      return json({ error: "hyperdrive binding unavailable" }, 503);
+    }
+
+    const raw = await request.text();
+    if (new TextEncoder().encode(raw).length > MAX_BODY_BYTES) {
+      return json({ error: `body exceeds ${MAX_BODY_BYTES} bytes` }, 413);
+    }
+    let body;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      return json({ error: "body must be JSON" }, 400);
+    }
+    const subnets = Array.isArray(body?.subnets) ? body.subnets : [];
+    const providers = Array.isArray(body?.providers) ? body.providers : [];
+    const surfaces = Array.isArray(body?.surfaces) ? body.surfaces : [];
+    for (const [name, rows] of [
+      ["subnets", subnets],
+      ["providers", providers],
+      ["surfaces", surfaces],
+    ]) {
+      if (rows.length > MAX_ROWS_PER_KIND) {
+        return json(
+          { error: `at most ${MAX_ROWS_PER_KIND} ${name} rows per request` },
+          413,
+        );
+      }
+      if (!rows.every(isValidRow)) {
+        return json({ error: `${name} must be an array of row objects` }, 400);
+      }
+    }
+    if (!subnets.length && !providers.length && !surfaces.length) {
+      return json({ error: "no rows provided" }, 400);
+    }
+
+    const sql = postgres(env.HYPERDRIVE.connectionString, {
+      max: 5,
+      prepare: false,
+      fetch_types: false,
+    });
+
+    const summary = {
+      providers_written: 0,
+      subnets_written: 0,
+      surfaces_written: 0,
+    };
+    try {
+      await sql`SET statement_timeout = '10000ms'`;
+
+      for (const p of providers) {
+        if (!p.id || !p.overlay || !p.source_commit) continue;
+        await sql`
+          INSERT INTO providers (id, overlay, source_commit)
+          VALUES (${p.id}, ${sql.json(p.overlay)}, ${p.source_commit})
+          ON CONFLICT (id) DO UPDATE SET
+            overlay = EXCLUDED.overlay,
+            source_commit = EXCLUDED.source_commit,
+            updated_at = now()
+          WHERE providers.overlay IS DISTINCT FROM EXCLUDED.overlay`;
+        summary.providers_written += 1;
+      }
+
+      for (const s of subnets) {
+        if (
+          !Number.isInteger(s.netuid) ||
+          !s.slug ||
+          !s.name ||
+          !s.overlay ||
+          !s.source_commit
+        )
+          continue;
+        await sql`
+          INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
+          VALUES (${s.netuid}, ${s.slug}, ${s.name}, ${s.source || "community"}, ${sql.json(s.overlay)}, ${s.source_commit})
+          ON CONFLICT (netuid) DO UPDATE SET
+            slug = EXCLUDED.slug,
+            name = EXCLUDED.name,
+            source = EXCLUDED.source,
+            overlay = EXCLUDED.overlay,
+            source_commit = EXCLUDED.source_commit,
+            updated_at = now()`;
+        summary.subnets_written += 1;
+      }
+
+      for (const surf of surfaces) {
+        if (
+          !Number.isInteger(surf.subnet_netuid) ||
+          !surf.surface_key ||
+          !surf.kind ||
+          !surf.url ||
+          !surf.overlay ||
+          !surf.source_commit
+        )
+          continue;
+        const result = await sql`
+          INSERT INTO surfaces (
+            subnet_netuid, provider_id, surface_key, kind, url,
+            authority, review_state, probe_eligible, public_safe,
+            overlay, source_commit
+          )
+          VALUES (
+            ${surf.subnet_netuid}, ${surf.provider_id ?? null}, ${surf.surface_key}, ${surf.kind}, ${surf.url},
+            ${surf.authority || "community"}, ${surf.review_state || "community-submitted"},
+            ${Boolean(surf.probe_eligible)}, ${surf.public_safe !== false},
+            ${sql.json(surf.overlay)}, ${surf.source_commit}
+          )
+          ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
+            provider_id = EXCLUDED.provider_id,
+            surface_key = EXCLUDED.surface_key,
+            authority = EXCLUDED.authority,
+            review_state = EXCLUDED.review_state,
+            probe_eligible = EXCLUDED.probe_eligible,
+            public_safe = EXCLUDED.public_safe,
+            overlay = EXCLUDED.overlay,
+            source_commit = EXCLUDED.source_commit,
+            updated_at = now()
+          WHERE surfaces.overlay IS DISTINCT FROM EXCLUDED.overlay
+          RETURNING (xmax = 0) AS inserted`;
+        if (result.length) {
+          const action = result[0].inserted ? "insert" : "update";
+          await sql`
+            INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
+            VALUES (${surf.subnet_netuid}, ${action}, ${sql.json(surf.overlay)}, ${surf.source_commit})`;
+          summary.surfaces_written += 1;
+        }
+      }
+
+      return json({ ok: true, ...summary });
+    } catch (err) {
+      console.error("registry-sync-api write failed:", err);
+      return json({ error: "write failed" }, 502);
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -111,7 +111,20 @@
   // Postgres-backed serving (ADR 0013): the dedicated data Worker (wrangler.data.jsonc)
   // owns the postgres.js driver + Hyperdrive binding; this Worker routes the
   // chain_events / deep-history paths to it, keeping this bundle lean.
-  "services": [{ "binding": "DATA_API", "service": "metagraphed-data-api" }],
+  //
+  // Registry-to-Postgres write path (registry-to-Postgres target architecture):
+  // the dedicated registry-sync Worker (wrangler.registry.jsonc) owns the
+  // SEPARATE registry Postgres's postgres.js driver + Hyperdrive binding; this
+  // Worker's /api/v1/internal/registry-sync route proxies to it after its own
+  // shared-secret check. The only write path in either direction -- GitHub
+  // Actions calls this route over HTTPS, never touches Postgres directly.
+  "services": [
+    { "binding": "DATA_API", "service": "metagraphed-data-api" },
+    {
+      "binding": "REGISTRY_SYNC_API",
+      "service": "metagraphed-registry-sync-api",
+    },
+  ],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV
   // (served live); the hourly trigger prunes the D1 time-series. 15 min (96
   // checks/day/surface) is ample for a registry's uptime + incident signal and

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -1,0 +1,41 @@
+{
+  // Dedicated registry-sync Worker — the sole write path into the registry
+  // Postgres instance (a separate database from the chain-indexer's, see
+  // deploy/postgres/registry-schema.sql). Deployed separately from the main
+  // api.mjs Worker for the same bundle-budget reason wrangler.data.jsonc
+  // already is: the postgres.js driver shouldn't grow every Worker that
+  // merely proxies to it. Reached only via the main Worker's
+  // REGISTRY_SYNC_API service binding (no public routes of its own).
+  // Deploy: wrangler deploy -c wrangler.registry.jsonc
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "metagraphed-registry-sync-api",
+  "main": "workers/registry-sync-api.mjs",
+  "compatibility_date": "2026-06-06",
+  "compatibility_flags": ["nodejs_compat"],
+  // This is a write path into a database, unlike wrangler.data.jsonc's
+  // read-only sibling -- explicitly disabled (wrangler otherwise defaults
+  // workers.dev to enabled) so the shared-secret check is the only way in,
+  // not "the shared-secret check, or just don't send one and see".
+  "workers_dev": false,
+  "preview_urls": false,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+    },
+  },
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "8a080e4e39354f96822cf75bcaee668d",
+      "localConnectionString": "postgresql://metagraphed_registry:postgres@localhost:5433/metagraphed_registry",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- Splits the registry tables (subnets/providers/surfaces/surface_history) out of `deploy/postgres/schema.sql` into a new `deploy/postgres/registry-schema.sql`, applied to a Postgres instance dedicated to the registry -- fully separate from the chain-indexer's database (different container, port, credentials, host resources).
- Replaces the write path's Tailscale/SSH-tunnel design with a dedicated `registry-sync` Worker (`wrangler.registry.jsonc`), reached only via the main Worker's `REGISTRY_SYNC_API` service binding at `POST /api/v1/internal/registry-sync`. GitHub Actions authenticates with a single shared secret over HTTPS -- no Tailscale, SSH, or direct network path from CI to the database at all.
- `scripts/sync-registry-to-postgres.mjs` (merge-triggered) and `scripts/backfill-registry-postgres.mjs` (scheduled full resync) now POST row batches to that endpoint instead of opening a Postgres connection themselves; a shared `postRegistrySync`/`chunkRows` helper lives in `scripts/lib.mjs`.
- Both GitHub Actions workflows drop every Tailscale/SSH-tunnel step in favor of a plain authenticated HTTPS call.

## Test plan
- [x] `npm run lint` / `npm run format:check`
- [x] `npm run validate`
- [x] `npm test` (228 files, 6415 tests)
- [x] `git diff --check`
- [x] `node scripts/backfill-registry-postgres.mjs --dry-run` (129 subnets / 131 providers / 1404 surfaces, matches the live registry DB)
- [x] `wrangler deploy -c wrangler.registry.jsonc` (real deploy, `workers_dev`/`preview_urls` disabled -- verified the old preview URL now 404s)
- [ ] Set `REGISTRY_SYNC_SECRET` as a GitHub Actions repo secret (same value already provisioned as the Worker secret) and do one real end-to-end POST once this merges and the main Worker redeploys with the new `REGISTRY_SYNC_API` binding.