### PR TITLE
feat(registry): add SN35 OxMarkets pools data-artifact surface (#4037)

### DIFF
--- a/registry/subnets/oxmarkets.json
+++ b/registry/subnets/oxmarkets.json
@@ -115,6 +115,25 @@
         "https://github.com/General-Tao-Ventures/cartha-principal-miner-template/blob/main/README.md"
       ],
       "url": "https://api.cartha.finance/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-35-oxmarkets-pools",
+      "kind": "data-artifact",
+      "name": "Cartha pools catalog",
+      "notes": "Public no-auth GET /pools on api.cartha.finance returning a JSON catalog of the tradeable liquidity pools on the SN35 OxMarkets (Cartha) market — each entry with name (e.g. EUR/USD, GBP/USD), poolId, vaultAddress, chainId, and network. Documented as GET /pools in the subnet OpenAPI spec (the already-registered schema on the sibling health surface); api.cartha.finance is the default VERIFIER_URL configured in the official Cartha principal miner template. Observed live and populated at submission time.",
+      "provider": "oxmarkets",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rust-toml"
+      },
+      "source_urls": [
+        "https://api.cartha.finance/openapi.json",
+        "https://github.com/General-Tao-Ventures/cartha-principal-miner-template/blob/main/README.md"
+      ],
+      "url": "https://api.cartha.finance/pools"
     }
   ],
   "contact": "contact@0xmarkets.io",


### PR DESCRIPTION
## Add or update a subnet surface

Closes #4037

Appends one community `data-artifact` surface to `registry/subnets/oxmarkets.json` — the public tradeable-pools catalog from SN35 OxMarkets' (Cartha) verifier API.

## Surface

- Netuid: 35
- Kind: data-artifact
- Public URL: https://api.cartha.finance/pools
- Source URL (proves the claim): https://api.cartha.finance/openapi.json (documents GET /pools as a public/security-None endpoint; api.cartha.finance is the VERIFIER_URL in the official Cartha principal miner template)
- Provider slug: oxmarkets

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (registered OpenAPI spec) independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct endpoint + kind from the health subnet-api surface).
- [x] Links a tracked issue that is still OPEN (`Closes #4037`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/oxmarkets.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/oxmarkets.json`
- [x] Live `GET https://api.cartha.finance/pools` returns `200 application/json`

