### PR TITLE
refactor(ui): extract shared CopyIconToggle for the copy/check icon swap

### DIFF
--- a/apps/ui/src/components/metagraphed/copy-button.tsx
+++ b/apps/ui/src/components/metagraphed/copy-button.tsx
@@ -1,6 +1,6 @@
-import { Check, Copy } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 import { useCopy } from "@/hooks/use-copy";
+import { CopyIconToggle } from "./copy-icon-toggle";
 
 /**
  * Icon-only copy button with the same green-check microinteraction as
@@ -28,20 +28,7 @@ export function CopyButton({
         className,
       )}
     >
-      <span className="relative inline-flex size-3 items-center justify-center" aria-hidden>
-        <Check
-          className={classNames(
-            "absolute size-3 text-health-ok transition-all duration-150",
-            copied ? "scale-100 opacity-100" : "scale-50 opacity-0",
-          )}
-        />
-        <Copy
-          className={classNames(
-            "absolute size-3 transition-all duration-150",
-            copied ? "scale-50 opacity-0" : "scale-100 opacity-100",
-          )}
-        />
-      </span>
+      <CopyIconToggle copied={copied} />
     </button>
   );
 }

--- a/apps/ui/src/components/metagraphed/copy-icon-toggle.tsx
+++ b/apps/ui/src/components/metagraphed/copy-icon-toggle.tsx
@@ -1,0 +1,47 @@
+import { Check, Copy } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+const SIZE_CLASS = {
+  3: "size-3",
+  3.5: "size-3.5",
+} as const;
+
+interface Props {
+  /** Whether the value was just copied — shows the check glyph while true. */
+  copied: boolean;
+  /** Icon size in Tailwind `size-*` units. */
+  size?: keyof typeof SIZE_CLASS;
+  /** Applied to the idle-state copy glyph only (e.g. hover-color overrides). */
+  className?: string;
+}
+
+/**
+ * Shared copy/check icon swap for copy-to-clipboard affordances. Cross-fades
+ * from the copy glyph to a green check for however long the caller's
+ * `useCopy` holds `copied` true, then back.
+ */
+export function CopyIconToggle({ copied, size = 3, className }: Props) {
+  const sizeClass = SIZE_CLASS[size];
+  return (
+    <span
+      className={classNames("relative inline-flex shrink-0 items-center justify-center", sizeClass)}
+      aria-hidden
+    >
+      <Check
+        className={classNames(
+          "absolute text-health-ok transition-all duration-150",
+          sizeClass,
+          copied ? "scale-100 opacity-100" : "scale-50 opacity-0",
+        )}
+      />
+      <Copy
+        className={classNames(
+          "absolute transition-all duration-150",
+          sizeClass,
+          copied ? "scale-50 opacity-0" : "scale-100 opacity-100",
+          className,
+        )}
+      />
+    </span>
+  );
+}

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Copy, Check, ExternalLink as ExternalLinkIcon } from "lucide-react";
+import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import { useMemo } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { HealthDot } from "./chips";
@@ -8,6 +8,7 @@ import { TimeAgo } from "./time-ago";
 import { BrandIcon } from "./brand-icon";
 import { safeExternalUrl } from "./external-link";
 import { Sparkline } from "./charts/sparkline";
+import { CopyIconToggle } from "./copy-icon-toggle";
 import { useCopy } from "@/hooks/use-copy";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames } from "@/lib/metagraphed/format";
@@ -266,11 +267,7 @@ function Row({
                     aria-label="Copy URL"
                     className="inline-flex size-7 items-center justify-center rounded-md text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
                   >
-                    {copied ? (
-                      <Check className="size-3.5 text-health-ok" />
-                    ) : (
-                      <Copy className="size-3.5" />
-                    )}
+                    <CopyIconToggle copied={copied} size={3.5} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">Copy URL</TooltipContent>
@@ -379,8 +376,7 @@ function MobileCard({
             onClick={() => copy(e.url!)}
             className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 text-[10px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-accent/40"
           >
-            {copied ? <Check className="size-3 text-health-ok" /> : <Copy className="size-3" />}{" "}
-            copy
+            <CopyIconToggle copied={copied} /> copy
           </button>
           {safeUrl ? (
             <a

--- a/apps/ui/src/components/metagraphed/key-chip.tsx
+++ b/apps/ui/src/components/metagraphed/key-chip.tsx
@@ -1,7 +1,7 @@
-import { Check, Copy } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopy } from "@/hooks/use-copy";
 import { classNames } from "@/lib/metagraphed/format";
+import { CopyIconToggle } from "./copy-icon-toggle";
 
 interface Props {
   /** Full value (e.g. coldkey/hotkey/long hash). */
@@ -39,23 +39,7 @@ export function KeyChip({ value, label = "value", head = 8, tail = 6, className 
           )}
         >
           <span className="truncate tabular-nums">{short}</span>
-          <span
-            className="relative inline-flex size-3 shrink-0 items-center justify-center"
-            aria-hidden
-          >
-            <Check
-              className={classNames(
-                "absolute size-3 text-health-ok transition-all duration-150",
-                copied ? "scale-100 opacity-100" : "scale-50 opacity-0",
-              )}
-            />
-            <Copy
-              className={classNames(
-                "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
-                copied ? "scale-50 opacity-0" : "scale-100 opacity-100",
-              )}
-            />
-          </span>
+          <CopyIconToggle copied={copied} className="text-ink-muted group-hover:text-ink" />
         </button>
       </TooltipTrigger>
       <TooltipContent side="top" className="max-w-[90vw] break-all font-mono text-[11px]">


### PR DESCRIPTION
Closes #3428

## What
Extracts a shared `CopyIconToggle({ copied, size?, className? })` component and wires it into the four places that were hand-rolling the same copy/check icon cross-fade: `copy-button.tsx`, `key-chip.tsx`, and `endpoint-list.tsx`'s `Row` and `MobileCard`.

## Why
All four sites duplicated the identical stacked-icon, opacity/scale cross-fade markup (`<Check>`/`<Copy>` absolutely positioned, transitioning on the same `copied` boolean from `useCopy`). `endpoint-list.tsx`'s two sites used a plain conditional swap instead of the cross-fade, so this also brings them in line with the pattern `copy-button.tsx`/`key-chip.tsx` already used.

## Changes
- `apps/ui/src/components/metagraphed/copy-icon-toggle.tsx` (new): `CopyIconToggle` — renders the stacked Check/Copy icons with the same transition classes every call site already used. `size` maps to a static `size-3`/`size-3.5` Tailwind class (no dynamic class-name construction, so Tailwind's compiler picks both up). `className` applies only to the idle-state copy glyph, so callers can override its color.
- `copy-button.tsx`: replaced its inline stacked-icon markup with `<CopyIconToggle copied={copied} />`.
- `key-chip.tsx`: replaced its inline stacked-icon markup with `<CopyIconToggle copied={copied} className="text-ink-muted group-hover:text-ink" />`, preserving its idle-state hover color exactly.
- `endpoint-list.tsx`: `Row` now renders `<CopyIconToggle copied={copied} size={3.5} />` (was a plain `copied ? <Check/> : <Copy/>` swap); `MobileCard` now renders `<CopyIconToggle copied={copied} />` (same). Both drop the now-unused direct `Copy`/`Check` import.

No changes to `useCopy` or any call site's props/behavior beyond the icon markup itself — the `copied` window duration and click handling are untouched.

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on all four changed files: clean (aside from pre-existing CRLF-only diffs unrelated to this change).
- Diff touches exactly the four files the issue names, with no leftover unused exports — the new `CopyIconToggle` is called at all four sites in this same diff.
