### PR TITLE
feat(ui): add an aggregate weight-setting activity KPI to the subnet validators panel

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -45,6 +45,7 @@ import {
   lineageQuery,
   agentCatalogDetailQuery,
   subnetWeightSettersQuery,
+  subnetWeightsQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -842,6 +843,35 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
 
 // Top-validator stake distribution + leaderboard. Rows drill into the same
 // per-UID neuron view (switches to the Metagraph tab where the detail renders).
+// #3479: aggregate weight-setting activity for this subnet over the trailing
+// 30-day window, from the already-shipped subnetWeightsQuery. A compact KPI strip
+// (distinct setters / total weight-sets / average per setter) summarising the
+// per-validator breakdown below; complements, and does not duplicate, that table.
+function WeightsSummaryLoader({ netuid }: { netuid: number }) {
+  const { data: res } = useSuspenseQuery(subnetWeightsQuery(netuid));
+  const w = res.data;
+  const cells = [
+    { label: "Distinct setters", value: formatNumber(w?.distinct_setters) },
+    { label: "Weight-sets (30d)", value: formatNumber(w?.weight_sets) },
+    {
+      label: "Avg per setter",
+      value: w?.sets_per_setter != null ? w.sets_per_setter.toFixed(1) : formatNumber(null),
+    },
+  ];
+  return (
+    <div className="mb-4 grid grid-cols-3 divide-x divide-border overflow-hidden rounded-xl border border-border bg-card">
+      {cells.map((c) => (
+        <div key={c.label} className="px-4 py-3">
+          <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            {c.label}
+          </div>
+          <div className="mt-0.5 font-mono text-lg tabular-nums text-ink-strong">{c.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // #3480: per-validator weight-setting leaderboard for this subnet over the
 // trailing 30-day window, from the already-shipped subnetWeightSettersQuery.
 // The API returns the setters pre-ranked by weight-set count; we show the top
@@ -860,8 +890,7 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
   return (
     <div className="mt-6">
       <h3 className="mb-2 font-mono text-[11px] uppercase tracking-widest text-ink-muted">
-        Weight-setters (30d): {formatNumber(d.distinct_setters)} validators,{" "}
-        {formatNumber(d.weight_sets)} sets
+        Weight-setters (per-validator breakdown)
       </h3>
       <div className="overflow-hidden rounded-xl border border-border bg-card">
         <div className="overflow-x-auto">
@@ -931,6 +960,11 @@ function ValidatorsPanel({ netuid }: { netuid: number }) {
               })
             }
           />
+        </Suspense>
+      </QueryErrorBoundary>
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+          <WeightsSummaryLoader netuid={netuid} />
         </Suspense>
       </QueryErrorBoundary>
       <QueryErrorBoundary>


### PR DESCRIPTION
Closes #3479

Wires the shipped-but-unused `subnetWeightsQuery` (#3680) into `ValidatorsPanel` as an aggregate **weight-setting activity** KPI strip — distinct setters, total weight-set events, and average per setter over the trailing 30-day window — above the per-validator leaderboard from #3480. No data-layer changes (the query / type from #3680 are consumed as-is via `useSuspenseQuery`, in the panel's existing `SectionAnchor` / `Suspense` / `QueryErrorBoundary` convention; a cold subnet degrades to zeros).

To avoid duplicating the aggregate, the #3480 leaderboard header is simplified to "Weight-setters (per-validator breakdown)" — the KPI strip now owns the distinct-setters + total-sets figures, and the leaderboard is the per-validator drill-down. Complementary, not duplicative.

## Screenshots (subnet 8, live api.metagraph.sh)

_Matched frames (same scroll anchor on the validators-table footer) — the KPI strip is the only change; tab between the two to see it appear above the leaderboard._

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/before-desktop-light.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/after-desktop-light.png"> |
| **Desktop · Dark** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/before-desktop-dark.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/after-desktop-dark.png"> |
| **Tablet · Light** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/before-tablet-light.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/after-tablet-light.png"> |
| **Tablet · Dark** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/before-tablet-dark.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/after-tablet-dark.png"> |
| **Mobile · Light** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/before-mobile-light.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/after-mobile-light.png"> |
| **Mobile · Dark** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/before-mobile-dark.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/weights-kpi-shots/after-mobile-dark.png"> |

## Verification
`tsc --noEmit`, `eslint` (0 errors), and `vite build` all pass; rendered against live api.metagraph.sh (SN8: 15 distinct setters / 1,939 weight-sets / 129.3 avg per setter over 30d).
