### PR TITLE
refactor(ui): extract a shared SegmentedToggle primitive for ViewModeToggle + DensityToggle

### DIFF
--- a/apps/ui/src/components/metagraphed/density-toggle.tsx
+++ b/apps/ui/src/components/metagraphed/density-toggle.tsx
@@ -1,5 +1,5 @@
 import { Rows3, Rows2 } from "lucide-react";
-import { classNames } from "@/lib/metagraphed/format";
+import { SegmentedToggle } from "@/components/ui/segmented-toggle";
 
 export type Density = "comfortable" | "compact";
 
@@ -22,35 +22,18 @@ export function DensityToggle({
     { value: "compact", label: "Compact", Icon: Rows2 },
   ];
   return (
-    <div
-      role="tablist"
-      aria-label="Row density"
-      className={classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className,
-      )}
-    >
-      {options.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return (
-          <button
-            key={v}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            aria-label={`${label} row density`}
-            title={`${label} rows`}
-            onClick={() => onChange(v)}
-            className={classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
-            )}
-          >
-            <Icon className="size-3.5" />
-            <span className="hidden sm:inline">{label}</span>
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedToggle
+      ariaLabel="Row density"
+      value={value}
+      onChange={onChange}
+      className={className}
+      options={options.map(({ value: v, label, Icon }) => ({
+        value: v,
+        label,
+        Icon,
+        ariaLabel: `${label} row density`,
+        title: `${label} rows`,
+      }))}
+    />
   );
 }

--- a/apps/ui/src/components/metagraphed/view-mode-toggle.tsx
+++ b/apps/ui/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,5 +1,5 @@
 import { LayoutGrid, List, Grid3x3 } from "lucide-react";
-import { classNames } from "@/lib/metagraphed/format";
+import { SegmentedToggle } from "@/components/ui/segmented-toggle";
 
 export type ViewMode = "table" | "grid" | "matrix";
 
@@ -26,35 +26,18 @@ export function ViewModeToggle({
 }) {
   const available = OPTIONS.filter((o) => options.includes(o.value));
   return (
-    <div
-      role="tablist"
-      aria-label="View mode"
-      className={classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className,
-      )}
-    >
-      {available.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return (
-          <button
-            key={v}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            aria-label={`Switch to ${label.toLowerCase()} view`}
-            title={label}
-            onClick={() => onChange(v)}
-            className={classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
-            )}
-          >
-            <Icon className="size-3.5" />
-            <span className="hidden sm:inline">{label}</span>
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedToggle
+      ariaLabel="View mode"
+      value={value}
+      onChange={onChange}
+      className={className}
+      options={available.map(({ value: v, label, Icon }) => ({
+        value: v,
+        label,
+        Icon,
+        ariaLabel: `Switch to ${label.toLowerCase()} view`,
+        title: label,
+      }))}
+    />
   );
 }

--- a/apps/ui/src/components/ui/segmented-toggle.tsx
+++ b/apps/ui/src/components/ui/segmented-toggle.tsx
@@ -1,0 +1,69 @@
+import type { LucideIcon } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+  Icon?: LucideIcon;
+  /** aria-label for this tab; defaults to `label`. */
+  ariaLabel?: string;
+  /** title for this tab; defaults to `label`. */
+  title?: string;
+}
+
+interface SegmentedToggleProps<T extends string> {
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentedOption<T>[];
+  /** aria-label for the tablist container. */
+  ariaLabel: string;
+  className?: string;
+}
+
+/**
+ * #3426: shared segmented (tablist) toggle. Renders the border/rounded wrapper
+ * and per-option `role="tab"` buttons with the active/inactive styling that
+ * `ViewModeToggle` and `DensityToggle` previously hand-rolled byte-for-byte.
+ * Presentational only — the markup is unchanged from those originals, so there
+ * is no visual or behavioral diff; it just removes the duplication.
+ */
+export function SegmentedToggle<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+  className,
+}: SegmentedToggleProps<T>) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={classNames(
+        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
+        className,
+      )}
+    >
+      {options.map(({ value: optionValue, label, Icon, ariaLabel: optionAriaLabel, title }) => {
+        const active = optionValue === value;
+        return (
+          <button
+            key={optionValue}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-label={optionAriaLabel ?? label}
+            title={title ?? label}
+            onClick={() => onChange(optionValue)}
+            className={classNames(
+              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
+              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
+            )}
+          >
+            {Icon ? <Icon className="size-3.5" /> : null}
+            <span className="hidden sm:inline">{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #3426

Extracts the `role="tablist"` segmented switch that `ViewModeToggle` and `DensityToggle` hand-rolled **byte-for-byte** into a shared `SegmentedToggle` primitive under `apps/ui/src/components/ui/`. Pure dedup — the rendered markup is unchanged, so there's **no visual or behavioral diff** (no screenshot table needed).

## What changed

- **New:** `apps/ui/src/components/ui/segmented-toggle.tsx` — `SegmentedToggle` taking  `options ({ value, label, Icon?, ariaLabel?, title? }[])`, `value`, `onChange`, `ariaLabel`,  `className`; renders the exact wrapper + `role="tab"` button markup (border/rounded wrapper,  active/inactive styling, `size-3.5` icon, `hidden sm:inline` label) the two toggles duplicated.
- **`view-mode-toggle.tsx`** — inline `<div role="tablist">…</div>` replaced with a  `SegmentedToggle` call; `ViewMode` type + `ViewModeToggle` signature (`value`/`onChange`/`options?`/`className`) unchanged.
- **`density-toggle.tsx`** — same swap; `Density` type + signature unchanged.
- The per-option `aria-label`/`title` strings are preserved verbatim (passed through options).
- `settings-popover`'s segmented helper is a *different* variant (full-width, `aria-pressed`,  different padding/colors) — intentionally left as-is per the issue.

## Testing

- `npx vitest run` (apps/ui) — **509 tests pass** (73 files)
- `npm run typecheck -w apps/ui` — clean
- `npm run lint` (changed files) — clean
- `npm run build -w apps/ui` — builds, within bundle budget
