### PR TITLE
feat(ui): wire Download CSV on Subnets page (#3403)

### DIFF
--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useEffect, useMemo } from "react";
+import { z } from "zod";
 import { Network, Radio, Layers, Activity } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { BrandIcon, prefetchBrandIcon } from "@/components/metagraphed/brand-icon";
@@ -17,6 +18,7 @@ import { ViewModeToggle, type ViewMode } from "@/components/metagraphed/view-mod
 import { useIsMobile } from "@/hooks/use-mobile";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import {
   ariaSort,
@@ -40,6 +42,7 @@ import {
   agentCatalogMapQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { joinHealth, matchesQuery, sortBy, tableSearchSchema } from "@/lib/metagraphed/url-state";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { AgentCatalogSummary, Subnet } from "@/lib/metagraphed/types";
@@ -92,6 +95,16 @@ export const Route = createFileRoute("/subnets/")({
   component: SubnetsPage,
 });
 
+type SubnetsSearch = z.infer<typeof tableSearchSchema>;
+
+/** Server-backed params only — sort/curation/health filters are client-side. */
+function subnetsQueryParams(search: SubnetsSearch): { q?: string; limit: number } {
+  return {
+    q: search.q || undefined,
+    limit: search.limit,
+  };
+}
+
 function SubnetsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -125,6 +138,7 @@ function SubnetsPage() {
       search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
       replace: true,
     });
+  const subnetsCsvUrl = buildUrl("/api/v1/subnets", subnetsQueryParams(search));
   return (
     <AppShell>
       <PageHero
@@ -139,6 +153,7 @@ function SubnetsPage() {
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
             <ResetFiltersButton active={filtersActive} onReset={onReset} />
+            <DownloadCsvButton url={subnetsCsvUrl} />
             <ShareButton />
           </>
         }
@@ -227,10 +242,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   // /api/v1/subnets supports only q + cursor/limit. `sort` returns HTTP 400, and
   // `curation`/`health` are ignored server-side — so those are applied
   // client-side (filtered/sorted over the fetched pages) and must NOT be sent.
-  const baseParams = {
-    q: search.q || undefined,
-    limit: search.limit,
-  };
+  const baseParams = subnetsQueryParams(search);
 
   const {
     data,


### PR DESCRIPTION
## Summary

- Add `DownloadCsvButton` to the Subnets page hero (before Share), wired to `/api/v1/subnets` via `buildUrl`
- Export URL sends **only** server-backed params: `q` and `limit` — same shape as `SubnetsTable`'s `baseParams` (no `sort`, `curation`, `health`, `serviceKind`, or `readiness`)
- Uses shared `DownloadCsvButton` from `@/components/metagraphed/download-csv-button`
- Closes #3403 · Part of #2542

## Screenshots

**Visual PR — held for manual review per Path C.** Capture `/subnets` page hero (Download CSV in actions row). Fixed viewport only — never `fullPage: true`. Set theme before each capture:

```js
localStorage.setItem("mg-theme", "dark"); // or "light"
location.reload();
```

Host 12 PNGs on a `screenshots` orphan branch in your fork (not on this feature branch). Reference as `https://raw.githubusercontent.com/<your-fork-owner>/metagraphed/screenshots/<file>.png`.

**Before server:** separate worktree at merge-base — `git worktree add ../metagraphed-before $(git merge-base main HEAD)` then `npm run dev --workspace=apps/ui` there.

**After server:** this branch — `npm run dev --workspace=apps/ui`.

Suggested filenames: `3403-desktop-light-before.png`, `3403-desktop-light-after.png`, etc.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light (1280×800) | <img width="1268" height="933" alt="image" src="https://github.com/user-attachments/assets/9901e053-3468-43a1-82fc-8a8a78b3c45e" /> | <img width="1255" height="932" alt="image" src="https://github.com/user-attachments/assets/a3142e4c-692c-432c-aa6f-e95a1a1ca291" /> |
| Desktop · Dark (1280×800) | <img width="1270" height="943" alt="image" src="https://github.com/user-attachments/assets/c8ff9c77-fc6c-4ce8-a32e-285f377fef3d" /> | <img width="1271" height="938" alt="image" src="https://github.com/user-attachments/assets/0b39d7e5-f2bc-48cb-be5f-19bf14101fbc" /> |
| Tablet · Light (768×1024) | <img width="1278" height="978" alt="image" src="https://github.com/user-attachments/assets/ae88484e-88d6-46d4-827b-b7485452ed3b" /> | <img width="1268" height="976" alt="image" src="https://github.com/user-attachments/assets/c8e5ee7c-1af2-48dd-aa05-c4dee41963ea" /> |
| Tablet · Dark (768×1024) | <img width="1265" height="961" alt="image" src="https://github.com/user-attachments/assets/1d8514fe-c569-4c77-a3eb-c94aa20a8adb" /> | <img width="1254" height="970" alt="image" src="https://github.com/user-attachments/assets/5c9ef3cb-fc9c-439b-8b5c-9c7a670e2301" /> |
| Mobile · Light (375×812) | <img width="1277" height="1001" alt="image" src="https://github.com/user-attachments/assets/a4eb07de-050d-4823-bfc7-e1737027ea8f" /> | <img width="1265" height="1009" alt="image" src="https://github.com/user-attachments/assets/f6b7eb60-dcf9-41cf-b9a8-2d61c9076eef" /> |
| Mobile · Dark (375×812) |<img width="1263" height="1000" alt="image" src="https://github.com/user-attachments/assets/bf58befb-ed4b-4840-82ba-741d755b32eb" /> | <img width="1271" height="996" alt="image" src="https://github.com/user-attachments/assets/1e6462aa-3ee5-48c3-a880-0e02cb8951f2" /> |

## Test plan

- [x] `/subnets` — Download CSV with search `q` and page size — URL has `q` + `limit` only
- [x] Apply client-side filters (curation/health/readiness) — CSV URL unchanged (no unsupported params)
- [x] Switch to Testnet — link uses prefixed API base
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
