### PR TITLE
feat(ui): add copy buttons on extrinsics hash and signer cells (#3396)

### DIFF
--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
+import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { CopyButton } from "@/components/metagraphed/copy-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -251,14 +253,17 @@ function ExtrinsicsTable() {
               <tr key={rowKey(x)} className="mg-row-accent hover:bg-surface/40">
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
                   {x.extrinsic_hash ? (
-                    <Link
-                      to="/extrinsics/$hash"
-                      params={{ hash: x.extrinsic_hash }}
-                      className="font-medium text-ink-strong hover:underline"
-                      title={x.extrinsic_hash}
-                    >
-                      {shortHash(x.extrinsic_hash)}
-                    </Link>
+                    <span className="inline-flex items-center gap-1 min-w-0">
+                      <Link
+                        to="/extrinsics/$hash"
+                        params={{ hash: x.extrinsic_hash }}
+                        className="font-medium text-ink-strong hover:underline truncate"
+                        title={x.extrinsic_hash}
+                      >
+                        {shortHash(x.extrinsic_hash)}
+                      </Link>
+                      <CopyButton value={x.extrinsic_hash} label="extrinsic hash" />
+                    </span>
                   ) : (
                     "—"
                   )}
@@ -282,11 +287,8 @@ function ExtrinsicsTable() {
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
                   {extrinsicCall(x.call_module, x.call_function)}
                 </td>
-                <td
-                  className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
-                  title={x.signer ?? undefined}
-                >
-                  {shortHash(x.signer) ?? "—"}
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">
                   <SuccessBadge success={x.success} />
@@ -305,27 +307,59 @@ function ExtrinsicsTable() {
 }
 
 function HashCardOrLink({ x }: { x: Extrinsic }) {
+  const className = "block rounded border border-border bg-card p-3 min-h-11 active:bg-surface";
   const inner = (
     <>
       <div className="flex items-center justify-between gap-2">
-        <div className="font-mono text-[12px] font-medium text-ink-strong truncate">
-          {shortHash(x.extrinsic_hash) ?? "(no hash)"}
+        <div className="flex items-center gap-1 min-w-0 flex-1">
+          {x.extrinsic_hash ? (
+            <>
+              <span className="font-mono text-[12px] font-medium text-ink-strong truncate">
+                {shortHash(x.extrinsic_hash)}
+              </span>
+              <span
+                role="presentation"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
+                <CopyButton value={x.extrinsic_hash} label="extrinsic hash" />
+              </span>
+            </>
+          ) : (
+            <span className="font-mono text-[12px] font-medium text-ink-strong">(no hash)</span>
+          )}
         </div>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="font-mono text-[11px] text-ink-muted shrink-0">
           <TimeAgo at={x.observed_at} />
         </span>
       </div>
       <div className="mt-1 font-mono text-[11px] text-ink truncate">
         {extrinsicCall(x.call_module, x.call_function)}
       </div>
-      <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
-        <span>{x.block_number != null ? `#${formatNumber(x.block_number)}` : "—"}</span>
-        <span>{shortHash(x.signer) ?? "no signer"}</span>
+      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+        <span className="shrink-0">
+          {x.block_number != null ? `#${formatNumber(x.block_number)}` : "—"}
+        </span>
+        {x.signer ? (
+          <span
+            role="presentation"
+            className="min-w-0 max-w-[55%]"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <CopyableCode value={x.signer} className="w-full" />
+          </span>
+        ) : (
+          <span>no signer</span>
+        )}
         <SuccessBadge success={x.success} />
       </div>
     </>
   );
-  const className = "block rounded border border-border bg-card p-3 min-h-11 active:bg-surface";
   return x.extrinsic_hash ? (
     <Link to="/extrinsics/$hash" params={{ hash: x.extrinsic_hash }} className={className}>
       {inner}

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -17,7 +17,9 @@ Every `/api/v1/*` response is a JSON envelope:
 {
   "ok": true,
   "schema_version": 1,
-  "data": {/* artifact payload, possibly filtered/paginated */},
+  "data": {
+    /* artifact payload, possibly filtered/paginated */
+  },
   "meta": {
     "artifact_path": "/metagraph/subnets.json",
     "cache": "standard",
@@ -25,7 +27,9 @@ Every `/api/v1/*` response is a JSON envelope:
     "generated_at": "1970-01-01T00:00:00.000Z",
     "published_at": "2026-06-09T13:57:16.231Z",
     "source": "static-assets",
-    "pagination": {/* present on list routes; see below */},
+    "pagination": {
+      /* present on list routes; see below */
+    },
   },
 }
 ```


### PR DESCRIPTION
## Summary

- Add copy-to-clipboard on **Hash** and **Signer** cells in the extrinsics table (desktop + mobile cards)
- Hash: keep `Link` to `/extrinsics/$hash`; add `CopyButton` beside it for the full hash
- Signer: `CopyableCode` when present; em-dash when null
- Mobile `HashCardOrLink`: same copy affordances; copy controls stop propagation so card link still works
- Closes #3396 · Part of #2542 · Twin of #3395 (blocks table)

## Screenshots (`/extrinsics` — live api.metagraph.sh)

| Viewport · Theme           | Before                                                                                                                                              | After                                                                                                                                                         |
| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Desktop · Light (1280×800) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-light-before.png)<br><sub>hash/signer — no copy</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-light-after.png)<br><sub>copy icon on hash; CopyableCode on signer</sub> |
| Desktop · Dark (1280×800)  | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-dark-before.png)<br><sub>before</sub>                 | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-desktop-dark-after.png)<br><sub>after</sub>                                     |
| Tablet · Light (768×1024)  | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-light-before.png)<br><sub>before</sub>                 | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-light-after.png)<br><sub>after</sub>                                     |
| Tablet · Dark (768×1024)   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-dark-before.png)<br><sub>before</sub>                 | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-tablet-dark-after.png)<br><sub>after</sub>                                     |
| Mobile · Light (375×812)   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-light-before.png)<br><sub>mobile cards — no copy</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-light-after.png)<br><sub>copy on hash + signer in card</sub>             |
| Mobile · Dark (375×812)    | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-dark-before.png)<br><sub>before</sub>                 | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3396-extrinsics-copy-mobile-dark-after.png)<br><sub>after</sub>                                     |

## Test plan

- [x] Desktop — hash link still navigates; copy button copies full hash without navigating
- [x] Desktop — signer copy copies full ss58; null signer shows em-dash
- [x] Mobile card — tap card navigates; tap copy does not navigate
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui` (changed file clean)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`