### PR TITLE
docs(readme): embed the live Gittensor contributor-impact card

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Issues are labeled `good first issue` and `help wanted` — start there.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/curation-playbook.md`](docs/curation-playbook.md).
 
+### Gittensor contributor impact
+
+<p align="center">
+  <a href="https://gittensor.io/miners/repository?name=JSONbored/metagraphed">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JSONbored/metagraphed/gittensor-impact-assets/gittensor-impact-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JSONbored/metagraphed/gittensor-impact-assets/gittensor-impact-light.svg">
+      <img src="https://raw.githubusercontent.com/JSONbored/metagraphed/gittensor-impact-assets/gittensor-impact-light.svg" alt="Gittensor contributor impact" width="600">
+    </picture>
+  </a>
+</p>
+
+Refreshed weekly by [`.github/workflows/gittensor-impact.yml`](.github/workflows/gittensor-impact.yml).
+
 ## Subnet catalog
 
 <!-- BEGIN:REGISTRY-CATALOG -->


### PR DESCRIPTION
## Docs Change

## Summary

Fast-follow to #4291 — the `gittensor-impact` workflow has now run successfully (after switching to branch-mode publishing to work around GitHub's new immutable-release restriction) and published `gittensor-impact-{dark,light}.svg` to the `gittensor-impact-assets` branch. This wires the actual rendered comparison card into the README (under `## Contributing`), replacing the placeholder-only state where just the small text badge was live.

## Checklist

- [ ] Links a tracked, currently-open issue — no linked issue, same rationale as #4291 (owner-initiated, ecosystem-driven change; per the metagraphed contributing skill a linked issue is optional).
- [x] This PR changes docs/templates only.
- [x] No generated `public/metagraph/**` artifacts are included.
- [x] No private research notes, local paths, secrets, wallet/PAT data, private URLs, or validator internals are included.
- [x] Any referenced API route or artifact path exists in the current backend contracts. — n/a, this references a raw.githubusercontent.com asset URL, not an API route.

## Validation

- [x] `npm run validate:docs`
- [ ] `npm run validate:intake` — not run (not applicable to a single README section addition; nothing intake-related changed)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`