### PR TITLE
feat(registry): add SN91 Bitstarter task-generation data-artifact surface (#4119)

### DIFF
--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -172,6 +172,24 @@
         "confidence": "medium"
       },
       "notes": "Public no-auth GET returning operational status JSON on the official Bitstarter updates/crowdfund host linked from app.bitstarter.ai project pages."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-91-alphacore-task-config",
+      "kind": "data-artifact",
+      "name": "AlphaCore task-generation config",
+      "notes": "Public no-auth static YAML data file committed in SN91 Bitstarter's official AlphaCoreBittensor/alphacore repository — the validator's task-generation configuration (providers, resource families, and task banks) loaded by the TaskGenerationPipeline via ALPHACORE_CONFIG to construct miner tasks. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo.",
+      "provider": "alphacore",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "source_urls": [
+        "https://github.com/AlphaCoreBittensor/alphacore/blob/main/modules/task_config.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/main/modules/task_config.yaml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest — `registry/subnets/bitstarter-1.json`. Append-only; no other field or surface changed.

Closes #4119

## Summary

Registers SN91 Bitstarter's public, no-auth **task-generation config** data file — filling the manifest's documented data-artifact gap. `modules/task_config.yaml` is committed in the subnet's official `AlphaCoreBittensor/alphacore` repository and is loaded by the validator's `TaskGenerationPipeline` (via `ALPHACORE_CONFIG`) to determine providers, resource families, and task banks when constructing miner tasks.

- **url:** `https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/main/modules/task_config.yaml` — HTTP 200, `text/plain` YAML, no auth.
- **source_url:** the file's GitHub blob in the same official repo already registered as this subnet's `source-repo` surface.

Public-safe: task-generation reference configuration only — no credentials.

## Validation

- `npm run validate:surface -- registry/subnets/bitstarter-1.json` → passed (7 surfaces, 1 file)
- `npm run scan:public-safety` → passed
