### PR TITLE
feat(registry): add NexisGen latest cycle scores data-artifact (SN70)

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -21,14 +21,14 @@
       "kind": "subnet-api",
       "name": "NexisGen validator API healthz",
       "notes": "Public no-auth GET /healthz on api.nexisgen.ai returning application liveness JSON (observed: {\"status\":\"ok\"}). Implemented in the official RendixNetwork/nexisgen FastAPI app and documented as a route in the subnet's own OpenAPI schema on the same host.",
-      "provider": "nexisgen",
-      "public_safe": true,
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "nexisgen",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
@@ -47,14 +47,14 @@
       "kind": "openapi",
       "name": "NexisGen validator API OpenAPI schema",
       "notes": "Machine-readable OpenAPI 3.1 schema (title \"Nexis Validator API\") for the NexisGen (SN70) validator API, documenting its public training-score, blacklist, and total-score routes plus a healthz liveness check. Served on api.nexisgen.ai, the API subdomain of the subnet's registered website nexisgen.ai, and already cited as a source for the existing healthz subnet-api surface.",
-      "provider": "nexisgen",
-      "public_safe": true,
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "nexisgen",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
@@ -66,6 +66,32 @@
         "https://github.com/RendixNetwork/nexisgen"
       ],
       "url": "https://api.nexisgen.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-latest-total-score",
+      "kind": "data-artifact",
+      "name": "NexisGen latest cycle total scores",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.nexisgen.ai/openapi.json",
+        "https://github.com/RendixNetwork/nexisgen/blob/main/nexis/api/app.py",
+        "https://api.nexisgen.ai/v1/get_latest_total_score"
+      ],
+      "url": "https://api.nexisgen.ai/v1/get_latest_total_score",
+      "notes": "Public no-auth GET /v1/get_latest_total_score on api.nexisgen.ai returning the current scoring cycle_id plus per-hotkey aggregate score map for SN70 NexisGen. Documented in the subnet OpenAPI schema (title \"Nexis Validator API\") already registered for this host; same first-party api.nexisgen.ai as the existing healthz surface.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      }
     }
   ],
   "website_url": "https://nexisgen.ai/"


### PR DESCRIPTION
## Summary
- Append community data-artifact surface for SN70 NexisGen at `https://api.nexisgen.ai/v1/get_latest_total_score` (current cycle scores JSON).
- Same first-party `api.nexisgen.ai` host as the existing healthz + OpenAPI surfaces; route is documented in the registered OpenAPI schema.

Closes #4082

## Validation
- [x] Exactly one subnet file changed: `registry/subnets/nexisgen.json`
- [x] `npm run validate:surface -- --file registry/subnets/nexisgen.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/nexisgen.json`
- [x] `npx prettier --check registry/subnets/nexisgen.json`
- [x] Live GET returns public JSON (`cycle_id` + `scores` map)

## Test plan
- [ ] CI review gate passes
- [ ] codecov passes
- [ ] Gittensory review returns manual review or approved


Made with [Cursor](https://cursor.com)