### PR TITLE
feat(registry): add SN90 DegenBrain market breakdown data-artifact (#4117)

### DIFF
--- a/registry/subnets/degenbrain.json
+++ b/registry/subnets/degenbrain.json
@@ -164,6 +164,25 @@
         "https://subnet90.com/"
       ],
       "url": "https://api.subnet90.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-90-degenbrain-market-breakdown",
+      "kind": "data-artifact",
+      "name": "DegenBrain market miner breakdown",
+      "notes": "Public no-auth GET /api/markets/{market_id}/breakdown on api.subnet90.com returning a JSON dataset of per-miner resolution breakdown for a prediction-market statement (statement text plus miner_breakdown entries with miner_id, resolution, confidence, summary, and sources). Documented as \"Get Market Breakdown\" in the subnet's registered OpenAPI spec; distinct from the existing /api/markets/pending and /api/resolutions subnet-api surfaces. Example market_id btc-100k-2024 is listed in the live pending-markets feed.",
+      "provider": "degenbrain",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://api.subnet90.com/openapi.json",
+        "https://subnet90.com/"
+      ],
+      "url": "https://api.subnet90.com/api/markets/btc-100k-2024/breakdown"
     }
   ],
   "website_url": "https://subnet90.com/"


### PR DESCRIPTION
## Summary

- Appends a community \data-artifact\ surface to \
egistry/subnets/degenbrain.json\ for SN90 DegenBrain.
- Registers the public no-auth GET \/api/markets/{market_id}/breakdown\ JSON endpoint on \pi.subnet90.com\ (example: \tc-100k-2024\), documented in the subnet's OpenAPI spec and distinct from the existing pending-markets and resolutions subnet-api surfaces.

Closes #4117

## Surface

| Field | Value |
|-------|-------|
| kind | data-artifact |
| url | https://api.subnet90.com/api/markets/btc-100k-2024/breakdown |
| source_urls | https://api.subnet90.com/openapi.json, https://subnet90.com/ |
| provider | degenbrain |

## Test plan

- [x] `npm run validate:surface -- registry/subnets/degenbrain.json`
- [x] `npm run scan:public-safety`
- [x] Verified URL returns 200 application/json (statement + miner_breakdown)
- [x] PR touches exactly one subnet file (append-only)