### PR TITLE
feat(ui): add typed data layer for account stake-flow

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-stake-flow.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-stake-flow.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountStakeFlowQuery, normalizeAccountStakeFlow } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/accounts/5F/stake-flow",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
+// options object; each call site keeps its own precise data type).
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+describe("normalizeAccountStakeFlow", () => {
+  it("passes a well-formed card through", () => {
+    const raw = {
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_staked_tao: 120.5,
+      total_unstaked_tao: 30.25,
+      net_flow_tao: 90.25,
+      gross_flow_tao: 150.75,
+      flow_ratio: 0.5987,
+      direction: "accumulating",
+      stake_events: 9,
+      unstake_events: 3,
+      subnet_count: 2,
+      concentration: 0.6123,
+      dominant_netuid: 7,
+      subnets: [
+        {
+          netuid: 7,
+          staked_tao: 100,
+          unstaked_tao: 20,
+          net_flow_tao: 80,
+          gross_flow_tao: 120,
+          flow_ratio: 0.6667,
+          direction: "accumulating",
+          stake_events: 6,
+          unstake_events: 2,
+        },
+        {
+          netuid: 3,
+          staked_tao: 20.5,
+          unstaked_tao: 10.25,
+          net_flow_tao: 10.25,
+          gross_flow_tao: 30.75,
+          flow_ratio: 0.3333,
+          direction: "churning",
+          stake_events: 3,
+          unstake_events: 1,
+        },
+      ],
+    };
+    expect(normalizeAccountStakeFlow(SS58, raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk to a zeroed card (ratios null, direction idle, never NaN)", () => {
+    for (const raw of [{}, null, { total_staked_tao: "nope", direction: "sideways" }]) {
+      const card = normalizeAccountStakeFlow(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.window).toBeNull();
+      expect(card.total_staked_tao).toBe(0);
+      expect(card.total_unstaked_tao).toBe(0);
+      expect(card.net_flow_tao).toBe(0);
+      expect(card.gross_flow_tao).toBe(0);
+      expect(card.stake_events).toBe(0);
+      expect(card.unstake_events).toBe(0);
+      expect(card.flow_ratio).toBeNull();
+      expect(card.concentration).toBeNull();
+      expect(card.dominant_netuid).toBeNull();
+      expect(card.direction).toBe("idle");
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+    }
+  });
+
+  it("drops junk subnet rows and coerces their cells", () => {
+    const card = normalizeAccountStakeFlow(SS58, {
+      subnets: [
+        null,
+        { staked_tao: 5 },
+        { netuid: 9, flow_ratio: "x", direction: "bogus", staked_tao: 4 },
+      ],
+    });
+    expect(card.subnets).toHaveLength(1);
+    expect(card.subnets[0]).toEqual({
+      netuid: 9,
+      staked_tao: 4,
+      unstaked_tao: 0,
+      net_flow_tao: 0,
+      gross_flow_tao: 0,
+      flow_ratio: null,
+      direction: "idle",
+      stake_events: 0,
+      unstake_events: 0,
+    });
+    expect(card.subnet_count).toBe(1);
+  });
+});
+
+describe("accountStakeFlowQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits its route with the window param", async () => {
+    resolveWith({ address: SS58, total_staked_tao: 42 });
+    const res = await runQuery(accountStakeFlowQuery(SS58, "7d"));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/stake-flow`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_staked_tao).toBe(42);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(accountStakeFlowQuery(SS58));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/stake-flow`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -31,6 +31,9 @@ import type {
   AccountAxonRemovalsSubnet,
   AccountWeightSetters,
   AccountWeightSettersSubnet,
+  AccountStakeFlow,
+  AccountStakeFlowSubnet,
+  StakeFlowDirection,
   AccountBalance,
   AccountDay,
   AccountEvent,
@@ -2339,6 +2342,80 @@ export const accountWeightSettersQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountWeightSetters(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// The stake-flow classifier emits one of four labels; anything else (cold store,
+// junk) degrades to "idle" so the card stays schema-stable.
+function coerceStakeFlowDirection(raw: unknown): StakeFlowDirection {
+  return raw === "accumulating" || raw === "exiting" || raw === "churning" || raw === "idle"
+    ? raw
+    : "idle";
+}
+
+function normalizeAccountStakeFlowSubnet(raw: unknown): AccountStakeFlowSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    staked_tao: firstFiniteNumber(raw.staked_tao) ?? 0,
+    unstaked_tao: firstFiniteNumber(raw.unstaked_tao) ?? 0,
+    net_flow_tao: firstFiniteNumber(raw.net_flow_tao) ?? 0,
+    gross_flow_tao: firstFiniteNumber(raw.gross_flow_tao) ?? 0,
+    flow_ratio: firstFiniteNumber(raw.flow_ratio) ?? null,
+    direction: coerceStakeFlowDirection(raw.direction),
+    stake_events: firstFiniteNumber(raw.stake_events) ?? 0,
+    unstake_events: firstFiniteNumber(raw.unstake_events) ?? 0,
+  };
+}
+
+// Per-account net stake-capital flow (StakeAdded/StakeRemoved) over a 7d/30d/90d
+// window — account totals plus a per-subnet breakdown from the account_events
+// stream. Every numeric cell coerces defensively: TAO totals and event counts fall
+// through to 0, ratios/concentration to null, and direction to "idle" on a cold
+// store or junk.
+export function normalizeAccountStakeFlow(ss58: string, raw: unknown): AccountStakeFlow {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountStakeFlowSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_staked_tao: firstFiniteNumber(rec.total_staked_tao) ?? 0,
+    total_unstaked_tao: firstFiniteNumber(rec.total_unstaked_tao) ?? 0,
+    net_flow_tao: firstFiniteNumber(rec.net_flow_tao) ?? 0,
+    gross_flow_tao: firstFiniteNumber(rec.gross_flow_tao) ?? 0,
+    flow_ratio: firstFiniteNumber(rec.flow_ratio) ?? null,
+    direction: coerceStakeFlowDirection(rec.direction),
+    stake_events: firstFiniteNumber(rec.stake_events) ?? 0,
+    unstake_events: firstFiniteNumber(rec.unstake_events) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountStakeFlowQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-stake-flow", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountStakeFlow>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/stake-flow`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountStakeFlow(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -977,6 +977,49 @@ export interface AccountWeightSetters {
 }
 
 /**
+ * Net-flow direction classification for a stake-flow card: accumulating (net in),
+ * exiting (net out), churning (large two-way flow, small net), or idle (no flow).
+ */
+export type StakeFlowDirection = "accumulating" | "exiting" | "churning" | "idle";
+
+/** Per-subnet StakeAdded/StakeRemoved row in /api/v1/accounts/{ss58}/stake-flow. */
+export interface AccountStakeFlowSubnet {
+  netuid: number;
+  staked_tao: number;
+  unstaked_tao: number;
+  net_flow_tao: number;
+  gross_flow_tao: number;
+  flow_ratio: number | null;
+  direction: StakeFlowDirection;
+  stake_events: number;
+  unstake_events: number;
+}
+
+/**
+ * One account's net stake-capital flow (StakeAdded/StakeRemoved) per subnet over a
+ * 7d/30d/90d window, from /api/v1/accounts/{ss58}/stake-flow — the account-level
+ * companion to /api/v1/subnets/{netuid}/stake-flow. Zeroed when the account had no
+ * stake events in the window.
+ */
+export interface AccountStakeFlow {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_staked_tao: number;
+  total_unstaked_tao: number;
+  net_flow_tao: number;
+  gross_flow_tao: number;
+  flow_ratio: number | null;
+  direction: StakeFlowDirection;
+  stake_events: number;
+  unstake_events: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountStakeFlowSubnet[];
+}
+
+/**
  * One neuron position a wallet holds on a subnet, from
  * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.
  * Score cells are null when absent; `yield` is null with zero stake.


### PR DESCRIPTION
## What

Adds the typed data layer for `GET /api/v1/accounts/{ss58}/stake-flow` to the
metagraphed-ui client, mirroring the existing account-analytics queries
(`accountAxonRemovalsQuery`, `accountWeightSettersQuery`):

- **`AccountStakeFlow`** type (+ `AccountStakeFlowSubnet` row + `StakeFlowDirection`)
  in `types.ts`, matching the `buildAccountStakeFlow` response shape and the
  generated `AccountStakeFlowArtifact` SDK type.
- **`normalizeAccountStakeFlow(ss58, raw)`** — degrades cold/malformed responses
  to a schema-stable card (numbers → 0/null, never NaN; per-subnet rows filtered).
- **`accountStakeFlowQuery(ss58, window = "30d")`** — a typed TanStack query over
  the windowed route.

## Why

Rounds out the per-account analytics data layer: an account's net staked-vs-unstaked
TAO flow (with per-subnet breakdown + accumulating/exiting/churning direction) had
no typed query yet, unlike its sibling `accountAxonRemovals` / `accountWeightSetters`.

## Notes

- **Data-layer only** — `apps/ui/src/lib/metagraphed/` + a test. No visual/route/
  component change.
- Gates green: `npm run typecheck` (tsc --noEmit) clean, `vitest` 5/5,
  eslint + prettier clean.