### PR TITLE
feat(ui): add windowed event-summary rollup tile to the subnet masthead

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -28,6 +28,7 @@ import {
 import {
   subnetEndpointsQuery,
   subnetDeregistrationsQuery,
+  subnetEventSummaryQuery,
   subnetHealthPercentilesQuery,
   subnetRegistrationsQuery,
   subnetTrajectoryQuery,
@@ -88,6 +89,11 @@ const KIND_BUCKETS: Array<{
   { id: "data", label: "Data", color: "var(--health-warn)", match: (k) => k === "data" },
   { id: "other", label: "Other", color: "var(--border)", match: () => true },
 ];
+
+// Cycled palette for the event-category breakdown — categories are
+// data-driven (not a fixed enum we want to hand-map), so we assign colors by
+// rank rather than by category name.
+const CATEGORY_COLORS = ["var(--accent)", "var(--ink-strong)", "var(--health-warn)"];
 
 function classifyKind(k: unknown): string {
   const key = String(k ?? "other").toLowerCase();
@@ -172,8 +178,15 @@ export function SubnetMasthead({
   const { data: pctRes } = useQuery(subnetHealthPercentilesQuery(netuid));
   const { data: regRes } = useQuery(subnetRegistrationsQuery(netuid));
   const { data: deregRes } = useQuery(subnetDeregistrationsQuery(netuid));
+  const { data: summaryRes } = useQuery(subnetEventSummaryQuery(netuid));
   const reg = regRes?.data;
   const dereg = deregRes?.data;
+  const summary = summaryRes?.data;
+  const topCategories = (summary?.categories ?? [])
+    .slice()
+    .sort((a, b) => b.event_count - a.event_count)
+    .slice(0, 3);
+  const summaryAt = summaryRes?.meta?.generated_at ?? generatedAt;
 
   // Subnet-wide daily uptime % + median latency, meaned across tracked surfaces.
   const trendWindowKey = uptimeRes?.data?.window ?? "90d";
@@ -576,6 +589,31 @@ export function SubnetMasthead({
           full="Number of primary source links recorded"
           updatedAt={generatedAt}
           viz={<DotRow dots={sourceKinds} />}
+        />
+        <StatWithSpark
+          label="Activity"
+          value={summary != null ? formatNumber(summary.total_events) : "—"}
+          hint={
+            topCategories.length
+              ? topCategories.map((c) => `${c.event_count} ${c.category}`).join(" · ")
+              : "on-chain events"
+          }
+          full="Windowed on-chain event rollup for this subnet (registrations, stake, serving, transfers, etc.)"
+          updatedAt={summaryAt}
+          windowLabel={summary?.window ?? "7d"}
+          viz={
+            topCategories.length ? (
+              <MiniStack
+                segments={topCategories.map((c, i) => ({
+                  label: c.category,
+                  value: c.event_count,
+                  color: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                }))}
+              />
+            ) : (
+              <NoDataSpark updatedAt={summaryAt} windowLabel={summary?.window ?? "7d"} />
+            )
+          }
         />
       </div>
     </header>

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -121,6 +121,8 @@ import type {
   Subnet,
   SubnetAxonRemovals,
   SubnetDeregistrations,
+  SubnetEventSummary,
+  SubnetEventCategorySummary,
   SubnetStakeMoves,
   SubnetServing,
   SubnetPrometheus,
@@ -3849,6 +3851,57 @@ export const subnetDeregistrationsQuery = (netuid: number, window = "30d") =>
       };
     },
     staleTime: STALE_MED,
+  });
+
+// #3486: windowed on-chain event rollup for one subnet — the dashboard-friendly
+// consolidation of what would otherwise be several separate per-kind/per-category
+// calls. Categories fall through to an empty array (never fabricated) on a cold
+// store or junk cell.
+function normalizeSubnetEventCategory(raw: unknown): SubnetEventCategorySummary {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    category: firstString(rec.category) ?? "other",
+    event_count: firstFiniteNumber(rec.event_count) ?? 0,
+    kind_count: firstFiniteNumber(rec.kind_count) ?? 0,
+    amount_tao: firstFiniteNumber(rec.amount_tao) ?? 0,
+    alpha_amount: firstFiniteNumber(rec.alpha_amount) ?? 0,
+    first_block: firstFiniteNumber(rec.first_block) ?? null,
+    last_block: firstFiniteNumber(rec.last_block) ?? null,
+    first_observed_at: firstString(rec.first_observed_at) ?? null,
+    last_observed_at: firstString(rec.last_observed_at) ?? null,
+  };
+}
+
+export function normalizeSubnetEventSummary(netuid: number, raw: unknown): SubnetEventSummary {
+  const rec = isRecord(raw) ? raw : {};
+  const categories = Array.isArray(rec.categories) ? rec.categories : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    total_events: firstFiniteNumber(rec.total_events) ?? 0,
+    kind_count: firstFiniteNumber(rec.kind_count) ?? 0,
+    category_count: firstFiniteNumber(rec.category_count) ?? 0,
+    categories: categories.map(normalizeSubnetEventCategory),
+  };
+}
+
+export const subnetEventSummaryQuery = (netuid: number, window = "7d") =>
+  queryOptions({
+    queryKey: k("subnet-event-summary", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetEventSummary>>(
+        `/api/v1/subnets/${netuid}/event-summary`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetEventSummary(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
   });
 
 // Per-subnet aggregate weight-setting activity over a 7d/30d window.

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1467,6 +1467,35 @@ export interface SubnetDeregistrations {
   deregistrations_per_hotkey: number | null;
 }
 
+/** One category aggregate within a {@link SubnetEventSummary} window. */
+export interface SubnetEventCategorySummary {
+  category: string;
+  event_count: number;
+  kind_count: number;
+  amount_tao: number;
+  alpha_amount: number;
+  first_block: number | null;
+  last_block: number | null;
+  first_observed_at: string | null;
+  last_observed_at: string | null;
+}
+
+/**
+ * Windowed on-chain event rollup for one subnet, from
+ * /api/v1/subnets/{netuid}/event-summary — consolidates per-kind/per-category
+ * aggregates that would otherwise need several separate calls (#3486).
+ */
+export interface SubnetEventSummary {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  total_events: number;
+  kind_count: number;
+  category_count: number;
+  categories: SubnetEventCategorySummary[];
+}
+
 /**
  * Validator-set & registration turnover scorecard for one subnet, from
  * /api/v1/subnets/{netuid}/turnover — diffs the window's start/end


### PR DESCRIPTION
Closes #3486

## What
Adds the missing `subnetEventSummaryQuery` against the already-live `GET /api/v1/subnets/{netuid}/event-summary` endpoint (`handleSubnetEventSummary`, `workers/request-handlers/entities.mjs:2785`), and wires one new stat-spine tile — **Activity** — into the subnet masthead using it.

## Why
The subnet masthead has no on-chain-activity tile at all today; the windowed event-summary endpoint already exists and consolidates event/category rollups that would otherwise require stitching together several separate calls.

## Changes
- `apps/ui/src/lib/metagraphed/types.ts`: adds `SubnetEventCategorySummary` and `SubnetEventSummary` types (mirrors the existing `SubnetRegistrations`/`SubnetDeregistrations` shape).
- `apps/ui/src/lib/metagraphed/queries.ts`: adds `normalizeSubnetEventSummary` + `subnetEventSummaryQuery(netuid, window)`, following the exact `queryOptions`/`apiFetch`/`staleTime` pattern used by sibling subnet queries (e.g. `subnetRegistrationsQuery`).
- `apps/ui/src/components/metagraphed/subnet-masthead.tsx`: calls the new query via `useQuery` alongside the masthead's existing subnet queries, and renders one new **Activity** tile showing `total_events` as the headline value with a top-3 category breakdown (via `MiniStack`), matching the existing tiles' loading/empty conventions (dash while loading, zero-value degrade, `NoDataSpark` when there are no categories to show).

Both the query and its UI wiring land in this single PR per the issue's explicit requirement (no data-layer-only PR).

## Note on #3483
The issue mentions coordinating with #3483 (registration/deregistration counters) to avoid a stat-spine conflict — that issue is already closed and its Registrations/Deregistrations tiles are already present in `subnet-masthead.tsx` on `main`, so this PR only adds the one new Activity tile alongside them.

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on all three changed files: clean (aside from pre-existing CRLF-only diffs unrelated to this change).
- Diff is strictly additive (120 insertions, 0 deletions across 3 files) — no existing behavior touched.
