### PR TITLE
feat(ui): add network stake-flow chart to explorer page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-stake-flow.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-stake-flow.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainStakeFlowQuery, normalizeChainStakeFlow } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/stake-flow",
+  });
+}
+
+async function runQuery(window?: "7d" | "30d", limit?: number) {
+  const opts = chainStakeFlowQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainStakeFlow", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeChainStakeFlow({
+        schema_version: 1,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          total_staked_tao: 100,
+          total_unstaked_tao: 80,
+          net_flow_tao: 20,
+          gross_flow_tao: 180,
+          stake_events: 10,
+          unstake_events: 8,
+          gaining: 1,
+          losing: 1,
+          flat: 0,
+        },
+        net_flow_distribution: {
+          count: 2,
+          mean: 10,
+          min: -5,
+          p25: -2,
+          median: 10,
+          p75: 15,
+          p90: 18,
+          max: 20,
+        },
+        subnets: [
+          {
+            netuid: 1,
+            total_staked_tao: 60,
+            total_unstaked_tao: 40,
+            net_flow_tao: 20,
+            gross_flow_tao: 100,
+            stake_events: 6,
+            unstake_events: 4,
+            direction: "inflow",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      subnet_count: 2,
+      network: { net_flow_tao: 20, total_staked_tao: 100 },
+      subnets: [{ netuid: 1, direction: "inflow" }],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainStakeFlow(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.network.total_staked_tao).toBe(0);
+      expect(card.network.net_flow_tao).toBe(0);
+      expect(card.subnets).toEqual([]);
+      expect(card.net_flow_distribution).toBeNull();
+    }
+  });
+});
+
+describe("chainStakeFlowQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the card", async () => {
+    resolveWith({
+      window: "7d",
+      subnet_count: 1,
+      network: { total_staked_tao: 5, total_unstaked_tao: 3, net_flow_tao: 2 },
+      subnets: [],
+    });
+    const res = await runQuery("7d", 12);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/stake-flow",
+      expect.objectContaining({ params: { window: "7d", limit: 12 } }),
+    );
+    expect(res.data.network.net_flow_tao).toBe(2);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/stake-flow",
+      expect.objectContaining({ params: { window: "30d", limit: 12 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -52,6 +52,8 @@ import type {
   ChainFeePayer,
   ChainTransferPair,
   ChainTransferPairs,
+  ChainStakeFlow,
+  ChainStakeFlowSubnet,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -184,6 +186,7 @@ const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
+const MAX_CHAIN_STAKE_FLOW_SUBNETS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -2626,6 +2629,94 @@ export const chainTransferPairsQuery = (
       });
       return {
         data: normalizeChainTransferPairs(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeStakeFlowDirection(raw: unknown): ChainStakeFlowSubnet["direction"] {
+  const s = firstString(raw);
+  if (s === "inflow" || s === "outflow" || s === "balanced") return s;
+  return null;
+}
+
+function normalizeChainStakeFlowSubnet(raw: unknown): ChainStakeFlowSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    total_staked_tao: firstFiniteNumber(raw.total_staked_tao) ?? 0,
+    total_unstaked_tao: firstFiniteNumber(raw.total_unstaked_tao) ?? 0,
+    net_flow_tao: firstFiniteNumber(raw.net_flow_tao) ?? 0,
+    gross_flow_tao: firstFiniteNumber(raw.gross_flow_tao) ?? 0,
+    stake_events: firstFiniteNumber(raw.stake_events) ?? 0,
+    unstake_events: firstFiniteNumber(raw.unstake_events) ?? 0,
+    direction: normalizeStakeFlowDirection(raw.direction),
+  };
+}
+
+function normalizeChainStakeFlowDistribution(raw: unknown): ChainStakeFlowDistribution | null {
+  if (!isRecord(raw)) return null;
+  const count = firstFiniteNumber(raw.count) ?? 0;
+  if (count <= 0) return null;
+  return {
+    count,
+    mean: firstFiniteNumber(raw.mean) ?? 0,
+    min: firstFiniteNumber(raw.min) ?? 0,
+    p25: firstFiniteNumber(raw.p25) ?? 0,
+    median: firstFiniteNumber(raw.median) ?? 0,
+    p75: firstFiniteNumber(raw.p75) ?? 0,
+    p90: firstFiniteNumber(raw.p90) ?? 0,
+    max: firstFiniteNumber(raw.max) ?? 0,
+  };
+}
+
+function normalizeChainStakeFlowNetwork(raw: unknown): ChainStakeFlowNetwork {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    total_staked_tao: firstFiniteNumber(rec.total_staked_tao) ?? 0,
+    total_unstaked_tao: firstFiniteNumber(rec.total_unstaked_tao) ?? 0,
+    net_flow_tao: firstFiniteNumber(rec.net_flow_tao) ?? 0,
+    gross_flow_tao: firstFiniteNumber(rec.gross_flow_tao) ?? 0,
+    stake_events: firstFiniteNumber(rec.stake_events) ?? 0,
+    unstake_events: firstFiniteNumber(rec.unstake_events) ?? 0,
+    gaining: firstFiniteNumber(rec.gaining) ?? 0,
+    losing: firstFiniteNumber(rec.losing) ?? 0,
+    flat: firstFiniteNumber(rec.flat) ?? 0,
+  };
+}
+
+export function normalizeChainStakeFlow(raw: unknown): ChainStakeFlow {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: normalizeChainStakeFlowNetwork(rec.network),
+    net_flow_distribution: normalizeChainStakeFlowDistribution(rec.net_flow_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_STAKE_FLOW_SUBNETS,
+      normalizeChainStakeFlowSubnet,
+    ),
+  };
+}
+
+/** Network-wide net stake capital flow (StakeAdded vs StakeRemoved) over a 7d/30d window. */
+export const chainStakeFlowQuery = (window: ChainWindow = "30d", limit = 12) =>
+  queryOptions({
+    queryKey: k("chain-stake-flow", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainStakeFlow>>("/api/v1/chain/stake-flow", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainStakeFlow(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1786,6 +1786,57 @@ export interface ChainTransferPairs {
   pairs: ChainTransferPair[];
 }
 
+/** Per-subnet net stake flow row in GET /api/v1/chain/stake-flow. */
+export interface ChainStakeFlowSubnet {
+  netuid: number;
+  total_staked_tao: number;
+  total_unstaked_tao: number;
+  net_flow_tao: number;
+  gross_flow_tao: number;
+  stake_events: number;
+  unstake_events: number;
+  direction: "inflow" | "outflow" | "balanced" | null;
+}
+
+/** Network rollup in GET /api/v1/chain/stake-flow. */
+export interface ChainStakeFlowNetwork {
+  total_staked_tao: number;
+  total_unstaked_tao: number;
+  net_flow_tao: number;
+  gross_flow_tao: number;
+  stake_events: number;
+  unstake_events: number;
+  gaining: number;
+  losing: number;
+  flat: number;
+}
+
+export interface ChainStakeFlowDistribution {
+  count: number;
+  mean: number;
+  min: number;
+  p25: number;
+  median: number;
+  p75: number;
+  p90: number;
+  max: number;
+}
+
+/**
+ * Network-wide net stake capital flow over a 7d/30d window from
+ * GET /api/v1/chain/stake-flow — StakeAdded vs StakeRemoved TAO, distinct from
+ * stake-transfers (#3467) and stake-moves (#3468).
+ */
+export interface ChainStakeFlow {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainStakeFlowNetwork;
+  net_flow_distribution: ChainStakeFlowDistribution | null;
+  subnets: ChainStakeFlowSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Activity, Boxes, Coins, Layers, Zap } from "lucide-react";
+import { Activity, ArrowDownUp, Boxes, Coins, Layers, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -18,10 +18,11 @@ import {
   chainCallsQuery,
   chainFeesQuery,
   chainSignersQuery,
+  chainStakeFlowQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import type { ChainCalls } from "@/lib/metagraphed/types";
+import type { ChainCalls, ChainStakeFlow } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
@@ -80,6 +81,7 @@ function ExplorerPage() {
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
+          "/api/v1/chain/stake-flow",
         ]}
       />
     </AppShell>
@@ -222,6 +224,155 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
   );
 }
 
+/**
+ * Network-wide net stake flow — StakeAdded vs StakeRemoved TAO over the window.
+ * Distinct from stake-transfers (#3467) and stake-moves (#3468) leaderboards.
+ */
+function StakeFlowSection({ flow, window }: { flow: ChainStakeFlow; window: string }) {
+  const net = flow.network;
+  const hasFlow = net.gross_flow_tao > 0 || flow.subnets.length > 0;
+  const inOutCap = Math.max(net.total_staked_tao, net.total_unstaked_tao, 1);
+  const topByNet = [...flow.subnets]
+    .sort((a, b) => Math.abs(b.net_flow_tao) - Math.abs(a.net_flow_tao))
+    .slice(0, 10);
+  const barCap = Math.max(1, ...topByNet.map((s) => Math.abs(s.net_flow_tao)));
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Stake flow
+          </h2>
+          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+            Net capital in vs out (StakeAdded − StakeRemoved) — not transfers or re-delegation
+            moves.
+          </p>
+        </div>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(flow.subnet_count)} subnets · {window}
+        </span>
+      </div>
+      {hasFlow ? (
+        <div className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <StatTile
+              icon={ArrowDownUp}
+              eyebrow="Staked in"
+              value={fmtTao(net.total_staked_tao)}
+              hint={`${formatNumber(net.stake_events)} StakeAdded`}
+              tone="ok"
+            />
+            <StatTile
+              icon={ArrowDownUp}
+              eyebrow="Unstaked out"
+              value={fmtTao(net.total_unstaked_tao)}
+              hint={`${formatNumber(net.unstake_events)} StakeRemoved`}
+            />
+            <StatTile
+              icon={Layers}
+              eyebrow="Net flow"
+              value={fmtTao(net.net_flow_tao)}
+              hint={`${formatNumber(net.gaining)} gaining · ${formatNumber(net.losing)} losing`}
+              tone={net.net_flow_tao >= 0 ? "ok" : "accent"}
+            />
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+                Network in vs out
+              </div>
+              <ul className="space-y-2">
+                {[
+                  { label: "Staked in", value: net.total_staked_tao, color: "var(--chart-6)" },
+                  { label: "Unstaked out", value: net.total_unstaked_tao, color: "var(--chart-3)" },
+                ].map((row) => {
+                  const pct = Math.max(2, Math.round((row.value / inOutCap) * 100));
+                  return (
+                    <li
+                      key={row.label}
+                      className="grid grid-cols-[6.5rem_1fr_auto] items-center gap-2"
+                    >
+                      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                        {row.label}
+                      </span>
+                      <span className="relative h-2 overflow-hidden rounded-full bg-surface">
+                        <span
+                          className="absolute inset-y-0 left-0 rounded-full"
+                          style={{ width: `${pct}%`, background: row.color }}
+                        />
+                      </span>
+                      <span className="font-mono text-[10px] tabular-nums text-ink-strong">
+                        {fmtTao(row.value)}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            <div>
+              <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+                Top subnets by |net flow|
+              </div>
+              {topByNet.length > 0 ? (
+                <ul className="space-y-1.5">
+                  {topByNet.map((s) => {
+                    const abs = Math.abs(s.net_flow_tao);
+                    const pct = Math.max(2, Math.round((abs / barCap) * 100));
+                    const positive = s.net_flow_tao >= 0;
+                    return (
+                      <li
+                        key={s.netuid}
+                        className="grid grid-cols-[3.5rem_1fr_auto] items-center gap-2"
+                      >
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: s.netuid }}
+                          className="font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent"
+                        >
+                          SN{s.netuid}
+                        </Link>
+                        <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
+                          <span
+                            className="absolute inset-y-0 left-0 rounded-full"
+                            style={{
+                              width: `${pct}%`,
+                              background: positive ? "var(--chart-6)" : "var(--chart-3)",
+                            }}
+                          />
+                        </span>
+                        <span
+                          className={
+                            positive
+                              ? "font-mono text-[10px] tabular-nums text-ink-strong"
+                              : "font-mono text-[10px] tabular-nums text-ink-muted"
+                          }
+                        >
+                          {positive ? "+" : "−"}
+                          {fmtTao(Math.abs(s.net_flow_tao))}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="font-mono text-[12px] text-ink-muted">No per-subnet flow yet.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">
+          No stake flow indexed in this window yet — the account_events tier fills this from
+          StakeAdded and StakeRemoved events.
+        </p>
+      )}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -231,6 +382,7 @@ function ExplorerDashboard() {
   const fees = useSuspenseQuery(chainFeesQuery(win)).data.data;
   const calls = useSuspenseQuery(chainCallsQuery(win)).data.data;
   const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
+  const stakeFlow = useSuspenseQuery(chainStakeFlowQuery(win)).data.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
   const chrono = [...activity.days].reverse();
@@ -450,6 +602,8 @@ function ExplorerDashboard() {
           )}
         </section>
       </div>
+
+      <StakeFlowSection flow={stakeFlow} window={win} />
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* call mix */}


### PR DESCRIPTION
Closes #3734

## Summary

Adds a network-wide net stake-flow section to the chain explorer, wired to `GET /api/v1/chain/stake-flow`. Shows StakeAdded vs StakeRemoved capital flow — distinct from stake-transfers (#3467) and stake-moves (#3468).

- `chainStakeFlowQuery` in `queries.ts` with window + limit params
- `StakeFlowSection` on `/explorer` with network KPI tiles, in-vs-out bars, and top subnets by |net flow|

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-light-before.png)<br><sub>before — no stake-flow section</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-light-after.png)<br><sub>after — net in/out KPIs + subnet bars</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/explorer-stake-flow-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] Open `/explorer` — stake flow section appears after fees, before call mix
- [x] Toggle 7d/30d window — stake flow refetches with matching window
- [x] Network totals and top-subnet bars render with live data
- [ ] Empty state when cold store returns zeros
- [x] Light + dark mode on desktop/tablet/mobile (see screenshot table)
