### PR TITLE
feat(ui): show dominance / total-stake / total-emission columns in the validator directory

### DIFF
--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -12,6 +12,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -157,6 +158,9 @@ function ValidatorsTable({
                 <th className={TH}>Coldkey</th>
                 <th className={`${TH} text-right`}>Active subnets</th>
                 <th className={`${TH} text-right`}>UIDs</th>
+                <th className={`${TH} text-right`}>Dominance</th>
+                <th className={`${TH} text-right`}>Total stake</th>
+                <th className={`${TH} text-right`}>Total emission</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -191,6 +195,15 @@ function ValidatorsTable({
                   </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                     {formatNumber(v.uid_count)}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {taoCompact(v.total_stake_tao)}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {taoCompact(v.total_emission_tao)}
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## What

Adds three economic columns — **Dominance** (`stake_dominance`), **Total stake** (`total_stake_tao`), and **Total emission** (`total_emission_tao`) — to the `/validators` global directory table introduced by #3358. All three values are already computed, served, and typed on `GlobalValidator` (#3357); this is a pure rendering follow-on.

## How

- **`apps/ui/src/routes/validators.index.tsx`** — three new right-aligned columns:
  - **Dominance** — `stake_dominance` (a 0..1 fraction) rendered as a percent, em-dash when `null` (network stake totals to 0)
  - **Total stake** / **Total emission** — `total_stake_tao` / `total_emission_tao` via the shared `taoCompact()` helper (`neuron-table.tsx`), which already renders em-dash for null/non-finite
- Sorting by these columns already works — `total_stake`, `total_emission`, and `stake_dominance` are existing `GlobalValidatorSort` values wired into the page's sort control since #3358.

Single-file, additive change. **No `queries.ts` / `types.ts` / backend change** — the values are already normalized and typed.

## Screenshots

Live mainnet `/validators` ranked by active subnets — the three new right-hand columns (top validator: 16.20% dominance, 54.57M stake, 3.6k emission).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-validators-econ-3359/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-validators-econ-3359/after.png) |

## Acceptance criteria

- [x] Dominance column from `stake_dominance`
- [x] Total Stake column from `total_stake_tao`
- [x] Total Emission column from `total_emission_tao`
- [x] Em-dash (not `0`/`0%`/`NaN`) when the value is `null`
- [x] Diff touches only the directory route file — no `metagraph-neurons.mjs`, `entities.mjs`, `queries.ts`, or `types.ts` changes
- [x] Before/after screenshots included

## Non-goals respected

No backend/data-layer change, no new sort keys (reuses existing), no active-subnet column (that's #3360).

## Gates

`npm run typecheck` ✓ (exit 0) · `eslint` ✓ (0 errors)

Closes #3359