### PR TITLE
feat(registry): add SN81 Grail Grafana OpenAPI surface (#4100)

### DIFF
--- a/registry/subnets/grail.json
+++ b/registry/subnets/grail.json
@@ -149,6 +149,33 @@
         "https://github.com/one-covenant/grail/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/one-covenant/grail/main/compute.min.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-81-grail-grafana-openapi",
+      "kind": "openapi",
+      "name": "Grail Grafana HTTP API OpenAPI",
+      "notes": "Public no-auth OpenAPI 3 schema (title \"Grafana HTTP API.\") served at grail-grafana.tplr.ai/public/openapi3.json — the same host already registered as this file's dashboard and subnet-api (health) surfaces. Same operator (one-covenant / tplr.ai) and identical publish convention already accepted for the sibling Templar (SN3) subnet's Grafana OpenAPI surface (grafana.tplr.ai/public/openapi3.json).",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "schema_status": "machine-readable",
+      "schema_url": "https://grail-grafana.tplr.ai/public/openapi3.json",
+      "source_urls": [
+        "https://grail-grafana.tplr.ai/",
+        "https://github.com/one-covenant/grail"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 15000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "url": "https://grail-grafana.tplr.ai/public/openapi3.json"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/grail.json` (pure 27-line append, no other file, no reformatting).

## Surface

- Netuid: 81
- Kind: openapi
- Public URL: https://grail-grafana.tplr.ai/public/openapi3.json
- Source URL (proves the claim): https://grail-grafana.tplr.ai/ (the same host already registered as this file's `dashboard` and `subnet-api`/health surfaces), plus https://github.com/one-covenant/grail (official source repo)
- Provider slug: one-covenant (already registered)

Live, public, no-auth OpenAPI 3 schema (`title: "Grafana HTTP API."`, valid JSON, 200) served on a host this registry already trusts as genuinely Grail's own infrastructure. Same operator (one-covenant / tplr.ai) and identical publish convention already accepted for the sibling Templar (SN3) subnet's Grafana OpenAPI surface (`registry/subnets/templar.json`, `grafana.tplr.ai/public/openapi3.json`). Fills this file's gap note "No verified machine-readable OpenAPI/Swagger schema yet."

Closes #4100

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (27-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `openapi` kind).
- [x] Links a tracked issue (`Closes #4100`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/grail.json` — passed (7 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/grail.json` — passed