### PR TITLE
fix(ui): centralize compact TAO formatting in formatTao

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -10,20 +10,12 @@ import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { Sparkline, type SparklinePoint } from "@/components/metagraphed/charts/sparkline";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
 // validators, volume) from the previously-unused /api/v1/economics. The artifact
 // carries all subnets; we fetch once (shared cache) and find this netuid.
-
-function fmtTao(v?: number): string {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
-}
 
 function Notice({ children }: { children: string }) {
   return (
@@ -165,9 +157,9 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         value={formatNumber(e.miner_count)}
         hint={e.max_uids ? `${e.max_uids} max UIDs` : undefined}
       />
-      <StatTile eyebrow="Total stake" value={fmtTao(e.total_stake_tao)} />
-      <StatTile eyebrow="Volume" value={fmtTao(e.subnet_volume_tao)} />
-      <StatTile eyebrow="Max stake" value={fmtTao(e.max_stake_tao)} />
+      <StatTile eyebrow="Total stake" value={formatTao(e.total_stake_tao)} />
+      <StatTile eyebrow="Volume" value={formatTao(e.subnet_volume_tao)} />
+      <StatTile eyebrow="Max stake" value={formatTao(e.max_stake_tao)} />
       <StatTile
         eyebrow="Registration"
         tone={e.registration_allowed === false ? "down" : "default"}

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -3,18 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
 type Win = "7d" | "30d" | "90d" | "1y" | "all";
 const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
-
-function taoStr(v?: number) {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
-}
 
 function scoreStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";
@@ -88,14 +81,19 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
           {series.stake.length > 0 ? (
-            <HistoryRow label="Stake" series={series.stake} color="var(--accent)" format={taoStr} />
+            <HistoryRow
+              label="Stake"
+              series={series.stake}
+              color="var(--accent)"
+              format={formatTao}
+            />
           ) : null}
           {series.emission.length > 0 ? (
             <HistoryRow
               label="Emission"
               series={series.emission}
               color="var(--health-warn)"
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
           {series.incentive.length > 0 ? (

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -4,21 +4,13 @@ import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
 
 // Lowercase windows, mirroring the /history API + the inline toggle conventions
 // used by health-trends.tsx. "all" maps to the API's widest supported window.
 type Win = "7d" | "30d" | "90d" | "1y" | "all";
 const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
-
-function taoStr(v?: number) {
-  if (v == null || !Number.isFinite(v)) return "—";
-  // Stake/emission can span a wide range; keep it compact and readable.
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
-}
 
 /**
  * Per-subnet on-chain history (#1302). A window selector drives a daily snapshot
@@ -96,7 +88,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               label="Total stake"
               series={series.stake}
               color={healthColorVar("warn")}
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
           {series.emission.length > 0 ? (
@@ -104,7 +96,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               label="Total emission"
               series={series.emission}
               color="var(--accent, #7aa2ff)"
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
         </div>

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -5,7 +5,34 @@ import {
   durationLabel,
   formatRelative,
   isStaleFreshness,
+  formatTao,
 } from "./format";
+
+describe("formatTao", () => {
+  it("returns the fallback for nullish / non-finite input", () => {
+    expect(formatTao(undefined)).toBe("—");
+    expect(formatTao(null)).toBe("—");
+    expect(formatTao(Number.NaN)).toBe("—");
+    expect(formatTao(Infinity)).toBe("—");
+    expect(formatTao(null, "n/a")).toBe("n/a");
+  });
+
+  it("uses the majority convention at boundary values shared across call sites", () => {
+    expect(formatTao(1)).toBe("1.00 τ");
+    expect(formatTao(5)).toBe("5.00 τ");
+    expect(formatTao(10)).toBe("10.00 τ");
+  });
+
+  it("formats sub-1 TAO with four decimal places", () => {
+    expect(formatTao(0.5)).toBe("0.5000 τ");
+    expect(formatTao(0.12345)).toBe("0.1235 τ");
+  });
+
+  it("compacts large values with k and M suffixes", () => {
+    expect(formatTao(1_500)).toBe("1.5k τ");
+    expect(formatTao(2_500_000)).toBe("2.50M τ");
+  });
+});
 
 describe("isUsableTimestamp", () => {
   it("rejects empty / nullish input", () => {

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -4,6 +4,15 @@ export function formatNumber(n: number | undefined | null, fallback = "—"): st
   return new Intl.NumberFormat("en-US").format(n);
 }
 
+/** Compact TAO label with Nk/NM compaction and consistent decimal thresholds app-wide. */
+export function formatTao(v: number | undefined | null, fallback = "—"): string {
+  if (v === undefined || v === null || !Number.isFinite(v)) return fallback;
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  if (v >= 1) return `${v.toFixed(2)} τ`;
+  return `${v.toFixed(4)} τ`;
+}
+
 /**
  * The upstream registry frequently emits "1970-01-01T00:00:00.000Z" as a
  * placeholder when an artifact hasn't been timestamped yet. Treat any

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -46,7 +46,7 @@ import {
   accountSubnetsQuery,
   accountTransfersQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
@@ -127,14 +127,6 @@ function AccountDetail({ ss58 }: { ss58: string }) {
   return <ValidAccountDetail ss58={ss58} />;
 }
 
-// Compact TAO formatter — mirrors the economics panel's fmtTao convention.
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
-}
-
 function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const sourceRef = ss58PathSegment(ss58);
   const account = useSuspenseQuery(accountQuery(ss58)).data.data as AccountSummary;
@@ -152,7 +144,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const balanceValue = balanceResult.isPending ? (
     <span className="text-ink-muted">…</span>
   ) : balance?.balance_tao != null ? (
-    fmtTao(balance.balance_tao)
+    formatTao(balance.balance_tao)
   ) : (
     "—"
   );

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -26,7 +26,7 @@ import {
   chainStakeFlowQuery,
   chainStakeTransfersQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type {
@@ -69,13 +69,7 @@ function sum(values: number[]): number {
 }
 
 function fmtTaoSigned(v: number): string {
-  return v < 0 ? `-${fmtTao(-v)}` : `+${fmtTao(v)}`;
-}
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
+  return v < 0 ? `-${formatTao(-v)}` : `+${formatTao(v)}`;
 }
 
 function ExplorerPage() {
@@ -356,9 +350,9 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
               value={fmtTaoSigned(net.net_flow_tao)}
               tone={net.net_flow_tao >= 0 ? "ok" : "down"}
             />
-            <StakeFlowMetric label="Gross flow" value={fmtTao(net.gross_flow_tao)} />
-            <StakeFlowMetric label="Staked" value={fmtTao(net.total_staked_tao)} />
-            <StakeFlowMetric label="Unstaked" value={fmtTao(net.total_unstaked_tao)} />
+            <StakeFlowMetric label="Gross flow" value={formatTao(net.gross_flow_tao)} />
+            <StakeFlowMetric label="Staked" value={formatTao(net.total_staked_tao)} />
+            <StakeFlowMetric label="Unstaked" value={formatTao(net.total_unstaked_tao)} />
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[10px] uppercase tracking-widest">
             <span className="text-health-ok">{formatNumber(net.gaining)} gaining</span>
@@ -491,11 +485,11 @@ function ExplorerDashboard() {
           value={formatNumber(totalEvents)}
           hint={`${win} total`}
         />
-        <StatTile icon={Coins} eyebrow="Fees" value={fmtTao(totalFees)} hint={`${win} total`} />
+        <StatTile icon={Coins} eyebrow="Fees" value={formatTao(totalFees)} hint={`${win} total`} />
         <StatTile
           icon={Coins}
           eyebrow="Tips"
-          value={fmtTao(totalTips)}
+          value={formatTao(totalTips)}
           hint={`${win} total`}
           tone={totalTips > 0 ? "ok" : "default"}
         />
@@ -576,28 +570,28 @@ function ExplorerDashboard() {
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.total_fee_tao)}
                 color="var(--accent)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Avg fee"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.avg_fee_tao ?? 0)}
                 color="var(--chart-3)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Total tips"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.total_tip_tao)}
                 color="var(--chart-6)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Avg tip"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.avg_tip_tao ?? 0)}
                 color="var(--chart-1)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
             </div>
           ) : (
@@ -638,10 +632,10 @@ function ExplorerDashboard() {
                       </Link>
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                      {fmtTao(p.total_fee_tao)}
+                      {formatTao(p.total_fee_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(p.total_tip_tao)}
+                      {formatTao(p.total_tip_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                       {formatNumber(p.extrinsic_count)}
@@ -695,10 +689,10 @@ function ExplorerDashboard() {
                       {formatNumber(s.tx_count)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(s.total_fee_tao)}
+                      {formatTao(s.total_fee_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(s.total_tip_tao)}
+                      {formatTao(s.total_tip_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                       {s.last_tx_block != null ? (

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -13,7 +13,7 @@ import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import {
   extrinsicCall,
@@ -190,12 +190,12 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           </FieldRow>
           <FieldRow label="Inclusion fee">
             <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.fee_tao != null ? fmtTao(extrinsic.fee_tao) : "—"}
+              {extrinsic.fee_tao != null ? formatTao(extrinsic.fee_tao) : "—"}
             </span>
           </FieldRow>
           <FieldRow label="Tip">
             <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.tip_tao != null ? fmtTao(extrinsic.tip_tao) : "—"}
+              {extrinsic.tip_tao != null ? formatTao(extrinsic.tip_tao) : "—"}
             </span>
           </FieldRow>
           <FieldRow label="Observed at">
@@ -311,13 +311,6 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
       />
     </>
   );
-}
-
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
 }
 
 function renderCallArgs(callArgs: unknown) {


### PR DESCRIPTION
Closes #3947

## Summary

- Add shared `formatTao()` to `apps/ui/src/lib/metagraphed/format.ts`, using the majority convention already used by economics panel, explorer, accounts, and extrinsics (`≥1 → 2dp`, `<1 → 4dp`, plus existing `k`/`M` compaction).
- Replace six hand-duplicated local formatters with imports of `formatTao`.
- Rebased onto latest `main` and updated `explorer.tsx` stake-flow helpers to use `formatTao` via `fmtTaoSigned()` (new on `main`).
- Add unit tests for boundary values (1, 5, 10 TAO) and compaction paths so patch coverage on the new helper is complete.

## Why

The same TAO value rendered differently depending on page — e.g. `5.00 τ` on the economics panel but `5.000 τ` on subnet/neuron history charts because chart files used a divergent `<10 → 3dp` rule. This centralizes formatting so all six call sites agree.

## Validation

```sh
npm run lint --workspace=apps/ui
npm run format:check --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui
```

- `formatTao` tests cover nullish/non-finite input, boundaries at 1/5/10 TAO, sub-1 precision, and k/M compaction.
- No changes outside `apps/ui/**`.
- Majority-convention pages (economics panel, explorer, accounts, extrinsics) should look unchanged; only chart sparkline labels change precision to match.

## Screenshots

Hosted on the `screenshots` branch in my fork per the repo UI-PR contract (`raw.githubusercontent.com`, not drag-and-drop attachments). Before captured on `main`; after on this branch. Desktop · dark · 1280×800.

**Visible change:** neuron history chart τ labels on `/subnets/1?uid=235` — `0.000 τ` (old chart `<10 → 3dp`) → `0.0000 τ` (shared `<1 → 4dp`). Economics + subnet history on `/subnets/1` unchanged for live large values (`2.53M τ`, `82.00 τ`).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-neuron-history-before.png" width="260">](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-neuron-history-before.png)<br><sub>/subnets/1?uid=235 neuron history — `0.000 τ`</sub> | [<img src="https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-neuron-history-after.png" width="260">](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-neuron-history-after.png)<br><sub>/subnets/1?uid=235 neuron history — `0.0000 τ`</sub> |
| Desktop · Light | _Skipped — τ label strings are theme-independent; dark capture shows the precision change._ | _Skipped — same._ |
| Tablet · Light | _Skipped — formatting change is not breakpoint-gated._ | _Skipped — same._ |
| Tablet · Dark | _Skipped — formatting change is not breakpoint-gated._ | _Skipped — same._ |
| Mobile · Light | _Skipped — formatting change is not breakpoint-gated._ | _Skipped — same._ |
| Mobile · Dark | _Skipped — formatting change is not breakpoint-gated._ | _Skipped — same._ |

**Supplemental (unchanged large values):** economics + network history on `/subnets/1` — [<img src="https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-subnet-economics-history-before.png" width="200">](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-subnet-economics-history-before.png) before · [<img src="https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-subnet-economics-history-after.png" width="200">](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots/3947-subnet-economics-history-after.png) after.

## Test plan

- [x] `npm test --workspace=apps/ui` — `formatTao` boundary tests pass
- [x] Economics panel TAO labels unchanged on `/subnets/1`
- [x] Neuron history chart labels align with `formatTao` (screenshot pair above)
- [x] Rebased onto latest `main`; `explorer.tsx` merge conflict resolved (`fmtTaoSigned` now wraps `formatTao`)