### PR TITLE
feat(registry): add SN56 Gradients auditing tasks subnet-api surface (#1274)

### DIFF
--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -274,6 +274,22 @@
         "https://www.gradients.io/"
       ],
       "url": "https://api.gradients.io/tournament/fees"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-auditing-tasks-api",
+      "kind": "subnet-api",
+      "name": "Gradients auditing tasks API",
+      "notes": "Public no-auth GET /auditing/tasks — audited task records (task id, organic flag, status, model) for the SN56 Gradients tournament. Documented in the subnet's openapi and served on the same api.gradients.io host as the subnet's registered API surfaces.",
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://api.gradients.io/openapi.json"],
+      "url": "https://api.gradients.io/auditing/tasks"
     }
   ],
   "website_url": "https://www.gradients.io/"


### PR DESCRIPTION
## Summary

Closes #1274

Adds the SN56 Gradients public **auditing tasks** API endpoint as a `subnet-api` surface — a previously-unregistered, public, no-auth endpoint of the subnet's API (which already has openapi + several endpoint surfaces registered).

## Surface

- **kind:** `subnet-api`
- **url:** https://api.gradients.io/auditing/tasks
- Public no-auth `GET` → `200 application/json` — audited task records (task id, organic
  flag, status, model).
- `authority: community`, `auth_required: false`, `public_safe: true`.

## Proof

- `source_urls[0]` = https://api.gradients.io/openapi.json — the subnet's own OpenAPI spec,
  which documents `/auditing/tasks`. Same `api.gradients.io` host as the subnet's existing
  registered API surfaces.

## Validation

- `npm run validate:surface -- registry/subnets/gradients.json` — passed (13 surfaces)
- `npm run scan:public-safety` — passed
- `npm run validate` — passed (exit 0)

Single-file change; no generated artifacts touched.
