### PR TITLE
feat(registry): add SN50 Synth leaderboard-historical data-artifact surface (#4054)

### DIFF
--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -47,6 +47,25 @@
         "https://github.com/synthdataco/synth-subnet/blob/main/README.md"
       ],
       "url": "https://api.synthdata.co/v2/leaderboard/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-50-synth-leaderboard-historical",
+      "kind": "data-artifact",
+      "name": "Synth leaderboard history",
+      "notes": "Public no-auth GET returning historical per-miner reward records over a date range (query params start_time/end_time/prompt_name), distinct from the already-registered /v2/leaderboard/latest snapshot. Documented in the subnet's own OpenAPI spec (already the registered schema_url) as \"Leaderboard - Leaderboard History V2\".",
+      "provider": "synth",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://api.synthdata.co/swagger.json",
+        "https://github.com/synthdataco/synth-subnet/blob/main/README.md"
+      ],
+      "url": "https://api.synthdata.co/v2/leaderboard/historical?start_time=2026-07-06T00:00:00Z&end_time=2026-07-07T00:00:00Z&prompt_name=crypto-24h"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/synth.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 50
- Kind: data-artifact
- Public URL: https://api.synthdata.co/v2/leaderboard/historical?start_time=2026-07-06T00:00:00Z&end_time=2026-07-07T00:00:00Z&prompt_name=crypto-24h
- Source URL (proves the claim): https://api.synthdata.co/swagger.json (the subnet's own OpenAPI spec — already the registered `schema_url` on the existing `openapi` surface in this file — documents this exact route as "Leaderboard - Leaderboard History V2"), plus https://github.com/synthdataco/synth-subnet/blob/main/README.md (official source repo, already the source_url on the sibling surfaces)
- Provider slug: synth (already registered)

Live no-auth JSON endpoint on the same `api.synthdata.co` host already backing this file's `openapi`/`subnet-api` surfaces, returning historical per-miner reward records over a date range — distinct from the already-registered `/v2/leaderboard/latest` snapshot endpoint. No auth/login/token/session/nonce/key/secret/wallet in the path.

Closes #4054

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership (the subnet's own OpenAPI spec documents this exact route).
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (distinct URL/facet from the existing `openapi`/`subnet-api` entries).
- [x] Links a tracked issue (`Closes #4054`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/synth.json` — passed (3 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/synth.json` — passed