### PR TITLE
fix(ui): add visible keyboard focus ring to SelectFilter and PageSizeSelect

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -105,7 +105,7 @@ export function SelectFilter({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="bg-transparent text-ink-strong text-xs focus:outline-none"
+        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <option value="">all</option>
         {options.map((o) => (
@@ -140,7 +140,7 @@ export function PageSizeSelect({
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
         aria-label="Results per page"
-        className="bg-transparent text-ink-strong text-xs focus:outline-none min-h-7"
+        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-7"
       >
         {options.map((n) => (
           <option key={n} value={n}>


### PR DESCRIPTION
## Summary

`SelectFilter` and `PageSizeSelect` in `table-controls.tsx` both render a native `<select>` styled with `focus:outline-none` and no replacement indicator, so keyboard users get zero visible focus indication when tabbing through any explorer filter bar (`subnets.index.tsx`, `surfaces.tsx`, `extrinsics.index.tsx`, `blocks.index.tsx`, `accounts.$ss58.tsx`). This appends the ring convention the codebase already uses — `focus:outline-none focus-visible:ring-2 focus-visible:ring-ring` + `rounded` (as composed in `section-anchor.tsx:80`, `info-tooltip.tsx:17`, and `resource-explorer.tsx:124/214/430/451`) — to both selects, so keyboard focus is always indicated while mouse clicks stay ring-free via `focus-visible`.

Closes #3452

## What changed

`apps/ui/src/components/metagraphed/table-controls.tsx` — the two `<select>` classNames only, one shared-component fix covering every filter bar:

```diff
 // SelectFilter
-        className="bg-transparent text-ink-strong text-xs focus:outline-none"
+        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"

 // PageSizeSelect
-        className="bg-transparent text-ink-strong text-xs focus:outline-none min-h-7"
+        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-7"
```

No markup, logic, or CSS-token changes — the diff only references the existing `ring` token utility that the components above already use, and `rounded` so the ring follows a corner radius per the same prior art.

## Screenshots

Captured on `/subnets`, fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes forced via `localStorage.setItem("mg-theme", …)` + reload. In every shot the **CURATION `SelectFilter`'s `<select>` holds real keyboard focus** (reached by pressing Tab, so `:focus-visible` applies exactly as it would for a keyboard user) — before: no visible indication at all; after: the standard 2px ring.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `npm run lint --workspace=apps/ui` — 0 errors (163 pre-existing warnings on `main`, none added)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm run typecheck --workspace=apps/ui` — clean (after `npm run build --workspace=packages/client`, as CI does)
- [x] `npm test --workspace=apps/ui` — 69 files / 489 tests passed
- [x] `npm run build --workspace=apps/ui` — green; no new imports/dependencies, so no bundle-budget impact
- [x] `git diff --check` — clean; diff touches only `table-controls.tsx`
- [x] Verified in-browser at all three viewports: ring appears on keyboard focus (Tab), not on mouse click
