### PR TITLE
fix(ci): unblock main after the MCP version auto-bump

### DIFF
--- a/apps/ui/.prettierignore
+++ b/apps/ui/.prettierignore
@@ -6,3 +6,8 @@ pnpm-lock.yaml
 package-lock.json
 bun.lock
 routeTree.gen.ts
+
+# release-please regenerates this CHANGELOG on every release in its own
+# format; it is machine-generated, not prettier-gated (same precedent as the
+# root CHANGELOG.md / packages/client/CHANGELOG.md entries).
+CHANGELOG.md

--- a/tests/subnet-evidence-mcp.test.mjs
+++ b/tests/subnet-evidence-mcp.test.mjs
@@ -350,7 +350,7 @@ describe("subnet-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_subnet_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.78.0");
+    assert.match(MCP_SERVER_VERSION, /^\d+\.\d+\.\d+$/);
     assert.match(MCP_INSTRUCTIONS, /list_subnet_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_evidence");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Two independent CI breaks on `main`, both surfaced because the open release-please PR (#4215) inherits main's state and was failing its `test` and `ui` checks as a result:

- `tests/subnet-evidence-mcp.test.mjs` hardcoded `MCP_SERVER_VERSION` as `"1.78.0"` at the moment `list_subnet_evidence` shipped (#3329). `sync-mcp-version`'s automatic bump to `1.78.1` (#4207) broke that pin — the assertion now checks the version matches semver shape instead of an exact string, since this value bumps automatically per repo convention.
- `apps/ui/.prettierignore` never got a `CHANGELOG.md` entry when `apps/ui` was folded into the monorepo, unlike the existing root `CHANGELOG.md` / `packages/client/CHANGELOG.md` precedent. release-please's generated bullet/spacing style isn't prettier-compliant, so every `apps/ui` release PR fails `format:check` until someone manually reformats the generated changelog.

## Test plan

- [x] `npm run test:ci` — 229 files / 6426 tests pass, coverage thresholds met
- [x] `npm run lint` && `npm run format:check` (root) — clean
- [x] `npm run lint --workspace=apps/ui` && `npm run format:check --workspace=apps/ui` — clean (verified against both the current tree and the release-please PR's generated `apps/ui/CHANGELOG.md` content)