### PR TITLE
feat(ui): surface account stake-move activity

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-stake-moves.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-stake-moves.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountStakeMovesQuery, normalizeAccountStakeMoves } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${SS58}/stake-moves`,
+  });
+}
+
+async function runQuery(ss58: string, window?: string) {
+  const opts = accountStakeMovesQuery(ss58, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeAccountStakeMoves", () => {
+  it("passes a well-formed card through", () => {
+    expect(
+      normalizeAccountStakeMoves(SS58, {
+        schema_version: 1,
+        address: SS58,
+        window: "30d",
+        total_movements: 5,
+        subnet_count: 2,
+        concentration: 0.68,
+        dominant_netuid: 1,
+        subnets: [
+          {
+            netuid: 1,
+            movements: 4,
+            first_moved_at: "2026-06-01T00:00:00.000Z",
+            last_moved_at: "2026-06-02T00:00:00.000Z",
+          },
+          {
+            netuid: 7,
+            movements: 1,
+            first_moved_at: "2026-06-03T00:00:00.000Z",
+            last_moved_at: "2026-06-03T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_movements: 5,
+      subnet_count: 2,
+      concentration: 0.68,
+      dominant_netuid: 1,
+      subnets: [
+        {
+          netuid: 1,
+          movements: 4,
+          first_moved_at: "2026-06-01T00:00:00.000Z",
+          last_moved_at: "2026-06-02T00:00:00.000Z",
+        },
+        {
+          netuid: 7,
+          movements: 1,
+          first_moved_at: "2026-06-03T00:00:00.000Z",
+          last_moved_at: "2026-06-03T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card", () => {
+    for (const raw of [{}, null, "x", { total_movements: "nope" }]) {
+      const card = normalizeAccountStakeMoves(SS58, raw);
+      expect(card.address).toBe(SS58);
+      expect(card.total_movements).toBe(0);
+      expect(card.subnet_count).toBe(0);
+      expect(card.concentration).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountStakeMovesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ address: SS58, window: "7d", total_movements: 2, subnet_count: 1 });
+    const res = await runQuery(SS58, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/stake-moves`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.total_movements).toBe(2);
+    expect(res.data.subnet_count).toBe(1);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(SS58);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${SS58}/stake-moves`,
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -29,6 +29,8 @@ import type {
   SourceHealthProvider,
   AccountAxonRemovals,
   AccountAxonRemovalsSubnet,
+  AccountStakeMoves,
+  AccountStakeMovesSubnet,
   AccountWeightSetters,
   AccountWeightSettersSubnet,
   AccountBalance,
@@ -2286,6 +2288,59 @@ export const accountAxonRemovalsQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountAxonRemovals(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountStakeMovesSubnet(raw: unknown): AccountStakeMovesSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    movements: firstFiniteNumber(raw.movements) ?? 0,
+    first_moved_at: firstString(raw.first_moved_at) ?? null,
+    last_moved_at: firstString(raw.last_moved_at) ?? null,
+  };
+}
+
+// Per-account stake-move (re-delegation) footprint over a 7d/30d/90d window. A flat
+// summary card — total movements + distinct subnets — from the account_events
+// StakeMoved stream. Every numeric cell coerces defensively: counts fall through
+// to 0 and concentration to null on a cold store or junk.
+export function normalizeAccountStakeMoves(ss58: string, raw: unknown): AccountStakeMoves {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountStakeMovesSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_movements: firstFiniteNumber(rec.total_movements) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountStakeMovesQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-stake-moves", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountStakeMoves>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/stake-moves`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountStakeMoves(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -951,6 +951,31 @@ export interface AccountAxonRemovals {
   subnets: AccountAxonRemovalsSubnet[];
 }
 
+/** Per-subnet StakeMoved row in /api/v1/accounts/{ss58}/stake-moves. */
+export interface AccountStakeMovesSubnet {
+  netuid: number;
+  movements: number;
+  first_moved_at: string | null;
+  last_moved_at: string | null;
+}
+
+/**
+ * One account's stake-move (re-delegation) footprint over a 7d/30d/90d window, from
+ * /api/v1/accounts/{ss58}/stake-moves — the account-level companion to
+ * /api/v1/subnets/{netuid}/stake-moves. Zeroed when the account had no
+ * StakeMoved events in the window.
+ */
+export interface AccountStakeMoves {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_movements: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountStakeMovesSubnet[];
+}
+
 /** Per-subnet WeightsSet row in /api/v1/accounts/{ss58}/weight-setters. */
 export interface AccountWeightSettersSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -12,6 +12,7 @@ import {
   Radar,
   Rows3,
   Scale,
+  Shuffle,
   Unplug,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -30,6 +31,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountStakeMovesQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
   accountEventsQuery,
@@ -247,6 +249,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       ) : null}
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
+
+      <AccountStakeMovesActivitySection ss58={ss58} />
 
       <AccountTeardownActivitySection ss58={ss58} />
 
@@ -635,6 +639,81 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
           eyebrow="Distinct subnets"
           value={formatNumber(distinctSubnets)}
           hint="subnets with teardown"
+          className={KPI_TILE}
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Stake-move (re-delegation) footprint over the trailing 30-day window — a flat
+ * count + distinct-subnet summary from /stake-moves. This is the discrete
+ * StakeMoved-event count, distinct from the stake-flow net-series chart.
+ * Non-blocking: while the dedicated query loads (or if it fails), the section
+ * never stalls the page.
+ */
+function AccountStakeMovesActivitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountStakeMovesQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="stake-moves"
+        title="Stake-move activity"
+        subtitle="Stake re-delegations (StakeMoved) for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="stake-moves"
+        title="Stake-move activity"
+        subtitle="Stake re-delegations (StakeMoved) for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load stake-move activity"
+          description="The stake-moves tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const movements = card?.total_movements ?? 0;
+  const distinctSubnets = card?.subnet_count ?? 0;
+  if (movements === 0 && distinctSubnets === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="stake-moves"
+      title="Stake-move activity"
+      subtitle="Stake re-delegations (StakeMoved) for this account over the trailing 30-day window."
+      tone="accent"
+      info="The account-level companion to subnet stake-move activity — counts how often this account re-delegated stake (StakeMoved), and across how many distinct subnets. Distinct from the net stake-flow series."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={Shuffle}
+          eyebrow="Stake moves"
+          tone="accent"
+          value={formatNumber(movements)}
+          hint={`StakeMoved · ${windowLabel}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Distinct subnets"
+          value={formatNumber(distinctSubnets)}
+          hint="subnets with stake moves"
           className={KPI_TILE}
         />
       </div>


### PR DESCRIPTION
## Summary

- Add a **Stake-move activity** section to the account detail page — the account-level companion to the subnet stake-move tier — surfacing how often an account re-delegated stake (StakeMoved) and across how many distinct subnets over the trailing 30-day window.
- The discrete re-delegation-event count, **distinct from the existing stake-flow net-series chart** (#3341). Reads the already-implemented `GET /api/v1/accounts/{ss58}/stake-moves`; no backend changes.

## What Changed

- `accountStakeMovesQuery(ss58, window = "30d")` + a defensive normalizer in `queries.ts`, mirroring the sibling account-activity queries — every numeric cell coerces to a schema-stable zeroed card on a cold/junk store (never throws).
- `AccountStakeMoves` / `AccountStakeMovesSubnet` types in `types.ts`.
- A non-blocking `AccountStakeMovesActivitySection` on `accounts.$ss58.tsx`, anchored near the footprint/stake area, showing total stake moves + distinct subnets as KPI tiles (loading / error / empty states match the page's existing section convention; the section self-hides when the account has no stake moves in the window).
- Unit tests for the normalizer (well-formed passthrough + cold/junk degradation) and the query window handling.

Template Used: Frontend / `apps/ui` (Path C).

## Screenshots

The live network currently reports zero stake-moves in every window, so the populated card was captured against a local fixture for the endpoint; all other data on the page is live. Before/after are framed on the weight-setting section so the region where the new card lands is directly comparable.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/stake-moves/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

Ran the `ui` CI job locally, all green:

- `npm run lint --workspace=apps/ui` — 0 errors
- `npm run format:check --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` — 475 passed (incl. 4 new)
- `npm run build --workspace=apps/ui`

Closes #3732
