### PR TITLE
fix(docs): collapse comment-only JSON object bodies per prettier

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -17,9 +17,7 @@ Every `/api/v1/*` response is a JSON envelope:
 {
   "ok": true,
   "schema_version": 1,
-  "data": {
-    /* artifact payload, possibly filtered/paginated */
-  },
+  "data": {/* artifact payload, possibly filtered/paginated */},
   "meta": {
     "artifact_path": "/metagraph/subnets.json",
     "cache": "standard",
@@ -27,9 +25,7 @@ Every `/api/v1/*` response is a JSON envelope:
     "generated_at": "1970-01-01T00:00:00.000Z",
     "published_at": "2026-06-09T13:57:16.231Z",
     "source": "static-assets",
-    "pagination": {
-      /* present on list routes; see below */
-    },
+    "pagination": {/* present on list routes; see below */},
   },
 }
 ```


### PR DESCRIPTION
## Summary
- `main`'s root `checks` / \"Lint + format\" job is currently red on `docs/api-stability.md`: two example object bodies in the response-envelope JSON sample (`data: { /* comment */ }`, `pagination: { /* comment */ }`) contain only a comment, which the pinned prettier collapses to one line.
- Pure formatting, no content/meaning change.

## Test plan
- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean