### PR TITLE
feat(registry): add SN107 Minos minimum-compute data artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,31 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Minos minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official minos-protocol/minos_subnet repository as min_compute.yml. Documents SN107 Minos operator requirements.",
+      "provider": "minos",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml",
+        "https://github.com/minos-protocol/minos_subnet"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Enriches **SN107 Minos** with its public minimum-compute specification as a `data-artifact` surface.

- **url:** `https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml` — public, no-auth, verified live (200).
- **What it is:** miner/validator hardware requirements (CPU, memory, storage, OS, bandwidth) at the root of the official `minos-protocol/minos_subnet` repo.

## Why it's safe to merge

- One file, one surface — appends a single `data-artifact` entry to `registry/subnets/minos.json`; `authority: community`, `review.state: community-submitted`; purely additive.
- Not a duplicate — this URL isn't registered on Minos or any other subnet.
- Same accepted pattern as the merged SN103 Djinn (#4262) and SN3 Templar (#4265) min_compute.yml data-artifacts.
- `validate:surface` + `scan:public-safety` pass; file is clean (no secrets).

Closes #4141
