### PR TITLE
feat(registry): add SN118 Ditto LongMemEval memory cases data-artifact surface (#4165)

### DIFF
--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -249,6 +249,25 @@
         "https://github.com/ditto-assistant/ditto-cli/blob/main/README.md"
       ],
       "url": "https://github.com/ditto-assistant/ditto-cli"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-118-ditto-memory-cases",
+      "kind": "data-artifact",
+      "name": "DittoBench LongMemEval memory cases",
+      "notes": "Public no-auth JSON benchmark of LongMemEval memory-recall questions (question_id, question_type, query, answer, answer_pair_ids) bundled in the official SN118 DittoBench starter kit at fixtures/seed-user/memory_cases.json. Loaded at runtime by seed.rs (MEMORY_CASES_JSON) for local mem-eval and evaluate flows over the bundled seed user.",
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/ditto-assistant/dittobench-starter-kit/blob/main/src/seed.rs",
+        "https://github.com/ditto-assistant/dittobench-starter-kit/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/ditto-assistant/dittobench-starter-kit/main/fixtures/seed-user/memory_cases.json"
     }
   ],
   "website_url": "https://heyditto.ai/"


### PR DESCRIPTION
## Summary

Closes #4165

Adds the public **LongMemEval memory evaluation cases** dataset for **SN118 Ditto** as a new `data-artifact` surface.

The registry already includes Ditto's website, docs, assistant app, and DittoBench starter kit repository, but no standalone static data artifact was registered yet. This PR adds the bundled memory-recall benchmark JSON shipped with the official miner starter kit.

## Surface Added

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://raw.githubusercontent.com/ditto-assistant/dittobench-starter-kit/main/fixtures/seed-user/memory_cases.json | Public JSON array of LongMemEval memory questions (question_id, question_type, query, answer, answer_pair_ids) |

## Verification

The artifact is publicly accessible without authentication.

- `GET` the raw GitHub URL returns HTTP 200 (`application/json`)
- Content is synthetic LongMemEval memory-recall benchmark cases — no wallet addresses, hotkeys, or credentials

## Source

Official SN118 DittoBench starter kit repository:

- https://github.com/ditto-assistant/dittobench-starter-kit/blob/main/src/seed.rs — `MEMORY_CASES_JSON` includes and parses `fixtures/seed-user/memory_cases.json` via `memory_cases()` for local mem-eval and evaluate flows
- https://github.com/ditto-assistant/dittobench-starter-kit/blob/main/README.md — documents `fixtures/seed-user/` as the bundled LongMemEval seed user (pairs, subjects, memory questions)

## Registry Safety

- Public, unauthenticated static artifact
- No secrets, tokens, localhost, or private infrastructure
- `authority: community`
- `auth_required: false`
- `public_safe: true`

## Validation

- `npm run validate:surface -- registry/subnets/ditto.json`
- `npm run scan:public-safety`

Single-file append-only change. No generated artifacts or schemas modified.