### PR TITLE
feat(registry): add SN3 Templar minimum-compute data artifact

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -174,6 +174,31 @@
         "confidence": "medium"
       },
       "url": "https://grafana.tplr.ai/public/openapi3.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Templar minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official one-covenant/templar repository as min_compute.yml. Documents SN3 Templar operator requirements for the decentralized pre-training run.",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/one-covenant/templar/blob/main/min_compute.yml",
+        "https://github.com/one-covenant/templar"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "url": "https://raw.githubusercontent.com/one-covenant/templar/main/min_compute.yml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Enriches **SN3 Templar** with its public minimum-compute specification as a `data-artifact` surface.

- **url:** `https://raw.githubusercontent.com/one-covenant/templar/main/min_compute.yml` — public, no-auth, verified live.
- **What it is:** the miner/validator hardware requirements (CPU, memory, storage, OS, bandwidth) at the root of the official `one-covenant/templar` repo.

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` entry to `registry/subnets/templar.json`; `authority: community`, `review.state: community-submitted`; purely additive.
- **Not a duplicate** — this URL isn't registered on Templar or any other subnet.
- **Same accepted pattern** as the merged SN103 Djinn min_compute.yml data-artifact (#4262, closing the analogous "add public data artifact" issue #4134).
- `npm run validate:surface` and `npm run scan:public-safety` pass locally; file is clean (no secrets/keys).

Closes #3999
