### PR TITLE
feat(registry): add SN60 Bitsec known-solutions data-artifact surface (#4066)

### DIFF
--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -49,6 +49,25 @@
         "https://bitsec.ai/api/docs"
       ],
       "url": "https://bitsec.ai/api/analytics"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-ai-known-solutions",
+      "kind": "data-artifact",
+      "name": "Bitsec.ai known-solutions dataset",
+      "notes": "Public no-auth JSON dataset of known-vulnerability benchmark projects (GET /projects/known-solutions) used to evaluate SN60 miner agents — each entry has real codebases (repo/commit/tarball) and vulnerability findings (severity, title, description). Documented in the subnet's own OpenAPI spec (already the registered schema_url) as \"Get Current Project Set Known Solutions\". Served on the official bitsec.ai domain.",
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://bitsec.ai/api/openapi.json",
+        "https://github.com/Bitsec-AI/subnet"
+      ],
+      "url": "https://bitsec.ai/api/projects/known-solutions"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/bitsec.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 60
- Kind: data-artifact
- Public URL: https://bitsec.ai/api/projects/known-solutions
- Source URL (proves the claim): https://bitsec.ai/api/openapi.json (the subnet's own OpenAPI spec — already the registered `schema_url` on the existing `openapi` surface in this file — explicitly documents this exact path as "Get Current Project Set Known Solutions"), plus https://github.com/Bitsec-AI/subnet (official source repo)
- Provider slug: bitsec-ai (already registered)

Live no-auth JSON endpoint returning Bitsec's (SN60, a code-security-audit subnet) benchmark corpus of known-vulnerable codebases + ground-truth findings (7 real project entries with repo/commit/tarball links and per-vulnerability severity/title/description) used to evaluate miner agents. Distinct URL from the two existing surfaces (`openapi` schema doc, `subnet-api` analytics endpoint) — no duplication.

Closes #4066

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership (the subnet's own OpenAPI spec documents this exact path).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (distinct URL/facet from the existing `openapi`/`subnet-api` entries).
- [x] Links a tracked issue (`Closes #4066`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitsec.json` — passed (3 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed