### PR TITLE
fix(ui): include health state text in subnet health matrix accessible name

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
@@ -49,7 +49,7 @@ export function SubnetHealthMatrix() {
                       "group aspect-square rounded-sm transition-all duration-150 ring-0 hover:ring-2 hover:ring-accent/40 hover:scale-110",
                       tone,
                     )}
-                    aria-label={`SN${s.netuid}${s.name ? ` — ${s.name}` : ""}`}
+                    aria-label={`SN${s.netuid}${s.name ? ` — ${s.name}` : ""} — ${s.health ?? "unknown"}`}
                   />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="text-[11px]">


### PR DESCRIPTION
## Summary

- `SubnetHealthMatrix` (`apps/ui/src/components/metagraphed/subnet-health-matrix.tsx`) now includes each cell's health state as text in its `aria-label`, instead of relying on color alone to convey it.

Closes #3958

## What Changed

- Extended the cell `aria-label` from `` `SN${netuid}${name ? ` — ${name}` : ""}` `` to also append the health state: `` `SN${netuid}${name ? ` — ${name}` : ""} — ${health ?? "unknown"}` ``.
- No other changes — the visible tooltip already shows the health state as text (`{s.health ?? "unknown"}`); this just brings the persistent accessible name (which a screen reader announces without needing to trigger the tooltip) up to the same standard.

## Why

The heatmap's only sighted signal for a subnet's health was cell color (`TONE` map). A screen-reader user got a name like "SN5 — Hone" with no equivalent to that color-coded ok/warn/down/unknown signal — this is a color-only accessibility gap.

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend markup, no registry/schema/API surface.

## Validation

- [x] `npx eslint src/components/metagraphed/subnet-health-matrix.tsx` — clean aside from pre-existing CRLF/line-ending noise from this Windows checkout
- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors; the 2 pre-existing errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout (missing built `packages/client` dist)
- [x] `git diff --check`
- [x] Per this issue's own acceptance criteria, this defect isn't visually observable in a screenshot (color rendering is unchanged; only the `aria-label` string gained a suffix), so a note stands in: traced the change directly — every cell's `aria-label` now interpolates `s.health ?? "unknown"` the same way the visible tooltip already does at line 61, so the accessible name and the sighted-only tooltip text are now equivalent for every possible `HealthState` value (`ok`/`warn`/`down`/`unknown`)

## Issue Link

Closes #3958