### PR TITLE
feat(ui): surface account deregistration activity

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-deregistrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-deregistrations.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountDeregistrationsQuery, normalizeAccountDeregistrations } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${SS58}/deregistrations`,
+  });
+}
+
+async function runQuery(ss58: string, window?: string) {
+  const opts = accountDeregistrationsQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeAccountDeregistrations", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeAccountDeregistrations(SS58, {
+        schema_version: 1,
+        address: SS58,
+        window: "30d",
+        total_deregistrations: 5,
+        subnet_count: 2,
+        concentration: 0.68,
+        dominant_netuid: 1,
+        subnets: [
+          {
+            netuid: 1,
+            deregistrations: 4,
+            first_deregistered_at: "2026-06-01T00:00:00.000Z",
+            last_deregistered_at: "2026-06-02T00:00:00.000Z",
+          },
+          {
+            netuid: 7,
+            deregistrations: 1,
+            first_deregistered_at: "2026-06-03T00:00:00.000Z",
+            last_deregistered_at: "2026-06-03T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_deregistrations: 5,
+      subnet_count: 2,
+      concentration: 0.68,
+      dominant_netuid: 1,
+      subnets: [
+        {
+          netuid: 1,
+          deregistrations: 4,
+          first_deregistered_at: "2026-06-01T00:00:00.000Z",
+          last_deregistered_at: "2026-06-02T00:00:00.000Z",
+        },
+        {
+          netuid: 7,
+          deregistrations: 1,
+          first_deregistered_at: "2026-06-03T00:00:00.000Z",
+          last_deregistered_at: "2026-06-03T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { total_deregistrations: "nope" }]) {
+      const card = normalizeAccountDeregistrations(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.total_deregistrations).toBe(0);
+      expect(card.subnet_count).toBe(0);
+      expect(card.concentration).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountDeregistrationsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ address: SS58, window: "7d", total_deregistrations: 2, subnet_count: 1 });
+    const res = await runQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/deregistrations`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_deregistrations).toBe(2);
+    expect(res.data.subnet_count).toBe(1);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/deregistrations`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -29,6 +29,8 @@ import type {
   SourceHealthProvider,
   AccountAxonRemovals,
   AccountAxonRemovalsSubnet,
+  AccountDeregistrations,
+  AccountDeregistrationsSubnet,
   AccountWeightSetters,
   AccountWeightSettersSubnet,
   AccountBalance,
@@ -2286,6 +2288,62 @@ export const accountAxonRemovalsQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountAxonRemovals(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountDeregistrationsSubnet(raw: unknown): AccountDeregistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    deregistrations: firstFiniteNumber(raw.deregistrations) ?? 0,
+    first_deregistered_at: firstString(raw.first_deregistered_at) ?? null,
+    last_deregistered_at: firstString(raw.last_deregistered_at) ?? null,
+  };
+}
+
+// Per-account deregistration (eviction) footprint over a 7d/30d/90d window. A flat
+// summary card — total deregistrations + distinct subnets — from the account_events
+// NeuronDeregistered stream. Every numeric cell coerces defensively: counts fall
+// through to 0 and concentration to null on a cold store or junk.
+export function normalizeAccountDeregistrations(
+  ss58: string,
+  raw: unknown,
+): AccountDeregistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountDeregistrationsSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_deregistrations: firstFiniteNumber(rec.total_deregistrations) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountDeregistrationsQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-deregistrations", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountDeregistrations>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/deregistrations`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountDeregistrations(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -951,6 +951,31 @@ export interface AccountAxonRemovals {
   subnets: AccountAxonRemovalsSubnet[];
 }
 
+/** Per-subnet NeuronDeregistered row in /api/v1/accounts/{ss58}/deregistrations. */
+export interface AccountDeregistrationsSubnet {
+  netuid: number;
+  deregistrations: number;
+  first_deregistered_at: string | null;
+  last_deregistered_at: string | null;
+}
+
+/**
+ * One account's deregistration (eviction) footprint over a 7d/30d/90d window, from
+ * /api/v1/accounts/{ss58}/deregistrations — the account-level companion to
+ * /api/v1/subnets/{netuid}/deregistrations. Zeroed when the account had no
+ * NeuronDeregistered events in the window.
+ */
+export interface AccountDeregistrations {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_deregistrations: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountDeregistrationsSubnet[];
+}
+
 /** Per-subnet WeightsSet row in /api/v1/accounts/{ss58}/weight-setters. */
 export interface AccountWeightSettersSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -13,6 +13,7 @@ import {
   Rows3,
   Scale,
   Unplug,
+  UserMinus,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
@@ -30,6 +31,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountDeregistrationsQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
   accountEventsQuery,
@@ -249,6 +251,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
       <AccountTeardownActivitySection ss58={ss58} />
+
+      <AccountDeregistrationActivitySection ss58={ss58} />
 
       <AccountWeightSettingSection ss58={ss58} />
 
@@ -635,6 +639,79 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
           eyebrow="Distinct subnets"
           value={formatNumber(distinctSubnets)}
           hint="subnets with teardown"
+          className={KPI_TILE}
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Deregistration (eviction) footprint over the trailing 30-day window — a flat
+ * count + distinct-subnet summary from /deregistrations. Non-blocking: while the
+ * dedicated query loads (or if it fails), the section never stalls the page.
+ */
+function AccountDeregistrationActivitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountDeregistrationsQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="deregistrations"
+        title="Deregistration activity"
+        subtitle="Neuron deregistrations (NeuronDeregistered) for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="deregistrations"
+        title="Deregistration activity"
+        subtitle="Neuron deregistrations (NeuronDeregistered) for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load deregistration activity"
+          description="The deregistrations tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const deregistrations = card?.total_deregistrations ?? 0;
+  const distinctSubnets = card?.subnet_count ?? 0;
+  if (deregistrations === 0 && distinctSubnets === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="deregistrations"
+      title="Deregistration activity"
+      subtitle="Neuron deregistrations (NeuronDeregistered) for this account over the trailing 30-day window."
+      tone="accent"
+      info="The account-level companion to subnet deregistration activity — counts how often this hotkey was deregistered (evicted) from a subnet, and on how many distinct subnets."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={UserMinus}
+          eyebrow="Deregistrations"
+          tone="accent"
+          value={formatNumber(deregistrations)}
+          hint={`NeuronDeregistered · ${windowLabel}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Distinct subnets"
+          value={formatNumber(distinctSubnets)}
+          hint="subnets with deregistration"
           className={KPI_TILE}
         />
       </div>


### PR DESCRIPTION
## Summary

- Add a **Deregistration activity** section to the account detail page — the account-level companion to the existing teardown (axon-removals) tier — surfacing how often a hotkey was deregistered (evicted) from a subnet, and across how many distinct subnets, over the trailing 30-day window.
- Reads the already-implemented `GET /api/v1/accounts/{ss58}/deregistrations` endpoint; no backend changes.

## What Changed

- `accountDeregistrationsQuery(ss58, window = "30d")` + a defensive normalizer in `queries.ts`, mirroring the sibling `accountAxonRemovalsQuery` — every numeric cell coerces to a schema-stable zeroed card on a cold/junk store (never throws).
- `AccountDeregistrations` / `AccountDeregistrationsSubnet` types in `types.ts`.
- A non-blocking `AccountDeregistrationActivitySection` on `accounts.$ss58.tsx`, rendered alongside the teardown section, showing total deregistrations + distinct subnets as KPI tiles (loading / error / empty states match the page's existing section convention; the section self-hides when the account has no deregistrations in the window).
- Unit tests for the normalizer (well-formed passthrough + cold/junk degradation) and the query window handling.

Template Used: Frontend / `apps/ui` (Path C).

## Screenshots

The live network currently reports zero deregistrations in every window, so the populated card was captured against a local fixture for the endpoint; all other data on the page is live. Before/after are framed on the weight-setting section so the region where the new card lands is directly comparable.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

Ran the `ui` CI job locally, all green:

- `npm run lint --workspace=apps/ui` — 0 errors
- `npm run format:check --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` — 475 passed (incl. 4 new)
- `npm run build --workspace=apps/ui`

Closes #3729
