### PR TITLE
feat(registry): add SN117 BrainPlay Codenames deployment profile data-artifact surface (#4161)

### DIFF
--- a/registry/subnets/brainplay.json
+++ b/registry/subnets/brainplay.json
@@ -91,6 +91,25 @@
         "https://play.shiftlayer.ai/"
       ],
       "url": "https://play.shiftlayer.ai/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-117-brainplay-codenames-profile",
+      "kind": "data-artifact",
+      "name": "BrainPlay Codenames miner deployment profile",
+      "notes": "Public no-auth JSON Targon serverless container spec for the SN117 Codenames competition, published in the official brainplay-subnet repository at deploy/profiles/codenames.json. Read by deploy/miner.py when miners pass --competition codenames to deploy and commit their model endpoint on-chain.",
+      "provider": "shiftlayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/README.md",
+        "https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/deploy/miner.py"
+      ],
+      "url": "https://raw.githubusercontent.com/shiftlayer-llc/brainplay-subnet/main/deploy/profiles/codenames.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #4161

Adds the public **Codenames miner deployment profile** for **SN117 BrainPlay** as a new `data-artifact` surface.

The registry already includes the BrainPlay source repository, public app, and API health endpoint, but no standalone static data artifact was registered yet. This PR adds the official Targon serverless container spec JSON miners use when deploying for the Codenames competition.

## Surface Added

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://raw.githubusercontent.com/shiftlayer-llc/brainplay-subnet/main/deploy/profiles/codenames.json | Public JSON container deployment profile (resource tier, image, env placeholders, replica settings) |

## Verification

The artifact is publicly accessible without authentication.

- `GET` the raw GitHub URL returns HTTP 200 (`application/json`)
- Content is a static deployment template with env placeholders (`${MODEL}`, `${MINER_HOTKEY}`, etc.) — no embedded wallet addresses or credentials

## Source

Official SN117 BrainPlay source repository:

- https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/README.md — documents miner profiles under `deploy/profiles/` and the `--competition codenames` deploy flow
- https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/deploy/miner.py — reads `deploy/profiles/{competition}.json` when deploying miner endpoints to Targon

## Registry Safety

- Public, unauthenticated static artifact
- No secrets, tokens, localhost, or private infrastructure
- `authority: community`
- `auth_required: false`
- `public_safe: true`

## Validation

- `npm run validate:surface -- registry/subnets/brainplay.json`
- `npm run scan:public-safety`

Single-file append-only change. No generated artifacts or schemas modified.