### PR TITLE
feat(registry): add SN93 Bitcast validator briefs/pools/x-briefs subnet-api surfaces (#427)

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -219,6 +219,54 @@
         "https://github.com/bitcast-network/bitcast/blob/main/setup.py"
       ],
       "url": "https://raw.githubusercontent.com/bitcast-network/bitcast/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-validator-briefs-api",
+      "kind": "subnet-api",
+      "name": "Bitcast validator briefs API",
+      "notes": "Public no-auth GET /api/v2/validator/briefs on bitcast-api.bitcast.network — the live incentivized YouTube brief definitions (id, brief text, reward pool, dates) that SN93 Bitcast validators score miners against. Declared no-auth (global security: none) in the subnet's own OpenAPI spec on the same host as its registered openapi + health surfaces.",
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://bitcast-api.bitcast.network/openapi.json"],
+      "url": "https://bitcast-api.bitcast.network/api/v2/validator/briefs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-validator-pools-api",
+      "kind": "subnet-api",
+      "name": "Bitcast validator pools API",
+      "notes": "Public no-auth GET /api/v2/validator/pools on bitcast-api.bitcast.network — the live reward-pool definitions (name, active flag, keywords, promoted accounts) that partition SN93 Bitcast brief incentives. Declared no-auth (global security: none) in the subnet's own OpenAPI spec on the same host as its registered openapi + health surfaces.",
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://bitcast-api.bitcast.network/openapi.json"],
+      "url": "https://bitcast-api.bitcast.network/api/v2/validator/pools"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-validator-x-briefs-api",
+      "kind": "subnet-api",
+      "name": "Bitcast validator X briefs API",
+      "notes": "Public no-auth GET /api/v2/validator/x-briefs on bitcast-api.bitcast.network — the live incentivized X (Twitter) brief definitions (id, brief text, display copy) that SN93 Bitcast validators score X-platform miners against. Declared no-auth (global security: none) in the subnet's own OpenAPI spec on the same host as its registered openapi + health surfaces.",
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://bitcast-api.bitcast.network/openapi.json"],
+      "url": "https://bitcast-api.bitcast.network/api/v2/validator/x-briefs"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #427

Enriches SN93 **Bitcast** with three previously-unregistered, public, no-auth endpoints of
its API gateway (`bitcast-api.bitcast.network`) — the same host that already serves the
subnet's registered OpenAPI and health surfaces.

## Surfaces (3)

- **subnet-api** — `/api/v2/validator/briefs` — live incentivized YouTube brief definitions (id, brief text, reward pool, dates) validators score miners against.
- **subnet-api** — `/api/v2/validator/pools` — reward-pool definitions (name, active flag, keywords, promoted accounts).
- **subnet-api** — `/api/v2/validator/x-briefs` — incentivized X (Twitter) brief definitions.

All `authority: community`, `auth_required: false`, `public_safe: true`.

## Proof

- All three are declared no-auth (**global `security: none`**) in the subnet's own OpenAPI spec (`bitcast-api.bitcast.network/openapi.json`, used as `source_url`) and each returns live `200 application/json`.
- `bitcast-api.bitcast.network` is the subnet's registered API host (already carries its openapi + `/health/ready` + `/health/database` surfaces); these `/api/v2/validator/*` paths duplicate none of the 11 existing surfaces.

## Validation

- `npm run validate:surface -- registry/subnets/bitcast.json` — passed (14 surfaces)
- `npm run scan:public-safety` — passed
- `npm run build` — passed (exit 0)
- `npm run validate` — passed (exit 0, 1475 surfaces)

Single-file, append-only diff (48 insertions, 0 deletions); no existing surfaces or generated artifacts touched.
