### PR TITLE
feat(ui): surface the source-health provider rollup on the providers page

### DIFF
--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -13,7 +13,12 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
-import { providersQuery, endpointsQuery, type ProviderCounts } from "@/lib/metagraphed/queries";
+import {
+  providersQuery,
+  endpointsQuery,
+  sourceHealthProvidersQuery,
+  type ProviderCounts,
+} from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
@@ -264,6 +269,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
       ) : null}
 
       <ProviderOverview providers={rows} counts={counts} />
+      <SourceHealthRollup />
 
       {/* Toolbar */}
       <div className="sticky top-14 z-10 -mx-1 px-1 py-2 backdrop-blur bg-paper/85 border-b border-border/60 flex flex-wrap items-center gap-2">
@@ -554,6 +560,27 @@ function CountTile({ icon, label, value }: { icon?: ReactNode; label: string; va
         )}
       >
         {value > 0 ? value : "—"}
+      </span>
+    </div>
+  );
+}
+
+// #3353: compact source-health status-mix rollup for the /providers page — the
+// summary-level companion to the full sortable provider table on /status, from
+// the same /api/v1/source-health query already wired for that page. Suspends
+// within the ProvidersGrid boundary alongside ProviderOverview.
+function SourceHealthRollup() {
+  const summary = useSuspenseQuery(sourceHealthProvidersQuery()).data.data.summary;
+  const status = summary.status_counts;
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-4 rounded border border-border bg-card p-3 font-mono text-[12px] tabular-nums">
+      <span className="mg-label">Source health</span>
+      <span className="text-health-ok">{status.ok ?? 0} ok</span>
+      <span className="text-health-warn">{status.degraded ?? 0} degraded</span>
+      <span className="text-health-down">{status.failed ?? 0} failed</span>
+      <span className="text-ink-muted">{status.unknown ?? 0} unknown</span>
+      <span className="ml-auto text-ink-muted">
+        {summary.provider_count ?? 0} providers · {summary.endpoint_count ?? 0} endpoints
       </span>
     </div>
   );


### PR DESCRIPTION
## What

Surfaces a compact **source-health provider rollup** directly on the `/providers` page — the per-provider status mix (ok / degraded / failed / unknown) plus provider and endpoint totals — below the existing kind / endpoint-health / top-providers overview tiles. `/api/v1/source-health` was already listed in the page's `ApiSourceFooter` but never rendered as data; this closes that gap.

## How

- **`apps/ui/src/routes/providers.index.tsx`** — new `SourceHealthRollup` component that calls the existing `sourceHealthProvidersQuery()` via `useSuspenseQuery` (suspending within the page's existing `ProvidersGrid` `Suspense`/`QueryErrorBoundary`), rendered right under `ProviderOverview`. It mirrors the summary-bar idiom already used by `SourceHealthTable` on `/status`, reading `summary.status_counts` + `summary.provider_count` / `endpoint_count`.

No data-layer change: `sourceHealthProvidersQuery` / `normalizeSourceHealth` / the `SourceHealth` type are already wired for `/status` and are reused untouched (per the issue's non-goals). Single-file, additive change.

## Screenshots

Live `/providers` (mainnet) — the new Source health bar (110 ok · 1 degraded · 1 failed · 19 unknown · 131 providers · 1477 endpoints) sits below the overview tiles.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-providers-sh-3353/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-providers-sh-3353/after.png) |

## Acceptance criteria

- [x] Diff touches `apps/ui/src/routes/providers.index.tsx` (not `queries.ts`/`types.ts`)
- [x] Calls `sourceHealthProvidersQuery()` via `useSuspenseQuery` (matching the file's existing convention)
- [x] Renders the `ok` / `degraded` / `failed` / `unknown` status mix + provider/endpoint totals from `summary`
- [x] Suspends within the existing `QueryErrorBoundary` + `Suspense`; no second full provider table added
- [x] Does not modify `sourceHealthProvidersQuery`, `normalizeSourceHealth`, types, `status.tsx`, or `status-diagnostics.tsx`

## Gates

`npm run typecheck` ✓ (exit 0) · `eslint` ✓ (0 errors)

Closes #3353