### PR TITLE
feat(registry): add SN77 Liquidity final miner weights data-artifact surface

### DIFF
--- a/registry/subnets/liquidity.json
+++ b/registry/subnets/liquidity.json
@@ -27,6 +27,24 @@
         "https://github.com/creativebuilds/sn77/blob/master/README.md"
       ],
       "url": "https://77.creativebuilds.io/pools"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-77-liquidity-weights",
+      "kind": "data-artifact",
+      "name": "SN77 final miner weights",
+      "notes": "Public no-auth GET /weights on 77.creativebuilds.io returning the subnet's final calculated per-miner weights as a JSON map of hotkey SS58 address to weight value (observed live: {success, weights:{<ss58>:<number>, ...250+ miners}, cached}). Documented as GET /weights in the official creativebuilds/sn77 README; same 77.creativebuilds.io host as the existing /pools surface.",
+      "provider": "liquidity",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "GildardoDev"
+      },
+      "source_urls": [
+        "https://github.com/creativebuilds/sn77/blob/master/README.md"
+      ],
+      "url": "https://77.creativebuilds.io/weights"
     }
   ]
 }


### PR DESCRIPTION
Closes #4094.

Adds the missing public data-artifact surface for SN77 Liquidity: `GET /weights` on `77.creativebuilds.io`, the subnet's public REST API.

Verified before submitting:
- Live and public: `GET https://77.creativebuilds.io/weights` returns HTTP 200 with no authentication, serving the subnet's final calculated per-miner weights as a JSON map of hotkey SS58 address to weight value (observed `{success, weights:{<ss58>:<number>, ...250+ miners}, cached}`).
- Genuinely SN77's: same `77.creativebuilds.io` host as this subnet's existing `/pools` surface, and documented in the official creativebuilds/sn77 README.
- Documented: the README lists `GET /weights` ("Final calculated miner weights") as a public no-auth endpoint, which is the cited source_url.

One surface appended to the single registry file, authority community, review community-submitted. No code or contract changes.
