### PR TITLE
feat(registry): add SN54 Yanez MIID miners-list data-artifact surface (#4060)

### DIFF
--- a/registry/subnets/yanez-miid.json
+++ b/registry/subnets/yanez-miid.json
@@ -54,6 +54,25 @@
         "https://tao-ui-dashboard.yanez.ai/"
       ],
       "url": "https://miners-stats.yanezcompliance.net/miners_stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-54-yanez-compliance-miners-list",
+      "kind": "data-artifact",
+      "name": "Yanez MIID miner UID catalog",
+      "notes": "Public no-auth GET returning the full catalog of registered SN54 miner UIDs (254 entries observed), distinct from the miners_stats scoring payload already registered as the subnet-api surface. Documented in the subnet's own OpenAPI spec (already the registered schema_url) as \"List Miners\" (operationId list_miners_miners_get), same host as the registered openapi/subnet-api surfaces.",
+      "provider": "yanez-compliance",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://miners-stats.yanezcompliance.net/openapi.json",
+        "https://github.com/yanez-compliance/MIID-subnet"
+      ],
+      "url": "https://miners-stats.yanezcompliance.net/miners"
     }
   ],
   "website_url": "https://www.yanez.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/yanez-miid.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 54
- Kind: data-artifact
- Public URL: https://miners-stats.yanezcompliance.net/miners
- Source URL (proves the claim): https://miners-stats.yanezcompliance.net/openapi.json (the subnet's own OpenAPI spec — already the registered `schema_url` on the existing `openapi` surface in this file — documents this exact route as "List Miners"), plus https://github.com/yanez-compliance/MIID-subnet (official source repo)
- Provider slug: yanez-compliance (already registered)

Live no-auth JSON endpoint on the same `miners-stats.yanezcompliance.net` host already backing this file's `openapi`/`subnet-api` surfaces, returning the full catalog of registered SN54 miner UIDs (254 entries) — a distinct UID catalog, not the per-miner scoring payload already registered as the `subnet-api` surface. No auth/login/token/session/nonce/key/secret/wallet in the path.

Closes #4060

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership (the subnet's own OpenAPI spec documents this exact route).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (distinct URL/facet from the existing `openapi`/`subnet-api` entries).
- [x] Links a tracked issue (`Closes #4060`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/yanez-miid.json` — passed (3 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/yanez-miid.json` — passed