### PR TITLE
feat(ui): add developer settings page for webhook subscriptions

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Compass, Github, Menu, X } from "lucide-react";
+import { ChevronRight, Compass, Github, Menu, Webhook, X } from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -146,6 +146,20 @@ export function AppShell({ children }: { children: ReactNode }) {
 
                 <NetworkSwitcher />
                 <ShortcutsPopover />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link
+                      to="/settings"
+                      aria-label="Developer settings"
+                      className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                    >
+                      <Webhook className="size-3.5" aria-hidden="true" />
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="text-[11px]">
+                    Developer settings — webhook subscriptions
+                  </TooltipContent>
+                </Tooltip>
                 <SettingsPopover />
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseNetuidsInput } from "./webhook-subscription-manager";
+
+describe("parseNetuidsInput", () => {
+  it("returns an empty list for blank input", () => {
+    expect(parseNetuidsInput("")).toEqual({ ok: true, value: [] });
+    expect(parseNetuidsInput("   ")).toEqual({ ok: true, value: [] });
+  });
+
+  it("parses a comma-separated list of netuids", () => {
+    expect(parseNetuidsInput("7, 43")).toEqual({ ok: true, value: [7, 43] });
+  });
+
+  it("tolerates stray whitespace and trailing commas", () => {
+    expect(parseNetuidsInput(" 1 ,2,, 3 ,")).toEqual({ ok: true, value: [1, 2, 3] });
+  });
+
+  it("rejects a non-numeric token with the offending value in the error", () => {
+    const result = parseNetuidsInput("7, abc");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("abc");
+  });
+
+  it("rejects a negative number (not a bare digit token)", () => {
+    expect(parseNetuidsInput("-1").ok).toBe(false);
+  });
+});

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -1,0 +1,497 @@
+import { useState, type FormEvent, type ReactNode } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { apiFetch, ApiError } from "@/lib/metagraphed/client";
+import { classNames } from "@/lib/metagraphed/format";
+import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { SectionHeading } from "@/components/metagraphed/section-heading";
+import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import type {
+  WebhookDeliveryStatus,
+  WebhookSubscriptionCreated,
+  WebhookSubscriptionFilters,
+  WebhookSubscriptionView,
+} from "@/lib/metagraphed/types";
+
+// Must match src/webhooks.mjs — WEBHOOK_SUBSCRIPTION_TOKEN_HEADER / WEBHOOK_SECRET_HEADER.
+const SUBSCRIPTION_TOKEN_HEADER = "x-metagraph-webhook-subscription-token";
+const SUBSCRIPTION_SECRET_HEADER = "x-metagraph-webhook-secret";
+
+const CHANGE_KINDS = ["subnets", "artifacts"] as const;
+
+const inputCls =
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+
+/** Comma-separated netuids -> integers, or an error describing the offending token. Empty input is valid (no filter). */
+export function parseNetuidsInput(
+  raw: string,
+): { ok: true; value: number[] } | { ok: false; error: string } {
+  const netuids: number[] = [];
+  for (const part of raw.split(",")) {
+    const token = part.trim();
+    if (!token) continue;
+    if (!/^\d+$/.test(token)) {
+      return { ok: false, error: `"${token}" is not a valid netuid` };
+    }
+    netuids.push(Number(token));
+  }
+  return { ok: true, value: netuids };
+}
+
+/** Distinguishes a 401/503 create rejection, a 404 lookup, and a 403 secret-mismatch delete. */
+function describeApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Unauthorized — check your subscription token.";
+    if (error.status === 503)
+      return error.message || "Webhook subscriptions are disabled on this deployment.";
+    if (error.status === 403) return "Secret mismatch — the subscription secret doesn't match.";
+    if (error.status === 404) return "No subscription found with that id.";
+    return error.message || "Request failed.";
+  }
+  return "Request failed.";
+}
+
+export function WebhookSubscriptionManager() {
+  return (
+    <div className="space-y-8">
+      <CreateSubscriptionSection />
+      <LookupSubscriptionSection />
+      <DeleteSubscriptionSection />
+    </div>
+  );
+}
+
+interface CreateVariables {
+  url: string;
+  token: string;
+  netuids: number[];
+  kinds: string[];
+  secret: string;
+}
+
+function CreateSubscriptionSection() {
+  const [url, setUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [netuidsRaw, setNetuidsRaw] = useState("");
+  const [netuidsError, setNetuidsError] = useState<string | null>(null);
+  const [kinds, setKinds] = useState<Set<string>>(new Set());
+  const [secret, setSecret] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async (vars: CreateVariables): Promise<WebhookSubscriptionCreated> => {
+      const filters: WebhookSubscriptionFilters = {};
+      if (vars.netuids.length > 0) filters.netuids = vars.netuids;
+      if (vars.kinds.length > 0) {
+        filters.kinds = vars.kinds as WebhookSubscriptionFilters["kinds"];
+      }
+      const res = await apiFetch<WebhookSubscriptionCreated>("/api/v1/webhooks/subscriptions", {
+        init: {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            [SUBSCRIPTION_TOKEN_HEADER]: vars.token,
+          },
+          body: JSON.stringify({
+            url: vars.url,
+            filters,
+            ...(vars.secret ? { secret: vars.secret } : {}),
+          }),
+        },
+      });
+      return res.data;
+    },
+  });
+
+  function toggleKind(kind: string) {
+    setKinds((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  }
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const parsed = parseNetuidsInput(netuidsRaw);
+    if (!parsed.ok) {
+      setNetuidsError(parsed.error);
+      return;
+    }
+    setNetuidsError(null);
+    mutation.mutate({
+      url: url.trim(),
+      token: token.trim(),
+      netuids: parsed.value,
+      kinds: Array.from(kinds),
+      secret: secret.trim(),
+    });
+  }
+
+  const result = mutation.data;
+
+  return (
+    <section aria-labelledby="create-subscription-heading">
+      <SectionHeading
+        title="Create subscription"
+        intro="Register a URL to receive change-feed webhooks. Creation requires a subscription token issued by a metagraphed operator — this app never bundles one."
+      />
+      <form onSubmit={onSubmit} className="space-y-3 rounded border border-border bg-card p-4">
+        <Field label="Webhook URL" required>
+          <input
+            type="url"
+            required
+            placeholder="https://hooks.example.com/mg"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <Field
+          label="Subscription token"
+          required
+          hint="Provided out-of-band by a metagraphed operator."
+        >
+          <input
+            type="password"
+            required
+            autoComplete="off"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <Field
+          label="Netuids filter"
+          hint="Comma-separated, optional — leave blank to receive all subnets."
+        >
+          <input
+            type="text"
+            inputMode="numeric"
+            placeholder="7, 43"
+            value={netuidsRaw}
+            onChange={(e) => {
+              setNetuidsRaw(e.target.value);
+              setNetuidsError(null);
+            }}
+            className={inputCls}
+          />
+          {netuidsError ? (
+            <p className="mt-1 text-[11px] text-health-down">{netuidsError}</p>
+          ) : null}
+        </Field>
+        <Field label="Kinds filter" hint="Optional — leave unchecked to receive all change kinds.">
+          <div className="flex gap-4">
+            {CHANGE_KINDS.map((kind) => (
+              <label key={kind} className="inline-flex items-center gap-1.5 text-[12px] text-ink">
+                <input
+                  type="checkbox"
+                  checked={kinds.has(kind)}
+                  onChange={() => toggleKind(kind)}
+                />
+                {kind}
+              </label>
+            ))}
+          </div>
+        </Field>
+        <Field label="Secret" hint="Optional, 16–256 characters — auto-generated if left blank.">
+          <input
+            type="password"
+            autoComplete="off"
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <button
+          type="submit"
+          disabled={mutation.isPending}
+          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+        >
+          {mutation.isPending ? "Creating…" : "Create subscription"}
+        </button>
+      </form>
+
+      {mutation.isPending ? <Skeleton className="mt-3 h-24 w-full" /> : null}
+
+      {mutation.isError ? <ErrorPanel message={describeApiError(mutation.error)} /> : null}
+
+      {result ? (
+        <div className="mt-3 space-y-3 rounded border border-accent/40 bg-primary-soft/40 p-4">
+          <p className="text-[12px] font-medium text-health-warn">
+            The secret below is shown once and is never echoed back by GET — store it now.
+          </p>
+          <CopyableCode label="id" value={result.id} truncate={false} className="w-full" />
+          <CopyableCode label="secret" value={result.secret} truncate={false} className="w-full" />
+          <div className="space-y-1 text-[11px] text-ink-muted">
+            <p>
+              Deliveries are signed {result.delivery.signature_algorithm} over the raw request body,
+              keyed by the secret above.
+            </p>
+            <p>
+              Signature header <code className="text-ink">{result.delivery.signature_header}</code>{" "}
+              · idempotency header{" "}
+              <code className="text-ink">{result.delivery.idempotency_header}</code> (dedupe
+              at-least-once retries)
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function LookupSubscriptionSection() {
+  const [id, setId] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async (subscriptionId: string): Promise<WebhookSubscriptionView> => {
+      const res = await apiFetch<WebhookSubscriptionView>(
+        `/api/v1/webhooks/subscriptions/${encodeURIComponent(subscriptionId)}`,
+      );
+      return res.data;
+    },
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = id.trim();
+    if (!trimmed) return;
+    mutation.mutate(trimmed);
+  }
+
+  const result = mutation.data;
+
+  return (
+    <section aria-labelledby="lookup-subscription-heading">
+      <SectionHeading
+        title="Look up subscription"
+        intro="Check a subscription's status and delivery health by id."
+      />
+      <form
+        onSubmit={onSubmit}
+        className="flex flex-wrap items-end gap-2 rounded border border-border bg-card p-4"
+      >
+        <Field label="Subscription id" required className="min-w-[280px] flex-1">
+          <input
+            type="text"
+            required
+            placeholder="00000000-0000-0000-0000-000000000000"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <button
+          type="submit"
+          disabled={mutation.isPending}
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:opacity-50"
+        >
+          {mutation.isPending ? "Looking up…" : "Look up"}
+        </button>
+      </form>
+
+      {mutation.isPending ? <Skeleton className="mt-3 h-24 w-full" /> : null}
+
+      {mutation.isError ? <ErrorPanel message={describeApiError(mutation.error)} /> : null}
+
+      {!mutation.isPending && !mutation.isError && !result ? (
+        <EmptyState
+          title="No subscription looked up yet"
+          description="Enter a subscription id above to see its status and delivery health."
+        />
+      ) : null}
+
+      {result ? (
+        <div className="mt-3 space-y-3 rounded border border-border bg-card p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <DeliveryStatusPill status={result.delivery.status} />
+            <span
+              className={classNames(
+                "font-mono text-[11px]",
+                result.active ? "text-health-ok" : "text-ink-muted",
+              )}
+            >
+              {result.active ? "active" : "inactive"}
+            </span>
+          </div>
+          <dl className="grid gap-2 text-[12px]">
+            <Row label="URL" value={result.url} />
+            <Row label="Created" value={result.created_at ?? "—"} />
+            <Row
+              label="Netuids"
+              value={result.filters.netuids?.length ? result.filters.netuids.join(", ") : "all"}
+            />
+            <Row
+              label="Kinds"
+              value={result.filters.kinds?.length ? result.filters.kinds.join(", ") : "all"}
+            />
+            <Row label="Pending deliveries" value={String(result.delivery.pending)} />
+            <Row label="Dead-lettered" value={String(result.delivery.dead_letter)} />
+          </dl>
+          {result.delivery.last_failure ? (
+            <div className="rounded border border-health-warn/30 bg-health-warn/5 p-2 text-[11px] text-ink-muted">
+              Last failure: {result.delivery.last_failure.reason ?? "unknown"}
+              {result.delivery.last_failure.status_code
+                ? ` (HTTP ${result.delivery.last_failure.status_code})`
+                : ""}{" "}
+              after {result.delivery.last_failure.attempts ?? "?"} attempt(s).
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function DeleteSubscriptionSection() {
+  const [id, setId] = useState("");
+  const [secret, setSecret] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async (vars: {
+      id: string;
+      secret: string;
+    }): Promise<{ id: string; deleted: boolean }> => {
+      const res = await apiFetch<{ id: string; deleted: boolean }>(
+        `/api/v1/webhooks/subscriptions/${encodeURIComponent(vars.id)}`,
+        {
+          init: {
+            method: "DELETE",
+            headers: { [SUBSCRIPTION_SECRET_HEADER]: vars.secret },
+          },
+        },
+      );
+      return res.data;
+    },
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmedId = id.trim();
+    const trimmedSecret = secret.trim();
+    if (!trimmedId || !trimmedSecret) return;
+    mutation.mutate({ id: trimmedId, secret: trimmedSecret });
+  }
+
+  return (
+    <section aria-labelledby="delete-subscription-heading">
+      <SectionHeading
+        title="Delete subscription"
+        intro="Requires the one-time secret returned when the subscription was created."
+      />
+      <form onSubmit={onSubmit} className="space-y-3 rounded border border-border bg-card p-4">
+        <Field label="Subscription id" required>
+          <input
+            type="text"
+            required
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <Field label="Secret" required>
+          <input
+            type="password"
+            required
+            autoComplete="off"
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <button
+          type="submit"
+          disabled={mutation.isPending}
+          className="inline-flex items-center gap-1.5 rounded border border-health-down/40 bg-health-down/5 px-3 py-1.5 text-[12px] font-medium text-health-down hover:bg-health-down/10 disabled:opacity-50"
+        >
+          {mutation.isPending ? "Deleting…" : "Delete subscription"}
+        </button>
+      </form>
+
+      {mutation.isPending ? <Skeleton className="mt-3 h-10 w-full" /> : null}
+
+      {mutation.isError ? <ErrorPanel message={describeApiError(mutation.error)} /> : null}
+
+      {mutation.data?.deleted ? (
+        <div
+          role="status"
+          className="mt-3 rounded border border-health-ok/30 bg-health-ok/5 p-3 text-[12px] text-health-ok"
+        >
+          Subscription {mutation.data.id} deleted.
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+const DELIVERY_TONE: Record<WebhookDeliveryStatus["status"], string> = {
+  ok: "text-health-ok border-health-ok/30 bg-health-ok/10",
+  retrying: "text-health-warn border-health-warn/30 bg-health-warn/10",
+  dead_letter: "text-health-down border-health-down/30 bg-health-down/10",
+};
+
+const DELIVERY_LABEL: Record<WebhookDeliveryStatus["status"], string> = {
+  ok: "OK",
+  retrying: "Retrying",
+  dead_letter: "Dead-lettered",
+};
+
+function DeliveryStatusPill({ status }: { status: WebhookDeliveryStatus["status"] }) {
+  return (
+    <span
+      className={classNames(
+        "inline-flex items-center rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+        DELIVERY_TONE[status],
+      )}
+    >
+      {DELIVERY_LABEL[status]}
+    </span>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="mt-3 rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+    >
+      {message}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  required,
+  className,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className={classNames("block", className)}>
+      <span className="mb-1 block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        {label}
+        {required ? <span className="text-health-down"> *</span> : null}
+      </span>
+      {children}
+      {hint ? <span className="mt-1 block text-[11px] text-ink-muted">{hint}</span> : null}
+    </label>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[auto_1fr] gap-3">
+      <dt className="whitespace-nowrap font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        {label}
+      </dt>
+      <dd className="min-w-0 truncate text-ink">{value}</dd>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2130,3 +2130,57 @@ export interface SemanticSearchResponse {
   results: SemanticSearchResult[];
   model: string;
 }
+
+/** Change-feed webhook subscription filters — both narrow, both optional. */
+export interface WebhookSubscriptionFilters {
+  netuids?: number[];
+  kinds?: Array<"subnets" | "artifacts">;
+}
+
+/** Rolled-up delivery health for a subscription, from GET .../webhooks/subscriptions/{id}. */
+export interface WebhookDeliveryStatus {
+  status: "ok" | "retrying" | "dead_letter";
+  pending: number;
+  dead_letter: number;
+  last_failure?: {
+    event_id?: string;
+    attempts?: number;
+    reason?: string;
+    status_code?: number;
+    state?: string;
+    last_attempt_at?: string;
+    next_attempt_at?: string | null;
+  } | null;
+}
+
+/**
+ * POST /api/v1/webhooks/subscriptions response. `secret` is returned exactly
+ * once here — GET never echoes it back.
+ */
+export interface WebhookSubscriptionCreated {
+  id: string;
+  url: string;
+  filters: WebhookSubscriptionFilters;
+  secret: string;
+  active: boolean;
+  created_at: string;
+  delivery: {
+    method: string;
+    content_type: string;
+    signature_header: string;
+    signature_algorithm: string;
+    event_id_header: string;
+    idempotency_header: string;
+    note: string;
+  };
+}
+
+/** GET /api/v1/webhooks/subscriptions/{id} response — no secret. */
+export interface WebhookSubscriptionView {
+  id: string;
+  url: string;
+  filters: WebhookSubscriptionFilters;
+  created_at: string | null;
+  active: boolean;
+  delivery: WebhookDeliveryStatus;
+}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GapsRouteImport } from './routes/gaps'
@@ -38,6 +39,11 @@ const SurfacesRoute = SurfacesRouteImport.update({
 const StatusRoute = StatusRouteImport.update({
   id: '/status',
   path: '/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SchemasRoute = SchemasRouteImport.update({
@@ -140,6 +146,7 @@ export interface FileRoutesByFullPath {
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
   '/schemas': typeof SchemasRoute
+  '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
   '/accounts/$ss58': typeof AccountsSs58Route
@@ -162,6 +169,7 @@ export interface FileRoutesByTo {
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
   '/schemas': typeof SchemasRoute
+  '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
   '/accounts/$ss58': typeof AccountsSs58Route
@@ -185,6 +193,7 @@ export interface FileRoutesById {
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
   '/schemas': typeof SchemasRoute
+  '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
   '/accounts/$ss58': typeof AccountsSs58Route
@@ -209,6 +218,7 @@ export interface FileRouteTypes {
     | '/gaps'
     | '/health'
     | '/schemas'
+    | '/settings'
     | '/status'
     | '/surfaces'
     | '/accounts/$ss58'
@@ -231,6 +241,7 @@ export interface FileRouteTypes {
     | '/gaps'
     | '/health'
     | '/schemas'
+    | '/settings'
     | '/status'
     | '/surfaces'
     | '/accounts/$ss58'
@@ -253,6 +264,7 @@ export interface FileRouteTypes {
     | '/gaps'
     | '/health'
     | '/schemas'
+    | '/settings'
     | '/status'
     | '/surfaces'
     | '/accounts/$ss58'
@@ -276,6 +288,7 @@ export interface RootRouteChildren {
   GapsRoute: typeof GapsRoute
   HealthRoute: typeof HealthRoute
   SchemasRoute: typeof SchemasRoute
+  SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
   SurfacesRoute: typeof SurfacesRoute
   AccountsSs58Route: typeof AccountsSs58Route
@@ -304,6 +317,13 @@ declare module '@tanstack/react-router' {
       path: '/status'
       fullPath: '/status'
       preLoaderRoute: typeof StatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/schemas': {
@@ -444,6 +464,7 @@ const rootRouteChildren: RootRouteChildren = {
   GapsRoute: GapsRoute,
   HealthRoute: HealthRoute,
   SchemasRoute: SchemasRoute,
+  SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,
   SurfacesRoute: SurfacesRoute,
   AccountsSs58Route: AccountsSs58Route,

--- a/apps/ui/src/routes/settings.tsx
+++ b/apps/ui/src/routes/settings.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { WebhookSubscriptionManager } from "@/components/metagraphed/webhook-subscription-manager";
+
+export const Route = createFileRoute("/settings")({
+  head: () => ({
+    meta: [
+      { title: "Developer settings — Metagraphed" },
+      {
+        name: "description",
+        content: "Create, look up, and delete change-feed webhook subscriptions.",
+      },
+      { property: "og:title", content: "Developer settings — Metagraphed" },
+      {
+        property: "og:description",
+        content: "Create, look up, and delete change-feed webhook subscriptions.",
+      },
+    ],
+  }),
+  component: SettingsPage,
+});
+
+function SettingsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Developer"
+        title="Developer settings"
+        description="Self-service webhook subscription management against the public subscription API. Nothing here is stored server-side beyond the subscription record itself — there is no account model."
+      />
+      <WebhookSubscriptionManager />
+      <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a `/settings` developer page (`apps/ui/src/routes/settings.tsx` +
  `apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx`) that
  lets a visitor create a webhook subscription, look one up by id (status +
  delivery health), and delete one they hold the secret for — entirely
  client-side against the existing public `/api/v1/webhooks/subscriptions`
  API. No server-side account model, no changes to `src/webhooks.mjs` or
  `workers/api.mjs`.
- Wires a discoverable entry point: a new "Webhook" icon button next to the
  existing display-preferences `SettingsPopover` gear in the header
  (`apps/ui/src/components/metagraphed/app-shell.tsx`), with its own tooltip
  ("Developer settings — webhook subscriptions") so it isn't confused with
  the theme/density popover.
- Create renders the returned `id` + one-time `secret` (with copy buttons and
  an explicit one-time-only warning) plus the delivery block (signature
  header/algorithm, idempotency header). Lookup renders `status`
  (`ok`/`retrying`/`dead_letter`) as a distinct pill plus pending/dead-letter
  counts and the last failure. Delete requires id + secret and reports the
  API's rejection reason.
- Loading (`Skeleton`), empty (`EmptyState`), and error states are handled
  per section, with error copy that distinguishes a 401/503 create rejection,
  a 404 lookup, and a 403 secret-mismatch delete.
- Three new mutation call sites (create/lookup/delete) call `apiFetch`
  directly, following the `verify-surface-button.tsx` precedent — no changes
  to `queries.ts` (still a read-only data layer by convention).

Closes #3494

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run format:check --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` (476 passed, incl. new
  `webhook-subscription-manager.test.ts` for the pure netuids-filter parser)
- `npm run build --workspace=apps/ui`
- Manually verified in a browser against the live production API
  (`https://api.metagraph.sh`): the page renders its three sections, the
  lookup empty state shows before a search, and submitting a random id
  correctly surfaces "No subscription found with that id."

## Screenshots

3 viewports × 2 themes, before/after. The home-page rows show the new header
entry point; the `/settings` page itself is brand new, so there is no
meaningful "before" for it beyond the app's generic 404 (not a useful visual
diff) — only "after" is shown for those rows.

### Header entry point (home page)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/home-mobile-dark-after.png)<br><sub>after</sub> |

### New `/settings` page (after only — route did not exist before)

| Viewport · Theme | After |
| --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-desktop-light-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-desktop-light-after.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-desktop-dark-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-desktop-dark-after.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-tablet-light-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-tablet-light-after.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-tablet-dark-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-tablet-dark-after.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-mobile-light-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-mobile-light-after.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-mobile-dark-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/settings-mobile-dark-after.png) |

## Template Used

- backend-code.md (closest fit — no dedicated frontend template in this repo)
