### PR TITLE
feat(ui): wire Download CSV on Extrinsics page

### DIFF
--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -18,8 +18,10 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -56,7 +58,24 @@ export const Route = createFileRoute("/extrinsics/")({
   component: ExtrinsicsPage,
 });
 
+type ExtrinsicsSearch = z.infer<typeof extrinsicsSearchSchema>;
+
+function extrinsicsQueryParams(search: ExtrinsicsSearch): Record<string, string | number> {
+  const queryParams: Record<string, string | number> = {
+    limit: search.limit,
+    offset: search.offset,
+  };
+  if (search.signer) queryParams.signer = search.signer;
+  if (search.call_module) queryParams.call_module = search.call_module;
+  if (search.call_function) queryParams.call_function = search.call_function;
+  if (search.success) queryParams.success = search.success;
+  return queryParams;
+}
+
 function ExtrinsicsPage() {
+  const search = Route.useSearch();
+  const extrinsicsCsvUrl = buildUrl("/api/v1/extrinsics", extrinsicsQueryParams(search));
+
   return (
     <AppShell>
       <PageHero
@@ -64,7 +83,12 @@ function ExtrinsicsPage() {
         live
         title="Extrinsics"
         description="Recent Bittensor extrinsics (transactions) indexed directly from the chain — newest first, with call, signer, and success."
-        actions={<ShareButton />}
+        actions={
+          <>
+            <DownloadCsvButton url={extrinsicsCsvUrl} />
+            <ShareButton />
+          </>
+        }
       />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
@@ -90,14 +114,7 @@ function ExtrinsicsTable() {
   const navigate = useNavigate({ from: Route.fullPath });
 
   // Only send filters the user actually set, so an empty bar is the plain feed.
-  const queryParams: Record<string, string | number> = {
-    limit: search.limit,
-    offset: search.offset,
-  };
-  if (search.signer) queryParams.signer = search.signer;
-  if (search.call_module) queryParams.call_module = search.call_module;
-  if (search.call_function) queryParams.call_function = search.call_function;
-  if (search.success) queryParams.success = search.success;
+  const queryParams = extrinsicsQueryParams(search);
 
   const rows = (useSuspenseQuery(extrinsicsQuery(queryParams)).data.data ?? []) as Extrinsic[];
 


### PR DESCRIPTION
## Summary

- Add `DownloadCsvButton` to the Extrinsics page hero (alongside Share), wired to `/api/v1/extrinsics` via `buildUrl`
- Export URL mirrors active search params: `signer`, `call_module`, `call_function`, `success`, `limit`, `offset` — same object as `extrinsicsQuery`
- Closes #3406 
## Screenshots

**Visual PR — held for manual review per Path C.** Capture `/extrinsics` page hero (Download CSV next to Share). Fixed viewport only — never `fullPage: true`. Set theme before each capture:

```js
localStorage.setItem("mg-theme", "dark"); // or "light"
location.reload();
```

Host 12 PNGs on a `screenshots` orphan branch in your fork (not on this feature branch). Reference as `https://raw.githubusercontent.com/<your-fork-owner>/metagraphed/screenshots/<file>.png`.

**Before server:** separate worktree at merge-base — `git worktree add ../metagraphed-before $(git merge-base main HEAD)` then `npm run dev --workspace=apps/ui` there.

**After server:** this branch — `npm run dev --workspace=apps/ui`.

Suggested filenames: `3406-desktop-light-before.png`, `3406-desktop-light-after.png`, etc.


| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light (1280×800) | <img width="1266" height="932" alt="image" src="https://github.com/user-attachments/assets/877b7fe2-06ca-4c9d-95d3-936879fcb6c6" /> | <img width="1257" height="931" alt="image" src="https://github.com/user-attachments/assets/7051f541-80cb-4ce4-92d6-a2ab3bb9ca7c" /> |
| Desktop · Dark (1280×800) | <img width="1264" height="932" alt="image" src="https://github.com/user-attachments/assets/f8e52458-64af-4e20-b2bd-66036899cbf7" /> | <img width="1263" height="930" alt="image" src="https://github.com/user-attachments/assets/25c74ebc-a507-439e-8afc-9f52e1f4d1bb" /> |
| Tablet · Light (768×1024) | <img width="1267" height="937" alt="image" src="https://github.com/user-attachments/assets/b757cf30-c371-4c12-8da9-fca4abc8ebc0" /> | <img width="1272" height="933" alt="image" src="https://github.com/user-attachments/assets/9b935763-176e-4dd4-89c8-aaede7092f87" /> |
| Tablet · Dark (768×1024) | <img width="1273" height="934" alt="image" src="https://github.com/user-attachments/assets/74dc5671-3719-4b77-ae17-989b9f80b8b8" /> | <img width="1268" height="934" alt="image" src="https://github.com/user-attachments/assets/9602dfec-c341-480c-8b3d-ba93f6d47b8b" /> |
| Mobile · Light (375×812) | <img width="1271" height="933" alt="image" src="https://github.com/user-attachments/assets/e6466fb7-e06d-4fbf-8e82-1296e6594a64" /> | <img width="1270" height="935" alt="image" src="https://github.com/user-attachments/assets/723726cb-1b72-4ca0-a4f2-b7fe0bbc221e" /> |
| Mobile · Dark (375×812) | <img width="1272" height="935" alt="image" src="https://github.com/user-attachments/assets/480a833e-f724-46b4-bbfc-8e1465b597bb" /> | <img width="1278" height="941" alt="image" src="https://github.com/user-attachments/assets/b6e8c0bb-c567-43a1-bcfd-54423f6c11b6" /> |

## Test plan

- [x] `/extrinsics` — Download CSV with default filters exports current page params
- [x] Apply signer/module/function/success filters + pagination — CSV URL matches URL search state
- [x] Switch to Testnet — link uses prefixed API base
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
