### PR TITLE
feat(registry): add SN13 Data Universe default desirability list data artifact

### DIFF
--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -327,6 +327,31 @@
         "https://sn13.api.macrocosmos.ai/openapi.json"
       ],
       "url": "https://sn13.api.macrocosmos.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-13-data-universe-desirability-defaults",
+      "kind": "data-artifact",
+      "name": "Data Universe default desirability list",
+      "notes": "Public no-auth JSON default dynamic-desirability list (per-source label weights used to value Reddit and X data) published at dynamic_desirability/default.json in the official macrocosm-os/data-universe repository. Documents the SN13 baseline data-scoring configuration.",
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/macrocosm-os/data-universe/blob/main/dynamic_desirability/default.json",
+        "https://github.com/macrocosm-os/data-universe"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "url": "https://raw.githubusercontent.com/macrocosm-os/data-universe/main/dynamic_desirability/default.json"
     }
   ],
   "website_url": "https://datauniverse.macrocosmos.ai/"


### PR DESCRIPTION
## Summary

Enriches **SN13 Data Universe** with its public default desirability list as a `data-artifact` surface.

- **url:** `https://raw.githubusercontent.com/macrocosm-os/data-universe/main/dynamic_desirability/default.json` — public, no-auth, verified live.
- **What it is:** the baseline dynamic-desirability list (per-source label weights used to value Reddit/X data) from the official `macrocosm-os/data-universe` repo — the canonical SN13 data-scoring config.

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` to `registry/subnets/data-universe.json` (provider `macrocosmos` already registered); purely additive.
- **Not a duplicate**; file verified clean (no secrets/keys/ss58).
- Same accepted pattern as the merged SN3 Templar (#4265) / SN103 Djinn (#4262) repo data-artifacts.
- `validate:surface` + `scan:public-safety` pass locally.

Closes #4012
