### PR TITLE
fix(registry): ignore same-request subnet deletes

### DIFF
--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -116,6 +116,11 @@ async function main() {
     }
   }
 
+  const upsertedSubnetNetuids = new Set(subnets.map((subnet) => subnet.netuid));
+  const safeDeleteSubnets = deleteSubnets.filter(
+    (deletion) => !upsertedSubnetNetuids.has(deletion.netuid),
+  );
+
   const summary = {
     providers_written: 0,
     subnets_written: 0,
@@ -130,14 +135,14 @@ async function main() {
     subnets.length ||
     surfaces.length ||
     pruneSurfaces.length ||
-    deleteSubnets.length
+    safeDeleteSubnets.length
   ) {
     const result = await postRegistrySync({
       providers,
       subnets,
       surfaces,
       prune_surfaces: pruneSurfaces,
-      delete_subnets: deleteSubnets,
+      delete_subnets: safeDeleteSubnets,
     });
     summary.providers_written = result?.providers_written ?? 0;
     summary.subnets_written = result?.subnets_written ?? 0;

--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -462,6 +462,33 @@ test("deletes a removed subnet after recording delete history for its surfaces",
   expect(text).toMatch(/DELETE FROM subnets/);
 });
 
+test("does not delete a subnet that is also upserted in the same request", async () => {
+  const res = await worker.fetch(
+    post(
+      {
+        subnets: [subnet()],
+        surfaces: [surface()],
+        delete_subnets: [{ netuid: 8, source_commit: "def456" }],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    subnets_written: 1,
+    surfaces_written: 1,
+    surfaces_deleted: 0,
+    subnets_deleted: 0,
+  });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).toMatch(/INSERT INTO subnets/);
+  expect(text).toMatch(/INSERT INTO surfaces/);
+  expect(text).not.toMatch(/DELETE FROM subnets/);
+});
+
 test("maps a DB failure to a clean 502 instead of throwing", async () => {
   failure.error = new Error("connection reset");
   const res = await worker.fetch(

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -131,6 +131,7 @@ export default {
         summary.providers_written += 1;
       }
 
+      const writtenSubnetNetuids = new Set();
       for (const s of subnets) {
         if (
           !Number.isInteger(s.netuid) ||
@@ -151,6 +152,7 @@ export default {
             source_commit = EXCLUDED.source_commit,
             updated_at = now()`;
         summary.subnets_written += 1;
+        writtenSubnetNetuids.add(s.netuid);
       }
 
       for (const prune of pruneSurfaces) {
@@ -200,6 +202,7 @@ export default {
       for (const deletion of deleteSubnets) {
         if (!Number.isInteger(deletion.netuid) || !deletion.source_commit)
           continue;
+        if (writtenSubnetNetuids.has(deletion.netuid)) continue;
         const deletedSurfaces = await sql`
           DELETE FROM surfaces
           WHERE subnet_netuid = ${deletion.netuid}


### PR DESCRIPTION
### Motivation
- Prevent a merge-triggered sync payload from deleting a subnet that the same request also upserts, which could remove the freshly-written parent row and cause FK failures when inserting surfaces.

### Description
- Filter the merge-triggered `delete_subnets` list in `scripts/sync-registry-to-postgres.mjs` so deletions whose `netuid` are also present in the same-request `subnets` list are omitted.
- Add a Worker-side guard in `workers/registry-sync-api.mjs` that records successfully written subnet `netuid`s and skips processing `delete_subnets` entries that conflict with those written netuids.
- Add a regression test in `tests/registry-sync-api.test.mjs` that exercises a request which upserts a subnet, includes a conflicting `delete_subnets`, and asserts no subnet delete SQL is emitted and surfaces are still inserted.

### Testing
- Ran `npm test -- tests/registry-sync-api.test.mjs` and all tests in that file passed.
- Ran `npx prettier --check` on the modified files and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca8e7f9bc832cb9a7f9cb441f8cb6)