### PR TITLE
feat(registry): add SN49 Nepher tournament evaluations subnet-api surface (#1286)

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -358,6 +358,22 @@
         "https://docs.nepher.ai/"
       ],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-evaluations-api",
+      "kind": "subnet-api",
+      "name": "Nepher tournament evaluations API",
+      "notes": "Public no-auth GET /api/v1/evaluations — per-agent evaluation records (score and tournament) from the SN49 tournament API. Documented in the subnet's openapi.json and served on the same tournament-api.nepher.ai host as the subnet's registered API surfaces.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations"
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Summary

Closes #1286

Adds the SN49 Nepher Robotics public **tournament evaluations** API endpoint as a `subnet-api` surface — a previously-unregistered, public, no-auth endpoint of the subnet's tournament API (which already has openapi + 6 endpoint surfaces registered).

## Surface

- **kind:** `subnet-api`
- **url:** https://tournament-api.nepher.ai/api/v1/evaluations
- Public no-auth `GET` → `200 application/json` — per-agent evaluation records
  (score and tournament) from the SN49 tournament API.
- `authority: community`, `auth_required: false`, `public_safe: true`.

## Proof

- `source_urls[0]` = `https://tournament-api.nepher.ai/openapi.json` — the subnet's own
  OpenAPI spec, which documents `/api/v1/evaluations`. Served on the same
  `tournament-api.nepher.ai` host as the subnet's existing registered API surfaces.

## Validation

- `npm run validate:surface -- registry/subnets/nepher-robotics.json` — passed (17 surfaces)
- `npm run scan:public-safety` — passed
- `npm run validate` — passed (exit 0)

Single-file change; no generated artifacts touched.
