### PR TITLE
fix(ui): document empty-state component rule, fix accounts endpoint-announcements mismatch

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -93,6 +93,22 @@ export function ErrorState({
   );
 }
 
+/**
+ * The default no-data/no-selection placeholder — issue #3962's rule for
+ * choosing between the three empty-state components:
+ *  - `EmptyState` (here): page-level guard clauses (not-found/invalid input),
+ *    single charts/stat panels, and generic lists that need at most one
+ *    action link and no retry wiring or provenance.
+ *  - `TableState` (table-state.tsx): a subnet/account-detail panel's primary
+ *    content — literal `<table>` or a StatTile scorecard sharing that panel
+ *    shell — that needs the empty/stale/error variant switch plus retry.
+ *  - `RegistryEmpty` (states/registry-empty.tsx): top-level registry index
+ *    pages whose content is inherently externally-sourced (endpoints,
+ *    surfaces, gaps) and needs multiple next-actions plus freshness/evidence
+ *    rows.
+ * Use `ErrorState` above instead of this for a genuine fetch error — it
+ * carries `onRetry` and the failing status/URL that this component doesn't.
+ */
 export function EmptyState({
   title = "Nothing here yet",
   description,

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -57,9 +57,16 @@ const TONE = {
 } as const;
 
 /**
- * Unified empty/error/stale state for registry surfaces. Surfaces a clear
- * headline, a plain-language explainer, an optional freshness hint, and a
- * compact row of "next actions" so users always know what to do next.
+ * Unified empty/error/stale state reserved for top-level registry
+ * index/listing pages (endpoints, surfaces, gaps) whose content is
+ * inherently about externally-sourced provenance. Surfaces a clear
+ * headline, a plain-language explainer, an optional freshness hint, an
+ * "evidence & sources" link, and a compact row of up to ~3 "next actions."
+ *
+ * Not for single-panel/chart no-data cases within a subnet or account detail
+ * page (use `TableState`, table-state.tsx) or for simple guard clauses (use
+ * `EmptyState`, states.tsx). See the rule documented on `EmptyState` in
+ * states.tsx (issue #3962).
  */
 export function RegistryEmpty({
   variant,

--- a/apps/ui/src/components/metagraphed/table-state.tsx
+++ b/apps/ui/src/components/metagraphed/table-state.tsx
@@ -34,9 +34,16 @@ interface Props {
 }
 
 /**
- * Unified empty / stale / error block for every registry table. Identical
- * padding, copy column, and CTA style so empty states feel consistent across
- * /endpoints, /surfaces, /providers, subnet detail tables.
+ * Unified empty / stale / error block for a subnet- or account-detail
+ * panel's primary content — a literal `<table>` or a StatTile/scorecard
+ * panel sharing the same detail-page shell — wherever that content needs
+ * the variant switch plus a single retry + CTA. Identical padding, copy
+ * column, and CTA style so these panels feel consistent with each other.
+ *
+ * Not for top-level registry index/listing pages (use `RegistryEmpty`,
+ * states/registry-empty.tsx, for those) or for simple guard clauses/charts
+ * that need no retry (use `EmptyState`/`ErrorState`, states.tsx). See the
+ * rule documented on `EmptyState` in states.tsx (issue #3962).
  */
 export function TableState({
   variant,

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1050,7 +1050,8 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
       right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
     >
       {isEmpty ? (
-        <EmptyState
+        <TableState
+          variant="empty"
           title="No endpoint announcements"
           description="This account had no AxonServed or PrometheusServed events in the window — typical for non-miner accounts or coldkeys without serving activity."
         />


### PR DESCRIPTION
## Summary

- Investigates the three overlapping empty-state components (#3962) and documents a rule for choosing between them, as code comments on each component's definition.
- Migrates the one call site where the audit found the *same file* using two different components for the identical shape of state (the exact pattern called out in the issue title).
- Reports the broader findings from the full 43-file audit for a maintainer to triage into follow-up issues (see below) — out of scope for this PR per the issue's own size guidance (M, ≤10 files).

## The rule (documented in code)

- **`EmptyState`/`ErrorState`** (`states.tsx`) — page-level guard clauses (not-found/invalid input), single charts/stat panels, and generic lists that need at most one action link and no retry wiring or provenance.
- **`TableState`** (`table-state.tsx`) — a subnet/account-detail panel's primary content (a literal `<table>` *or* a StatTile scorecard sharing that panel shell) that needs the empty/stale/error variant switch plus a single retry + CTA.
- **`RegistryEmpty`** (`states/registry-empty.tsx`) — top-level registry index/listing pages whose content is inherently externally-sourced (endpoints, surfaces, gaps) and needs multiple next-actions plus freshness/evidence rows.

All three do serve genuinely distinct purposes once this line is drawn — this isn't a case for collapsing them into one component, per the issue's own non-goal.

## What changed

`apps/ui/src/routes/accounts.$ss58.tsx`: `AccountEndpointAnnouncementSection`'s zero-count branch used plain `EmptyState`, while its sibling `AccountWeightSettingSection` — same file, same "optional enrichment tier is empty" shape, same author — used `TableState variant="empty"` for the identical case (both sections already share the `TableState variant="error"` treatment for their error branches). Migrated the empty branch to `TableState` to match.

## Broader findings (not migrated in this PR — flagging for a maintainer to triage)

The full audit turned up more mismatches than fit in one M-sized PR. Rather than open new issues (held back this round), listing them here for a maintainer to decide/file:

1. **Registry-index inconsistency**: `providers.index.tsx` and `subnets.index.tsx` are true registry-listing pages (like `/endpoints`, `/surfaces`, `/gaps`) but still use plain `EmptyState` instead of `RegistryEmpty`, with `generatedAt`/staleness data already in scope but unused for this. `evidence-panel.tsx`'s true-empty branch is the single best-fit candidate for `RegistryEmpty`'s `evidenceHref` prop in the app (every row already carries `url` + `recorded_at`) yet uses the plainest component. Its query-error branch also renders `EmptyState` (no retry) for a genuine `query.error` — a correctness bug independent of the RegistryEmpty question.
2. **Real `<table>` sites still on `EmptyState`** (no retry/CTA wired despite guarding genuine paginated tables): `index.tsx` (home preview), `extrinsics.index.tsx`, `blocks.index.tsx`, `validators.index.tsx`, and 3 nested tables in `blocks.$ref.tsx`.
3. **Hand-rolled 4th pattern**: `operational-panel.tsx`, `subnet-compare-drawer.tsx` (×2), `charts/latency-heatmap.tsx`, and `charts/economics-mini.tsx` all duplicate `EmptyState`'s dashed-border/centered-text visual language by hand instead of importing it.
4. **Cross-file same-surface inconsistency**: network-wide "incidents" is `TableState` on `/health` but `EmptyState` on `/endpoints` (`analytics/incidents-timeline.tsx`); the chain-wide decentralization scorecard (`network-decentralization-panel.tsx`) is `EmptyState` while its subnet-scope twin (`concentration-panel.tsx`) is `TableState`.

## Screenshots

Migrated call site: `/accounts/5GsbTgfvgCH4xdqSkiPb7EaBBFLHjWH5vfEALhJaewSFpZX9` (a coldkey with zero endpoint announcements), scrolled to the "Endpoint announcements" section. Before/after, 3 viewports × 2 themes.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/endpoint-announcements-mobile-dark-after.png)<br><sub>after</sub> |

## Validation

- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 75 files / 521 tests passing
- `npm run build --workspace=apps/ui` — clean
- `npm run lint` / `format:check` — this checkout has `core.autocrlf=true` and the repo has no `.gitattributes`, so every file (including on unmodified `main`) reports CRLF prettier errors locally; confirmed via `git diff --check` (clean) and by running prettier/eslint against the staged (LF-normalized) blobs directly, which are clean.

Closes #3962
