### PR TITLE
feat(registry): add SN27 NI Compute GPU-performance data-artifact surface (#4026)

### DIFF
--- a/registry/subnets/ni-compute.json
+++ b/registry/subnets/ni-compute.json
@@ -33,6 +33,24 @@
         "https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py"
       ],
       "url": "https://github.com/neuralinternet/SN27-opencompute"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-27-nodexo-data-artifact",
+      "kind": "data-artifact",
+      "name": "NI Compute GPU performance reference config",
+      "notes": "Public no-auth static YAML data file committed in SN27 NI Compute's official neuralinternet/SN27-opencompute repository — the validator's GPU scoring reference data: gpu_performance (per-GPU-model FP16 TFLOPS + effective-VRAM tables), gpu_time_models, merkle_proof challenge parameters, and subnet_config used to score miner compute. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo. Public-safe: contains only hardware reference tables and challenge parameters, no credentials.",
+      "provider": "nodexo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "source_urls": [
+        "https://github.com/neuralinternet/SN27-opencompute/blob/main/config.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/neuralinternet/SN27-opencompute/main/config.yaml"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest — `registry/subnets/ni-compute.json`. Append-only; no other field or surface changed.

Closes #4026

## Summary

Registers SN27 NI Compute's public, no-auth **GPU performance reference** data file — filling the manifest's documented data-artifact gap. `config.yaml` is committed at the root of the subnet's official `neuralinternet/SN27-opencompute` repository and drives the validator's compute scoring:

- `gpu_performance` — per-GPU-model FP16 TFLOPS and effective-VRAM lookup tables
- `gpu_time_models` — timing models used to normalise benchmark results
- `merkle_proof` — challenge parameters for the proof-of-GPU verification
- `subnet_config` / `server_settings` — scoring configuration

- **url:** `https://raw.githubusercontent.com/neuralinternet/SN27-opencompute/main/config.yaml` — HTTP 200, `text/plain` YAML, no auth.
- **source_url:** the file's GitHub blob in the same official repo already registered as this subnet's `source-repo` surface.

Public-safe: the file contains only hardware reference tables and challenge parameters — no credentials.

## Validation

- `npm run validate:surface -- registry/subnets/ni-compute.json` → passed (2 surfaces, 1 file)
- `npm run scan:public-safety` → passed
