### PR TITLE
feat(registry): add SN45 Talisman AI dashboard-stats data-artifact surface (#4050)

### DIFF
--- a/registry/subnets/talisman-ai.json
+++ b/registry/subnets/talisman-ai.json
@@ -104,6 +104,25 @@
         "https://github.com/Team-Rizzo/talisman-ai/blob/main/README.md#L153"
       ],
       "url": "https://api.alpharidge.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-talisman-dashboard-stats",
+      "kind": "data-artifact",
+      "name": "Talisman dashboard stats",
+      "notes": "Public no-auth GET /dashboard/stats on api.alpharidge.ai returning live SN45 content-analysis totals (tweets/telegram/articles analyzed, latest_analysis_at, sentiment distribution) — counts advance between successive requests, confirming a genuinely live feed. Documented in the subnet's own OpenAPI spec (already the registered schema_url on the sibling openapi surface) as \"Dashboard Stats\" / \"Public dashboard overview statistics\".",
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://api.alpharidge.ai/openapi.json",
+        "https://github.com/Team-Rizzo/talisman-ai"
+      ],
+      "url": "https://api.alpharidge.ai/dashboard/stats"
     }
   ],
   "social": { "x": "https://x.com/wearetalisman" },


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/talisman-ai.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 45
- Kind: data-artifact
- Public URL: https://api.alpharidge.ai/dashboard/stats
- Source URL (proves the claim): https://api.alpharidge.ai/openapi.json (the subnet's own OpenAPI spec — already the registered `schema_url` on the existing `openapi` surface in this file — documents this exact route as "Dashboard Stats" / "Public dashboard overview statistics"), plus https://github.com/Team-Rizzo/talisman-ai (official source repo)
- Provider slug: talisman-ai (already registered)

Live no-auth JSON endpoint returning SN45's content-analysis totals (tweets/telegram/articles analyzed, latest analysis timestamp, sentiment distribution). Re-fetched twice a few seconds apart during verification — the counts and timestamp both advanced, confirming this is a genuinely live feed, not a static/cached placeholder. Distinct URL from the two existing community surfaces (`openapi` schema doc, `subnet-api` health check) — no duplication.

Closes #4050

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership (the subnet's own OpenAPI spec documents this exact route).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (distinct URL/facet from the existing `openapi`/`subnet-api` entries).
- [x] Links a tracked issue (`Closes #4050`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/talisman-ai.json` — passed (5 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed