### PR TITLE
feat(registry): add SN41 Almanac NFL Champion market data-artifact surface

### DIFF
--- a/registry/subnets/almanac.json
+++ b/registry/subnets/almanac.json
@@ -28,6 +28,25 @@
         "https://github.com/sportstensor/sn41/blob/main/api_trading.py"
       ],
       "url": "https://api.almanac.market/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-41-almanac-nfl-champion-market",
+      "kind": "data-artifact",
+      "name": "Almanac NFL Champion 2027 market snapshot",
+      "notes": "Public no-auth GET /api/markets/events/{event_id} on api.almanac.market returning full market metadata (title, description, resolution rules, image/icon URLs, active/closed/archived flags) for a specific SN41 Almanac prediction market (NFL Champion 2027, event id 202857). Same api.almanac.market host as the existing health surface; the underlying /markets/search and /markets/events/{id} routes are used by the official sportstensor/sn41 trading client (api_trading.py) to browse and inspect markets.",
+      "provider": "almanac",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": [
+        "https://github.com/sportstensor/sn41/blob/main/api_trading.py",
+        "https://api.almanac.market/api/markets/search?q=nfl"
+      ],
+      "url": "https://api.almanac.market/api/markets/events/202857"
     }
   ],
   "website_url": "https://almanac.market/"


### PR DESCRIPTION
Closes #4047

## What
Adds a public data-artifact surface for SN41 Almanac to `registry/subnets/almanac.json`: a specific market snapshot from the subnet's REST API.

## Evidence
- `GET https://api.almanac.market/api/markets/events/202857` — confirmed live, no-auth, returns full market metadata (title "NFL Champion 2027", description, resolution rules, image/icon URLs, active/closed/archived flags) as `application/json`.
- The underlying `/markets/search` and `/markets/events/{id}` routes are used by the official `sportstensor/sn41` trading client (`api_trading.py`) to browse and inspect markets — same `api.almanac.market` host already registered as this subnet's health surface.
- `public_safe: true`, `auth_required: false` — confirmed via direct request (no credentials sent, full data returned).

## Testing
`npm run validate:surface -- registry/subnets/almanac.json`: passes (2 surfaces across 1 subnet file).

Diff touches exactly one file, strictly additive (19 insertions, 0 deletions).
