### PR TITLE
feat(registry): add SN71 Leadpoet country reference list data-artifact surface

### DIFF
--- a/registry/subnets/leadpoet.json
+++ b/registry/subnets/leadpoet.json
@@ -37,6 +37,22 @@
         "https://github.com/leadpoet/leadpoet"
       ],
       "url": "https://leadpoet.com/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-71-leadpoet-geo-countries",
+      "kind": "data-artifact",
+      "name": "Leadpoet country reference list",
+      "notes": "Public no-auth GET /api/geo/countries on leadpoet.com returning the ISO country code/label reference list used by the platform's lead-fulfillment forms. Documented in the subnet's own OpenAPI schema, titled \"Leadpoet Public API\" (leadpoet.com/api/openapi.json, already cited as a source for the existing health surface); same leadpoet.com host.",
+      "provider": "leadpoet",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": ["https://leadpoet.com/api/openapi.json"],
+      "url": "https://leadpoet.com/api/geo/countries"
     }
   ],
   "source_repo": "https://github.com/leadpoet/leadpoet",


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one new surface object to the existing `registry/subnets/leadpoet.json` manifest. No other lines in the file are touched.

Closes #4084

## Surface

- Netuid: 71
- Kind: data-artifact
- Public URL: https://leadpoet.com/api/geo/countries
- Source URL (proves the claim): https://leadpoet.com/api/openapi.json
- Provider slug: leadpoet

## What it is

`GET /api/geo/countries` on `leadpoet.com` — the same official host already documented in this file's existing `sn-71-leadpoet-health-api` surface — returns the ISO country code/label reference list used by the platform's lead-fulfillment forms. The route is documented directly in the subnet's own OpenAPI schema, titled "Leadpoet Public API" (`leadpoet.com/api/openapi.json`), already cited as a source for the existing health surface in this same file. Verified live and populated at submission time, no auth required.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file — append-only, one new surface object, zero other lines touched (verified via `git diff --stat`: 16 insertions, 0 deletions).
- [x] `authority: community`, `review.state: community-submitted`, matching this file's existing community surface style.
- [x] The `url` is public and safe for read-only probes; the `source_url` (the operator's own OpenAPI schema, explicitly titled a *Public* API, already referenced by this file's existing surface) independently documents this exact route.
- [x] Public-safe: no auth, no secrets, no wallet/PAT data, no private URLs/dashboards. The response is a static country reference list — no user or wallet data at all.
- [x] Does not duplicate the existing `subnet-api` (health) surface — different route, different kind.
- [x] Links a tracked issue that is still OPEN: Closes #4084.

## Validation

- [x] `npm run validate:surface -- registry/subnets/leadpoet.json` — "Surface validation passed: 2 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — "Public-safety scan passed."
- [x] `git diff --stat` — confirms exactly 16 lines added, 0 removed, 0 modified elsewhere in the file.

## Issue Link

Closes #4084