### PR TITLE
feat(ui): surface axon-removal teardown activity in the subnet operational panel

### DIFF
--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -6,6 +6,7 @@ import {
   subnetHealthPercentilesQuery,
   subnetHealthTrendsQuery,
   subnetEndpointsQuery,
+  subnetAxonRemovalsQuery,
   flattenSurfaceIncidents,
 } from "@/lib/metagraphed/queries";
 import type {
@@ -161,6 +162,13 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
               }
               hint={`${ok} ok · ${warn} warn · ${down} down${unknown ? ` · ${unknown} unknown` : ""}. Click a segment to filter resources.`}
             />
+          </div>
+
+          {/* #3482: chain teardown activity — axon (serving-endpoint) removals over
+            the window, from the already-shipped subnetAxonRemovalsQuery. Its own KPI
+            strip below the health ribbon; #3481 (serving/prometheus) shares this row. */}
+          <div className="grid grid-cols-2 md:grid-cols-4 divide-x divide-border border-b border-border">
+            <AxonRemovalsStat netuid={netuid} />
           </div>
 
           {!filter.isAll ? (
@@ -331,6 +339,30 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
         </div>
       )}
     </PanelShell>
+  );
+}
+
+/**
+ * #3482: teardown-activity KPI — axon (serving-endpoint) removals for this subnet
+ * over the trailing window, from the already-shipped subnetAxonRemovalsQuery
+ * (#3660). The endpoint returns a flat window aggregate (removals / distinct
+ * removers), so it renders as a single `Stat` tile matching the health ribbon's
+ * convention: "…" while pending, "—" on error, the count otherwise.
+ */
+function AxonRemovalsStat({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetAxonRemovalsQuery(netuid));
+  const a = res?.data;
+  const removals = a?.removals ?? 0;
+  const removers = a?.distinct_removers ?? 0;
+  const win = a?.window ?? "30d";
+  const value = isError ? "—" : isPending && !a ? "…" : formatNumber(removals);
+  return (
+    <Stat
+      label={`Teardowns · ${win}`}
+      value={value}
+      tone={removals > 0 ? "warn" : "default"}
+      hint={`Axon (serving-endpoint) removals for SN${netuid} over the ${win} window — ${removers} distinct ${removers === 1 ? "remover" : "removers"}. Source: /api/v1/subnets/{netuid}/axon-removals.`}
+    />
   );
 }
 


### PR DESCRIPTION
## Screenshots

| Before | After |
|--------|-------|
| <img width="1439" height="461" alt="before" src="https://github.com/user-attachments/assets/0f47a434-4671-4e6c-aef3-5c8e65db3579" /> | <img width="1369" height="516" alt="after" src="https://github.com/user-attachments/assets/00d6c0cf-d183-4ee6-9bcf-29f40acc0b72" /> |

## Summary

Closes **#3482**.

Adds a **Teardowns · {window}** KPI to the subnet **Operational status** panel, surfacing recent axon-removal activity from the existing `subnetAxonRemovalsQuery` introduced in #3660. The query already existed but was not previously displayed anywhere in the UI.

## Implementation

**Modified file**

- `apps/ui/src/components/metagraphed/operational-panel.tsx`

### New KPI

Adds an `AxonRemovalsStat` component that:

- Fetches teardown data using `subnetAxonRemovalsQuery(netuid)` via `useQuery`.
- Displays a **Teardowns · {window}** statistic.
- Shows:
  - Total teardown count
  - Distinct remover count as supporting context

### Layout

The new KPI is rendered in its own strip directly beneath the existing operational health ribbon.

This keeps the current uptime and latency metrics uncluttered while leaving space for future operational metrics, including the serving/Prometheus additions discussed in #3481.

### Loading & Error States

The tile follows the panel's existing conventions:

- Pending → `...`
- Error → `—`
- Success → teardown count with distinct-remover hint

### Scope

This PR only consumes the existing data layer.

No changes were made to:

- `queries.ts`
- `types.ts`

## Validation

- ✅ `npm run typecheck -w apps/ui`
- ✅ `npm run lint` (changed file)
- ✅ `npm run build -w apps/ui`
