### PR TITLE
feat(registry): add SN13 Data Universe OpenAPI schema surface

### DIFF
--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -300,6 +300,33 @@
         "https://www.npmjs.com/package/macrocosmos"
       ],
       "url": "https://github.com/macrocosm-os/macrocosmos-ts"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-13-data-universe-openapi",
+      "kind": "openapi",
+      "name": "Data Universe Validator API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"Data Universe Validator API\", version 1.0.0) served by the SN13 validator API on the macrocosmos-hosted sn13.api.macrocosmos.ai host. Documents the on-demand data-query, bucket, label-size, age-size, and desirability routes. Unauthenticated GET returns the full paths object.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://sn13.api.macrocosmos.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/macrocosm-os/data-universe",
+        "https://sn13.api.macrocosmos.ai/openapi.json"
+      ],
+      "url": "https://sn13.api.macrocosmos.ai/openapi.json"
     }
   ],
   "website_url": "https://datauniverse.macrocosmos.ai/"


### PR DESCRIPTION
## Summary

Enriches **SN13 Data Universe** with its public, machine-readable **OpenAPI 3.1.0 schema** as an `openapi` surface.

## Surface

- **url:** `https://sn13.api.macrocosmos.ai/openapi.json` — unauthenticated GET returns the full OpenAPI 3.1.0 document (title *"Data Universe Validator API"*, version 1.0.0), verified live (200).
- **What it documents:** the SN13 validator API's on-demand data-query, bucket, label-size, age-size, and desirability routes.
- **Provenance:** served on the macrocosmos-hosted `sn13.api.macrocosmos.ai` host for the official `macrocosm-os/data-universe` subnet (cited as a `source_url`).

## Why it's safe to merge

- **One file, one surface** — appends a single `openapi` entry to `registry/subnets/data-universe.json`; `authority: community`, `review.state: community-submitted`; purely additive (no existing surface touched).
- **Not a duplicate** — this URL isn't registered on SN13 or any other subnet.
- **Matches the accepted pattern** — sibling to the merged SN9 IOTA `openapi` surface on the same `*.api.macrocosmos.ai` host family.
- `npm run validate:surface`, `npm run scan:public-safety`, root `lint`, and `format:check` all pass locally.

> Note: supersedes a prior attempt that was auto-closed purely on a stale-base `prettier --check` failure in an unrelated `docs/` file; this branch is cut from current `main` with all checks green.

Closes #4011
