### PR TITLE
feat(review): opt into gate.aiJudgmentBlockers for the registry surface lane

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -37,6 +37,20 @@ blockedPaths:
   # community data submission.
   - "apps/**"
 
+# AI-judgment blocker promotion (JSONbored/gittensory#3907): the registry surface lane's own
+# deterministic checks (owner-match, freshness, dead/private source_url, duplicate detection) already
+# cover the failure modes a submission can have -- so by default (the engine-wide "advisory" setting)
+# a decisive surface-lane merge overrides even a confident AI-judgment-only finding, since an AI
+# opinion alone should never one-shot-close a structurally-clean submission. That default left a real
+# gap here: metagraphed's registry entries are validated for STRUCTURE and provenance, not semantic
+# correctness, so a content-correctness defect the AI reviewer correctly caught under "Blockers" (PR
+# #3910: a provider slug semantically wrong for its domain) still merged. "gate" lets that kind of
+# AI-judgment blocker survive into the gate's own decision instead of being silently overridden --
+# an explicit trade-off (a confident AI false positive can now one-shot-close a clean PR) accepted
+# because this repo's registry data has no other net for pure semantic-correctness defects.
+gate:
+  aiJudgmentBlockers: gate
+
 # Review-evasion protection (config-as-code override; layered OVER the dashboard's own default of
 # "off"): closing or converting-to-draft your OWN PR while gittensory has an active review pass
 # running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is treated


### PR DESCRIPTION
## Summary

- Follow-up to `JSONbored/gittensory` PR #4171, which added the `gate.aiJudgmentBlockers: "gate" | "advisory"` config-as-code knob (default `"advisory"`, byte-identical everywhere that doesn't opt in). Advances JSONbored/gittensory#3907, whose own Notes section named this exact metagraphed-side follow-up as the one remaining piece, gated on #4171 shipping first.
- This repo's registry surface lane already runs deterministic structural/provenance checks (owner-match, freshness, dead/private `source_url`, duplicate detection), but has no equivalent net for pure semantic-correctness defects. PR #3910 is the concrete repro: the AI reviewer correctly flagged a `provider` slug that was semantically wrong for its domain under "Blockers," yet the engine-wide `"advisory"` default let the surface lane's decisive merge override that finding, and the PR still merged.
- Sets `gate.aiJudgmentBlockers: gate` in this repo's own `.gittensory.yml` so a confident AI-judgment-only blocker now survives into the gate's own decision instead of being silently overridden. This is a config-as-code-only field (no DB column, no dashboard toggle) — the change is entirely this one file.

## Scope

- [x] Conventional Commit title.
- [x] Focused — one config field, root-level `.gittensory.yml` only, no application code.
- [x] Owner PR — held for manual merge per this repo's own root-file rule (`blockedPaths: ["*", ".*"]`), not an autonomously mergeable community data submission.

## Validation

- [x] `git diff --check` — clean.
- [x] Validated YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.gittensory.yml'))"`).
- [x] No `src/**`/`workers/**`/`registry/**` touched — no CI/coverage obligation for this change.

## Safety

- [x] No secrets, PATs, wallet paths, or private URLs.
- [x] No behavior change for any other repo — this field is per-repo config-as-code, read only from this file.
- [x] **Explicit, documented trade-off, not a silent behavior change:** opting in means a confident AI false positive can now one-shot-close an otherwise-clean submission. The comment in `.gittensory.yml` states this plainly, matching the trade-off documented on the field itself in `JSONbored/gittensory`.

## Notes

Once this merges, JSONbored/gittensory#3907's full scope (engine-side mechanism + this repo's opt-in) is complete.