### PR TITLE
feat(registry): add SN121 Sundae Bar SBC9 skill evaluation data-artifact surface (#4171)

### DIFF
--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -82,6 +82,25 @@
         "https://github.com/sundae-bar/sb-validator/blob/main/README.md"
       ],
       "url": "https://api.sundaebar.ai/api/v2/validators"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-121-sundae-bar-sbc9-eval-dataset",
+      "kind": "data-artifact",
+      "name": "Sundae Bar SBC9 skill evaluation dataset",
+      "notes": "Public no-auth JSONL benchmark dataset of customer-email response scenarios with rubric ground-truth metadata, published in the official SN121 sb-validator repository at python/dataset_sbc9.jsonl. Loaded at grader runtime by skill_evaluation.py (_load_variant_specifics) for skill-integrity checks during validator evaluation flows.",
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/sundae-bar/sb-validator/blob/main/python/skill_evaluation.py",
+        "https://github.com/sundae-bar/sb-validator/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/sundae-bar/sb-validator/main/python/dataset_sbc9.jsonl"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Closes #4171

Adds the public **SBC9 skill evaluation benchmark dataset** for **SN121 sundae_bar** as a new `data-artifact` surface.

The registry already includes the Sundae Bar website, source repository, and coordinator API health endpoint, but no standalone static data artifact was registered yet. This PR adds the official JSONL evaluation dataset published in the `sb-validator` repository.

## Surface Added

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://raw.githubusercontent.com/sundae-bar/sb-validator/main/python/dataset_sbc9.jsonl | Public JSONL benchmark of customer-email response scenarios with rubric ground-truth metadata |

## Verification

The artifact is publicly accessible without authentication.

- `GET` the raw GitHub URL returns HTTP 200 (`application/json` / JSONL)
- Content is synthetic customer-support evaluation scenarios (input prompts + ground-truth rubrics) — no wallet addresses, hotkeys, or credentials

## Source

Official SN121 validator repository:

- https://github.com/sundae-bar/sb-validator/blob/main/python/skill_evaluation.py — `_load_variant_specifics()` loads `dataset_sbc9.jsonl` from `python/dataset_sbc9.jsonl` at grader runtime for skill-integrity checks
- https://github.com/sundae-bar/sb-validator/blob/main/README.md — documents the SN121 skill evaluation validator stack

## Registry Safety

- Public, unauthenticated static artifact
- No secrets, tokens, localhost, or private infrastructure
- `authority: community`
- `auth_required: false`
- `public_safe: true`

## Validation

- `npm run validate:surface -- registry/subnets/sundae-bar.json`
- `npm run scan:public-safety`

Single-file append-only change. No generated artifacts or schemas modified.