### PR TITLE
feat(ui): add account hover-card variant

### DIFF
--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -188,9 +188,7 @@ function AccountMiniProfile({ ss58 }: { ss58: string }) {
   return (
     <div className="space-y-2">
       <div className="min-w-0">
-        <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-          account
-        </div>
+        <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">account</div>
         <div className="font-mono text-[10px] text-ink-muted truncate">{ss58}</div>
       </div>
       <dl className="grid grid-cols-2 gap-2 pt-1">

--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -4,7 +4,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { BrandIcon } from "./brand-icon";
 import { CurationChip, HealthPill } from "./chips";
 import { TimeAgo } from "./time-ago";
-import { subnetQuery, providerQuery } from "@/lib/metagraphed/queries";
+import { subnetQuery, providerQuery, accountQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 interface SubnetHoverProps {
@@ -17,7 +17,12 @@ interface ProviderHoverProps {
   slug: string;
   children: ReactNode;
 }
-type Props = SubnetHoverProps | ProviderHoverProps;
+interface AccountHoverProps {
+  kind: "account";
+  ss58: string;
+  children: ReactNode;
+}
+type Props = SubnetHoverProps | ProviderHoverProps | AccountHoverProps;
 
 /**
  * Detect a touch-primary device. On those we don't render a hover card at
@@ -50,7 +55,11 @@ export function EntityHoverCard(props: Props) {
   if (coarse) return <>{props.children}</>;
 
   const ariaLabel =
-    props.kind === "subnet" ? `Preview subnet ${props.netuid}` : `Preview provider ${props.slug}`;
+    props.kind === "subnet"
+      ? `Preview subnet ${props.netuid}`
+      : props.kind === "provider"
+        ? `Preview provider ${props.slug}`
+        : `Preview account ${props.ss58}`;
 
   return (
     <HoverCard openDelay={250} closeDelay={120}>
@@ -65,8 +74,10 @@ export function EntityHoverCard(props: Props) {
       >
         {props.kind === "subnet" ? (
           <SubnetMiniProfile netuid={props.netuid} />
-        ) : (
+        ) : props.kind === "provider" ? (
           <ProviderMiniProfile slug={props.slug} />
+        ) : (
+          <AccountMiniProfile ss58={props.ss58} />
         )}
       </HoverCardContent>
     </HoverCard>
@@ -162,6 +173,35 @@ function ProviderMiniProfile({ slug }: { slug: string }) {
         <Mini label="Endpoints" value={String(p.endpoints_count ?? sum?.endpoint_count ?? "—")} />
         <Mini label="Authority" value={p.authority ?? "—"} />
       </dl>
+    </div>
+  );
+}
+
+function AccountMiniProfile({ ss58 }: { ss58: string }) {
+  const { data, isPending, error } = useQuery({
+    ...accountQuery(ss58),
+    staleTime: 5 * 60_000,
+  });
+  if (isPending) return <Loading />;
+  if (error || !data?.data) return <Failed />;
+  const a = data.data;
+  return (
+    <div className="space-y-2">
+      <div className="min-w-0">
+        <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
+          account
+        </div>
+        <div className="font-mono text-[10px] text-ink-muted truncate">{ss58}</div>
+      </div>
+      <dl className="grid grid-cols-2 gap-2 pt-1">
+        <Mini label="Events" value={formatNumber(a.event_count)} />
+        <Mini label="Subnets" value={formatNumber(a.subnet_count)} />
+      </dl>
+      {a.last_seen_at ? (
+        <div className="pt-1 border-t border-border font-mono text-[10px] text-ink-muted">
+          last seen <TimeAgo at={a.last_seen_at} />
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a third `Props` union member to `EntityHoverCard`, `AccountHoverProps`
  (`kind: "account"`, `ss58: string`), and a matching `AccountMiniProfile`
  renderer, so ss58/account-address links can get a hover preview. This is a
  prerequisite for #3398, which will wire `kind="account"` onto ss58 links in
  the blocks & extrinsics tables — no call sites are wired up in this PR.

## What Changed

- `apps/ui/src/components/metagraphed/entity-hover-card.tsx`:
  - Extended `Props` to `SubnetHoverProps | ProviderHoverProps | AccountHoverProps`.
  - Extended `ariaLabel` in `EntityHoverCard` with an `account` branch
    (`` `Preview account ${props.ss58}` ``).
  - Extended the `kind === ...` render switch with a third branch calling
    `AccountMiniProfile({ ss58 })`.
  - Added `AccountMiniProfile`, modeled on `ProviderMiniProfile`: fetches via
    the existing `accountQuery(ss58)` with `staleTime: 5 * 60_000` (matching
    the other two profiles), renders `Loading`/`Failed` fallbacks, and a
    `Mini` tile grid (`Events`, `Subnets` — same labels as the full account
    detail page) plus a freshness row (`last seen <TimeAgo .../>`), matching
    `SubnetMiniProfile`'s tile-grid + freshness-row structure. The ss58 is
    rendered with the same `font-mono text-[10px] text-ink-muted truncate`
    treatment `ProviderMiniProfile` uses for its slug, so the full
    47-48-char address never renders unclipped in the 320px card.
  - No existing call site (`routes/index.tsx`, `routes/subnets.index.tsx`,
    `routes/providers.index.tsx`) was touched.

## Screenshots

Not applicable — this PR only adds a new `Props` union variant and its
renderer; no call site in the app passes `kind="account"` yet (that's
#3398's scope), so no rendered output anywhere in the app changes as a
result of this diff.

## Validation

- [x] `npm run lint --workspace=apps/ui` / `npx eslint <changed file>` — changed file is clean (repo-wide CRLF prettier errors on unrelated files pre-exist on `main`, confirmed via `git stash`)
- [x] `npx prettier --check <changed file>`
- [x] `npm run typecheck --workspace=apps/ui` — no new errors from this change (the 2 pre-existing errors in `queries.ts`/`types.ts` reproduce identically on `main` without this change)
- [x] `npm test --workspace=apps/ui` — 71 files / 498 tests passed
- [x] `npm run build --workspace=apps/ui` — succeeds
- [x] `git diff --check` — clean

Closes #3397
