### PR TITLE
feat(registry): add SN102 ConnitoAI previous-phase-blocks data-artifact surface

### DIFF
--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -1,69 +1,72 @@
 {
-  "schema_version": 1,
-  "netuid": 102,
-  "name": "ConnitoAI",
-  "slug": "sn-102",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/Connito-AI/Connito",
-  "dashboard_url": "https://taomarketcap.com/subnets/102",
-  "website_url": "https://connito.ai/",
-  "notes": "Reviewed overlay for SN102 using the official ConnitoAI website and source repository. The previously discovered miner docs URL currently returns 404 and is not promoted.",
+  "contact": "isabella@connito.ai",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "Previously discovered Connito miner docs URL currently returns 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:50:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/102",
+  "name": "ConnitoAI",
+  "netuid": 102,
+  "notes": "Reviewed overlay for SN102 using the official ConnitoAI website and source repository. The previously discovered miner docs URL currently returns 404 and is not promoted.",
+  "schema_version": 1,
+  "slug": "sn-102",
+  "social": {
+    "x": "https://x.com/connitoai"
+  },
+  "source_repo": "https://github.com/Connito-AI/Connito",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-102-connito-website",
-      "name": "ConnitoAI website",
-      "kind": "website",
-      "url": "https://connito.ai/",
-      "provider": "connito",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "id": "sn-102-connito-website",
+      "kind": "website",
+      "name": "ConnitoAI website",
+      "notes": "Official ConnitoAI website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official ConnitoAI website."
+      "provider": "connito",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "url": "https://connito.ai/"
     },
     {
-      "id": "sn-102-connito-source",
-      "name": "ConnitoAI source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Connito-AI/Connito",
-      "provider": "connito",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "id": "sn-102-connito-source",
+      "kind": "source-repo",
+      "name": "ConnitoAI source repository",
+      "notes": "Official ConnitoAI source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official ConnitoAI source repository."
+      "provider": "connito",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "url": "https://github.com/Connito-AI/Connito"
     },
     {
       "auth_required": false,
@@ -108,10 +111,24 @@
         "https://connito.ai/docs/reference/sn-owner-api"
       ],
       "url": "https://cycle-api.connito.ai/get_phase"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-data-artifact",
+      "kind": "data-artifact",
+      "name": "ConnitoAI previous phase block ranges",
+      "notes": "Public no-auth GET /previous_phase_blocks on cycle-api.connito.ai returning the block-height range of each named phase (Distribute, Train, MinerCommit1/2, Submission, Validate, Merge, ValidatorCommit1/2) in the prior training cycle. Documented in the subnet's own OpenAPI schema (already-registered sn-102-connito-phase-openapi surface); same cycle-api.connito.ai host as the existing /get_phase surface.",
+      "provider": "connito",
+      "public_safe": true,
+      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is on the official phase-oracle host queried by miners and validators.",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": ["https://cycle-api.connito.ai/openapi.json"],
+      "url": "https://cycle-api.connito.ai/previous_phase_blocks"
     }
   ],
-  "social": {
-    "x": "https://x.com/connitoai"
-  },
-  "contact": "isabella@connito.ai"
+  "website_url": "https://connito.ai/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one surface to the existing `registry/subnets/connitoai.json` manifest.

Closes #4132

## Surface

- Netuid: 102
- Kind: data-artifact
- Public URL: https://cycle-api.connito.ai/previous_phase_blocks
- Source URL (proves the claim): https://cycle-api.connito.ai/openapi.json
- Provider slug: connito

## What it is

`GET /previous_phase_blocks` on `cycle-api.connito.ai` — the same official phase-oracle host already documented in this file's existing `sn-102-connito-phase-openapi` and `sn-102-connito-phase-get-phase` surfaces — returns the block-height range of each named training-cycle phase (Distribute, Train, MinerCommit1/2, Submission, Validate, Merge, ValidatorCommit1/2) from the prior cycle. The route is one of the no-auth cycle-coordination routes the subnet's own OpenAPI schema documents (already a registered surface in this same file). Verified live and populated at submission time, no auth required.

Note on diff size: this PR was generated with `npm run surface:add -- --write`, which serializes the whole subnet file through the repo's canonical `stableStringify` writer (alphabetically-sorted keys). Two of this file's pre-existing surfaces (`website`, `source-repo`) predate that canonicalization and were still in their original key order, so this run normalized them too — no content changed on any existing field, only key ordering/whitespace on entries this same tool already writes in canonical form elsewhere in the file (the `openapi` and `get_phase` surfaces were already canonical). `git diff` confirms zero value changes outside the one new surface object.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only — one new surface object; pre-existing surfaces re-serialized in canonical key order by the official write tool, no field values changed).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (the operator's own OpenAPI schema, already a registered surface in this file) independently documents cycle-coordination routes on this exact host.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards.
- [x] Does not duplicate the existing `openapi` or `subnet-api` (get_phase) surfaces — different route, different kind (historical phase block-ranges, not the schema or the current-phase oracle).
- [x] Links a tracked issue that is still OPEN: Closes #4132.

## Validation

- [x] `npm run validate:surface -- registry/subnets/connitoai.json` — "Surface validation passed: 5 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."
- [x] `npx prettier --check registry/subnets/connitoai.json` — clean

## Issue Link

Closes #4132