### PR TITLE
feat(registry): add SN35 OxMarkets Cartha lp-stats data-artifact surface

### DIFF
--- a/registry/subnets/oxmarkets.json
+++ b/registry/subnets/oxmarkets.json
@@ -115,6 +115,22 @@
         "https://github.com/General-Tao-Ventures/cartha-principal-miner-template/blob/main/README.md"
       ],
       "url": "https://api.cartha.finance/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-35-oxmarkets-lp-stats",
+      "kind": "data-artifact",
+      "name": "Cartha liquidity-providing metrics",
+      "notes": "Public no-auth GET /v1/lp-stats on api.cartha.finance returning aggregated liquidity-providing metrics for the 0xMarkets landing page (observed top-level fields: apy_tiers, max_apy, tvl, weekly_rewards, emissions, prices, epoch, extras, last_updated). Documented as GET /v1/lp-stats in the subnet OpenAPI spec (api.cartha.finance/openapi.json, already cited for the existing health and OpenAPI surfaces); same api.cartha.finance host as the Cartha Verifier API.",
+      "provider": "oxmarkets",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "GildardoDev"
+      },
+      "source_urls": ["https://api.cartha.finance/openapi.json"],
+      "url": "https://api.cartha.finance/v1/lp-stats"
     }
   ],
   "contact": "contact@0xmarkets.io",


### PR DESCRIPTION
Closes #4037.

Adds the missing public data-artifact surface for SN35 OxMarkets: `GET /v1/lp-stats` on `api.cartha.finance`, the subnet's Cartha Verifier API.

Verified before submitting:
- Live and public: `GET https://api.cartha.finance/v1/lp-stats` returns HTTP 200 with no authentication, serving aggregated liquidity-providing metrics for the 0xMarkets landing page (top-level fields observed: apy_tiers, max_apy, tvl, weekly_rewards, emissions, prices, epoch, extras, last_updated).
- Genuinely SN35's: `api.cartha.finance` is the Cartha Verifier API host already cited by this subnet's existing OpenAPI and health surfaces, and is the default VERIFIER_URL in the official Cartha principal miner template.
- Documented: the route appears in the subnet's own OpenAPI spec at api.cartha.finance/openapi.json, which is the cited source_url.

One surface appended to the single registry file, authority community, review community-submitted. No code or contract changes.
