### PR TITLE
feat(ui): add subnet identity-change history tab to the subnet profile

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -47,6 +47,7 @@ import {
   agentCatalogDetailQuery,
   subnetWeightSettersQuery,
   subnetWeightsQuery,
+  subnetIdentityHistoryQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -145,6 +146,7 @@ const TABS = [
   { id: "metagraph", label: "Metagraph" },
   { id: "validators", label: "Validators" },
   { id: "activity", label: "Activity" },
+  { id: "identity", label: "Identity history" },
   { id: "services", label: "Callable services" },
   { id: "surfaces", label: "Surfaces" },
   { id: "endpoints", label: "Endpoints" },
@@ -170,6 +172,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   yield: "metagraph",
   turnover: "metagraph",
   validators: "validators",
+  identity: "identity",
   services: "services",
   "agent-readiness": "services",
   surfaces: "surfaces",
@@ -262,6 +265,7 @@ function ProfileShell({ netuid }: { netuid: number }) {
           {tab === "metagraph" ? <MetagraphPanel netuid={netuid} /> : null}
           {tab === "validators" ? <ValidatorsPanel netuid={netuid} /> : null}
           {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
+          {tab === "identity" ? <IdentityHistoryPanel netuid={netuid} /> : null}
           {tab === "services" ? <CallableServicesPanel netuid={netuid} /> : null}
           {tab === "surfaces" ? <SurfacesPanel netuid={netuid} /> : null}
           {tab === "endpoints" ? <EndpointsPanel netuid={netuid} /> : null}
@@ -442,6 +446,83 @@ function SubnetLineageSection({ netuid }: { netuid: number }) {
 }
 
 /* ----------------------------- panels ----------------------------- */
+
+function IdentityHistoryPanel({ netuid }: { netuid: number }) {
+  return (
+    <SectionAnchor
+      id="identity"
+      title="Identity history"
+      subtitle="On-chain name, symbol, and metadata changes for this subnet, newest first."
+      info="GET /api/v1/subnets/{netuid}/identity-history — each row is an observed on-chain SubnetIdentitiesV3 snapshot, so the timeline shows how the subnet's registered identity changed over time."
+    >
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+          <IdentityHistoryList netuid={netuid} />
+        </Suspense>
+      </QueryErrorBoundary>
+    </SectionAnchor>
+  );
+}
+
+function IdentityHistoryList({ netuid }: { netuid: number }) {
+  const { data: res } = useSuspenseQuery(subnetIdentityHistoryQuery(netuid));
+  const entries = res.data.entries;
+
+  if (entries.length === 0) {
+    return (
+      <EmptyState
+        title="No identity history yet"
+        description="This subnet has no recorded on-chain identity changes."
+      />
+    );
+  }
+
+  return (
+    <ol className="space-y-2">
+      {entries.map((entry, i) => (
+        <li
+          key={`${entry.identity_hash}-${i}`}
+          className="rounded-lg border border-border bg-card p-3"
+        >
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <span className="font-display text-sm font-semibold text-ink-strong">
+              {entry.subnet_name ?? "Unnamed"}
+              {entry.symbol ? (
+                <span className="ml-1.5 font-mono text-xs text-ink-muted">{entry.symbol}</span>
+              ) : null}
+            </span>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {entry.observed_at ? <TimeAgo at={entry.observed_at} /> : "unknown time"}
+              {entry.block_number != null ? ` · block #${formatNumber(entry.block_number)}` : ""}
+            </span>
+          </div>
+          {entry.description ? (
+            <p className="mt-1 text-xs text-ink-muted">{entry.description}</p>
+          ) : null}
+          {entry.subnet_url || entry.github_repo || entry.discord ? (
+            <div className="mt-1.5 flex flex-wrap gap-3 text-[11px]">
+              {entry.subnet_url ? (
+                <ExternalLink href={entry.subnet_url} className="text-accent-text hover:underline">
+                  website
+                </ExternalLink>
+              ) : null}
+              {entry.github_repo ? (
+                <ExternalLink href={entry.github_repo} className="text-accent-text hover:underline">
+                  repo
+                </ExternalLink>
+              ) : null}
+              {entry.discord ? (
+                <ExternalLink href={entry.discord} className="text-accent-text hover:underline">
+                  discord
+                </ExternalLink>
+              ) : null}
+            </div>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}
 
 function SurfacesPanel({ netuid }: { netuid: number }) {
   return (


### PR DESCRIPTION
## Summary

Consumes the `subnetIdentityHistoryQuery` typed data layer shipped in #3646 by adding an **Identity history** tab to the subnet profile page, listing the subnet's on-chain identity changes (name / symbol / metadata) newest-first — filling the gap where nothing rendered that endpoint.

Closes #3487

## What changed

`apps/ui/src/routes/subnets.$netuid.tsx` only (the data layer already shipped — `queries.ts`/`types.ts` untouched, per the issue):

- Adds `{ id: "identity", label: "Identity history" }` to the `TABS` array and a matching `SECTION_TO_TAB` entry (so cross-tab deep links resolve).
- Adds the `{tab === "identity" ? <IdentityHistoryPanel .../> : null}` render branch, mirroring the existing panel dispatch.
- New `IdentityHistoryPanel` + `IdentityHistoryList` components following the page's `SectionAnchor` + `QueryErrorBoundary` + `Suspense` + `useSuspenseQuery` idiom (same as `ValidatorsPanel`/`SubnetLineageSection`). Each entry renders `subnet_name`/`symbol`, a `TimeAgo` timestamp + block number, optional description, and website/repo/discord `ExternalLink`s. Loading (`Skeleton`), empty (`EmptyState`), and error (`QueryErrorBoundary`) states match the page convention.

## Screenshots

Route `/subnets/1?tab=identity`, tab bar scrolled into view, fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes. The endpoint is currently empty for all subnets, so the panel correctly renders its **empty state** (an acceptance-criterion state); **before** has no such tab.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3487-after-mobile-dark.png)<br><sub>after</sub> |

## Validation (full local run)

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm test` (apps/ui) — 521 passed
- [x] `npm run build` (apps/ui) — green
- [x] `npm run lint` — my diff adds 0 errors (`npx eslint` on the file is clean; the repo's pre-existing prettier-version lint noise is unrelated and untouched)
- [x] Data layer (`queries.ts`/`types.ts`) untouched, per the issue
