### PR TITLE
feat(ui): add a network-wide stake-flow section to the chain explorer

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -52,6 +52,10 @@ import type {
   ChainActivity,
   ChainActivityDay,
   ChainCalls,
+  ChainStakeFlow,
+  ChainStakeFlowDistribution,
+  ChainStakeFlowNetwork,
+  ChainStakeFlowSubnet,
   ChainCallEntry,
   ChainFees,
   ChainFeeDay,
@@ -194,6 +198,7 @@ const MAX_ACCOUNT_HISTORY_DAYS = 180;
 const MAX_ACCOUNT_DAY_EVENT_KINDS = 32;
 const MAX_CHAIN_ACTIVITY_DAYS = 31;
 const MAX_CHAIN_CALLS = 12;
+const MAX_STAKE_FLOW_SUBNETS = 24;
 const MAX_CHAIN_SIGNERS = 20;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
@@ -2959,6 +2964,81 @@ export const chainStakeTransfersQuery = (window = "7d", limit = 20) =>
       };
     },
     staleTime: STALE_MED,
+  });
+
+function normalizeChainStakeFlowNetwork(raw: unknown): ChainStakeFlowNetwork | null {
+  if (!isRecord(raw)) return null;
+  return {
+    total_staked_tao: coerceFiniteNumber(raw.total_staked_tao) ?? 0,
+    total_unstaked_tao: coerceFiniteNumber(raw.total_unstaked_tao) ?? 0,
+    net_flow_tao: coerceFiniteNumber(raw.net_flow_tao) ?? 0,
+    gross_flow_tao: coerceFiniteNumber(raw.gross_flow_tao) ?? 0,
+    stake_events: coerceFiniteNumber(raw.stake_events) ?? 0,
+    unstake_events: coerceFiniteNumber(raw.unstake_events) ?? 0,
+    gaining: coerceFiniteNumber(raw.gaining) ?? 0,
+    losing: coerceFiniteNumber(raw.losing) ?? 0,
+    flat: coerceFiniteNumber(raw.flat) ?? 0,
+  };
+}
+
+function normalizeChainStakeFlowDistribution(raw: unknown): ChainStakeFlowDistribution | null {
+  if (!isRecord(raw)) return null;
+  return {
+    count: coerceFiniteNumber(raw.count) ?? 0,
+    mean: coerceFiniteNumber(raw.mean) ?? null,
+    min: coerceFiniteNumber(raw.min) ?? null,
+    p25: coerceFiniteNumber(raw.p25) ?? null,
+    median: coerceFiniteNumber(raw.median) ?? null,
+    p75: coerceFiniteNumber(raw.p75) ?? null,
+    p90: coerceFiniteNumber(raw.p90) ?? null,
+    max: coerceFiniteNumber(raw.max) ?? null,
+  };
+}
+
+function normalizeChainStakeFlowSubnet(raw: unknown): ChainStakeFlowSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    total_staked_tao: coerceFiniteNumber(raw.total_staked_tao) ?? 0,
+    total_unstaked_tao: coerceFiniteNumber(raw.total_unstaked_tao) ?? 0,
+    net_flow_tao: coerceFiniteNumber(raw.net_flow_tao) ?? 0,
+    gross_flow_tao: coerceFiniteNumber(raw.gross_flow_tao) ?? 0,
+    stake_events: coerceFiniteNumber(raw.stake_events) ?? 0,
+    unstake_events: coerceFiniteNumber(raw.unstake_events) ?? 0,
+    direction: firstString(raw.direction) ?? "balanced",
+  };
+}
+
+export const chainStakeFlowQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-stake-flow", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/stake-flow", {
+        params: { window },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: 1,
+          window,
+          observed_at: firstString(d.observed_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          network: normalizeChainStakeFlowNetwork(d.network),
+          net_flow_distribution: normalizeChainStakeFlowDistribution(d.net_flow_distribution),
+          subnets: normalizeChainRows(
+            d.subnets,
+            MAX_STAKE_FLOW_SUBNETS,
+            normalizeChainStakeFlowSubnet,
+          ),
+        } as ChainStakeFlow,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainStakeFlow>;
+    },
+    staleTime: STALE_SHORT,
   });
 
 const READINESS_COMPONENT_KEYS = [

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -558,7 +558,11 @@ export interface Lineage {
 
 /** The five D1-computed registry leaderboards from /api/v1/registry/leaderboards. */
 export type LeaderboardBoardKey =
-  "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing";
+  | "healthiest"
+  | "fastest-rpc"
+  | "most-complete"
+  | "most-enriched"
+  | "fastest-growing";
 
 /**
  * One ranked subnet in a leaderboard. Every row carries netuid/slug/name; only
@@ -1844,6 +1848,46 @@ export interface ChainCalls {
   total_extrinsics: number;
   call_count: number;
   calls: ChainCallEntry[];
+}
+export interface ChainStakeFlowNetwork {
+  total_staked_tao: number;
+  total_unstaked_tao: number;
+  net_flow_tao: number;
+  gross_flow_tao: number;
+  stake_events: number;
+  unstake_events: number;
+  gaining: number;
+  losing: number;
+  flat: number;
+}
+export interface ChainStakeFlowDistribution {
+  count: number;
+  mean: number | null;
+  min: number | null;
+  p25: number | null;
+  median: number | null;
+  p75: number | null;
+  p90: number | null;
+  max: number | null;
+}
+export interface ChainStakeFlowSubnet {
+  netuid: number;
+  total_staked_tao: number;
+  total_unstaked_tao: number;
+  net_flow_tao: number;
+  gross_flow_tao: number;
+  stake_events: number;
+  unstake_events: number;
+  direction: string;
+}
+export interface ChainStakeFlow {
+  schema_version: number;
+  window: string;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainStakeFlowNetwork | null;
+  net_flow_distribution: ChainStakeFlowDistribution | null;
+  subnets: ChainStakeFlowSubnet[];
 }
 export interface ChainSignerEntry {
   signer: string;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -22,12 +22,13 @@ import {
   chainEventsInfiniteQuery,
   chainFeesQuery,
   chainSignersQuery,
+  chainStakeFlowQuery,
   chainStakeTransfersQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
-import type { ChainCalls, ChainEvent } from "@/lib/metagraphed/types";
+import type { ChainCalls, ChainEvent, ChainStakeFlow } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
@@ -61,6 +62,9 @@ function sum(values: number[]): number {
   return values.reduce((a, b) => a + (Number.isFinite(b) ? b : 0), 0);
 }
 
+function fmtTaoSigned(v: number): string {
+  return v < 0 ? `-${fmtTao(-v)}` : `+${fmtTao(v)}`;
+}
 function fmtTao(v: number): string {
   if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
   if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
@@ -90,6 +94,7 @@ function ExplorerPage() {
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
+          "/api/v1/chain/stake-flow",
           "/api/v1/chain/stake-transfers",
           "/api/v1/chain-events",
         ]}
@@ -234,6 +239,127 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
   );
 }
 
+/** Compact labeled metric for the stake-flow summary row. */
+function StakeFlowMetric({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value: string;
+  tone?: "ok" | "down" | "default";
+}) {
+  const valueClass =
+    tone === "ok" ? "text-health-ok" : tone === "down" ? "text-health-down" : "text-ink-strong";
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        {label}
+      </div>
+      <div className={`mt-0.5 font-mono text-sm tabular-nums ${valueClass}`}>{value}</div>
+    </div>
+  );
+}
+
+/**
+ * Network-wide stake flow (#3734) — total staked vs unstaked across every subnet
+ * for the window, the gaining/losing/flat split, and the biggest movers by
+ * absolute net flow as a signed bar list (green inflow / red outflow).
+ * Chain-direct: GET /api/v1/chain/stake-flow.
+ */
+function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
+  const net = flow.network;
+  const dist = flow.net_flow_distribution;
+  // Biggest movers by absolute net flow, largest first.
+  const movers = [...flow.subnets]
+    .sort((a, b) => Math.abs(b.net_flow_tao) - Math.abs(a.net_flow_tao))
+    .slice(0, 12);
+  const cap = Math.max(1, ...movers.map((s) => Math.abs(s.net_flow_tao)));
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Stake flow
+        </h2>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(flow.subnet_count)} subnets
+        </span>
+      </div>
+
+      {net ? (
+        <div className="mb-5 space-y-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <StakeFlowMetric
+              label="Net flow"
+              value={fmtTaoSigned(net.net_flow_tao)}
+              tone={net.net_flow_tao >= 0 ? "ok" : "down"}
+            />
+            <StakeFlowMetric label="Gross flow" value={fmtTao(net.gross_flow_tao)} />
+            <StakeFlowMetric label="Staked" value={fmtTao(net.total_staked_tao)} />
+            <StakeFlowMetric label="Unstaked" value={fmtTao(net.total_unstaked_tao)} />
+          </div>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[10px] uppercase tracking-widest">
+            <span className="text-health-ok">{formatNumber(net.gaining)} gaining</span>
+            <span className="text-health-down">{formatNumber(net.losing)} losing</span>
+            <span className="text-ink-muted">{formatNumber(net.flat)} flat</span>
+            <span className="text-ink-muted">
+              {formatNumber(net.stake_events + net.unstake_events)} events
+            </span>
+          </div>
+        </div>
+      ) : null}
+
+      {movers.length > 0 ? (
+        <ul className="space-y-1.5">
+          {movers.map((s) => {
+            const pct = Math.max(2, Math.round((Math.abs(s.net_flow_tao) / cap) * 100));
+            const inflow = s.net_flow_tao >= 0;
+            return (
+              <li key={s.netuid}>
+                <Link
+                  to="/subnets/$netuid"
+                  params={{ netuid: s.netuid }}
+                  className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
+                >
+                  <span className="truncate font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    SN{s.netuid}
+                  </span>
+                  <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
+                    <span
+                      className="absolute inset-y-0 left-0 rounded-full"
+                      style={{
+                        width: `${pct}%`,
+                        background: inflow ? "var(--health-ok)" : "var(--health-down)",
+                      }}
+                    />
+                  </span>
+                  <span
+                    className={`text-right font-mono text-[10px] tabular-nums ${
+                      inflow ? "text-health-ok" : "text-health-down"
+                    }`}
+                  >
+                    {fmtTaoSigned(s.net_flow_tao)}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">No stake flow in this window yet.</p>
+      )}
+
+      {dist ? (
+        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+          Median net flow {fmtTaoSigned(dist.median ?? 0)}, p90 {fmtTaoSigned(dist.p90 ?? 0)},
+          across {formatNumber(dist.count)} subnets.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -243,6 +369,7 @@ function ExplorerDashboard() {
   const fees = useSuspenseQuery(chainFeesQuery(win)).data.data;
   const calls = useSuspenseQuery(chainCallsQuery(win)).data.data;
   const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
+  const stakeFlow = useSuspenseQuery(chainStakeFlowQuery(win)).data.data;
   const stakeTransfers = useSuspenseQuery(chainStakeTransfersQuery(win)).data.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
@@ -528,6 +655,8 @@ function ExplorerDashboard() {
           )}
         </section>
       </div>
+
+      <StakeFlowSection flow={stakeFlow} />
 
       {/* stake-transfer leaderboard */}
       <section className="rounded-lg border border-border bg-card p-5">


### PR DESCRIPTION
Closes #3734

Wires the shipped-but-unconsumed `GET /api/v1/chain/stake-flow` aggregate into the chain explorer as a new **Stake flow** section, mirroring the existing `CallMixSection` / "Most active accounts" pattern already in `explorer.tsx`.

## What it adds
- **Data layer** — `ChainStakeFlow` (+ `ChainStakeFlowNetwork` / `…Distribution` / `…Subnet`) in `types.ts`, and `chainStakeFlowQuery` + normalizers in `queries.ts`, following the exact `chainCallsQuery` / `chainSignersQuery` `queryOptions` → `apiFetch` → normalize shape (`isRecord` / `coerceFiniteNumber` / `firstString`, `normalizeChainRows`).
- **UI** — a `StakeFlowSection` in `explorer.tsx`, fetched with `useSuspenseQuery(chainStakeFlowQuery(win))` and rendered after "Most active accounts":
  - network **net / gross / staked / unstaked** totals (net flow signed + tone-colored),
  - the **gaining / losing / flat** split with the total stake+unstake event count,
  - the **biggest movers by absolute net flow** as a signed bar list (green inflow / red outflow) that links through to each subnet,
  - a **median / p90** distribution footnote.
- Appends `/api/v1/chain/stake-flow` to the `ApiSourceFooter` paths.

Honors the `7d` / `30d` window toggle already on the page. No changes outside these three files.

## Verification
`tsc --noEmit` clean · `eslint .` clean (no new warnings) · `prettier --check` clean · `vite build` clean.

## Screenshots

> **Note on the data shown.** The `/api/v1/chain/*` family is currently served an **empty edge-cache variant to browser clients** (`vary: Accept, Accept-Encoding`, `cf-cache-status: HIT`, `max-age=14400`) — which is why the existing **Call mix** and **Most active accounts** sections also render empty in the live explorer today. Server-side, `GET /api/v1/chain/stake-flow` returns a full payload (129 subnets, ~8.2k τ net flow). To show the populated output, the shots below render the section against **that live payload, captured server-side and injected via a Playwright route mock**; the **empty state** (what a browser renders today, degrading cleanly — identical to its siblings) is included last. So this section behaves exactly like the shipped chain-explorer sections and populates automatically once the endpoint's browser cache serves data.

### Populated (live `/chain/stake-flow` payload) — desktop / tablet / mobile × light + dark

| | Light | Dark |
|---|---|---|
| **Desktop** | ![desktop light](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/data-desktop-light.png) | ![desktop dark](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/data-desktop-dark.png) |
| **Tablet** | ![tablet light](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/data-tablet-light.png) | ![tablet dark](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/data-tablet-dark.png) |
| **Mobile** | ![mobile light](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/data-mobile-light.png) | ![mobile dark](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/data-mobile-dark.png) |

### Empty state (what a live browser renders today)

| Light | Dark |
|---|---|
| ![empty light](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/empty-desktop-light.png) | ![empty dark](https://raw.githubusercontent.com/e11734937-beep/metagraphed/assets/stakeflow-shots/empty-desktop-dark.png) |
