### PR TITLE
feat(ui): add block-production stats header to the blocks index page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { blocksSummaryQuery, normalizeBlocksSummary } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/blocks/summary",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
+// options object; each call site keeps its own precise data type).
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+describe("normalizeBlocksSummary", () => {
+  it("passes a well-formed card through", () => {
+    const raw = {
+      schema_version: 1,
+      block_count: 4200,
+      first_block: 1000,
+      last_block: 5199,
+      first_observed_at: "2026-07-01T00:00:00.000Z",
+      last_observed_at: "2026-07-01T14:00:00.000Z",
+      block_time: {
+        count: 4100,
+        mean_ms: 12010,
+        min_ms: 11800,
+        max_ms: 24300,
+        p50_ms: 12000,
+        p90_ms: 12400,
+      },
+      throughput: {
+        total_extrinsics: 84000,
+        total_events: 210000,
+        mean_extrinsics_per_block: 20,
+        mean_events_per_block: 50,
+        max_extrinsics_in_block: 312,
+      },
+      distinct_authors: 128,
+      author_concentration: {
+        holders: 128,
+        total: 4200,
+        gini: 0.42,
+        hhi: 0.03,
+        hhi_normalized: 0.02,
+        nakamoto_coefficient: 44,
+        top_1pct_share: 0.05,
+        top_5pct_share: 0.18,
+        top_10pct_share: 0.31,
+        top_20pct_share: 0.5,
+        entropy: 6.7,
+        entropy_normalized: 0.96,
+      },
+      distinct_spec_versions: 2,
+      latest_spec_version: 224,
+    };
+    const card = normalizeBlocksSummary(raw);
+    expect(card.block_count).toBe(4200);
+    expect(card.first_block).toBe(1000);
+    expect(card.last_block).toBe(5199);
+    expect(card.block_time?.mean_ms).toBe(12010);
+    expect(card.block_time?.p90_ms).toBe(12400);
+    expect(card.throughput?.mean_extrinsics_per_block).toBe(20);
+    expect(card.throughput?.mean_events_per_block).toBe(50);
+    expect(card.distinct_authors).toBe(128);
+    expect(card.author_concentration?.nakamoto_coefficient).toBe(44);
+    expect(card.author_concentration?.gini).toBe(0.42);
+    expect(card.latest_spec_version).toBe(224);
+  });
+
+  it("degrades a cold store to a schema-stable zeroed card (nested objects null)", () => {
+    const raw = {
+      schema_version: 1,
+      block_count: 0,
+      first_block: null,
+      last_block: null,
+      first_observed_at: null,
+      last_observed_at: null,
+      block_time: null,
+      throughput: null,
+      distinct_authors: 0,
+      author_concentration: null,
+      distinct_spec_versions: 0,
+      latest_spec_version: null,
+    };
+    const card = normalizeBlocksSummary(raw);
+    expect(card.block_count).toBe(0);
+    expect(card.first_block).toBeNull();
+    expect(card.block_time).toBeNull();
+    expect(card.throughput).toBeNull();
+    expect(card.author_concentration).toBeNull();
+    expect(card.latest_spec_version).toBeNull();
+  });
+
+  it("degrades junk / missing input to a zeroed card, never NaN", () => {
+    for (const raw of [{}, null, undefined, "nope", { block_count: "many" }]) {
+      const card = normalizeBlocksSummary(raw);
+      expect(card.block_count).toBe(0);
+      expect(card.distinct_authors).toBe(0);
+      expect(card.distinct_spec_versions).toBe(0);
+      expect(card.block_time).toBeNull();
+      expect(card.throughput).toBeNull();
+      expect(card.author_concentration).toBeNull();
+      expect(card.first_block).toBeNull();
+      expect(card.latest_spec_version).toBeNull();
+    }
+  });
+
+  it("collapses an all-null block_time / throughput to null (never a partial NaN card)", () => {
+    const card = normalizeBlocksSummary({
+      block_count: 1,
+      block_time: {},
+      throughput: {},
+      author_concentration: { holders: 0 },
+    });
+    expect(card.block_time).toBeNull();
+    expect(card.throughput).toBeNull();
+    expect(card.author_concentration).toBeNull();
+  });
+});
+
+describe("blocksSummaryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits /api/v1/blocks/summary and normalizes the response", async () => {
+    resolveWith({ block_count: 12, distinct_authors: 4, latest_spec_version: 224 });
+    const res = await runQuery(blocksSummaryQuery());
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/blocks/summary",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(res.data.block_count).toBe(12);
+    expect(res.data.distinct_authors).toBe(4);
+    expect(res.data.latest_spec_version).toBe(224);
+  });
+
+  it("degrades a cold response to a zeroed card without throwing", async () => {
+    resolveWith(null);
+    const res = await runQuery(blocksSummaryQuery());
+    expect(res.data.block_count).toBe(0);
+    expect(res.data.block_time).toBeNull();
+    expect(res.data.author_concentration).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -73,6 +73,9 @@ import type {
   ChainEventsFeed,
   Coverage,
   BlockExtrinsics,
+  BlockTimeStats,
+  BlockThroughput,
+  BlocksSummary,
   CurationLevel,
   Endpoint,
   EndpointIncident,
@@ -1679,6 +1682,75 @@ export const blockChainEventsQuery = (ref: string) =>
         data: normalizeBlockChainEvents(res.data),
       } as ApiResult<BlockChainEvents>;
     },
+    staleTime: STALE_SHORT,
+  });
+
+// Block-production summary (#3488): aggregate health of the recent-blocks window —
+// inter-block time distribution, extrinsic/event throughput, block-author
+// decentralization, and the runtime spec-version spread. Null-safe: a cold/absent
+// store degrades to a schema-stable zeroed card (block_count 0, nested objects
+// null), never a throw or 404.
+function normalizeBlockTimeStats(raw: unknown): BlockTimeStats | null {
+  if (!isRecord(raw)) return null;
+  const count = coerceFiniteNumber(raw.count);
+  // No interval to measure (< 2 consecutive blocks) → the whole block collapses.
+  if (count == null || count === 0) return null;
+  return {
+    count,
+    mean_ms: coerceFiniteNumber(raw.mean_ms) ?? 0,
+    min_ms: coerceFiniteNumber(raw.min_ms) ?? 0,
+    max_ms: coerceFiniteNumber(raw.max_ms) ?? 0,
+    p50_ms: coerceFiniteNumber(raw.p50_ms) ?? 0,
+    p90_ms: coerceFiniteNumber(raw.p90_ms) ?? 0,
+  };
+}
+
+function normalizeBlockThroughput(raw: unknown): BlockThroughput | null {
+  if (!isRecord(raw)) return null;
+  const totalExtrinsics = coerceFiniteNumber(raw.total_extrinsics);
+  const totalEvents = coerceFiniteNumber(raw.total_events);
+  // Backend emits null on a cold store; a malformed all-null object collapses too.
+  if (totalExtrinsics == null && totalEvents == null) return null;
+  return {
+    total_extrinsics: totalExtrinsics ?? 0,
+    total_events: totalEvents ?? 0,
+    mean_extrinsics_per_block: coerceFiniteNumber(raw.mean_extrinsics_per_block) ?? 0,
+    mean_events_per_block: coerceFiniteNumber(raw.mean_events_per_block) ?? 0,
+    max_extrinsics_in_block: coerceFiniteNumber(raw.max_extrinsics_in_block) ?? 0,
+  };
+}
+
+export function normalizeBlocksSummary(raw: unknown): BlocksSummary {
+  const d = isRecord(raw) ? raw : {};
+  return {
+    schema_version: coerceFiniteNumber(d.schema_version) ?? 1,
+    block_count: coerceFiniteNumber(d.block_count) ?? 0,
+    first_block: coerceFiniteNumber(d.first_block) ?? null,
+    last_block: coerceFiniteNumber(d.last_block) ?? null,
+    first_observed_at: coerceString(d.first_observed_at) ?? null,
+    last_observed_at: coerceString(d.last_observed_at) ?? null,
+    block_time: normalizeBlockTimeStats(d.block_time),
+    throughput: normalizeBlockThroughput(d.throughput),
+    distinct_authors: coerceFiniteNumber(d.distinct_authors) ?? 0,
+    author_concentration: normalizeConcentrationMetricsOrNull(d.author_concentration),
+    distinct_spec_versions: coerceFiniteNumber(d.distinct_spec_versions) ?? 0,
+    latest_spec_version: coerceFiniteNumber(d.latest_spec_version) ?? null,
+  };
+}
+
+/**
+ * Block-production summary (#3488) — inter-block time, throughput, and
+ * block-author decentralization over the recent-blocks window. Schema-stable
+ * zeroed card on a cold store (never 404/throws).
+ */
+export const blocksSummaryQuery = () =>
+  queryOptions({
+    queryKey: k("blocks-summary"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/blocks/summary", { signal });
+      return { ...res, data: normalizeBlocksSummary(res.data) } as ApiResult<BlocksSummary>;
+    },
+    // Block summary tracks the fast-moving blocks feed — keep this short.
     staleTime: STALE_SHORT,
   });
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -848,6 +848,52 @@ export interface ChainEventsFeed {
   [key: string]: unknown;
 }
 
+/**
+ * Inter-block time distribution (ms) from /api/v1/blocks/summary — null when
+ * fewer than two consecutive blocks are in the window (no interval to measure).
+ */
+export interface BlockTimeStats {
+  count: number;
+  mean_ms: number;
+  min_ms: number;
+  max_ms: number;
+  p50_ms: number;
+  p90_ms: number;
+}
+
+/** Extrinsic/event throughput over the summary window — null on a cold store. */
+export interface BlockThroughput {
+  total_extrinsics: number;
+  total_events: number;
+  mean_extrinsics_per_block: number;
+  mean_events_per_block: number;
+  max_extrinsics_in_block: number;
+}
+
+/**
+ * Block-production summary from /api/v1/blocks/summary (#3488): aggregate health
+ * of the recent-blocks window — inter-block time, throughput, block-author
+ * decentralization, and the runtime spec-version spread. A cold/absent store
+ * degrades to a schema-stable zeroed card (block_count 0, nested objects null).
+ */
+export interface BlocksSummary {
+  schema_version?: number;
+  block_count: number;
+  first_block: number | null;
+  last_block: number | null;
+  first_observed_at: string | null;
+  last_observed_at: string | null;
+  block_time: BlockTimeStats | null;
+  throughput: BlockThroughput | null;
+  distinct_authors: number;
+  // Block-authorship decentralization — the same Gini/HHI/Nakamoto scorecard as
+  // the stake/emission tiers, computed over each author's block count.
+  author_concentration: ConcentrationMetrics | null;
+  distinct_spec_versions: number;
+  latest_spec_version: number | null;
+  [key: string]: unknown;
+}
+
 export interface ExtrinsicCallArg {
   name?: string | null;
   value?: unknown;

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -3,13 +3,14 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Timer, Activity, Users } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ListShell } from "@/components/metagraphed/list-shell";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import {
   PageSizeSelect,
   ResetFiltersButton,
@@ -17,8 +18,8 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
-import { blocksQuery } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { Block } from "@/lib/metagraphed/types";
@@ -67,12 +68,58 @@ function BlocksPage() {
         actions={<ShareButton />}
       />
       <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-28 w-full mb-8" />}>
+          <BlockProductionHeader />
+        </Suspense>
+      </QueryErrorBoundary>
+      <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <BlocksTable />
         </Suspense>
       </QueryErrorBoundary>
-      <ApiSourceFooter paths={["/api/v1/blocks"]} artifacts={["/metagraph/blocks.json"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/blocks", "/api/v1/blocks/summary"]}
+        artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
+      />
     </AppShell>
+  );
+}
+
+// #3488: point-in-time block-production health above the raw blocks feed —
+// inter-block cadence, per-block throughput, and block-author decentralization
+// from /api/v1/blocks/summary, in its own Suspense/error boundary so a slow or
+// failed summary never blocks the table below.
+function BlockProductionHeader() {
+  const summary = useSuspenseQuery(blocksSummaryQuery()).data.data;
+  const blockTime = summary.block_time;
+  const throughput = summary.throughput;
+  const nakamoto = summary.author_concentration?.nakamoto_coefficient;
+  const nakamotoTone: "ok" | "warn" | "down" | "default" =
+    nakamoto == null ? "default" : nakamoto <= 1 ? "down" : nakamoto <= 3 ? "warn" : "ok";
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+      <StatTile
+        icon={Timer}
+        eyebrow="Inter-block time"
+        value={blockTime ? humaniseSeconds(blockTime.mean_ms / 1000) : "—"}
+        hint={blockTime ? `p90 ${humaniseSeconds(blockTime.p90_ms / 1000)}` : undefined}
+      />
+      <StatTile
+        icon={Activity}
+        eyebrow="Throughput"
+        value={throughput ? `${formatNumber(throughput.mean_extrinsics_per_block)} ext/block` : "—"}
+        hint={
+          throughput ? `${formatNumber(throughput.mean_events_per_block)} events/block` : undefined
+        }
+      />
+      <StatTile
+        icon={Users}
+        eyebrow="Author decentralization"
+        value={nakamoto != null ? formatNumber(nakamoto) : "—"}
+        hint="Nakamoto coefficient"
+        tone={nakamotoTone}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

Adds a **block-production stats header** to the top of the `/blocks` index page, surfacing point-in-time chain health above the raw blocks feed:

- **Inter-block time** — mean block cadence (with p90 hint), from `block_time`
- **Throughput** — mean extrinsics/block (with events/block hint), from `throughput`
- **Author decentralization** — block-author Nakamoto coefficient, tone-coded (`down`≤1, `warn`≤3, else `ok`), from `author_concentration`

All three read from `GET /api/v1/blocks/summary`, rendered as `StatTile`s in their own `Suspense`/`QueryErrorBoundary` pair so a slow or failed summary never blocks the table below.

## How

- **`apps/ui/src/lib/metagraphed/queries.ts`** — `blocksSummaryQuery` `queryOptions` factory + `normalizeBlocksSummary` (null-safe coercion via the existing `isRecord`/`coerceFiniteNumber` helpers; junk/cold responses zero out, never `NaN`).
- **`apps/ui/src/lib/metagraphed/types.ts`** — `BlocksSummary`, `BlockTimeStats`, `BlockThroughput`.
- **`apps/ui/src/routes/blocks.index.tsx`** — `BlockProductionHeader` component (three tiles) inserted between the `PageHero` and the existing table boundary; `/api/v1/blocks/summary` added to the API source footer.
- **`apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts`** — normalize happy-path, cold/junk-safe, and route/params coverage (6 tests).

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-blocks-3488/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-blocks-3488/after.png) |

## Gates

`npm run typecheck` ✓ (exit 0) · `vitest run` ✓ (6/6) · `eslint` ✓ (0 errors) · `prettier --check` ✓

Closes #3488