### PR TITLE
feat(ui): add a validator stake-dominance treemap to the subnet validators panel

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/treemap-mini.tsx
@@ -1,0 +1,163 @@
+import { classNames } from "@/lib/metagraphed/format";
+
+export interface TreemapMiniDatum {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+interface LaidOutTile extends TreemapMiniDatum {
+  /** Position + size as percentages of the map box. */
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  /** Share of the total value, 0–1. */
+  share: number;
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const sum = (ns: number[]) => ns.reduce((a, b) => a + b, 0);
+
+// A tile only shows its value readout when it is large enough to fit one without
+// clipping — width/height are percentages of the map box.
+const MIN_TILE_W_FOR_VALUE = 12;
+const MIN_TILE_H_FOR_VALUE = 14;
+
+/** Worst (largest) aspect ratio in a row laid along `side`. */
+function worstRatio(areas: number[], side: number): number {
+  if (areas.length === 0 || side <= 0) return Infinity;
+  const s = sum(areas);
+  if (s <= 0) return Infinity;
+  const max = Math.max(...areas);
+  const min = Math.min(...areas);
+  const s2 = s * s;
+  const side2 = side * side;
+  return Math.max((side2 * max) / s2, s2 / (side2 * min));
+}
+
+/**
+ * Squarified treemap layout (Bruls, Huizing & van Wijk) over a 100×100 box, so
+ * each tile's area is proportional to its value. Pure + dependency-free; returns
+ * tiles positioned in percentage units ready for absolute CSS placement.
+ */
+function squarify(data: TreemapMiniDatum[]): LaidOutTile[] {
+  const positive = data.filter((d) => d.value > 0);
+  const total = sum(positive.map((d) => d.value));
+  if (total <= 0) return [];
+
+  // Areas normalized so they sum to the box area (100 × 100 = 10_000).
+  const items = positive
+    .map((d) => ({ datum: d, area: (d.value / total) * 10_000, share: d.value / total }))
+    .sort((a, b) => b.area - a.area);
+
+  const tiles: LaidOutTile[] = [];
+  let rect: Rect = { x: 0, y: 0, w: 100, h: 100 };
+  let row: typeof items = [];
+
+  const layoutRow = (rowItems: typeof items, r: Rect): Rect => {
+    const rowArea = sum(rowItems.map((i) => i.area));
+    if (rowArea <= 0) return r;
+    if (r.w >= r.h) {
+      // Stack the row as a column on the left edge.
+      const dw = rowArea / r.h;
+      let y = r.y;
+      for (const it of rowItems) {
+        const h = it.area / dw;
+        tiles.push({ ...it.datum, share: it.share, x: r.x, y, w: dw, h });
+        y += h;
+      }
+      return { x: r.x + dw, y: r.y, w: r.w - dw, h: r.h };
+    }
+    // Stack the row along the top edge.
+    const dh = rowArea / r.w;
+    let x = r.x;
+    for (const it of rowItems) {
+      const w = it.area / dh;
+      tiles.push({ ...it.datum, share: it.share, x, y: r.y, w, h: dh });
+      x += w;
+    }
+    return { x: r.x, y: r.y + dh, w: r.w, h: r.h - dh };
+  };
+
+  for (const item of items) {
+    const side = Math.min(rect.w, rect.h);
+    const current = row.map((i) => i.area);
+    const withItem = [...current, item.area];
+    if (row.length === 0 || worstRatio(withItem, side) <= worstRatio(current, side)) {
+      row.push(item);
+    } else {
+      rect = layoutRow(row, rect);
+      row = [item];
+    }
+  }
+  if (row.length > 0) layoutRow(row, rect);
+
+  return tiles;
+}
+
+interface Props {
+  data: TreemapMiniDatum[];
+  className?: string;
+  /** Formats the value shown on each tile + in its title. Defaults to `String`. */
+  formatValue?: (value: number) => string;
+  /** Accessible name for the whole map. */
+  ariaLabel?: string;
+}
+
+/**
+ * Tiny squarified treemap, no dependencies. Each tile's area is proportional to
+ * its value — a dominance/concentration view that complements a ranked bar list
+ * (e.g. validator stake share within a subnet).
+ */
+export function TreemapMini({ data, className, formatValue = String, ariaLabel }: Props) {
+  const tiles = squarify(data);
+  if (tiles.length === 0) return null;
+
+  const label =
+    ariaLabel ??
+    `Treemap of ${tiles.length} items sized by share: ` +
+      tiles.map((t) => `${t.label} ${(t.share * 100).toFixed(1)}%`).join(", ");
+
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className={classNames("relative aspect-[16/9] w-full overflow-hidden rounded-md", className)}
+    >
+      {tiles.map((t) => (
+        <div
+          key={t.label}
+          title={`${t.label} · ${formatValue(t.value)} · ${(t.share * 100).toFixed(1)}%`}
+          className="absolute overflow-hidden p-1"
+          style={{
+            left: `${t.x}%`,
+            top: `${t.y}%`,
+            width: `${t.w}%`,
+            height: `${t.h}%`,
+          }}
+        >
+          <div
+            className="flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5"
+            style={{ background: t.color ?? "var(--accent)" }}
+          >
+            <span className="truncate font-mono text-[10px] font-medium leading-none text-accent-foreground">
+              {t.label}
+            </span>
+            {t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? (
+              <span className="truncate font-mono text-[9px] leading-none text-accent-foreground/80">
+                {formatValue(t.value)}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { subnetValidatorsQuery } from "@/lib/metagraphed/queries";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
+import { TreemapMini, type TreemapMiniDatum } from "@/components/metagraphed/charts/treemap-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
 import { FreshnessIndicator } from "@/components/metagraphed/freshness";
@@ -38,6 +39,16 @@ export function ValidatorsTableLoader({
       }));
   }, [validators]);
 
+  // Same top-N stake-ranked set as `stakeBars`, but sized by area so the
+  // concentration of stake across the leading validators reads at a glance —
+  // a complement to the ranked bar list, not a replacement. Shares are derived
+  // client-side from the values already in hand (no network-wide total exists
+  // on the payload).
+  const stakeTiles = useMemo<TreemapMiniDatum[]>(
+    () => stakeBars.map((b) => ({ label: b.label, value: b.value, color: b.color })),
+    [stakeBars],
+  );
+
   if (validators.length === 0) {
     return (
       <TableState
@@ -72,6 +83,21 @@ export function ValidatorsTableLoader({
             </span>
           </div>
           <BarMini data={stakeBars} />
+          {stakeTiles.length > 1 ? (
+            <div className="mt-4 border-t border-border pt-3">
+              <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+                Stake dominance
+                <span className="ml-2 normal-case tracking-normal text-ink-subtle">
+                  share within the top {stakeTiles.length}
+                </span>
+              </div>
+              <TreemapMini
+                data={stakeTiles}
+                formatValue={(v) => `${taoCompact(v)} τ`}
+                ariaLabel={`Validator stake dominance across the top ${stakeTiles.length} validators, sized by stake share`}
+              />
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="flex items-center justify-end">{freshness}</div>


### PR DESCRIPTION
## Summary

`ValidatorsTableLoader` (`apps/ui/src/components/metagraphed/validators-panel.tsx`) visualized validator stake with a single `BarMini` ranked list. That reads rank well but not *concentration* — how much of the subnet's stake the leading validators hold.

This adds a complementary **"Stake dominance"** treemap beneath the existing bar list: each tile's **area is proportional to that validator's share** of stake across the same top-N set. It's additive — the ranked `BarMini` is untouched.

## What changed

- **New** `apps/ui/src/components/metagraphed/charts/treemap-mini.tsx` — a dependency-free squarified treemap (Bruls–Huizing–van Wijk), same zero-dep CSS convention as `bar-mini.tsx` / `donut.tsx`. Exports `TreemapMiniDatum` (label/value/color, mirroring `BarMiniDatum`) and the `TreemapMini` component. Pure layout, `role="img"` with a synthesized aria-label, per-tile `title` with exact value + share.
- **Edit** `validators-panel.tsx` — a second `useMemo` (`stakeTiles`) derived from the same top-N stake-ranked set as `stakeBars`, rendered as `TreemapMini` inside the existing stake card, alongside (not replacing) the `BarMini`. Tile values formatted with the already-imported `taoCompact`.
- The `validators.length === 0` empty state and the `stakeBars.length > 0` guard are unchanged; the treemap only renders when there's more than one tile.
- No new network request — consumes the same `subnetValidatorsQuery(netuid)` data. No `routes/`, `workers/`, `src/`, or `schemas/` changes.

## Screenshots

Live `api.metagraph.sh`, **subnet 1** (`/subnets/1?tab=validators`) — 9 real validators, so the "after" is fully live data (validator #252 holds ~1.5M τ, hence the dominant tile).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/before-desktop-light.png"> | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/after-desktop-light.png"> |
| Desktop · Dark | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/before-desktop-dark.png"> | <img width="320" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/after-desktop-dark.png"> |
| Tablet · Light | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/before-tablet-light.png"> | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/after-tablet-light.png"> |
| Tablet · Dark | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/before-tablet-dark.png"> | <img width="260" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/after-tablet-dark.png"> |
| Mobile · Light | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/before-mobile-light.png"> | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/after-mobile-light.png"> |
| Mobile · Dark | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/before-mobile-dark.png"> | <img width="150" src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/validators-stake-treemap/after-mobile-dark.png"> |

## Validation

Run from `apps/ui/` (after `cd packages/client && npm run build`):

- `tsc --noEmit` — clean
- `eslint` on both changed files — 0 errors/warnings
- `vitest run` — 71 files / 498 tests pass
- `vite build` — succeeds

Closes #3388
