### PR TITLE
feat(registry): add SN52 Dojo Worker API OpenAPI spec surface

### DIFF
--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -163,6 +163,33 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public Tensorplex Dojo (SN52) HuggingFace DPO dataset of human-feedback preference pairs collected through the subnet's Dojo human-feedback-loop platform; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset. Distinct from the subnet's registered Dojo-Synthetic-SFT dataset."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-52-tensorplex-openapi",
+      "kind": "openapi",
+      "name": "Dojo Worker API OpenAPI spec",
+      "notes": "Swagger 2.0 spec (20 paths) for the Dojo Worker API, committed in the official tensorplex-labs/dojo-worker-api repository at docs/swagger.json and served here via the jsDelivr view of that exact repo file (raw.githubusercontent.com serves it as text/plain, which machine-readable validation rejects). The previously hosted API base https://dojo.network/api/v1 (the TASK_API_URL default in tensorplex-labs/dojo internal/config/env.go) currently 301-redirects every path to the GitHub repo, so the committed spec is the subnet's only live machine-readable API description.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://cdn.jsdelivr.net/gh/tensorplex-labs/dojo-worker-api@main/docs/swagger.json",
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo-worker-api",
+        "https://raw.githubusercontent.com/tensorplex-labs/dojo-worker-api/main/docs/swagger.json"
+      ],
+      "url": "https://cdn.jsdelivr.net/gh/tensorplex-labs/dojo-worker-api@main/docs/swagger.json"
     }
   ],
   "contact": "jarvis@tensorplex.ai"


### PR DESCRIPTION
Closes #725

## Summary

Appends one community `openapi` surface to `registry/subnets/dojo.json`: the **Dojo Worker API Swagger 2.0 spec** (20 paths — auth, tasks, miner API-keys, metrics), maintained in the official `tensorplex-labs/dojo-worker-api` repository at `docs/swagger.json`.

## Surface

| Kind | URL | Proof |
|------|-----|-------|
| **openapi** | `https://cdn.jsdelivr.net/gh/tensorplex-labs/dojo-worker-api@main/docs/swagger.json` | Committed spec in the official [tensorplex-labs/dojo-worker-api](https://github.com/tensorplex-labs/dojo-worker-api) repo (same org as the registered `source_repo`); raw file also cited as a `source_url` |

## Notes

- **Why the jsDelivr view of the repo file:** `raw.githubusercontent.com` serves the identical file as `text/plain`, which machine-readable OpenAPI validation rejects; jsDelivr serves the exact same repo path with `content-type: application/json`. `surface:add` verified it: `OK openapi spec verified (Dojo Worker API, 20 paths) → schema_url + schema_status set`.
- **On the issue's other half (public API endpoint):** the Dojo task API's compiled-in production base `https://dojo.network/api/v1` (the `TASK_API_URL` default in `tensorplex-labs/dojo` `internal/config/env.go`) currently **301-redirects every path to the GitHub repo**, so there is no live hosted endpoint to register — the committed spec is SN52's only live machine-readable API description today. Documented in the surface `notes`.
- Purely additive: +27/−0, appends one surface, no existing surface or subnet metadata touched.

## Checklist

- [x] Changes exactly one `registry/subnets/dojo.json` file
- [x] `authority: community`, `review.state: community-submitted`, `submitted_by: dalledajay-coder`
- [x] Provider slug `tensorplex` (already registered)
- [x] HTTPS URLs only; `public_safe: true`; spec URL is unauthenticated
- [x] `npm run validate:surface -- registry/subnets/dojo.json` — passed (8 surfaces)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/dojo.json` — passed
