### PR TITLE
feat(registry): add SN55 NIOME miner-scores data-artifact surface (#4062)

### DIFF
--- a/registry/subnets/niome.json
+++ b/registry/subnets/niome.json
@@ -34,6 +34,24 @@
         "https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py"
       ],
       "url": "https://niome-api.genomes.io/api/tasks"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-55-niome-data-artifact",
+      "kind": "data-artifact",
+      "name": "NIOME miner scores dataset",
+      "notes": "Public no-auth GET returning SN55 NIOME's per-miner scoring dataset as JSON — an items[] array of scored genome-annotation submissions (annotation_score, f1_score, final_score, VCF score, per-submission log and timestamps) produced by the validator. Served on niome-api.genomes.io (the subnet's official API host) and declared as MINER_SCORE_URL alongside the already-registered TASK_URL in the official genomesio/subnet-niome validator constants. Distinct from the existing tasks surface — this is the scored-output dataset, not the task feed.",
+      "provider": "niome",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "source_urls": [
+        "https://github.com/genomesio/subnet-niome/blob/main/niome_subnet/utils/constants.py"
+      ],
+      "url": "https://niome-api.genomes.io/api/miner_scores"
     }
   ],
   "website_url": "https://niome.genomes.io/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest — `registry/subnets/niome.json`. Append-only; no other field or surface changed.

Closes #4062

## Summary

Registers SN55 NIOME's public, no-auth **miner scores** dataset — filling the manifest's documented data-artifact gap. `GET https://niome-api.genomes.io/api/miner_scores` returns the subnet's per-miner scoring dataset as JSON: an `items[]` array of scored genome-annotation submissions (`annotation_score`, `f1_score`, `final_score`, VCF score, per-submission log and timestamps) produced by the NIOME validator.

- **url:** `https://niome-api.genomes.io/api/miner_scores` — HTTP 200, `application/json`, no auth.
- **source_url:** the official `genomesio/subnet-niome` validator constants declare `MINER_SCORE_URL = f"{BASE_URL}/api/miner_scores"` on the same `niome-api.genomes.io` host already registered for the subnet's `/api/tasks` surface.

Distinct from the existing NIOME tasks surface — that is the task feed; this is the scored-output dataset.

## Validation

- `npm run validate:surface -- registry/subnets/niome.json` → passed (2 surfaces, 1 file)
- `npm run scan:public-safety` → passed
