### PR TITLE
feat(registry): enrich SN29 Coldint — competitions config subnet-api (#724)

### DIFF
--- a/registry/subnets/coldint.json
+++ b/registry/subnets/coldint.json
@@ -150,6 +150,31 @@
         "timeout_ms": 10000
       },
       "notes": "TaoStats subnet dashboard linked by the Coldint README."
+    },
+    {
+      "id": "sn-29-coldint-competitions-api",
+      "name": "Coldint competitions configuration API",
+      "kind": "subnet-api",
+      "url": "https://github.com/coldint/sn29/raw/main/competitions.json",
+      "provider": "coldint",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/coldint/coldint_validator/blob/main/constants/__init__.py",
+        "https://github.com/coldint/sn29/blob/main/README.md"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "notes": "Public no-auth GET competitions.json on the official SN29 dynamic-configuration repository (github.com/coldint/sn29). Validators poll this URL on COMPETITIONS_URL in constants/__init__.py via requests.get to load live competition parameters without restart."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface on `registry/subnets/coldint.json` for the SN29 Coldint public competitions-configuration JSON endpoint validators poll at runtime.

Closes #724.

## Surface

| Field | Value |
|-------|-------|
| Netuid | **29** (Coldint) |
| Kind | **subnet-api** |
| URL | `https://github.com/coldint/sn29/raw/main/competitions.json` |
| Provider | **coldint** |
| Probe | `GET` → `expect: json` (live HTTP 200 JSON object) |

## Source evidence

- `coldint_validator/constants/__init__.py` — `COMPETITIONS_URL = "https://github.com/coldint/sn29/raw/main/competitions.json"`; validators fetch this URL via `requests.get` in `model/competitions.py` `load_competitions()`.
- `coldint/sn29` README — official SN29 dynamic-configuration repository documenting live competition updates.

Distinct from existing website/source-repo/docs/data-artifact surfaces; this registers the subnet's live competitions config contract as `subnet-api`.

## Checklist

- [x] Changes exactly one `registry/subnets/coldint.json` file (append-only, 25-line insertion)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Includes `probe` block matching sibling surfaces (`enabled`, `method`, `expect`, `timeout_ms`)
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] `public_safe: true`, `auth_required: false`
- [x] No overlap with open PR paths (`compute-horde.json`, `swap.json`, `streetvision-by-natix.json`, UI routes)
- [x] Links tracked open issue (`Closes #724`)

## Validation

- [x] `npm run validate:surface -- registry/subnets/coldint.json`
- [x] `npm run scan:public-safety`

## Conflict avoidance

Merge-simulated clean against all currently open PR branches for `registry/subnets/coldint.json`; single-file append at end of `surfaces` array.


Made with [Cursor](https://cursor.com)