### PR TITLE
feat(registry): add SN64 Chutes miner scores + stats subnet-api surfaces (#427)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -615,6 +615,38 @@
         "https://chutes.ai/docs"
       ],
       "url": "https://api.chutes.ai/payments/summary/tao"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-scores-api",
+      "kind": "subnet-api",
+      "name": "Chutes miner scores API",
+      "notes": "Public no-auth GET /miner/scores on api.chutes.ai — Chutes-computed per-miner scoring breakdown (raw and normalized bounty/compute values) for SN64 Chutes. Declared as a no-auth route (security: none) in the official Chutes OpenAPI spec on the same api.chutes.ai gateway that hosts the subnet's registered surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-stats-api",
+      "kind": "subnet-api",
+      "name": "Chutes miner stats API",
+      "notes": "Public no-auth GET /miner/stats on api.chutes.ai — Chutes-computed per-miner instance and compute statistics (rolling instance counts and utilization windows) for SN64 Chutes. Declared as a no-auth route (security: none) in the official Chutes OpenAPI spec on the same api.chutes.ai gateway that hosts the subnet's registered surfaces.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/stats"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Summary

Closes #427

Enriches SN64 **Chutes** with two previously-unregistered, public, no-auth endpoints of
its official API gateway (`api.chutes.ai`) — the same host that already serves the subnet's
registered surfaces.

## Surfaces (2)

- **subnet-api** — https://api.chutes.ai/miner/scores
  Chutes-computed per-miner scoring breakdown (raw + normalized bounty/compute values).
- **subnet-api** — https://api.chutes.ai/miner/stats
  Chutes-computed per-miner instance and compute statistics (rolling instance counts / utilization windows).

Both `authority: community`, `auth_required: false`, `public_safe: true`.

## Proof

- On-chain `SubnetIdentitiesV3` for netuid 64 identifies **Chutes** (Chutes Global Corp); `api.chutes.ai` is the official gateway already hosting the subnet's registered surfaces.
- Both routes are declared **`security: none`** (no auth) in the official Chutes OpenAPI spec — used as their `source_url` (`https://api.chutes.ai/openapi.json`) — and each returns live `200 application/json`.
- Neither URL duplicates any of the 30 existing Chutes surfaces (`/miner/*` vs the registered `/invocations/*`).

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed (32 surfaces)
- `npm run scan:public-safety` — passed
- `npm run build` — passed (exit 0)
- `npm run validate` — passed (exit 0, 1472 surfaces)

Single-file change; no generated artifacts touched.
