### PR TITLE
feat(ui): add subnetEventsQuery kind param and eventKindFilterOptions

### DIFF
--- a/apps/ui/src/lib/metagraphed/event-kinds.test.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   EVENT_KIND_CATEGORIES,
+  EVENT_KIND_LABELS,
   eventKindCategory,
   eventKindCategoryLabel,
+  eventKindFilterOptions,
   eventKindLabel,
 } from "./event-kinds";
 
@@ -54,5 +56,16 @@ describe("eventKindCategoryLabel", () => {
   it("returns explorer-facing category names", () => {
     expect(eventKindCategoryLabel("stake")).toBe("Stake");
     expect(eventKindCategoryLabel("other")).toBe("Other");
+  });
+});
+
+describe("eventKindFilterOptions", () => {
+  it("maps every known kind to a value/label pair for SelectFilter", () => {
+    const options = eventKindFilterOptions();
+    expect(options).toHaveLength(Object.keys(EVENT_KIND_LABELS).length);
+    expect(options.find((o) => o.value === "StakeAdded")).toEqual({
+      value: "StakeAdded",
+      label: "Stake added",
+    });
   });
 });

--- a/apps/ui/src/lib/metagraphed/event-kinds.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.ts
@@ -103,3 +103,10 @@ export function eventKindLabel(kind: string | null | undefined): string {
 export function eventKindCategoryLabel(category: EventKindCategory): string {
   return EVENT_KIND_CATEGORY_LABELS[category];
 }
+
+export type EventKindFilterOption = { value: string; label: string };
+
+/** SelectFilter-ready options from {@link EVENT_KIND_LABELS} for subnet event-kind filters. */
+export function eventKindFilterOptions(): EventKindFilterOption[] {
+  return Object.entries(EVENT_KIND_LABELS).map(([value, label]) => ({ value, label }));
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { subnetEventsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/events",
+  });
+}
+
+async function runQuery(netuid: number, params?: { kind?: string }) {
+  const opts = subnetEventsQuery(netuid, params);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("subnetEventsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches the unfiltered feed with limit=100 by default", async () => {
+    resolveWith({ netuid: 7, events: [] });
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/events",
+      expect.objectContaining({ params: { limit: 100 } }),
+    );
+  });
+
+  it("forwards an optional kind filter to the API", async () => {
+    resolveWith({ netuid: 7, events: [] });
+    await runQuery(7, { kind: "StakeAdded" });
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/events",
+      expect.objectContaining({ params: { limit: 100, kind: "StakeAdded" } }),
+    );
+  });
+
+  it("includes kind in the query key when set", () => {
+    expect(subnetEventsQuery(7, { kind: "Transfer" }).queryKey).toContain("Transfer");
+    expect(subnetEventsQuery(7).queryKey).not.toContain("Transfer");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -2978,14 +2978,16 @@ export const subnetHealthQuery = (netuid: number) =>
  * newest first, from the account_events tier filtered by netuid. Schema-stable
  * zero for a cold/unknown subnet.
  */
-export const subnetEventsQuery = (netuid: number) =>
+export type SubnetEventsParams = { kind?: string };
+
+export const subnetEventsQuery = (netuid: number, params: SubnetEventsParams = {}) =>
   queryOptions({
-    queryKey: k("subnet-events", netuid),
+    queryKey: k("subnet-events", netuid, params.kind ?? null),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Record<string, unknown>>(
-        `/api/v1/subnets/${netuid}/events?limit=100`,
-        { signal },
-      );
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/subnets/${netuid}/events`, {
+        params: { limit: 100, ...params },
+        signal,
+      });
       const d = (res.data ?? {}) as Record<string, unknown>;
       const events = normalizeAccountEvents(d.events);
       return {


### PR DESCRIPTION
## Summary

Lib-only data layer for subnet on-chain-activity kind filtering: forward optional `kind` on `subnetEventsQuery` and expose `eventKindFilterOptions()` from `EVENT_KIND_LABELS`. No routes, components, or visual changes in this PR.

## What changed

- **`event-kinds.ts`** — `eventKindFilterOptions()` returns `{ value, label }[]` for `SelectFilter`
- **`queries.ts`** — `subnetEventsQuery(netuid, { kind? })` passes `kind` + `limit=100` to `/api/v1/subnets/{netuid}/events`
- **`queries.subnet-events.test.ts`** — default fetch, kind forwarding, query-key isolation
- **`event-kinds.test.ts`** — filter-options coverage

## Test plan

- [x] `vitest run src/lib/metagraphed/event-kinds.test.ts src/lib/metagraphed/queries.subnet-events.test.ts` — 12 tests
- [x] Prettier + ESLint clean
- [ ] CI green