### PR TITLE
feat(registry): add SN124 Swarm leaderboard subnet-api surface (#4175)

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -52,6 +52,24 @@
         "https://github.com/swarm-subnet/swarm/blob/main/docs/king_of_the_hill.md"
       ],
       "url": "https://api.swarm124.com/kings/active"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-124-swarm-leaderboard-api",
+      "kind": "subnet-api",
+      "name": "Swarm leaderboard API",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/leaderboard",
+      "notes": "Public no-auth GET /leaderboard — ranked miner model leaderboard (rank, model id, uid, benchmark score) for SN124 Swarm. Served on the same api.swarm124.com host as the subnet's registered health API; the endpoint is defined in the subnet's backend API module."
     }
   ],
   "website_url": "https://www.swarm124.com/"


### PR DESCRIPTION
## Summary

Closes #4175

Adds the SN124 **Swarm** public leaderboard API endpoint as a `subnet-api` surface — a previously-unregistered, public, no-auth endpoint of the subnet's API (which already has a registered `/health` surface on the same host).

## Surface

- **kind:** `subnet-api`
- **url:** `https://api.swarm124.com/leaderboard`
- Public no-auth `GET` → `200 application/json` — the ranked miner-model leaderboard
  (rank, model id, uid, benchmark score) for SN124 Swarm.
- `authority: community`, `auth_required: false`, `public_safe: true`.

## Proof

- `source_urls[0]` = `https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py`
  — the subnet's own backend API module, which defines this endpoint. Served on the same
  `api.swarm124.com` host as the subnet's existing registered `/health` API surface.

## Validation

- `npm run validate:surface -- registry/subnets/swarm.json` — passed
- `npm run scan:public-safety` — passed
- `npm run validate` — passed (exit 0)

Single-file change; no generated artifacts touched.
