### PR TITLE
feat(ui): recognize sn<netuid> / netuid <n> shorthand in the omnibox and command palette

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -359,6 +359,19 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
         icon: Hash,
       });
     }
+    const netuidMatch = /^(?:sn\s*(\d+)|netuid\s*(\d+))$/i.exec(q);
+    if (netuidMatch) {
+      const n = Number(netuidMatch[1] ?? netuidMatch[2]);
+      if (Number.isFinite(n) && n >= 0 && n <= 1024) {
+        targets.push({
+          label: `Subnet ${n}`,
+          hint: "go to subnet by netuid",
+          target: { to: "/subnets/$netuid", params: { netuid: String(n) } },
+          kind: "subnet",
+          icon: Layers,
+        });
+      }
+    }
     return targets;
   }, [debounced]);
 

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -106,7 +106,7 @@ type NavTarget =
       label: string;
       hint: string;
       to: string;
-      params?: Record<string, string>;
+      params?: Record<string, string | number>;
       icon: typeof User;
       badge: string;
     };
@@ -225,6 +225,22 @@ export function NavOmnibox({ onOpenPalette }: Props) {
         icon: Hash,
         badge: "partial hash",
       });
+    }
+
+    const netuidMatch = /^(?:sn\s*(\d+)|netuid\s*(\d+))$/i.exec(q);
+    if (netuidMatch) {
+      const n = Number(netuidMatch[1] ?? netuidMatch[2]);
+      if (Number.isFinite(n) && n >= 0 && n <= 1024) {
+        targets.push({
+          kind: "nav",
+          label: `Subnet ${n}`,
+          hint: "Go to subnet by netuid",
+          to: "/subnets/$netuid",
+          params: { netuid: n },
+          icon: Layers,
+          badge: "subnet",
+        });
+      }
     }
 
     return targets;


### PR DESCRIPTION
## Summary

- `NavOmnibox` and `CommandPaletteBody` now recognize `sn<netuid>` / `netuid <n>` shorthand (e.g. `sn74`, `SN 74`, `netuid 74`, `netuid74`) as a direct-navigation target to `/subnets/$netuid`, alongside the existing ss58/block-number/hash recognizers in each file.

Closes #3392

## What Changed

- `apps/ui/src/components/metagraphed/nav-omnibox.tsx`: added a `sn<netuid>`/`netuid <n>` branch to the `navTargets` `useMemo`, pushing a `{ kind: "nav", to: "/subnets/$netuid", params: { netuid: n }, icon: Layers, badge: "subnet" }` target — `netuid` is a `Number`, matching this file's own convention for the same route in `commit()`'s hit-based subnet navigation. Widened the `NavTarget` "nav" variant's `params` type from `Record<string, string>` to `Record<string, string | number>` to allow this.
- `apps/ui/src/components/metagraphed/command-palette-body.tsx`: same recognizer added to the `navigateTargets` `useMemo`, pushing a `{ target: { to: "/subnets/$netuid", params: { netuid: String(n) } }, kind: "subnet", icon: Layers }` entry — stringified, matching this file's own existing convention in `resolveHref` for the identical route (`params: { netuid: String(hit.netuid) }`).
- Both regexes are case-insensitive, accept optional whitespace after the prefix (`sn74`, `sn 74`, `netuid74`, `netuid 74`, `netuid  74` all match), and range-validate the parsed netuid to 0–1024 (same bound `__root.tsx`'s 404-recovery form already uses for this exact route) before pushing a target — an out-of-range or non-numeric suffix (`sn99999`, `netuid abc`, `sn`) produces no target and falls through to fuzzy search as before.
- No changes to the existing ss58/block/hash recognizer branches in either file.

Scoped only to this one recognizer per the issue's coordination note (#3393/#3394 touch the same arrays and are separate PRs).

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend components, no registry/schema/API surface.

## Validation

- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors (2 pre-existing, unrelated errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout, need `npm run build:client` first)
- [x] `npx eslint` on both changed files — clean (aside from a pre-existing environment-wide CRLF/Windows-checkout artifact that reproduces on every file in this tree and isn't part of the actual git diff, confirmed via `git diff --check`)
- [x] `npm test --workspace=apps/ui` — all 71 files / 498 tests pass (no existing test file covers either component; not required per the issue, and this change adds no new branches to already-tested code)
- [x] Manually verified the regex + range-check logic against the issue's full acceptance-criteria case list (`sn74`, `SN74`, `sn 74`, `netuid 74`, `netuid74`, `netuid  74`, `NETUID74` all resolve to netuid 74; `sn`, `netuid abc`, `sn99999`, bare `netuid` all correctly produce no target)
- [x] `git diff --check`

## Issue Link

Closes #3392