### PR TITLE
feat(registry): add Bitstarter updates health subnet-api (SN91)

### DIFF
--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -145,6 +145,33 @@
         "timeout_ms": 10000
       },
       "notes": "Public Bitstarter app workflow for incubator project submissions."
+    },
+    {
+      "id": "sn-91-bitstarter-updates-health-api",
+      "name": "Bitstarter updates platform health API",
+      "kind": "subnet-api",
+      "url": "https://updates.bitstarter.ai/api/health",
+      "provider": "bitstarter",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://bitstarter.ai/",
+        "https://app.bitstarter.ai/",
+        "https://updates.bitstarter.ai/api/health"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie",
+        "confidence": "medium"
+      },
+      "notes": "Public no-auth GET returning operational status JSON on the official Bitstarter updates/crowdfund host linked from app.bitstarter.ai project pages."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary
- append one community `subnet-api` surface for SN91 at `https://updates.bitstarter.ai/api/health`
- append-only change: existing surfaces untouched (+27 lines on one new block)
- public no-auth JSON health endpoint on the official Bitstarter updates/crowdfund host linked from [app.bitstarter.ai](https://app.bitstarter.ai/) project pages

## Why prior PR #1089 was closed
Gittensory rejected `https://api.bitstarter.ai/health` because it returns HTTP 530 (Cloudflare error 1016). The live API is on `updates.bitstarter.ai`, not `api.bitstarter.ai`.

## Research notes
- live response: `{"status":"ok","message":"All systems operational"}`
- OpenAPI/Swagger: no machine-readable schema found on `updates.bitstarter.ai`, `api.bitstarter.ai`, or `app.bitstarter.ai`
- this PR covers the public API half of #714

## Test plan
- [x] `npm run validate:surface -- registry/subnets/bitstarter-1.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/bitstarter-1.json`
- [x] diff is append-only (`git diff` shows +27 lines on one surface block)
- [x] live probe: `curl https://updates.bitstarter.ai/api/health` returns `application/json`

Closes #714
