### PR TITLE
feat(registry): add SN123 MANTIS datalog archive subnet-api surface

### DIFF
--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -89,6 +89,24 @@
         "submitted_by": "dev-miro26"
       },
       "notes": "Public no-auth JSON data artifact of asset prices and funding rates published by the SN123 MANTIS validator — the PRICE_DATA_URL declared in the official repo's config.py (line 63). Freshness/uptime are probe-derived and not asserted here."
+    },
+    {
+      "id": "sn-123-mantis-subnet-api",
+      "name": "MANTIS datalog archive endpoint",
+      "kind": "subnet-api",
+      "url": "https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db",
+      "provider": "mantis",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://raw.githubusercontent.com/Barbariandev/MANTIS/main/config.py"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "peter-minion"
+      },
+      "notes": "Public no-auth endpoint serving the SN123 MANTIS datalog archive — a SQLite database of the subnet's historical raw payloads / training datalog that the validator and model-iteration tooling download. This is the DATALOG_ARCHIVE_URL declared in the official repo's config.py. Verified reachable (HTTP 200, body begins \"SQLite format 3\"). Freshness/uptime/size are probe-derived and not asserted here."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `subnet-api` surface to `registry/subnets/mantis.json` (SN123 MANTIS). Append-only — one file, no generated artifacts.

## Surface

- Netuid: 123
- Kind: subnet-api
- Public URL: https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db
- Source URL (proves the claim): https://raw.githubusercontent.com/Barbariandev/MANTIS/main/config.py
- Provider slug: mantis

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only).
- [x] Community surface: `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it — the official `Barbariandev/MANTIS` `config.py` declares this URL as `DATALOG_ARCHIVE_URL` (alongside the already-registered `PRICE_DATA_URL`).
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, or private URLs; no generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct host/object from the `latest_prices.json` data-artifact).
- [x] Links a tracked issue (`Closes #4173`).

## Validation

- Verified reachable: `HEAD` on the URL → `200`; a ranged `GET` confirms the body begins `SQLite format 3` (a real SQLite database), served no-auth over HTTPS.
- One file changed; append-only; schema-valid.

Closes #4173
