### PR TITLE
feat(ui): add network weight-setting leaderboard to /leaderboards

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainWeightsQuery, normalizeChainWeights } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/weights",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainWeightsQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainWeights", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainWeights({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: { distinct_setters: 5, weight_sets: 70, sets_per_setter: 14 },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          { netuid: 1, distinct_setters: 4, weight_sets: 40, sets_per_setter: 10 },
+          { netuid: 2, distinct_setters: 2, weight_sets: 30, sets_per_setter: 15 },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: { distinct_setters: 5, weight_sets: 70, sets_per_setter: 14 },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        { netuid: 1, distinct_setters: 4, weight_sets: 40, sets_per_setter: 10 },
+        { netuid: 2, distinct_setters: 2, weight_sets: 30, sets_per_setter: 15 },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainWeights(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+      expect(card.network).toEqual({
+        distinct_setters: 0,
+        weight_sets: 0,
+        sets_per_setter: null,
+      });
+      expect(card.intensity_distribution).toBeNull();
+    }
+  });
+
+  it("drops malformed subnet rows and coerces a junk sets_per_setter to null", () => {
+    const card = normalizeChainWeights({
+      network: { sets_per_setter: { pct: 1 } },
+      subnets: [{ distinct_setters: 4 }, { netuid: 2, weight_sets: 30 }],
+    });
+    expect(card.subnets).toHaveLength(1);
+    expect(card.subnets[0]?.netuid).toBe(2);
+    expect(card.subnets[0]?.sets_per_setter).toBeNull();
+    expect(card.network.sets_per_setter).toBeNull();
+  });
+});
+
+describe("chainWeightsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the leaderboard", async () => {
+    resolveWith({
+      window: "30d",
+      subnet_count: 1,
+      network: { distinct_setters: 4, weight_sets: 40, sets_per_setter: 10 },
+      subnets: [{ netuid: 1, distinct_setters: 4, weight_sets: 40, sets_per_setter: 10 }],
+    });
+    const res = await runQuery("30d", 5);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/weights",
+      expect.objectContaining({ params: { window: "30d", limit: 5 } }),
+    );
+    expect(res.data.subnet_count).toBe(1);
+    expect(res.data.subnets).toHaveLength(1);
+  });
+
+  it("defaults to the 7d window and limit 20", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/weights",
+      expect.objectContaining({ params: { window: "7d", limit: 20 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -67,6 +67,8 @@ import type {
   ChainStakeTransfers,
   ChainStakeTransferSubnet,
   ChainIntensityDistribution,
+  ChainWeights,
+  ChainWeightsSubnet,
   ChainConcentration,
   ChainPerformance,
   ChainSigners,
@@ -210,6 +212,7 @@ const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
+const MAX_CHAIN_WEIGHTS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3008,6 +3011,57 @@ export const chainStakeTransfersQuery = (window = "7d", limit = 20) =>
       });
       return {
         data: normalizeChainStakeTransfers(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainWeightsSubnet(raw: unknown): ChainWeightsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_setters: firstFiniteNumber(raw.distinct_setters) ?? 0,
+    weight_sets: firstFiniteNumber(raw.weight_sets) ?? 0,
+    sets_per_setter: firstFiniteNumber(raw.sets_per_setter) ?? null,
+  };
+}
+
+// #3469: network-wide weight-setting leaderboard over a 7d/30d window — the
+// account_events kind-filtered sibling of /api/v1/chain/stake-transfers. Every
+// numeric cell coerces defensively: counts fall through to 0, averages to null
+// (never NaN), and malformed subnet rows are dropped on a cold store or junk.
+export function normalizeChainWeights(raw: unknown): ChainWeights {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_setters: firstFiniteNumber(networkRec.distinct_setters) ?? 0,
+      weight_sets: firstFiniteNumber(networkRec.weight_sets) ?? 0,
+      sets_per_setter: firstFiniteNumber(networkRec.sets_per_setter) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(rec.subnets, MAX_CHAIN_WEIGHTS, normalizeChainWeightsSubnet),
+  };
+}
+
+export const chainWeightsQuery = (window = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-weights", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainWeights>>("/api/v1/chain/weights", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainWeights(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2039,6 +2039,40 @@ export interface ChainStakeTransfers {
   subnets: ChainStakeTransferSubnet[];
 }
 
+/** One subnet's row on the network-wide weight-setting leaderboard (#3469). */
+export interface ChainWeightsSubnet {
+  netuid: number;
+  distinct_setters: number;
+  weight_sets: number;
+  sets_per_setter: number | null;
+}
+
+/** Network-wide weight-setting rollup — true distinct-setter count (not a per-subnet sum) + total weight-sets. */
+export interface ChainWeightsNetwork {
+  distinct_setters: number;
+  weight_sets: number;
+  sets_per_setter: number | null;
+}
+
+/**
+ * Network-wide validator weight-setting leaderboard over a 7d/30d window
+ * (#3469), from GET /api/v1/chain/weights — subnets ranked by WeightsSet
+ * event count, distinct setters, and sets per setter, plus the true
+ * network-wide distinct-setter rollup and a distribution summary of the
+ * per-subnet update intensity. The account_events kind-filtered sibling of
+ * /api/v1/chain/stake-transfers. Zeroed with an empty subnets list when the
+ * store is cold.
+ */
+export interface ChainWeights {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainWeightsNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainWeightsSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
+import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as ExplorerRouteImport } from './routes/explorer'
@@ -50,6 +51,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SchemasRoute = SchemasRouteImport.update({
   id: '/schemas',
   path: '/schemas',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LeaderboardsRoute = LeaderboardsRouteImport.update({
+  id: '/leaderboards',
+  path: '/leaderboards',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HealthRoute = HealthRouteImport.update({
@@ -151,6 +157,7 @@ export interface FileRoutesByFullPath {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -175,6 +182,7 @@ export interface FileRoutesByTo {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -200,6 +208,7 @@ export interface FileRoutesById {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -226,6 +235,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -250,6 +260,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -274,6 +285,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -299,6 +311,7 @@ export interface RootRouteChildren {
   ExplorerRoute: typeof ExplorerRoute
   GapsRoute: typeof GapsRoute
   HealthRoute: typeof HealthRoute
+  LeaderboardsRoute: typeof LeaderboardsRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
@@ -344,6 +357,13 @@ declare module '@tanstack/react-router' {
       path: '/schemas'
       fullPath: '/schemas'
       preLoaderRoute: typeof SchemasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/leaderboards': {
+      id: '/leaderboards'
+      path: '/leaderboards'
+      fullPath: '/leaderboards'
+      preLoaderRoute: typeof LeaderboardsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/health': {
@@ -483,6 +503,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExplorerRoute: ExplorerRoute,
   GapsRoute: GapsRoute,
   HealthRoute: HealthRoute,
+  LeaderboardsRoute: LeaderboardsRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -1,0 +1,178 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { BrandIcon } from "@/components/metagraphed/brand-icon";
+import { chainWeightsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, classNames } from "@/lib/metagraphed/format";
+
+export const Route = createFileRoute("/leaderboards")({
+  head: () => ({
+    meta: [
+      { title: "Leaderboards — Metagraphed" },
+      {
+        name: "description",
+        content: "Network-wide activity leaderboards computed live from chain-indexed events.",
+      },
+      { property: "og:title", content: "Leaderboards — Metagraphed" },
+      {
+        property: "og:description",
+        content: "Network-wide activity leaderboards computed live from chain-indexed events.",
+      },
+    ],
+  }),
+  component: LeaderboardsPage,
+});
+
+function LeaderboardsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Network"
+        live
+        title="Leaderboards"
+        description="Network-wide activity boards computed live from chain-indexed events — ranked by subnet."
+      />
+      <WeightsLeaderboard />
+      <ApiSourceFooter paths={["/api/v1/chain/weights"]} />
+    </AppShell>
+  );
+}
+
+const WINDOWS = ["7d", "30d"] as const;
+type Win = (typeof WINDOWS)[number];
+
+// #3469: network-wide weight-setting leaderboard — the per-subnet ranking, network
+// rollup, and update-intensity distribution from GET /api/v1/chain/weights. First
+// section on the new /leaderboards route; siblings (#3465, #3466, #3470, #3473)
+// extend this same route with their own boards.
+function WeightsLeaderboard() {
+  const [win, setWin] = useState<Win>("7d");
+  const { data: res, isPending, isError, error, refetch } = useQuery(chainWeightsQuery(win));
+  const data = res?.data;
+
+  const toggle = (
+    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          onClick={() => setWin(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <section className="mb-10">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="font-display text-lg font-semibold text-ink-strong">
+          Weight-setting activity
+        </h2>
+        {toggle}
+      </div>
+
+      {isPending ? (
+        <div className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : isError ? (
+        <ErrorState error={error} context="weight-setting activity" onRetry={() => void refetch()} />
+      ) : !data || data.subnets.length === 0 ? (
+        <EmptyState
+          title="No weight-setting activity yet"
+          description="No WeightsSet events were recorded on chain for this window."
+        />
+      ) : (
+        <>
+          <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <StatTile
+              eyebrow="Distinct setters"
+              value={formatNumber(data.network.distinct_setters)}
+            />
+            <StatTile
+              eyebrow="Weight-sets"
+              value={formatNumber(data.network.weight_sets)}
+              hint={data.window ? `over ${data.window}` : undefined}
+            />
+            <StatTile
+              eyebrow="Sets per setter"
+              value={
+                data.network.sets_per_setter != null
+                  ? data.network.sets_per_setter.toFixed(1)
+                  : "—"
+              }
+            />
+          </div>
+          <div className="overflow-hidden rounded-xl border border-border bg-card">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-surface/50 text-ink-muted">
+                  <tr>
+                    <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
+                      #
+                    </th>
+                    <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
+                      Subnet
+                    </th>
+                    <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                      Distinct setters
+                    </th>
+                    <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                      Weight-sets
+                    </th>
+                    <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                      Sets per setter
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {data.subnets.map((s, i) => (
+                    <tr key={s.netuid} className="hover:bg-surface/40">
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">{i + 1}</td>
+                      <td className="px-3 py-2.5">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: s.netuid }}
+                          className="inline-flex items-center gap-2 hover:underline"
+                        >
+                          <BrandIcon
+                            size={18}
+                            name={`Subnet ${s.netuid}`}
+                            fallback={s.netuid}
+                            netuid={s.netuid}
+                          />
+                          <span className="font-medium text-ink-strong">SN{s.netuid}</span>
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                        {formatNumber(s.distinct_setters)}
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                        {formatNumber(s.weight_sets)}
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                        {s.sets_per_setter != null ? s.sets_per_setter.toFixed(1) : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -9,6 +9,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { chainWeightsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, classNames } from "@/lib/metagraphed/format";
+import type { ChainIntensityDistribution } from "@/lib/metagraphed/types";
 
 export const Route = createFileRoute("/leaderboards")({
   head: () => ({
@@ -117,6 +118,9 @@ function WeightsLeaderboard() {
               }
             />
           </div>
+          {data.intensity_distribution ? (
+            <IntensityDistributionStrip dist={data.intensity_distribution} />
+          ) : null}
           <div className="overflow-hidden rounded-xl border border-border bg-card">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
@@ -176,5 +180,33 @@ function WeightsLeaderboard() {
         </>
       )}
     </section>
+  );
+}
+
+// Spread of per-subnet update intensity (weight-sets per setter) across every subnet that
+// set weights in the window — the distribution the ranked table's rows are drawn from,
+// not just a rollup of the visible page.
+function IntensityDistributionStrip({ dist }: { dist: ChainIntensityDistribution }) {
+  const cells: Array<[string, number]> = [
+    ["min", dist.min],
+    ["p25", dist.p25],
+    ["median", dist.median],
+    ["mean", dist.mean],
+    ["p75", dist.p75],
+    ["p90", dist.p90],
+    ["max", dist.max],
+  ];
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-x-5 gap-y-1.5 rounded-lg border border-border bg-card px-4 py-3">
+      <span className="mg-label">Update intensity (sets/setter)</span>
+      {cells.map(([label, value]) => (
+        <span key={label} className="font-mono text-[11px] text-ink-muted">
+          {label} <strong className="text-ink-strong">{value.toFixed(1)}</strong>
+        </span>
+      ))}
+      <span className="ml-auto font-mono text-[11px] text-ink-muted">
+        {formatNumber(dist.count)} subnets
+      </span>
+    </div>
   );
 }

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -88,7 +88,11 @@ function WeightsLeaderboard() {
           <Skeleton className="h-64 w-full" />
         </div>
       ) : isError ? (
-        <ErrorState error={error} context="weight-setting activity" onRetry={() => void refetch()} />
+        <ErrorState
+          error={error}
+          context="weight-setting activity"
+          onRetry={() => void refetch()}
+        />
       ) : !data || data.subnets.length === 0 ? (
         <EmptyState
           title="No weight-setting activity yet"
@@ -109,9 +113,7 @@ function WeightsLeaderboard() {
             <StatTile
               eyebrow="Sets per setter"
               value={
-                data.network.sets_per_setter != null
-                  ? data.network.sets_per_setter.toFixed(1)
-                  : "—"
+                data.network.sets_per_setter != null ? data.network.sets_per_setter.toFixed(1) : "—"
               }
             />
           </div>


### PR DESCRIPTION
## Summary

- Wires the previously-unconsumed `GET /api/v1/chain/weights` endpoint into a
  new `/leaderboards` route: the per-subnet weight-setting leaderboard ranked
  by `weight_sets`, the network rollup (distinct setters, total weight-sets,
  sets-per-setter), with a 7d/30d window toggle.
- Adds the `ChainWeights` type (`apps/ui/src/lib/metagraphed/types.ts`) and a
  `chainWeightsQuery` + `normalizeChainWeights` query function
  (`apps/ui/src/lib/metagraphed/queries.ts`), following the existing
  `chainStakeTransfersQuery` pattern.
- No `/leaderboards` route existed yet, so this PR creates the route shell at
  `apps/ui/src/routes/leaderboards.tsx`. Sibling issues (#3465, #3466, #3470,
  #3473) extend this same route with their own boards.

## Template Used

- None of the standard templates match a pure `apps/ui/**` frontend change
  (Path C in the repo's contribution playbook) — this PR touches only
  `apps/ui/src/lib/metagraphed/{types,queries}.ts` and a new
  `apps/ui/src/routes/leaderboards.tsx` (+ its generated `routeTree.gen.ts`
  entry and a query unit test). No `registry/`, `schemas/`, `src/`, or
  `workers/` files are touched.

## Screenshots

New page, so "before" is the app's 404 (the route didn't exist on `main`)
and "after" is the rendered leaderboard, both against live production data
(`GET /api/v1/chain/weights`).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/leaderboards-weights-mobile-dark-after.png)<br><sub>after</sub> |

## Validation

- [x] `npm run lint --workspace=apps/ui` (clean on changed files)
- [x] `npm run format:check --workspace=apps/ui` (clean on changed files)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (521 passed, incl. new
      `queries.chain-weights.test.ts`)
- [x] `npm run build --workspace=apps/ui`

Closes #3469