### PR TITLE
feat(registry): enrich SN3 Templar — add Grafana OpenAPI spec

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -145,6 +145,35 @@
         "https://grafana.tplr.ai/"
       ],
       "url": "https://grafana.tplr.ai/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-openapi",
+      "kind": "openapi",
+      "name": "Templar Grafana HTTP API OpenAPI",
+      "notes": "Public no-auth OpenAPI 3.0.3 schema (title \"Grafana HTTP API.\", 208 paths) on grafana.tplr.ai/public/openapi3.json. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README; the built-in Swagger UI at grafana.tplr.ai/swagger loads this spec alongside the legacy v2 merge at public/api-merged.json.",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "schema_status": "machine-readable",
+      "schema_url": "https://grafana.tplr.ai/public/openapi3.json",
+      "source_urls": [
+        "https://grafana.tplr.ai/swagger",
+        "https://github.com/one-covenant/templar",
+        "https://github.com/one-covenant/crusades/blob/main/src/crusades/logging.py"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie",
+        "confidence": "medium"
+      },
+      "url": "https://grafana.tplr.ai/public/openapi3.json"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds the live OpenAPI 3.0.3 schema for the Grafana HTTP API hosted on `grafana.tplr.ai` (208 paths). This is the same first-party SN3 operator host already registered for the eval-metrics dashboard and the `/api/health` subnet-api surface.

Closes #3998

## Surface

| Field | Value |
|-------|-------|
| kind | `openapi` |
| url / schema_url | `https://grafana.tplr.ai/public/openapi3.json` |
| provider | `one-covenant` |
| provenance | Public Swagger UI at `grafana.tplr.ai/swagger`; Templar README Grafana link; Crusades logging references `grafana.tplr.ai` |

## Research notes

- Crusades FastAPI (`one-covenant/crusades`) auto-generates `/openapi.json` only when a validator runs the API locally; no public hosted Crusades tournament API URL was found.
- `www.tplr.ai/tournament/openapi.json` is an SPA catch-all (HTML), not machine-readable JSON.
- Grafana serves verified OpenAPI 3.0.3 + Swagger 2.0 specs at `public/openapi3.json` and `public/api-merged.json`.

## Registry safety

- [x] Single file: `registry/subnets/templar.json` only (append-only)
- [x] `authority: community`, `review.state: community-submitted`
- [x] `public_safe: true`, `auth_required: false`
- [x] Local `validate:surface` + `scan:public-safety` passed

## Test plan

- [x] `npx prettier --check registry/subnets/templar.json`
- [x] `npm run validate:surface -- --file registry/subnets/templar.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/templar.json`
- [ ] CI + Gittensory review gate
