### PR TITLE
fix(ui): correct stale hardcoded fallback colors for --accent/--ink-muted

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/sparkline.tsx
+++ b/apps/ui/src/components/metagraphed/charts/sparkline.tsx
@@ -36,7 +36,7 @@ export function Sparkline({
   points,
   width = 120,
   height = 28,
-  color = "var(--accent, #7aa2ff)",
+  color = "var(--accent, #00c899)",
   fill = true,
   className,
   ariaLabel,

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -82,7 +82,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
           {series.neurons.length > 0 ? (
-            <HistoryRow label="Neurons" series={series.neurons} color="var(--accent, #7aa2ff)" />
+            <HistoryRow label="Neurons" series={series.neurons} color="var(--accent, #00c899)" />
           ) : null}
           {series.validators.length > 0 ? (
             <HistoryRow
@@ -103,7 +103,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
             <HistoryRow
               label="Total emission"
               series={series.emission}
-              color="var(--accent, #7aa2ff)"
+              color="var(--accent, #00c899)"
               format={taoStr}
             />
           ) : null}

--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -10,7 +10,7 @@ import type { Subnet } from "@/lib/metagraphed/types";
 
 const UP = healthColorVar("ok");
 const DOWN = healthColorVar("down");
-const FLAT = "var(--ink-muted, #8a8f98)";
+const FLAT = "var(--ink-muted, #616b6c)";
 
 function priceStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";


### PR DESCRIPTION
Closes #3979

## What
Replaces the stale hardcoded fallback hex values in three files with accurate approximations of the real `--accent`/`--ink-muted` tokens:

- `apps/ui/src/components/metagraphed/charts/sparkline.tsx:39` — `var(--accent, #7aa2ff)` → `var(--accent, #00c899)`
- `apps/ui/src/components/metagraphed/subnet-history-chart.tsx:85,106` — same
- `apps/ui/src/components/metagraphed/subnet-price-ticker.tsx:13` — `var(--ink-muted, #8a8f98)` → `var(--ink-muted, #616b6c)`

## Why
`#7aa2ff` is a blue, but the real `--accent` token (`src/styles.css:131`, light mode: `oklch(0.74 0.15 168)`) is a mint/teal — converted to sRGB hex that's `#00c899`, not blue. Likewise `--ink-muted` (`src/styles.css:110`, light mode: `oklch(0.52 0.012 200)`) converts to `#616b6c`, not `#8a8f98`. If the CSS custom property ever fails to resolve (unstyled-content flash, SSR edge case, embedding without `styles.css`), these charts would render the wrong brand color instead of a close approximation of the real one.

## Screenshots

`SubnetHistoryChart`'s Neurons/Total Emission rows (both using `var(--accent, ...)`), with the CSS custom property forced invalid (`--accent: initial`) to trigger the fallback path — normal rendering with the variable present is completely unaffected, since `var()` always prefers a valid custom property over its fallback:

| Before (fallback `#7aa2ff`, wrong blue) | After (fallback `#00c899`, correct mint) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-chart-fallback-colors/before.png) | ![after](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-chart-fallback-colors/after.png) |

## Acceptance criteria
- [x] Screenshot of the fallback color rendering (via a forced-invalid `--accent`), confirming the corrected value
- [x] All three files appear in the diff
- [x] The fallback color visually approximates the real `--accent`/`--ink-muted` tokens
- [x] Normal rendering (CSS variable present, the common case) is unaffected — only the fallback value changed, not the component logic

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on all three changed files: clean (aside from pre-existing CRLF-only diffs unrelated to this change).
- `npx vitest run`: full suite passes on this branch.
- Diff is 4 insertions / 4 deletions across exactly the three files the issue names.
