### PR TITLE
feat(surface): add SN74 Gittensor scoring-configuration data-artifact

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -416,6 +416,28 @@
         "https://api.gittensor.io/swagger"
       ],
       "url": "https://api.gittensor.io/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-data-artifact-api-gittensor-io-6",
+      "kind": "data-artifact",
+      "name": "Gittensor scoring configuration",
+      "notes": "Public no-auth GET /configurations/general on api.gittensor.io returning the subnet's live scoring configuration (language weights, PR base/bonus scores, issue close-window, mitigated extensions). Documented in the subnet OpenAPI (/swagger-json) as 'Get general configuration data'.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "swengieer0829"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/configurations/general"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary

Adds one community **`data-artifact`** surface to **SN74 Gittensor**: the public, no-auth **`GET /configurations/general`** endpoint on `api.gittensor.io`, which returns the subnet's live scoring configuration — language-file weights, PR base/bonus scores, issue close-window, and mitigated extensions.

- **url:** `https://api.gittensor.io/configurations/general`
- **proof (`source_urls`):** `https://api.gittensor.io/swagger-json` — the subnet's own OpenAPI (title *"Gittensor DAS"*), which documents this endpoint as *"Get general configuration data"*.
- **provider:** `gittensor` · **authority:** `community` · **auth_required:** `false` · **public_safe:** `true` · **probe:** HEAD (matches the sibling `api.gittensor.io` data-artifacts).

Distinct from the existing `api.gittensor.io` surfaces (`dash/stats`, `dash/repos`, `dash/languages`, `issues`, `issues/stats`, `prs`, `miners`, root health) — none expose the scoring-config blob. Verified live (HTTP 200, `application/json`, no auth). One file, append-only; no generated artifacts touched.

## No-issue rationale

This is a deliberate no-issue PR (explained per the review contract, which accepts a linked issue *or* a no-issue rationale):

- The only open maintainer enrichment issue for SN74 (#1275) requests an **SSE stream**, which `api.gittensor.io` does **not** expose (confirmed against its OpenAPI — there is no `text/event-stream` endpoint). Linking #1275 would misrepresent this change, so it is intentionally not linked.
- There is no maintainer issue for an SN74 **data-artifact** surface, and issue creation is restricted for outside contributors on this repo, so a linking issue could not be filed.
- The surface is nonetheless a genuine, verified, non-duplicate enrichment, proven by the subnet's own machine-readable OpenAPI.

## Context

Resubmission of #3893, which auto-closed **solely** for "no linked issue" — the surface itself reviewed clean (readiness 93/100, CI green, no overlap). This PR addresses that review's nits:

- Dropped the generic `gittensor.io/` `source_url`; kept only the `swagger-json` proof (the reviewer noted it alone suffices).
- Trimmed the surface `notes`.
- Added a `probe` block (`HEAD`), matching the sibling `api.gittensor.io` data-artifact surfaces.

## Validation

```
npm run surface:add -- --netuid 74 --kind data-artifact \
  --url https://api.gittensor.io/configurations/general \
  --source-url https://api.gittensor.io/swagger-json \
  --provider gittensor --submitted-by swengieer0829 --write
npm run validate:surface -- registry/subnets/gittensor.json   # Surface validation passed
npm run build                                                  # passed
npm run validate                                               # passed (1415 surfaces validated)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
