### PR TITLE
feat(ui): wire the review/enrichment-targets queue into the gaps review surface (#3355)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5526,6 +5526,37 @@ export const reviewEnrichmentQueueQuery = () =>
     staleTime: STALE_LONG,
   });
 
+export const reviewEnrichmentTargetsQuery = () =>
+  queryOptions({
+    queryKey: k("review-enrichment-targets"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/enrichment-targets",
+        "targets",
+        undefined,
+        signal,
+      );
+      // API rows: ReviewEnrichmentTarget { netuid, name, slug, target_id,
+      // target_type, target_action, priority_score, missing_kinds,
+      // recommended_action, contribution_prompt, ... }.
+      const rows = res.data.map((r) => ({
+        id: (r.target_id as string) ?? (r.slug as string) ?? String(r.netuid ?? ""),
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        target_type: r.target_type as string | undefined,
+        target_action: r.target_action as string | undefined,
+        priority:
+          typeof r.priority_score === "number"
+            ? String(Math.round(r.priority_score as number))
+            : undefined,
+        missing_kinds: stringArrayFromUnknown(r.missing_kinds),
+        note: (r.recommended_action as string) ?? (r.contribution_prompt as string),
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
 function normalizeSchema(raw: unknown): SchemaInfo {
   if (!raw || typeof raw !== "object") return raw as SchemaInfo;
   const s = raw as Record<string, unknown>;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -29,6 +29,7 @@ import {
   reviewProfileCompletenessQuery,
   reviewAdapterCandidatesQuery,
   reviewEnrichmentQueueQuery,
+  reviewEnrichmentTargetsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
@@ -201,6 +202,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="enrichment-targets"
+          eyebrow="Targets"
+          title="Enrichment targets"
+          description="Contributor-ready targets grouped by missing surface kind, with the recommended next action per target."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <EnrichmentTargets />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -209,6 +223,7 @@ function GapsPage() {
           "/api/v1/review/profile-completeness",
           "/api/v1/review/adapter-candidates",
           "/api/v1/review/enrichment-queue",
+          "/api/v1/review/enrichment-targets",
         ]}
       />
     </AppShell>
@@ -997,6 +1012,69 @@ function EnrichmentQueue() {
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function EnrichmentTargets() {
+  const { data } = useSuspenseQuery(reviewEnrichmentTargetsQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No enrichment targets"
+        description="Nothing is currently flagged as a contributor-ready enrichment target."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-4 py-2.5 text-left">Netuid</th>
+              <th className="px-4 py-2.5 text-left">Name</th>
+              <th className="px-4 py-2.5 text-left">Target type</th>
+              <th className="px-4 py-2.5 text-left">Priority</th>
+              <th className="px-4 py-2.5 text-left">Missing / next action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => (
+              <tr key={r.id} className="mg-row-hover">
+                <td className="px-4 py-2.5 font-mono text-[11px]">
+                  {r.netuid != null ? (
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="hover:text-accent"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-[13px] text-ink">{r.name ?? "—"}</td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.target_type ?? "—"}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                  {r.note ??
+                    (r.missing_kinds && r.missing_kinds.length > 0
+                      ? r.missing_kinds.join(", ")
+                      : "—")}
+                </td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary

- Adds the missing `reviewEnrichmentTargetsQuery` data-layer function (`apps/ui/src/lib/metagraphed/queries.ts`), calling `GET /api/v1/review/enrichment-targets` (already live, `src/contracts.mjs`) and normalizing rows following the same pattern as the three sibling review queries in the same file.
- Wires a new "Enrichment targets" `PageSection` into `apps/ui/src/routes/gaps.tsx`, immediately after the existing "Enrichment queue" section, rendering `netuid`, `name`, `target_type`, `priority_score`, and a missing/next-action note column — mirroring `EnrichmentQueue()`'s existing table idiom exactly.
- Appends `/api/v1/review/enrichment-targets` to the page's `ApiSourceFooter` paths.

This is a distinct, additive board from the existing `enrichment-queue` section (per-target contributor task board vs. per-subnet aggregate rollup) and is scoped only to the flat `targets` list, per the issue's non-goals (no `groups`/`summary` rollup rendering, no filter UI).

Closes #3355

## Screenshot

This PR changes rendered output (a new page section on `/gaps`), which per this repo's contribution rules requires a before/after screenshot table hosted via GitHub's own image upload. I don't have interactive access to drag-and-drop image upload from this environment, so I can't attach one myself. The code is implemented, tested, and builds cleanly (see Validation below) — **a maintainer/reviewer will need to pull this branch, run the dev server, and drop before/after screenshots into this PR** before it can clear the visual-change gate. Happy to have this held for manual review in the meantime.

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — no new errors (2 pre-existing baseline errors unrelated to this change, confirmed identical via `git stash`)
- [x] `npm run lint --workspace=apps/ui` — no new errors (only pre-existing `react-refresh/only-export-components` warnings already present in the file)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 511/511 tests passing (73/73 files)
- [x] `npm run build --workspace=apps/ui` — builds cleanly
- [x] Bundle-size budget check (matching CI's script exactly) — 256 KB / 300 KB gzipped initial load (this route is lazy-loaded, not part of the initial-load closure)

## Non-goals (per issue)

- Rendering `enrichment-evidence` (#3354) or the global `/api/v1/review/gaps` priority board (#3356) — separate sibling issues touching the same file.
- Rendering the artifact's `groups`/`summary` rollup, or any filter/query-param UI beyond the base render.