### PR TITLE
feat(registry): add Minos network statistics data-artifact (SN107)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-data-artifact",
+      "kind": "data-artifact",
+      "name": "Minos network statistics",
+      "notes": "Public no-auth GET /dashboard/network-stats on api.theminos.ai returning aggregate SN107 Minos platform metrics (active miners, task counts, evaluation totals, validator connectivity, and 24h averages). Documented as a safe public GET endpoint in the official minos_subnet repository endpoint-safety reference; same first-party host as the registered health surface.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/docs/ai-assistant/memory-pack/endpoint-safety.md",
+        "https://api.theminos.ai/dashboard/network-stats"
+      ],
+      "url": "https://api.theminos.ai/dashboard/network-stats"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary
- Adds a public `data-artifact` surface for SN107 Minos at `GET /dashboard/network-stats` on `api.theminos.ai`
- Live JSON returns aggregate platform metrics (active miners, task/evaluation counts, validator connectivity, 24h averages)
- Documented as a safe public GET endpoint in the official `minos_subnet` endpoint-safety reference

Closes #4141

## Test plan
- [x] `npm run validate:surface -- --file registry/subnets/minos.json`
- [x] `npm run scan:public-safety -- --file registry/subnets/minos.json`
- [x] `npx prettier --check registry/subnets/minos.json`
- [x] Live probe: `curl -sS https://api.theminos.ai/dashboard/network-stats`
- [ ] CI + codecov pass
- [ ] Gittensory manual review / approval
