### PR TITLE
fix(registry): prune revoked Postgres surfaces

### DIFF
--- a/scripts/backfill-registry-postgres.mjs
+++ b/scripts/backfill-registry-postgres.mjs
@@ -114,6 +114,7 @@ async function main() {
     providers_written: 0,
     subnets_written: 0,
     surfaces_written: 0,
+    surfaces_deleted: 0,
   };
 
   // Providers + subnets are small (low hundreds) -- one request each is
@@ -129,6 +130,12 @@ async function main() {
     if (!chunk.length) continue;
     const result = await postRegistrySync({ surfaces: chunk });
     summary.surfaces_written += result?.surfaces_written ?? 0;
+  }
+
+  for (const chunk of chunkRows(buildSurfacePruneRows(subnets, surfaces))) {
+    if (!chunk.length) continue;
+    const result = await postRegistrySync({ prune_surfaces: chunk });
+    summary.surfaces_deleted += result?.surfaces_deleted ?? 0;
   }
 
   console.log(stableStringify(summary));
@@ -177,6 +184,26 @@ function collectOverlays(
       });
     }
   }
+}
+
+function buildSurfacePruneRows(subnets, surfaces) {
+  const bySubnet = new Map(
+    subnets.map((subnet) => [
+      subnet.netuid,
+      {
+        subnet_netuid: subnet.netuid,
+        current_surfaces: [],
+        source_commit: subnet.source_commit,
+      },
+    ]),
+  );
+  for (const surface of surfaces) {
+    bySubnet.get(surface.subnet_netuid)?.current_surfaces.push({
+      kind: surface.kind,
+      url: surface.url,
+    });
+  }
+  return [...bySubnet.values()];
 }
 
 async function currentCommitSha() {

--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -218,6 +218,13 @@ async function collectSubnetFile(
     subnet_netuid: overlay.netuid,
     current_surfaces: currentSurfaces,
     source_commit: args.head,
+    // This file's `surfaces` array is only ever the community-authored ones --
+    // it has no visibility into machine-generated/candidate-promoted surfaces
+    // the same subnet may also carry (that's generateBaselineOverlaySet's job,
+    // via the scheduled backfill). Scope the Worker's prune to authority =
+    // 'community' so this fast path can never delete a row it has no way to
+    // know about.
+    authority_scope: "community",
   });
 }
 

--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -77,15 +77,22 @@ async function main() {
   const providers = [];
   const subnets = [];
   const surfaces = [];
+  const pruneSurfaces = [];
+  const deleteSubnets = [];
   const skippedInvalid = [];
 
   for (const file of changedFiles) {
     const stillExists = fileExistsAtHead(file);
     if (!stillExists) {
-      // Deletions aren't synced yet (rare — this repo's surface model is
-      // append-only in practice); leaving the last-known row in place is
-      // safer than guessing at removal semantics here.
-      console.log(`${file} was deleted in this push; leaving its row(s) as-is`);
+      if (file.startsWith("registry/subnets/")) {
+        const deletedSubnet = readSubnetFromCommit(args.base, file);
+        if (deletedSubnet) {
+          deleteSubnets.push({
+            netuid: deletedSubnet.netuid,
+            source_commit: args.head,
+          });
+        }
+      }
       continue;
     }
     const absolutePath = path.join(repoRoot, file);
@@ -103,7 +110,7 @@ async function main() {
         skippedInvalid.push(file);
         continue;
       }
-      await collectSubnetFile(absolutePath, subnets, surfaces);
+      await collectSubnetFile(absolutePath, subnets, surfaces, pruneSurfaces);
     } else {
       await collectProviderFile(absolutePath, providers);
     }
@@ -113,14 +120,30 @@ async function main() {
     providers_written: 0,
     subnets_written: 0,
     surfaces_written: 0,
+    surfaces_deleted: 0,
+    subnets_deleted: 0,
     skipped_invalid: skippedInvalid,
   };
 
-  if (providers.length || subnets.length || surfaces.length) {
-    const result = await postRegistrySync({ providers, subnets, surfaces });
+  if (
+    providers.length ||
+    subnets.length ||
+    surfaces.length ||
+    pruneSurfaces.length ||
+    deleteSubnets.length
+  ) {
+    const result = await postRegistrySync({
+      providers,
+      subnets,
+      surfaces,
+      prune_surfaces: pruneSurfaces,
+      delete_subnets: deleteSubnets,
+    });
     summary.providers_written = result?.providers_written ?? 0;
     summary.subnets_written = result?.subnets_written ?? 0;
     summary.surfaces_written = result?.surfaces_written ?? 0;
+    summary.surfaces_deleted = result?.surfaces_deleted ?? 0;
+    summary.subnets_deleted = result?.subnets_deleted ?? 0;
   }
 
   console.log(stableStringify(summary));
@@ -141,7 +164,12 @@ async function collectProviderFile(absolutePath, providersOut) {
   providersOut.push({ id: overlay.id, overlay, source_commit: args.head });
 }
 
-async function collectSubnetFile(absolutePath, subnetsOut, surfacesOut) {
+async function collectSubnetFile(
+  absolutePath,
+  subnetsOut,
+  surfacesOut,
+  pruneSurfacesOut,
+) {
   const overlay = await readJson(absolutePath);
   if (!Number.isInteger(overlay.netuid) || !overlay.slug || !overlay.name) {
     console.error(
@@ -165,7 +193,9 @@ async function collectSubnetFile(absolutePath, subnetsOut, surfacesOut) {
     source_commit: args.head,
   });
 
+  const currentSurfaces = [];
   for (const surface of surfaces) {
+    currentSurfaces.push({ kind: surface.kind, url: surface.url });
     surfacesOut.push({
       subnet_netuid: overlay.netuid,
       provider_id: surface.provider || null,
@@ -184,6 +214,11 @@ async function collectSubnetFile(absolutePath, subnetsOut, surfacesOut) {
       source_commit: args.head,
     });
   }
+  pruneSurfacesOut.push({
+    subnet_netuid: overlay.netuid,
+    current_surfaces: currentSurfaces,
+    source_commit: args.head,
+  });
 }
 
 function gitDiffFiles(base, head) {
@@ -195,6 +230,21 @@ function gitDiffFiles(base, head) {
     throw new Error(`git diff ${base}..${head} failed: ${result.stderr}`);
   }
   return result.stdout.split("\n").filter(Boolean);
+}
+
+function readSubnetFromCommit(commit, file) {
+  const result = spawnSync("git", ["show", `${commit}:${file}`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  try {
+    const overlay = JSON.parse(result.stdout);
+    if (Number.isInteger(overlay.netuid)) return overlay;
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 function fileExistsAtHead(file) {

--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -5,6 +5,7 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 const sqlCalls = vi.hoisted(() => []);
 const surfaceResult = vi.hoisted(() => ({ current: [{ inserted: true }] }));
+const deleteResult = vi.hoisted(() => ({ surfaces: [], subnets: [] }));
 const failure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
@@ -17,6 +18,12 @@ vi.mock("postgres", () => ({
       }
       if (/INSERT INTO surfaces/.test(text)) {
         return Promise.resolve(surfaceResult.current);
+      }
+      if (/DELETE FROM surfaces/.test(text)) {
+        return Promise.resolve(deleteResult.surfaces);
+      }
+      if (/DELETE FROM subnets/.test(text)) {
+        return Promise.resolve(deleteResult.subnets);
       }
       return Promise.resolve([]);
     };
@@ -76,6 +83,8 @@ const surface = () => ({
 beforeEach(() => {
   sqlCalls.length = 0;
   surfaceResult.current = [{ inserted: true }];
+  deleteResult.surfaces = [];
+  deleteResult.subnets = [];
   failure.error = null;
 });
 
@@ -257,6 +266,73 @@ test("records an update action in surface_history when the row already existed",
     /INSERT INTO surface_history/.test(c.text),
   );
   expect(historyCall.values).toContain("update");
+});
+
+test("prunes surfaces absent from the current subnet payload and records delete history", async () => {
+  deleteResult.surfaces = [
+    {
+      id: "00000000-0000-0000-0000-000000000001",
+      subnet_netuid: 8,
+      overlay: { kind: "docs", url: "https://stale.example/docs" },
+    },
+  ];
+
+  const res = await worker.fetch(
+    post(
+      {
+        prune_surfaces: [
+          {
+            subnet_netuid: 8,
+            current_surfaces: [
+              { kind: "docs", url: "https://example.com/docs" },
+            ],
+            source_commit: "def456",
+          },
+        ],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ surfaces_deleted: 1 });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).toMatch(/DELETE FROM surfaces/);
+  const historyCall = sqlCalls.find((c) =>
+    /INSERT INTO surface_history/.test(c.text),
+  );
+  expect(historyCall.values).toContain("delete");
+});
+
+test("deletes a removed subnet after recording delete history for its surfaces", async () => {
+  deleteResult.surfaces = [
+    {
+      id: "00000000-0000-0000-0000-000000000002",
+      subnet_netuid: 9,
+      overlay: { kind: "subnet-api", url: "https://stale.example/api" },
+    },
+  ];
+  deleteResult.subnets = [{ netuid: 9 }];
+
+  const res = await worker.fetch(
+    post(
+      { delete_subnets: [{ netuid: 9, source_commit: "def456" }] },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    surfaces_deleted: 1,
+    subnets_deleted: 1,
+  });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).toMatch(/DELETE FROM surfaces/);
+  expect(text).toMatch(/DELETE FROM subnets/);
 });
 
 test("maps a DB failure to a clean 502 instead of throwing", async () => {

--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -306,6 +306,133 @@ test("prunes surfaces absent from the current subnet payload and records delete 
   expect(historyCall.values).toContain("delete");
 });
 
+test("REGRESSION: prune_surfaces with authority_scope 'community' passes a true scope flag, bounding the DELETE to community-authority rows", async () => {
+  deleteResult.surfaces = [];
+
+  const res = await worker.fetch(
+    post(
+      {
+        prune_surfaces: [
+          {
+            subnet_netuid: 8,
+            current_surfaces: [
+              { kind: "docs", url: "https://example.com/docs" },
+            ],
+            source_commit: "def456",
+            authority_scope: "community",
+          },
+        ],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  const deleteCall = sqlCalls.find((c) => /DELETE FROM surfaces/.test(c.text));
+  expect(deleteCall.text).toMatch(/authority = /);
+  // The scope flag is bound as a real parameter (true), not spliced into the query text.
+  expect(deleteCall.values).toContain(true);
+  expect(deleteCall.values).toContain("community");
+});
+
+test("does not scope by authority when authority_scope is absent (the scheduled full-resync path)", async () => {
+  deleteResult.surfaces = [];
+
+  const res = await worker.fetch(
+    post(
+      {
+        prune_surfaces: [
+          {
+            subnet_netuid: 8,
+            current_surfaces: [
+              { kind: "docs", url: "https://example.com/docs" },
+            ],
+            source_commit: "def456",
+          },
+        ],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  const deleteCall = sqlCalls.find((c) => /DELETE FROM surfaces/.test(c.text));
+  // The scope flag is still present in the query shape (always-composed OR clause),
+  // but bound to false so it never actually filters by authority.
+  expect(deleteCall.values).toContain(false);
+});
+
+test("skips a prune_surfaces entry missing subnet_netuid/current_surfaces/source_commit instead of failing the request", async () => {
+  const res = await worker.fetch(
+    post(
+      {
+        prune_surfaces: [
+          { subnet_netuid: 8 }, // missing current_surfaces and source_commit
+        ],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ surfaces_deleted: 0 });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).not.toMatch(/DELETE FROM surfaces/);
+});
+
+test("deletes every surface for a subnet when current_surfaces has no valid kind/url entries", async () => {
+  deleteResult.surfaces = [
+    {
+      id: "00000000-0000-0000-0000-000000000003",
+      subnet_netuid: 8,
+      overlay: { kind: "docs", url: "https://stale.example/docs" },
+    },
+  ];
+
+  const res = await worker.fetch(
+    post(
+      {
+        prune_surfaces: [
+          { subnet_netuid: 8, current_surfaces: [], source_commit: "def456" },
+        ],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ surfaces_deleted: 1 });
+  const deleteCall = sqlCalls.find((c) => /DELETE FROM surfaces/.test(c.text));
+  expect(deleteCall.text).not.toMatch(/ANY/);
+});
+
+test("skips a delete_subnets entry missing netuid/source_commit instead of failing the request", async () => {
+  const res = await worker.fetch(
+    post(
+      { delete_subnets: [{ netuid: null, source_commit: "def456" }] },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    surfaces_deleted: 0,
+    subnets_deleted: 0,
+  });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).not.toMatch(/DELETE FROM subnets/);
+});
+
 test("deletes a removed subnet after recording delete history for its surfaces", async () => {
   deleteResult.surfaces = [
     {

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -69,10 +69,18 @@ export default {
     const subnets = Array.isArray(body?.subnets) ? body.subnets : [];
     const providers = Array.isArray(body?.providers) ? body.providers : [];
     const surfaces = Array.isArray(body?.surfaces) ? body.surfaces : [];
+    const pruneSurfaces = Array.isArray(body?.prune_surfaces)
+      ? body.prune_surfaces
+      : [];
+    const deleteSubnets = Array.isArray(body?.delete_subnets)
+      ? body.delete_subnets
+      : [];
     for (const [name, rows] of [
       ["subnets", subnets],
       ["providers", providers],
       ["surfaces", surfaces],
+      ["prune_surfaces", pruneSurfaces],
+      ["delete_subnets", deleteSubnets],
     ]) {
       if (rows.length > MAX_ROWS_PER_KIND) {
         return json(
@@ -84,7 +92,13 @@ export default {
         return json({ error: `${name} must be an array of row objects` }, 400);
       }
     }
-    if (!subnets.length && !providers.length && !surfaces.length) {
+    if (
+      !subnets.length &&
+      !providers.length &&
+      !surfaces.length &&
+      !pruneSurfaces.length &&
+      !deleteSubnets.length
+    ) {
       return json({ error: "no rows provided" }, 400);
     }
 
@@ -98,6 +112,8 @@ export default {
       providers_written: 0,
       subnets_written: 0,
       surfaces_written: 0,
+      surfaces_deleted: 0,
+      subnets_deleted: 0,
     };
     try {
       await sql`SET statement_timeout = '10000ms'`;
@@ -135,6 +151,54 @@ export default {
             source_commit = EXCLUDED.source_commit,
             updated_at = now()`;
         summary.subnets_written += 1;
+      }
+
+      for (const prune of pruneSurfaces) {
+        if (
+          !Number.isInteger(prune.subnet_netuid) ||
+          !Array.isArray(prune.current_surfaces) ||
+          !prune.source_commit
+        )
+          continue;
+        const keepKeys = prune.current_surfaces
+          .filter((surface) => surface?.kind && surface?.url)
+          .map((surface) => `${surface.kind}\u001f${surface.url}`);
+        const deleted = keepKeys.length
+          ? await sql`
+              DELETE FROM surfaces
+              WHERE subnet_netuid = ${prune.subnet_netuid}
+                AND NOT (kind || ${"\u001f"} || url = ANY(${keepKeys}))
+              RETURNING id, subnet_netuid, overlay`
+          : await sql`
+              DELETE FROM surfaces
+              WHERE subnet_netuid = ${prune.subnet_netuid}
+              RETURNING id, subnet_netuid, overlay`;
+        for (const row of deleted) {
+          await sql`
+            INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
+            VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${sql.json(row.overlay)}, ${prune.source_commit})`;
+          summary.surfaces_deleted += 1;
+        }
+      }
+
+      for (const deletion of deleteSubnets) {
+        if (!Number.isInteger(deletion.netuid) || !deletion.source_commit)
+          continue;
+        const deletedSurfaces = await sql`
+          DELETE FROM surfaces
+          WHERE subnet_netuid = ${deletion.netuid}
+          RETURNING id, subnet_netuid, overlay`;
+        for (const row of deletedSurfaces) {
+          await sql`
+            INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
+            VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${sql.json(row.overlay)}, ${deletion.source_commit})`;
+          summary.surfaces_deleted += 1;
+        }
+        const deletedSubnets = await sql`
+          DELETE FROM subnets
+          WHERE netuid = ${deletion.netuid}
+          RETURNING netuid`;
+        summary.subnets_deleted += deletedSubnets.length;
       }
 
       for (const surf of surfaces) {

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -163,15 +163,31 @@ export default {
         const keepKeys = prune.current_surfaces
           .filter((surface) => surface?.kind && surface?.url)
           .map((surface) => `${surface.kind}\u001f${surface.url}`);
+        // `authority_scope: "community"` (set by the merge-triggered fast path,
+        // scripts/sync-registry-to-postgres.mjs) bounds this prune to ONLY the
+        // community-authority rows for the subnet -- the fast path's
+        // current_surfaces comes from a single registry/subnets/<slug>.json file
+        // and has no visibility into machine-generated/candidate-promoted
+        // surfaces (authority: "registry-observed") the same subnet may also
+        // carry, so without this scope it would delete those rows on every
+        // merge that touches the file. The scheduled full resync
+        // (scripts/backfill-registry-postgres.mjs) computes current_surfaces
+        // from the complete baseline-augmented view and omits authority_scope,
+        // so it keeps pruning across every authority as before. Passed as a
+        // plain boolean parameter (not spliced SQL) so the condition is a
+        // no-op OR branch when unscoped, rather than composing raw fragments.
+        const scopeToCommunity = prune.authority_scope === "community";
         const deleted = keepKeys.length
           ? await sql`
               DELETE FROM surfaces
               WHERE subnet_netuid = ${prune.subnet_netuid}
+                AND (NOT ${scopeToCommunity} OR authority = ${"community"})
                 AND NOT (kind || ${"\u001f"} || url = ANY(${keepKeys}))
               RETURNING id, subnet_netuid, overlay`
           : await sql`
               DELETE FROM surfaces
               WHERE subnet_netuid = ${prune.subnet_netuid}
+                AND (NOT ${scopeToCommunity} OR authority = ${"community"})
               RETURNING id, subnet_netuid, overlay`;
         for (const row of deleted) {
           await sql`


### PR DESCRIPTION
### Motivation
- Prevent stale or revoked surfaces from persisting in the Postgres registry when they are removed from the git registry or demoted by machine-generated overlays. 
- Ensure deletions are recorded in the append-only `surface_history` ledger so removals are auditable and the serving source-of-truth reflects current registry state.

### Description
- Add `prune_surfaces` and `delete_subnets` request payload handling to `workers/registry-sync-api.mjs` that deletes matching `surfaces` rows and inserts `delete` actions into `surface_history` before removing subnets. 
- Have the scheduled full-resync (`scripts/backfill-registry-postgres.mjs`) compute per-subnet current surface identities via `buildSurfacePruneRows` and send `prune_surfaces` chunks to the registry-sync Worker. 
- Have the merge-triggered fast-path (`scripts/sync-registry-to-postgres.mjs`) produce `prune_surfaces` for changed subnet files and `delete_subnets` for subnet manifests removed from the commit (adds `readSubnetFromCommit` to recover deleted manifest metadata). 
- Add regression coverage in `tests/registry-sync-api.test.mjs` to assert pruning behavior and deleted-subnet cleanup, and update the worker tests to mock DELETE behavior.

### Testing
- Ran `npm test -- tests/registry-sync-api.test.mjs` and the registry-sync Worker unit tests passed. 
- Ran `npm run lint` and `npm run format:check` (fixed formatting) and both succeeded. 
- Ran `npm run build` which produced generated artifacts successfully. 
- Ran `npm run validate` which initially failed before building due to missing generated artifacts, and completed successfully after `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba94eeb48832ca81479961dbb179a)