### PR TITLE
feat(registry): add NexisGen latest cycle scores data-artifact (SN70)

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -73,7 +73,7 @@
       "id": "sn-70-nexisgen-latest-total-score",
       "kind": "data-artifact",
       "name": "NexisGen latest cycle total scores",
-      "notes": "Public no-auth GET /v1/get_latest_total_score on api.nexisgen.ai returning the current scoring cycle_id plus per-hotkey aggregate score map for SN70 NexisGen. Documented in the subnet OpenAPI schema (title \"Nexis Validator API\") already registered for this host; same first-party api.nexisgen.ai as the existing healthz surface.",
+      "notes": "Public no-auth GET /v1/get_latest_total_score on api.nexisgen.ai returning the current scoring cycle_id plus a miner aggregate score map for SN70 NexisGen. Documented in the subnet OpenAPI schema (title \"Nexis Validator API\") already registered for this host; same first-party api.nexisgen.ai as the existing healthz surface.",
       "provider": "nexisgen",
       "public_safe": true,
       "probe": {

--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -66,6 +66,32 @@
         "https://github.com/RendixNetwork/nexisgen"
       ],
       "url": "https://api.nexisgen.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-latest-total-score",
+      "kind": "data-artifact",
+      "name": "NexisGen latest cycle total scores",
+      "notes": "Public no-auth GET /v1/get_latest_total_score on api.nexisgen.ai returning the current scoring cycle_id plus per-hotkey aggregate score map for SN70 NexisGen. Documented in the subnet OpenAPI schema (title \"Nexis Validator API\") already registered for this host; same first-party api.nexisgen.ai as the existing healthz surface.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.nexisgen.ai/openapi.json",
+        "https://github.com/RendixNetwork/nexisgen/blob/main/nexis/api/app.py",
+        "https://api.nexisgen.ai/v1/get_latest_total_score"
+      ],
+      "url": "https://api.nexisgen.ai/v1/get_latest_total_score"
     }
   ],
   "website_url": "https://nexisgen.ai/"


### PR DESCRIPTION
## Summary
- Append-only community data-artifact for SN70 NexisGen at `https://api.nexisgen.ai/v1/get_latest_total_score`.
- Same first-party host as existing healthz + OpenAPI; route listed in the registered OpenAPI schema.
- Replaces #4373 (blocked: diff reordered keys on existing surfaces).

Closes #4082

## Validation
- [x] Exactly one subnet file changed: `registry/subnets/nexisgen.json`
- [x] Append-only (no edits to existing surfaces)
- [x] `npm run validate:surface -- --file registry/subnets/nexisgen.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/nexisgen.json`
- [x] `npx prettier --check registry/subnets/nexisgen.json`
- [x] Live GET returns public JSON (`cycle_id` + `scores`)

## Test plan
- [ ] CI passes
- [ ] codecov passes
- [ ] Gittensory returns manual review or approved


Made with [Cursor](https://cursor.com)