### PR TITLE
feat(ui): add a /validators global validator directory page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -336,6 +336,7 @@ function SiteFooter() {
           <FooterLink to="/surfaces">Surfaces</FooterLink>
           <FooterLink to="/endpoints">Endpoints</FooterLink>
           <FooterLink to="/providers">Providers</FooterLink>
+          <FooterLink to="/validators">Validators</FooterLink>
         </FooterCol>
         <FooterCol title="Operations">
           <FooterLink to="/health">Health</FooterLink>

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as EndpointsRouteImport } from './routes/endpoints'
 import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ValidatorsIndexRouteImport } from './routes/validators.index'
 import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
@@ -84,6 +85,11 @@ const AboutRoute = AboutRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ValidatorsIndexRoute = ValidatorsIndexRouteImport.update({
+  id: '/validators/',
+  path: '/validators/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SubnetsIndexRoute = SubnetsIndexRouteImport.update({
@@ -159,6 +165,7 @@ export interface FileRoutesByFullPath {
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
+  '/validators/': typeof ValidatorsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -182,6 +189,7 @@ export interface FileRoutesByTo {
   '/extrinsics': typeof ExtrinsicsIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/subnets': typeof SubnetsIndexRoute
+  '/validators': typeof ValidatorsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
+  '/validators/': typeof ValidatorsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -231,6 +240,7 @@ export interface FileRouteTypes {
     | '/extrinsics/'
     | '/providers/'
     | '/subnets/'
+    | '/validators/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -254,6 +264,7 @@ export interface FileRouteTypes {
     | '/extrinsics'
     | '/providers'
     | '/subnets'
+    | '/validators'
   id:
     | '__root__'
     | '/'
@@ -277,6 +288,7 @@ export interface FileRouteTypes {
     | '/extrinsics/'
     | '/providers/'
     | '/subnets/'
+    | '/validators/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -301,6 +313,7 @@ export interface RootRouteChildren {
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
   SubnetsIndexRoute: typeof SubnetsIndexRoute
+  ValidatorsIndexRoute: typeof ValidatorsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -380,6 +393,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/validators/': {
+      id: '/validators/'
+      path: '/validators'
+      fullPath: '/validators/'
+      preLoaderRoute: typeof ValidatorsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/subnets/': {
@@ -477,6 +497,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,
   SubnetsIndexRoute: SubnetsIndexRoute,
+  ValidatorsIndexRoute: ValidatorsIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -1,0 +1,208 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
+import { ShareButton } from "@/components/metagraphed/share-button";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { validatorsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+
+// The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
+// Stake / emission / dominance / trust get their own columns in #3359; this
+// baseline page only renders hotkey identity + subnet/UID counts (#3360 adds the
+// dedicated active-subnet column), but every sort key stays selectable.
+const validatorSortKeys = [
+  "subnet_count",
+  "uid_count",
+  "stake_dominance",
+  "total_stake",
+  "total_emission",
+  "avg_validator_trust",
+  "max_validator_trust",
+] as const;
+
+const SORT_LABELS: Record<GlobalValidatorSort, string> = {
+  subnet_count: "Active subnets",
+  uid_count: "UIDs",
+  stake_dominance: "Dominance",
+  total_stake: "Total stake",
+  total_emission: "Total emission",
+  avg_validator_trust: "Avg trust",
+  max_validator_trust: "Max trust",
+};
+
+const validatorsSearchSchema = z.object({
+  sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
+});
+
+export const Route = createFileRoute("/validators/")({
+  validateSearch: zodValidator(validatorsSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Validators — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Network-wide Bittensor validator directory — hotkeys ranked across subnets, with active-subnet and UID counts, computed live from the chain-direct metagraph.",
+      },
+      { property: "og:title", content: "Validators — Metagraphed" },
+      {
+        property: "og:description",
+        content: "Network-wide Bittensor validator directory across all subnets.",
+      },
+    ],
+  }),
+  component: ValidatorsPage,
+});
+
+function ValidatorsPage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const sort = search.sort ?? "subnet_count";
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Directory"
+        live
+        title="Validators"
+        description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
+        actions={<ShareButton />}
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+          <ValidatorsTable
+            sort={sort}
+            onSortChange={(v) =>
+              navigate({
+                search: (prev: Record<string, unknown>) => ({ ...prev, sort: v }) as never,
+                replace: true,
+              })
+            }
+          />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/validators"]} />
+    </AppShell>
+  );
+}
+
+const TH = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
+
+function SortSelect({
+  value,
+  onChange,
+}: {
+  value: GlobalValidatorSort;
+  onChange: (v: GlobalValidatorSort) => void;
+}) {
+  return (
+    <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
+      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Sort</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as GlobalValidatorSort)}
+        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Sort validators"
+      >
+        {validatorSortKeys.map((k) => (
+          <option key={k} value={k}>
+            {SORT_LABELS[k]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function ValidatorsTable({
+  sort,
+  onSortChange,
+}: {
+  sort: GlobalValidatorSort;
+  onSortChange: (v: GlobalValidatorSort) => void;
+}) {
+  const res = useSuspenseQuery(validatorsQuery({ sort })).data;
+  const validators = res.data.validators;
+  const generatedAt = res.meta?.generated_at ?? null;
+
+  return (
+    <div className="space-y-3">
+      {isStaleFreshness(generatedAt) ? (
+        <StaleBanner
+          generatedAt={generatedAt}
+          refreshQueryKeys={[validatorsQuery({ sort }).queryKey]}
+        />
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
+        </span>
+        <SortSelect value={sort} onChange={onSortChange} />
+      </div>
+
+      {validators.length > 0 ? (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/50">
+              <tr>
+                <th className={TH}>Hotkey</th>
+                <th className={TH}>Coldkey</th>
+                <th className={`${TH} text-right`}>Active subnets</th>
+                <th className={`${TH} text-right`}>UIDs</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {validators.map((v) => (
+                <tr key={v.hotkey} className="hover:bg-surface/40">
+                  <td className="px-3 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: v.hotkey }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                      title={v.hotkey}
+                    >
+                      {shortHash(v.hotkey) ?? v.hotkey}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                    {v.coldkey ? (
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: v.coldkey }}
+                        className="hover:text-accent hover:underline"
+                        title={v.coldkey}
+                      >
+                        {shortHash(v.coldkey) ?? v.coldkey}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(v.subnet_count)}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(v.uid_count)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <EmptyState
+          title="No validators indexed yet"
+          description="The global validator directory is empty for this window."
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds the **`/validators` global validator directory** — a network-wide table of validator hotkeys ranked across all Bittensor subnets. Until now there was only a per-subnet validators panel; nothing surfaced the global leaderboard, even though the data layer (`validatorsQuery`, #3357) already shipped.

## How

- **New `apps/ui/src/routes/validators.index.tsx`** — a `createFileRoute("/validators/")` page following the `providers.index.tsx` shape (`AppShell` + `PageHero` + `Suspense`/`QueryErrorBoundary` + `ApiSourceFooter`). Calls the existing `validatorsQuery({ sort })` via `useSuspenseQuery` and renders a table of `GlobalValidator` rows: **hotkey · coldkey · active subnets · UIDs**. Includes a `sort` control (URL-backed, cycling the `GlobalValidatorSort` keys), a `StaleBanner`, and an empty state.
- **`app-shell.tsx`** — a `FooterLink to="/validators"`.
- **`routeTree.gen.ts`** — regenerated for the new route.

Scope kept to the issue's baseline: stake / emission / dominance / trust columns are #3359, and the dedicated active-subnet column is #3360 — this PR adds neither. **No `queries.ts` / `types.ts` change** — the #3357 data layer is reused as-is.

## Screenshots

Live mainnet — `/validators` ranked by active subnets (top validator across 113 subnets).

| Before (route 404) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-validators-3358/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-validators-3358/after.png) |

## Acceptance criteria

- [x] `apps/ui/src/routes/validators.index.tsx` registers a `/validators` route via `createFileRoute`
- [x] Renders a table of `GlobalValidator` rows from `validatorsQuery(...)` (no new endpoint)
- [x] A working `sort` control cycles the `GlobalValidatorSort` values and re-queries
- [x] Loading (`Suspense` skeleton) + error (`QueryErrorBoundary`) states present, matching `providers.index.tsx`
- [x] Empty state when `validators.length === 0`
- [x] `app-shell.tsx` gains a `FooterLink to="/validators"`
- [x] No changes to `queries.ts` / `types.ts`
- [x] Before/after screenshots included

## Non-goals respected

No dominance/stake/emission/trust columns (#3359), no dedicated active-subnet column beyond baseline (#3360), no detail page, no chart, no backend change, no mega-menu wiring.

## Gates

`npm run typecheck` ✓ (exit 0) · `eslint` ✓ (0 errors)

Closes #3358