### PR TITLE
feat(registry): add SN21 AdTAO training-episodes data-artifact surface (#4019)

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -118,6 +118,25 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Official public AdTAO (SN21) validator API on the operator's validator.adtao.io host. An unauthenticated GET on /health returns live JSON service status (service, current epoch label, episodes loaded, submission window, deadline). The /v1/epochs routes are described in the linked OpenAPI schema."
+    },
+    {
+      "id": "sn-21-adtao-training-episodes",
+      "name": "AdTAO training episodes sample dataset",
+      "kind": "data-artifact",
+      "url": "https://raw.githubusercontent.com/ippcteam/SN21-adtao/main/data/training/training_episodes.json",
+      "provider": "adtao",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/ippcteam/SN21-adtao/blob/main/README.md",
+        "https://github.com/ippcteam/SN21-adtao/blob/main/scripts/train_example_model.py"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rust-toml"
+      },
+      "notes": "Public no-auth JSON dataset of bundled sample prediction episodes (account state, action context, and known outcomes) published in the official SN21 AdTAO source repository at data/training/. Documented in the repo README as the bundled sample data (10 episodes with known outcomes) and consumed by scripts/train_example_model.py for local baseline-model training."
     }
   ],
   "social": { "x": "https://x.com/ppcrebel" },


### PR DESCRIPTION
## Add or update a subnet surface

Closes #4019

Appends one community `data-artifact` surface to `registry/subnets/adtao.json` — the public bundled sample dataset published in SN21 AdTAO's official source repository.

## Surface

- Netuid: 21
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/ippcteam/SN21-adtao/main/data/training/training_episodes.json
- Source URL (proves the claim): https://github.com/ippcteam/SN21-adtao/blob/main/README.md (documents `data/training/` as the bundled sample data; consumed by `scripts/train_example_model.py`)
- Provider slug: adtao

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #4019`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/adtao.json`
- [x] `npm run scan:public-safety`

