### PR TITLE
feat(ui): add a cross-subnet portfolio section to the account page

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -587,6 +587,17 @@ function fmtStake(v: number | null | undefined): string {
 const KPI_TILE =
   "rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]";
 
+// Compact TAO formatter for the portfolio KPI tiles — a long raw value like
+// "338,030.153 τ" wraps + overflows a narrow StatTile, so summarise it (338.0k τ).
+function fmtTaoCompact(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "0 τ";
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  if (v >= 1) return `${v.toFixed(2)} τ`;
+  return `${v.toFixed(4)} τ`;
+}
+
 // #3491: cross-subnet portfolio for this account, from the already-shipped
 // accountPortfolioQuery. An aggregate stake / emission / yield KPI row plus the
 // per-subnet position table (netuid, role, stake, emission, incentive). Non-
@@ -647,14 +658,14 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
         <StatTile
           icon={Coins}
           eyebrow="Total stake"
-          value={fmtStake(p.total_stake_tao)}
-          hint={`${formatNumber(p.validator_count)} validator / ${formatNumber(p.miner_count)} miner`}
+          value={fmtTaoCompact(p.total_stake_tao)}
+          hint={`${formatNumber(p.validator_count)} val / ${formatNumber(p.miner_count)} min`}
           className={KPI_TILE}
         />
         <StatTile
           icon={Sparkles}
           eyebrow="Total emission"
-          value={fmtStake(p.total_emission_tao)}
+          value={fmtTaoCompact(p.total_emission_tao)}
           hint="summed across positions"
           className={KPI_TILE}
         />
@@ -662,7 +673,7 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
           icon={TrendingUp}
           eyebrow="Overall yield"
           value={p.overall_yield != null ? p.overall_yield.toExponential(2) : "—"}
-          hint="emission / stake"
+          hint="return rate"
           className={KPI_TILE}
         />
       </div>

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -4,6 +4,8 @@ import { Suspense, type ReactNode } from "react";
 import {
   Activity,
   Boxes,
+  TrendingUp,
+  Sparkles,
   ChevronLeft,
   ChevronRight,
   Clock,
@@ -32,6 +34,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountPortfolioQuery,
   accountDeregistrationsQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
@@ -252,6 +255,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       ) : null}
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
+
+      <AccountPortfolioSection ss58={ss58} />
 
       <AccountTeardownActivitySection ss58={ss58} />
 
@@ -581,6 +586,135 @@ function fmtStake(v: number | null | undefined): string {
 
 const KPI_TILE =
   "rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]";
+
+// #3491: cross-subnet portfolio for this account, from the already-shipped
+// accountPortfolioQuery. An aggregate stake / emission / yield KPI row plus the
+// per-subnet position table (netuid, role, stake, emission, incentive). Non-
+// blocking: while it loads or if it fails, the rest of the account page is
+// unaffected.
+function AccountPortfolioSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountPortfolioQuery(ss58));
+  const p = result.data?.data;
+
+  if (result.isPending && !p) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="portfolio"
+        title="Portfolio"
+        subtitle="Cross-subnet neuron positions for this account: per-subnet stake, emission, and role, with an aggregate stake and yield summary."
+      />
+    );
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="portfolio"
+        title="Portfolio"
+        subtitle="Cross-subnet neuron positions for this account: per-subnet stake, emission, and role, with an aggregate stake and yield summary."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load portfolio"
+          description="The portfolio tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  const positions = p?.positions ?? [];
+  if (!p || positions.length === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="portfolio"
+      title="Portfolio"
+      subtitle="Cross-subnet neuron positions for this account: per-subnet stake, emission, and role, with an aggregate stake and yield summary."
+      tone="accent"
+      info="The account's registered neurons across every subnet, from /api/v1/accounts/{ss58}/portfolio — total stake and emission, the validator / miner split, and the per-subnet breakdown."
+      right={<SectionBadge tone="accent">{formatNumber(p.subnet_count)} subnets</SectionBadge>}
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile
+          icon={Boxes}
+          eyebrow="Positions"
+          tone="accent"
+          value={formatNumber(p.position_count)}
+          hint={`across ${formatNumber(p.subnet_count)} subnets`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="Total stake"
+          value={fmtStake(p.total_stake_tao)}
+          hint={`${formatNumber(p.validator_count)} validator / ${formatNumber(p.miner_count)} miner`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Sparkles}
+          eyebrow="Total emission"
+          value={fmtStake(p.total_emission_tao)}
+          hint="summed across positions"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={TrendingUp}
+          eyebrow="Overall yield"
+          value={p.overall_yield != null ? p.overall_yield.toExponential(2) : "—"}
+          hint="emission / stake"
+          className={KPI_TILE}
+        />
+      </div>
+      <DataPanel>
+        <table className="w-full text-left text-sm">
+          <thead className="bg-surface/50">
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={TH}>Role</th>
+              <th className={`${TH} text-right`}>Stake</th>
+              <th className={`${TH} text-right`}>Emission</th>
+              <th className={`${TH} text-right`}>Incentive</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {positions.map((pos) => (
+              <tr key={`${pos.netuid}-${pos.uid ?? "x"}`} className="hover:bg-surface/30">
+                <td className="px-5 py-4 font-mono text-[12px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: pos.netuid }}
+                    className="text-ink hover:text-accent hover:underline"
+                  >
+                    SN{pos.netuid}
+                  </Link>
+                </td>
+                <td className="px-5 py-4 font-mono text-[11px]">
+                  {pos.role === "validator" ? (
+                    <span className="text-emerald-500">validator</span>
+                  ) : pos.role === "miner" ? (
+                    <span className="text-sky-500">miner</span>
+                  ) : (
+                    <span className="text-ink-muted">{"—"}</span>
+                  )}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {fmtStake(pos.stake_tao)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {fmtStake(pos.emission_tao)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {pos.incentive != null ? pos.incentive.toFixed(4) : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </DataPanel>
+    </SectionAnchor>
+  );
+}
 
 /**
  * Axon-removal (teardown) footprint over the trailing 30-day window — a flat


### PR DESCRIPTION
Closes #3491

Wires the shipped-but-unused `accountPortfolioQuery` (#3595) into the account page as a **Portfolio** section — an aggregate stake / emission / yield KPI row plus a per-subnet position table (netuid, role, stake, emission, incentive), inserted between the Subnet-footprint and Weight-setting sections. No data-layer changes — the query / type from #3595 are consumed as-is via `useQuery`, in the page's existing `SectionAnchor` / `DataPanel` / `StatTile` idiom; loading / error / empty states mirror the sibling sections (a cold account renders nothing).

_Follow-up: the KPI values now use a compact TAO format (e.g. `310.3k τ`) so a long stake no longer wraps, and the hints are shortened (`8 val / 3 min`, `return rate`) so they no longer clip — per @JSONbored's review._

## Screenshots (account 5DvDypN8…, live api.metagraph.sh)

_Matched frames (same scroll anchor at the Subnet-footprint boundary) — the Portfolio section is the only change._

| Viewport · Theme | Before | After |
|---|---|---|
| **Desktop · Light** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/before-desktop-light.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/after-desktop-light.png"> |
| **Desktop · Dark** | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/before-desktop-dark.png"> | <img width="360" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/after-desktop-dark.png"> |
| **Tablet · Light** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/before-tablet-light.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/after-tablet-light.png"> |
| **Tablet · Dark** | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/before-tablet-dark.png"> | <img width="300" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/after-tablet-dark.png"> |
| **Mobile · Light** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/before-mobile-light.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/after-mobile-light.png"> |
| **Mobile · Dark** | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/before-mobile-dark.png"> | <img width="190" src="https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/portfolio-shots-v2/after-mobile-dark.png"> |

## Verification
`tsc --noEmit`, `eslint`, `prettier@3.9.4 --check`, and `vite build` all pass; rendered against live api.metagraph.sh.