### PR TITLE
feat(registry): add SN22 Desearch Python SDK surface

### DIFF
--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -297,6 +297,31 @@
         "https://www.desearch.ai/openapi.json"
       ],
       "url": "https://api.desearch.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-py-sdk",
+      "kind": "sdk",
+      "name": "Desearch Python SDK",
+      "notes": "Official async Desearch Python SDK on PyPI (desearch-py, v1.2.1) for the Desearch API. Published by the Desearch-ai GitHub org that also hosts the registered SN22 source repository (Desearch-ai/subnet-22); the desearch.py README declares it the \"Official async Python SDK for the Desearch API\" installed via pip install desearch-py.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/Desearch-ai/desearch.py",
+        "https://github.com/Desearch-ai/desearch.py/blob/main/README.md"
+      ],
+      "url": "https://pypi.org/project/desearch-py/"
     }
   ],
   "website_url": "https://www.desearch.ai/"


### PR DESCRIPTION
## Summary

Adds the official **Desearch Python SDK** as an `sdk` surface for **SN22 Desearch** — a high-value callable surface the file didn't have.

## Surface

- kind: `sdk`
- url: https://pypi.org/project/desearch-py/
- Verified live (PyPI JSON API): `desearch-py` **v1.2.1**, summary "A Python SDK for interacting with the Desearch API service", author "Desearch", 13 releases (most recent 2026-05-14).

## Operator match (proof)

- The subnet's registered `source_repo` is `https://github.com/Desearch-ai/subnet-22` (org **Desearch-ai**).
- The same org publishes the SDK repo `https://github.com/Desearch-ai/desearch.py`, whose README states **"Official async Python SDK for the Desearch API"** and **`pip install desearch-py`** — independently proving the operator publishes this package.
- `source_urls` point to that repo + README (the proving sources).

## Non-duplication

`desearch.json` previously had no `sdk` surface and no PyPI reference; `desearch-py`/`desearch.py`/`pypi` appear in no existing surface here or in any other subnet file.

## Validation (local)

- `npm run validate:surface -- registry/subnets/desearch.json` → passes
- `npm run scan:public-safety` → passes
- Diff is a single file (`registry/subnets/desearch.json`), one appended community surface, no other changes.
