### PR TITLE
feat(registry): enrich SN2 DSperse — add circuit repository OpenAPI

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -185,6 +185,35 @@
         "https://github.com/inference-labs-inc/subnet-2/blob/main/crates/sn2-types/src/constants.rs"
       ],
       "url": "https://sn2-api.inferencelabs.com/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-circuit-repository-openapi",
+      "kind": "openapi",
+      "name": "DSperse circuit repository OpenAPI",
+      "notes": "Public no-auth OpenAPI 3.1 schema for the SN2 circuit repository API (title \"Circuit Repository API\", 11 paths) on repository.inferencelabs.com. Validators and miners fetch active ZK circuits from this host; the official subnet-2 client sets CIRCUIT_API_URL to https://repository.inferencelabs.com in crates/sn2-types/src/constants.rs.",
+      "provider": "inference-labs",
+      "public_safe": true,
+      "schema_status": "machine-readable",
+      "schema_url": "https://repository.inferencelabs.com/openapi.json",
+      "source_urls": [
+        "https://github.com/inference-labs-inc/subnet-2/blob/main/crates/sn2-types/src/constants.rs",
+        "https://sn2-docs.inferencelabs.com/technical-roadmap.md",
+        "https://repository.inferencelabs.com/docs"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie",
+        "confidence": "medium"
+      },
+      "url": "https://repository.inferencelabs.com/openapi.json"
     }
   ],
   "website_url": "https://subnet2.inferencelabs.com/"


### PR DESCRIPTION
## Summary
- Adds a verified public `openapi` surface for SN2 DSperse at the live Circuit Repository API schema on `repository.inferencelabs.com`.
- OpenAPI 3.1 (`Circuit Repository API`, 11 paths) documents the ZK circuit distribution API used by SN2 validators and miners; `CIRCUIT_API_URL` in the official subnet-2 client points to this host.

Closes #3997.

## Surface
| Field | Value |
|-------|-------|
| Kind | `openapi` |
| URL | `https://repository.inferencelabs.com/openapi.json` |
| Provider | `inference-labs` |
| Auth | none (schema fetch; individual API routes may vary) |

## Provenance
- `crates/sn2-types/src/constants.rs` sets `CIRCUIT_API_URL = "https://repository.inferencelabs.com"`
- SN2 docs describe the circuit repository architecture (`sn2-docs.inferencelabs.com/technical-roadmap.md`)
- Scalar docs UI live at `repository.inferencelabs.com/docs`

## Validation
- [x] Exactly one file changed: `registry/subnets/dsperse.json` (append-only, +29 lines)
- [x] `npm run validate:surface -- registry/subnets/dsperse.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/dsperse.json`
- [x] `npm run surface:add` dry-run verified machine-readable OpenAPI (11 paths)

## Test plan
- [ ] CI validate workflow passes
- [ ] Gittensory review completes

Made with [Cursor](https://cursor.com)