### PR TITLE
feat(ui): add top-accounts activity chart to the accounts index page

### DIFF
--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -1,10 +1,17 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { Suspense, useState } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { BarMini, type BarMiniDatum } from "@/components/metagraphed/charts/bar-mini";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { chainSignersQuery } from "@/lib/metagraphed/queries";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { formatNumber } from "@/lib/metagraphed/format";
 
 export const Route = createFileRoute("/accounts/")({
   head: () => ({
@@ -25,6 +32,57 @@ export const Route = createFileRoute("/accounts/")({
   }),
   component: AccountsPage,
 });
+
+/** How many top accounts the activity ranking shows. */
+const TOP_ACCOUNTS = 12;
+/** Window the `/api/v1/chain/signers` ranking covers (matches the query default). */
+const ACTIVITY_WINDOW_DAYS = 7;
+
+/**
+ * Top accounts ranked by extrinsics signed in the last 7 days, sourced from the
+ * same `/api/v1/chain/signers` feed the explorer's "Most active accounts" table
+ * uses — surfaced here as a `BarMini` ranking so the accounts index opens on a
+ * live leaderboard instead of a blank lookup box. Each account is a link through
+ * to its detail page.
+ */
+function TopActiveAccounts() {
+  const signers = useSuspenseQuery(chainSignersQuery()).data.data.signers;
+  const top = signers.slice(0, TOP_ACCOUNTS);
+
+  if (top.length === 0) {
+    return (
+      <p className="font-mono text-[12px] text-ink-muted">
+        No account activity in this window yet.
+      </p>
+    );
+  }
+
+  const bars: BarMiniDatum[] = top.map((s) => ({
+    label: shortHash(s.signer) ?? s.signer,
+    value: s.tx_count,
+  }));
+
+  return (
+    <>
+      <BarMini data={bars} />
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {top.map((s) => (
+          <li key={s.signer}>
+            <Link
+              to="/accounts/$ss58"
+              params={{ ss58: s.signer }}
+              title={s.signer}
+              className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 font-mono text-[10px] text-ink-strong hover:border-ink/30 hover:text-accent"
+            >
+              {shortHash(s.signer) ?? s.signer}
+              <span className="tabular-nums text-ink-muted">{formatNumber(s.tx_count)} tx</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
 
 function AccountsPage() {
   const navigate = useNavigate();
@@ -84,7 +142,21 @@ function AccountsPage() {
             : "Paste a hotkey or coldkey ss58 address to view its activity."}
         </p>
       </form>
-      <ApiSourceFooter paths={["/api/v1/accounts/{ss58}"]} />
+      <section className="mx-auto mt-10 w-full max-w-2xl rounded-lg border border-border bg-card p-5">
+        <h2 className="mb-1 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Most active accounts
+        </h2>
+        <p className="mb-4 font-mono text-[11px] text-ink-muted">
+          Ranked by extrinsics signed on-chain in the last {ACTIVITY_WINDOW_DAYS} days — jump
+          straight to an account below.
+        </p>
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-40 w-full" />}>
+            <TopActiveAccounts />
+          </Suspense>
+        </QueryErrorBoundary>
+      </section>
+      <ApiSourceFooter paths={["/api/v1/accounts/{ss58}", "/api/v1/chain/signers"]} />
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary

`apps/ui/src/routes/accounts.index.tsx` was a single ss58 lookup form — nothing to see before you already have an address in hand. `chainSignersQuery` (`/api/v1/chain/signers`, ranked by `tx_count`) already exists and is already fetched once, but only as the "Most active accounts" table on `explorer.tsx`; it had never been surfaced on the accounts page.

This adds an additive **"Most active accounts"** section below the lookup form: a `BarMini` ranking of the top 12 accounts by extrinsics signed in the last 7 days, with each account also exposed as a link chip through to `/accounts/$ss58`. The lookup form keeps its primary role.

## What changed

- One file: `apps/ui/src/routes/accounts.index.tsx`.
- New `TopActiveAccounts` component: `useSuspenseQuery(chainSignersQuery())`, `slice(0, 12)`, mapped to `BarMiniDatum[]` (`label: shortHash(signer)`, `value: tx_count`) and rendered with the existing `BarMini` primitive — no new chart component.
- Each entry links to `/accounts/$ss58` (same `<Link>` pattern as the explorer signers table).
- Wrapped in `<Suspense>` with a `Skeleton` fallback; empty window renders "No account activity in this window yet."
- `ApiSourceFooter` now lists `/api/v1/chain/signers` alongside `/api/v1/accounts/{ss58}`.
- No `workers/`, `src/`, `schemas/`, or backend changes.

## Screenshots

The live 7-day `/api/v1/chain/signers` window is currently empty (`signer_count: 0`), so the **after** shots are rendered against a representative sample of that exact payload to show the populated state; the **before** shots are the live page. Layout, theming, and the empty-state path are otherwise real.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/before-desktop-light.png"> | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/after-desktop-light.png"> |
| Desktop · Dark | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/before-desktop-dark.png"> | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/after-desktop-dark.png"> |
| Tablet · Light | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/before-tablet-light.png"> | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/after-tablet-light.png"> |
| Tablet · Dark | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/before-tablet-dark.png"> | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/after-tablet-dark.png"> |
| Mobile · Light | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/before-mobile-light.png"> | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/after-mobile-light.png"> |
| Mobile · Dark | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/before-mobile-dark.png"> | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/accounts-top-activity/after-mobile-dark.png"> |

## Validation

Run from `apps/ui/` (after `cd packages/client && npm run build`):

- `tsc --noEmit` — clean
- `eslint src/routes/accounts.index.tsx` — 0 errors (only the pre-existing `react-refresh/only-export-components` route warning, same as other route files)
- `vitest run` — 71 files / 498 tests pass
- `vite build` — succeeds

Closes #3389
