### PR TITLE
feat(registry): add SN67 Harnyx WebWalkerQA benchmark data artifact

### DIFF
--- a/registry/subnets/harnyx.json
+++ b/registry/subnets/harnyx.json
@@ -28,6 +28,24 @@
       },
       "source_urls": ["https://github.com/harnyx/harnyx", "https://harnyx.ai/"],
       "url": "https://harnyx.ai/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-67-harnyx-data-artifact",
+      "kind": "data-artifact",
+      "name": "Harnyx WebWalkerQA miner-task benchmark",
+      "notes": "Public WebWalkerQA question-answer evaluation set (680 records: Question, answer, domain, source_website, golden_path, difficulty_level) from the SN67 Harnyx miner-task benchmark suite, used to score web-navigation research tasks. No-auth static JSON dataset, pinned to an immutable commit.",
+      "provider": "harnyx",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "source_urls": [
+        "https://github.com/harnyx/harnyx/blob/41771ae6b74fc8b2f14b365745c1292782ed9d3a/packages/commons/src/harnyx_commons/miner_task_benchmark/webwalkerqa/data/versions/2026-05-14-webwalkerqa-test-single-source-easy__correctness-v1/test.json"
+      ],
+      "url": "https://raw.githubusercontent.com/harnyx/harnyx/41771ae6b74fc8b2f14b365745c1292782ed9d3a/packages/commons/src/harnyx_commons/miner_task_benchmark/webwalkerqa/data/versions/2026-05-14-webwalkerqa-test-single-source-easy__correctness-v1/test.json"
     }
   ],
   "source_repo": "https://github.com/harnyx/harnyx",


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest — `registry/subnets/harnyx.json`. Append-only; no other field changed.

Closes #4076

## Summary

Registers **SN67 Harnyx**'s public WebWalkerQA benchmark set as a `data-artifact` surface.

- **url:** the `test.json` evaluation set, pinned to an immutable commit (`41771ae`) — public, no-auth, verified live.
- **What it is:** a 680-record question-answer benchmark (fields: `Question`, `answer`, `domain`, `source_website`, `golden_path`, `difficulty_level`) from Harnyx's `miner_task_benchmark` suite, used to score miner web-navigation research tasks. It's the canonical evaluation dataset for understanding how SN67 grades miners.

## Surface

- Netuid: 67
- Kind: data-artifact
- Public URL: `raw.githubusercontent.com/harnyx/harnyx/41771ae…/…/webwalkerqa/…/test.json`
- Source URL: the same file's GitHub blob in SN67's registered `source-repo` (`harnyx/harnyx`) — establishes ownership.
- Provider slug: `harnyx` (already registered)

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` to `registry/subnets/harnyx.json`; purely additive (+18 / −0), no existing field touched.
- **Not a duplicate** — SN67 had only a `subnet-api` surface; no prior `data-artifact`.
- **Ownership established** — hosted in `harnyx/harnyx`, SN67's already-registered `source-repo`.
- **Durable** — URL pinned to an immutable commit SHA rather than a moving branch ref.
- Same accepted raw-GitHub-file pattern as the merged SN13 Data Universe (#4272) and SN87 Luminar (#4279) data-artifacts.
- `validate:surface`, `validate`, `scan:public-safety`, `format:check`, and `build` all pass locally.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, verified-live JSON dataset hosted in the subnet's own source repo.
