### PR TITLE
fix(ui): wire /health view and status params to a real validateSearch

### DIFF
--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,5 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { resolveRefetchInterval, usePageVisible } from "@/hooks/use-refetch-interval";
 import { Suspense, useEffect, useMemo, useState } from "react";
@@ -40,7 +42,34 @@ const INTERVAL_OPTIONS: Array<{ label: string; value: number }> = [
 
 const INCIDENT_INITIAL_VISIBLE = 12;
 
+// Mirrors the six Health mega-menu quick-filter links (nav-mega-menu-data.ts
+// `MEGA_PANELS` "health" panel) so `/health?view=...` and `/health?status=...`
+// deep-link into a specific section/filter instead of always rendering the
+// same fixed page. `status` also backs the page's own incident-filter chips.
+const HEALTH_VIEWS = ["", "matrix", "incidents", "sources", "freshness"] as const;
+type HealthView = (typeof HEALTH_VIEWS)[number];
+
+const HEALTH_STATUSES = ["all", "down", "warn", "resolved"] as const;
+type StateFilter = (typeof HEALTH_STATUSES)[number];
+
+const healthSearchSchema = z.object({
+  view: fallback(z.enum(HEALTH_VIEWS), "").default(""),
+  status: fallback(z.enum(HEALTH_STATUSES), "all").default("all"),
+});
+
+// Which section a `view` deep-link should scroll to + highlight. A bare
+// `status` (no `view`) targets the incidents section too, since that's the
+// only place `status` has any effect.
+const VIEW_SECTION_ID: Record<HealthView, string | null> = {
+  "": null,
+  matrix: "subnet-matrix",
+  incidents: "incidents",
+  sources: "source-health",
+  freshness: "status-board",
+};
+
 export const Route = createFileRoute("/health")({
+  validateSearch: zodValidator(healthSearchSchema),
   head: () => ({
     meta: [
       { title: "Health — Metagraphed" },
@@ -61,12 +90,36 @@ export const Route = createFileRoute("/health")({
 });
 
 function HealthPage() {
+  const search = Route.useSearch();
   const [enabled, setEnabled] = useState(true);
   const [intervalMs, setIntervalMs] = useState(30_000);
   const visible = usePageVisible();
   const effectiveInterval = resolveRefetchInterval(intervalMs, enabled, visible);
   // #1117: push a refresh on each registry publish, on top of the poll interval.
   useRegistryEvents();
+
+  // `search.view` is cast here because `fallback().default()` (zod-adapter,
+  // pinned to zod v3 types) loses its literal-union output type under this
+  // repo's zod v4 — a pre-existing gap shared by every other route's search
+  // schema, just not one any of them happens to index a Record with.
+  const activeSectionId =
+    VIEW_SECTION_ID[search.view as HealthView] ?? (search.status !== "all" ? "incidents" : null);
+  const sectionRing = (id: string) =>
+    activeSectionId === id ? "ring-1 ring-accent/40 rounded-2xl" : undefined;
+
+  useEffect(() => {
+    if (!activeSectionId) return;
+    const t = window.setTimeout(() => {
+      document
+        .getElementById(activeSectionId)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 80);
+    return () => window.clearTimeout(t);
+    // Deep-link arrival only — deliberately not re-run when `search` changes
+    // afterward (e.g. clicking an incident-filter chip below), or the page
+    // would yank itself back to this section every time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <AppShell>
@@ -95,6 +148,7 @@ function HealthPage() {
             title="Global health, at a glance"
             description="Probe-derived state across every monitored surface."
             toolbar={<TimeRangeScrub />}
+            className={sectionRing("status-board")}
           >
             <QueryErrorBoundary>
               <Suspense fallback={<Skeleton className="h-56 w-full" />}>
@@ -135,6 +189,7 @@ function HealthPage() {
           eyebrow="Coverage"
           title="Subnet health matrix"
           description="Every active subnet, colored by latest probe state. Click a cell to open."
+          className={sectionRing("subnet-matrix")}
         >
           <SubnetHealthMatrix />
         </PageSection>
@@ -144,6 +199,7 @@ function HealthPage() {
           eyebrow="Sources"
           title="Source freshness"
           description="Where the registry pulls evidence from and how fresh each source is."
+          className={sectionRing("source-health")}
         >
           <QueryErrorBoundary>
             <Suspense fallback={<Skeleton className="h-32 w-full" />}>
@@ -157,6 +213,7 @@ function HealthPage() {
           eyebrow="Incidents"
           title="Live & recent incidents"
           description="Grouped by host. Ongoing incidents bubble to the top."
+          className={sectionRing("incidents")}
         >
           <QueryErrorBoundary>
             <Suspense fallback={<Skeleton className="h-32 w-full" />}>
@@ -523,12 +580,17 @@ function severityRank(state: HealthState | undefined): SeverityRank {
   return 0;
 }
 
-type StateFilter = "all" | "down" | "warn" | "resolved";
-
 function Incidents({ interval }: { interval: number | false }) {
   const { data } = useSuspenseQuery({ ...endpointIncidentsQuery(), refetchInterval: interval });
   const rows = useMemo(() => (data.data ?? []) as EndpointIncident[], [data]);
-  const [filter, setFilter] = useState<StateFilter>("all");
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const filter = search.status;
+  const setFilter = (next: StateFilter) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, status: next }) as never,
+      resetScroll: false,
+    });
   const [showAll, setShowAll] = useState(false);
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
 


### PR DESCRIPTION
## Summary

- `src/routes/health.tsx` had no `validateSearch`, so the primary nav mega-menu's six Health quick-filter links (`?view=matrix/incidents/sources/freshness`, `?status=warn/down`, see `nav-mega-menu-data.ts:141-150`) were dead — the route never read any of these params, so the page always rendered the same fixed sections regardless of which link was clicked.
- The page's own incident-filter chips (All/Down/Degraded/Resolved) also lived in local `useState` (`health.tsx:531`), so they weren't deep-linkable, back/forward did nothing inside the page, and the filtered view couldn't be shared.
- Added a real `validateSearch` (`view`: `""|matrix|incidents|sources|freshness`, `status`: `all|down|warn|resolved`) and wired both into `HealthPage`:
  - `view` (or a bare `status !== "all"`) now scrolls to and highlights the corresponding section (`subnet-matrix`, `incidents`, `source-health`, `status-board` for `freshness`, since that's where the freshness sparkline/stats card lives) on deep-link arrival only — it deliberately does not re-scroll on every subsequent search change, so clicking a filter chip you're already looking at doesn't yank the page.
  - The `Incidents` component's filter chips now read/write `search.status` via `useNavigate` instead of local state, so the chip pressed, the filtered list, reload, share, and back/forward all agree with the URL.
- `nav-mega-menu-data.ts`'s six existing links already use `view`/`status` param names that match what the new schema implements 1:1 — no change needed there.

## Template Used

- Frontend (`apps/ui/`) — a URL-state wiring fix confined to `apps/ui/src/routes/health.tsx`; not a registry surface, provider profile, or backend/schema change, so none of the four registry PR templates apply.

## Screenshots

Captured with two separate dev servers (`before` = `git merge-base main HEAD`, `after` = this branch), fixed viewports (no `fullPage`), and `mg-theme` forced + reloaded per the repo's screenshot contract. Showing 2 of the 6 mega-menu destinations per the issue's acceptance criteria — this is a pure URL-state/scroll-target change with no responsive-layout code, so all three viewports are shown for the primary destination and desktop-only (both themes) for the second, rather than the full 3×2 matrix twice over.

### Destination: `?status=down` (Down quick filter + incident-chip state)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-light-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-light-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-dark-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-dark-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-light-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-light-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-dark-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-dark-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-light-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-light-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-dark-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-dark-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-A-mobile-dark-after.png)<br><sub>after</sub> |

`before` shows the exact bug: `?status=down` is silently ignored, so the page still renders the default top-of-page hero. `after` scrolls to and highlights the Incidents section, presses the "Down" chip, and filters the list — all driven purely by the URL (SSR-verified: the pressed chip and highlighted section come back correctly from a cold request to the URL, no client JS required to reach that state).

### Destination: `?view=matrix` (Subnet matrix quick filter), Desktop only

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-light-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-light-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-dark-before.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-dark-after.png" width="320">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/health-search-3971-B-desktop-dark-after.png)<br><sub>after</sub> |

## Validation

- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui` / `npx prettier --check` on the changed file
- [x] `npm test --workspace=apps/ui` (521 passed)
- [x] `npm run build --workspace=apps/ui`
- [x] Manually verified in-browser at desktop/tablet/mobile, light/dark (see screenshots above), plus SSR HTML diffing across all six mega-menu URLs to confirm each lands on a distinct, correctly-scrolled/highlighted/filtered state

## Non-goals

- Did not redesign any Health page section or add new health metrics — this is a URL-state wiring fix for functionality that already existed.
- Did not change the mega-menu's link labels, grouping, or param names (`nav-mega-menu-data.ts` is untouched — its existing `view`/`status` values already match the new schema).

Closes #3971
