### PR TITLE
feat(registry): add Chutes TEE server measurements subnet-api surface (SN64)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -615,6 +615,28 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/payments/summary/tao"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-tee-measurements-api",
+      "kind": "subnet-api",
+      "name": "Chutes TEE server measurements API",
+      "notes": "Public no-auth GET returning TEE server measurement records (version, hardware name, MRTD, boot RTMR values). Documented in the subnet's own OpenAPI (api.chutes.ai/openapi.json, path /servers/tee/measurements); same host as the existing pricing, bounties, fmv, and payment-totals subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/servers/tee/measurements"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `subnet-api` surface to `registry/subnets/chutes.json`.

## Surface

- Netuid: 64
- Kind: subnet-api
- Public URL: https://api.chutes.ai/servers/tee/measurements
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

## Summary

Registers the public no-auth **TEE server measurements** endpoint on `api.chutes.ai`. The path `/servers/tee/measurements` is declared in the subnet's own OpenAPI spec and returns JSON measurement records (version, hardware name, MRTD, boot RTMR values). Distinct from existing Chutes pricing, bounties, FMV, and payment-totals subnet-api surfaces on the same host.

No linked issue — this is an unscoped surface enrichment for a documented public API path not yet in the SN64 manifest. (Not filing against #1273, which targets an SSE stream.)

## Checklist

- [x] Changes exactly one `registry/subnets/chutes.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `source_url` is the subnet OpenAPI that documents this path.
- [x] Public-safe: no auth-only flows, secrets, or private URLs.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] No overlap with open registry PRs (swap, compute-horde, streetvision).

## Validation

- [x] `npm run validate:surface -- registry/subnets/chutes.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: `GET https://api.chutes.ai/servers/tee/measurements` returns JSON array of TEE measurement records
- [ ] CI green (Validate + Gittensory Gate + Codecov)


Made with [Cursor](https://cursor.com)