### PR TITLE
feat(registry): add SN100 Plaτform challenges-dashboard data-artifact surface (#4128)

### DIFF
--- a/registry/subnets/pla-form.json
+++ b/registry/subnets/pla-form.json
@@ -146,6 +146,25 @@
         "https://github.com/PlatformNetwork/platform/blob/main/README.md"
       ],
       "url": "https://chain.joinbase.ai/v1/registry"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-100-platform-network-challenges-dashboard",
+      "kind": "data-artifact",
+      "name": "Plaτform challenges dashboard SVG",
+      "notes": "Public no-auth GET returning a rendered SVG dashboard (registered BASE challenges with status, miners, and emissions) on the same chain.joinbase.ai host as the registered OpenAPI/subnet-api surfaces. Documented in the subnet's own OpenAPI spec (chain.joinbase.ai/openapi.json, path /v1/challenges/dashboard.svg, summary \"Get Challenges Dashboard Svg\").",
+      "provider": "platform-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://chain.joinbase.ai/openapi.json",
+        "https://chain.joinbase.ai/v1/weights/latest"
+      ],
+      "url": "https://chain.joinbase.ai/v1/challenges/dashboard.svg"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/pla-form.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 100
- Kind: data-artifact
- Public URL: https://chain.joinbase.ai/v1/challenges/dashboard.svg
- Source URL (proves the claim): https://chain.joinbase.ai/openapi.json (the subnet's own OpenAPI spec — already the registered `schema_url` on the existing `openapi` surface in this file — documents this exact route with summary "Get Challenges Dashboard Svg"), plus https://chain.joinbase.ai/v1/weights/latest (a sibling documented endpoint on the same host that returns `netuid: 100` directly, independently confirming SN100 ownership)
- Provider slug: platform-network (already registered)

Live no-auth endpoint on the same `chain.joinbase.ai` host already backing this file's `openapi`/`subnet-api` surfaces, returning a real rendered SVG (`image/svg+xml`, 200) titled "BASE challenge dashboard" — registered challenges with status, miners, and emissions. Distinct URL/kind from the two existing community surfaces — no duplication.

Closes #4128

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership (the subnet's own OpenAPI spec documents this exact route).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4128`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/pla-form.json` — passed (6 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/pla-form.json` — passed