### PR TITLE
feat(registry): enrich SN127 Astrid — Arena wallet-activity data artifact

### DIFF
--- a/registry/subnets/astrid.json
+++ b/registry/subnets/astrid.json
@@ -27,6 +27,25 @@
         "https://github.com/astridintelligence/sn-127/blob/master/README.md"
       ],
       "url": "https://arena-api.astrid.global/public/arena/completed-competitions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-127-astrid-data-artifact",
+      "kind": "data-artifact",
+      "name": "Astrid Arena competition wallet-activity dataset",
+      "notes": "Public no-auth GET returning the full wallet-activity dataset (totals plus orders/positions/trades records) for a completed SN127 Astrid Arena competition (Miners Showdown 3). The competitionId is sourced from the public completed-competitions endpoint already in this manifest, and the wallet-activity dataset path is documented in the official astridintelligence/sn-127 validator client (src/core/arena/api.ts, fetchAllTrades). Returns application/json; distinct from the completed-competitions API surface.",
+      "provider": "astrid",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/astridintelligence/sn-127/blob/master/src/core/arena/api.ts",
+        "https://github.com/astridintelligence/sn-127/blob/master/README.md"
+      ],
+      "url": "https://arena-api.astrid.global/public/competitions/190482a8-70b8-463d-b6c5-d1808bc7db9f/wallet-activity"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends **one** community `data-artifact` surface to `registry/subnets/astrid.json` — the public, no-auth **Arena wallet-activity dataset** (bulk `totals` + `orders`/`positions`/`trades` records) for a completed SN127 Astrid Arena competition.

Closes #4181

## Surface

- Netuid: 127 (Astrid)
- Kind: `data-artifact`
- Public URL: `https://arena-api.astrid.global/public/competitions/190482a8-70b8-463d-b6c5-d1808bc7db9f/wallet-activity`
- Source URL (proves it's official + SN127's): `https://github.com/astridintelligence/sn-127/blob/master/src/core/arena/api.ts` (also README)
- Provider slug: `astrid`

### Why this is a genuine, verifiable data artifact

- The wallet-activity path is documented in the official `astridintelligence/sn-127` validator client — `src/core/arena/api.ts` `fetchAllTrades()` fetches `GET /public/competitions/{competitionId}/wallet-activity`.
- The `competitionId` (`190482a8-…`, "Miners Showdown 3") comes from the public `completed-competitions` endpoint already in this manifest, proving it is real SN127 data.
- Live check: `HTTP 200`, `application/json`, ~124 KB payload — `{"totals":{"orders":3390,"positions":1649,"trades":3328}, "orders":[…]}`. No auth, no query params required.
- Distinct from the existing `completed-competitions` subnet-api surface (different path, different dataset).

## Checklist

- [x] Changes exactly one `registry/subnets/astrid.json` file (append-only, 19 insertions, 0 deletions/reformatting).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] `url` is public + safe for read-only probes; `source_url` independently proves it's SN127's.
- [x] `public_safe: true`, `auth_required: false`.
- [x] Does not duplicate an existing surface (new host path not present in registry).
- [x] Links a tracked, open issue (`Closes #4181`).

## Conflict avoidance

| Open PR | Touches `astrid.json`? |
|---|---|
| #4183 (registry-sync scripts/worker/tests) | No |
| #4072 (CODE_OF_CONDUCT / CONTRIBUTING) | No |
| #3918 (charts/treemap-mini, validators-panel) | No |
| #3917 (accounts.index route) | No |
| #3910 (registry/subnets/gittensor.json) | No |
| #3882 (operational-panel) | No |

Append-only at the end of `surfaces[]`; mergeable after any/all open PRs land **without rebase**.

## Validation

- [x] `npm run surface:add` live verification: `OK reachable + public-safe.`
- [x] `npm run validate:surface -- registry/subnets/astrid.json` → passed (2 surfaces, 1 file)
- [x] `npm run scan:public-safety` → passed
- [x] `npx prettier --check registry/subnets/astrid.json` → clean

## Codecov

Registry-only JSON change — no executable lines added, so codecov **patch** has no coverable lines (100%/N-A) and **project** coverage is unchanged.

Made with [Cursor](https://cursor.com)