### PR TITLE
feat(registry): add SN122 Bitrecs Amazon fashion sample data-artifact surface (#4172)

### DIFF
--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -87,6 +87,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Bitrecs source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-122-bitrecs-amazon-fashion-sample",
+      "kind": "data-artifact",
+      "name": "Bitrecs Amazon fashion sample catalog",
+      "notes": "Public no-auth JSON sample ecommerce product-review catalog (ASIN, rating, title, price metadata) published in the official SN122 Bitrecs source repository at tests/data/amazon/fashion/. Referenced by the repo README (sample data setup) and exercised by tests/test_json.py for local recommendation-engine validation.",
+      "provider": "bitrecs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/bitrecs/bitrecs-subnet/blob/main/README.md",
+        "https://github.com/bitrecs/bitrecs-subnet/blob/main/tests/test_json.py"
+      ],
+      "url": "https://raw.githubusercontent.com/bitrecs/bitrecs-subnet/main/tests/data/amazon/fashion/amazon_fashion_sample_1000.json"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Closes #4172

Adds a public `data-artifact` surface for SN122 Bitrecs: the official Amazon fashion sample product-review catalog JSON published in the subnet's source repository under `tests/data/amazon/fashion/`.

## Surface

- **Netuid:** 122
- **Kind:** `data-artifact`
- **Public URL:** `https://raw.githubusercontent.com/bitrecs/bitrecs-subnet/main/tests/data/amazon/fashion/amazon_fashion_sample_1000.json`
- **Source URLs (prove the claim):**
  - `https://github.com/bitrecs/bitrecs-subnet/blob/main/README.md` — documents the sample `.json`/`.csv` files under `tests/data/` required for local testing
  - `https://github.com/bitrecs/bitrecs-subnet/blob/main/tests/test_json.py` — test suite loads this exact file path for recommendation-engine validation
- **Provider slug:** `bitrecs` (already registered)

Public no-auth GET → JSON array of anonymized ecommerce product reviews (ASIN, rating, title, price metadata). Distinct URL from the three existing official surfaces (`website`, `docs`, `source-repo`). Fetched surface content contains no wallet addresses, credentials, or private-key material.

## Why not the artifact template?

PR #4240 was closed because registering `miner/miner_artifact.yaml` from bitrecs-v2 caused Gittensory to flag wallet material in the fetched YAML (embedded SS58 address). This surface uses the subnet's published sample catalog data instead.

## Checklist

- [x] Changes exactly one `registry/subnets/bitrecs.json` file, append-only.
- [x] `authority: community` and `review.state: community-submitted`.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing surface.
- [x] Links tracked issue `Closes #4172`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitrecs.json` — passed (4 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed