### PR TITLE
test(ui): add AGPL-3.0 badge to footer to validate visual-capture pipeline

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -354,8 +354,11 @@ function SiteFooter() {
       </div>
       <div className="border-t border-border/70">
         <div className="max-w-[1400px] mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
-          <span>
+          <span className="inline-flex items-center gap-2">
             © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+            <span className="rounded border border-border px-1.5 py-0.5 uppercase tracking-wider text-ink-subtle">
+              AGPL-3.0
+            </span>
           </span>
           <EndpointHealthPill />
         </div>


### PR DESCRIPTION
## Summary

- **Deliberate test PR, not a feature.** Adds a small, real, visible "AGPL-3.0" text badge next to the footer copyright line on the homepage (`/`), to validate gittensory's newly-activated before/after visual-capture pipeline end-to-end on a real metagraphed `apps/ui` PR.
- Already verified working end-to-end on the equivalent gittensory-ui test PR (JSONbored/gittensory#4180) -- this is the second-repo confirmation.

## What Changed

- `apps/ui/src/components/metagraphed/app-shell.tsx`: one small `<span>` added next to the existing footer copyright line, styled consistently with the footer's existing conventions (matches `EndpointHealthPill`'s bordered/muted style already used in the same row).

## Registry Safety

- [ ] Links a tracked, currently-open issue (`Closes #<n>`) -- N/A, deliberate infra-validation test PR, not a feature/fix.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited -- N/A, no generated artifacts touched.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented -- N/A, no such changes.

## Validation

- [x] `npm --workspace apps/ui run typecheck`
- [x] `npx eslint apps/ui/src/components/metagraphed/app-shell.tsx` (clean)
- [x] `npx prettier --check apps/ui/src/components/metagraphed/app-shell.tsx` (clean)
- [x] `git diff --check`
- [ ] The remaining root-level `validate*`/`test:coverage` scripts -- not run; this change is isolated to one static UI label with no logic, schema, or API surface, verified via the UI-specific checks above.

## Notes

- Expected to be **held for manual review** regardless of CI outcome -- this repo's own contributing skill requires any PR touching visual output (`apps/ui/**` components/routes/styles) to always be held for manual review. That's expected; this isn't meant to auto-merge.
- Watch for the gittensory-orb review comment's "Visual preview" table -- that's the actual thing being validated here, not the code change itself.
