### PR TITLE
feat(ui): add account endpoint-announcement activity panel

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-serving-prometheus.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-serving-prometheus.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  accountPrometheusQuery,
+  accountServingQuery,
+  normalizeAccountPrometheus,
+  normalizeAccountServing,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+async function runServingQuery(ss58: string, window?: string) {
+  const opts = accountServingQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+async function runPrometheusQuery(ss58: string, window?: string) {
+  const opts = accountPrometheusQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeAccountServing", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeAccountServing(SS58, {
+        schema_version: 1,
+        address: SS58,
+        window: "30d",
+        total_announcements: 12,
+        subnet_count: 2,
+        concentration: 0.56,
+        dominant_netuid: 1,
+        subnets: [
+          {
+            netuid: 1,
+            announcements: 8,
+            first_served_at: "2026-06-01T00:00:00.000Z",
+            last_served_at: "2026-06-15T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      total_announcements: 12,
+      subnet_count: 2,
+      subnets: [{ netuid: 1, announcements: 8 }],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { total_announcements: "nope" }]) {
+      const card = normalizeAccountServing(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.total_announcements).toBe(0);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("normalizeAccountPrometheus", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeAccountPrometheus(SS58, {
+        schema_version: 1,
+        address: SS58,
+        window: "30d",
+        total_announcements: 5,
+        subnet_count: 1,
+        subnets: [
+          {
+            netuid: 7,
+            announcements: 5,
+            first_announced_at: "2026-06-20T00:00:00.000Z",
+            last_announced_at: "2026-06-20T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      total_announcements: 5,
+      subnet_count: 1,
+      subnets: [{ netuid: 7, announcements: 5 }],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { total_announcements: "nope" }]) {
+      const card = normalizeAccountPrometheus(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.total_announcements).toBe(0);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountServingQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: { address: SS58, window: "7d", total_announcements: 3, subnet_count: 1 },
+      meta: {} as ApiResult<unknown>["meta"],
+      url: `/api/v1/accounts/${SS58}/serving`,
+    });
+    const res = await runServingQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/serving`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_announcements).toBe(3);
+  });
+
+  it("defaults to the 30d window", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: {},
+      meta: {} as ApiResult<unknown>["meta"],
+      url: `/api/v1/accounts/${SS58}/serving`,
+    });
+    await runServingQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/serving`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});
+
+describe("accountPrometheusQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: { address: SS58, window: "7d", total_announcements: 2, subnet_count: 1 },
+      meta: {} as ApiResult<unknown>["meta"],
+      url: `/api/v1/accounts/${SS58}/prometheus`,
+    });
+    const res = await runPrometheusQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/prometheus`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_announcements).toBe(2);
+  });
+
+  it("defaults to the 30d window", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: {},
+      meta: {} as ApiResult<unknown>["meta"],
+      url: `/api/v1/accounts/${SS58}/prometheus`,
+    });
+    await runPrometheusQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/prometheus`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -31,6 +31,10 @@ import type {
   AccountAxonRemovalsSubnet,
   AccountWeightSetters,
   AccountWeightSettersSubnet,
+  AccountPrometheus,
+  AccountPrometheusSubnet,
+  AccountServing,
+  AccountServingSubnet,
   AccountBalance,
   AccountDay,
   AccountEvent,
@@ -2339,6 +2343,104 @@ export const accountWeightSettersQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountWeightSetters(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountServingSubnet(raw: unknown): AccountServingSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    announcements: firstFiniteNumber(raw.announcements) ?? 0,
+    first_served_at: firstString(raw.first_served_at) ?? null,
+    last_served_at: firstString(raw.last_served_at) ?? null,
+  };
+}
+
+export function normalizeAccountServing(ss58: string, raw: unknown): AccountServing {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountServingSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_announcements: firstFiniteNumber(rec.total_announcements) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountServingQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-serving", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountServing>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/serving`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountServing(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountPrometheusSubnet(raw: unknown): AccountPrometheusSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    announcements: firstFiniteNumber(raw.announcements) ?? 0,
+    first_announced_at: firstString(raw.first_announced_at) ?? null,
+    last_announced_at: firstString(raw.last_announced_at) ?? null,
+  };
+}
+
+export function normalizeAccountPrometheus(ss58: string, raw: unknown): AccountPrometheus {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountPrometheusSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_announcements: firstFiniteNumber(rec.total_announcements) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountPrometheusQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-prometheus", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountPrometheus>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/prometheus`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountPrometheus(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -976,6 +976,55 @@ export interface AccountWeightSetters {
   subnets: AccountWeightSettersSubnet[];
 }
 
+/** Per-subnet AxonServed row in /api/v1/accounts/{ss58}/serving. */
+export interface AccountServingSubnet {
+  netuid: number;
+  announcements: number;
+  first_served_at: string | null;
+  last_served_at: string | null;
+}
+
+/**
+ * One account's axon-serving footprint over a 7d/30d/90d window, from
+ * /api/v1/accounts/{ss58}/serving — the account-level companion to
+ * /api/v1/subnets/{netuid}/serving. Zeroed when the account had no AxonServed
+ * events in the window.
+ */
+export interface AccountServing {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_announcements: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountServingSubnet[];
+}
+
+/** Per-subnet PrometheusServed row in /api/v1/accounts/{ss58}/prometheus. */
+export interface AccountPrometheusSubnet {
+  netuid: number;
+  announcements: number;
+  first_announced_at: string | null;
+  last_announced_at: string | null;
+}
+
+/**
+ * One account's Prometheus-endpoint serving footprint over a 7d/30d/90d window,
+ * from /api/v1/accounts/{ss58}/prometheus — the account-level companion to
+ * /api/v1/subnets/{netuid}/prometheus. Zeroed when cold.
+ */
+export interface AccountPrometheus {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_announcements: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountPrometheusSubnet[];
+}
+
 /**
  * One neuron position a wallet holds on a subnet, from
  * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -9,6 +9,7 @@ import {
   Clock,
   Coins,
   Fingerprint,
+  Gauge,
   Radar,
   Rows3,
   Scale,
@@ -34,7 +35,9 @@ import {
   accountBalanceQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
+  accountPrometheusQuery,
   accountQuery,
+  accountServingQuery,
   accountSubnetsQuery,
   accountTransfersQuery,
 } from "@/lib/metagraphed/queries";
@@ -252,6 +255,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountWeightSettingSection ss58={ss58} />
 
+      <AccountEndpointAnnouncementSection ss58={ss58} />
+
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
           id="kinds"
@@ -309,6 +314,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
+            { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
+            { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
           ]}
         />
       </SectionAnchor>
@@ -319,6 +326,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/history`,
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
+          `/api/v1/accounts/${sourceRef}/serving`,
+          `/api/v1/accounts/${sourceRef}/prometheus`,
         ]}
       />
     </>
@@ -751,6 +760,96 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
             </table>
           </DataPanel>
         </>
+      )}
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Axon + Prometheus endpoint announcement footprint over the trailing 30-day
+ * window — a combined serving/Prometheus summary from /serving and /prometheus.
+ * Non-blocking: shows a graceful empty state when the account announced no
+ * endpoints (typical for non-miner accounts).
+ */
+function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
+  const servingResult = useQuery(accountServingQuery(ss58));
+  const prometheusResult = useQuery(accountPrometheusQuery(ss58));
+  const serving = servingResult.data?.data;
+  const prometheus = prometheusResult.data?.data;
+  const windowLabel = serving?.window ?? prometheus?.window ?? "30d";
+
+  const pending =
+    (servingResult.isPending && !serving) || (prometheusResult.isPending && !prometheus);
+  const bothError = servingResult.isError && prometheusResult.isError && !serving && !prometheus;
+
+  if (pending) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="endpoint-announcements"
+        title="Endpoint announcements"
+        subtitle="Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (bothError) {
+    return (
+      <SectionAnchor
+        id="endpoint-announcements"
+        title="Endpoint announcements"
+        subtitle="Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load endpoint announcement activity"
+          description="The serving and prometheus tiers are optional enrichment — the rest of the account page is unaffected."
+          error={servingResult.error ?? prometheusResult.error}
+          onRetry={() => {
+            void servingResult.refetch();
+            void prometheusResult.refetch();
+          }}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const servingCount = serving?.total_announcements ?? 0;
+  const prometheusCount = prometheus?.total_announcements ?? 0;
+  const isEmpty = servingCount === 0 && prometheusCount === 0;
+
+  return (
+    <SectionAnchor
+      id="endpoint-announcements"
+      title="Endpoint announcements"
+      subtitle="Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing 30-day window."
+      tone="accent"
+      info="The account-level companion to subnet serving + prometheus activity — counts how often this hotkey announced axon and Prometheus endpoints."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      {isEmpty ? (
+        <EmptyState
+          title="No endpoint announcements"
+          description="This account had no AxonServed or PrometheusServed events in the window — typical for non-miner accounts or coldkeys without serving activity."
+        />
+      ) : (
+        <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+          <StatTile
+            icon={Radar}
+            eyebrow="Axon serving"
+            tone="accent"
+            value={formatNumber(servingCount)}
+            hint={`AxonServed · ${windowLabel}`}
+            className={KPI_TILE}
+          />
+          <StatTile
+            icon={Gauge}
+            eyebrow="Prometheus"
+            value={formatNumber(prometheusCount)}
+            hint={`PrometheusServed · ${windowLabel}`}
+            className={KPI_TILE}
+          />
+        </div>
       )}
     </SectionAnchor>
   );


### PR DESCRIPTION
Closes #3733

## Summary

Adds endpoint-announcement activity (AxonServed + PrometheusServed) to the account detail page, mirroring the combined serving/prometheus panel pattern from #3481 at the account level.

- `accountServingQuery` / `accountPrometheusQuery` in `queries.ts` with 30d window default
- `AccountEndpointAnnouncementSection` on `/accounts/$ss58` with two KPI tiles
- Graceful empty state for accounts with no serving activity

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-light-before.png)<br><sub>before — no endpoint-announcements section</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-light-after.png)<br><sub>after — Axon serving + Prometheus KPI tiles</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/PlayBody/metagraphed/screenshots/account-endpoint-announcements-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] Open an active miner account — serving and/or Prometheus counts appear
- [x] Open a coldkey/non-miner account — empty state message, page unaffected
- [ ] Error on both tiers shows retry strip; partial success still renders tiles
- [x] Light + dark mode on desktop/tablet/mobile (see screenshot table)

