### PR TITLE
fix(ui): announce registry-ticker rotation via aria-live for assistive tech

### DIFF
--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -119,7 +119,7 @@ export function RegistryTicker() {
               <StatChip key={s.label} stat={s} />
             ))}
           </span>
-          <span className="xl:hidden inline-flex">
+          <span className="xl:hidden inline-flex" aria-live="polite" aria-atomic="true">
             <StatChip stat={stats[rot]!} />
           </span>
         </div>


### PR DESCRIPTION
## Summary

- The rotating mobile/md stat chip in `RegistryTicker` (`apps/ui/src/components/metagraphed/registry-ticker.tsx`) is now wrapped in an `aria-live="polite"` region, so a screen reader announces each new stat as it rotates in.

Closes #3959

## What Changed

- Added `aria-live="polite"` and `aria-atomic="true"` to the existing `<span className="xl:hidden inline-flex">` wrapper around the rotating `<StatChip>` (the same container the component already used for this variant — no new element introduced).
- `aria-atomic="true"` ensures the whole chip's text is re-announced as one unit on each rotation, rather than a partial-diff announcement.
- No changes to the rotation interval, the stats shown, or the `xl:flex` full-row variant (unaffected — it's a separate, non-rotating branch).

## Why

The ticker swaps its displayed stat on a 6s timer with no `aria-live` region anywhere in the component. Screen-reader users got no notification that the content was changing underneath them, while sighted users see the rotation directly.

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend markup, no registry/schema/API surface.

## Validation

- [x] `npx eslint src/components/metagraphed/registry-ticker.tsx` — clean aside from pre-existing CRLF/line-ending noise from this Windows checkout
- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors; the 2 pre-existing errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout (missing built `packages/client` dist)
- [x] `git diff --check`
- [x] Per this issue's own acceptance criteria, this fix has no visual component, so verified via the accessibility tree instead of a screenshot: `aria-live`/`aria-atomic` are DOM attributes, not rendered content — the visible rotation and its 6s timing are byte-for-byte unchanged (the diff touches only the wrapping `<span>`'s attributes). Because `aria-live` regions only re-announce on an actual text-content change (native browser/AT behavior, not app logic), a re-render that leaves the current stat's text unchanged does not fire a spurious announcement — only a genuine rotation or a live value update does.

## Issue Link

Closes #3959