### PR TITLE
feat(ui): add network-wide stake-transfers leaderboard to explorer page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-stake-transfers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-stake-transfers.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainStakeTransfersQuery, normalizeChainStakeTransfers } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/stake-transfers",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainStakeTransfersQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainStakeTransfers", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainStakeTransfers({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: { distinct_senders: 5, transfers: 70, transfers_per_sender: 14 },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          { netuid: 1, distinct_senders: 4, transfers: 40, transfers_per_sender: 10 },
+          { netuid: 2, distinct_senders: 2, transfers: 30, transfers_per_sender: 15 },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: { distinct_senders: 5, transfers: 70, transfers_per_sender: 14 },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        { netuid: 1, distinct_senders: 4, transfers: 40, transfers_per_sender: 10 },
+        { netuid: 2, distinct_senders: 2, transfers: 30, transfers_per_sender: 15 },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainStakeTransfers(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+      expect(card.network).toEqual({
+        distinct_senders: 0,
+        transfers: 0,
+        transfers_per_sender: null,
+      });
+      expect(card.intensity_distribution).toBeNull();
+    }
+  });
+
+  it("drops malformed subnet rows and coerces a junk transfers_per_sender to null", () => {
+    const card = normalizeChainStakeTransfers({
+      network: { transfers_per_sender: { pct: 1 } },
+      subnets: [{ distinct_senders: 4 }, { netuid: 2, transfers: 30 }],
+    });
+    expect(card.subnets).toHaveLength(1);
+    expect(card.subnets[0]?.netuid).toBe(2);
+    expect(card.subnets[0]?.transfers_per_sender).toBeNull();
+    expect(card.network.transfers_per_sender).toBeNull();
+  });
+});
+
+describe("chainStakeTransfersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the leaderboard", async () => {
+    resolveWith({
+      window: "30d",
+      subnet_count: 1,
+      network: { distinct_senders: 4, transfers: 40, transfers_per_sender: 10 },
+      subnets: [{ netuid: 1, distinct_senders: 4, transfers: 40, transfers_per_sender: 10 }],
+    });
+    const res = await runQuery("30d", 5);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/stake-transfers",
+      expect.objectContaining({ params: { window: "30d", limit: 5 } }),
+    );
+    expect(res.data.subnet_count).toBe(1);
+    expect(res.data.subnets).toHaveLength(1);
+  });
+
+  it("defaults to the 7d window and limit 20", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/stake-transfers",
+      expect.objectContaining({ params: { window: "7d", limit: 20 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -52,6 +52,9 @@ import type {
   ChainFeePayer,
   ChainTransferPair,
   ChainTransferPairs,
+  ChainStakeTransfers,
+  ChainStakeTransferSubnet,
+  ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -185,6 +188,7 @@ const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
+const MAX_CHAIN_STAKE_TRANSFERS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -2645,6 +2649,78 @@ export const chainTransferPairsQuery = (
       });
       return {
         data: normalizeChainTransferPairs(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainStakeTransferSubnet(raw: unknown): ChainStakeTransferSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_senders: firstFiniteNumber(raw.distinct_senders) ?? 0,
+    transfers: firstFiniteNumber(raw.transfers) ?? 0,
+    transfers_per_sender: firstFiniteNumber(raw.transfers_per_sender) ?? null,
+  };
+}
+
+function normalizeChainIntensityDistribution(raw: unknown): ChainIntensityDistribution | null {
+  if (!isRecord(raw)) return null;
+  const count = firstFiniteNumber(raw.count);
+  if (count == null) return null;
+  return {
+    count,
+    mean: firstFiniteNumber(raw.mean) ?? 0,
+    min: firstFiniteNumber(raw.min) ?? 0,
+    p25: firstFiniteNumber(raw.p25) ?? 0,
+    median: firstFiniteNumber(raw.median) ?? 0,
+    p75: firstFiniteNumber(raw.p75) ?? 0,
+    p90: firstFiniteNumber(raw.p90) ?? 0,
+    max: firstFiniteNumber(raw.max) ?? 0,
+  };
+}
+
+// #3467: network-wide stake-transfer leaderboard over a 7d/30d window — the
+// between-coldkeys sibling of /api/v1/chain/stake-moves (within-account
+// re-delegation churn). Every numeric cell coerces defensively: counts fall
+// through to 0, averages to null (never NaN), and malformed subnet rows are
+// dropped on a cold store or junk.
+export function normalizeChainStakeTransfers(raw: unknown): ChainStakeTransfers {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_senders: firstFiniteNumber(networkRec.distinct_senders) ?? 0,
+      transfers: firstFiniteNumber(networkRec.transfers) ?? 0,
+      transfers_per_sender: firstFiniteNumber(networkRec.transfers_per_sender) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_STAKE_TRANSFERS,
+      normalizeChainStakeTransferSubnet,
+    ),
+  };
+}
+
+export const chainStakeTransfersQuery = (window = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-stake-transfers", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainStakeTransfers>>("/api/v1/chain/stake-transfers", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainStakeTransfers(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1795,6 +1795,52 @@ export interface ChainTransferPairs {
   pairs: ChainTransferPair[];
 }
 
+/** One subnet's row on the network-wide stake-transfer leaderboard (#3467). */
+export interface ChainStakeTransferSubnet {
+  netuid: number;
+  distinct_senders: number;
+  transfers: number;
+  transfers_per_sender: number | null;
+}
+
+/** Network-wide stake-transfer rollup — true distinct-sender count (not a per-subnet sum) + total transfers. */
+export interface ChainStakeTransferNetwork {
+  distinct_senders: number;
+  transfers: number;
+  transfers_per_sender: number | null;
+}
+
+/** Distribution summary of per-subnet transfer intensity (count, mean, min, p25, median, p75, p90, max). */
+export interface ChainIntensityDistribution {
+  count: number;
+  mean: number;
+  min: number;
+  p25: number;
+  median: number;
+  p75: number;
+  p90: number;
+  max: number;
+}
+
+/**
+ * Network-wide stake-transfer leaderboard over a 7d/30d window (#3467), from
+ * GET /api/v1/chain/stake-transfers — subnets ranked by StakeTransferred event
+ * count, distinct senders, and transfers per sender, plus the true network-wide
+ * distinct-sender rollup and a distribution summary of the per-subnet transfer
+ * intensity. The between-coldkeys sibling of /api/v1/chain/stake-moves
+ * (within-account re-delegation churn). Zeroed with an empty subnets list when
+ * the store is cold.
+ */
+export interface ChainStakeTransfers {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainStakeTransferNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainStakeTransferSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -22,6 +22,7 @@ import {
   chainEventsInfiniteQuery,
   chainFeesQuery,
   chainSignersQuery,
+  chainStakeTransfersQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -89,6 +90,7 @@ function ExplorerPage() {
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
+          "/api/v1/chain/stake-transfers",
           "/api/v1/chain-events",
         ]}
       />
@@ -241,6 +243,7 @@ function ExplorerDashboard() {
   const fees = useSuspenseQuery(chainFeesQuery(win)).data.data;
   const calls = useSuspenseQuery(chainCallsQuery(win)).data.data;
   const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
+  const stakeTransfers = useSuspenseQuery(chainStakeTransfersQuery(win)).data.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
   const chrono = [...activity.days].reverse();
@@ -525,6 +528,64 @@ function ExplorerDashboard() {
           )}
         </section>
       </div>
+
+      {/* stake-transfer leaderboard */}
+      <section className="rounded-lg border border-border bg-card p-5">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Stake-transfer leaderboard
+            </h2>
+            <p className="mt-1 font-mono text-[11px] text-ink-muted">
+              {formatNumber(stakeTransfers.network.transfers)} transfers across{" "}
+              {formatNumber(stakeTransfers.network.distinct_senders)} senders network-wide
+            </p>
+          </div>
+          <span className="font-mono text-[11px] text-ink-muted">
+            {stakeTransfers.subnets.length} subnets
+          </span>
+        </div>
+        {stakeTransfers.subnets.length > 0 ? (
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={`${TH} text-right`}>Transfers</th>
+                <th className={`${TH} text-right`}>Distinct senders</th>
+                <th className={`${TH} text-right`}>Transfers per sender</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {stakeTransfers.subnets.map((s) => (
+                <tr key={s.netuid} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: s.netuid }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{s.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(s.transfers)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(s.distinct_senders)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="font-mono text-[12px] text-ink-muted">
+            No stake transfers in this window yet.
+          </p>
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a network-wide stake-transfer leaderboard section to the chain explorer page (`/explorer`), per #3467.
- Adds the `ChainStakeTransfers` data-layer type (`apps/ui/src/lib/metagraphed/types.ts`) and `chainStakeTransfersQuery`/`normalizeChainStakeTransfers` (`apps/ui/src/lib/metagraphed/queries.ts`) for `GET /api/v1/chain/stake-transfers`, following the existing `chainTransferPairsQuery` pattern exactly.
- Wires the query into `ExplorerDashboard` alongside the existing `activity`/`fees`/`calls`/`signers` suspense reads, reusing the page's existing `7d`/`30d` window toggle (no new UI control).
- Renders a per-subnet leaderboard table (netuid, transfers, distinct senders, transfers per sender) each linking to `/subnets/$netuid`, with the network-wide rollup (total transfers, true distinct senders) as a header caption, and the established empty-state fallback (`No stake transfers in this window yet.`) when cold — matching the "Top fee payers" section's idiom already in this file.
- Adds `/api/v1/chain/stake-transfers` to the page's `ApiSourceFooter` sources list.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `ChainStakeTransfers`, `ChainStakeTransferSubnet`, `ChainStakeTransferNetwork`, `ChainIntensityDistribution`
- `apps/ui/src/lib/metagraphed/queries.ts`: `normalizeChainStakeTransfers`, `chainStakeTransfersQuery`
- `apps/ui/src/lib/metagraphed/queries.chain-stake-transfers.test.ts`: normalizer + query unit tests (pass-through, cold/junk zeroing, malformed-row dropping, param defaults)
- `apps/ui/src/routes/explorer.tsx`: new leaderboard section + query wiring + footer source path

## Screenshots

Captured against a live dev server hitting production data (`https://api.metagraph.sh`); the network's `chain/*` live-compute tiers were cold for this window at capture time, so both before and after show the established empty-state fallback for all sibling sections — this is itself one of the required states (see acceptance criteria: cold/empty response → plain fallback message).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/stake-transfers-leaderboard-mobile-dark-after.png)<br><sub>after</sub> |

## Validation

- [x] `npm run lint` / `npm run format:check` — clean on changed files (repo-wide run is blocked by pre-existing CRLF line endings from this Windows checkout's `core.autocrlf`, unrelated to this change; `git diff --check` on the diff itself is clean)
- [x] `npm run typecheck --workspace=apps/ui` — no new errors (2 pre-existing errors on `main` unrelated to this change: an `ApiSchema<"HealthStatus">` indexing type error and a missing `@jsonbored/metagraphed` declaration file)
- [x] `npm test --workspace=apps/ui` — 480 passed (68 files), including the new `queries.chain-stake-transfers.test.ts`
- [x] `npm run build --workspace=apps/ui` — succeeds
- [x] Manually verified in a real browser against both the pre-change and post-change dev server

Closes #3467