### PR TITLE
feat(registry): add SN87 Luminar benchmark submission sample data-artifact (#4112)

### DIFF
--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -237,6 +237,25 @@
         "https://luminar.network/"
       ],
       "url": "https://luminar.network/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-87-luminar-benchmark-submission-sample",
+      "kind": "data-artifact",
+      "name": "Luminar benchmark submission sample",
+      "notes": "Public no-auth CSV sample miner detection output (video_id, frame_idx, category, n_items, box_2d columns with bounding-box JSON) published in the official Luminar-Network/luminar-sn repository at benchmark/test/test_submission.csv. Documents the per-frame submission schema scored by luminar/validator/scoring.py and illustrated in the README Required output format section for SN87 traffic object-detection agents.",
+      "provider": "luminar-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/Luminar-Network/luminar-sn/blob/main/README.md",
+        "https://github.com/Luminar-Network/luminar-sn/blob/main/luminar/validator/scoring.py"
+      ],
+      "url": "https://raw.githubusercontent.com/Luminar-Network/luminar-sn/main/benchmark/test/test_submission.csv"
     }
   ],
   "website_url": "https://luminar.network/"


### PR DESCRIPTION
Closes #4112

## Summary

Register the official Luminar (SN87) benchmark submission sample CSV as a community `data-artifact` surface.

The file demonstrates the per-frame miner output schema (`video_id`, `frame_idx`, `category`, `n_items`, `box_2d`) used for traffic object-detection scoring.

**Proof:** the repository README Required output format section documents the column layout; `luminar/validator/scoring.py` states GT and miner output both use this CSV format.

Distinct from existing website, docs, demo, source-repo, and `/healthz` subnet-api surfaces.

## Validation

- [x] `npm run validate:surface -- registry/subnets/luminar-network.json`
- [x] `npm run scan:public-safety`
- [x] Fetched artifact contains bounding-box coordinates only (no credentials or wallet material)