### PR TITLE
feat(registry): add SN70 NexisGen validator-API OpenAPI schema surface

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -39,6 +39,33 @@
         "https://github.com/RendixNetwork/nexisgen"
       ],
       "url": "https://api.nexisgen.ai/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-openapi",
+      "kind": "openapi",
+      "name": "NexisGen validator API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema (title \"Nexis Validator API\") for the NexisGen (SN70) validator API, documenting its public training-score, blacklist, and total-score routes plus a healthz liveness check. Served on api.nexisgen.ai, the API subdomain of the subnet's registered website nexisgen.ai, and already cited as a source for the existing healthz subnet-api surface.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.nexisgen.ai/openapi.json",
+      "source_urls": [
+        "https://nexisgen.ai/",
+        "https://github.com/RendixNetwork/nexisgen"
+      ],
+      "url": "https://api.nexisgen.ai/openapi.json"
     }
   ],
   "website_url": "https://nexisgen.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/nexisgen.json`. Append-only; no other field changed.

Closes #4081

## Summary

Registers SN70 NexisGen's machine-readable OpenAPI schema. `https://api.nexisgen.ai/openapi.json` is a valid OpenAPI 3.1 document (title "Nexis Validator API") describing the subnet's public validator API — training-score, blacklist, and total-score routes plus a `/healthz` liveness check. It is served on `api.nexisgen.ai`, the API subdomain of the subnet's registered website `nexisgen.ai`, and is already cited as a source on the existing `sn-70-nexisgen-validator-api-healthz` subnet-api surface — so ownership and publication are established.

## Surface

- Netuid: 70
- Kind: openapi
- Public URL: https://api.nexisgen.ai/openapi.json
- Source URLs: https://nexisgen.ai/ · https://github.com/RendixNetwork/nexisgen
- Provider slug: nexisgen

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only schema document on the subnet's own registered domain.
- [x] Public-safe: a schema document only — no credentials or non-public data.
- [x] Not a duplicate — the manifest had no openapi surface (distinct from the existing subnet-api healthz).
- [x] Links a tracked issue (`Closes #4081`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/nexisgen.json` → passed (2 surfaces)
- [x] `npm run scan:public-safety` → passed
