### PR TITLE
feat(registry): add SN24 Quasar current-run subnet-api (#577)

### DIFF
--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -218,6 +218,32 @@
         "https://huggingface.co/silx-ai"
       ],
       "url": "https://huggingface.co/datasets/silx-ai/Quasar-SN3"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-24-quasar-current-run-api",
+      "kind": "subnet-api",
+      "name": "Quasar current training run manifest",
+      "notes": "Public no-auth GET on the subnet's anonymous mainnet S3 bucket (QUASAR_S3_ANONYMOUS=true in QUASAR-SUBNET README) returning the active run_id, status, and checkpoint manifest URI. Miners and validators discover the live run from this object at quasar/netuid=24/runs/current.json per incentive/bucket/paths.py current_run_key(). Distinct from static HuggingFace model/data artifacts.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "silx-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/README.md",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/incentive/bucket/paths.py",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/incentive/coordination/current_run.py"
+      ],
+      "url": "https://quasar-incentive-sn24-529337356998-us-east-1.s3.us-east-1.amazonaws.com/quasar/netuid=24/runs/current.json"
     }
   ],
   "website_url": "https://silxinc.com/",


### PR DESCRIPTION
Closes #577

## Summary
- Registers the public anonymous S3 `current.json` run-discovery endpoint as a community `subnet-api` on SN24 Quasar
- Partial fulfillment of #577 (API half): QUASAR-SUBNET documents no machine-readable OpenAPI/Swagger; `quasar.ai` / `silxinc.com` API paths 404

## Surface
| Field | Value |
|-------|-------|
| Netuid | 24 (Quasar) |
| Kind | `subnet-api` |
| URL | `https://quasar-incentive-sn24-529337356998-us-east-1.s3.us-east-1.amazonaws.com/quasar/netuid=24/runs/current.json` |
| Provider | `silx-labs` |
| Probe | `GET` → `expect: json` |

## Source evidence
- [README](https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/README.md) — `QUASAR_S3_BUCKET`, `QUASAR_S3_ANONYMOUS=true`, netuid 24; miners discover active run from public current-run metadata
- [`incentive/bucket/paths.py`](https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/incentive/bucket/paths.py) — `current_run_key()`
- [`incentive/coordination/current_run.py`](https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/incentive/coordination/current_run.py)

## Test plan
- [x] `npm run validate:surface -- --file registry/subnets/quasar.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/quasar.json`
- [x] Manual GET returns JSON (`run_id`, `status`, `checkpoint_manifest_uri`) without auth