### PR TITLE
refactor(ui): use the shared useCopy hook in ShareButton instead of reimplementing clipboard/toast/timer

### DIFF
--- a/apps/ui/src/components/metagraphed/share-button.tsx
+++ b/apps/ui/src/components/metagraphed/share-button.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Check, Share2 } from "lucide-react";
 import { toast } from "sonner";
 import { classNames } from "@/lib/metagraphed/format";
+import { useCopy } from "@/hooks/use-copy";
 
 interface Props {
   /** Optional explicit URL; defaults to current window.location.href. */
@@ -11,25 +12,34 @@ interface Props {
 }
 
 export function ShareButton({ url, label = "Share view", className }: Props) {
-  const [copied, setCopied] = useState(false);
+  // #3425: reuse the shared useCopy hook for the clipboard write, copied-state,
+  // and reset timer (the app-wide primitive every other copy affordance uses),
+  // keeping ShareButton's two extras it doesn't cover — the window.location.href
+  // fallback and the sr-only aria-live announcement. toastOnSuccess is off so the
+  // distinct "Link copied" success toast below is preserved; useCopy already
+  // surfaces the failure toast, so the error path isn't double-notified.
+  const { copied, copy } = useCopy({ toastOnSuccess: false });
   const [announcement, setAnnouncement] = useState("");
 
+  // Reset the sr-only announcement back to empty once the copied state clears
+  // (via useCopy's own timer), reproducing the original's `setAnnouncement("")`
+  // reset without introducing a second parallel timer — driven off useCopy's
+  // `copied` return value as the issue directs. The failure announcement, which
+  // never sets `copied`, persists as it did originally.
+  useEffect(() => {
+    if (!copied) setAnnouncement("");
+  }, [copied]);
+
   const onClick = async () => {
-    try {
-      const href = url ?? (typeof window !== "undefined" ? window.location.href : "");
-      if (!href) return;
-      await navigator.clipboard.writeText(href);
-      setCopied(true);
-      setAnnouncement(`Link copied to clipboard: ${href}`);
+    const href = url ?? (typeof window !== "undefined" ? window.location.href : "");
+    if (!href) return;
+    const ok = await copy(href);
+    if (ok) {
       toast.success("Link copied", {
         description: "Filters, sort, and pagination are preserved in the URL.",
       });
-      window.setTimeout(() => setCopied(false), 1400);
-      window.setTimeout(() => setAnnouncement(""), 2000);
-    } catch {
-      toast.error("Couldn't copy link", {
-        description: "Your browser blocked clipboard access.",
-      });
+      setAnnouncement(`Link copied to clipboard: ${href}`);
+    } else {
       setAnnouncement("Couldn't copy link to clipboard.");
     }
   };


### PR DESCRIPTION
## Summary

Closes #3425

Refactors `ShareButton` to consume the shared `useCopy` hook for its clipboard write,`copied` state, and reset timer — the primitive every other copy affordance already uses.
Resubmit of the closed PR, with the reviewer's flagged behavioral drift fixed.

## Reviewer fix (vs. the closed PR)

The prior version dropped the aria-live announcement's reset-to-empty behavior. Restored:
an effect now clears the announcement once `copied` resets (via useCopy's own timer),reproducing the original `setAnnouncement("")` reset **without a second parallel timer** — driven off useCopy's `copied` value as the issue directs. The failure announcement, which never sets `copied`, persists as it did originally.

## What changed (only `share-button.tsx`)

- `const { copied, copy } = useCopy({ toastOnSuccess: false })`; removed the local `copied`
  useState, the direct `navigator.clipboard.writeText`, and the `setCopied` reset timer.
- Preserved: the `url ?? window.location.href` fallback, the empty-href early return, the
  distinct "Link copied" success toast, and the sr-only `aria-live` announcement (now
  correctly resetting to empty on success).
- `use-copy.ts`, other consumers, and the 5 `ShareButton` call sites are untouched.

## Testing

- `npx vitest run` (apps/ui) — **498 tests pass** (71 files)
- `npm run typecheck -w apps/ui` — clean
- `npm run lint` (changed file) — clean
- `npm run build -w apps/ui` — builds, within bundle budget
