### PR TITLE
fix(health): coerce D1 string-typed netuid in live surface_status fallback

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1311,21 +1311,40 @@ function isoFromMs(ms) {
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
+// D1 can hand the INTEGER netuid column back as a numeric string here. Accept
+// ONLY a real integer >= 0 or an all-digits string (rejecting "1e3"/"0x10"
+// Number() coercions and an oversized digit run that can't round-trip exactly,
+// matching subnet-identity-history.mjs's rowNetuid, #2938) so a blank/null/
+// non-numeric cell is dropped rather than read as valid subnet 0.
+function normalizedNetuid(value) {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const netuid = Number(value);
+    return Number.isSafeInteger(netuid) ? netuid : null;
+  }
+  return null;
+}
+
 function liveFromD1Rows(rows) {
-  const surfaces = rows.map((r) => ({
-    surface_id: r.surface_id,
-    surface_key: r.surface_key ?? null,
-    netuid: r.netuid,
-    kind: r.kind,
-    provider: r.provider,
-    url: r.url,
-    status: normalizeProbeStatus(r.status),
-    classification: r.classification,
-    latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
-    status_code: Number.isInteger(r.status_code) ? r.status_code : null,
-    last_checked: isoFromMs(r.last_checked),
-    last_ok: isoFromMs(r.last_ok),
-  }));
+  const surfaces = rows
+    .map((r) => ({ ...r, netuid: normalizedNetuid(r.netuid) }))
+    .filter((r) => r.netuid != null)
+    .map((r) => ({
+      surface_id: r.surface_id,
+      surface_key: r.surface_key ?? null,
+      netuid: r.netuid,
+      kind: r.kind,
+      provider: r.provider,
+      url: r.url,
+      status: normalizeProbeStatus(r.status),
+      classification: r.classification,
+      latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
+      status_code: Number.isInteger(r.status_code) ? r.status_code : null,
+      last_checked: isoFromMs(r.last_checked),
+      last_ok: isoFromMs(r.last_ok),
+    }));
   const byNetuid = new Map();
   for (const row of surfaces) {
     const group = byNetuid.get(row.netuid) || [];

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1369,6 +1369,77 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.match(live.surfaces[0].last_ok, /^20\d\d-/);
   });
 
+  test("D1 fallback coerces string netuids, groups + sorts subnets, and nulls bad status_code/latency_ms", async () => {
+    // D1 hands the INTEGER netuid column back as "7" on this read path; the
+    // emitted netuid both keys the per-subnet summary Map and rides into the
+    // response, so a raw string would splinter one subnet's rows across two
+    // group keys. A blank cell must be dropped, not coerced to subnet 0.
+    const netuidRow = (surfaceId, netuid, extra = {}) => ({
+      surface_id: surfaceId,
+      surface_key: `srf-${surfaceId}`,
+      netuid,
+      kind: "subnet-api",
+      provider: "p",
+      url: "https://p",
+      status: "ok",
+      classification: "up",
+      latency_ms: 10,
+      status_code: 200,
+      last_checked: 1_700_000_000_000,
+      last_ok: 1_700_000_000_000,
+      ...extra,
+    });
+    const db = d1With([
+      netuidRow("7:subnet-api:a", "7"),
+      // A non-integer status_code and a non-finite latency_ms from D1 must both
+      // coerce to null (never ship a bad number), exercising the else branch of
+      // each guard on a row that survives the netuid filter.
+      netuidRow("7:subnet-api:b", 7, { status_code: null, latency_ms: "nope" }),
+      // A second, lower-numbered subnet so the per-subnet summary sort runs and
+      // orders subnet 3 ahead of subnet 7 (single-group input never calls it).
+      netuidRow("3:subnet-api:c", "3"),
+      netuidRow("dropped:blank", ""),
+      netuidRow("dropped:null", null),
+      netuidRow("dropped:negative", -1),
+      netuidRow("dropped:non-integer", 7.5),
+      netuidRow("dropped:non-digit-string", "abc"),
+      netuidRow("dropped:exponential-string", "1e3"),
+      // A digit run that can't round-trip through Number() exactly (loses
+      // precision past MAX_SAFE_INTEGER) must be dropped, not silently rounded
+      // into a different, wrong netuid.
+      netuidRow("dropped:unsafe-integer-string", "99999999999999999999"),
+    ]);
+    const live = await resolveLiveHealth({
+      readHealthKv: async () => null,
+      env: {},
+      db,
+      now: () => 1_700_000_600_000,
+    });
+    assert.deepEqual(
+      live.surfaces.map((s) => s.surface_id),
+      ["7:subnet-api:a", "7:subnet-api:b", "3:subnet-api:c"],
+    );
+    // Every returned surface has the coerced numeric netuid, not just the first
+    // — the bug involved mixed row types landing in the same response.
+    assert.deepEqual(
+      live.surfaces.map((s) => s.netuid),
+      [7, 7, 3],
+    );
+    assert.equal(typeof live.surfaces[0].netuid, "number");
+    // The bad status_code/latency_ms row is nulled out, not shipped as-is.
+    const nulled = live.surfaces.find((s) => s.surface_id === "7:subnet-api:b");
+    assert.equal(nulled.status_code, null);
+    assert.equal(nulled.latency_ms, null);
+    // Both netuid-7 rows land in the SAME group; the summary is sorted ascending
+    // by netuid, so subnet 3 leads subnet 7.
+    assert.deepEqual(
+      live.subnets.map((s) => s.netuid),
+      [3, 7],
+    );
+    assert.equal(live.subnets.find((s) => s.netuid === 7).surface_count, 2);
+    assert.equal(live.subnets.find((s) => s.netuid === 3).surface_count, 1);
+  });
+
   test("D1 fallback folds unrecognized surface status into unknown in global status_counts", async () => {
     const now = 1_700_000_600_000;
     const db = {


### PR DESCRIPTION
## Summary

- `src/health-serving.mjs`'s `liveFromD1Rows()` — the D1 fallback path `resolveLiveHealth()` uses when KV `health:current` is cold — now coerces the `surface_status.netuid` D1 column to a real integer, dropping a blank/null/non-numeric/unsafe cell instead of silently reading it as subnet 0 or shipping a string.

## What changed

- Added `normalizedNetuid(value)` to `src/health-serving.mjs`, matching `rowNetuid` in `src/subnet-identity-history.mjs` (#2938) and `subnetNetuid` in `src/chain-yield.mjs`: accept ONLY a real integer `>= 0` or an all-digits string, rejecting `Number()`-coercible-but-non-decimal forms like `"1e3"`/`"0x10"`, blank/null cells, and an oversized digit string that can't round-trip through `Number()` exactly (guarded via `Number.isSafeInteger`).
- `liveFromD1Rows()` coerces + drops any row whose `netuid` fails that check before it reaches the per-subnet grouping `Map` or the response.
- Full-branch regression test in `tests/health-serving.test.mjs`: a string `"7"` netuid coerces to `7` and groups with a sibling `netuid: 7` row under one subnet-7 summary; a second, lower-numbered subnet exercises the ascending per-subnet sort; a surviving row with a non-integer `status_code` / non-finite `latency_ms` is nulled; blank, `null`, negative, non-integer, non-digit-string, exponential-string, and unsafe-integer-string cells are all dropped.

## Why

D1/SQLite can hand an `INTEGER` column back as a numeric string on this read path (the same class of issue as #2938, #2641, #2474). Here the emitted `netuid` is used as a `Map` key to group surfaces into the per-subnet `subnets` summary **and** rides directly into the live-health API response. A raw string netuid would:
- Splinter one subnet's surfaces across two group keys (`7` vs `"7"`) if any row for that subnet came back typed differently, corrupting the `subnets[]` counts.
- Ship a string `netuid` where every sibling live-health route ships a number — an inconsistent contract for API consumers.

This file was untouched by #2938 (which covered `analytics-live.mjs` and `subnet-identity-history.mjs`), so this D1 read path was still exposed.

## Registry safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no artifacts committed; `npm run build` output reverted per deploy-owned-artifact policy.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — internal D1-row shaping only, no contract change.)

## Validation

- [x] `npm run lint` · `npx prettier --check` clean
- [x] `git diff --check` clean
- [x] `npm run build` (deploy-owned artifacts auto-reverted; diff touches only the two source files)
- [x] `npm run test:coverage` — 231 files / 6446 tests pass; every changed line in the patch is covered (no partials)
- [x] `npm run validate` — 129 subnets / 1415 surfaces / 131 providers OK

## Issue link

No linked issue — small, self-contained internal fix with the repro, impact, and expected behavior documented above.
