### PR TITLE
feat(ui): add a cross-subnet biggest-movers band to the home page

### DIFF
--- a/apps/ui/src/components/metagraphed/movers-band.tsx
+++ b/apps/ui/src/components/metagraphed/movers-band.tsx
@@ -1,0 +1,64 @@
+import { Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { subnetMoversQuery } from "@/lib/metagraphed/queries";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
+
+// Signed TAO delta: taoCompact already carries a leading minus for negatives and
+// renders an em-dash for null/non-finite, so we only prepend "+" for gains.
+function signedTao(delta: number): string {
+  return `${delta >= 0 ? "+" : ""}${taoCompact(delta)} τ`;
+}
+
+/**
+ * #3344: cross-subnet biggest-movers band for the Home page — the top subnets by
+ * stake change over the endpoint's default 30d window, each linking to its detail
+ * page. Ships with the endpoint defaults (window=30d, sort=stake); interactive
+ * window/sort controls are a deliberate follow-up. Renders nothing when the
+ * board is empty (cold store / single snapshot).
+ */
+export function MoversBand() {
+  const res = useSuspenseQuery(subnetMoversQuery()).data;
+  const movers = res.data.movers.slice(0, 10);
+  const network = res.data.network;
+
+  if (movers.length === 0) return null;
+
+  return (
+    <section className="mt-section-gap">
+      <div className="mb-4">
+        <h2 className="font-display text-lg font-semibold text-ink-strong">Biggest movers</h2>
+        <p className="font-mono text-[11px] text-ink-muted">
+          Subnets by stake change · {res.data.window} window
+          {network ? ` · ${network.gainers} up · ${network.losers} down` : ""}
+        </p>
+      </div>
+      <ul className="grid gap-1.5 sm:grid-cols-2">
+        {movers.map((m, i) => {
+          const up = m.stake_delta_tao >= 0;
+          return (
+            <li key={m.netuid}>
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid: m.netuid }}
+                className="grid grid-cols-[2rem_1fr_auto] items-center gap-2 rounded border border-border bg-card px-3 py-2 hover:bg-surface/40"
+              >
+                <span className="font-mono text-[10px] text-ink-muted">#{i + 1}</span>
+                <span className="font-mono text-[12px] text-ink-strong">SN{m.netuid}</span>
+                <span
+                  className={
+                    up
+                      ? "font-mono text-[11px] tabular-nums text-health-ok"
+                      : "font-mono text-[11px] tabular-nums text-health-down"
+                  }
+                >
+                  {signedTao(m.stake_delta_tao)}
+                  {m.stake_pct_change != null ? ` (${m.stake_pct_change.toFixed(1)}%)` : ""}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-movers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-movers.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetMovers, subnetMoversQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/movers",
+  });
+}
+
+async function runQuery(params?: { window?: string; sort?: string; limit?: number }) {
+  const opts = params == null ? subnetMoversQuery() : subnetMoversQuery(params);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetMovers", () => {
+  it("passes a well-formed board through", () => {
+    const card = normalizeSubnetMovers({
+      schema_version: 1,
+      window: "30d",
+      sort: "stake",
+      subnet_count: 1,
+      network: { gainers: 5, losers: 3, unchanged: 2 },
+      movers: [
+        {
+          netuid: 64,
+          stake_start_tao: 100,
+          stake_end_tao: 250,
+          stake_delta_tao: 150,
+          stake_pct_change: 1.5,
+          stake_share_pct: 2.1,
+          emission_delta_tao: 9,
+          validators_delta: 4,
+          neurons_delta: 8,
+        },
+      ],
+    });
+    expect(card.network).toEqual({ gainers: 5, losers: 3, unchanged: 2 });
+    expect(card.movers).toHaveLength(1);
+    expect(card.movers[0]?.netuid).toBe(64);
+    expect(card.movers[0]?.stake_delta_tao).toBe(150);
+    expect(card.movers[0]?.stake_pct_change).toBe(1.5);
+  });
+
+  it("degrades a cold / junk store to a schema-stable card, never NaN", () => {
+    for (const raw of [{}, null, "x", { movers: "nope", network: "nope" }]) {
+      const card = normalizeSubnetMovers(raw);
+      expect(card.movers).toEqual([]);
+      expect(card.network).toBeNull();
+      expect(card.window).toBe("30d");
+      expect(card.sort).toBe("stake");
+    }
+  });
+
+  it("drops malformed mover rows (no netuid) and coerces junk numbers to 0 / null", () => {
+    const card = normalizeSubnetMovers({
+      movers: [
+        { stake_delta_tao: 5 }, // no netuid -> dropped
+        { netuid: 12, stake_delta_tao: "junk", stake_pct_change: "junk" }, // kept, coerced
+      ],
+    });
+    expect(card.movers).toHaveLength(1);
+    expect(card.movers[0]?.netuid).toBe(12);
+    expect(card.movers[0]?.stake_delta_tao).toBe(0);
+    expect(card.movers[0]?.stake_pct_change).toBeNull();
+  });
+});
+
+describe("subnetMoversQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window/sort/limit params and normalizes", async () => {
+    resolveWith({ movers: [{ netuid: 1, stake_delta_tao: 3 }] });
+    const res = await runQuery({ window: "7d", sort: "emission", limit: 5 });
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/movers",
+      expect.objectContaining({ params: { window: "7d", sort: "emission", limit: 5 } }),
+    );
+    expect(res.data.movers).toHaveLength(1);
+  });
+
+  it("defaults to no explicit params (endpoint defaults 30d / stake)", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/movers",
+      expect.objectContaining({ params: {} }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -137,6 +137,8 @@ import type {
   SubnetNeuronHistoryPoint,
   SubnetStakeTransfers,
   SubnetRegistrations,
+  SubnetMovers,
+  SubnetMover,
   MetagraphNeuron,
   SubnetMetagraph,
   SubnetValidators,
@@ -702,6 +704,75 @@ function normalizeLeaderboards(raw: unknown): Leaderboards {
 // #1111: registry leaderboards — five live, D1-computed boards (healthiest,
 // fastest-rpc, most-complete, most-enriched, fastest-growing). One artifact carries
 // all boards; the homepage discovery module renders the top rows of each.
+function normalizeSubnetMover(raw: unknown): SubnetMover | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    stake_start_tao: coerceFiniteNumber(raw.stake_start_tao) ?? 0,
+    stake_end_tao: coerceFiniteNumber(raw.stake_end_tao) ?? 0,
+    stake_delta_tao: coerceFiniteNumber(raw.stake_delta_tao) ?? 0,
+    stake_pct_change: coerceFiniteNumber(raw.stake_pct_change) ?? null,
+    stake_share_pct: coerceFiniteNumber(raw.stake_share_pct) ?? null,
+    emission_delta_tao: coerceFiniteNumber(raw.emission_delta_tao) ?? 0,
+    validators_delta: coerceFiniteNumber(raw.validators_delta) ?? 0,
+    neurons_delta: coerceFiniteNumber(raw.neurons_delta) ?? 0,
+  };
+}
+
+// #3344: cross-subnet biggest-movers board from /api/v1/subnets/movers. Every
+// numeric cell coerces defensively; a cold store or junk payload degrades to a
+// schema-stable card (movers [], network null), never NaN.
+export function normalizeSubnetMovers(raw: unknown): SubnetMovers {
+  const d = isRecord(raw) ? raw : {};
+  const movers = Array.isArray(d.movers)
+    ? d.movers.flatMap((row) => {
+        const normalized = normalizeSubnetMover(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  const net = isRecord(d.network) ? d.network : null;
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    window: firstString(d.window) ?? "30d",
+    sort: firstString(d.sort) ?? "stake",
+    subnet_count: firstFiniteNumber(d.subnet_count) ?? movers.length,
+    network: net
+      ? {
+          gainers: firstFiniteNumber(net.gainers) ?? 0,
+          losers: firstFiniteNumber(net.losers) ?? 0,
+          unchanged: firstFiniteNumber(net.unchanged) ?? 0,
+        }
+      : null,
+    movers,
+  };
+}
+
+export interface SubnetMoversParams extends QueryParams {
+  window?: string;
+  sort?: string;
+  limit?: number;
+}
+
+export const subnetMoversQuery = (params: SubnetMoversParams = {}) =>
+  queryOptions({
+    queryKey: k(
+      "subnet-movers",
+      params.window ?? "30d",
+      params.sort ?? "stake",
+      params.limit ?? 20,
+    ),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetMovers>>("/api/v1/subnets/movers", {
+        params,
+        signal,
+      });
+      return { data: normalizeSubnetMovers(res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
 export const leaderboardsQuery = () =>
   queryOptions({
     queryKey: k("registry-leaderboards"),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1452,6 +1452,40 @@ export interface SubnetRegistrations {
   registrations_per_registrant: number | null;
 }
 
+/** One subnet's movement over the comparison window on the /subnets/movers board. */
+export interface SubnetMover {
+  netuid: number;
+  stake_start_tao: number;
+  stake_end_tao: number;
+  stake_delta_tao: number;
+  stake_pct_change: number | null;
+  stake_share_pct: number | null;
+  emission_delta_tao: number;
+  validators_delta: number;
+  neurons_delta: number;
+}
+
+/** Network-wide gainer/loser tallies accompanying the movers board. */
+export interface SubnetMoversNetwork {
+  gainers: number;
+  losers: number;
+  unchanged: number;
+}
+
+/**
+ * Cross-subnet biggest-movers board from /api/v1/subnets/movers (#3344): subnets
+ * ranked by how much their stake/emission/validator set changed over a window.
+ * A cold/absent store degrades to a schema-stable card (movers [], network null).
+ */
+export interface SubnetMovers {
+  schema_version: number;
+  window: string;
+  sort: string;
+  subnet_count: number;
+  network: SubnetMoversNetwork | null;
+  movers: SubnetMover[];
+}
+
 /**
  * Per-subnet neuron-deregistration (eviction) event volume over a 7d/30d window
  * (#1657), from /api/v1/subnets/{netuid}/deregistrations — the eviction-side

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -17,6 +17,7 @@ import { CopyableCode } from "@/components/metagraphed/copyable-code";
 import { InfoTooltip } from "@/components/metagraphed/info-tooltip";
 import { safeExternalUrl } from "@/components/metagraphed/external-link";
 import { LeaderboardsModule } from "@/components/metagraphed/leaderboards";
+import { MoversBand } from "@/components/metagraphed/movers-band";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { ScrollReveal } from "@/components/metagraphed/scroll-reveal";
 import { CoverageFunnel } from "@/components/metagraphed/analytics/coverage-funnel";
@@ -176,6 +177,11 @@ function OverviewPage() {
       </ScrollReveal>
 
       <LeaderboardsModule />
+      <QueryErrorBoundary fallback={() => null}>
+        <Suspense fallback={<Skeleton className="h-48 w-full mt-section-gap" />}>
+          <MoversBand />
+        </Suspense>
+      </QueryErrorBoundary>
 
       <QuickActionsRow />
 


### PR DESCRIPTION
## What

Adds a **cross-subnet biggest-movers band** to the Home page — the top subnets by stake change over the endpoint's default 30d window, from `GET /api/v1/subnets/movers`. The Home page had registry leaderboards and a static subnet list, but nothing surfacing cross-subnet movement.

## How

- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetMoversQuery(params?)` `queryOptions` factory + `normalizeSubnetMovers` (coerce-safe: a cold/junk store degrades to `{ movers: [], network: null }`, never NaN), mirroring the sibling `leaderboardsQuery` normalize pattern.
- **`apps/ui/src/lib/metagraphed/types.ts`** — `SubnetMovers`, `SubnetMover`, `SubnetMoversNetwork`.
- **`apps/ui/src/components/metagraphed/movers-band.tsx`** — new `MoversBand`: a ranked list (2-col), each row `SN{netuid}` linking to `/subnets/$netuid` with a signed TAO delta (+/-) and pct change, plus a gainers/losers caption. Renders nothing when the board is empty.
- **`apps/ui/src/routes/index.tsx`** — render `MoversBand` after `LeaderboardsModule`, wrapped in the page's `QueryErrorBoundary`/`Suspense` discovery-module convention (2 additive lines).
- **`apps/ui/src/lib/metagraphed/queries.subnet-movers.test.ts`** — normalize happy-path, cold/junk-safe, malformed-row dropping, and params coverage (5 tests).

Ships with endpoint defaults (`window=30d`, `sort=stake`); interactive window/sort controls are a deliberate follow-up per the issue's non-goals.

## Screenshots

Live mainnet Home — the new band between the leaderboards and quick-actions (top mover SN0 +6.50M τ, 129 up · 0 down, 30d window).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-home-movers-3344/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-home-movers-3344/after.png) |

## Acceptance criteria

- [x] Diff touches a file under `apps/ui/src/routes/` + `components/` (not just `queries.ts`/`types.ts`)
- [x] `queries.ts` gains a typed query calling `GET /api/v1/subnets/movers` via `apiFetch`, following the `queryOptions` sibling pattern
- [x] The Home component calls it via `useSuspenseQuery`
- [x] Renders a ranked list from `movers[]`, each linking to `/subnets/$netuid`, showing subnet identity + its stake delta
- [x] Loading/empty/error handled — `QueryErrorBoundary` + `Suspense` (Skeleton) per the discovery-module pattern; empty `movers[]` renders nothing

## Non-goals respected

No `/movers` route, no window/sort UI (ships with defaults), no change to `LeaderboardsModule`/`leaderboards.tsx`, no `explorer.tsx` touch.

## Gates

`npm run typecheck` ✓ (exit 0) · `vitest run` ✓ (5/5) · `eslint` (my files) ✓

Closes #3344