### PR TITLE
fix(data-api): cut over Hyperdrive binding from Railway to self-hosted indexer Postgres

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -8,8 +8,9 @@
   "main": "workers/data-api.mjs",
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
-  // Smart placement: run the Worker close to the Hyperdrive origin (Railway Postgres)
-  // to minimize the per-request DB round-trip, not at the nearest edge to the client.
+  // Smart placement: run the Worker close to the Hyperdrive origin (self-hosted indexer
+  // box Postgres, reached via Cloudflare Tunnel) to minimize the per-request DB round-trip,
+  // not at the nearest edge to the client.
   "placement": { "mode": "smart" },
   // Full observability — logs AND traces (matches the main Worker).
   "observability": {
@@ -28,7 +29,7 @@
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      "id": "d8c62acb5520402b82d039ec482f7cc3",
+      "id": "2e989d5380044b57b57cb6481c18487e",
       "localConnectionString": "postgresql://postgres:postgres@localhost:5432/metagraphed",
     },
   ],


### PR DESCRIPTION
## Summary
- `metagraphed-data-api`'s `HYPERDRIVE` binding was still pointed at Railway's Postgres (`metagraphed-core` Hyperdrive config), fed by a now-redundant duplicate `indexer-rs` instance
- Repoints it at the dedicated indexer box's own Postgres, reached via a Cloudflare Tunnel private-network binding (`metagraphed-pg-postgres` Hyperdrive config), which the box's own `indexer-rs` has been live-tailing since 2026-07-04
- This is a config-only change; already deployed and verified live prior to this PR (`wrangler deploy -c wrangler.data.jsonc`)

## Test plan
- [x] Deployed live, confirmed `/api/v1/chain-events` returns current data with `"source":"data-worker-postgres"` and a recent block number from the new source
- [x] No repo code references the Railway Hyperdrive origin anywhere else (grepped for the connection host/creds)
- [ ] Railway's `indexer-rs`/Postgres to be decommissioned in a follow-up once this is confirmed stable in production for a few days