### PR TITLE
feat(registry): add SN99 Leoma network score summary data-artifact surface

### DIFF
--- a/registry/subnets/leoma.json
+++ b/registry/subnets/leoma.json
@@ -34,6 +34,22 @@
         "https://api.leoma.ai/openapi.json"
       ],
       "url": "https://api.leoma.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-scores-stats",
+      "kind": "data-artifact",
+      "name": "Leoma network score summary",
+      "notes": "Public no-auth GET /scores/stats on api.leoma.ai returning network-wide aggregate counters (total_validators, total_miners, total_samples, total_score_entries, overall_pass_rate). Documented as a route in the subnet's own OpenAPI schema (api.leoma.ai/openapi.json, already cited as a source for the existing health surface); same api.leoma.ai host.",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/scores/stats"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one new surface object to the existing `registry/subnets/leoma.json` manifest. No other lines in the file are touched.

Closes #4127

## Surface

- Netuid: 99
- Kind: data-artifact
- Public URL: https://api.leoma.ai/scores/stats
- Source URL (proves the claim): https://api.leoma.ai/openapi.json
- Provider slug: leoma

## What it is

`GET /scores/stats` on `api.leoma.ai` — the same official host already documented in this file's existing `sn-99-leoma-health` surface — returns network-wide aggregate counters: `total_validators`, `total_miners`, `total_samples`, `total_score_entries`, `overall_pass_rate`. The route is documented directly in the subnet's own OpenAPI schema (`api.leoma.ai/openapi.json`), already cited as a source for the existing health surface in this same file. Verified live and populated at submission time (3 validators, 4 miners, 71223 samples observed), no auth required.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file — append-only, one new surface object, zero other lines touched (verified via `git diff --stat`: 16 insertions, 0 deletions).
- [x] `authority: community`, `review.state: community-submitted`, matching this file's existing community surface style.
- [x] The `url` is public and safe for read-only probes; the `source_url` (the operator's own OpenAPI schema, already referenced by this file's existing surface) independently documents this exact route.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards. The response carries only aggregate counters — no hotkeys, coldkeys, or per-miner identifiers.
- [x] Does not duplicate the existing `subnet-api` (health) surface — different route, different kind.
- [x] Links a tracked issue that is still OPEN: Closes #4127.

## Validation

- [x] `npm run validate:surface -- registry/subnets/leoma.json` — "Surface validation passed: 2 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."
- [x] `git diff --stat` — confirms exactly 16 lines added, 0 removed, 0 modified elsewhere in the file.

## Issue Link

Closes #4127