### PR TITLE
fix(ui): reflow subnet masthead stat grid with flex-wrap

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -405,8 +405,12 @@ export function SubnetMasthead({
         </div>
       </div>
 
-      {/* Stat spine — sparkline-bearing tiles. Auto-wrap on narrow widths. */}
-      <div className="mt-5 grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] divide-x divide-border rounded-xl border border-border bg-card overflow-hidden">
+      {/* Stat spine — sparkline-bearing tiles. Flex-wrap (not grid) so a
+          trailing partial row's tiles stretch to fill the row instead of
+          leaving empty column slots — grid tracks are shared across every
+          row, but flex lines size independently (same pattern as the
+          flex-wrap strip in operational-panel.tsx). */}
+      <div className="mt-5 flex flex-wrap divide-x divide-border rounded-xl border border-border bg-card overflow-hidden [&>*]:grow [&>*]:basis-[150px] [&>*]:min-w-[150px]">
         <StatWithSpark
           label="Netuid"
           value={String(netuid).padStart(3, "0")}


### PR DESCRIPTION
## Summary

- The subnet masthead's stat spine (`apps/ui/src/components/metagraphed/subnet-masthead.tsx`) used a CSS Grid with `grid-cols-[repeat(auto-fit,minmax(150px,1fr))]`. Grid tracks are shared across every row, so once tile count isn't a clean multiple of the fitted column count, the trailing row's tiles sit flush left with empty column slots trailing off to the right (visible now at 9 tiles: Latency P50 / Completeness / Evidence left alone in row 2).
- Switched the container to `flex flex-wrap` with each tile given `grow basis-[150px] min-w-[150px]` (applied via the `[&>*]:` child selector so no per-tile call site needed editing). Flexbox sizes each wrapped line independently, so a trailing partial row's tiles stretch to fill the row instead of leaving empty space — the same pattern already used for the single-tile flex-wrap strip in `operational-panel.tsx`.
- No tiles were removed or reordered; this is a pure layout/CSS change confined to the one file.

## Template Used

- Frontend (`apps/ui/`) — no visual layout change beyond this file; not a registry surface, provider profile, or backend/schema change, so none of the four registry PR templates apply.

## Screenshots (desktop + tablet, light + dark, before/after)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-desktop-light.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-desktop-light.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-desktop-dark.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-desktop-dark.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-tablet-light.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-tablet-light.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-tablet-dark.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-tablet-dark.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/masthead-grid-reflow-after-tablet-dark.png)<br><sub>after</sub> |

Captured against SN1's live masthead (9 tiles, the same count called out in the issue) with two separate dev servers (`before` = `git merge-base main HEAD`, `after` = this branch), fixed viewports (no `fullPage`), and `mg-theme` forced + reloaded per the repo's screenshot contract.

## Validation

- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (511 passed)
- [x] `npm run build --workspace=apps/ui`
- [x] `npx prettier --check` on the changed file
- [x] Manually verified in-browser at desktop/tablet, light/dark (see screenshots above)

## Non-goals

- No masthead tiles were removed or reordered.
- Did not touch the sibling economics-panel grid — no such component exists in the repo yet to make consistent with.

Closes #3991
