### PR TITLE
feat(registry): add SN102 ConnitoAI previous-phase-blocks data-artifact surface

### DIFF
--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -108,6 +108,23 @@
         "https://connito.ai/docs/reference/sn-owner-api"
       ],
       "url": "https://cycle-api.connito.ai/get_phase"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-data-artifact",
+      "kind": "data-artifact",
+      "name": "ConnitoAI previous phase block ranges",
+      "notes": "Public no-auth GET /previous_phase_blocks on cycle-api.connito.ai returning the block-height range of each named phase (Distribute, Train, MinerCommit1/2, Submission, Validate, Merge, ValidatorCommit1/2) in the prior training cycle. Documented in the subnet's own OpenAPI schema (already-registered sn-102-connito-phase-openapi surface); same cycle-api.connito.ai host as the existing /get_phase surface.",
+      "provider": "connito",
+      "public_safe": true,
+      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is on the official phase-oracle host queried by miners and validators.",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": ["https://cycle-api.connito.ai/openapi.json"],
+      "url": "https://cycle-api.connito.ai/previous_phase_blocks"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one new surface object to the existing `registry/subnets/connitoai.json` manifest. No other lines in the file are touched.

Closes #4132

## Surface

- Netuid: 102
- Kind: data-artifact
- Public URL: https://cycle-api.connito.ai/previous_phase_blocks
- Source URL (proves the claim): https://cycle-api.connito.ai/openapi.json
- Provider slug: connito

## What it is

`GET /previous_phase_blocks` on `cycle-api.connito.ai` — the same official phase-oracle host already documented in this file's existing `sn-102-connito-phase-openapi` and `sn-102-connito-phase-get-phase` surfaces — returns the block-height range of each named training-cycle phase (Distribute, Train, MinerCommit1/2, Submission, Validate, Merge, ValidatorCommit1/2) from the prior cycle. The route is one of the no-auth cycle-coordination routes the subnet's own OpenAPI schema documents (already a registered surface in this same file). Verified live and populated at submission time, no auth required.

(Resubmission of #4208, which the gate closed for a false-positive "duplicate entry" flag — that PR ran the full `stableStringify` canonical writer over the whole file, which re-serialized two older pre-existing surfaces in sorted key order with no content change; the reviewer's diff-based duplicate check apparently read those reformatted-but-identical lines as new/duplicate additions. This version is a strictly append-only 17-line diff — the two older surfaces are completely untouched.)

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file — append-only, one new surface object, zero other lines touched.
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (the operator's own OpenAPI schema, already a registered surface in this file) independently documents cycle-coordination routes on this exact host.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards.
- [x] Does not duplicate the existing `openapi` or `subnet-api` (get_phase) surfaces, or the `website`/`source-repo` surfaces — different route, different kind, and this diff doesn't touch any of them.
- [x] Links a tracked issue that is still OPEN: Closes #4132.

## Validation

- [x] `npm run validate:surface -- registry/subnets/connitoai.json` — "Surface validation passed: 5 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."
- [x] `git diff --stat` — confirms exactly 17 lines added, 0 removed, 0 modified elsewhere in the file.

## Issue Link

Closes #4132