### PR TITLE
feat(ui): promote exact subnet title match to omnibox Go to (#3394)

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -21,6 +21,7 @@ import { safeExternalUrl } from "./external-link";
 import { loadRecent, pushRecent } from "@/lib/metagraphed/search-history";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { pickPromotedSubnetHit, hitKind } from "@/lib/metagraphed/search-hit-score";
 
 interface Props {
   /** Opens the full command palette modal (still bound to ⌘K). */
@@ -30,6 +31,7 @@ interface Props {
 interface Hit {
   id: string;
   kind?: string;
+  type?: string;
   title?: string;
   url?: string;
   netuid?: number;
@@ -89,7 +91,7 @@ const NAV_LINKS = [
 ] as const;
 
 function hrefFor(hit: Hit): string {
-  const k = (hit.kind ?? "").toLowerCase();
+  const k = hitKind(hit);
   if (k === "subnet" && hit.netuid != null) return `/subnets/${hit.netuid}`;
   if (k === "provider" && hit.slug) return `/providers/${hit.slug}`;
   if (k === "surface") return "/surfaces";
@@ -153,15 +155,22 @@ export function NavOmnibox({ onOpenPalette }: Props) {
   });
   const hits = ((data?.data as Hit[] | undefined) ?? []).slice(0, 8);
 
+  const promotedSubnet = useMemo(() => pickPromotedSubnetHit(hits, debounced), [hits, debounced]);
+
+  const visibleHits = useMemo(() => {
+    if (!promotedSubnet) return hits;
+    return hits.filter((h) => h.id !== promotedSubnet.id);
+  }, [hits, promotedSubnet]);
+
   const grouped = useMemo(() => {
     const m = new Map<string, Hit[]>();
-    for (const h of hits) {
-      const k = (h.kind ?? "other").toLowerCase();
+    for (const h of visibleHits) {
+      const k = hitKind(h) || "other";
       if (!m.has(k)) m.set(k, []);
       m.get(k)!.push(h);
     }
     return m;
-  }, [hits]);
+  }, [visibleHits]);
 
   // Detect direct-navigation targets from the query — ss58 wallet address,
   // decimal block number, 0x tx hash, or partial 0x block hash.
@@ -243,8 +252,20 @@ export function NavOmnibox({ onOpenPalette }: Props) {
       }
     }
 
+    if (promotedSubnet?.netuid != null) {
+      targets.push({
+        kind: "nav",
+        label: promotedSubnet.title ?? `Subnet ${promotedSubnet.netuid}`,
+        hint: `netuid ${promotedSubnet.netuid}`,
+        to: "/subnets/$netuid",
+        params: { netuid: promotedSubnet.netuid },
+        icon: Layers,
+        badge: "subnet",
+      });
+    }
+
     return targets;
-  }, [debounced]);
+  }, [debounced, promotedSubnet]);
 
   const flat: NavTarget[] = useMemo(() => {
     const items: NavTarget[] = [...navTargets];
@@ -274,7 +295,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
       window.open(safeHref, "_blank", "noopener,noreferrer");
       return;
     }
-    const k = (item.hit.kind ?? "").toLowerCase();
+    const k = hitKind(item.hit);
     if (k === "subnet" && item.hit.netuid != null) {
       navigate({ to: "/subnets/$netuid", params: { netuid: item.hit.netuid } });
     } else if (k === "provider" && item.hit.slug) {

--- a/apps/ui/src/lib/metagraphed/search-hit-score.test.ts
+++ b/apps/ui/src/lib/metagraphed/search-hit-score.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { pickPromotedSubnetHit, scoreHit } from "./search-hit-score";
+
+describe("scoreHit", () => {
+  it("scores an exact title match at the promotion threshold", () => {
+    expect(scoreHit({ type: "subnet", title: "Chutes" }, "chutes")).toBe(102);
+  });
+
+  it("does not reach the promotion threshold for prefix-only matches", () => {
+    expect(scoreHit({ type: "subnet", title: "Chutes AI" }, "chut")).toBe(62);
+  });
+});
+
+describe("pickPromotedSubnetHit", () => {
+  const hits = [
+    { id: "1", type: "subnet", title: "Chutes", netuid: 64 },
+    { id: "2", type: "subnet", title: "Apex", netuid: 1 },
+    { id: "3", type: "provider", title: "Chutes", slug: "chutes" },
+  ];
+
+  it("returns the best exact subnet title match", () => {
+    expect(pickPromotedSubnetHit(hits, "chutes")).toEqual(hits[0]);
+  });
+
+  it("returns null when no subnet title matches exactly", () => {
+    expect(pickPromotedSubnetHit(hits, "chut")).toBeNull();
+  });
+
+  it("returns null for empty query", () => {
+    expect(pickPromotedSubnetHit(hits, "   ")).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/search-hit-score.ts
+++ b/apps/ui/src/lib/metagraphed/search-hit-score.ts
@@ -1,0 +1,52 @@
+/** Minimum scoreHit value for an exact title match (before kind bonuses). */
+export const EXACT_TITLE_MATCH_SCORE = 100;
+
+export interface ScorableHit {
+  kind?: string;
+  type?: string;
+  title?: string;
+  url?: string;
+  id?: string;
+  netuid?: number;
+}
+
+export function hitKind(hit: ScorableHit): string {
+  return (hit.kind ?? hit.type ?? "").toLowerCase();
+}
+
+/** Mirrors command-palette-body.tsx scoreHit — shared for omnibox subnet promotion (#3394). */
+export function scoreHit(hit: ScorableHit, q: string, recentSet: Set<string> = new Set()): number {
+  const t = (hit.title ?? hit.url ?? hit.id ?? "").toLowerCase();
+  const n = q.toLowerCase();
+  let s = 0;
+  if (!n) return 0;
+  if (t === n) s += EXACT_TITLE_MATCH_SCORE;
+  else if (t.startsWith(n)) s += 60;
+  else if (t.includes(` ${n}`)) s += 30;
+  else if (t.includes(n)) s += 10;
+  if (recentSet.has(n) && t.includes(n)) s += 8;
+  const kind = hitKind(hit);
+  if (kind === "subnet" || kind === "provider") s += 2;
+  return s;
+}
+
+/** Best subnet hit to promote into omnibox "Go to" when the title matches exactly. */
+export function pickPromotedSubnetHit<T extends ScorableHit>(hits: T[], q: string): T | null {
+  const query = q.trim();
+  if (!query) return null;
+
+  let best: T | null = null;
+  let bestScore = 0;
+  for (const hit of hits) {
+    if (hitKind(hit) !== "subnet") continue;
+    if (hit.netuid == null) continue;
+    const s = scoreHit(hit, query);
+    if (s > bestScore) {
+      bestScore = s;
+      best = hit;
+    }
+  }
+
+  if (!best || bestScore < EXACT_TITLE_MATCH_SCORE) return null;
+  return best;
+}


### PR DESCRIPTION
## Summary

- Promote a strong subnet-name search hit into the navbar omnibox **Go to** section when the query exactly matches a subnet title (case-insensitive)
- Add `search-hit-score.ts` with `scoreHit`, `hitKind`, and `pickPromotedSubnetHit` (mirrors `command-palette-body.tsx`; reads API `type` as well as `kind`)
- Promoted subnet is removed from the grouped **Subnets** list below to avoid duplication; keyboard nav via `flat` + `commit()` unchanged
- Closes #3394 · Part of #2542

**Follow-up (out of scope):** same promotion gap exists in `command-palette-body.tsx` — not touched here per issue.

## Screenshots (query: `Chutes` — live api.metagraph.sh)

| Viewport · Theme           | Before                                                                                                                                                                                                                                                                                                                                            | After                                                                                                                                                                                                                                                                                                                                     |
| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Desktop · Light (1280×800) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-light-before.png)<br><sub>Chutes only in grouped hits — no Go to promotion</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-light-after.png)<br><sub>Chutes promoted to Go to with subnet badge</sub> |
| Desktop · Dark (1280×800)  | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-dark-before.png)<br><sub>before</sub>                                             | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-desktop-dark-after.png)<br><sub>after</sub>                                        |
| Tablet · Light (768×1024)  | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-light-before.png)<br><sub>before</sub>                                             | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-light-after.png)<br><sub>after</sub>                                        |
| Tablet · Dark (768×1024)   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-dark-before.png)<br><sub>before</sub>                                               | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-tablet-dark-after.png)<br><sub>after</sub>                                          |
| Mobile · Light (375×812)   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-light-before.png)<br><sub>before</sub>                                             | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-light-after.png)<br><sub>after</sub>                                        |
| Mobile · Dark (375×812)    | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-dark-before.png)<br><sub>before</sub>                                               | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3394-omnibox-subnet-go-to-mobile-dark-after.png)<br><sub>after</sub>                                          |

## Test plan

- [x] Type `Chutes` — subnet appears in **Go to** with `subnet` badge; not duplicated in **Subnets** group
- [x] Type `chut` — no subnet promotion; existing ss58/block/hash Go to behavior unchanged
- [x] `npm test --workspace=apps/ui` — `search-hit-score.test.ts` (5 tests)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui` (changed files)

