### PR TITLE
fix(ui): resolve dangling aria-labelledby refs in webhook subscription manager

### DIFF
--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -132,6 +132,7 @@ function CreateSubscriptionSection() {
   return (
     <section aria-labelledby="create-subscription-heading">
       <SectionHeading
+        id="create-subscription-heading"
         title="Create subscription"
         intro="Register a URL to receive change-feed webhooks. Creation requires a subscription token issued by a metagraphed operator — this app never bundles one."
       />
@@ -264,6 +265,7 @@ function LookupSubscriptionSection() {
   return (
     <section aria-labelledby="lookup-subscription-heading">
       <SectionHeading
+        id="lookup-subscription-heading"
         title="Look up subscription"
         intro="Check a subscription's status and delivery health by id."
       />
@@ -376,6 +378,7 @@ function DeleteSubscriptionSection() {
   return (
     <section aria-labelledby="delete-subscription-heading">
       <SectionHeading
+        id="delete-subscription-heading"
         title="Delete subscription"
         intro="Requires the one-time secret returned when the subscription was created."
       />


### PR DESCRIPTION
## Summary

- All three sections of `WebhookSubscriptionManager` (`apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx`) now pass a matching `id` prop into `SectionHeading`, so each section's `aria-labelledby` reference resolves to a real, rendered `<h2>` id instead of dangling.

Closes #3956

## What Changed

- `create-subscription-heading` section (~line 133-137): added `id="create-subscription-heading"` to the `SectionHeading` call.
- `lookup-subscription-heading` section (~line 265-269): added `id="lookup-subscription-heading"` to the `SectionHeading` call.
- `delete-subscription-heading` section (~line 377-381): added `id="delete-subscription-heading"` to the `SectionHeading` call.
- No other changes — `SectionHeading` (`section-heading.tsx`) already accepts and forwards an `id` prop onto its rendered `<h2>`; the three `<section aria-labelledby="...">` wrappers already had the correct target strings, they just had nothing on the page to point at.

## Why

Each `<section>` declared `aria-labelledby` pointing at an id like `create-subscription-heading`, but `SectionHeading` was called without an `id` prop, so the rendered `<h2>` had no id at all — the reference resolved to nothing. Assistive tech announcing the section landmark would get no accessible name from the (non-existent) referenced element, exactly the class of defect this issue reports for all three sections.

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend markup, no registry/schema/API surface.

## Validation

- [x] `npx vitest run src/components/metagraphed/webhook-subscription-manager.test.ts` (workspace apps/ui) — 5 passed, unaffected (pure-logic tests, no rendering change)
- [x] `npx eslint` on the changed file — clean aside from pre-existing CRLF/line-ending noise from this Windows checkout (confirmed the actual git-stored blob and diff hunk are LF-only)
- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors; the 2 pre-existing errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout in this environment (missing built `packages/client` dist)
- [x] `git diff --check`
- [x] Per this issue's own acceptance criteria, this defect isn't visually observable in a normal screenshot (`SectionHeading`'s rendered `<h2>` text/styling is unchanged — only its `id` attribute is added), so a brief note stands in for a screenshot: traced each `id` string through `SectionHeading` -> its `<h2 id={id}>` -> confirmed it matches the corresponding `<section aria-labelledby="...">` string exactly, for all three sections; visual appearance is unchanged (no className/text/layout touched)

## Issue Link

Closes #3956