### PR TITLE
feat(registry): enrich SN33 ReadyAI — priority-queue request subnet-api (#1282)

### DIFF
--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -191,6 +191,31 @@
         "https://huggingface.co/ReadyAi"
       ],
       "url": "https://huggingface.co/datasets/ReadyAi/organic_query_results_dataset"
+    },
+    {
+      "id": "sn-33-readyai-priorityqueue-request-api",
+      "name": "ReadyAI priority queue domain request API",
+      "kind": "subnet-api",
+      "url": "https://api.readyai.ai/api/v1/priorityqueue/request",
+      "provider": "readyai",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://api.readyai.ai/openapi.json",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md"
+      ],
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "notes": "Public no-auth PUT /api/v1/priorityqueue/request on api.readyai.ai for users to request a domain for priority Common Crawl processing (upserts requested_domains). Documented in the subnet OpenAPI spec with no security requirement on PUT; GET on the same path is admin-authenticated, so recurring read probes are intentionally disabled."
     }
   ],
   "website_url": "https://readyai.ai/"


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface on `registry/subnets/readyai.json` for the SN33 ReadyAI public priority-queue domain-request endpoint documented in the subnet OpenAPI spec.

Closes #1282.

## Surface

| Field | Value |
|-------|-------|
| Netuid | 33 (ReadyAI) |
| Kind | `subnet-api` |
| URL | `https://api.readyai.ai/api/v1/priorityqueue/request` |
| Provider | `readyai` |
| Auth | `auth_required: false` (PUT has no security in OpenAPI) |
| Probe | disabled — PUT-only public method; GET on same path is admin-authenticated |

## Source evidence

- `https://api.readyai.ai/openapi.json` — `PUT /api/v1/priorityqueue/request` with description *"No authentication required — intended for public use"*
- SN33 source README — documents `api.readyai.ai` as the subnet API host

Distinct from the existing `/health` subnet-api surface; registers the public write path for domain priority requests.

## Checklist

- [x] Changes exactly one `registry/subnets/readyai.json` file (append-only, 25-line insertion)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL safe; `source_urls` prove the subnet publishes it
- [x] `public_safe: true`, `auth_required: false`
- [x] Links tracked **open** issue (`Closes #1282`)

## Validation

- `npm run validate:surface -- registry/subnets/readyai.json`
- `npm run scan:public-safety`