### PR TITLE
feat(registry): enrich SN29 Coldint — hall of fame data-artifact

### DIFF
--- a/registry/subnets/coldint.json
+++ b/registry/subnets/coldint.json
@@ -175,6 +175,31 @@
         "submitted_by": "jimcody1995"
       },
       "notes": "Public no-auth GET competitions.json on the official SN29 dynamic-configuration repository (github.com/coldint/sn29). Validators poll this URL on COMPETITIONS_URL in constants/__init__.py via requests.get to load live competition parameters without restart."
+    },
+    {
+      "id": "sn-29-coldint-hall-of-fame-config",
+      "name": "Coldint hall of fame configuration",
+      "kind": "data-artifact",
+      "url": "https://github.com/coldint/sn29/raw/main/hall_of_fame.json",
+      "provider": "coldint",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/coldint/coldint_validator/blob/main/constants/__init__.py",
+        "https://github.com/coldint/sn29/blob/main/README.md"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "notes": "Public no-auth GET hall_of_fame.json on the official SN29 dynamic-configuration repository (github.com/coldint/sn29). Validators poll this URL on HOF_URL in constants/__init__.py via requests.get to load hall-of-fame reward records alongside competitions.json."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `data-artifact` surface on `registry/subnets/coldint.json` for the SN29 Coldint public hall-of-fame JSON endpoint validators poll at runtime (sibling to the `competitions.json` surface merged in #3863).

## Surface

| Field | Value |
|-------|-------|
| Netuid | 29 (Coldint) |
| Kind | `data-artifact` |
| URL | `https://github.com/coldint/sn29/raw/main/hall_of_fame.json` |
| Provider | `coldint` |
| Probe | `GET` → `expect: json` (live HTTP 200 JSON object) |

## Source evidence

- `coldint_validator/constants/__init__.py` — `HOF_URL = "https://github.com/coldint/sn29/raw/main/hall_of_fame.json"`
- `coldint/sn29` README — documents Hall of Fame reward distribution as a core dynamic-configuration use case alongside competitions

Distinct from the existing `competitions.json` `subnet-api` surface; this registers the subnet's live hall-of-fame config contract.

## Checklist

- [x] Changes exactly one `registry/subnets/coldint.json` file (append-only, 25-line insertion)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Includes probe block matching sibling surfaces (`enabled`, `method`, `expect`, `timeout_ms`)
- [x] Public URL safe for read-only probes; source URLs prove the subnet publishes it
- [x] `public_safe: true`, `auth_required: false`

## Validation

- `npm run validate:surface -- registry/subnets/coldint.json`
- `npm run scan:public-safety`