### PR TITLE
feat(ui): add account registration activity section

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -31,6 +31,8 @@ import type {
   AccountAxonRemovalsSubnet,
   AccountDeregistrations,
   AccountDeregistrationsSubnet,
+  AccountRegistrations,
+  AccountRegistrationsSubnet,
   AccountBalance,
   AccountDay,
   AccountEvent,
@@ -2345,6 +2347,60 @@ export const accountDeregistrationsQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountDeregistrations(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountRegistrationsSubnet(
+  raw: unknown,
+): AccountRegistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    registrations: firstFiniteNumber(raw.registrations) ?? 0,
+    first_observed: firstString(raw.first_observed) ?? null,
+    last_observed: firstString(raw.last_observed) ?? null,
+  };
+}
+
+export function normalizeAccountRegistrations(
+  ss58: string,
+  raw: unknown,
+): AccountRegistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountRegistrationsSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_registrations: firstFiniteNumber(rec.total_registrations) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountRegistrationsQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-registrations", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountRegistrations>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/registrations`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountRegistrations(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -29,6 +29,8 @@ import type {
   SourceHealthProvider,
   AccountAxonRemovals,
   AccountAxonRemovalsSubnet,
+  AccountDeregistrations,
+  AccountDeregistrationsSubnet,
   AccountBalance,
   AccountDay,
   AccountEvent,
@@ -2284,6 +2286,65 @@ export const accountAxonRemovalsQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountAxonRemovals(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Per-account deregistration (NeuronDeregistered) footprint over a 7d/30d/90d
+// window. A flat summary card — total deregistrations + distinct subnets — from
+// the account_events NeuronDeregistered stream. Every numeric cell coerces
+// defensively: counts fall through to 0 and concentration to null on a cold
+// store or junk.
+function normalizeAccountDeregistrationsSubnet(
+  raw: unknown,
+): AccountDeregistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    deregistrations: firstFiniteNumber(raw.deregistrations) ?? 0,
+    first_deregistered_at: firstString(raw.first_deregistered_at) ?? null,
+    last_deregistered_at: firstString(raw.last_deregistered_at) ?? null,
+  };
+}
+
+export function normalizeAccountDeregistrations(
+  ss58: string,
+  raw: unknown,
+): AccountDeregistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountDeregistrationsSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_deregistrations: firstFiniteNumber(rec.total_deregistrations) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountDeregistrationsQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-deregistrations", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountDeregistrations>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/deregistrations`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountDeregistrations(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -975,6 +975,29 @@ export interface AccountDeregistrations {
   subnets: AccountDeregistrationsSubnet[];
 }
 
+export interface AccountRegistrationsSubnet {
+  netuid: number;
+  registrations: number;
+  first_observed: string | null;
+  last_observed: string | null;
+}
+
+/**
+ * One account's registration (NeuronRegistered) footprint over a
+ * 7d/30d/90d window, from /api/v1/accounts/{ss58}/registrations.
+ * Zeroed when the account had no NeuronRegistered events in the window.
+ */
+export interface AccountRegistrations {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_registrations: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountRegistrationsSubnet[];
+}
+
 /**
  * One neuron position a wallet holds on a subnet, from
  * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -951,6 +951,30 @@ export interface AccountAxonRemovals {
   subnets: AccountAxonRemovalsSubnet[];
 }
 
+export interface AccountDeregistrationsSubnet {
+  netuid: number;
+  deregistrations: number;
+  first_deregistered_at: string | null;
+  last_deregistered_at: string | null;
+}
+
+/**
+ * One account's deregistration (NeuronDeregistered) footprint over a
+ * 7d/30d/90d window, from /api/v1/accounts/{ss58}/deregistrations —
+ * the eviction-side complement to /accounts/{ss58}/registrations.
+ * Zeroed when the account had no NeuronDeregistered events in the window.
+ */
+export interface AccountDeregistrations {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_deregistrations: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountDeregistrationsSubnet[];
+}
+
 /**
  * One neuron position a wallet holds on a subnet, from
  * /api/v1/accounts/{ss58}/portfolio: its economics plus emission/stake yield.

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -12,6 +12,7 @@ import {
   Radar,
   Rows3,
   Unplug,
+  UserMinus,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
@@ -30,6 +31,7 @@ import { AccountHistoryChart } from "@/components/metagraphed/account-history-ch
 import {
   accountAxonRemovalsQuery,
   accountBalanceQuery,
+  accountDeregistrationsQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
   accountQuery,
@@ -247,6 +249,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
       <AccountTeardownActivitySection ss58={ss58} />
+      <AccountDeregistrationActivitySection ss58={ss58} />
 
       {account.event_kinds.length > 0 ? (
         <SectionAnchor
@@ -631,6 +634,79 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
           eyebrow="Distinct subnets"
           value={formatNumber(distinctSubnets)}
           hint="subnets with teardown"
+          className={KPI_TILE}
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Per-account deregistration (NeuronDeregistered) activity over a 7d/30d/90d
+ * window — the eviction-side complement to the registrations summary. A flat
+ * KPI card: total deregistrations + distinct subnets evicted from.
+ */
+function AccountDeregistrationActivitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountDeregistrationsQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="deregistrations"
+        title="Deregistration activity"
+        subtitle="NeuronDeregistered events for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="deregistrations"
+        title="Deregistration activity"
+        subtitle="NeuronDeregistered events for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load deregistration activity"
+          description="The deregistrations tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const deregistrations = card?.total_deregistrations ?? 0;
+  const distinctSubnets = card?.subnet_count ?? 0;
+  if (deregistrations === 0 && distinctSubnets === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="deregistrations"
+      title="Deregistration activity"
+      subtitle="NeuronDeregistered events for this account over the trailing 30-day window."
+      tone="accent"
+      info="The eviction-side complement to account registrations — counts how many times this account was deregistered, and on how many distinct subnets."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={UserMinus}
+          eyebrow="Deregistrations"
+          tone="accent"
+          value={formatNumber(deregistrations)}
+          hint={`NeuronDeregistered · ${windowLabel}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Distinct subnets"
+          value={formatNumber(distinctSubnets)}
+          hint="subnets evicted from"
           className={KPI_TILE}
         />
       </div>

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -13,6 +13,7 @@ import {
   Rows3,
   Unplug,
   UserMinus,
+  UserPlus,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
@@ -34,6 +35,7 @@ import {
   accountDeregistrationsQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
+  accountRegistrationsQuery,
   accountQuery,
   accountSubnetsQuery,
   accountTransfersQuery,
@@ -249,6 +251,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
       <AccountTeardownActivitySection ss58={ss58} />
+      <AccountRegistrationActivitySection ss58={ss58} />
       <AccountDeregistrationActivitySection ss58={ss58} />
 
       {account.event_kinds.length > 0 ? (
@@ -634,6 +637,79 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
           eyebrow="Distinct subnets"
           value={formatNumber(distinctSubnets)}
           hint="subnets with teardown"
+          className={KPI_TILE}
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
+/**
+ * Per-account registration (NeuronRegistered) activity over a 7d/30d/90d
+ * window — the onboarding-side complement to the deregistration summary. A flat
+ * KPI card: total registrations + distinct subnets registered on.
+ */
+function AccountRegistrationActivitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountRegistrationsQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="registrations"
+        title="Registration activity"
+        subtitle="NeuronRegistered events for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="registrations"
+        title="Registration activity"
+        subtitle="NeuronRegistered events for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load registration activity"
+          description="The registrations tier is optional enrichment."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const registrations = card?.total_registrations ?? 0;
+  const distinctSubnets = card?.subnet_count ?? 0;
+  if (registrations === 0 && distinctSubnets === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="registrations"
+      title="Registration activity"
+      subtitle="NeuronRegistered events for this account over the trailing 30-day window."
+      tone="accent"
+      info="The onboarding-side complement to account deregistrations — counts how many times this account registered a neuron, and on how many distinct subnets."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Registrations"
+          tone="accent"
+          value={formatNumber(registrations)}
+          hint={`NeuronRegistered · ${windowLabel}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Distinct subnets"
+          value={formatNumber(distinctSubnets)}
+          hint="subnets registered on"
           className={KPI_TILE}
         />
       </div>


### PR DESCRIPTION
## Summary

Closes #3730. Adds a NeuronRegistered activity summary to the account detail page — the onboarding-side complement to the existing deregistration section. The backend endpoint `GET /api/v1/accounts/{ss58}/registrations` already exists but had no frontend consumer.

## Changes

- **types.ts**: Add `AccountRegistrations` and `AccountRegistrationsSubnet` aggregate types
- **queries.ts**: Add `normalizeAccountRegistrations` + `accountRegistrationsQuery` (follows deregistrations pattern)
- **accounts.$ss58.tsx**: Add `AccountRegistrationActivitySection` with KPI cards (total registrations + distinct subnets), wired alongside deregistration activity

## How verified

- TypeScript check passes (2 pre-existing errors unrelated to this change)
- Query + normalize pattern matches the sibling deregistrations query
- Loading/empty/error states match the page's existing section convention