### PR TITLE
feat(registry): add ConnitoAI SN102 phase API + OpenAPI surfaces

### DIFF
--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -64,6 +64,50 @@
         "timeout_ms": 10000
       },
       "notes": "Official ConnitoAI source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-phase-openapi",
+      "kind": "openapi",
+      "name": "ConnitoAI SN Owner Phase API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Connito SN102 SN Owner Phase Service (FastAPI title: Phase Service). Served at cycle-api.connito.ai; documents no-auth cycle-coordination routes such as GET /get_phase and GET /blocks_until_next_phase per the official SN Owner Phase API reference.",
+      "provider": "connito",
+      "public_safe": true,
+      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; miners and validators use this host as the locked owner_url in official configuration.",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://cycle-api.connito.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/Connito-AI/Connito/blob/master/connito/shared/config.py",
+        "https://github.com/Connito-AI/Connito/blob/master/docs/miner-faq/miner-config.md",
+        "https://connito.ai/docs/reference/sn-owner-api"
+      ],
+      "url": "https://cycle-api.connito.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-phase-get-phase",
+      "kind": "subnet-api",
+      "name": "ConnitoAI SN Owner phase API",
+      "notes": "Public no-auth GET /get_phase on cycle-api.connito.ai returning the current training-cycle phase JSON (block height, phase_name, cycle_length, blocks_remaining_in_phase). Default owner_url in official Connito CycleCfg (config.py) and hard-pinned in miner-config.md; documented in the SN Owner Phase API reference.",
+      "provider": "connito",
+      "public_safe": true,
+      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is the official phase oracle queried by miners and validators.",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://cycle-api.connito.ai/openapi.json",
+        "https://github.com/Connito-AI/Connito/blob/master/connito/shared/config.py",
+        "https://connito.ai/docs/reference/sn-owner-api"
+      ],
+      "url": "https://cycle-api.connito.ai/get_phase"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #717

## Summary
Append two community surfaces to `registry/subnets/connitoai.json` for the official ConnitoAI SN102 **SN Owner Phase API** at `cycle-api.connito.ai`.

## Surfaces
| Kind | URL | Proof |
|------|-----|-------|
| **openapi** | `https://cycle-api.connito.ai/openapi.json` | FastAPI Phase Service (`phase_service.py`); SN Owner Phase API docs |
| **subnet-api** | `https://cycle-api.connito.ai/get_phase` | Default `owner_url` in `connito/shared/config.py` (`CycleCfg`); hard-pinned in `docs/miner-faq/miner-config.md` |

## Notes
- Both endpoints are **no-auth** cycle-coordination reads documented in [SN Owner Phase API](https://connito.ai/docs/reference/sn-owner-api).
- Validator model-distribution routes (`/health`, `/submit`, etc.) are per-validator and Bearer-gated — not promoted here.
- `cycle-api.connito.ai` sits behind Cloudflare WAF; simple datacenter probes may receive challenge responses (documented in Connito `troubleshooting.md`). Surfaces include `rate_limit_notes` accordingly.

## Checklist
- [x] Changes exactly one `registry/subnets/connitoai.json` file
- [x] `authority: community`, `review.state: community-submitted`, `submitted_by: bohdansolovie`
- [x] Provider slug **connito** (already on main)
- [x] HTTPS URLs only; notes avoid identity/ledger field samples
- [x] `npm run validate:surface -- registry/subnets/connitoai.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/connitoai.json`