### PR TITLE
feat(registry): add SN103 Djinn minimum compute requirements data-artifact (#4134)

### DIFF
--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -83,6 +83,25 @@
         "https://www.djinn.gg/"
       ],
       "url": "https://www.djinn.gg/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-103-djinn-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Djinn minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official Djinn-Inc/djinn repository as min_compute.yml. Documents SN103 operator requirements for TLSNotary proof miners and MPC validators without GPU.",
+      "provider": "djinn",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn/blob/main/min_compute.yml",
+        "https://github.com/Djinn-Inc/djinn/blob/main/CONTRIBUTING.md"
+      ],
+      "url": "https://raw.githubusercontent.com/Djinn-Inc/djinn/main/min_compute.yml"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4134

## Summary
- Register the official Djinn (SN103) `min_compute.yml` hardware specification as a community `data-artifact` surface.
- YAML documents public miner/validator CPU, memory, storage, OS, and bandwidth requirements for TLSNotary miners and MPC validators.
- Proof: file ships at the root of the official Djinn-Inc/djinn repository; CONTRIBUTING.md anchors the same source repo.

## Validation
- [x] `npm run validate:surface -- registry/subnets/djinn.json`
- [x] `npm run scan:public-safety`
- [x] Fetched artifact contains no SS58/wallet/private-key material