### PR TITLE
feat(registry): add SN50 Synth validation-scores data-artifact surface (#4054)

### DIFF
--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -47,6 +47,26 @@
         "https://github.com/synthdataco/synth-subnet/blob/main/README.md"
       ],
       "url": "https://api.synthdata.co/v2/leaderboard/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-50-synth-validation-scores",
+      "kind": "data-artifact",
+      "name": "Synth latest validation scores dataset",
+      "notes": "Public no-auth GET /validation/scores/latest on api.synthdata.co returning a JSON dataset of the latest per-miner, per-asset forecast validation scores for the SN50 Synth price-prediction network (miner_uid, asset, prompt_score, crps, scored_time, time_length). Documented as a security-free GET (\"Validations - Latest Scores\") in the subnet's registered OpenAPI spec at api.synthdata.co/swagger.json; distinct from the leaderboard subnet-api surface on the same host. Verified 200 application/json.",
+      "provider": "synth",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rust-toml"
+      },
+      "schema_url": "https://api.synthdata.co/swagger.json",
+      "source_urls": [
+        "https://api.synthdata.co/swagger.json",
+        "https://github.com/synthdataco/synth-subnet/blob/main/README.md"
+      ],
+      "url": "https://api.synthdata.co/validation/scores/latest"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Closes #4054

Appends one community `data-artifact` surface to `registry/subnets/synth.json` — the public per-miner forecast validation-scores dataset from SN50 Synth's API.

## Surface

- Netuid: 50
- Kind: data-artifact
- Public URL: https://api.synthdata.co/validation/scores/latest
- Source URL (proves the claim): https://api.synthdata.co/swagger.json (documents GET /validation/scores/latest as a security-free public endpoint)
- Provider slug: synth

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` (registered OpenAPI spec) independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct endpoint + dataset from the leaderboard subnet-api surface).
- [x] Links a tracked issue that is still OPEN (`Closes #4054`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/synth.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/synth.json`
- [x] Live `GET` returns `200 application/json`
