### PR TITLE
feat(registry): add SN82 Compelle validator game config data-artifact (#4103)

### DIFF
--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -83,6 +83,25 @@
         "https://compelle.com/"
       ],
       "url": "https://compelle.com/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-82-compelle-validator-config",
+      "kind": "data-artifact",
+      "name": "Compelle validator game configuration",
+      "notes": "Public no-auth JSON validator consensus configuration (netuid 82, LLM model identifiers, judge panel, Elo parameters, tournament settings, and bundled debate topics) published in the official compelle/compelle-validator repository at compelle/config.json. Documented in the README Configuration section as the shared game-parameter contract every validator runs.",
+      "provider": "compelle",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/compelle/compelle-validator/blob/main/README.md",
+        "https://github.com/compelle/compelle-validator/blob/main/compelle/config.json"
+      ],
+      "url": "https://raw.githubusercontent.com/compelle/compelle-validator/main/compelle/config.json"
     }
   ]
 }


### PR DESCRIPTION
Closes #4103

## Summary

Register the official Compelle (SN82) validator consensus game configuration as a community `data-artifact` surface.

The JSON file documents netuid, LLM model identifiers, judge panel, Elo/tournament parameters, and bundled debate topics that every validator runs under the same consensus contract.

**Proof:** the repository README Configuration section documents `compelle/config.json` as the shared game-parameter contract; remote gist rotation uses the same topic schema.

Distinct from the existing website, source-repo, and `/api/health` subnet-api surfaces.

## Validation

- [x] `npm run validate:surface -- registry/subnets/compelle.json`
- [x] `npm run scan:public-safety`
- [x] Fetched artifact contains public game parameters only (empty wallet placeholders, no credentials)