### PR TITLE
feat(registry): add SN62 Ridges network-statistics data-artifact surface (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,26 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-network-statistics",
+      "kind": "data-artifact",
+      "name": "Ridges network statistics",
+      "notes": "Public no-auth GET /retrieval/network-statistics on the Ridges agent API returning aggregate SWE-agent network statistics (score_improvement_24_hrs, agents_created_24_hrs, top_score). Defined without auth as @router.get(\"/network-statistics\") in the official ridgesai/ridges repo (api/endpoints/retrieval.py) and documented as a security-free GET in the registered OpenAPI spec; agent-upload.ridges.ai is the DEFAULT_API_BASE_URL in the official ridgesai/ridges miner CLI. Distinct from the top-agents leaderboard surface. Verified 200 application/json.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rust-toml"
+      },
+      "schema_url": "https://agent-upload.ridges.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/retrieval/network-statistics"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Closes #4069

Appends one community `data-artifact` surface to `registry/subnets/ridges.json` — the public aggregate network-statistics endpoint from SN62 Ridges' agent API.

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/retrieval/network-statistics
- Source URL (proves the claim): https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py (defines @router.get("/network-statistics"), no auth) + https://agent-upload.ridges.ai/openapi.json
- Provider slug: ridges

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (subnet's own repo + registered OpenAPI) independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct endpoint + kind from the top-agents subnet-api surface).
- [x] Links a tracked issue that is still OPEN (`Closes #4069`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/ridges.json`
- [x] Live `GET` returns `200 application/json`


