### PR TITLE
feat(registry): add SN61 RedTeam active challenges registry data-artifact (#4068)

### DIFF
--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -126,6 +126,25 @@
         "https://dashboard.theredteam.io/"
       ],
       "url": "https://dashboard.theredteam.io/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-61-redteam-active-challenges",
+      "kind": "data-artifact",
+      "name": "RedTeam active challenges registry",
+      "notes": "Public no-auth YAML challenge-pool registry listing active SN61 RedTeam challenges (names, incentive weights, Docker images, controller targets, resource limits, and container run configuration) published in the official RedTeamSubnet/RedTeam repository at src/redteam_core/challenge_pool/active_challenges.yaml. Loaded at validator startup by active_challenges_manager.py via ACTIVE_CHALLENGES_FILE.",
+      "provider": "redteam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/RedTeamSubnet/RedTeam/blob/main/src/redteam_core/challenge_pool/active_challenges_manager.py",
+        "https://github.com/RedTeamSubnet/RedTeam/blob/main/src/redteam_core/challenge_pool/active_challenges.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/RedTeamSubnet/RedTeam/main/src/redteam_core/challenge_pool/active_challenges.yaml"
     }
   ],
   "contact": "oscar@theredteam.io"


### PR DESCRIPTION
Closes #4068

## Summary

Register the official RedTeam (SN61) active challenge-pool registry as a community `data-artifact` surface.

The YAML file lists live challenges (ab_sniffer_v6, flowradar_v2, etc.) with incentive weights, Docker images, controller targets, resource limits, and container run configuration used by validators.

**Proof:** `src/redteam_core/challenge_pool/active_challenges_manager.py` loads `active_challenges.yaml` at startup via `ACTIVE_CHALLENGES_FILE` (defaulting to that path).

Distinct from existing website, docs, dashboard, source-repo, and `/healthz` subnet-api surfaces.

## Validation

- [x] `npm run validate:surface -- registry/subnets/redteam.json`
- [x] `npm run scan:public-safety`
- [x] Fetched artifact uses env-var placeholders only (no literal API keys or wallet material)