### PR TITLE
feat(registry): add SN76 Byzantium miner agent config data-artifact (#4092)

### DIFF
--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -66,6 +66,25 @@
       },
       "source_urls": ["https://github.com/safe-scan-ai/cancer-ai"],
       "url": "https://github.com/safe-scan-ai/cancer-ai"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-76-byzantium-agent-config",
+      "kind": "data-artifact",
+      "name": "Byzantium miner agent configuration",
+      "notes": "Public no-auth JSON miner agent-kit configuration (minerHandle, campaign, linkBase, Farcaster channel targets, posting rate limits, and persona traits) published in the official byzantiumaitao-arch/byzantium repository at ai-agent-kit/byzantium.config.json. Documented in ai-agent-kit/README.md as the primary file miners edit to configure the ElizaOS-based social promotion agent for SN76 click campaigns.",
+      "provider": "byzantium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/byzantiumaitao-arch/byzantium/blob/main/ai-agent-kit/README.md",
+        "https://github.com/byzantiumaitao-arch/byzantium/blob/main/ai-agent-kit/byzantium.config.json"
+      ],
+      "url": "https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/ai-agent-kit/byzantium.config.json"
     }
   ],
   "website_url": "https://www.byzantiumai.net/"


### PR DESCRIPTION
Closes #4092

## Summary

Register the official Byzantium (SN76) miner agent-kit configuration as a community `data-artifact` surface.

The JSON file defines the miner handle, campaign, tracking link base, Farcaster channel targets, posting rate limits, and persona traits for the ElizaOS-based social promotion agent.

**Proof:** `ai-agent-kit/README.md` documents `byzantium.config.json` as the primary file miners edit during setup.

Distinct from the existing website and source-repo surfaces.

## Validation

- [x] `npm run validate:surface -- registry/subnets/byzantium.json`
- [x] `npm run scan:public-safety`
- [x] Fetched artifact contains public campaign config only (no API keys or wallet material)