### PR TITLE
feat(registry): add SN32 ItsAI leaderboard data-artifact surface (#4036)

### DIFF
--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -134,6 +134,24 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Public no-auth GET returning the ItsAI (SN32) content-detection API health as JSON. Hosted on api.its-ai.org, the API subdomain of the registered website its-ai.org; the API is documented at docs.its-ai.org and implemented in the team's It-s-AI/api FastAPI repo. Fills the file's noted missing public-API-endpoint gap."
+    },
+    {
+      "id": "sn-32-its-ai-data-artifact",
+      "name": "ItsAI SN32 leaderboard (Hugging Face Space)",
+      "kind": "data-artifact",
+      "url": "https://huggingface.co/spaces/sergak0/ai-detection-leaderboard",
+      "provider": "its-ai",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/It-s-AI/llm-detection/blob/main/docs/FAQ.md"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "notes": "Live SN32 miner leaderboard (UID/incentive/emission plus F1, false-positive, and average-precision scores from the Yuma validator) hosted as a public, no-auth Hugging Face Space. Explicitly named as the team's own leaderboard in docs/FAQ.md (\"Yes, we do have a leaderboard based on OTF scores\"); the app itself titles the page \"Subnet 32 Leaderboard\" and links back to github.com/It-s-AI/llm-detection. Fills the file's noted missing standalone-data-artifact gap."
     }
   ],
   "social": { "x": "https://x.com/ai_detection" },


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/itsai.json` (pure 18-line append, no other file, no reformatting).

## Surface

- Netuid: 32
- Kind: data-artifact
- Public URL: https://huggingface.co/spaces/sergak0/ai-detection-leaderboard
- Source URL (proves the claim): https://github.com/It-s-AI/llm-detection/blob/main/docs/FAQ.md — the official SN32 source repo's own FAQ explicitly names this as the team's leaderboard: "Is there a leaderboard where I can see the performance rankings of miners? Yes, we do have a leaderboard based on OTF scores: https://huggingface.co/spaces/sergak0/ai-detection-leaderboard"
- Provider slug: its-ai (already registered)

Live, public, no-auth Hugging Face Space (confirmed `RUNNING` via the HF API) showing the SN32 miner leaderboard (UID/incentive/emission plus F1, false-positive, and average-precision scores from the Yuma validator). The app itself titles the page "Subnet 32 Leaderboard" and links back to the official `It-s-AI/llm-detection` repo. Fills this file's noted gap for a standalone data artifact.

Closes #4036

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (18-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves official ownership (the team's own FAQ names this exact leaderboard).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4036`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/itsai.json` — passed (7 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/itsai.json` — passed