### PR TITLE
feat(registry): add SN11 TrajectoryRL miner-directory data-artifact surface

### DIFF
--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -192,6 +192,28 @@
         "submitted_by": "boskodev790"
       },
       "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client."
+    },
+    {
+      "id": "sn-11-trajectoryrl-miners",
+      "name": "TrajectoryRL miner directory",
+      "kind": "data-artifact",
+      "url": "https://trajrl.com/api/miners",
+      "provider": "trajectoryrl",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://trajrl.com/"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Public no-auth GET returning the TrajectoryRL (SN11) miner directory as JSON — aggregate counters (total / active / qualified miner counts, validator count) plus a per-miner array of 256 rows carrying uid, name, incentive, score, rank, activity flags, and latest-model fields. Served on trajrl.com, the subnet's own registered domain (same host as the existing website and /api/stats subnet-api), and distinct from that aggregate-only stats surface."
     }
   ],
   "social": { "x": "https://x.com/trajectoryrl" },


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/trajectoryrl.json`. Append-only; no other field changed.

Closes #4008

## Summary

Registers SN11 TrajectoryRL's public no-auth data endpoint — filling the manifest's documented data-artifact gap. `https://trajrl.com/api/miners` returns the subnet's miner directory as JSON: aggregate counters (total / active / qualified miner counts, validator count) plus a per-miner array of 256 rows carrying `uid`, `name`, `incentive`, `score`, `rank`, activity flags, and latest-model fields. It is served on `trajrl.com` — the subnet's own registered domain, the same host as the existing website, dashboards, and `/api/stats` subnet-api — so ownership is direct. Distinct from the aggregate-only `/api/stats` subnet-api surface.

## Surface

- Netuid: 11
- Kind: data-artifact
- Public URL: https://trajrl.com/api/miners
- Source URL: https://trajrl.com/
- Provider slug: trajectoryrl

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, safe read-only endpoint on the subnet's own registered domain.
- [x] Public-safe: public directory/scoring fields only — no credentials or non-public data.
- [x] Not a duplicate — the manifest had no data-artifact surface (distinct from the `/api/stats` subnet-api).
- [x] Links a tracked issue (`Closes #4008`).

## Validation (full local run)

- [x] `npm run build` → clean
- [x] `npm run validate` → passed (1475 surfaces)
- [x] `npm run validate:surface -- registry/subnets/trajectoryrl.json` → passed
- [x] `npm run scan:public-safety` → passed
- [x] `npm run test:ci:artifacts` → 27/27 passed
