### PR TITLE
refactor(ui): reuse nakamotoTone helper in BlockProductionHeader

### DIFF
--- a/apps/ui/src/lib/metagraphed/network-decentralization.test.ts
+++ b/apps/ui/src/lib/metagraphed/network-decentralization.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { networkDecentralizationModel } from "./network-decentralization";
+import { networkDecentralizationModel, nakamotoTone } from "./network-decentralization";
 import type { ChainConcentration, ChainPerformance } from "./types";
 
 function findTile(model: ReturnType<typeof networkDecentralizationModel>, key: string) {
@@ -155,5 +155,21 @@ describe("networkDecentralizationModel", () => {
     expect(findTile(model, "trust-median")?.value).toBe("—");
     expect(findTile(model, "trust-median")?.hint).toBeUndefined();
     expect(findTile(model, "validator-trust-median")?.value).toBe("1.000");
+  });
+});
+
+// #3990: nakamotoTone is exported so BlockProductionHeader (blocks.index.tsx)
+// can call the same shared helper instead of re-implementing its thresholds.
+describe("nakamotoTone", () => {
+  it("is down at and below 1, warn at and below 3, ok above 3", () => {
+    expect(nakamotoTone(1)).toBe("down");
+    expect(nakamotoTone(3)).toBe("warn");
+    expect(nakamotoTone(4)).toBe("ok");
+    expect(nakamotoTone(105)).toBe("ok");
+  });
+
+  it("is default for a missing value", () => {
+    expect(nakamotoTone(null)).toBe("default");
+    expect(nakamotoTone(undefined)).toBe("default");
   });
 });

--- a/apps/ui/src/lib/metagraphed/network-decentralization.ts
+++ b/apps/ui/src/lib/metagraphed/network-decentralization.ts
@@ -70,7 +70,7 @@ function giniTone(v: number | null | undefined): DecentralizationTone {
   return "ok";
 }
 
-function nakamotoTone(v: number | null | undefined): DecentralizationTone {
+export function nakamotoTone(v: number | null | undefined): DecentralizationTone {
   const n = num(v);
   if (n == null) return "default";
   if (n <= 1) return "down";

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -20,6 +20,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
+import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { Block } from "@/lib/metagraphed/types";
@@ -94,8 +95,7 @@ function BlockProductionHeader() {
   const blockTime = summary.block_time;
   const throughput = summary.throughput;
   const nakamoto = summary.author_concentration?.nakamoto_coefficient;
-  const nakamotoTone: "ok" | "warn" | "down" | "default" =
-    nakamoto == null ? "default" : nakamoto <= 1 ? "down" : nakamoto <= 3 ? "warn" : "ok";
+  const nakamotoStatTone = nakamotoTone(nakamoto);
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
       <StatTile
@@ -117,7 +117,7 @@ function BlockProductionHeader() {
         eyebrow="Author decentralization"
         value={nakamoto != null ? formatNumber(nakamoto) : "—"}
         hint="Nakamoto coefficient"
-        tone={nakamotoTone}
+        tone={nakamotoStatTone}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- `BlockProductionHeader` (`apps/ui/src/routes/blocks.index.tsx`) now calls the existing `nakamotoTone()` helper from `apps/ui/src/lib/metagraphed/network-decentralization.ts` instead of re-implementing the identical threshold ternary inline.

Closes #3990

## What Changed

- Exported `nakamotoTone` from `network-decentralization.ts` (was previously module-private).
- Replaced the inline `nakamoto <= 1 ? "down" : nakamoto <= 3 ? "warn" : "ok"` ternary in `BlockProductionHeader` with a call to the shared helper (renamed the local binding to `nakamotoStatTone` to avoid shadowing the imported function name).
- Added a direct unit test for the newly-exported `nakamotoTone` (boundary values at 1/3/4, plus the null/undefined default case) in `network-decentralization.test.ts`, alongside the existing indirect coverage via `networkDecentralizationModel`.

## Why

Both call sites compute the exact same tone for the exact same metric (author/stake Nakamoto coefficient). If the thresholds for what counts as "down"/"warn"/"ok" ever change, the inline copy in `blocks.index.tsx` would silently diverge from the canonical helper. This is a pure de-duplication, not a behavior change — the thresholds are identical before and after.

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend logic, no registry/schema/API surface.

## Validation

- [x] `npx vitest run src/lib/metagraphed/network-decentralization.test.ts` (workspace apps/ui) — 5 passed (3 pre-existing + 2 new)
- [x] `npx eslint` on both changed files — clean aside from pre-existing CRLF/line-ending noise from this Windows checkout (confirmed the actual git-stored blobs and diff hunks are LF-only) and 3 pre-existing `react-refresh/only-export-components` warnings at unrelated lines
- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors; the 2 pre-existing errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout in this environment (missing built `packages/client` dist)
- [x] `git diff --check`
- [x] Per this issue's own acceptance criteria, no before/after screenshot is required: this is a pure refactor with identical thresholds, confirmed via the diff and the new unit test that rendered tone for sample data (1 → down, 3 → warn, 4/105 → ok, null → default) is unchanged from before

## Issue Link

Closes #3990