### PR TITLE
feat(registry): add SN8 Vanta slippage-estimates data-artifact surface (#4005)

### DIFF
--- a/registry/subnets/vanta.json
+++ b/registry/subnets/vanta.json
@@ -161,6 +161,31 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public no-auth GET all_model_parameters.json on the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Provides the per-asset buy/sell slippage model parameters (intercept and coefficients) that the validator loads via vali_objects/utils/vali_bkp_utils.py to score miner positions."
+    },
+    {
+      "id": "sn-8-vanta-slippage-estimates",
+      "name": "Vanta empirical slippage estimates dataset",
+      "kind": "data-artifact",
+      "url": "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/slippage_estimates.json",
+      "provider": "vanta",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/vali_bkp_utils.py",
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/price_slippage_model.py"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rust-toml"
+      },
+      "notes": "Public no-auth static JSON dataset slippage_estimates.json committed in the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Distinct from the model-coefficients surface: this is the precomputed per-asset, per-trade-size empirical slippage lookup table (e.g. crypto BTCUSDC/ETHUSDC long/short across notional buckets). The path is resolved in vali_objects/utils/vali_bkp_utils.py and loaded by the PriceSlippageModel in vali_objects/utils/price_slippage_model.py to estimate execution slippage when scoring miner positions. Whitelisted for commit in .gitignore, so it is intentionally published."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Closes #4005

Appends one community `data-artifact` surface to `registry/subnets/vanta.json` — the empirical slippage-estimates dataset committed in SN8 Vanta's official source repository.

## Surface

- Netuid: 8
- Kind: data-artifact
- Public URL: https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/slippage_estimates.json
- Source URL (proves the claim): https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/price_slippage_model.py (PriceSlippageModel loads it; path resolved in vali_objects/utils/vali_bkp_utils.py)
- Provider slug: vanta

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated via helper — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it (loaded by the validator's PriceSlippageModel; whitelisted in .gitignore).
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct file + dataset + kind from the model-coefficients subnet-api surface).
- [x] Links a tracked issue that is still OPEN (`Closes #4005`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/vanta.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/vanta.json`
- [x] Live `GET` on the raw URL returns `200`
