### PR TITLE
feat(ui): add alpha-price sparkline to subnet economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -3,10 +3,12 @@ import {
   economicsQuery,
   subnetStakeMovesQuery,
   subnetStakeTransfersQuery,
+  subnetTrajectoryQuery,
 } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
+import { Sparkline, type SparklinePoint } from "@/components/metagraphed/charts/sparkline";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
@@ -114,6 +116,18 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
 
+  // #3362: alpha-price trend for the "Alpha price" tile, from the already-shipped
+  // subnetTrajectoryQuery — same points.alpha_price_tao extraction as
+  // subnet-price-ticker.tsx. Fetched alongside economicsQuery() but never gates the
+  // panel's own loading/empty states, which stay keyed off economicsQuery() only.
+  const { data: trajRes } = useQuery(subnetTrajectoryQuery(netuid));
+  const pricePoints: SparklinePoint[] = (trajRes?.data.points ?? []).flatMap((p) =>
+    typeof p.alpha_price_tao === "number" && Number.isFinite(p.alpha_price_tao)
+      ? [{ t: p.date, v: p.alpha_price_tao }]
+      : [],
+  );
+  const priceValues = pricePoints.map((p) => p.v);
+
   if (isPending && !e) return <Notice>Loading economics…</Notice>;
   if (!e) return <Notice>No on-chain economic data for this subnet.</Notice>;
 
@@ -127,6 +141,16 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
       <StatTile
         eyebrow="Alpha price"
         value={e.alpha_price_tao != null ? `${e.alpha_price_tao.toFixed(4)} τ` : "—"}
+        chart={
+          <Sparkline
+            values={priceValues}
+            points={pricePoints}
+            width={72}
+            height={28}
+            formatValue={(v) => `${v.toFixed(4)} τ`}
+            ariaLabel="Alpha price trend"
+          />
+        }
       />
       <StatTile
         eyebrow="Validators"


### PR DESCRIPTION
Closes #3362

Adds an alpha-price sparkline to the "Alpha price" `StatTile` in `EconomicsPanel`, driven by the historical `alpha_price_tao` values already carried in `subnetTrajectoryQuery(netuid)`'s trajectory points. Same points → finite-number extraction pattern already used by `subnet-price-ticker.tsx`, wired via the existing `Sparkline` primitive into the tile's `chart` slot.

## What changed

- `apps/ui/src/components/metagraphed/economics-panel.tsx`: `EconomicsPanel` now also calls `useQuery(subnetTrajectoryQuery(netuid))` alongside the existing `economicsQuery()` call, derives an aligned `SparklinePoint[]` (date + `alpha_price_tao`) from `trajRes?.data.points`, and passes it into a `Sparkline` mounted as the Alpha price tile's `chart` prop.
- The trajectory query never gates the panel's loading/empty states — those stay keyed off `economicsQuery()`/`isPending` exactly as before. `Sparkline`'s own flat-baseline fallback handles the &lt;2-point / unpriced-subnet case, so no extra empty-state branching was needed.
- No changes to `queries.ts` or `types.ts` — `subnetTrajectoryQuery` and `TrajectoryPoint.alpha_price_tao` already existed and needed no changes.

## Screenshots (subnet 64 — Chutes, live api.metagraph.sh)

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | ![b](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-desktop-light-before.png) | ![a](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-desktop-light-after.png) |
| **Desktop · Dark** | ![b](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-desktop-dark-before.png) | ![a](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-desktop-dark-after.png) |
| **Tablet · Light** | ![b](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-tablet-light-before.png) | ![a](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-tablet-light-after.png) |
| **Tablet · Dark** | ![b](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-tablet-dark-before.png) | ![a](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-tablet-dark-after.png) |
| **Mobile · Light** | ![b](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-mobile-light-before.png) | ![a](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-mobile-light-after.png) |
| **Mobile · Dark** | ![b](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-mobile-dark-before.png) | ![a](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/alpha-price-sparkline-mobile-dark-after.png) |

## Validation

- `npm run lint` / `npm run format:check` — clean on the changed file
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 498 tests passed
- `npm run build --workspace=apps/ui` — succeeds
- Manually verified against live `api.metagraph.sh` data for subnet 64 (Chutes), which has 380 daily trajectory points with `alpha_price_tao`

## Non-goals (per issue)

- No market-cap/FDV tiles (#3361)
- No network-wide trend chart (#3365)
- Did not touch `charts/economics-mini.tsx`'s stale comment
