### PR TITLE
fix(ui): fetch subnet-scoped evidence from the dedicated per-subnet route

### DIFF
--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -30,16 +30,20 @@ function nextEvidenceCursor(meta?: ApiMeta): string | number | undefined {
 /**
  * Grouped evidence/source panel.
  *
- * Uses cursor-based pagination (?limit=&cursor=) against /api/v1/evidence and
- * exposes a "Load more" control that walks the next cursor returned in API
- * metadata. The panel also supports a source-type filter and group sort.
+ * Uses cursor-based pagination (?limit=&cursor=) against the dedicated
+ * /api/v1/subnets/{netuid}/evidence route when a netuid is known, and against
+ * the global /api/v1/evidence ledger otherwise (e.g. the site-wide /surfaces
+ * page). Exposes a "Load more" control that walks the next cursor returned in
+ * API metadata. The panel also supports a source-type filter and group sort.
  */
 export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
   const [sourceFilter, setSourceFilter] = useState<string>("");
   const [sortMode, setSortMode] = useState<SortMode>("recent");
 
   const query = useInfiniteQuery({
-    queryKey: metagraphedQueryKey("evidence", {
+    // Distinct key prefix per branch so the subnet-scoped and global caches
+    // never collide.
+    queryKey: metagraphedQueryKey(netuid != null ? "subnet-evidence" : "evidence", {
       netuid: netuid ?? null,
       pageSize,
     }),
@@ -47,8 +51,8 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
     queryFn: async ({ pageParam, signal }) => {
       const params: Record<string, string | number> = { limit: pageSize };
       if (pageParam != null) params.cursor = pageParam;
-      if (netuid != null) params.netuid = netuid;
-      const res = await apiFetch<unknown>("/api/v1/evidence", { params, signal });
+      const path = netuid != null ? `/api/v1/subnets/${netuid}/evidence` : "/api/v1/evidence";
+      const res = await apiFetch<unknown>(path, { params, signal });
       const raw = res.data as unknown;
       let items: EvidenceItem[] = [];
       if (Array.isArray(raw)) items = raw as EvidenceItem[];


### PR DESCRIPTION
## Summary

- `EvidencePanel` now fetches from the dedicated `GET /api/v1/subnets/{netuid}/evidence` route when rendered with a `netuid`, instead of always hitting the global `GET /api/v1/evidence` ledger with a `netuid` query-string filter.

Closes #3347

## What Changed

- `apps/ui/src/components/metagraphed/evidence-panel.tsx`: the component's own paginated `useInfiniteQuery` (it fetches directly via `apiFetch` inside `queryFn` rather than consuming a `queryOptions` object, since it needs cursor/pageParam handling) now branches its request path: `` `/api/v1/subnets/${netuid}/evidence` `` when `netuid != null`, unchanged `/api/v1/evidence` otherwise. `netuid` is no longer sent as a query param once it's part of the path.
- The `metagraphedQueryKey` prefix branches too (`"subnet-evidence"` vs `"evidence"`), so the subnet-scoped and global caches never collide.
- Updated the component's JSDoc to describe the branch.
- No call-site changes needed: both `subnets.$netuid.tsx` usages already pass `netuid={netuid}`, and `surfaces.tsx` already calls `<EvidencePanel />` with no netuid — the fix is entirely inside the component's existing prop contract.

(Resubmission of #4286, which a maintainer correctly rejected for dead code: that version also added a `subnetEvidenceQuery` helper to `queries.ts` that nothing in the diff actually called — the real fix lives entirely in this component's own inline fetch branch. This version drops that unused export and touches only `evidence-panel.tsx`.)

## Why

The dedicated per-subnet route (`src/contracts.mjs:3310-3320`) already existed server-side, but nothing in the frontend called it — the Evidence tab and the Overview panel's embedded evidence section were both filtering the whole global ledger client-side via a query param instead of hitting the purpose-built endpoint.

## Registry Safety

- N/A — this PR touches only `apps/ui/` frontend code, no registry/schema/API surface (the backend route already existed).

## Validation

- [x] `npx eslint src/components/metagraphed/evidence-panel.tsx` — clean aside from pre-existing CRLF/line-ending noise from this Windows checkout
- [x] `npx tsc --noEmit` (workspace apps/ui) — no new errors; the 2 pre-existing errors in `queries.ts`/`types.ts` reproduce identically on a clean `main` checkout (missing built `packages/client` dist)
- [x] `git diff --check`
- [x] `git diff --stat` — confirms exactly one file changed, no unused exports added anywhere
- [x] No new UI primitive, no layout/filter/sort behavior change — traced the diff directly: loading/error/empty states, grouping, and rendering are byte-for-byte unchanged; only the request path, the netuid-carrying mechanism (path segment vs. query param), and the cache-key prefix changed. Verified against all three call sites: `subnets.$netuid.tsx` (netuid passed, now hits the subnet-scoped route) and `surfaces.tsx` (no netuid, unchanged global route).

## Issue Link

Closes #3347