### PR TITLE
feat(registry): add SN101 eni / Tag101 provider profile

### DIFF
--- a/registry/providers/eni.json
+++ b/registry/providers/eni.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "authority": "community",
   "github_url": "https://github.com/tag101-ai/tag101",
   "id": "eni",

--- a/registry/providers/eni.json
+++ b/registry/providers/eni.json
@@ -1,0 +1,10 @@
+﻿{
+  "authority": "community",
+  "github_url": "https://github.com/tag101-ai/tag101",
+  "id": "eni",
+  "kind": "subnet-team",
+  "name": "Tag101",
+  "public_notes": "Subnet 101 (eni / Tag101) team profile — decentralized social post tagging. Identity from the official tag101-ai/tag101 source repository registered as SN101 source_repo. Review input only (authority: community).",
+  "schema_version": 1,
+  "website_url": "https://github.com/tag101-ai/tag101"
+}


### PR DESCRIPTION
﻿## Provider Profile Submission

This PR adds or updates exactly one provider/operator profile review file.

## Provider

- Provider slug: eni
- Provider name: Tag101
- Provider kind: subnet-team
- Website URL: https://github.com/tag101-ai/tag101
- GitHub URL: https://github.com/tag101-ai/tag101
- Contact URL: n/a

## Checklist

- [x] Links a tracked, currently-open issue (`Refs #4131`) — provider prerequisite for the SN101 data-artifact surface on that issue.
- [x] This PR changes exactly one `registry/providers/*.json` file.
- [x] Matched the community provider stub shape used by other subnet-team profiles (e.g. talkhead).
- [x] The profile contains only public-safe metadata.
- [x] The provider/operator identity is supported by the public SN101 source repo `tag101-ai/tag101`.
- [x] This does not claim endpoint health, uptime, latency, archive support, or pool eligibility.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Why this PR (before the #4131 surface)

Previous attempt [#4270](https://github.com/JSONbored/metagraphed/pull/4270) bundled `registry/providers/eni.json` + `registry/subnets/eni.json` and was auto-closed for multi-file shape. This splits the debut: provider profile first (this PR), then a single-file surface append for `min_compute.yml` closing #4131.

`website_url` is HTTPS (GitHub source repo) because `http://tag101.ai` only forwards and was flagged on #4270.

## Validation

- [x] `npm run validate:intake`
- [x] `npm run scan:public-safety`

Closes #4131
