### PR TITLE
fix(ui): align leaderboard card padding with sibling KPI/panel cards

### DIFF
--- a/apps/ui/src/components/metagraphed/leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards.tsx
@@ -94,7 +94,7 @@ function BoardCard({
   metric: (row: LeaderboardRow) => string | null;
 }) {
   return (
-    <div className="rounded-xl border border-border bg-card p-5">
+    <div className="rounded-xl border border-border bg-card p-4">
       <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
         {label}
       </div>


### PR DESCRIPTION
Closes #3981

## What
Changes the leaderboard card padding in `leaderboards.tsx` from `p-5` to `p-4`, matching the padding convention used by every other KPI/panel card in the app (`validators-panel.tsx`, `yield-panel.tsx`, `readiness-scorecard.tsx`, `panel-shell.tsx`, and 9 others all use `rounded-xl border border-border bg-card p-4`).

## Note on scope
The issue mentions this component also renders on `accounts.$ss58.tsx` — as of the current `main`, `LeaderboardsModule` is only imported/rendered on the homepage (`routes/index.tsx:178`); there's no reference to it in `accounts.$ss58.tsx` (confirmed via a repo-wide search). The screenshots below are from the homepage, the only place this component currently renders.

## Screenshots

Homepage "Top subnets, ranked live." section, live mainnet data:

| Before (`p-5`) | After (`p-4`) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-leaderboards-3981/before.png) | ![after](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-leaderboards-3981/after.png) |

Content (5 rows, the max per board) isn't cramped at the reduced padding — row spacing (`space-y-0.5`, `py-1.5` per row) is unchanged, only the outer card padding shrunk by 4px to match siblings.

## Acceptance criteria
- [x] `leaderboards.tsx` appears in the diff
- [x] Leaderboard cards now use `p-4`, matching sibling cards
- [x] No content is cramped — spot-checked the 5-row "Healthiest" board above
- [x] Before/after screenshot showing the corrected spacing on the homepage (the only page this component currently renders on)

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean (aside from pre-existing CRLF-only diffs unrelated to this change).
- Diff is a single-line change in one file.
