### PR TITLE
fix(ui): clamp command palette width off the viewport edge on mobile

### DIFF
--- a/apps/ui/src/components/ui/command.tsx
+++ b/apps/ui/src/components/ui/command.tsx
@@ -26,7 +26,7 @@ Command.displayName = CommandPrimitive.displayName;
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0">
+      <DialogContent className="overflow-hidden p-0 max-w-[calc(100vw-2rem)] sm:max-w-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Summary

Below the `sm:` (640px) breakpoint the ⌘K command palette rendered `w-full` with zero horizontal inset, so on a narrow phone it spanned exactly 100vw and touched both screen edges. This clamps `CommandDialog`'s `DialogContent` to leave a gutter on mobile, mirroring the app's existing `max-w-[calc(100vw-2rem)]` inset convention (`nav-omnibox.tsx`). Desktop sizing is unchanged.

Closes #3455

## What changed

`apps/ui/src/components/ui/command.tsx` — the `CommandDialog` `<DialogContent>` className only:

```diff
- className="overflow-hidden p-0"
+ className="overflow-hidden p-0 max-w-[calc(100vw-2rem)] sm:max-w-lg"
```

`max-w-[calc(100vw-2rem)]` overrides the base `w-full`/`max-w-lg` via Tailwind-merge below `sm`; `sm:max-w-lg` restores the exact desktop width at `sm` and above. The shared `dialog.tsx` `DialogContent` primitive is untouched, as are `CommandPaletteBody` and the input/list/item styling.

## Screenshots

Palette opened via ⌘K on `/`, fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes. The fix is scoped below `sm:`, so **Tablet and Desktop are identical before/after by design** (confirming no change to the `max-w-lg` desktop sizing); the change is visible on **Mobile** — before it touches both edges, after it has a gutter.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-mobile-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-tablet-dark.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3455-after-desktop-dark.png)<br><sub>after</sub> |

## Validation

- [x] `lint` + `format:check` + `typecheck` (apps/ui) — clean
- [x] `vite build` — green
- [x] `dialog.tsx` untouched; only the `CommandDialog` call-site className changed
- [x] Verified at 375px: palette no longer touches the left/right edges; unchanged at `sm+`
