### PR TITLE
feat(registry): add SN107 Minos hap.py benchmark summary data artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,31 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-happy-summary",
+      "kind": "data-artifact",
+      "name": "Minos hap.py benchmark summary",
+      "notes": "Public no-auth CSV hap.py variant-calling benchmark summary (per-type TRUTH/QUERY TP/FN/FP counts and precision/recall fields) published in the official minos-protocol/minos_subnet repository. Documents the SN107 Minos genomics evaluation output format.",
+      "provider": "minos",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/tests/fixtures/happy_summary.csv",
+        "https://github.com/minos-protocol/minos_subnet"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/tests/fixtures/happy_summary.csv"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Enriches **SN107 Minos** with a public benchmark-summary CSV as a `data-artifact` surface.

- **url:** `https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/tests/fixtures/happy_summary.csv` — public, no-auth, verified live.
- **What it is:** a hap.py variant-calling benchmark summary (per-type TRUTH/QUERY TP/FN/FP + precision/recall) from the official `minos-protocol/minos_subnet` repo — the SN107 genomics evaluation output format.

## Why it's safe

- One file, one `data-artifact` surface on `registry/subnets/minos.json` (provider `minos` already registered); purely additive.
- Not a duplicate; file verified clean (no secrets/keys/ss58).
- Same accepted pattern as merged repo data-artifacts (SN3 Templar #4265, SN13 #4272).

Closes #4141