### PR TITLE
feat(ui): wire Download CSV on Blocks page (#3404)

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -18,8 +18,10 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -58,7 +60,26 @@ export const Route = createFileRoute("/blocks/")({
   component: BlocksPage,
 });
 
+type BlocksSearch = z.infer<typeof blocksSearchSchema>;
+
+function blocksQueryParams(search: BlocksSearch): Record<string, string | number> {
+  const queryParams: Record<string, string | number> = {
+    limit: search.limit,
+    offset: search.offset,
+  };
+  if (search.author) queryParams.author = search.author;
+  if (search.spec_version) queryParams.spec_version = search.spec_version;
+  if (search.block_start) queryParams.block_start = search.block_start;
+  if (search.block_end) queryParams.block_end = search.block_end;
+  if (search.min_extrinsics) queryParams.min_extrinsics = search.min_extrinsics;
+  if (search.min_events) queryParams.min_events = search.min_events;
+  return queryParams;
+}
+
 function BlocksPage() {
+  const search = Route.useSearch();
+  const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
+
   return (
     <AppShell>
       <PageHero
@@ -66,7 +87,12 @@ function BlocksPage() {
         live
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
-        actions={<ShareButton />}
+        actions={
+          <>
+            <DownloadCsvButton url={blocksCsvUrl} />
+            <ShareButton />
+          </>
+        }
       />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-28 w-full mb-8" />}>
@@ -128,16 +154,7 @@ function BlocksTable() {
   const navigate = useNavigate({ from: Route.fullPath });
 
   // Only send filters the user actually set, so an empty bar is the plain feed.
-  const queryParams: Record<string, string | number> = {
-    limit: search.limit,
-    offset: search.offset,
-  };
-  if (search.author) queryParams.author = search.author;
-  if (search.spec_version) queryParams.spec_version = search.spec_version;
-  if (search.block_start) queryParams.block_start = search.block_start;
-  if (search.block_end) queryParams.block_end = search.block_end;
-  if (search.min_extrinsics) queryParams.min_extrinsics = search.min_extrinsics;
-  if (search.min_events) queryParams.min_events = search.min_events;
+  const queryParams = blocksQueryParams(search);
 
   const rows = (useSuspenseQuery(blocksQuery(queryParams)).data.data ?? []) as Block[];
 


### PR DESCRIPTION
## Summary

- Add `DownloadCsvButton` to the Blocks page hero (alongside Share), wired to `/api/v1/blocks` via `buildUrl`
- Export URL mirrors active search params: `author`, `spec_version`, `block_start`, `block_end`, `min_extrinsics`, `min_events`, `limit`, `offset` — same object as `blocksQuery`
- Uses shared `DownloadCsvButton` from `@/components/metagraphed/download-csv-button` (on main via #3408)
- Closes #3404 · Part of #2542

## Screenshots

**Visual PR — held for manual review per Path C.** Capture `/blocks` page hero (Download CSV next to Share). Fixed viewport only — never `fullPage: true`. Set theme before each capture:

```js
localStorage.setItem("mg-theme", "dark"); // or "light"
location.reload();
```

Host 12 PNGs on a `screenshots` orphan branch in your fork (not on this feature branch). Reference as `https://raw.githubusercontent.com/<your-fork-owner>/metagraphed/screenshots/<file>.png`.

**Before server:** separate worktree at merge-base — `git worktree add ../metagraphed-before $(git merge-base main HEAD)` then `npm run dev --workspace=apps/ui` there.

**After server:** this branch — `npm run dev --workspace=apps/ui`.

Suggested filenames: `3404-desktop-light-before.png`, `3404-desktop-light-after.png`, etc.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light (1280×800) | <img width="1265" height="941" alt="image" src="https://github.com/user-attachments/assets/e2b86232-bc72-47dd-a5cd-490812ffaf3b" /> | <img width="1263" height="938" alt="image" src="https://github.com/user-attachments/assets/2b4bb443-4700-418a-a6fa-7fa304e06073" /> |
| Desktop · Dark (1280×800) | <img width="1262" height="944" alt="image" src="https://github.com/user-attachments/assets/0fa1481c-24a5-4e36-afe5-c97653da1b5a" /> | <img width="1274" height="943" alt="image" src="https://github.com/user-attachments/assets/7f7d3443-a178-4e1d-8805-aaa742543b72" /> |
| Tablet · Light (768×1024) | <img width="1271" height="1035" alt="image" src="https://github.com/user-attachments/assets/1e697e67-6ed9-4d8f-86b3-0db6f211f574" /> | <img width="1267" height="987" alt="image" src="https://github.com/user-attachments/assets/178b50f4-0bfe-4e40-9493-ce04fbacac1f" /> |
| Tablet · Dark (768×1024) | <img width="1276" height="936" alt="image" src="https://github.com/user-attachments/assets/4d1a5ab9-7f5c-4d57-a3ec-38843bcedb26" /> | <img width="1271" height="936" alt="image" src="https://github.com/user-attachments/assets/95bec68d-1bc6-4233-8548-f8d2d3cbd33c" /> |
| Mobile · Light (375×812) | <img width="1270" height="1026" alt="image" src="https://github.com/user-attachments/assets/f0b5824d-687f-4bc0-896b-8f0da5b1879f" /> | <img width="1274" height="1020" alt="image" src="https://github.com/user-attachments/assets/56f1f7cf-3d95-4673-8ca0-f30a6e0e8c15" /> |
| Mobile · Dark (375×812) | <img width="1272" height="935" alt="image" src="https://github.com/user-attachments/assets/369bca75-63d5-43d1-9125-8f2595ebe2dd" /> | <img width="1269" height="927" alt="image" src="https://github.com/user-attachments/assets/fc8b7683-63fd-4417-bb3d-8a972bbdd260" /> |

## Test plan

- [x] `/blocks` — Download CSV with default filters exports current page params
- [x] Apply author/spec/block-range/min filters + pagination — CSV URL matches URL search state
- [x] Switch to Testnet — link uses prefixed API base
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
