### PR TITLE
feat(registry): add SN101 eni minimum-compute data artifact

### DIFF
--- a/registry/providers/eni.json
+++ b/registry/providers/eni.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/tag101-ai/tag101",
+  "id": "eni",
+  "kind": "subnet-team",
+  "name": "eni",
+  "public_notes": "Subnet 101 (eni) team profile. Identity from the public tag101-ai/tag101 source repository and the tag101.ai website. Review input only (authority: community).",
+  "schema_version": 1,
+  "website_url": "http://tag101.ai/"
+}

--- a/registry/subnets/eni.json
+++ b/registry/subnets/eni.json
@@ -26,5 +26,31 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-101-eni-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "eni minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official tag101-ai/tag101 repository as min_compute.yml. Documents SN101 eni operator requirements.",
+      "provider": "eni",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/tag101-ai/tag101/blob/main/min_compute.yml",
+        "https://github.com/tag101-ai/tag101"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "url": "https://raw.githubusercontent.com/tag101-ai/tag101/main/min_compute.yml"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN101 eni** with its public minimum-compute specification as a `data-artifact` surface, debuting the `eni` provider (the subnet had no registered surfaces yet).

- **url:** `https://raw.githubusercontent.com/tag101-ai/tag101/main/min_compute.yml` — public, no-auth, verified live.
- **What it is:** miner/validator hardware requirements (CPU, memory, storage, OS, bandwidth) at the root of the official `tag101-ai/tag101` repo.

## Files

- `registry/subnets/eni.json` — appends one `data-artifact` surface (authority: community, community-submitted).
- `registry/providers/eni.json` — debut provider profile (required, since eni had no registered provider).

## Why it's safe

- Same accepted pattern as the merged SN3 Templar (#4265) and SN103 Djinn (#4262) min_compute.yml data-artifacts.
- Not a duplicate; file verified clean (no secrets/keys/ss58); `validate:surface` + `scan:public-safety` pass.

Closes #4131
