### PR TITLE
feat(registry): add SN72 StreetVision roadwork rows-API surface (#681)

### DIFF
--- a/registry/subnets/streetvision-by-natix.json
+++ b/registry/subnets/streetvision-by-natix.json
@@ -169,6 +169,25 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Public NATIX StreetVision HuggingFace image+text dataset (~8.5k road/roadwork scenes with structured scene/weather/lighting metadata) backing the SN72 roadwork image-classification task; not gated. The StreetVision README (source) declares the Bittensor subnet and links the natix-network-org HF org that owns it."
+    },
+    {
+      "id": "sn-72-natix-roadwork-rows-api",
+      "name": "StreetVision roadwork dataset rows API",
+      "kind": "data-artifact",
+      "url": "https://datasets-server.huggingface.co/rows?dataset=natix-network-org/roadwork&config=default&split=train&offset=0&length=100",
+      "provider": "natix",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/natixnetwork/streetvision-subnet",
+        "https://huggingface.co/datasets/natix-network-org/roadwork"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "notes": "Public no-auth Hugging Face Datasets Server rows API for the official StreetVision roadwork dataset — returns machine-readable JSON (schema + row records with image/id/width/height/scene metadata), a distinct callable endpoint from the existing HF dataset webpage surface above. Fills the file's gap note for a verified safe public subnet API endpoint."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/streetvision-by-natix.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 72
- Kind: data-artifact
- Public URL: https://datasets-server.huggingface.co/rows?dataset=natix-network-org/roadwork&config=default&split=train&offset=0&length=100
- Source URL (proves the claim): https://github.com/natixnetwork/streetvision-subnet (official SN72 source repo, already the registered `source_repo`), plus https://huggingface.co/datasets/natix-network-org/roadwork (the official NATIX-owned dataset this API serves, already an existing surface in this file)
- Provider slug: natix (already registered)

This is the Hugging Face Datasets Server "rows" API for the official StreetVision `roadwork` dataset — a distinct, machine-readable, callable JSON endpoint (schema + row records: image, id, width, height, scene metadata) separate from the existing HF dataset webpage surface already in the file. No auth required, no auth/login/token/session/key/nonce/wallet wording in the path. Directly fills this file's own gap note: "No verified safe public subnet API endpoint yet."

Closes #681

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Generated to match the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct URL from the existing HF dataset-page surface).
- [x] Links a tracked issue (`Closes #681`).

## Gate Expectations

Public-safe surface, minimal single-surface append.

## Validation

- [x] `npm run validate:surface -- registry/subnets/streetvision-by-natix.json` — passed (8 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed