### PR TITLE
test(mcp): update stale hardcoded SemVer assertion after the 1.78.1 bump

### DIFF
--- a/tests/subnet-evidence-mcp.test.mjs
+++ b/tests/subnet-evidence-mcp.test.mjs
@@ -350,7 +350,7 @@ describe("subnet-evidence-mcp", () => {
   });
 
   test("MCP server exports wire list_subnet_evidence at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.78.0");
+    assert.equal(MCP_SERVER_VERSION, "1.78.1");
     assert.match(MCP_INSTRUCTIONS, /list_subnet_evidence/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_subnet_evidence");
     assert.ok(tool);


### PR DESCRIPTION
## What
Updates a stale hardcoded SemVer assertion in `tests/subnet-evidence-mcp.test.mjs:353` from `"1.78.0"` to `"1.78.1"`, matching the real `MCP_SERVER_VERSION` constant in `src/mcp-server.mjs:532` (and `server.json`) after #4207's version bump.

## Why
#4207 ("chore(mcp): bump server version to 1.78.1") bumped `MCP_SERVER_VERSION` and `server.json` but missed updating this one test's hardcoded expectation, so `tests/subnet-evidence-mcp.test.mjs > subnet-evidence-mcp > MCP server exports wire list_subnet_evidence at the bumped SemVer` has been failing on `main` since that merge — confirmed via a clean `npx vitest run tests/subnet-evidence-mcp.test.mjs` on the current `main` HEAD, which fails with:

```
AssertionError: Expected values to be strictly equal:
'1.78.1' !== '1.78.0'
```

This means every PR rebased onto (or opened against) current `main` inherits a failing CI `test` check through no fault of its own diff — I hit this directly when a routine proactive rebase of an otherwise-clean PR got auto-closed by the review gate with `CI is failing (test)` as the stated reason.

## Fix
One-line update to the hardcoded literal so the test reflects the version `main` actually ships.

## Testing
`npx vitest run tests/subnet-evidence-mcp.test.mjs`: all 29 tests in the file now pass (was 28 passed / 1 failed on `main` before this change).
