### PR TITLE
fix(ui): surface a real error state on the account chain-events feed

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1082,6 +1082,25 @@ function AccountEventsSection({
     );
   }
 
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="events"
+        title="Chain events"
+        subtitle="Full first-party event feed for this account, newest first — filter by kind, page through history."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Couldn't load chain events"
+          description="The chain-events feed is temporarily unavailable — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
   return (
     <SectionAnchor
       id="events"


### PR DESCRIPTION
## Summary

- `AccountEventsSection` (`apps/ui/src/routes/accounts.$ss58.tsx`) now checks `result.isError` and renders a distinct error state, instead of silently falling through to the "No chain events indexed" empty-state copy on a failed fetch.

Closes #3435

## What Changed

- Inserted an `isError` branch between the existing pending/skeleton guard and the populated/empty fork, rendering `TableState variant="error"` with the real `result.error` and an `onRetry` wired to `result.refetch()` — the exact same pattern this file already uses for its sibling sections (teardown activity, deregistrations, weight-setting activity, serving/prometheus announcements), so this just closes the one section that was missing it.
- No changes to `AccountExtrinsicsSection` / `AccountTransfersSection` (out of scope, tracked separately by #3434) or `AccountHistoryChart` (already handles `isError` correctly).
- No changes to `apps/ui/src/lib/metagraphed/queries.ts` / `accountEventsQuery` — render-branch fix only.

## Why

TanStack Query v5's `status` is `'pending' | 'error' | 'success'`. A failed fetch with no cached data has `isPending === false` and `isError === true`, so before this fix it skipped the loading skeleton and landed in the exact same empty-state block a genuinely cold, inactive account gets — a real backend failure was indistinguishable from "this account has never done anything," with no way to tell what went wrong or retry.

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend rendering, no registry/schema/API surface.

## Validation

- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors (2 pre-existing, unrelated errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout, need `npm run build:client` first)
- [x] `npm test --workspace=apps/ui` — all 73 files / 509 tests pass
- [x] `git diff --check`
- [x] Verified against every acceptance criterion in #3435: error branch surfaces `result.error` (not generic empty copy), the existing pending/skeleton behavior is unchanged, and a genuinely cold/inactive account with a successful empty response still renders the unchanged "No chain events indexed" empty state (only the new `isError` branch sits between the two, so the empty-state fork's own condition — `events.length === 0` — is untouched)

## Issue Link

Closes #3435