### PR TITLE
feat(ui): surface per-subnet validator/registration turnover scorecard

### DIFF
--- a/apps/ui/src/components/metagraphed/turnover-panel.tsx
+++ b/apps/ui/src/components/metagraphed/turnover-panel.tsx
@@ -1,0 +1,99 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { UserPlus, UserMinus, RefreshCw, Users, ShieldCheck } from "lucide-react";
+import { subnetTurnoverQuery } from "@/lib/metagraphed/queries";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { TableState } from "@/components/metagraphed/table-state";
+import { formatNumber } from "@/lib/metagraphed/format";
+
+function pctStr(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+// Higher retention/stability is better; a churned-away set reads as "down".
+function retentionTone(v?: number | null): "ok" | "warn" | "down" | "default" {
+  if (v == null) return "default";
+  if (v >= 0.9) return "ok";
+  if (v >= 0.7) return "warn";
+  return "down";
+}
+
+function stabilityTone(score?: number | null): "ok" | "warn" | "down" | "default" {
+  if (score == null) return "default";
+  if (score >= 90) return "ok";
+  if (score >= 70) return "warn";
+  return "down";
+}
+
+/**
+ * Validator-set & registration turnover scorecard for one subnet (#3343): how
+ * much the validator set and neuron population rotated across the selected
+ * window's start/end neuron_daily snapshots. `comparable: false` (cold store
+ * or single-snapshot window) renders the non-comparable empty state instead of
+ * zeroed tiles that would read as flawless retention.
+ */
+export function TurnoverLoader({ netuid }: { netuid: number }) {
+  const { data } = useSuspenseQuery(subnetTurnoverQuery(netuid));
+  const meta = data.meta;
+  const t = data.data;
+
+  if (!t.comparable) {
+    return (
+      <TableState
+        variant="empty"
+        title="Not enough history to compare"
+        description="Validator-set and registration turnover is computed by diffing the window's start and end metagraph snapshots. This will appear once at least two daily snapshots have been captured."
+        generatedAt={meta?.generated_at}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StatTile
+          icon={ShieldCheck}
+          eyebrow="Stability score"
+          value={t.stability_score ?? "—"}
+          hint="/ 100"
+          tone={stabilityTone(t.stability_score)}
+        />
+        <StatTile
+          icon={RefreshCw}
+          eyebrow="Validator retention"
+          value={pctStr(t.validator_retention)}
+          hint={`${formatNumber(t.validators_start)} → ${formatNumber(t.validators_end)}`}
+          tone={retentionTone(t.validator_retention)}
+        />
+        <StatTile
+          icon={RefreshCw}
+          eyebrow="Neuron retention"
+          value={pctStr(t.neuron_retention)}
+          hint={`${formatNumber(t.neurons_start)} → ${formatNumber(t.neurons_end)}`}
+          tone={retentionTone(t.neuron_retention)}
+        />
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Validators entered"
+          value={formatNumber(t.validators_entered)}
+        />
+        <StatTile
+          icon={UserMinus}
+          eyebrow="Validators exited"
+          value={formatNumber(t.validators_exited)}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="UIDs deregistered"
+          value={formatNumber(t.uids_deregistered)}
+        />
+      </div>
+      {t.start_date && t.end_date ? (
+        <p className="font-mono text-[11px] text-ink-muted">
+          Compared {t.start_date} → {t.end_date}
+          {t.window ? ` (${t.window})` : ""}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-turnover.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-turnover.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetTurnover, subnetTurnoverQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/turnover",
+  });
+}
+
+async function runQuery(netuid: number, window?: string) {
+  const opts = subnetTurnoverQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetTurnover", () => {
+  it("passes a well-formed comparable card through", () => {
+    expect(
+      normalizeSubnetTurnover(7, {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        start_date: "2026-06-01",
+        end_date: "2026-07-01",
+        comparable: true,
+        validators_start: 10,
+        validators_end: 9,
+        validators_entered: 1,
+        validators_exited: 2,
+        validator_retention: 0.8,
+        neurons_start: 256,
+        neurons_end: 250,
+        uids_deregistered: 6,
+        neuron_retention: 0.97,
+        stability_score: 88,
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      window: "30d",
+      start_date: "2026-06-01",
+      end_date: "2026-07-01",
+      comparable: true,
+      validators_start: 10,
+      validators_end: 9,
+      validators_entered: 1,
+      validators_exited: 2,
+      validator_retention: 0.8,
+      neurons_start: 256,
+      neurons_end: 250,
+      uids_deregistered: 6,
+      neuron_retention: 0.97,
+      stability_score: 88,
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable, non-comparable card", () => {
+    for (const raw of [{}, null, "x", { validators_start: "nope" }]) {
+      const card = normalizeSubnetTurnover(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.comparable).toBe(false);
+      expect(card.validators_start).toBe(0);
+      expect(card.validators_end).toBe(0);
+      expect(card.validator_retention).toBeNull();
+      expect(card.neuron_retention).toBeNull();
+      expect(card.stability_score).toBeNull();
+      expect(card.start_date).toBeNull();
+      expect(card.end_date).toBeNull();
+    }
+  });
+
+  it("never treats a non-boolean comparable value as true", () => {
+    const card = normalizeSubnetTurnover(7, { comparable: 1, validators_start: 4 });
+    expect(card.comparable).toBe(false);
+    expect(card.validators_start).toBe(4);
+  });
+});
+
+describe("subnetTurnoverQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes the card", async () => {
+    resolveWith({ netuid: 7, window: "7d", comparable: true, stability_score: 95 });
+    const res = await runQuery(7, "7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/turnover",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data.stability_score).toBe(95);
+    expect(res.data.comparable).toBe(true);
+  });
+
+  it("defaults to the 30d window", async () => {
+    resolveWith({});
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/turnover",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -125,6 +125,7 @@ import type {
   SubnetWeightSetter,
   SubnetWeightSetters,
   SubnetWeights,
+  SubnetTurnover,
   SubnetIdentityHistoryEntry,
   SubnetNeuronHistory,
   SubnetNeuronHistoryPoint,
@@ -3746,6 +3747,48 @@ export const subnetWeightsQuery = (netuid: number, window = "30d") =>
       });
       return {
         data: normalizeSubnetWeights(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Per-subnet validator-set & registration turnover (churn) scorecard: diffs the
+// window's start/end neuron_daily snapshots. `comparable: false` on a cold store
+// or single-snapshot window — ratio/score fields stay null rather than zeroed.
+export function normalizeSubnetTurnover(netuid: number, raw: unknown): SubnetTurnover {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    start_date: firstString(rec.start_date) ?? null,
+    end_date: firstString(rec.end_date) ?? null,
+    comparable: rec.comparable === true,
+    validators_start: firstFiniteNumber(rec.validators_start) ?? 0,
+    validators_end: firstFiniteNumber(rec.validators_end) ?? 0,
+    validators_entered: firstFiniteNumber(rec.validators_entered) ?? 0,
+    validators_exited: firstFiniteNumber(rec.validators_exited) ?? 0,
+    validator_retention: firstFiniteNumber(rec.validator_retention) ?? null,
+    neurons_start: firstFiniteNumber(rec.neurons_start) ?? 0,
+    neurons_end: firstFiniteNumber(rec.neurons_end) ?? 0,
+    uids_deregistered: firstFiniteNumber(rec.uids_deregistered) ?? 0,
+    neuron_retention: firstFiniteNumber(rec.neuron_retention) ?? null,
+    stability_score: firstFiniteNumber(rec.stability_score) ?? null,
+  };
+}
+
+export const subnetTurnoverQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-turnover", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetTurnover>>(`/api/v1/subnets/${netuid}/turnover`, {
+        params: { window },
+        signal,
+      });
+      return {
+        data: normalizeSubnetTurnover(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1471,6 +1471,32 @@ export interface SubnetDeregistrations {
   deregistrations_per_hotkey: number | null;
 }
 
+/**
+ * Validator-set & registration turnover scorecard for one subnet, from
+ * /api/v1/subnets/{netuid}/turnover — diffs the window's start/end
+ * `neuron_daily` snapshots. `comparable: false` on a cold store or a
+ * single-snapshot window; the ratio/score fields are null in that case, not
+ * zeroed (a zero would read as flawless retention).
+ */
+export interface SubnetTurnover {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  comparable: boolean;
+  validators_start: number;
+  validators_end: number;
+  validators_entered: number;
+  validators_exited: number;
+  validator_retention: number | null;
+  neurons_start: number;
+  neurons_end: number;
+  uids_deregistered: number;
+  neuron_retention: number | null;
+  stability_score: number | null;
+}
+
 /** One daily per-UID snapshot from /subnets/{n}/neurons/{uid}/history. */
 export interface SubnetNeuronHistoryPoint {
   snapshot_date: string;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -30,6 +30,7 @@ import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
 import { YieldLoader } from "@/components/metagraphed/yield-panel";
+import { TurnoverLoader } from "@/components/metagraphed/turnover-panel";
 import { NeuronDetailCard } from "@/components/metagraphed/neuron-detail-card";
 import { NeuronHistoryChart } from "@/components/metagraphed/neuron-history-chart";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
@@ -166,6 +167,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   neuron: "metagraph",
   concentration: "metagraph",
   yield: "metagraph",
+  turnover: "metagraph",
   validators: "validators",
   services: "services",
   "agent-readiness": "services",
@@ -833,6 +835,20 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-48 w-full" />}>
             <YieldLoader netuid={netuid} />
+          </Suspense>
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="turnover"
+        title="Turnover"
+        subtitle="Validator-set and registration churn: entered/exited validators, deregistered UIDs, retention, and a stability score across the window."
+        info="GET /api/v1/subnets/{netuid}/turnover — diffs the window's start/end metagraph snapshots into a validator-set + registration-churn scorecard."
+        tone="muted"
+      >
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+            <TurnoverLoader netuid={netuid} />
           </Suspense>
         </QueryErrorBoundary>
       </SectionAnchor>


### PR DESCRIPTION
## Summary

- Adds `subnetTurnoverQuery` / `normalizeSubnetTurnover` (`apps/ui/src/lib/metagraphed/queries.ts`) and a `SubnetTurnover` type (`apps/ui/src/lib/metagraphed/types.ts`) for `GET /api/v1/subnets/{netuid}/turnover`, following the existing `subnetWeightsQuery`/`SubnetWeights` pattern.
- Adds a new `TurnoverLoader` component (`apps/ui/src/components/metagraphed/turnover-panel.tsx`) rendering a validator-set/registration turnover scorecard: stability score, validator/neuron retention, validators entered/exited, and UIDs deregistered.
- Wires a new `SectionAnchor id="turnover"` into `MetagraphPanel` (`apps/ui/src/routes/subnets.$netuid.tsx`), registered in `SECTION_TO_TAB` for hash deep-linking.
- Renders the non-comparable empty state (via `TableState`) instead of zeroed tiles when `comparable === false` (cold store / single-snapshot window), so a churned subnet never reads as flawlessly retained.

## What Changed

- `apps/ui/src/lib/metagraphed/types.ts`: new `SubnetTurnover` interface.
- `apps/ui/src/lib/metagraphed/queries.ts`: new `normalizeSubnetTurnover` + `subnetTurnoverQuery`.
- `apps/ui/src/lib/metagraphed/queries.subnet-turnover.test.ts`: unit tests for both (normalize edge cases + query param/default coverage), mirroring `queries.subnet-weights.test.ts`.
- `apps/ui/src/components/metagraphed/turnover-panel.tsx`: new `TurnoverLoader` component.
- `apps/ui/src/routes/subnets.$netuid.tsx`: new `turnover` `SectionAnchor` + `SECTION_TO_TAB` entry.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/turnover-panel-after-mobile-dark.png)<br><sub>after</sub> |

Captured against subnet 64 (real production data, `https://api.metagraph.sh`) at fixed viewports (375×812 / 768×1024 / 1280×800), theme forced via `localStorage.setItem("mg-theme", ...)` + reload per the repo's screenshot contract.

## Validation

- [x] `npm run lint --workspace=apps/ui` / `npm run format:check --workspace=apps/ui` (clean on touched files; pre-existing CRLF noise repo-wide is a local-checkout artifact, not from this diff)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (509 tests passing, incl. 5 new for `normalizeSubnetTurnover`/`subnetTurnoverQuery`)
- [x] `npm run build --workspace=apps/ui`

Closes #3343
