### PR TITLE
feat(registry): add SN70 NexisGen invalid-hotkeys data-artifact surface (#4082)

### DIFF
--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -66,6 +66,24 @@
         "https://github.com/RendixNetwork/nexisgen"
       ],
       "url": "https://api.nexisgen.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-70-nexisgen-data-artifact",
+      "kind": "data-artifact",
+      "name": "NexisGen invalid-hotkeys eligibility ledger",
+      "notes": "Public no-auth JSON ledger committed in NexisGen's official repository (RendixNetwork/nexisgen, the manifest's registered source_repo) recording per-cycle invalidated miner hotkeys as {invalid_hotkeys:[{cycle_id, hotkey, reason}]}. It is the static, first-party backing data for the subnet's own public `GET /v1/invalid-hotkeys` (\"List Invalid Hotkeys\") route documented in the registered OpenAPI. Hotkeys are public on-chain SS58 identifiers. Served read-only via raw.githubusercontent; distinct from the existing healthz subnet-api and openapi surfaces.",
+      "provider": "nexisgen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/RendixNetwork/nexisgen/blob/main/eligibility/invalid_hotkeys.json"
+      ],
+      "url": "https://raw.githubusercontent.com/RendixNetwork/nexisgen/main/eligibility/invalid_hotkeys.json"
     }
   ],
   "website_url": "https://nexisgen.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest —
`registry/subnets/nexisgen.json`. Append-only; no other field or surface changed.

Closes #4082

## Summary

Registers SN70 NexisGen's public, no-auth **eligibility ledger** — filling the
manifest's documented data-artifact gap. `eligibility/invalid_hotkeys.json` lives in
NexisGen's official repository (`RendixNetwork/nexisgen`, the manifest's registered
`source_repo`) and is served read-only over `raw.githubusercontent.com`. It records
per-cycle invalidated miner hotkeys as `{invalid_hotkeys:[{cycle_id, hotkey, reason}]}`
and is the static, first-party backing data for the subnet's own public
`GET /v1/invalid-hotkeys` ("List Invalid Hotkeys") route documented in the already-
registered NexisGen OpenAPI. Hotkeys are public on-chain SS58 identifiers, so the file
is public-safe. Distinct from the existing `healthz` subnet-api and `openapi` surfaces
(a static data artifact, not the live API host — which is also the more reliable of
the two to probe).

## Surface

- Netuid: 70
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/RendixNetwork/nexisgen/main/eligibility/invalid_hotkeys.json
- Source URL (proves the claim): https://github.com/RendixNetwork/nexisgen/blob/main/eligibility/invalid_hotkeys.json
- Provider slug: nexisgen

## Checklist

- [x] Changes exactly one `registry/subnets/nexisgen.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes (verified live `200`, no auth); the `source_url` (the file's page in the official repo, which is the manifest's registered `source_repo`) independently proves first-party ownership.
- [x] Public-safe: read-only public ledger of on-chain SS58 hotkeys — no auth/credentialed flow, secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface — the manifest had no data-artifact; the raw ledger URL is distinct from the healthz and openapi surfaces.
- [x] Links a tracked, still-open issue (`Closes #4082`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/nexisgen.json` → passed (3 surfaces)
- [x] `npm run scan:public-safety` → passed
- [x] `npx prettier --check registry/subnets/nexisgen.json` → clean
