### PR TITLE
feat(registry): add SN92 Tensorclaw model-series allowlist data-artifact (#4120)

### DIFF
--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -129,6 +129,26 @@
         "timeout_ms": 10000
       },
       "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-92-tensorclaw-valid-model-series",
+      "kind": "data-artifact",
+      "name": "Tensorclaw supported model series allowlist",
+      "notes": "Public no-auth plain-text allowlist of supported LLM model families (gpt, deepseek, qwen, kimi, glm, claude, llama, mistral, gemini) used by SN92 Tensorclaw validators for model-availability scoring. Archived copy of the root-level VALID_MODEL_SERIES.txt from the official tensorclaw/tensorclaw repository; configs/validator.env in the same archive sets VALID_MODEL_SERIES to the official GitHub raw path and BITTENSOR_NETUID=92.",
+      "provider": "tensorclaw",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://github.com/fx-integral/academia-archives/blob/main/repos/tensorclaw__tensorclaw/VALID_MODEL_SERIES.txt",
+        "https://github.com/fx-integral/academia-archives/blob/main/repos/tensorclaw__tensorclaw/configs/validator.env",
+        "https://github.com/fx-integral/academia-archives/blob/main/repos/tensorclaw__tensorclaw/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/fx-integral/academia-archives/main/repos/tensorclaw__tensorclaw/VALID_MODEL_SERIES.txt"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community surface to exactly one subnet manifest — `registry/subnets/tensorclaw.json`.

## Surface

- Netuid: 92
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/fx-integral/academia-archives/main/repos/tensorclaw__tensorclaw/VALID_MODEL_SERIES.txt
- Source URL (proves the claim): archived `VALID_MODEL_SERIES.txt` plus `configs/validator.env` (`VALID_MODEL_SERIES` + `BITTENSOR_NETUID=92`) and README in `fx-integral/academia-archives` mirror of `tensorclaw/tensorclaw`
- Provider slug: tensorclaw

## Checklist

- [x] Changes exactly one `registry/subnets/tensorclaw.json` file (append-only).
- [x] Generated with research + `surface:add` shape — `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; `source_urls` prove SN92 publishes/uses this allowlist.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing surface (prior closed #3928 used a third-party fork URL and `subnet-api` kind).
- [x] Links open issue #4120 (`Closes #4120`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/tensorclaw.json`
- [x] `npm run scan:public-safety`

## Summary

Registers SN92 Tensorclaw's `VALID_MODEL_SERIES.txt` supported-model allowlist as a community `data-artifact`. The official `tensorclaw/tensorclaw` raw path currently 404s; this uses the verified academia-archives mirror with first-party proof from the archived validator config and README (SN92 Tensorclaw subnet).

Closes #4120