### PR TITLE
feat(registry): add SN13 Data Universe OpenAPI schema surface

### DIFF
--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -300,6 +300,33 @@
         "https://www.npmjs.com/package/macrocosmos"
       ],
       "url": "https://github.com/macrocosm-os/macrocosmos-ts"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-13-data-universe-openapi",
+      "kind": "openapi",
+      "name": "Data Universe Validator API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"Data Universe Validator API\", version 1.0.0) served by the SN13 validator API on the macrocosmos-hosted sn13.api.macrocosmos.ai host. Documents the on-demand data-query, bucket, label-size, age-size, and desirability routes. Unauthenticated GET returns the full paths object.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://sn13.api.macrocosmos.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/macrocosm-os/data-universe",
+        "https://sn13.api.macrocosmos.ai/openapi.json"
+      ],
+      "url": "https://sn13.api.macrocosmos.ai/openapi.json"
     }
   ],
   "website_url": "https://datauniverse.macrocosmos.ai/"


### PR DESCRIPTION
Closes #4011

## Summary

Adds the public, machine-readable **OpenAPI 3.1.0** schema served by the SN13 Data Universe validator API as an `openapi` surface — the exact gap tracked by #4011 (and the manifest's own `gap_notes`: "No verified machine-readable OpenAPI/Swagger schema yet").

## Surface

- **Netuid:** 13 (Data Universe)
- **Kind:** `openapi`
- **URL / schema_url:** https://sn13.api.macrocosmos.ai/openapi.json
- Unauthenticated `GET` returns HTTP 200 with the full OpenAPI document (title "Data Universe Validator API", version 1.0.0), documenting the on-demand data-query, bucket, label-size, age-size, and desirability routes.
- **source_urls:** the official `macrocosm-os/data-universe` repository and the live schema URL on the subnet's own `sn13.api.macrocosmos.ai` host.

## Checks

- `validate:surface` passes (659 surfaces / 128 files)
- `validate:schemas`, `validate:private-boundary` pass
- One focused change: appends a single `openapi` surface to `registry/subnets/data-universe.json`; no other field touched
- `authority: community`, `review.state: community-submitted`