### PR TITLE
feat(registry): add SN98 ForeverMoney minimum compute requirements data-artifact (#4125)

### DIFF
--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -91,6 +91,32 @@
         "confidence": "medium"
       },
       "notes": "Public no-auth GET returning vault TVL aggregates grouped by trading pair on the official ForeverMoney Insights dashboard API host."
+    },
+    {
+      "id": "sn-98-forevermoney-min-compute-spec",
+      "name": "ForeverMoney minimum compute requirements",
+      "kind": "data-artifact",
+      "url": "https://raw.githubusercontent.com/SN98-ForeverMoney/forever-money/main/min_compute.yml",
+      "provider": "forevermoney",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money/blob/main/min_compute.yml",
+        "https://github.com/SN98-ForeverMoney/forever-money/blob/main/setup.py"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight",
+        "confidence": "medium"
+      },
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official SN98-ForeverMoney/forever-money repository as min_compute.yml. Documents baseline CPU, memory, storage, and network bandwidth requirements for SN98 ForeverMoney miners and validators."
     }
   ],
   "social": {


### PR DESCRIPTION
Adds one `data-artifact` surface to `registry/subnets/forevermoney.json` for the SN98 ForeverMoney `min_compute.yml` published at the root of the official subnet repository.

- **url**: raw `min_compute.yml` from `SN98-ForeverMoney/forever-money` (public, no auth)
- **source_urls**: the GitHub blob of `min_compute.yml` plus `setup.py`, independently proving the subnet publishes it
- Documents baseline CPU, memory, storage, and network bandwidth requirements for miners and validators
- `authority: community`, `review.state: community-submitted`; purely additive (one surface appended, nothing else changed)

Closes #4125