### PR TITLE
feat(registry): add SN124 Swarm king-of-the-hill data-artifact surface

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -1,17 +1,19 @@
 {
-  "schema_version": 1,
-  "netuid": 124,
-  "name": "Swarm",
-  "slug": "sn-124",
-  "status": "active",
   "categories": [],
+  "contact": "admin@swarm124.com",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "Swarm",
+  "netuid": 124,
+  "schema_version": 1,
+  "slug": "sn-124",
   "social": {
     "x": "https://x.com/swarmsubnet"
   },
+  "source_repo": "https://github.com/swarm-subnet/swarm",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -32,9 +34,25 @@
         "https://github.com/swarm-subnet/swarm/blob/main/docs/miner.md"
       ],
       "url": "https://api.swarm124.com/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-124-swarm-data-artifact",
+      "kind": "data-artifact",
+      "name": "Swarm king-of-the-hill active window",
+      "notes": "Public no-auth GET /kings/active on api.swarm124.com returning the live \"king of the hill\" leaderboard window (per-lineage uid, hotkey, coldkey, github_url, score, share, rank). docs/king_of_the_hill.md documents this route as public on the same SWARM_BACKEND_API_URL host as the existing health surface (observed live: 10-entry active window with real scores/ranks).",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/docs/king_of_the_hill.md"
+      ],
+      "url": "https://api.swarm124.com/kings/active"
     }
   ],
-  "source_repo": "https://github.com/swarm-subnet/swarm",
-  "website_url": "https://www.swarm124.com/",
-  "contact": "admin@swarm124.com"
+  "website_url": "https://www.swarm124.com/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one surface to the existing `registry/subnets/swarm.json` manifest.

Closes #4176

## Surface

- Netuid: 124
- Kind: data-artifact
- Public URL: https://api.swarm124.com/kings/active
- Source URL (proves the claim): https://github.com/swarm-subnet/swarm/blob/main/docs/king_of_the_hill.md
- Provider slug: swarm

## What it is

`GET /kings/active` on `api.swarm124.com` — the same official backend host already documented in this file's existing `sn-124-swarm-health` surface (via `SWARM_BACKEND_API_URL` in the official CLI/validator client) — returns the live "king of the hill" leaderboard window: per-lineage `uid`, `hotkey`, `coldkey`, `github_url`, `score`, `share`, and `rank`. `docs/king_of_the_hill.md` in the official `swarm-subnet/swarm` repo states verbatim: "The live window and a diagnostics snapshot ... are public at `/kings/active` and `/kings/diagnostics`." Verified live and reachable at submission time (10-entry active window with real scores/ranks/GitHub links), no auth required.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (official repo docs) independently proves the subnet publishes it, and documents the exact route by name.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards.
- [x] Does not duplicate the existing `sn-124-swarm-health` surface (different route, different kind: `subnet-api` health check vs. this `data-artifact` leaderboard).
- [x] Links a tracked issue that is still OPEN: Closes #4176.

## Validation

- [x] `npm run validate:surface -- registry/subnets/swarm.json` — "Surface validation passed: 2 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."

## Issue Link

Closes #4176