### PR TITLE
feat(registry): add SN107 Minos minimum compute requirements data-artifact (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Minos minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official minos-protocol/minos_subnet repository as min_compute.yml. Documents SN107 genomic variant-calling operator CPU, memory, storage, and GPU requirements for sandbox pipeline miners and validators.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
Closes #4141

## Summary
- Register the official Minos (SN107) `min_compute.yml` hardware specification as a community `data-artifact` surface.
- YAML documents miner/validator minimum CPU, memory, storage, and GPU requirements for the genomic variant-calling sandbox pipeline.
- Proof: file ships at the root of minos-protocol/minos_subnet; README.md lists it as the minimal compute requirements reference.

## Validation
- [x] `npm run validate:surface -- registry/subnets/minos.json`
- [x] `npm run scan:public-safety`
- [x] Fetched artifact contains no SS58/wallet/private-key material