### PR TITLE
feat(registry): add SN101 eni task-server subnet-api surface (#4129)

### DIFF
--- a/registry/providers/tag101.json
+++ b/registry/providers/tag101.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/tag101-ai/tag101",
+  "id": "tag101",
+  "kind": "subnet-team",
+  "name": "Tag101",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://tag101.ai/"
+}

--- a/registry/subnets/eni.json
+++ b/registry/subnets/eni.json
@@ -1,21 +1,6 @@
 {
-  "schema_version": 1,
-  "netuid": 101,
-  "name": "eni",
-  "slug": "eni",
-  "status": "active",
   "categories": ["baseline-curated", "identity-reviewed"],
-  "source_repo": "https://github.com/tag101-ai/tag101",
-  "website_url": "http://tag101.ai/",
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN101 eni. Public directories list the subnet, but no official website, source repository, API, OpenAPI schema, or docs site has been verified.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "No verified official website yet.",
       "No verified live source repository yet.",
@@ -24,7 +9,43 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
-  "surfaces": []
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "eni",
+  "netuid": 101,
+  "notes": "Reviewed overlay for SN101 eni. Public directories list the subnet, but no official website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "schema_version": 1,
+  "slug": "eni",
+  "source_repo": "https://github.com/tag101-ai/tag101",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-101-tag101-subnet-api",
+      "kind": "subnet-api",
+      "name": "eni task-server API",
+      "notes": "Official reference task-server the validator/miner stack talks to (README: \"Validators retrieve posts from the database via API\"). Hardcoded as DEFAULT_TASK_SERVER_URL in chain/settings.py and overridable via --task-server.url/TASK_SERVER_URL. Live and routed (GET / -> 404 JSON; GET on the known POST routes -> 405, confirming the routes exist) but every functional endpoint (/tasks/lease, /tasks/report, /scoreboards, /scoreboards/latest, /miners/axon, /miners/axons per tasks/framework/client.py) requires a wallet-hotkey-signed JSON body, so there is no plain no-auth GET surface on this host.",
+      "provider": "tag101",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsdevninja"
+      },
+      "source_urls": [
+        "https://github.com/tag101-ai/tag101/blob/main/chain/settings.py",
+        "https://github.com/tag101-ai/tag101/blob/main/tasks/framework/client.py",
+        "https://github.com/tag101-ai/tag101/blob/main/README.md"
+      ],
+      "url": "https://crawler.tag101.ai/"
+    }
+  ],
+  "website_url": "http://tag101.ai/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends a surface to exactly one subnet manifest — `registry/subnets/eni.json` — plus a debut `registry/providers/tag101.json` for the previously-unregistered provider slug.

## Surface

- Netuid: 101
- Kind: subnet-api
- Public URL: https://crawler.tag101.ai/
- Source URL (proves the claim):
  - https://github.com/tag101-ai/tag101/blob/main/chain/settings.py (`DEFAULT_TASK_SERVER_URL = "https://crawler.tag101.ai"`, the default `--task-server.url`)
  - https://github.com/tag101-ai/tag101/blob/main/tasks/framework/client.py (the `TaskServerClient` calling `/tasks/lease`, `/tasks/report`, `/scoreboards`, `/scoreboards/latest`, `/miners/axon`, `/miners/axons` on that host)
  - https://github.com/tag101-ai/tag101/blob/main/README.md ("Validators retrieve posts from the database via API")
- Provider slug: tag101 (debut — scaffolded `registry/providers/tag101.json`, not previously registered)

## Notes

SN101 (eni) had no public surfaces registered. Its GitHub org (`tag101-ai/tag101`) has a single repo with no `/docs`/API-doc site, and the on-chain `website_url` (`tag101.ai`) currently times out, so this PR focuses on the one surface the official code actually proves: the reference task-server every validator/miner talks to.

`https://crawler.tag101.ai` is live — `GET /` returns a JSON `404` and `GET` on each of the six routes above returns `405` (confirming the routes exist and only accept `POST`), but every one of them requires a wallet-hotkey-signed JSON body (see the `Signed*Request`/`Signed*Snapshot` models in `tasks/framework/client.py`), so there is no plain no-auth `GET` on this host. It's submitted with `auth_required: true` accordingly — per the surface template, authenticated surfaces route to manual review rather than auto-merge, which is the correct/expected outcome here rather than a claim of no-auth access.

Closes #4129

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest (optionally plus one `registry/providers/*.json` for a debut provider).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and resolves; the `source_url`s independently prove the subnet publishes/uses it.
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs — `auth` is not filled with any credential, only a boolean flag.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #4129`).

## Gate Expectations

This is an authenticated surface (every functional endpoint requires a wallet-hotkey-signed body), so per the template it's expected to route to manual review rather than auto-merge.

## Validation

- [x] `npm run validate:surface -- registry/subnets/eni.json`
- [x] `npm run scan:public-safety`