### PR TITLE
fix: prevent health incident/trend netuid coercion to subnet 0

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -366,13 +366,9 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
   const formatWindow = (rows, days) => {
     const bySubnet = new Map();
     for (const row of rows || []) {
-      const netuid = Number(row.netuid);
+      const netuid = parseNonNegativeInt(row.netuid);
       const date = String(row.date || "");
-      if (
-        !Number.isInteger(netuid) ||
-        netuid < 0 ||
-        !/^\d{4}-\d{2}-\d{2}$/.test(date)
-      ) {
+      if (netuid == null || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
         continue;
       }
       const samples = Math.max(0, Number(row.total) || 0);
@@ -480,6 +476,16 @@ function toFiniteOrNull(value) {
   if (value == null) return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
+}
+function parseNonNegativeInt(value) {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 // p50/p95/p99 + avg/min/max latency per surface, computed in SQL (one row per
@@ -680,7 +686,8 @@ export function formatGlobalIncidents({
     if (acceptedIncidents >= incidentLimit) {
       break;
     }
-    const netuid = Number(row.netuid);
+    const netuid = parseNonNegativeInt(row.netuid);
+    if (netuid == null) continue;
     const key = `${netuid}/${surfaceLookupKey(row)}`;
     const entry = bySurface.get(key) || {
       netuid,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -3078,6 +3078,20 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
           ended_at: 20,
           failed_samples: 2,
         },
+        {
+          netuid: {},
+          surface_id: "z",
+          started_at: 30,
+          ended_at: 40,
+          failed_samples: 1,
+        },
+        {
+          netuid: "9007199254740993",
+          surface_id: "z2",
+          started_at: 50,
+          ended_at: 60,
+          failed_samples: 1,
+        },
       ],
     });
     assert.equal(out.summary.incident_count, 1);

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -942,6 +942,7 @@ describe("formatBulkTrends", () => {
       windows: {
         "7d": [
           { netuid: -1, date: "2026-06-10", total: 1, ok_count: 1 },
+          { netuid: " ", date: "2026-06-10", total: 1, ok_count: 1 },
           { netuid: 7, date: "not-a-date", total: 1, ok_count: 1 },
         ],
       },
@@ -3058,6 +3059,30 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
       ],
     });
     assert.equal(capped.summary.incident_count, 1);
+  });
+
+  test("skips blank netuid values instead of coercing to subnet 0", () => {
+    const out = formatGlobalIncidents({
+      incidentRows: [
+        {
+          netuid: " ",
+          surface_id: "x",
+          started_at: 1,
+          ended_at: 2,
+          failed_samples: 1,
+        },
+        {
+          netuid: "7",
+          surface_id: "y",
+          started_at: 10,
+          ended_at: 20,
+          failed_samples: 2,
+        },
+      ],
+    });
+    assert.equal(out.summary.incident_count, 1);
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].netuid, 7);
   });
 });
 

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -937,6 +937,21 @@ describe("formatBulkTrends", () => {
     assert.equal(sn7.points[1].latency_sample_count, 90);
   });
 
+  test("accepts numeric-string netuids while rejecting blank ones", () => {
+    const out = formatBulkTrends({
+      windows: {
+        "7d": [
+          { netuid: "7", date: "2026-06-10", total: 2, ok_count: 2 },
+          { netuid: " ", date: "2026-06-10", total: 5, ok_count: 5 },
+        ],
+      },
+    });
+    assert.deepEqual(
+      out.windows["7d"].subnets.map((s) => s.netuid),
+      [7],
+    );
+  });
+
   test("empty or invalid rows keep the schema-stable cold shape", () => {
     const out = formatBulkTrends({
       windows: {


### PR DESCRIPTION
## Summary

- Root cause: `formatBulkTrends()` and `formatGlobalIncidents()` in `src/health-serving.mjs` used `Number(row.netuid)`, so blank/whitespace D1 cells coerced to subnet `0`.
- Fix: add `parseNonNegativeInt()` and use it in both formatters so only valid non-negative integer netuids are accepted.
- Coverage: regression tests for blank/object/unsafe-integer rejection and numeric-string acceptance.

## Impact

- Prevents false cross-subnet incidents and bulk health-trend aggregates from being attributed to subnet 0.
- Aligns with the merged blank-netuid guard series (#2813, #2898, #3027).

## Issue

No matching open upstream issue exists for this remaining `health-serving.mjs` gap.

Per [CONTRIBUTING.md](https://github.com/JSONbored/metagraphed/blob/main/CONTRIBUTING.md), issue creation on `JSONbored/metagraphed` is maintainer-only. `RealDiligent` cannot file issues here (`CreateIssue` permission denied by repo policy).

This PR is a no-issue backend correctness fix: sibling to the already-merged blank-cell coercion guards above, scoped strictly to the two health formatters that still used raw `Number(row.netuid)`.

**Maintainer:** please link or file a tracking issue and re-run Gittensory if required before merge.

## Test plan

- [x] `npx vitest run tests/health-serving.test.mjs` (142 passed)

## Risk / tradeoffs

- Low risk: only malformed netuid cells are dropped; valid integer netuids (number or digit-only string) are preserved.
