### PR TITLE
feat(ui): add a network-wide stake-moves section to the chain explorer

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -56,6 +56,10 @@ import type {
   ChainStakeFlowDistribution,
   ChainStakeFlowNetwork,
   ChainStakeFlowSubnet,
+  ChainStakeMoves,
+  ChainStakeMovesDistribution,
+  ChainStakeMovesNetwork,
+  ChainStakeMovesSubnet,
   ChainCallEntry,
   ChainEventsStats,
   ChainEventsStatsEntry,
@@ -202,6 +206,7 @@ const MAX_ACCOUNT_DAY_EVENT_KINDS = 32;
 const MAX_CHAIN_ACTIVITY_DAYS = 31;
 const MAX_CHAIN_CALLS = 12;
 const MAX_STAKE_FLOW_SUBNETS = 24;
+const MAX_STAKE_MOVES_SUBNETS = 24;
 // The endpoint returns the top 100 pallet.method groups, busiest first.
 const MAX_CHAIN_EVENT_GROUPS = 100;
 const DEFAULT_CHAIN_EVENT_BLOCKS = 1000;
@@ -3086,6 +3091,71 @@ export const chainStakeFlowQuery = (window: ChainWindow = "7d") =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainStakeFlow>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeChainStakeMovesNetwork(raw: unknown): ChainStakeMovesNetwork | null {
+  if (!isRecord(raw)) return null;
+  return {
+    distinct_movers: coerceFiniteNumber(raw.distinct_movers) ?? 0,
+    movements: coerceFiniteNumber(raw.movements) ?? 0,
+    movements_per_mover: coerceFiniteNumber(raw.movements_per_mover) ?? 0,
+  };
+}
+
+function normalizeChainStakeMovesDistribution(raw: unknown): ChainStakeMovesDistribution | null {
+  if (!isRecord(raw)) return null;
+  return {
+    count: coerceFiniteNumber(raw.count) ?? 0,
+    mean: coerceFiniteNumber(raw.mean) ?? null,
+    min: coerceFiniteNumber(raw.min) ?? null,
+    p25: coerceFiniteNumber(raw.p25) ?? null,
+    median: coerceFiniteNumber(raw.median) ?? null,
+    p75: coerceFiniteNumber(raw.p75) ?? null,
+    p90: coerceFiniteNumber(raw.p90) ?? null,
+    max: coerceFiniteNumber(raw.max) ?? null,
+  };
+}
+
+function normalizeChainStakeMovesSubnet(raw: unknown): ChainStakeMovesSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_movers: coerceFiniteNumber(raw.distinct_movers) ?? 0,
+    movements: coerceFiniteNumber(raw.movements) ?? 0,
+    movements_per_mover: coerceFiniteNumber(raw.movements_per_mover) ?? 0,
+  };
+}
+
+export const chainStakeMovesQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-stake-moves", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/stake-moves", {
+        params: { window },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: 1,
+          window,
+          observed_at: firstString(d.observed_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          network: normalizeChainStakeMovesNetwork(d.network),
+          intensity_distribution: normalizeChainStakeMovesDistribution(d.intensity_distribution),
+          subnets: normalizeChainRows(
+            d.subnets,
+            MAX_STAKE_MOVES_SUBNETS,
+            normalizeChainStakeMovesSubnet,
+          ),
+        } as ChainStakeMoves,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainStakeMoves>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1927,6 +1927,36 @@ export interface ChainStakeFlow {
   net_flow_distribution: ChainStakeFlowDistribution | null;
   subnets: ChainStakeFlowSubnet[];
 }
+export interface ChainStakeMovesNetwork {
+  distinct_movers: number;
+  movements: number;
+  movements_per_mover: number;
+}
+export interface ChainStakeMovesDistribution {
+  count: number;
+  mean: number | null;
+  min: number | null;
+  p25: number | null;
+  median: number | null;
+  p75: number | null;
+  p90: number | null;
+  max: number | null;
+}
+export interface ChainStakeMovesSubnet {
+  netuid: number;
+  distinct_movers: number;
+  movements: number;
+  movements_per_mover: number;
+}
+export interface ChainStakeMoves {
+  schema_version: number;
+  window: string;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainStakeMovesNetwork | null;
+  intensity_distribution: ChainStakeMovesDistribution | null;
+  subnets: ChainStakeMovesSubnet[];
+}
 export interface ChainSignerEntry {
   signer: string;
   tx_count: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -24,6 +24,7 @@ import {
   chainFeesQuery,
   chainSignersQuery,
   chainStakeFlowQuery,
+  chainStakeMovesQuery,
   chainStakeTransfersQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -34,6 +35,7 @@ import type {
   ChainEvent,
   ChainEventsStats,
   ChainStakeFlow,
+  ChainStakeMoves,
 } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
@@ -101,6 +103,7 @@ function ExplorerPage() {
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
           "/api/v1/chain/stake-flow",
+          "/api/v1/chain/stake-moves",
           "/api/v1/chain/stake-transfers",
           "/api/v1/chain-events",
           "/api/v1/chain-events/stats",
@@ -426,6 +429,85 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
   );
 }
 
+/**
+ * Network-wide stake moves (#3468) - re-delegation churn across every subnet for
+ * the window: distinct movers, total movements, and moves-per-mover, plus the
+ * busiest subnets by movement count and the intensity distribution.
+ * Chain-direct: GET /api/v1/chain/stake-moves.
+ */
+function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
+  const net = moves.network;
+  const dist = moves.intensity_distribution;
+  // Server sorts subnets by movements desc; re-sort defensively, take the top 12.
+  const busiest = [...moves.subnets].sort((a, b) => b.movements - a.movements).slice(0, 12);
+  const cap = Math.max(1, ...busiest.map((s) => s.movements));
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Stake moves
+        </h2>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(moves.subnet_count)} subnets
+        </span>
+      </div>
+
+      {net ? (
+        <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <StakeFlowMetric label="Distinct movers" value={formatNumber(net.distinct_movers)} />
+          <StakeFlowMetric label="Movements" value={formatNumber(net.movements)} />
+          <StakeFlowMetric label="Moves / mover" value={net.movements_per_mover.toFixed(2)} />
+        </div>
+      ) : null}
+
+      {busiest.length > 0 ? (
+        <div>
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Busiest subnets
+          </div>
+          <ul className="space-y-1.5">
+            {busiest.map((s) => {
+              const pct = Math.max(2, Math.round((s.movements / cap) * 100));
+              return (
+                <li key={s.netuid}>
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: s.netuid }}
+                    className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
+                  >
+                    <span className="truncate font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                      SN{s.netuid}
+                    </span>
+                    <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
+                      <span
+                        className="absolute inset-y-0 left-0 rounded-full"
+                        style={{ width: `${pct}%`, background: "var(--accent)" }}
+                      />
+                    </span>
+                    <span className="text-right font-mono text-[10px] tabular-nums text-ink-strong">
+                      {formatNumber(s.movements)}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">No stake moves in this window yet.</p>
+      )}
+
+      {dist ? (
+        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+          Median {(dist.median ?? 0).toFixed(1)} moves per mover, up to {(dist.max ?? 0).toFixed(1)}{" "}
+          in the busiest subnet, across {formatNumber(dist.count)} subnets.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -436,6 +518,7 @@ function ExplorerDashboard() {
   const calls = useSuspenseQuery(chainCallsQuery(win)).data.data;
   const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
   const stakeFlow = useSuspenseQuery(chainStakeFlowQuery(win)).data.data;
+  const stakeMoves = useSuspenseQuery(chainStakeMovesQuery(win)).data.data;
   const stakeTransfers = useSuspenseQuery(chainStakeTransfersQuery(win)).data.data;
   const eventMix = useSuspenseQuery(chainEventsStatsQuery()).data.data;
 
@@ -724,6 +807,8 @@ function ExplorerDashboard() {
       </div>
 
       <StakeFlowSection flow={stakeFlow} />
+
+      <StakeMovesSection moves={stakeMoves} />
 
       {/* stake-transfer leaderboard */}
       <section className="rounded-lg border border-border bg-card p-5">


### PR DESCRIPTION
Closes #3468

Adds a network-wide **Stake moves** (re-delegation churn) section to the chain explorer, mirroring the existing `StakeFlowSection` in the same file. Wires the live `GET /api/v1/chain/stake-moves` aggregate.

## What it adds
- **Data layer** — `ChainStakeMoves` (+ `…Network` / `…Distribution` / `…Subnet`) in `types.ts`, and `chainStakeMovesQuery` + normalizers in `queries.ts`, following the exact `chainStakeFlowQuery` pattern (`queryOptions` → `apiFetch` → `isRecord`/`coerceFiniteNumber` normalize, `normalizeChainRows`).
- **UI** — a `StakeMovesSection` in `explorer.tsx`, fetched with `useSuspenseQuery(chainStakeMovesQuery(win))` and rendered after the Stake flow section:
  - network **distinct movers / movements / moves-per-mover**,
  - a **Busiest subnets** bar list (top subnets by movement count, each linking to the subnet),
  - an intensity **distribution footnote** (median moves-per-mover + the busiest subnet).
- Appends `/api/v1/chain/stake-moves` to the `ApiSourceFooter` paths.

Honors the `7d` / `30d` window toggle already on the page. No changes outside these three files. Reuses the file's existing `StakeFlowMetric` (generic label/value tile).

## Verification
`tsc --noEmit` clean · `eslint .` clean (no new warnings) · `prettier --check` clean (prettier 3.9.4, per lockfile) · `vite build` clean.

## Screenshots

> **Note on the data shown.** As with the sibling **Stake flow** / **Call mix** / **Most active accounts** sections, the `/api/v1/chain/*` family is currently served an empty edge-cache variant to browser clients (`vary: Accept, Accept-Encoding`, `cf-cache-status: HIT`) — so these sections render empty in the live explorer today. Server-side, `GET /api/v1/chain/stake-moves` returns a full payload (129 subnets, 363 movers, 5,695 movements). The populated shots below render the section against that live payload (captured server-side, injected via a Playwright route mock); the empty state (what a browser renders today, degrading cleanly) is included last.

### Populated (live `/chain/stake-moves` payload) — desktop / tablet / mobile × light + dark

| | Light | Dark |
|---|---|---|
| **Desktop** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/data-desktop-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/data-desktop-dark.png) |
| **Tablet** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/data-tablet-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/data-tablet-dark.png) |
| **Mobile** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/data-mobile-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/data-mobile-dark.png) |

### Empty state (what a live browser renders today)

| Light | Dark |
|---|---|
| ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/empty-desktop-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/stakemoves-shots/empty-desktop-dark.png) |
