### PR TITLE
feat(registry): add SN12 Compute Horde collateral contract ABI data artifact

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -132,6 +132,24 @@
         "submitted_by": "galuis116"
       },
       "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
+    },
+    {
+      "id": "sn-12-compute-horde-data-artifact",
+      "name": "Compute Horde collateral contract ABI",
+      "kind": "data-artifact",
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json",
+      "provider": "compute-horde",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "notes": "Public JSON ABI of the ComputeHorde on-chain collateral smart contract (deposit/reclaim/slash collateral keyed by NETUID), committed in the SN12 validator source. No-auth static data artifact for encoding/decoding the subnet collateral system's calls and events."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest — `registry/subnets/compute-horde.json`. Append-only; no other field changed.

Closes #4010

## Summary

Registers **SN12 Compute Horde**'s public collateral-contract ABI as a `data-artifact` surface.

- **url:** `https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json` — public, no-auth, verified live (HTTP 200).
- **What it is:** the JSON ABI of ComputeHorde's on-chain collateral smart contract — `deposit` / `reclaimCollateral` / `slashCollateral` functions keyed by `NETUID`, plus `Deposit` / `Reclaimed` / `Slashed` events — committed in the SN12 validator source (`compute_horde_validator/validator/collateral_abi.json`). It's the canonical artifact an integrator needs to encode/decode calls and events for the subnet's collateral system.

## Surface

- Netuid: 12
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json
- Source URL: https://github.com/backend-developers-ltd/ComputeHorde/blob/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json — the file in SN12's registered `source-repo`, which establishes ownership.
- Provider slug: `compute-horde` (already registered)

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` to `registry/subnets/compute-horde.json`; purely additive (+18 / −0), no existing field touched.
- **Not a duplicate** — SN12 had no `data-artifact` surface. The file is a 29-entry ABI array; no secrets/keys/ss58.
- **Ownership established** — the artifact lives in `backend-developers-ltd/ComputeHorde`, SN12's already-registered `source-repo`.
- Same accepted raw-GitHub-file pattern as the merged SN13 Data Universe (#4272) and SN87 Luminar (#4279) data-artifacts.
- `validate:surface`, `validate`, `scan:public-safety`, and `build` all pass locally.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, verified-live data artifact hosted in the subnet's own source repo.
