### PR TITLE
feat(registry): add NexisGen validator API OpenAPI surface (SN70)

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -1,18 +1,47 @@
 {
-  "schema_version": 1,
-  "netuid": 70,
-  "name": "NexisGen",
-  "slug": "sn-70",
-  "status": "active",
   "categories": [],
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "NexisGen",
+  "netuid": 70,
+  "schema_version": 1,
+  "slug": "sn-70",
   "social": {
     "x": "https://x.com/nexisgen_ai"
   },
-  "surfaces": [],
   "source_repo": "https://github.com/RendixNetwork/nexisgen",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-openapi",
+      "kind": "openapi",
+      "name": "NexisGen validator API OpenAPI schema",
+      "notes": "Public no-auth OpenAPI 3.1 schema for the SN70 NexisGen validator API (title \"Nexis Validator API\", version 2.0.0, 7 paths) on api.nexisgen.ai. Documents /healthz, training-score, blacklist, and admin routes used by subnet validators.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.nexisgen.ai/openapi.json",
+      "source_urls": [
+        "https://api.nexisgen.ai/healthz",
+        "https://github.com/RendixNetwork/nexisgen/blob/main/nexis/api/app.py",
+        "https://api.nexisgen.ai/openapi.json"
+      ],
+      "url": "https://api.nexisgen.ai/openapi.json"
+    }
+  ],
   "website_url": "https://nexisgen.ai/"
 }


### PR DESCRIPTION
## Summary
- Append community OpenAPI surface for SN70 NexisGen at `https://api.nexisgen.ai/openapi.json` (title "Nexis Validator API", 7 paths).
- First-party `api.nexisgen.ai` host; `/healthz` and routes implemented in RendixNetwork/nexisgen.

Closes #4081

## Validation
- [x] Exactly one subnet file changed: `registry/subnets/nexisgen.json`
- [x] `npm run validate:surface -- --file registry/subnets/nexisgen.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/nexisgen.json`
- [x] `npx prettier --check registry/subnets/nexisgen.json`
- [x] Live GET on `https://api.nexisgen.ai/openapi.json` returns machine-readable OpenAPI JSON

## Test plan
- [ ] CI review gate passes
- [ ] codecov passes


Made with [Cursor](https://cursor.com)