### PR TITLE
feat(registry): add SN107 Minos minimum compute requirements data-artifact surface (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-min-compute",
+      "kind": "data-artifact",
+      "name": "Minos minimum compute requirements",
+      "notes": "Public no-auth YAML machine-readable miner and validator hardware requirements (CPU, GPU, memory, storage, Docker images, network, dataset sizes) published in the official SN107 minos_subnet repository at min_compute.yml. Listed in the repo README project layout and used by operators sizing genomics variant-calling nodes.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Closes #4141

Adds the public **minimum compute requirements** specification for **SN107 Minos** as a new `data-artifact` surface.

The registry already includes the Minos Platform API health endpoint, but no standalone static data artifact was registered yet. This PR adds the official machine-readable miner/validator hardware and runtime requirements YAML shipped in the minos_subnet repository.

## Surface Added

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml | Public YAML spec for miner/validator CPU, memory, storage, Docker images, network, and dataset requirements |

## Verification

The artifact is publicly accessible without authentication.

- `GET` the raw GitHub URL returns HTTP 200 (`text/plain` / YAML)
- Content documents hardware and Docker requirements for GATK/DeepVariant/BCFtools genomics workloads — no wallet addresses, hotkeys, or credentials

## Source

Official SN107 Minos source repository:

- https://github.com/minos-protocol/minos_subnet/blob/main/README.md — project layout documents `min_compute.yml` as minimal compute requirements
- https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml — the published specification file

## Registry Safety

- Public, unauthenticated static artifact
- No secrets, tokens, localhost, or private infrastructure
- `authority: community`
- `auth_required: false`
- `public_safe: true`

## Validation

- `npm run validate:surface -- registry/subnets/minos.json`
- `npm run scan:public-safety`

Single-file append-only change. No generated artifacts or schemas modified.