### PR TITLE
feat(registry): add SN122 Bitrecs V2 miner artifact template data-artifact surface (#4172)

### DIFF
--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -87,6 +87,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Bitrecs source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-122-bitrecs-artifact-template",
+      "kind": "data-artifact",
+      "name": "Bitrecs V2 miner artifact template",
+      "notes": "Public no-auth YAML artifact template defining the SN122 Bitrecs V2 miner submission format (name, version_num, status, miner_hotkey, provider, model, prompt templates, sampling_params). Referenced as the canonical example in the official bitrecs-v2 miner setup docs; miners publish artifacts as single-commit GitHub Gists in this shape.",
+      "provider": "bitrecs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/bitrecs/bitrecs-v2/blob/main/docs/miner_setup.md",
+        "https://github.com/bitrecs/bitrecs-v2/blob/main/miner/miner_artifact.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/bitrecs/bitrecs-v2/main/miner/miner_artifact.yaml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Closes #4172

Adds the SN122 Bitrecs V2 canonical miner artifact template as a `data-artifact` surface — a previously-unregistered, public, no-auth YAML file that defines the artifact format miners submit for evaluation on netuid 122.

## Surface

- **Netuid:** 122
- **Kind:** `data-artifact`
- **Public URL:** `https://raw.githubusercontent.com/bitrecs/bitrecs-v2/main/miner/miner_artifact.yaml`
- **Source URLs (prove the claim):**
  - `https://github.com/bitrecs/bitrecs-v2/blob/main/docs/miner_setup.md` — official miner setup docs link to this file as the example artifact template (“View example miner_artifact.yml”)
  - `https://github.com/bitrecs/bitrecs-v2/blob/main/miner/miner_artifact.yaml` — the artifact file itself in the subnet's official V2 repository
- **Provider slug:** `bitrecs` (already registered)

Public no-auth GET → YAML artifact template with required miner submission fields (`name`, `version_num`, `status`, `miner_hotkey`, `provider`, `model`, `system_prompt_template`, `user_prompt_template`, `sampling_params`). Distinct from the three existing official surfaces (`website`, `docs`, `source-repo`) — no URL duplication.

## Proof

The Bitrecs V2 miner setup guide documents that miners create an `artifact.yaml` and points to `miner/miner_artifact.yaml` as the canonical example. Miners publish artifacts as single-commit GitHub Gists in this shape before submitting via the Bitrecs CLI.

## Checklist

- [x] Changes exactly one `registry/subnets/bitrecs.json` file, append-only.
- [x] `authority: community` and `review.state: community-submitted`.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing surface (new URL and facet).
- [x] Links tracked issue `Closes #4172` (issue intent: public data artifact).

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitrecs.json` — passed (4 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed