### PR TITLE
feat(registry): enrich SN83 CliqueAI — lambda OpenAPI + subnet-api surfaces

### DIFF
--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -1,0 +1,56 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "CliqueAI",
+  "netuid": 83,
+  "schema_version": 1,
+  "slug": "sn-83",
+  "source_repo": "https://github.com/toptensor/CliqueAI",
+  "status": "active",
+  "website_url": "https://cliqueai.toptensor.ai/",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-openapi",
+      "kind": "openapi",
+      "name": "CliqueAI lambda OpenAPI",
+      "notes": "Machine-readable OpenAPI 3.1 spec for the SN83 CliqueAI lambda service (observed: FastAPI title, paths including /graph/lambda and /validator/ip). The official toptensor/CliqueAI client pins LAMBDA_URL to http://lambda.toptensor.ai.",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "http://lambda.toptensor.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py",
+        "http://lambda.toptensor.ai/openapi.json"
+      ],
+      "url": "http://lambda.toptensor.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-subnet-api",
+      "kind": "subnet-api",
+      "name": "CliqueAI validator IP API",
+      "notes": "Public no-auth GET /validator/ip on lambda.toptensor.ai returning a JSON array of validator host IPs (observed: HTTP 200). Documented in the subnet's OpenAPI spec on the same host; CliqueAI/common/base/consts.py sets LAMBDA_URL to http://lambda.toptensor.ai.",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py",
+        "http://lambda.toptensor.ai/openapi.json"
+      ],
+      "url": "http://lambda.toptensor.ai/validator/ip"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Scaffold `registry/subnets/cliqueai.json` for SN83 CliqueAI (netuid 83).
- Add community **openapi** surface for the machine-readable FastAPI spec at `http://lambda.toptensor.ai/openapi.json` (official `LAMBDA_URL` in [toptensor/CliqueAI `common/base/consts.py`](https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py)).
- Add community **subnet-api** surface for public no-auth `GET /validator/ip` on the same host (documented in that OpenAPI spec).

Closes #675

## Surface
- Netuid: 83
- Kind: openapi + subnet-api
- Public URL: `http://lambda.toptensor.ai/openapi.json`, `http://lambda.toptensor.ai/validator/ip`
- Source URL: `https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py`, live OpenAPI on lambda host
- Provider slug: `cliqueai`

## Checklist
- [x] Changes exactly one `registry/subnets/cliqueai.json` file (new scaffold + surfaces).
- [x] Generated with `npm run subnet:new` + `npm run surface:add`.
- [x] Public-safe, no-auth, verified live.
- [x] Links tracked issue `Closes #675`.

## Validation
- [x] `npm run validate:surface -- registry/subnets/cliqueai.json`
- [x] `npm run scan:public-safety`

## Test plan
- [x] Local surface validation + public-safety scan pass.
- [ ] CI checks, codecov patch/project, and Gittensory Gate on PR.

Made with [Cursor](https://cursor.com)