### PR TITLE
feat(registry): add SN113 TensorUSD vault contract ABI data-artifact surface (#4152)

### DIFF
--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -108,6 +108,25 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Public no-auth GET returning the TensorUSD (SN113) backend API health (status + component/database connectivity). Hosted on api.tensorusd.com, the API subdomain of the subnet's registered website tensorusd.com."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-113-tensorusd-vault-abi",
+      "kind": "data-artifact",
+      "name": "TensorUSD vault contract ABI",
+      "notes": "Public no-auth JSON contract metadata (ink! ABI) for the SN113 TensorUSD vault pallet contract. Loaded by miners and validators via ContractMetadata.create_from_file in the official tensorusd/common/contract.py module; the README documents the matching mainnet Vault contract address.",
+      "provider": "tensorusd",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/TensorUSD/subnet/blob/main/tensorusd/common/contract.py",
+        "https://github.com/TensorUSD/subnet/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/TensorUSD/subnet/main/tensorusd/common/abis/tusdt_vault.json"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Closes #4152

Adds the SN113 TensorUSD vault contract metadata ABI as a `data-artifact` surface — a previously-unregistered, public, no-auth JSON file published in the subnet's official source repository.

## Surface

- **Netuid:** 113
- **Kind:** `data-artifact`
- **Public URL:** `https://raw.githubusercontent.com/TensorUSD/subnet/main/tensorusd/common/abis/tusdt_vault.json`
- **Source URLs (prove the claim):**
  - `https://github.com/TensorUSD/subnet/blob/main/tensorusd/common/contract.py` — `TensorUSDVaultContract` loads this file via `ContractMetadata.create_from_file(metadata_file=metadata_path)` and documents it as the `tusdt_vault.json` metadata path
  - `https://github.com/TensorUSD/subnet/blob/main/README.md` — documents the mainnet Vault contract address used with this ABI by miners/validators
- **Provider slug:** `tensorusd` (already registered)

Public no-auth GET → ink! contract metadata JSON for the TensorUSD vault pallet. Distinct from the existing `/health` subnet-api surface and the official website/docs/source-repo entries. Fetched content contains contract interface definitions only — no credentials or private-key material.

## Checklist

- [x] Changes exactly one `registry/subnets/tensorusd.json` file, append-only.
- [x] `authority: community` and `review.state: community-submitted`.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing surface.
- [x] Links tracked issue `Closes #4152`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/tensorusd.json` — passed (5 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed