### PR TITLE
feat(registry): add SN108 TalkHead minimum-compute data-artifact (#4143)

### DIFF
--- a/registry/subnets/talkhead.json
+++ b/registry/subnets/talkhead.json
@@ -31,6 +31,25 @@
         "https://www.talkhead.ai/"
       ],
       "url": "https://api.talkhead.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-108-talkhead-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "TalkHead minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official talkheadai/talkhead-executor repository as min_compute.yml. Documents baseline CPU, GPU (10GB+ VRAM, CUDA 8.6+), memory, storage, OS, and bandwidth floors for SN108 TalkHead talking-head model evaluation. Linked from the talkhead-subnet README as the official executor/scoring repo.",
+      "provider": "talkhead",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://github.com/talkheadai/talkhead-executor/blob/main/min_compute.yml",
+        "https://github.com/talkheadai/talkhead-subnet/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/talkheadai/talkhead-executor/main/min_compute.yml"
     }
   ],
   "source_repo": "https://github.com/talkheadai/talkhead-subnet",


### PR DESCRIPTION
﻿## Add or update a subnet surface

This PR appends or updates surface(s) on exactly one subnet manifest —
`registry/subnets/talkhead.json`. If the manifest did not exist on the base
branch, this PR may include the required `subnet:new` scaffold fields in that
same new file.

## Surface

- Netuid: 108
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/talkheadai/talkhead-executor/main/min_compute.yml
- Source URL (proves the claim): https://github.com/talkheadai/talkhead-executor/blob/main/min_compute.yml (plus talkhead-subnet README naming the executor repo)
- Provider slug: talkhead

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an
      existing manifest, or a `subnet:new` scaffold plus surface(s) for a missing
      manifest (optionally plus one `registry/providers/*.json` for a debut
      provider).
- [x] Generated with `npm run surface:add` — lands `authority: community` and
      `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`
      independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data,
      private URLs, private dashboards, validator internals, or generated
      `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #<n>`) — a closed or missing link is an automatic close.

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be
merged automatically after public checks pass. Base-layer RPC/WSS/archive,
authenticated surfaces, unknown providers, and identity disputes route to manual
review.

## Validation

- [x] `npm run validate:surface -- registry/subnets/talkhead.json`
- [x] `npm run scan:public-safety`

## Summary

Appends TalkHead's official `min_compute.yml` (CPU/GPU/memory/storage/OS/bandwidth floors for SN108 talking-head evaluation) as a community `data-artifact` on `registry/subnets/talkhead.json`. Verified HTTP 200, no-auth, from `talkheadai/talkhead-executor`, which the subnet README names as the executor/scoring repo.

Closes #4143
