### PR TITLE
feat(registry): add SN120 Affine current-champion-rank data-artifact surface

### DIFF
--- a/registry/subnets/affine.json
+++ b/registry/subnets/affine.json
@@ -1,14 +1,15 @@
 {
-  "schema_version": 1,
-  "netuid": 120,
-  "name": "Affine",
-  "slug": "sn-120",
-  "status": "active",
   "categories": [],
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "Affine",
+  "netuid": 120,
+  "schema_version": 1,
+  "slug": "sn-120",
+  "source_repo": "https://github.com/AffineFoundation/affine-cortex",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -49,8 +50,23 @@
         "https://github.com/AffineFoundation/affine-cortex/blob/main/affine/utils/api_client.py"
       ],
       "url": "https://api.affine.io/api/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-data-artifact",
+      "kind": "data-artifact",
+      "name": "Affine current champion rank",
+      "notes": "Public no-auth GET /api/v1/rank/current on api.affine.io returning the current champion window (model reference, revision, since-block) plus past champions with their emission share. Documented as GET /api/v1/rank/current in the subnet's own OpenAPI 3.1 schema (already-registered sn-120-affine-openapi surface); same api.affine.io host as the existing health surface. Observed live and populated at submission time.",
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": ["https://api.affine.io/openapi.json"],
+      "url": "https://api.affine.io/api/v1/rank/current"
     }
   ],
-  "source_repo": "https://github.com/AffineFoundation/affine-cortex",
   "website_url": "https://www.affine.io/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one surface to the existing `registry/subnets/affine.json` manifest.

Closes #4169

## Surface

- Netuid: 120
- Kind: data-artifact
- Public URL: https://api.affine.io/api/v1/rank/current
- Source URL (proves the claim): https://api.affine.io/openapi.json
- Provider slug: affine

## What it is

`GET /api/v1/rank/current` on `api.affine.io` — the same official backend host already documented in this file's existing `sn-120-affine-openapi` and `sn-120-affine-health` surfaces — returns the current champion window (model reference, revision, since-block) plus past champions with their emission share. The route is documented (`/api/v1/rank/current`) directly in the subnet's own OpenAPI 3.1 schema, already registered as `sn-120-affine-openapi` in this same file — i.e. the operator's own machine-readable API contract is the proof. Verified live and populated at submission time, no auth required.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (the operator's own OpenAPI schema, already a registered surface in this file) independently documents this exact route.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards.
- [x] Does not duplicate the existing `openapi` or `subnet-api` (health) surfaces — different route, different kind (a live ranking/data feed, not the schema or a liveness check).
- [x] Links a tracked issue that is still OPEN: Closes #4169.

## Validation

- [x] `npm run validate:surface -- registry/subnets/affine.json` — "Surface validation passed: 3 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."

## Issue Link

Closes #4169