### PR TITLE
feat(registry): add SN62 Ridges top-scores-over-time data-artifact surface (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-top-scores-over-time",
+      "kind": "data-artifact",
+      "name": "Ridges top-scores-over-time dataset",
+      "notes": "Public, unauthenticated GET /retrieval/top-scores-over-time on agent-upload.ridges.ai returning an hourly historical time-series (802 points spanning 2026-06-04 through the present) of the top SWE-agent score per hour — a genuine dataset, distinct from the live top-agents leaderboard snapshot already registered as the subnet-api surface. Documented in the subnet's own OpenAPI spec (already the registered schema_url) with summary \"Top Scores Over Time\", and defined in the same api/endpoints/retrieval.py source file backing the sibling subnet-api surface.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/retrieval/top-scores-over-time"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/ridges.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/retrieval/top-scores-over-time
- Source URL (proves the claim): https://agent-upload.ridges.ai/openapi.json (the subnet's own OpenAPI spec — already the registered `schema_url` on the existing `openapi`/`subnet-api` surfaces in this file — documents this exact route with summary "Top Scores Over Time"), plus https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py (the same source file backing the sibling `subnet-api` surface, defining this route)
- Provider slug: ridges (already registered)

Live no-auth JSON endpoint returning an hourly historical time-series (802 points, 2026-06-04 through present) of the top SWE-agent score per hour — a genuine dataset distinct from the already-registered `top-agents` live leaderboard snapshot (`subnet-api` surface). No auth/login/token/session/nonce/key/secret/wallet in the path.

Closes #4069

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership (the subnet's own OpenAPI spec documents this exact route).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (distinct URL/facet from the existing `subnet-api`/`openapi` entries).
- [x] Links a tracked issue (`Closes #4069`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json` — passed (4 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed