### PR TITLE
feat(registry): add SN76 Byzantium validator-weights subnet-api surface (#4090)

### DIFF
--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -85,6 +85,25 @@
         "https://github.com/byzantiumaitao-arch/byzantium/blob/main/ai-agent-kit/byzantium.config.json"
       ],
       "url": "https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/ai-agent-kit/byzantium.config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-76-byzantium-validator-weights",
+      "kind": "subnet-api",
+      "name": "Byzantium validator weights API",
+      "notes": "Public no-auth GET returning per-miner reward weights (computed from settled per-click authenticity scores, normalized to sum 1.0, with payout hotkey per miner) for weight-copy validators. The route's own source comment states it is \"the ONLY public validator endpoint\" in v1. Hosted on link.byzantiumai.net, the link-service subdomain of the registered byzantiumai.net website, documented in the official byzantiumaitao-arch/byzantium repository.",
+      "provider": "byzantium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://github.com/byzantiumaitao-arch/byzantium/blob/main/link-service/app/api/validator/weights/route.ts",
+        "https://github.com/byzantiumaitao-arch/byzantium/blob/main/MINER_GUIDE.md"
+      ],
+      "url": "https://link.byzantiumai.net/api/validator/weights"
     }
   ],
   "website_url": "https://www.byzantiumai.net/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/byzantium.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 76
- Kind: subnet-api
- Public URL: https://link.byzantiumai.net/api/validator/weights
- Source URL (proves the claim): https://github.com/byzantiumaitao-arch/byzantium/blob/main/link-service/app/api/validator/weights/route.ts — the route's own source comment states it is "the ONLY public validator endpoint" in v1, defined on the `link-service` subdomain of the already-registered `byzantiumai.net` website; plus https://github.com/byzantiumaitao-arch/byzantium/blob/main/MINER_GUIDE.md (independently references the same `link.byzantiumai.net` host)
- Provider slug: byzantium (already registered)

Live no-auth JSON endpoint returning per-miner reward weights (computed from settled per-click authenticity scores, normalized to sum 1.0, with payout hotkey per miner) for weight-copy validators. Fills the file's gap note "No verified safe public subnet API endpoint yet." No auth/login/token/session/nonce/key/secret/wallet in the path — confirmed live with a direct curl (`200`, real JSON body with `generated_at`/`formula`/`weights[]` fields) immediately before this submission, and confirmed from source that the file's one `isAdminRequest` check only gates an optional preview parameter, not general access.

Closes #4090

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `subnet-api` kind).
- [x] Links a tracked issue (`Closes #4090`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/byzantium.json` — passed (4 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/byzantium.json` — passed
- [x] Live curl of the URL immediately before submission: `200`, real JSON body