### PR TITLE
feat(registry): add SN74 Gittensor per-repo commits subnet-api surface (#1275)

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -416,6 +416,22 @@
         "https://api.gittensor.io/swagger"
       ],
       "url": "https://api.gittensor.io/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repo-commits-api",
+      "kind": "subnet-api",
+      "name": "Gittensor per-repo commits API",
+      "notes": "Public no-auth GET /dash/repos/commits — per-repository contribution stats (repository, emission share, commits, additions/deletions) for the SN74 Gittensor dashboard. Documented in the subnet's openapi and served on the same api.gittensor.io host as the subnet's registered API surfaces.",
+      "provider": "gittensory",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/repos/commits"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary

Closes #1275

Adds the public **per-repository commits** API for **SN74 Gittensor** as a new `subnet-api` surface.

The registry already includes Gittensor's OpenAPI specification and multiple API endpoint surfaces, but the public repository-commit statistics endpoint was not yet registered. This PR adds that missing callable API surface.

## Surface Added

| Kind | URL | Notes |
|------|-----|-------|
| `subnet-api` | https://api.gittensor.io/dash/repos/commits | Public REST endpoint exposing per-repository contribution statistics |

## Verification

The endpoint is publicly accessible without authentication.

- `GET /dash/repos/commits`
  - Returns HTTP 200 (`application/json`)
  - Provides per-repository contribution data, including:
    - Repository
    - Emission share
    - Commit count
    - Lines added
    - Lines deleted

## Source

Official API documentation:

- https://api.gittensor.io/swagger-json

The OpenAPI specification documents the `/dash/repos/commits` endpoint and is hosted on the same `api.gittensor.io` domain as the subnet's existing registered API surfaces.

## Registry Safety

- ✅ Public, unauthenticated endpoint
- ✅ No secrets, tokens, localhost, or private infrastructure
- ✅ `authority: community`
- ✅ `auth_required: false`
- ✅ `public_safe: true`

## Validation

- ✅ `npm run validate:surface -- registry/subnets/gittensor.json`
- ✅ `npm run scan:public-safety`
- ✅ `npm run validate`

Single-file change. No generated artifacts or schemas were modified.