### PR TITLE
feat(registry): add SN37 Aurelius seed-dataset data-artifact surface (#4038)

### DIFF
--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -124,6 +124,24 @@
         "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md"
       ],
       "url": "https://new-collector-api-production.up.railway.app/health/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-37-aurelius-data-artifact",
+      "kind": "data-artifact",
+      "name": "Aurelius seed dataset",
+      "notes": "Public no-auth JSONL dataset committed in SN37 Aurelius's official repository — the seed corpus of moral-reasoning dilemma scenario configs (one JSON object per line: {config:{name,tension_archetype,morebench_context,premise,...}}) that bootstraps the validator scoring pipeline. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo. Distinct from the existing Aurelius Central API subnet-api surfaces.",
+      "provider": "aurelius",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/data/seed_dataset.jsonl"
+      ],
+      "url": "https://raw.githubusercontent.com/Aurelius-Protocol/Aurelius-Protocol/main/data/seed_dataset.jsonl"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest —
`registry/subnets/aurelius.json`. Append-only; no other field or surface changed.

Closes #4038

## Summary

Registers SN37 Aurelius's public, no-auth **seed dataset** — filling the manifest's
documented data-artifact gap. `data/seed_dataset.jsonl` lives in Aurelius's official
repository (`Aurelius-Protocol/Aurelius-Protocol`, already registered as the subnet's
`source-repo`) and is served read-only over `raw.githubusercontent.com`. It is the
seed corpus of moral-reasoning dilemma scenario configs that bootstraps the validator
scoring pipeline: one JSON object per line, each carrying a `config` block
(`name`, `tension_archetype`, `morebench_context`, `premise`, …). Distinct from the
existing Aurelius Central API `subnet-api` / `openapi` / `docs` surfaces (a static
dataset artifact, not the live API).

## Surface

- Netuid: 37
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/Aurelius-Protocol/Aurelius-Protocol/main/data/seed_dataset.jsonl
- Source URL (proves the claim): https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/data/seed_dataset.jsonl
- Provider slug: aurelius

## Checklist

- [x] Changes exactly one `registry/subnets/aurelius.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes (verified live `200`, no auth); the `source_url` (the file's page in the official repo) independently proves the subnet publishes it.
- [x] Public-safe: read-only public dataset — no auth/credentialed flow, secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface — the manifest had no data-artifact; the raw dataset URL is distinct from the source-repo and API surfaces.
- [x] Links a tracked, still-open issue (`Closes #4038`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/aurelius.json` → passed (7 surfaces)
- [x] `npm run scan:public-safety` → passed
- [x] `npm run build` → clean (deploy-owned artifacts auto-reverted)
- [x] `npm run validate` → passed (1476 surfaces)
- [x] `npx prettier --check registry/subnets/aurelius.json` → clean
