### PR TITLE
feat(deploy): add systemd-scheduled Postgres backup for indexer box

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -209,6 +209,14 @@ One-time setup:
 4. Set an **R2 lifecycle rule** on the bucket for retention (e.g. expire after 30
    days) — the robust way, not a script-side prune.
 
+**Bare-metal / systemd deployment (self-hosted indexer box, no Railway cron
+available)**: same Dockerfile + script, built and run locally, scheduled by
+`deploy/backup/metagraphed-pg-backup.{service,timer}` instead of Railway's
+managed cron — see the header comment in that `.service` file for the exact
+setup steps. Use a distinct `BACKUP_PREFIX` per Postgres instance backed up
+to the same bucket (e.g. `indexer-postgres` vs. `postgres`) so dumps from
+different databases don't collide under one prefix.
+
 ## Backups + PITR (mandatory)
 
 Postgres holds derived state. It is **re-derivable** (re-index from the chain via

--- a/deploy/backup/metagraphed-pg-backup.service
+++ b/deploy/backup/metagraphed-pg-backup.service
@@ -1,0 +1,28 @@
+# Bare-metal equivalent of deploy/backup.railway.json — same image (this
+# directory's Dockerfile + backup-postgres.sh, unmodified), triggered by the
+# companion .timer instead of Railway's managed cron. For a self-hosted
+# indexer box, not Railway.
+#
+# One-time setup on the box:
+#   1. Copy this directory's Dockerfile + backup-postgres.sh to the box and
+#      `docker build -f deploy/backup/Dockerfile -t metagraphed-pg-backup .`
+#      (build context = the copied deploy/backup/'s parent, matching the
+#      Dockerfile's `COPY deploy/backup/backup-postgres.sh` path).
+#   2. Write the env vars this script needs (DATABASE_URL pointed at the
+#      box's local Postgres, R2_BUCKET, R2_ENDPOINT, AWS_ACCESS_KEY_ID,
+#      AWS_SECRET_ACCESS_KEY, BACKUP_PREFIX) to a root-only file, e.g.
+#      /opt/metagraphed-indexer/backup/backup.env (chmod 600) — NEVER commit
+#      that file; update ExecStart's --env-file path below to match.
+#   3. Copy both units to /etc/systemd/system/, then:
+#      systemctl daemon-reload && systemctl enable --now metagraphed-pg-backup.timer
+#   4. Verify once with `systemctl start metagraphed-pg-backup.service` and
+#      confirm the object lands in R2 before trusting the timer alone.
+[Unit]
+Description=metagraphed indexer Postgres -> R2 backup (mirrors deploy/backup.railway.json)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStartPre=-/usr/bin/docker rm -f metagraphed-pg-backup
+ExecStart=/usr/bin/docker run --rm --name metagraphed-pg-backup --network host --env-file /opt/metagraphed-indexer/backup/backup.env metagraphed-pg-backup:latest

--- a/deploy/backup/metagraphed-pg-backup.timer
+++ b/deploy/backup/metagraphed-pg-backup.timer
@@ -1,0 +1,15 @@
+# See metagraphed-pg-backup.service for setup. Daily cadence matches the RPO
+# rationale in backup-postgres.sh (chain data is re-derivable, so ~daily is
+# plenty — no PITR needed). RandomizedDelaySec avoids a fixed-second stampede
+# against other box cron (apt/mdcheck/etc.); Persistent=true catches up a
+# run missed by a reboot instead of silently skipping it.
+[Unit]
+Description=Daily metagraphed indexer Postgres -> R2 backup
+
+[Timer]
+OnCalendar=*-*-* 04:00:00 UTC
+RandomizedDelaySec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- The self-hosted indexer box (`meta-indexer-01-us-lax1`) had no backup coverage for its Postgres — Railway's `pg-backup` service only covers Railway's own (now-frozen, being decommissioned) Postgres.
- Adds `deploy/backup/metagraphed-pg-backup.{service,timer}`, a systemd unit pair that runs the **same, unmodified** `deploy/backup/Dockerfile` + `backup-postgres.sh` Railway already uses for its scheduled `pg_dump | gzip | aws s3 cp` job — just triggered by a local systemd timer instead of Railway's managed cron.
- Writes to the same `metagraphed-backups` R2 bucket, under a distinct `indexer-postgres/` prefix (vs. Railway's `postgres/`) so the two don't collide. Added a matching R2 lifecycle rule (14-day expiry) for the new prefix.
- Documents the bare-metal deployment path in `deploy/README.md` alongside the existing Railway instructions.

## Verification performed live on the box (not just deployed)
- Built the image, ran the service manually: completed successfully (31GB DB → 1.6GiB compressed dump, confirmed independently via `aws s3 ls` against R2, not just the script's own log).
- Restored that exact dump into a fresh scratch TimescaleDB container end-to-end (download from R2 → decompress → `psql` apply, ~30 min for the full dataset).
- Compared row counts (`blocks`/`extrinsics`/`chain_events`/`account_events`) between the restored scratch DB and the live DB: every count was slightly *lower* in the restore, by a small, proportional amount across all four tables — exactly the expected signature of a consistent snapshot of a database that kept ingesting (live tail + backfill) in the ~29 minutes between the dump and the live baseline query. No mismatches, no missing tables, no corruption.
- Enabled the timer (`systemctl enable --now`); next run confirmed scheduled.

This unblocks fully decommissioning Railway's `indexer-rs`/Postgres/Redis/`pg-backup` (tracked separately) — that cleanup was explicitly held until this backup existed and was verified.

## Test plan
- [x] Manual backup run succeeded (`systemctl start metagraphed-pg-backup.service`, `Result=success`)
- [x] Object independently verified in R2 via `aws s3 ls`
- [x] Full restore into a scratch DB succeeded with matching (time-consistent) row counts
- [x] Timer enabled and scheduled
- [x] CI green on this PR