### PR TITLE
docs(gittensor): add impact badge, CI card job, and contributing disclosure

### DIFF
--- a/.github/workflows/gittensor-impact.yml
+++ b/.github/workflows/gittensor-impact.yml
@@ -1,0 +1,40 @@
+name: Gittensor Impact
+
+# Publishes the Gittensor SN74 impact card (dark/light SVG comparing Gittensor
+# vs non-Gittensor contribution on this repo) as GitHub Release assets on a
+# schedule. Third-party action pinned past its last tagged release (v1.1.4)
+# to pick up the per-repo API endpoint fix — see the pinned SHA's commit.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "40 5 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gittensor-impact
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Scoped here rather than at workflow level (defense-in-depth): this is the
+    # only job that needs write access, to publish SVG assets to the pinned
+    # `gittensor-impact` release via matthewevans/gittensor-impact-action.
+    permissions:
+      contents: write
+    # matthewevans/gittensor-impact-action is a ~1.5-day-old repo; require a
+    # human approval before it runs with contents:write, on top of the SHA pin.
+    environment: gittensor-impact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Generate and publish Gittensor impact card
+        uses: matthewevans/gittensor-impact-action@397fd470899cba47367458289a374eea9cb0d76a # main, 2026-07-06 (#1 per-repo API endpoint)
+        with:
+          title: Metagraphed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,8 @@ Callable surface with documented limits? Add an optional structured `rate_limit`
 
 **Scoring and rewards are not ours to grant.** Contribution scoring and any Gittensor rewards are set by the subnet's on-chain hyperparameters and validators, not by this repo. Merging a PR is not a promise of score, ranking, or compensation, and all review decisions are at maintainer discretion and final.
 
+**This repository is itself Gittensor-listed.** PRs merged here by registered miners may earn TAO under the subnet's own rules — see the badge in `README.md` for a live, aggregate merged-PR/line-count summary. That eligibility and scoring is Gittensor's, not ours, and doesn't change the review bar above.
+
 ## Deeper docs
 
 - [`docs/curation-playbook.md`](docs/curation-playbook.md) — what to curate and in what order.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Bittensor subnet integration registry. For every subnet it answers: **what d
 [![npm](https://img.shields.io/npm/v/@jsonbored/metagraphed?logo=npm&label=npm)](https://www.npmjs.com/package/@jsonbored/metagraphed)
 [![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
+[![Gittensor impact](https://api.gittensor.io/repos/JSONbored%2Fmetagraphed/badge.svg)](https://gittensor.io/miners/repository?name=JSONbored/metagraphed)
 
 **[Website](https://metagraph.sh)** &nbsp;·&nbsp; [API](https://api.metagraph.sh) &nbsp;·&nbsp; [OpenAPI](https://api.metagraph.sh/metagraph/openapi.json) &nbsp;·&nbsp; [GraphQL](https://api.metagraph.sh/api/v1/graphql) &nbsp;·&nbsp; [MCP](https://api.metagraph.sh/mcp) &nbsp;·&nbsp; [Agent docs](https://api.metagraph.sh/llms.txt) &nbsp;·&nbsp; [Agent workflows](https://api.metagraph.sh/agent-workflows.md) &nbsp;·&nbsp; [Feeds](https://api.metagraph.sh/api/v1/feeds/registry) &nbsp;·&nbsp; [npm](https://www.npmjs.com/package/@jsonbored/metagraphed) &nbsp;·&nbsp; [PyPI](https://pypi.org/project/metagraphed/)
 


### PR DESCRIPTION
## Summary

- Metagraphed is itself a Gittensor-listed repo (its own README already tracks Gittensor SN74 as a subnet in the registry catalog). Adds the live `api.gittensor.io` impact badge to the top README badge row.
- Adds a short disclosure to `CONTRIBUTING.md` noting the repo is Gittensor-listed and that scoring/rewards are Gittensor's, not ours (mirrors the existing "Scoring and rewards are not ours to grant" paragraph right above it).
- Adds `.github/workflows/gittensor-impact.yml`, a weekly + manually-dispatchable job that publishes a fuller SVG contributor-impact card via `matthewevans/gittensor-impact-action`, pinned to commit SHA `397fd470899cba47367458289a374eea9cb0d76a` (not a floating tag).

Security posture on the third-party action (source reviewed line-by-line): zero third-party pip deps, no shell-injection-prone subprocess calls, one outbound GET wrapped in try/except with graceful degradation, HTML-escaped SVG output, tokens never logged. Given the action's repo is only ~1.5 days old, `contents: write` is scoped to just the one job that needs it (workflow default is `read`), **and** the job is additionally gated behind a new `gittensor-impact` GitHub Environment requiring manual approval before each run — both mitigations a security scanner asked for on the sibling gittensory PR.

Did **not** touch the `<!-- BEGIN:REGISTRY-CATALOG -->` generated block, and did not wire the bigger rendered picture-card into the README yet — its release assets don't exist until the workflow runs (and gets approved) once post-merge; planned as a fast-follow.

## Template Used

- Backend/code change (touches `.github/workflows/`, alongside a docs-only README/CONTRIBUTING edit)

## Registry Safety

- [ ] Links a tracked, currently-open issue — no linked issue: this is an owner-initiated docs/CI change made in direct response to the Gittensor ecosystem's own badge announcement, not tracked as a GitHub issue. (Per the metagraphed contributing skill, a linked issue is optional and a PR is judged on its own merit without one.)
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (the registry catalog block is untouched).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. — not applicable, no API/schema changes.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:docs`
- [x] `npm run validate:workflows`
- [x] `npm run scan:public-safety`
- [x] `npm test` (231 files, 6453 tests, all passed)
- [x] `git diff --check`
- [ ] `npm run validate:schemas` / `validate:api` / `validate:openapi` / `validate:types` / `validate:artifact-budgets` / `validate:intake` / `worker:test` / `test:coverage` — not applicable, no schema/API/worker code changed (README, CONTRIBUTING, and one new declarative GitHub Actions workflow only)