### PR TITLE
feat(registry): add SN39 Basilica GPU-host hardware profile data artifact

### DIFF
--- a/registry/subnets/basilica.json
+++ b/registry/subnets/basilica.json
@@ -129,6 +129,24 @@
         "https://www.basilica.ai/"
       ],
       "url": "https://api.basilica.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-39-one-covenant-data-artifact",
+      "kind": "data-artifact",
+      "name": "Basilica A100 SXM5 GPU-host hardware profile",
+      "notes": "Public lshw hardware profile of an NVIDIA A100 SXM5 80GB GPU host (CPU, memory, PCI topology, GPU) serving as a reference capability sample for SN39 Basilica's validator hardware attestation. No-auth static JSON, pinned to an immutable commit.",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "source_urls": [
+        "https://github.com/one-covenant/basilica/blob/1a75c1cb7c62caabe929b280931f0e074e2757f2/crates/basilica-validator/tests/fixtures/lshw/a100_sxm5_30vcpu.json"
+      ],
+      "url": "https://raw.githubusercontent.com/one-covenant/basilica/1a75c1cb7c62caabe929b280931f0e074e2757f2/crates/basilica-validator/tests/fixtures/lshw/a100_sxm5_30vcpu.json"
     }
   ],
   "website_url": "https://www.basilica.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest — `registry/subnets/basilica.json`. Append-only; no other field changed.

Closes #4042

## Summary

Registers **SN39 Basilica**'s public GPU-host hardware profile as a `data-artifact` surface.

- **url:** an `lshw` hardware profile JSON, pinned to an immutable commit (`1a75c1c`) — public, no-auth, verified live.
- **What it is:** the full `lshw` capability profile of an **NVIDIA A100 SXM5 80GB** GPU host (CPU, memory, PCI topology, GPU, NICs) that SN39 Basilica's validator uses as a reference sample for hardware attestation. Basilica is a GPU-compute/attestation subnet, so a canonical hardware-capability profile is directly relevant integration data.

## Surface

- Netuid: 39
- Kind: data-artifact
- Public URL: `raw.githubusercontent.com/one-covenant/basilica/1a75c1c…/…/lshw/a100_sxm5_30vcpu.json`
- Source URL: the same file's GitHub blob in SN39's registered `source-repo` (`one-covenant/basilica`) — establishes ownership.
- Provider slug: `one-covenant` (already registered; the repo owner)

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` to `registry/subnets/basilica.json`; purely additive (+18 / −0), no existing field touched.
- **Not a duplicate** — SN39 had no `data-artifact` surface.
- **Ownership established** — hosted in `one-covenant/basilica`, SN39's already-registered `source-repo`.
- **Durable** — URL pinned to an immutable commit SHA rather than a moving branch ref.
- **Clean** — no secrets/keys; the profile's serial/UUID fields are already redacted upstream.
- Same accepted raw-GitHub-file pattern as the merged SN13 (#4272), SN87 (#4279), and SN67 (#4381) data-artifacts.
- `validate:surface`, `validate`, `scan:public-safety`, `format:check`, and `build` all pass locally.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, verified-live JSON hosted in the subnet's own source repo.
