### PR TITLE
fix(ui): raise NetworkSwitcher and SettingsPopover triggers to 44px tap targets

### DIFF
--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -72,7 +72,7 @@ export function NetworkSwitcher() {
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-ink hover:border-ink/30 transition-colors min-h-7"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-ink hover:border-ink/30 transition-colors min-h-11"
           title={`Network: ${network.label} · ${base}`}
         >
           <Globe2 className="size-3 text-ink-muted" />

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -32,7 +32,7 @@ export function SettingsPopover() {
           type="button"
           aria-label="Settings"
           title="Settings"
-          className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+          className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
         >
           <Settings className="size-3.5" aria-hidden="true" />
         </button>


### PR DESCRIPTION
## Summary

The two always-visible header trigger buttons are undersized tap targets: `NetworkSwitcher`'s trigger used `min-h-7` and `SettingsPopover`'s used `min-h-7 min-w-7` — both ~28px, well under the codebase's own documented `min-h-11` (44px) tap-target standard (`list-shell.tsx:15`, used at 10+ call sites). This raises both to the 44px standard: height-only for the network switcher (its rendered width already clears 44px), and `min-h-11 min-w-11` for the square icon-only settings button. Icon sizes (`size-3`/`size-3.5`), text sizes, padding, and popover markup/behavior are untouched — only the clickable box grows, with the existing `items-center`/`justify-center` flex centering keeping the content centered.

Closes #3453

## What changed

Two classNames, nothing else:

```diff
 // apps/ui/src/components/metagraphed/network-switcher.tsx — PopoverTrigger button
-          className="... hover:border-ink/30 transition-colors min-h-7"
+          className="... hover:border-ink/30 transition-colors min-h-11"

 // apps/ui/src/components/metagraphed/settings-popover.tsx — PopoverTrigger button
-          className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted ..."
+          className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted ..."
```

Per the issue's deliverable, I verified the network switcher's rendered width with the existing `px-2` once height grows: `getBoundingClientRect()` reports **115×44** (before: 115×28) at every viewport, so no `min-w-11` is needed there. The settings button measures **44×44** (before: 28×28). `ShortcutsPopover`, the mobile hamburger, the GitHub/Discord links, and `app-shell.tsx` are untouched, as the issue scopes.

## Screenshots

Captured on `/subnets`, fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes forced via `localStorage.setItem("mg-theme", …)` + reload.

One honest caveat on visibility (not caused by this PR): the header cluster currently **overflows the viewport's right edge** — the pre-existing overflow tracked separately in #3454/#3457, identical before/after here. Measured on the live page: at 375px both buttons render off-viewport (x≈484–647); at 768px and even 1280px the settings gear still sits past the right edge (x≈1322 at 1280), while the network switcher is fully visible at Desktop/Tablet and shows the height change there. So the three standard rows demonstrate the network switcher visually, and the settings button's change is proven by its measured box (28×28 → 44×44 via `getBoundingClientRect()` at every viewport). Because the standard sizes physically cannot show the settings gear, I added one **clearly-labeled supplementary Wide-desktop row (1600×400)** where the full header cluster fits and both buttons are visible before/after — supplementary to, not replacing, the three contract sizes.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-mobile-dark.png)<br><sub>after</sub> |
| **Wide desktop · Light** <br><sub>supplementary 1600×400 — only width where the full header cluster (incl. settings gear) fits on-screen</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-widedesktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-widedesktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-widedesktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-widedesktop-light.png)<br><sub>after</sub> |
| **Wide desktop · Dark** <br><sub>supplementary 1600×400</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-widedesktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-before-widedesktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-widedesktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/sn3453-after-widedesktop-dark.png)<br><sub>after</sub> |

## Validation

- [x] `npm run lint --workspace=apps/ui` — 0 errors (163 pre-existing warnings on `main`, none added)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm run typecheck --workspace=apps/ui` — clean (after `npm run build --workspace=packages/client`, as CI does)
- [x] `npm test --workspace=apps/ui` — 69 files / 489 tests passed
- [x] `npm run build --workspace=apps/ui` — green; className-only change, no bundle impact
- [x] Both popovers verified in-browser: open/close and content unchanged; only the trigger hit areas grew (measured 28→44px)
- [x] `git diff --check` clean; diff touches only the two files the issue names
