### PR TITLE
feat(ui): add on-chain event-summary tile to the subnet masthead

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -28,6 +28,7 @@ import {
 import {
   subnetEndpointsQuery,
   subnetDeregistrationsQuery,
+  subnetEventSummaryQuery,
   subnetHealthPercentilesQuery,
   subnetRegistrationsQuery,
   subnetTrajectoryQuery,
@@ -146,6 +147,21 @@ function aggregateSurfaceP50(rows: SurfaceLatencyPercentiles[] | undefined): num
   return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
 }
 
+// #3486: coarse-category palette for the subnet event-mix rollup tile. Mirrors
+// the fixed category enum the event-summary endpoint returns; anything unmapped
+// falls back to the muted ink token.
+const EVENT_CATEGORY_COLOR: Record<string, string> = {
+  registration: "var(--chart-1)",
+  stake: "var(--chart-2)",
+  serving: "var(--chart-3)",
+  consensus: "var(--chart-4)",
+  delegation: "var(--chart-5)",
+  transfer: "var(--chart-1)",
+  identity: "var(--chart-2)",
+  governance: "var(--chart-3)",
+  other: "var(--ink-muted)",
+};
+
 export function SubnetMasthead({
   netuid,
   profile,
@@ -174,6 +190,18 @@ export function SubnetMasthead({
   const { data: deregRes } = useQuery(subnetDeregistrationsQuery(netuid));
   const reg = regRes?.data;
   const dereg = deregRes?.data;
+  const { data: eventSummaryRes } = useQuery(subnetEventSummaryQuery(netuid));
+  const eventSummary = eventSummaryRes?.data;
+  // Top event categories by volume, fed into the MiniStack breakdown viz.
+  const eventSegments = (eventSummary?.categories ?? [])
+    .slice()
+    .sort((a, b) => b.event_count - a.event_count)
+    .slice(0, 5)
+    .map((c) => ({
+      label: c.category,
+      value: c.event_count,
+      color: EVENT_CATEGORY_COLOR[c.category] ?? "var(--ink-muted)",
+    }));
 
   // Subnet-wide daily uptime % + median latency, meaned across tracked surfaces.
   const trendWindowKey = uptimeRes?.data?.window ?? "90d";
@@ -572,6 +600,19 @@ export function SubnetMasthead({
           full="Number of primary source links recorded"
           updatedAt={generatedAt}
           viz={<DotRow dots={sourceKinds} />}
+        />
+        <StatWithSpark
+          label="Events"
+          value={eventSummary ? formatNumber(eventSummary.total_events) : "—"}
+          hint={
+            eventSegments.length
+              ? eventSegments.map((s) => `${s.value} ${s.label}`).join(" · ")
+              : "on-chain events"
+          }
+          full="Windowed on-chain event rollup for this subnet (registrations, stake, serving, transfers, etc.)"
+          updatedAt={eventSummaryRes?.meta?.generated_at ?? generatedAt}
+          windowLabel={eventSummary?.window ?? "7d"}
+          viz={eventSegments.length ? <MiniStack segments={eventSegments} /> : undefined}
         />
       </div>
     </header>

--- a/apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetEventSummary, subnetEventSummaryQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/64/event-summary",
+  });
+}
+
+async function runQuery(netuid = 64, window?: string) {
+  const opts =
+    window == null ? subnetEventSummaryQuery(netuid) : subnetEventSummaryQuery(netuid, window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetEventSummary", () => {
+  it("passes a well-formed rollup through", () => {
+    expect(
+      normalizeSubnetEventSummary(64, {
+        schema_version: 1,
+        netuid: 64,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        total_events: 1234,
+        kind_count: 6,
+        category_count: 2,
+        categories: [
+          {
+            category: "stake",
+            event_count: 800,
+            kind_count: 3,
+            amount_tao: 42,
+            alpha_amount: 0,
+            first_block: 100,
+            last_block: 200,
+            first_observed_at: "2026-06-30T00:00:00Z",
+            last_observed_at: "2026-07-01T00:00:00Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 64,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      total_events: 1234,
+      kind_count: 6,
+      category_count: 2,
+      categories: [
+        {
+          category: "stake",
+          event_count: 800,
+          kind_count: 3,
+          amount_tao: 42,
+          alpha_amount: 0,
+          first_block: 100,
+          last_block: 200,
+          first_observed_at: "2026-06-30T00:00:00Z",
+          last_observed_at: "2026-07-01T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed card, never NaN", () => {
+    for (const raw of [{}, null, "x", { total_events: "nope", categories: "nope" }]) {
+      const card = normalizeSubnetEventSummary(64, raw);
+      expect(card.total_events).toBe(0);
+      expect(card.category_count).toBe(0);
+      expect(card.categories).toEqual([]);
+      expect(card.window).toBe("7d");
+      expect(card.netuid).toBe(64);
+    }
+  });
+
+  it("drops malformed category rows (missing category or count) and coerces junk numbers", () => {
+    const card = normalizeSubnetEventSummary(64, {
+      categories: [
+        { event_count: 5 }, // no category -> dropped
+        { category: "stake", event_count: "nope" }, // junk count -> dropped
+        { category: "serving", event_count: 10, amount_tao: "junk" }, // kept, amount coerces to 0
+      ],
+    });
+    expect(card.categories).toHaveLength(1);
+    expect(card.categories[0]?.category).toBe("serving");
+    expect(card.categories[0]?.event_count).toBe(10);
+    expect(card.categories[0]?.amount_tao).toBe(0);
+  });
+
+  it("falls back category_count to the normalized category length when absent", () => {
+    const card = normalizeSubnetEventSummary(64, {
+      categories: [
+        { category: "stake", event_count: 1 },
+        { category: "serving", event_count: 2 },
+      ],
+    });
+    expect(card.category_count).toBe(2);
+  });
+});
+
+describe("subnetEventSummaryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the subnet event-summary route with the window param and normalizes", async () => {
+    resolveWith({ total_events: 42, categories: [{ category: "stake", event_count: 42 }] });
+    const res = await runQuery(64, "30d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/64/event-summary",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+    expect(res.data.total_events).toBe(42);
+    expect(res.data.categories).toHaveLength(1);
+  });
+
+  it("defaults to the 7d window", async () => {
+    resolveWith({});
+    await runQuery(64);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/64/event-summary",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -130,6 +130,8 @@ import type {
   SubnetNeuronHistoryPoint,
   SubnetStakeTransfers,
   SubnetRegistrations,
+  SubnetEventSummary,
+  SubnetEventCategorySummary,
   MetagraphNeuron,
   SubnetMetagraph,
   SubnetValidators,
@@ -3340,6 +3342,66 @@ export const subnetTrajectoryQuery = (netuid: number) =>
       return { data: normalizeTrajectory(res.data), meta: res.meta, url: res.url };
     },
     staleTime: STALE_LONG,
+  });
+
+function normalizeSubnetEventCategory(raw: unknown): SubnetEventCategorySummary | null {
+  if (!isRecord(raw)) return null;
+  const category = firstString(raw.category);
+  const eventCount = coerceFiniteNumber(raw.event_count);
+  if (!category || eventCount == null) return null;
+  return {
+    category,
+    event_count: eventCount,
+    kind_count: coerceFiniteNumber(raw.kind_count) ?? 0,
+    amount_tao: coerceFiniteNumber(raw.amount_tao) ?? 0,
+    alpha_amount: coerceFiniteNumber(raw.alpha_amount) ?? 0,
+    first_block: coerceFiniteNumber(raw.first_block) ?? null,
+    last_block: coerceFiniteNumber(raw.last_block) ?? null,
+    first_observed_at: firstString(raw.first_observed_at) ?? null,
+    last_observed_at: firstString(raw.last_observed_at) ?? null,
+  };
+}
+
+// #3486: windowed on-chain event rollup for one subnet from
+// /api/v1/subnets/{netuid}/event-summary — total account_events over the window
+// plus a per-category breakdown. Every numeric cell coerces defensively: a cold
+// store or junk payload degrades to a zeroed card (total_events 0, categories []),
+// never NaN or undefined.
+export function normalizeSubnetEventSummary(netuid: number, raw: unknown): SubnetEventSummary {
+  const d = isRecord(raw) ? raw : {};
+  const categories = Array.isArray(d.categories)
+    ? d.categories.flatMap((row) => {
+        const normalized = normalizeSubnetEventCategory(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    window: firstString(d.window) ?? "7d",
+    observed_at: firstString(d.observed_at) ?? null,
+    total_events: firstFiniteNumber(d.total_events) ?? 0,
+    kind_count: firstFiniteNumber(d.kind_count) ?? 0,
+    category_count: firstFiniteNumber(d.category_count) ?? categories.length,
+    categories,
+  };
+}
+
+export const subnetEventSummaryQuery = (netuid: number, window = "7d") =>
+  queryOptions({
+    queryKey: k("subnet-event-summary", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetEventSummary>>(
+        `/api/v1/subnets/${netuid}/event-summary`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetEventSummary(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
   });
 
 // #1115: long-range daily uptime history + reliability grade per surface, over a

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1452,6 +1452,36 @@ export interface SubnetRegistrations {
   registrations_per_registrant: number | null;
 }
 
+/** One coarse-category aggregate row from the subnet event-summary rollup. */
+export interface SubnetEventCategorySummary {
+  category: string;
+  event_count: number;
+  kind_count: number;
+  amount_tao: number;
+  alpha_amount: number;
+  first_block: number | null;
+  last_block: number | null;
+  first_observed_at: string | null;
+  last_observed_at: string | null;
+}
+
+/**
+ * Windowed on-chain event rollup for one subnet from
+ * /api/v1/subnets/{netuid}/event-summary (#3486): total account_events over the
+ * 7d/30d/90d window plus a per-category breakdown. A cold/absent store degrades
+ * to a schema-stable zeroed card (total_events 0, categories []).
+ */
+export interface SubnetEventSummary {
+  schema_version: number;
+  netuid: number;
+  window: string;
+  observed_at: string | null;
+  total_events: number;
+  kind_count: number;
+  category_count: number;
+  categories: SubnetEventCategorySummary[];
+}
+
 /**
  * Per-subnet neuron-deregistration (eviction) event volume over a 7d/30d window
  * (#1657), from /api/v1/subnets/{netuid}/deregistrations — the eviction-side


### PR DESCRIPTION
## What

Adds an **on-chain event-summary tile** to each subnet's masthead stat spine, rendering the windowed event rollup from `GET /api/v1/subnets/{netuid}/event-summary` — the compact dashboard companion to the raw per-event feed in the Activity tab. The spine previously covered identity, participants, endpoints, surfaces, uptime, latency, completeness, and evidence, but had no tile summarizing recent chain activity.

## How

- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetEventSummaryQuery(netuid, window)` `queryOptions` factory + `normalizeSubnetEventSummary` (coerce-safe via the existing `isRecord`/`coerceFiniteNumber` helpers; a cold/junk store degrades to a zeroed card — `total_events` 0, `categories []` — never NaN), mirroring the sibling subnet queries.
- **`apps/ui/src/lib/metagraphed/types.ts`** — `SubnetEventSummary`, `SubnetEventCategorySummary`.
- **`apps/ui/src/components/metagraphed/subnet-masthead.tsx`** — an **"Events"** `StatWithSpark` tile (total_events headline + a `MiniStack` per-category breakdown) appended after the Evidence tile, wired via `useQuery` alongside the existing masthead queries. Renders `"—"` while loading and degrades gracefully to a zero state.
- **`apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts`** — normalize happy-path, cold/junk-safe, malformed-row dropping, and route/window coverage (6 tests).

## Screenshots

SN64 (Chutes), 7d window — the new Events tile (total events + stake/consensus category split) sits alongside Completeness and Evidence.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-subnet-events-3486/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-subnet-events-3486/after.png) |

## Acceptance criteria

- [x] Diff touches `apps/ui/src/components/metagraphed/subnet-masthead.tsx` (not just `queries.ts`/`types.ts`)
- [x] Masthead imports and calls `subnetEventSummaryQuery` via `useQuery` (matching the existing convention)
- [x] Tile renders `total_events` as its headline and a category breakdown (`MiniStack`) from `categories[]` — not a placeholder
- [x] Loading renders `"—"`; empty/zero degrades gracefully; query error contained by the page's existing `QueryErrorBoundary`
- [x] Distinct from the Activity tab's raw event table; does not add the registration/deregistration counters (#3483) — labeled "Events" to avoid colliding with the Activity tab

## Gates

`npm run typecheck` ✓ (exit 0) · `vitest run` ✓ (6/6)

Closes #3486