### PR TITLE
feat(registry): add Leadpoet public web API OpenAPI surface (SN71)

### DIFF
--- a/registry/subnets/leadpoet.json
+++ b/registry/subnets/leadpoet.json
@@ -1,17 +1,19 @@
 {
-  "schema_version": 1,
-  "netuid": 71,
-  "name": "Leadpoet",
-  "slug": "sn-71",
-  "status": "active",
   "categories": [],
+  "contact": "hello@leadpoet.com",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "Leadpoet",
+  "netuid": 71,
+  "schema_version": 1,
+  "slug": "sn-71",
   "social": {
     "x": "https://x.com/leadpoetai"
   },
+  "source_repo": "https://github.com/leadpoet/leadpoet",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -37,9 +39,35 @@
         "https://github.com/leadpoet/leadpoet"
       ],
       "url": "https://leadpoet.com/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-71-leadpoet-openapi",
+      "kind": "openapi",
+      "name": "Leadpoet public web API OpenAPI schema",
+      "notes": "Public no-auth OpenAPI 3.x schema for the SN71 Leadpoet web API (title \"Leadpoet Public API\", 5 paths) on leadpoet.com. Documents /api/health, /api/contact, and geo lookup routes for agents and prospective customers; same host as the existing health surface.",
+      "provider": "leadpoet",
+      "public_safe": true,
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://leadpoet.com/api/openapi.json",
+      "source_urls": [
+        "https://leadpoet.com/api/health",
+        "https://leadpoet.com/api/openapi.json",
+        "https://github.com/leadpoet/leadpoet"
+      ],
+      "url": "https://leadpoet.com/api/openapi.json"
     }
   ],
-  "source_repo": "https://github.com/leadpoet/leadpoet",
-  "website_url": "https://leadpoet.com/",
-  "contact": "hello@leadpoet.com"
+  "website_url": "https://leadpoet.com/"
 }


### PR DESCRIPTION
## Summary
- Append community OpenAPI surface for SN71 Leadpoet at `https://leadpoet.com/api/openapi.json` (title "Leadpoet Public API", 5 paths).
- Same first-party `leadpoet.com` host as the existing `/api/health` surface.

Closes #4083

## Validation
- [x] Exactly one subnet file changed: `registry/subnets/leadpoet.json`
- [x] `npm run validate:surface -- --file registry/subnets/leadpoet.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/leadpoet.json`
- [x] `npx prettier --check registry/subnets/leadpoet.json`
- [x] Live GET on `https://leadpoet.com/api/openapi.json` returns machine-readable OpenAPI JSON

## Test plan
- [ ] CI review gate passes
- [ ] Gittensory review returns manual review or approved


Made with [Cursor](https://cursor.com)