### PR TITLE
feat(registry): add SN105 Beam orchestrator UID-range data-artifact surface

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -52,6 +52,22 @@
         "https://github.com/Beam-Network/beam/blob/main/README.md"
       ],
       "url": "https://beamcore.b1m.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-uid-ranges",
+      "kind": "data-artifact",
+      "name": "BeamCore orchestrator UID range config",
+      "notes": "Public no-auth GET /config/uid-ranges on beamcore.b1m.ai returning the public orchestrator UID window (public_orchestrator_uid_start, public_orchestrator_uid_end, max_orchestrators). Documented as a route in the subnet's own OpenAPI schema (already-registered sn-105-beam-openapi surface); same beamcore.b1m.ai host as the existing health surface.",
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/config/uid-ranges"
     }
   ],
   "source_repo": null,


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one new surface object to the existing `registry/subnets/beam.json` manifest. No other lines in the file are touched.

Closes #4138

## Surface

- Netuid: 105
- Kind: data-artifact
- Public URL: https://beamcore.b1m.ai/config/uid-ranges
- Source URL (proves the claim): https://beamcore.b1m.ai/openapi.json
- Provider slug: beam

## What it is

`GET /config/uid-ranges` on `beamcore.b1m.ai` — the same official BeamCore control-plane host already documented in this file's existing `sn-105-beam-openapi` and `sn-105-beam-health` surfaces — returns the public orchestrator UID window (`public_orchestrator_uid_start`, `public_orchestrator_uid_end`, `max_orchestrators`). The route is documented directly in the subnet's own OpenAPI schema, already a registered surface in this same file. Verified live and populated at submission time, no auth required.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file — append-only, one new surface object, zero other lines touched (verified via `git diff --stat`: 16 insertions, 0 deletions).
- [x] Generated matching the same schema/style as this file's existing community surfaces — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (the operator's own OpenAPI schema, already a registered surface in this file) independently documents this exact route.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards.
- [x] Does not duplicate the existing `openapi` or `subnet-api` (health) surfaces — different route, different kind, and this diff doesn't touch either of them.
- [x] Links a tracked issue that is still OPEN: Closes #4138.

## Validation

- [x] `npm run validate:surface -- registry/subnets/beam.json` — "Surface validation passed: 3 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."
- [x] `git diff --stat` — confirms exactly 16 lines added, 0 removed, 0 modified elsewhere in the file.

## Issue Link

Closes #4138