### PR TITLE
feat(registry): add SN57 Sparket miner-leaderboard data-artifact surface

### DIFF
--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -91,6 +91,28 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Public no-auth GET returning the Sparket (SN57) backend API health as JSON (status, db connectivity, version, and sync lag). Served on the subnet's own registered website domain sparket.ai under /api/v1/. Fills the file's noted missing public-API-endpoint gap."
+    },
+    {
+      "id": "sn-57-sparket-leaderboard",
+      "name": "Sparket miner leaderboard",
+      "kind": "data-artifact",
+      "url": "https://sparket.ai/api/v1/leaderboard",
+      "provider": "sparket",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://sparket.ai/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the Sparket (SN57) miner leaderboard as JSON — per-miner rank, uid, hotkey, component scores (skill/accuracy/edge/timeliness/uniqueness), incentive, and weight (25 ranked rows plus a meta block). Served on the subnet's own registered domain sparket.ai under /api/v1/; all fields are public on-chain identifiers and scoring data. Fills the file's noted missing standalone-data-artifact gap."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/sparket.json`. Append-only; no other file or field changed.

Closes #4064

## Summary

Registers SN57 Sparket's public no-auth data endpoint — filling the manifest's own documented gap ("No verified standalone static data artifact yet"). `https://sparket.ai/api/v1/leaderboard` returns the live miner leaderboard as JSON: 25 ranked rows plus a `meta` block, each row carrying `rank`, `uid`, `hotkey`, the component scores (skill / accuracy / edge / timeliness / uniqueness), `incentive`, and `weight`. It is served on the subnet's own registered domain `sparket.ai` under `/api/v1/` (the same host as the already-registered website and `/health` subnet-api), so ownership is direct.

## Surface

- Netuid: 57
- Kind: data-artifact
- Public URL: https://sparket.ai/api/v1/leaderboard
- Source URL: https://sparket.ai/
- Provider slug: sparket

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only endpoint on the subnet's own registered domain.
- [x] Public-safe: only public on-chain identifiers (hotkey/uid) and scoring data — no secrets, wallet keys, or private URLs.
- [x] Not a duplicate — the manifest had no data-artifact surface (distinct from the existing `/health` subnet-api).
- [x] Links a tracked issue (`Closes #4064`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/sparket.json` → passed (4 surfaces)
- [x] `npm run scan:public-safety` → passed
