### PR TITLE
feat(registry): add SN107 Minos knowledge-pack data-artifact surface (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,24 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-knowledge-pack",
+      "kind": "data-artifact",
+      "name": "Minos public knowledge-graph pack manifest",
+      "notes": "Public no-auth static YAML data file committed in SN107 Minos's official minos-protocol/minos_subnet repository — the 'Minos SN107 Public Knowledge Graph' memory-pack manifest (version, description, and pack contents), a public-safe knowledge pack for miners, validators, and agent runtimes. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/docs/ai-assistant/memory-pack/manifest.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/docs/ai-assistant/memory-pack/manifest.yaml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest — `registry/subnets/minos.json`. Append-only; no other field or surface changed.

Closes #4141

## Summary

Registers SN107 Minos's public, no-auth **knowledge-graph pack** manifest — filling the manifest's documented data-artifact gap. `docs/ai-assistant/memory-pack/manifest.yaml` is committed in the subnet's official `minos-protocol/minos_subnet` repository and is the entry point for the "Minos SN107 Public Knowledge Graph" — a public-safe knowledge pack (version, description, and pack contents) intended for miners, validators, and agent runtimes.

- **url:** `https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/docs/ai-assistant/memory-pack/manifest.yaml` — HTTP 200, `text/plain` YAML, no auth.
- **source_url:** the file's GitHub blob in the same official repo already registered as this subnet's `source-repo`/API host.

Public-safe by design (the pack is explicitly labelled public-safe) — no credentials.

## Validation

- `npm run validate:surface -- registry/subnets/minos.json` → passed (2 surfaces, 1 file)
- `npm run scan:public-safety` → passed
