### PR TITLE
fix(ui): collapse the NavOmnibox 'Jump to' grid to 2 columns on mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -352,7 +352,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
             <div>
               <div className="px-3 pt-3 pb-2">
                 <p className="mg-label mb-2">Jump to</p>
-                <div className="grid grid-cols-3 gap-1.5">
+                <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3">
                   {NAV_LINKS.map((r) => (
                     <Link
                       key={r.to}


### PR DESCRIPTION
## Summary

The NavOmnibox "Jump to" grid was hard-coded `grid-cols-3` at every width, so on a ~375px phone each of the three columns got ~120px — too narrow for the label + hint pair, forcing heavy truncation (e.g. "Provide…"). This makes the column count responsive: 2 columns on mobile, 3 from `sm:` up (unchanged desktop).

Closes #3457

## What changed

`apps/ui/src/components/metagraphed/nav-omnibox.tsx` — the "Jump to" grid wrapper only:

```diff
- <div className="grid grid-cols-3 gap-1.5">
+ <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-3">
```

Below `sm:` the six `NAV_LINKS` lay out in 2 roomier columns (each cell ~175px vs ~120px), so labels like "Providers" read in full instead of truncating; at `sm:` (640px) and above the layout is the existing 3-column grid, unchanged. The existing `truncate` classes are untouched, and no other part of the dropdown (width, Recent, results) is modified.

> Scope note: the dropdown's own right-edge overflow at 375px (the header input still spanning full width on mobile) is the separate concern tracked in **#3454** and is intentionally left alone here — this PR only reduces the "Jump to" column count so each visible cell gets more width.

## Screenshots

Dropdown opened by focusing the NavOmnibox input, fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes. The change is scoped below `sm:`, so **Tablet and Desktop are identical before/after by design**; the difference is on **Mobile** — 3 cramped columns ("Provide…") → 2 roomier columns.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-mobile-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-tablet-dark.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3457-after-desktop-dark.png)<br><sub>after</sub> |

## Validation

- [x] `lint` + `format:check` + `typecheck` (apps/ui) — clean
- [x] `vite build` — green
- [x] only `nav-omnibox.tsx` changed; `truncate` intact; all 6 NAV_LINKS reachable
- [x] 2 columns at 375px, unchanged 3-column layout at `sm+`
