### PR TITLE
feat(surface): add SN74 Gittensor scoring-configuration data-artifact

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -416,6 +416,25 @@
         "https://api.gittensor.io/swagger"
       ],
       "url": "https://api.gittensor.io/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-data-artifact-api-gittensor-io-6",
+      "kind": "data-artifact",
+      "name": "Gittensor scoring configuration",
+      "notes": "Public no-auth GET /configurations/general on api.gittensor.io returning the subnet's live scoring configuration (observed: languageFileScoring weights, repositoryPrScoring defaultMergedPrBaseScore/bonus, maxIssueCloseWindowDays, mitigatedExtensions). Documented in the subnet OpenAPI (api.gittensor.io/swagger-json, 'Gittensor DAS') as 'Get general configuration data'; same host as the existing Gittensor dash data-artifact surfaces.",
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "swengieer0829"
+      },
+      "source_urls": [
+        "https://api.gittensor.io/swagger-json",
+        "https://gittensor.io/"
+      ],
+      "url": "https://api.gittensor.io/configurations/general"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary

Adds one community **`data-artifact`** surface to **SN74 Gittensor**: the public, no-auth **`GET /configurations/general`** endpoint on `api.gittensor.io`, which returns the subnet's live scoring configuration — language-file scoring weights, PR base/bonus scores, issue close-window, and mitigated extensions.

- **url:** `https://api.gittensor.io/configurations/general`
- **proof (`source_urls`):**
  - `https://api.gittensor.io/swagger-json` — the subnet's own OpenAPI (title *"Gittensor DAS"*), which documents this endpoint as *"Get general configuration data"*.
  - `https://gittensor.io/` — the official SN74 project site.
- **provider:** `gittensor` (registered) · **authority:** `community` · **auth_required:** `false` · **public_safe:** `true`

### Why it's not a duplicate
The existing `api.gittensor.io` surfaces cover `dash/stats`, `dash/repos`, `dash/languages`, `issues`, `issues/stats`, `prs`, `miners`, and the root health endpoint. **None expose the scoring-configuration blob** — `/configurations/general` is a distinct, documented endpoint. Verified live (HTTP 200, `application/json`, no auth) and confirmed present in the OpenAPI spec.

Only `registry/subnets/gittensor.json` changes — one appended surface, no generated artifacts touched (one subnet = one file = one PR).

## Validation

```
npm run surface:add -- --netuid 74 --kind data-artifact \
  --url https://api.gittensor.io/configurations/general \
  --source-url https://api.gittensor.io/swagger-json \
  --source-url https://gittensor.io/ \
  --provider gittensor --submitted-by swengieer0829 --write
npm run validate:surface -- registry/subnets/gittensor.json   # Surface validation passed
npm run build                                                  # passed
npm run validate                                               # passed (1415 surfaces validated)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
