### PR TITLE
feat(registry): add SN83 CliqueAI validator W&B dashboard surface

### DIFF
--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -1,0 +1,32 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "CliqueAI",
+  "netuid": 83,
+  "schema_version": 1,
+  "slug": "sn-83",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-dashboard",
+      "kind": "dashboard",
+      "name": "CliqueAI validator W&B dashboard",
+      "notes": "Public Weights & Biases project for SN83 CliqueAI validator runs (entity toptensor-ai, project CliqueAI). Explicitly documented as the subnet's \"W&B Dashboard\" in the official toptensor/CliqueAI repo (docs/wandb_logging.md). Publicly readable (W&B access USER_READ, 66+ logged validator runs); the same GitHub org (toptensor) owns both the SN83 source repo and this W&B entity.",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/docs/wandb_logging.md"
+      ],
+      "url": "https://wandb.ai/toptensor-ai/CliqueAI/table"
+    }
+  ]
+}

--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -16,7 +16,7 @@
       "id": "sn-83-cliqueai-dashboard",
       "kind": "dashboard",
       "name": "CliqueAI validator W&B dashboard",
-      "notes": "Public Weights & Biases project for SN83 CliqueAI validator runs (entity toptensor-ai, project CliqueAI). Explicitly documented as the subnet's \"W&B Dashboard\" in the official toptensor/CliqueAI repo (docs/wandb_logging.md). Publicly readable (W&B access USER_READ, 66+ logged validator runs); the same GitHub org (toptensor) owns both the SN83 source repo and this W&B entity.",
+      "notes": "Public Weights & Biases project for SN83 CliqueAI validator runs (entity toptensor-ai, project CliqueAI). Explicitly documented as the subnet's \"W&B Dashboard\" in the official toptensor/CliqueAI repo (docs/wandb_logging.md), which also defines the structured per-run logging schema (WandbRunLogData) written to this project. Publicly readable (W&B access USER_READ, 66+ logged validator runs); the same GitHub org (toptensor) owns both the SN83 source repo and this W&B entity.",
       "provider": "cliqueai",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #675

## Summary

Adds **SN83 CliqueAI** to the registry — the subnet had no `registry/subnets/` file at all — and registers its one genuinely public, machine-usable surface: the official **Weights & Biases validator dashboard**.

## Surface

- kind: `dashboard`
- url: `https://wandb.ai/toptensor-ai/CliqueAI/table`
- provider: `cliqueai` (existing provider profile)

## Proof of ownership (airtight)

- The official SN83 source repo `toptensor/CliqueAI` documents this exact URL in `docs/wandb_logging.md`: **"W&B Dashboard: https://wandb.ai/toptensor-ai/CliqueAI/table"** — that file is the `source_url`.
- The **same GitHub org (`toptensor`)** owns both the registered SN83 source repo and the `toptensor-ai` W&B entity.

## Verified live + public

- `GET https://wandb.ai/toptensor-ai/CliqueAI/table` → HTTP 200 (no login redirect).
- W&B public GraphQL confirms the project is publicly readable: `access: "USER_READ"`, `runCount: 66` (real logged validator runs).

## Scope note

SN83 CliqueAI does not currently expose a public HTTP API or OpenAPI/Swagger spec — the repo README and site (`cliqueai.toptensor.ai`, a JS SPA) document none, and no `cliqueai` PyPI/npm package exists. The public **W&B validator dashboard is the subnet's verified public machine-usable surface today**, so this registers a real surface rather than inventing an API. This is also the first registry entry for SN83 (the subnet was entirely absent).

## Non-duplication

No `registry/subnets/cliqueai.json` existed before this PR, and no existing surface (in any subnet file) references `wandb.ai/toptensor-ai` or the CliqueAI W&B project. No other open PR targets SN83.

## Validation (local)

- `npm run subnet:new -- --netuid 83 --write` (scaffold) + `npm run surface:add -- --netuid 83 --kind dashboard ... --write`
- `npm run validate:surface -- registry/subnets/cliqueai.json` → passes
- `npm run scan:public-safety` → passes
- `git diff --stat` → a single new file `registry/subnets/cliqueai.json`, no generated artifacts.
