### PR TITLE
feat(registry): add SN51 lium.io executor-stats data-artifact surface (#4055)

### DIFF
--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -103,6 +103,31 @@
       "schema_url": "https://lium.io/api/openapi.json",
       "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
       "url": "https://lium.io/api/reclaims"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-executor-stats",
+      "kind": "data-artifact",
+      "name": "Lium executor GPU utilization statistics",
+      "notes": "Public no-auth GET /api/executors/stats on lium.io returning a JSON dataset of live GPU-rental statistics aggregated per GPU type across the SN51 lium.io compute marketplace (gpu_type, rented_count, all_count, utilization percentage). Documented as a security-free public endpoint in the official Lium Backend API OpenAPI spec. Verified 200 application/json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rust-toml"
+      },
+      "source_urls": [
+        "https://lium.io/api/openapi.json",
+        "https://lium.io/api/executors/stats"
+      ],
+      "url": "https://lium.io/api/executors/stats"
     }
   ],
   "source_repo": "https://github.com/Datura-ai/lium-io"


### PR DESCRIPTION
## Add or update a subnet surface

Closes #4055

Appends one community `data-artifact` surface to `registry/subnets/lium-io.json` — the public GPU-utilization statistics dataset from SN51 lium.io's official Lium Backend API.

## Surface

- Netuid: 51
- Kind: data-artifact
- Public URL: https://lium.io/api/executors/stats
- Source URL (proves the claim): https://lium.io/api/openapi.json (official Lium Backend API OpenAPI spec documents `/executors/stats` as a `security: None` public endpoint)
- Provider slug: lium

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #4055`).

## Gate Expectations

Public-safe surface — a no-auth `GET https://lium.io/api/executors/stats` returns a JSON dataset of live GPU-rental statistics aggregated per GPU type across the SN51 lium.io compute marketplace (`gpu_type`, `rented_count`, `all_count`, utilization percentage), documented as a public (`security: None`) endpoint in the official OpenAPI spec on the same `lium.io` host as the existing machines/version/reclaims surfaces.

## Validation

- [x] `npm run validate:surface -- registry/subnets/lium-io.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/lium-io.json`
- [x] Live GET https://lium.io/api/executors/stats returns `200 application/json`
