### PR TITLE
fix: prevent health incident/trend netuid coercion to subnet 0

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -366,13 +366,9 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
   const formatWindow = (rows, days) => {
     const bySubnet = new Map();
     for (const row of rows || []) {
-      const netuid = Number(row.netuid);
+      const netuid = parseNonNegativeInt(row.netuid);
       const date = String(row.date || "");
-      if (
-        !Number.isInteger(netuid) ||
-        netuid < 0 ||
-        !/^\d{4}-\d{2}-\d{2}$/.test(date)
-      ) {
+      if (netuid == null || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
         continue;
       }
       const samples = Math.max(0, Number(row.total) || 0);
@@ -480,6 +476,16 @@ function toFiniteOrNull(value) {
   if (value == null) return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
+}
+function parseNonNegativeInt(value) {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 // p50/p95/p99 + avg/min/max latency per surface, computed in SQL (one row per
@@ -680,7 +686,8 @@ export function formatGlobalIncidents({
     if (acceptedIncidents >= incidentLimit) {
       break;
     }
-    const netuid = Number(row.netuid);
+    const netuid = parseNonNegativeInt(row.netuid);
+    if (netuid == null) continue;
     const key = `${netuid}/${surfaceLookupKey(row)}`;
     const entry = bySurface.get(key) || {
       netuid,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -3078,6 +3078,20 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
           ended_at: 20,
           failed_samples: 2,
         },
+        {
+          netuid: {},
+          surface_id: "z",
+          started_at: 30,
+          ended_at: 40,
+          failed_samples: 1,
+        },
+        {
+          netuid: "9007199254740993",
+          surface_id: "z2",
+          started_at: 50,
+          ended_at: 60,
+          failed_samples: 1,
+        },
       ],
     });
     assert.equal(out.summary.incident_count, 1);

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -942,6 +942,7 @@ describe("formatBulkTrends", () => {
       windows: {
         "7d": [
           { netuid: -1, date: "2026-06-10", total: 1, ok_count: 1 },
+          { netuid: " ", date: "2026-06-10", total: 1, ok_count: 1 },
           { netuid: 7, date: "not-a-date", total: 1, ok_count: 1 },
         ],
       },
@@ -3058,6 +3059,30 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
       ],
     });
     assert.equal(capped.summary.incident_count, 1);
+  });
+
+  test("skips blank netuid values instead of coercing to subnet 0", () => {
+    const out = formatGlobalIncidents({
+      incidentRows: [
+        {
+          netuid: " ",
+          surface_id: "x",
+          started_at: 1,
+          ended_at: 2,
+          failed_samples: 1,
+        },
+        {
+          netuid: "7",
+          surface_id: "y",
+          started_at: 10,
+          ended_at: 20,
+          failed_samples: 2,
+        },
+      ],
+    });
+    assert.equal(out.summary.incident_count, 1);
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].netuid, 7);
   });
 });
 


### PR DESCRIPTION
## Summary
- Root cause: health incident/trend formatters used `Number(row.netuid)`, so blank-string cells (`""`/whitespace) were coerced to `0` and misattributed to subnet 0.
- Fix: add strict non-negative integer parsing for netuid cells and reuse it in both `formatBulkTrends()` and `formatGlobalIncidents()`.
- Coverage: add regression tests proving blank netuid rows are ignored and valid string integers still parse.

## Impact
- Prevents false incident and trend data from being published under subnet 0.
- Keeps analytics stable when malformed D1 cells appear.

## Test plan
- [x] `npx vitest run tests/health-serving.test.mjs`

## Risk / tradeoffs
- Low risk: only malformed netuid rows are filtered; valid integer netuids (number or numeric string) are preserved.
