### PR TITLE
feat(registry): add SN83 CliqueAI lambda OpenAPI + validator IP API (#675)

### DIFF
--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -1,0 +1,48 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "CliqueAI",
+  "netuid": 83,
+  "schema_version": 1,
+  "slug": "sn-83",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-openapi",
+      "kind": "openapi",
+      "name": "CliqueAI FastAPI",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "http://lambda.toptensor.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py"
+      ],
+      "url": "http://lambda.toptensor.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-subnet-api",
+      "kind": "subnet-api",
+      "name": "CliqueAI subnet-api",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": ["http://lambda.toptensor.ai/openapi.json"],
+      "url": "http://lambda.toptensor.ai/validator/ip"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Scaffolds `registry/subnets/cliqueai.json` for SN83 CliqueAI and appends two community surfaces for the subnet's public lambda coordination API: machine-readable OpenAPI and a no-auth read endpoint documented in that spec.

Closes #675

## Surfaces

| Field | OpenAPI | Subnet API |
|-------|---------|------------|
| Netuid | 83 (CliqueAI) | 83 (CliqueAI) |
| Kind | `openapi` | `subnet-api` |
| URL | `http://lambda.toptensor.ai/openapi.json` | `http://lambda.toptensor.ai/validator/ip` |
| Provider | `cliqueai` | `cliqueai` |
| Auth | none | none |
| Probe | GET, expect JSON schema | GET, expect JSON |

## Source evidence

- Official `LAMBDA_URL = "http://lambda.toptensor.ai"` in [toptensor/CliqueAI `common/base/consts.py`](https://github.com/toptensor/CliqueAI/blob/main/common/base/consts.py)
- Live OpenAPI at `http://lambda.toptensor.ai/openapi.json` (FastAPI 3.1.0, 5 paths including `GET /validator/ip`)
- Live probe: `GET /validator/ip` returns a public JSON array of validator IPs

## Notes

- `cliqueai.toptensor.ai` serves the marketing/dashboard HTML shell; the operational API host is `lambda.toptensor.ai` per the official subnet source.
- This PR covers the public API + OpenAPI halves of #675 in one subnet file (same pattern as partial fulfillment on other enrichment issues).

## Validation

- [x] `npm run validate:surface -- registry/subnets/cliqueai.json`
- [x] `npm run scan:public-safety`
- [x] Diff touches exactly one file: `registry/subnets/cliqueai.json`
- [x] Append-only community surfaces (`authority: community`, `review.state: community-submitted`, `submitted_by: carlh7777`)