### PR TITLE
feat(registry): enrich SN8 Vanta — scoring model parameters config API

### DIFF
--- a/registry/subnets/vanta.json
+++ b/registry/subnets/vanta.json
@@ -136,6 +136,31 @@
         "timeout_ms": 10000
       },
       "notes": "Official Vanta Network source repository."
+    },
+    {
+      "id": "sn-8-vanta-model-parameters",
+      "name": "Vanta scoring model parameters",
+      "kind": "subnet-api",
+      "url": "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json",
+      "provider": "vanta",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/vali_bkp_utils.py",
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/model_parameters/all_model_parameters.json"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "notes": "Public no-auth GET all_model_parameters.json on the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Provides the per-asset buy/sell slippage model parameters (intercept and coefficients) that the validator loads via vali_objects/utils/vali_bkp_utils.py to score miner positions."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Enriches **SN8 Vanta** with its public, no-auth scoring-model-parameters config as a `subnet-api` surface — a machine-usable endpoint the registry was missing.

## Surface

- **url:** `https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json` — public, no-auth, returns JSON (verified 200).
- **What it is:** the per-asset buy/sell slippage model parameters (intercept + coefficients) that Vanta validators load to score miner positions.
- **Provenance:** the file is loaded by the validator via `vali_objects/utils/vali_bkp_utils.py` in the official `taoshidev/vanta-network` repo (cited as a `source_url`), so it's a genuine first-party config surface, not a third-party mirror.

## Why it's safe to merge

- **One file, one surface** — appends a single `subnet-api` entry to `registry/subnets/vanta.json`; `authority: community`, `review.state: community-submitted`; purely additive (no existing surface touched).
- **Not a duplicate** — this URL isn't registered on Vanta or any other subnet.
- **Same accepted pattern as the merged SN29 Coldint surface** (#3863, a raw-repo `competitions.json` config registered as `subnet-api`, which closed the analogous "add public API endpoint + OpenAPI/Swagger spec" issue #724).
- `npm run validate:surface` and `npm run scan:public-safety` both pass locally.

Closes #715
