### PR TITLE
docs(registry): remove retired candidate lane and stale apps/ui docs

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -11,7 +11,8 @@
 wantedPaths:
   - "registry/subnets/**"
   - "registry/providers/**"
-  - "registry/candidates/community/**"
+  # registry/candidates/community/** — retired lane, no longer a valid PR path.
+  # Community surfaces now live in registry/subnets/<slug>.json (see CONTRIBUTING.md).
   - "registry/reviews/**"
   - "registry/adapters/**"
 

--- a/apps/ui/CONTRIBUTING.md
+++ b/apps/ui/CONTRIBUTING.md
@@ -1,33 +1,40 @@
-# Contributing to metagraphed-ui
+# Contributing to apps/ui
 
 Thanks for helping improve the [Metagraphed](https://github.com/JSONbored/metagraphed)
-frontend. This guide gets you from clone to a green PR.
+frontend. `apps/ui` is an npm workspace inside the `metagraphed` monorepo — this guide
+gets you from clone to a green PR.
 
 ## Setup
 
-[Bun](https://bun.sh) is the canonical toolchain.
+Node 22 and npm are the canonical toolchain.
 
 ```bash
-bun install
-bun run dev
+npm install                       # root install wires the apps/ui workspace too
+npm run dev --workspace=apps/ui
 ```
 
-The app fetches live data from `https://metagraph.sh` by default — no backend setup or
-secrets are required to develop against real data. To point at a different backend, set
-`VITE_METAGRAPH_API_BASE`.
+The app fetches live data from `https://api.metagraph.sh` by default — no backend setup
+or secrets are required to develop against real data. To point at a different backend,
+set `VITE_METAGRAPH_API_BASE`.
 
 ## Before you open a PR
 
-Run the three checks CI enforces — a PR is only mergeable when all pass:
+Run the same checks CI's `ui` job enforces, in this order — a PR is only mergeable when
+all pass:
 
 ```bash
-bun run lint       # ESLint + Prettier (errors block; the repo is Prettier-clean)
-bun run typecheck  # tsc --noEmit (the routes are fully typed — no `any` escape hatches)
-bun run build      # production SSR build must succeed
+npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui
+npm run typecheck --workspace=apps/ui
+npm test --workspace=apps/ui
+npm run build --workspace=apps/ui
 ```
 
-If lint flags formatting, run `bun run format`. Prettier is the single source of truth
-for style and is enforced through ESLint's `prettier/prettier` rule — don't hand-format.
+If lint flags formatting, run `npm run format --workspace=apps/ui`. Prettier is the
+single source of truth for style and is enforced through ESLint's `prettier/prettier`
+rule — don't hand-format.
+
+CI also gzip-measures the initial client JS for a cold `/` visit against a bundle-size
+budget — keep new dependencies/imports lean.
 
 ## Code conventions
 
@@ -37,6 +44,8 @@ for style and is enforced through ESLint's `prettier/prettier` rule — don't ha
 - **Data fetching** goes through the query helpers in `src/lib/metagraphed/queries.ts`
   and `useSuspenseQuery` / error boundaries — don't fetch ad hoc in components.
 - **Components** live in `src/components/metagraphed/`; route trees in `src/routes/`.
+- Reuse existing design tokens (`src/styles.css`) and shared components instead of
+  inventing new one-off styles.
 - Keep diffs focused. Don't reformat or refactor unrelated files in a feature PR.
 
 ## Lovable-managed surface
@@ -46,18 +55,39 @@ Parts of the build are managed by [Lovable](https://lovable.dev). **Do not edit*
 Cloudflare build is driven entirely by build-time env vars (see [DEPLOY.md](./DEPLOY.md))
 so Lovable's visual edits stay non-conflicting. App code under `src/` is fair game.
 
+## Screenshot contract (required for any visual change)
+
+**Non-negotiable for any PR that changes rendered output — PRs without it are
+auto-closed, no exceptions.** See the root
+[`.claude/skills/metagraphed/SKILL.md`](../../.claude/skills/metagraphed/SKILL.md)'s
+"Path C — Frontend PR" section (Phase C2) for the exact capture steps: fixed viewport
+sizes (mobile 375×812, tablet 768×1024, desktop 1280×800), both themes, before/after,
+hosted on a branch and linked in a table in the PR body — never a full-page capture,
+never images committed to your feature branch.
+
+A PR confined to non-visual code (`src/lib/**`, `src/hooks/**`, test files) with no
+rendered-output change skips this — it isn't rendering anything different.
+
+## Linked issue
+
+Every PR must reference an open issue (`Closes #<n>` / `Refs #<n>`) in the PR body, and
+that issue must still be open at submission time — a missing or already-closed link is
+an automatic close before content is even reviewed. Pick a `gittensor:bug` /
+`gittensor:feature` issue scoped to `apps/ui/`.
+
 ## Pull requests
 
 1. Branch off `main`.
-2. Make the change; keep it scoped to one concern.
-3. Run the three checks above until green.
-4. Open the PR with a clear description of what and why. CI must pass to merge.
+2. Make the change; keep it scoped to one concern (aim for ≤10 files / ≤1000 LOC).
+3. Run the checks above until green.
+4. Fill the screenshot table if the change is visual, and link the issue you're closing.
+5. Open the PR with a clear description of what and why. CI must pass to merge.
 
 ## Where issues live
 
-The roadmap and most issues are tracked in the
-**[metagraphed](https://github.com/JSONbored/metagraphed/issues)** backend repo. Open
-**UI-specific** issues (rendering, routing, accessibility, design) in this repo.
+All issues — backend, roadmap, and UI-specific — are tracked in
+**[JSONbored/metagraphed](https://github.com/JSONbored/metagraphed/issues)**. There is
+no separate frontend repo anymore; `apps/ui` is a workspace within this monorepo.
 
 ## License
 

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -1,11 +1,11 @@
 <div align="center">
 
-# metagraphed-ui
+# apps/ui — metagraphed frontend
 
 **The web frontend for [Metagraphed](https://github.com/JSONbored/metagraphed)** — the Bittensor subnet integration registry.
 
 [![Live](https://img.shields.io/badge/live-metagraph.sh-2ea44f)](https://metagraph.sh)
-[![CI](https://github.com/JSONbored/metagraphed-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/JSONbored/metagraphed-ui/actions/workflows/ci.yml)
+[![Validate](https://github.com/JSONbored/metagraphed/actions/workflows/validate.yml/badge.svg)](https://github.com/JSONbored/metagraphed/actions/workflows/validate.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
 
 [**metagraph.sh**](https://metagraph.sh) · [Backend](https://github.com/JSONbored/metagraphed) · [Deploy](./DEPLOY.md)
@@ -18,7 +18,8 @@ The web app at **[metagraph.sh](https://metagraph.sh)** — for every Bittensor 
 what it exposes (APIs, docs, schemas), whether it's healthy, and how to call it. It
 holds **no** subnet data; it renders what the
 [metagraphed](https://github.com/JSONbored/metagraphed) backend serves at
-`api.metagraph.sh`.
+`api.metagraph.sh`. This directory (`apps/ui`) is an npm workspace within the
+`metagraphed` monorepo, not a standalone repository.
 
 ## Stack
 
@@ -28,33 +29,30 @@ Radix/shadcn. Deploys as a Cloudflare Worker — see [DEPLOY.md](./DEPLOY.md).
 
 ## Getting started
 
-[Bun](https://bun.sh) is the canonical toolchain. No secrets needed — it talks to the
-live API.
+Node 22 and npm are the canonical toolchain. No secrets needed — it talks to the live
+API.
 
 ```bash
-bun install
-bun run dev        # dev server
+npm install                       # from the repo root — wires the apps/ui workspace too
+npm run dev --workspace=apps/ui   # dev server
 ```
 
-Run the same checks CI gates on before you push:
+Run the same checks CI's `ui` job gates on before you push:
 
 ```bash
-bun run lint       # ESLint + Prettier
-bun run typecheck  # tsc --noEmit
-bun run build      # production SSR build
+npm run lint --workspace=apps/ui
+npm run typecheck --workspace=apps/ui
+npm run build --workspace=apps/ui
 ```
 
 > The API base defaults to `https://api.metagraph.sh` (override with
-> `VITE_METAGRAPH_API_BASE`). CI installs via `npm ci --legacy-peer-deps` to match the
-> Cloudflare deploy path — `bun.lock` pins a few packages to a private mirror that 403s
-> in CI, so both lockfiles are kept in sync.
+> `VITE_METAGRAPH_API_BASE`).
 
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). Parts of the build are Lovable-managed —
-don't edit `vite.config.ts`. Backend and roadmap issues live in the
-[metagraphed](https://github.com/JSONbored/metagraphed/issues) repo; open UI-specific
-issues here.
+don't edit `vite.config.ts`. All issues — backend, roadmap, and UI-specific — are
+tracked in [JSONbored/metagraphed](https://github.com/JSONbored/metagraphed/issues).
 
 ## License
 

--- a/registry/candidates/README.md
+++ b/registry/candidates/README.md
@@ -1,46 +1,39 @@
-# Candidate Surfaces
+# Candidate Surfaces (machine-generated only)
 
-This directory is for unverified subnet interface candidates discovered from third-party sources or community submissions.
+This directory holds **machine-generated** candidate data only. The old direct-PR
+candidate lane — where a contributor ran a helper to create one
+`registry/candidates/community/*.json` file per surface — is **retired and rejected by
+CI**. Recreating `registry/candidates/community/*.json` fails validation; there is no
+`community/` subdirectory here anymore.
 
-Candidate entries are not published as verified registry surfaces. They must stay separate until maintainer review confirms:
+`generated/public-sources.json` is the only file in this directory. It's produced by the
+build pipeline from on-chain identity data (`SubnetIdentitiesV3`) and other public
+sources — never hand-authored, never edited in a PR.
 
-- the public URL is live;
-- auth and rate-limit requirements are labeled;
-- source docs support the claim;
-- the probe is safe and read-only;
-- no secrets, private dashboards, credentialed flows, or validator-sensitive data are included.
+## Where community surface submissions go now
 
-Generated public-source candidates live in `generated/public-sources.json`.
-Community-submitted direct PR candidates live in `community/*.json`.
-
-Use the helper to generate the direct PR file shape:
+Surfaces live in **one file per subnet**: `registry/subnets/<slug>.json` → its
+`surfaces[]` array. A community contribution appends a surface to that one file with
+`npm run surface:add`, which sets `authority: "community"` and
+`review.state: "community-submitted"` for you. If the subnet has no manifest yet,
+scaffold it first with `npm run subnet:new`, then add the surface to that same new file.
 
 ```bash
-npm run candidate:new -- --netuid 7 --kind docs --url https://docs.all-ways.io/community-submission-example --source-url https://docs.all-ways.io/how-it-works.html --provider allways --submitted-by <github-login> --write
+npm run surface:add -- \
+  --netuid 43 --kind subnet-api \
+  --url https://api.example.com/v1 \
+  --source-url https://github.com/example/project/blob/main/README.md \
+  --provider <provider-slug> --submitted-by <github-login> --write
 ```
 
-Schema-backed examples live under `docs/examples/submissions` so they do not get
-ingested as registry data.
+See [`CONTRIBUTING.md`](../../CONTRIBUTING.md)'s "Community submissions" section and
+[`docs/curation-playbook.md`](../../docs/curation-playbook.md) for the full model,
+allowed surface `kind`s, and validation steps
+(`npm run validate:surface -- registry/subnets/<slug>.json`).
 
-Direct PR submissions must:
+## Allowed states (generated data only)
 
-- change exactly one `registry/candidates/community/*.json` file;
-- include one `candidates[0]` entry only;
-- include `submission.submitted_by` and `submission.submitted_by_url` matching the PR author;
-- use public-safe `url` and `source_url` values;
-- avoid generated artifacts, secrets, private URLs, wallet data, and validator-local data.
-
-The generated bundle is allowed to contain:
-
-- official/project websites;
-- source repositories;
-- documentation links;
-- dashboards and leaderboard-style URLs;
-- public data-artifact URLs.
-
-The generated bundle must not contain owner key fields, contact emails, Discord handles, wallet data, private dashboards, credentialed validator flows, or social-only links.
-
-Allowed states:
+The generated candidate entries in `generated/public-sources.json` carry one of:
 
 - `schema-invalid`
 - `schema-valid`
@@ -49,4 +42,6 @@ Allowed states:
 - `stale`
 - `rejected`
 
-Only `verified` candidates should be promoted into curated subnet overlays under `registry/subnets`.
+Only `verified` candidates are eligible for promotion into subnet overlays under
+`registry/subnets/`, and that promotion is build/maintainer-owned, not a contributor
+action.


### PR DESCRIPTION
## Docs Change

## Summary

- `registry/candidates/README.md` still documented the retired per-surface direct-PR candidate lane (`npm run candidate:new`, submitting to `registry/candidates/community/*.json`). That command and directory no longer exist and CI rejects any PR that recreates `registry/candidates/community/*.json` — a contributor following this README does real work and gets an automatic close. Rewrote it: the directory now holds only machine-generated data (`generated/public-sources.json`), and contributors are pointed at the current single-file surface model (`npm run surface:add` on `registry/subnets/<slug>.json`), matching `CONTRIBUTING.md`'s "Community submissions" section and `docs/curation-playbook.md`.
- `.gittensory.yml`'s `wantedPaths` still listed `registry/candidates/community/**`, a path that can no longer legitimately appear in a PR now that the lane is retired. Replaced the entry with an explanatory comment so the gate-scope manifest doesn't reference a dead path.
- `apps/ui/CONTRIBUTING.md` and `apps/ui/README.md` were untouched leftovers from before `metagraphed-ui` was folded into this monorepo: Bun install/run/lint/typecheck/build commands that no longer apply (this workspace uses npm), a CI badge pointing at the old standalone `metagraphed-ui` repo's now-unused workflow, and framing ("open UI-specific issues in this repo") implying `apps/ui` still lives in a separate repo. Rewrote both to use the real `npm run <script> --workspace=apps/ui` commands (verified against `apps/ui/package.json`), point the badge at this repo's actual `Validate` workflow, state the screenshot-table and linked-open-issue requirements for `apps/ui` PRs, and make clear all issues live in `JSONbored/metagraphed`.

## Checklist

- [x] This PR changes docs/templates only.
- [x] No generated `public/metagraph/**` artifacts are included.
- [x] No private research notes, local paths, secrets, wallet/PAT data, private
      URLs, or validator internals are included.
- [x] Any referenced API route or artifact path exists in the current backend
      contracts.

## Validation

- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`