### PR TITLE
feat(ui): add ss58 format guidance to the invalid-account empty state

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -106,13 +106,17 @@ function AccountDetail({ ss58 }: { ss58: string }) {
         <PageHeading
           eyebrow="Explorer"
           title="Invalid account address"
-          description="Account addresses must be a valid ss58 (base58) string."
+          description="Account addresses must be a valid ss58 (base58) string — 46–49 characters, starting with 5 for Bittensor."
         />
         <EmptyState
           title="Invalid account address"
-          description="Use a valid hotkey or coldkey ss58 address."
+          description="Valid Bittensor addresses are 46–49 characters from the base58 alphabet (which excludes 0, O, I, and l) and start with 5. Check for a truncated paste or a wrong-chain address, then try one like the example below."
           action={{ label: "Back to accounts", href: "/accounts" }}
         />
+        <p className="mt-3 text-center text-[11px] text-ink-muted">Example valid address</p>
+        <code className="mx-auto mt-1 block max-w-md break-all rounded border border-border bg-surface/50 px-2.5 py-1.5 text-center font-mono text-[11px] text-ink-strong">
+          5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        </code>
       </>
     );
   }


### PR DESCRIPTION
## Summary

Enriches the invalid-address empty state in `accounts.$ss58.tsx` with concrete ss58 format guidance, so a mistyped/wrong-chain/truncated address in the URL tells the visitor exactly what a valid one looks like. Copy/markup only — the `isValidSs58` / `SS58` validation in `accounts.ts` is unchanged.

Closes #3400

## What changed

`apps/ui/src/routes/accounts.$ss58.tsx`, the `!isValidSs58(ss58)` branch of `AccountDetail`:

- `PageHeading` description now states the length + prefix: "…46–49 characters, starting with 5 for Bittensor."
- `EmptyState` description now explains the base58 charset (excludes `0 O I l`), the 46–49 length, the leading `5`, and points at the example — while keeping the "Back to accounts" recovery action.
- Adds a sibling `<code>` block (the `EmptyState` `description` prop is a plain `string`, so the monospace example is rendered as sibling JSX, per the issue) showing a real example address `5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` — the same placeholder used on `accounts.index.tsx`.

Facts mirror the `SS58` regex in `apps/ui/src/lib/metagraphed/accounts.ts` (line 6); the regex itself is untouched.

## Screenshots

Route `/accounts/not-a-valid-address`, fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3400-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `lint` + `format:check` + `typecheck` (apps/ui) — clean
- [x] `vite build` — green
- [x] `isValidSs58` / `SS58` regex unchanged; "Back to accounts" action still renders
