### PR TITLE
feat(registry): add SN70 NexisGen openapi + subnet-api surfaces (#4080)

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -1,18 +1,53 @@
 {
-  "schema_version": 1,
-  "netuid": 70,
-  "name": "NexisGen",
-  "slug": "sn-70",
-  "status": "active",
   "categories": [],
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "NexisGen",
+  "netuid": 70,
+  "schema_version": 1,
+  "slug": "sn-70",
   "social": {
     "x": "https://x.com/nexisgen_ai"
   },
-  "surfaces": [],
   "source_repo": "https://github.com/RendixNetwork/nexisgen",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-openapi",
+      "kind": "openapi",
+      "name": "NexisGen Nexis Validator API",
+      "notes": "Public no-auth OpenAPI 3.1 spec (Nexis Validator API v2.0.0, 7 documented paths) served on api.nexisgen.ai — the same nexisgen.ai host declared in the subnet's on-chain SubnetIdentitiesV3 (website + source repo). Machine-readable description of SN70 NexisGen's public validator API.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.nexisgen.ai/openapi.json",
+      "source_urls": ["https://github.com/RendixNetwork/nexisgen"],
+      "url": "https://api.nexisgen.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-latest-total-score-api",
+      "kind": "subnet-api",
+      "name": "NexisGen latest total score API",
+      "notes": "Public no-auth GET /v1/get_latest_total_score on api.nexisgen.ai — the most recent evaluation cycle's aggregate miner scores (cycle id plus per-miner aggregate and component scores) for SN70 NexisGen. Documented in the subnet's public OpenAPI spec on the same host.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://api.nexisgen.ai/openapi.json"],
+      "url": "https://api.nexisgen.ai/v1/get_latest_total_score"
+    }
+  ],
   "website_url": "https://nexisgen.ai/"
 }


### PR DESCRIPTION
## Summary

Closes #4080

Enriches SN70 **NexisGen** with its public, no-auth API — both the machine-readable OpenAPI spec and a live callable endpoint — on `api.nexisgen.ai`, a subdomain of the `nexisgen.ai` host declared in the subnet's on-chain identity.

## Surfaces (2)

- **openapi** — https://api.nexisgen.ai/openapi.json  OpenAPI 3.1 spec ("Nexis Validator API v2.0.0", 7 documented paths). Verified machine-readable by `validate:surface`.
- **subnet-api** — https://api.nexisgen.ai/v1/get_latest_total_score  Public no-auth `GET` → `200 application/json` — the latest evaluation cycle's aggregate miner scores.

Both `authority: community`, `auth_required: false`, `public_safe: true`.

## Proof

- On-chain `SubnetIdentitiesV3` for netuid 70 declares subnet_url: https://nexisgen.ai/ and github_repo: https://github.com/RendixNetwork/nexisgen — the surface host `api.nexisgen.ai` is the same domain.
- The `subnet-api` endpoint is documented in the subnet's own public OpenAPI spec (used as its `source_url`).

## Validation

- `npm run validate:surface -- registry/subnets/nexisgen.json` — passed (2 surfaces)
- `npm run scan:public-safety` — passed
- `npm run build` — passed (exit 0)
- `npm run validate` — passed (exit 0, 1439 surfaces)

Single-file change; no generated artifacts touched.
