### PR TITLE
fix(security): pin registry fetch DNS

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1080,9 +1080,12 @@ export async function safeFetch(
   url,
   {
     accept = "*/*",
+    headers = null,
     maxRedirects = 5,
+    method = "GET",
     timeoutMs = 12000,
     resolver = lookup,
+    signal = null,
   } = {},
 ) {
   let target = url;
@@ -1098,16 +1101,18 @@ export async function safeFetch(
       addresses[0].address,
       addresses[0].family,
     );
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const controller = signal ? null : new AbortController();
+    const timer = controller
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
     let response;
     try {
       response = await fetch(target, {
-        method: "GET",
+        method,
         redirect: "manual",
-        signal: controller.signal,
+        signal: signal || controller.signal,
         dispatcher,
-        headers: { "user-agent": "metagraphed/0.0", accept },
+        headers: headers || { "user-agent": "metagraphed/0.0", accept },
       });
     } catch (error) {
       return {
@@ -1115,7 +1120,9 @@ export async function safeFetch(
         error: error.name === "AbortError" ? "timeout" : error.message,
       };
     } finally {
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
     }
     const location = response.headers.get("location");
     if (SAFE_FETCH_REDIRECT_CODES.has(response.status) && location) {

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -13,6 +13,7 @@ import {
   isUnsafeResolvedUrl,
   loadSubnets,
   repoRoot,
+  safeFetch,
   writeJson,
 } from "./lib.mjs";
 import {
@@ -39,6 +40,19 @@ const priorHistory = await loadPriorHistory();
 // history-derived fields (last_ok, uptime_sample_ratio) the build artifacts need.
 const probeOptions = {
   isUnsafeUrl: isUnsafeResolvedUrl,
+  fetchImpl: async (url, init = {}) => {
+    const result = await safeFetch(url, {
+      headers: init.headers,
+      method: init.method || "GET",
+      signal: init.signal,
+    });
+    if (!result.response) {
+      throw new Error(
+        result.unsafe ? "unsafe URL" : result.error || "fetch failed",
+      );
+    }
+    return result.response;
+  },
   connect: nodeWebSocketConnector(),
 };
 

--- a/scripts/snapshot-openapi.mjs
+++ b/scripts/snapshot-openapi.mjs
@@ -8,9 +8,9 @@ import {
   flattenSurfaces,
   hashJson,
   isJsonContentType,
-  isUnsafeResolvedUrl,
   isUnsafeUrl,
   loadSubnets,
+  safeFetch,
   sanitizeOpenApiDocument,
   stableStringify,
   writeJson,
@@ -276,40 +276,21 @@ function candidateSchemaUrls(surface) {
   return [...new Set(urls.filter((url) => !isUnsafeUrl(url)))];
 }
 
-async function fetchJson(url, redirectCount = 0) {
-  if (await isUnsafeResolvedUrl(url)) {
-    return { ok: false, unsafe_url: true, error: "unsafe URL" };
-  }
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 12000);
+async function fetchJson(url) {
   try {
-    const response = await fetch(url, {
+    const fetched = await safeFetch(url, {
       headers: {
         accept: "application/json",
         "user-agent": "metagraphed-openapi-snapshot/0.0",
       },
-      redirect: "manual",
-      signal: controller.signal,
     });
-    const location = response.headers.get("location");
-    if (
-      [301, 302, 303, 307, 308].includes(response.status) &&
-      location &&
-      redirectCount < 5
-    ) {
-      const redirectTarget = new URL(location, url).toString();
-      if (await isUnsafeResolvedUrl(redirectTarget)) {
-        await response.body?.cancel();
-        return {
-          ok: false,
-          private_redirect_blocked: true,
-          error: "redirect target is unsafe",
-        };
-      }
-      await response.body?.cancel();
-      return fetchJson(redirectTarget, redirectCount + 1);
+    if (fetched.unsafe) {
+      return { ok: false, unsafe_url: true, error: "unsafe URL" };
     }
+    if (!fetched.response) {
+      return { ok: false, error: fetched.error || "fetch failed" };
+    }
+    const response = fetched.response;
 
     const contentType = response.headers.get("content-type") || "";
     if (!response.ok || !isJsonContentType(contentType)) {
@@ -349,8 +330,6 @@ async function fetchJson(url, redirectCount = 0) {
     };
   } catch (error) {
     return { ok: false, error: error.message, error_class: error.name };
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/tests/safe-fetch.test.mjs
+++ b/tests/safe-fetch.test.mjs
@@ -109,6 +109,34 @@ describe("safeFetch SSRF guard", () => {
     assert.equal(fetchCalls[0][0], "http://rebind.example.test/surface");
     assert.ok(fetchCalls[0][1].dispatcher);
   });
+
+  test("preserves caller method, headers, and abort signal with pinned fetches", async () => {
+    const signal = AbortSignal.timeout(1000);
+    const fetchCalls = [];
+    vi.stubGlobal("fetch", async (url, options) => {
+      fetchCalls.push([String(url), options]);
+      return mockResponse({ status: 204, contentType: null });
+    });
+
+    const result = await safeFetch("http://1.1.1.1/health", {
+      method: "HEAD",
+      headers: {
+        accept: "application/json",
+        "user-agent": "metagraphed-smoke-probe/0.0",
+      },
+      signal,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(fetchCalls[0][1].method, "HEAD");
+    assert.deepEqual(fetchCalls[0][1].headers, {
+      accept: "application/json",
+      "user-agent": "metagraphed-smoke-probe/0.0",
+    });
+    assert.equal(fetchCalls[0][1].signal, signal);
+    assert.ok(fetchCalls[0][1].dispatcher);
+  });
 });
 
 describe("createPinnedLookup", () => {

--- a/tests/scripts-lib-branch-coverage.test.mjs
+++ b/tests/scripts-lib-branch-coverage.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import {
   buildEvidenceSubjectNetuidIndex,
   netuidForEvidenceClaim,
@@ -189,6 +189,29 @@ describe("safeFetch (error envelope)", () => {
       assert.equal(out.error, "timeout");
     } finally {
       globalThis.fetch = realFetch;
+    }
+  });
+
+  test("fires the real timer and calls controller.abort() when the caller passes no signal", async () => {
+    const realFetch = globalThis.fetch;
+    vi.useFakeTimers();
+    globalThis.fetch = (_url, options) =>
+      new Promise((_resolve, reject) => {
+        options.signal.addEventListener("abort", () => {
+          const err = new Error("This operation was aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    try {
+      const resultPromise = safeFetch("https://8.8.8.8/x", { timeoutMs: 50 });
+      await vi.advanceTimersByTimeAsync(50);
+      const out = await resultPromise;
+      assert.equal(out.ok, false);
+      assert.equal(out.error, "timeout");
+    } finally {
+      globalThis.fetch = realFetch;
+      vi.useRealTimers();
     }
   });
 });


### PR DESCRIPTION
### Motivation
- Close a DNS TOCTOU/SSRF window where `snapshot-openapi` and the Node smoke-probe resolved hostnames then performed unpinned `fetch` calls, allowing a DNS rebind to reach private/internal addresses. 
- Ensure production build steps that capture OpenAPI JSON and probe-enabled surfaces cannot be tricked into including internal JSON by an attacker-controlled public domain. 

### Description
- Route OpenAPI snapshot fetches through the existing pinned `safeFetch` helper so every redirect hop is DNS-validated and the vetted address is pinned into the connection dispatcher. 
- Extend `safeFetch` in `scripts/lib.mjs` to preserve caller `method`, `headers`, and `signal` while still pinning validated DNS answers into the connection. 
- Inject `safeFetch` as the `fetchImpl` for the Node smoke-probe wrapper (`scripts/probes-smoke.mjs`) so probe-enabled `public_safe` surfaces use pinned DNS behavior. 
- Add a regression test to `tests/safe-fetch.test.mjs` verifying that `safeFetch` preserves caller method, headers, abort signals, and attaches a pinned dispatcher. 

### Testing
- Ran lint with `npm run lint -- --quiet` which completed with no errors. 
- Ran the targeted unit tests with `npm test -- tests/safe-fetch.test.mjs tests/health-probe-core.test.mjs`, and all tests passed (`118 passed`). 
- Verified formatting with `npx prettier --check` on the modified files which reported no style issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d11889e88832c82ab86ef0e6976e9)