### PR TITLE
fix(ui): surface error states for account extrinsics and transfers (#3434)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -294,8 +294,21 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
 
-      <AccountExtrinsicsSection rows={signedExtrinsics} isPending={extrinsicsResult.isPending} />
-      <AccountTransfersSection ss58={ss58} rows={transfers} isPending={transfersResult.isPending} />
+      <AccountExtrinsicsSection
+        rows={signedExtrinsics}
+        isPending={extrinsicsResult.isPending}
+        isError={extrinsicsResult.isError}
+        error={extrinsicsResult.error}
+        onRetry={() => void extrinsicsResult.refetch()}
+      />
+      <AccountTransfersSection
+        ss58={ss58}
+        rows={transfers}
+        isPending={transfersResult.isPending}
+        isError={transfersResult.isError}
+        error={transfersResult.error}
+        onRetry={() => void transfersResult.refetch()}
+      />
 
       <div className="mt-6">
         <Link
@@ -392,7 +405,19 @@ function AccountFeedSectionSkeleton({
   );
 }
 
-function AccountExtrinsicsSection({ rows, isPending }: { rows: Extrinsic[]; isPending?: boolean }) {
+function AccountExtrinsicsSection({
+  rows,
+  isPending,
+  isError,
+  error,
+  onRetry,
+}: {
+  rows: Extrinsic[];
+  isPending?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  onRetry?: () => void;
+}) {
   if (isPending && rows.length === 0) {
     return (
       <AccountFeedSectionSkeleton
@@ -400,6 +425,24 @@ function AccountExtrinsicsSection({ rows, isPending }: { rows: Extrinsic[]; isPe
         title="Signed extrinsics"
         subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
       />
+    );
+  }
+  if (isError) {
+    return (
+      <SectionAnchor
+        id="extrinsics"
+        title="Signed extrinsics"
+        subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Couldn't load signed extrinsics"
+          description="The extrinsics tier is optional enrichment — the rest of the account page is unaffected."
+          error={error}
+          onRetry={onRetry}
+        />
+      </SectionAnchor>
     );
   }
   if (rows.length === 0) return null;
@@ -481,10 +524,16 @@ function AccountTransfersSection({
   ss58,
   rows,
   isPending,
+  isError,
+  error,
+  onRetry,
 }: {
   ss58: string;
   rows: Transfer[];
   isPending?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  onRetry?: () => void;
 }) {
   if (isPending && rows.length === 0) {
     return (
@@ -493,6 +542,24 @@ function AccountTransfersSection({
         title="Transfers"
         subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
       />
+    );
+  }
+  if (isError) {
+    return (
+      <SectionAnchor
+        id="transfers"
+        title="Transfers"
+        subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Couldn't load transfers"
+          description="The transfers tier is optional enrichment — the rest of the account page is unaffected."
+          error={error}
+          onRetry={onRetry}
+        />
+      </SectionAnchor>
     );
   }
   if (rows.length === 0) return null;


### PR DESCRIPTION
## Summary

- Wire `isError` / `error` / `onRetry` from the non-blocking `accountExtrinsicsQuery` and `accountTransfersQuery` results into `AccountExtrinsicsSection` and `AccountTransfersSection`.
- On fetch failure, render the same `TableState variant="error"` pattern already used by sibling account feeds (`AccountEventsSection`, teardown, deregistrations, etc.) instead of silently returning `null`.

Closes #3434

## What changed

- `ValidAccountDetail` passes query error state into both sections.
- `AccountExtrinsicsSection` and `AccountTransfersSection` branch to an error panel after the existing pending skeleton guard and before the empty `return null`.

## Why

A failed extrinsics/transfers fetch with no cached rows previously looked identical to a cold account with zero activity — no section, no feedback, no retry.

## Test plan

- [x] Verified error branch mirrors `AccountEventsSection` / `AccountTeardownActivitySection` patterns in the same file
- [ ] `npm run lint --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui`
- [ ] `npm test --workspace=apps/ui`
