### PR TITLE
feat(registry): add Mainframe PDB structure file subnet-api (SN25)

### DIFF
--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -74,6 +74,33 @@
         "timeout_ms": 10000
       },
       "notes": "Public MIT-licensed benchmark data artifact published under the Macrocosmos (macrocosm-os) Hugging Face organization, the operator of SN25 Mainframe (github.com/macrocosm-os/mainframe, macrocosmos.ai). Daily parquet snapshots of a multiple-choice question benchmark with per-miner evaluation and voting records, spanning October 2024 through August 2025 in the 100K-1M row range."
+    },
+    {
+      "id": "sn-25-mainframe-pdb-file-api",
+      "name": "Mainframe PDB structure file API",
+      "kind": "subnet-api",
+      "url": "https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb",
+      "provider": "macrocosmos",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/macrocosm-os/mainframe/blob/main/folding_api/utility_endpoints.py",
+        "https://github.com/macrocosm-os/mainframe/blob/main/README.md",
+        "https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie",
+        "confidence": "medium"
+      },
+      "notes": "Public no-auth GET returning PDB structure text from the official SN25 DigitalOcean Spaces bucket. The folding API utility route checks this host first before falling back to RCSB/PDBe mirrors."
     }
   ],
   "social": { "x": "https://x.com/macrocosmosai" },


### PR DESCRIPTION
## Summary
- append one community `subnet-api` surface for SN25 at `https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb`
- append-only change: existing surfaces untouched (+27 lines on one new block)
- public no-auth GET returning PDB structure text from the official SN25 DigitalOcean Spaces bucket referenced in [folding_api/utility_endpoints.py](https://github.com/macrocosm-os/mainframe/blob/main/folding_api/utility_endpoints.py)

## Research notes
- `api.macrocosmos.ai/health` and `/openapi.json` return 404 (prior closed PRs #1085/#1061)
- `mainframe.api.macrocosmos.ai/healthz` returns empty 200 and failed `surface:add` reachability checks from this environment
- FastAPI folding routes (`/fold`, `/search`, `/pdb/.../file` on api hosts) are not publicly deployed; the utility code uses the SN25 Spaces bucket as the live public PDB source
- OpenAPI/Swagger: no machine-readable schema found on Macrocosmos API hosts for SN25
- this PR covers the public API half of #691

## Test plan
- [x] `npm run validate:surface -- registry/subnets/mainframe.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/mainframe.json`
- [x] diff is append-only (`git diff` shows +27 lines on one surface block)
- [x] live probe: `curl https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb` returns PDB text (`text/plain`)

Closes #691