### PR TITLE
feat(ui): surface axon-removal teardown activity in the subnet operational panel

### DIFF
--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -6,6 +6,7 @@ import {
   subnetHealthPercentilesQuery,
   subnetHealthTrendsQuery,
   subnetEndpointsQuery,
+  subnetAxonRemovalsQuery,
   flattenSurfaceIncidents,
 } from "@/lib/metagraphed/queries";
 import type {
@@ -161,6 +162,14 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
               }
               hint={`${ok} ok · ${warn} warn · ${down} down${unknown ? ` · ${unknown} unknown` : ""}. Click a segment to filter resources.`}
             />
+          </div>
+
+          {/* #3482: chain teardown activity — axon (serving-endpoint) removals over
+            the window, from the already-shipped subnetAxonRemovalsQuery. A flex strip
+            below the health ribbon so the lone tile sits flush left (no empty grid
+            columns); #3481 (serving/prometheus) tiles wrap in alongside it. */}
+          <div className="flex flex-wrap divide-x divide-border border-b border-border">
+            <AxonRemovalsStat netuid={netuid} />
           </div>
 
           {!filter.isAll ? (
@@ -331,6 +340,30 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
         </div>
       )}
     </PanelShell>
+  );
+}
+
+/**
+ * #3482: teardown-activity KPI — axon (serving-endpoint) removals for this subnet
+ * over the trailing window, from the already-shipped subnetAxonRemovalsQuery
+ * (#3660). The endpoint returns a flat window aggregate (removals / distinct
+ * removers), so it renders as a single `Stat` tile matching the health ribbon's
+ * convention: "…" while pending, "—" on error, the count otherwise.
+ */
+function AxonRemovalsStat({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetAxonRemovalsQuery(netuid));
+  const a = res?.data;
+  const removals = a?.removals ?? 0;
+  const removers = a?.distinct_removers ?? 0;
+  const win = a?.window ?? "30d";
+  const value = isError ? "—" : isPending && !a ? "…" : formatNumber(removals);
+  return (
+    <Stat
+      label={`Teardowns · ${win}`}
+      value={value}
+      tone={removals > 0 ? "warn" : "default"}
+      hint={`Axon (serving-endpoint) removals for SN${netuid} over the ${win} window — ${removers} distinct ${removers === 1 ? "remover" : "removers"}. Source: /api/v1/subnets/{netuid}/axon-removals.`}
+    />
   );
 }
 


### PR DESCRIPTION
## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light |<img width="1360" height="451" alt="before-light" src="https://github.com/user-attachments/assets/a2f53880-e88b-4a05-b16a-f8a913b7d010" />| <img width="1392" height="519" alt="after-light" src="https://github.com/user-attachments/assets/32bbe81b-6bce-4ff2-8cef-fa1dcae7add7" /> |
| Desktop · Dark | <img width="1439" height="461" alt="before" src="https://github.com/user-attachments/assets/f189f212-45d6-4d4c-8ba8-f7ec2d043020" /> | <img width="1369" height="516" alt="after" src="https://github.com/user-attachments/assets/f8bbc2bd-c2c4-4167-b764-efac95f6c5ce" /> |
| Tablet · Light | <img width="558" height="458" alt="before-tablet" src="https://github.com/user-attachments/assets/31509386-ab72-43c0-8d42-48529a232efa" /> | <img width="542" height="502" alt="after-tablet" src="https://github.com/user-attachments/assets/af8858de-7ed7-427b-9dae-f38c02f541c4" /> |
| Tablet · Dark | <img width="550" height="464" alt="before-tablet-dark" src="https://github.com/user-attachments/assets/7c894aa1-b5e8-4cd2-ad3d-8b77bf5174c9" /> | <img width="542" height="506" alt="before-tablet-light" src="https://github.com/user-attachments/assets/08eb0058-59b1-4dd6-a216-2d87c27283b8" /> |
| Mobile · Light | <img width="368" height="671" alt="before-mobile" src="https://github.com/user-attachments/assets/dd241525-15de-447e-9e2b-c24997726b0d" /> | <img width="368" height="690" alt="after-mobile" src="https://github.com/user-attachments/assets/d8773395-4e1b-465b-b99e-b727a76dcd07" /> |
| Mobile · Dark | <img width="358" height="641" alt="before-mobile-dark" src="https://github.com/user-attachments/assets/119af95d-694e-414a-b3da-f70dd4c4ed2a" /> | <img width="362" height="702" alt="after-mobile-dark" src="https://github.com/user-attachments/assets/e4bc8847-5902-41ac-bff8-967cc521b92e" /> |

## Summary

Closes #3482

Adds a **Teardowns · {window}** KPI to the subnet **Operational status** panel, surfacing axon-removal activity from the already-shipped `subnetAxonRemovalsQuery` (#3660), which had no UI consumer.

## Implementation

- Only file changed: `apps/ui/src/components/metagraphed/operational-panel.tsx`
- Adds `AxonRemovalsStat`, which calls `subnetAxonRemovalsQuery(netuid)` via `useQuery` and renders a `Stat` tile (count + distinct-remover hint) matching the panel's convention ("…" pending, "—" error, count otherwise).
- Rendered in a flex strip below the health ribbon so the tile sits flush-left with no empty columns; the adjacent #3481 (serving/prometheus) tiles wrap in alongside it.
- Per the issue: `queries.ts` / `types.ts` untouched (data layer shipped in #3660).

## Testing

- `npm run typecheck -w apps/ui` — clean
- `npm run lint` (changed file) — clean
- `npm run build -w apps/ui` — builds, within bundle budget
