### PR TITLE
refactor(ui): promote the 1400px shell max-width to a shared spacing token

### DIFF
--- a/apps/ui/src/components/metagraphed/accent-band.tsx
+++ b/apps/ui/src/components/metagraphed/accent-band.tsx
@@ -37,7 +37,7 @@ export function AccentBand({ children, pattern = false, className, innerClassNam
       ) : null}
       <div
         className={classNames(
-          "relative max-w-[1400px] mx-auto px-4 md:px-8 py-14 md:py-20",
+          "relative max-w-shell-max mx-auto px-4 md:px-8 py-14 md:py-20",
           innerClassName,
         )}
       >

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -127,7 +127,7 @@ export function AppShell({ children }: { children: ReactNode }) {
             data-scrolled={scrolled ? "true" : "false"}
             className="mg-header sticky top-0 z-30 border-b border-border bg-paper/90 backdrop-blur supports-[backdrop-filter]:bg-paper/75"
           >
-            <div className="max-w-[1400px] mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
+            <div className="max-w-shell-max mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
               <button
                 className="lg:hidden rounded-md p-2 text-ink hover:bg-surface min-h-10 min-w-10 inline-flex items-center justify-center"
                 onClick={() => setMobileOpen(true)}
@@ -199,7 +199,7 @@ export function AppShell({ children }: { children: ReactNode }) {
             {/* Secondary breadcrumb row (desktop only, hidden on home) */}
             {crumbs.length > 1 ? (
               <div className="hidden md:block border-t border-border/70 bg-paper/60">
-                <div className="max-w-[1400px] mx-auto px-4 md:px-8 h-9 flex items-center">
+                <div className="max-w-shell-max mx-auto px-4 md:px-8 h-9 flex items-center">
                   <nav
                     aria-label="Breadcrumb"
                     className="flex items-center gap-1.5 text-xs text-ink-muted min-w-0"
@@ -261,7 +261,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           <main
             id="main-content"
             key={pathname}
-            className="flex-1 px-4 md:px-10 py-10 md:py-14 max-w-[1400px] mx-auto w-full mg-route-enter"
+            className="flex-1 px-4 md:px-10 py-10 md:py-14 max-w-shell-max mx-auto w-full mg-route-enter"
           >
             {children}
           </main>
@@ -294,7 +294,7 @@ function SiteFooter() {
         aria-hidden
         className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent"
       />
-      <div className="max-w-[1400px] mx-auto px-4 md:px-10 py-14 grid gap-10 md:grid-cols-4 text-[12px] text-ink-muted">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 py-14 grid gap-10 md:grid-cols-4 text-[12px] text-ink-muted">
         <div className="md:col-span-2">
           <div className="font-display text-base font-semibold text-ink-strong inline-flex items-baseline gap-1">
             Metagraphed
@@ -348,12 +348,12 @@ function SiteFooter() {
         </FooterCol>
       </div>
       <div className="border-t border-border/70">
-        <div className="max-w-[1400px] mx-auto px-4 md:px-10 py-3">
+        <div className="max-w-shell-max mx-auto px-4 md:px-10 py-3">
           <RegistryPulseStrip />
         </div>
       </div>
       <div className="border-t border-border/70">
-        <div className="max-w-[1400px] mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+        <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
           <span>
             © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
           </span>

--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -67,7 +67,7 @@ export function IncidentStrip() {
           : "bg-health-warn/10 border-health-warn/30 text-ink-strong",
       )}
     >
-      <div className="max-w-[1400px] mx-auto px-4 md:px-8 py-1.5 flex items-center gap-3">
+      <div className="max-w-shell-max mx-auto px-4 md:px-8 py-1.5 flex items-center gap-3">
         <AlertTriangle
           className={classNames(
             "size-3.5 shrink-0",

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -99,7 +99,7 @@ export function RegistryTicker() {
 
   return (
     <div className="hidden md:block border-t border-border/60 bg-surface/40">
-      <div className="max-w-[1400px] mx-auto px-4 md:px-8 h-9 flex items-center justify-between gap-4">
+      <div className="max-w-shell-max mx-auto px-4 md:px-8 h-9 flex items-center justify-between gap-4">
         {/* Left: rotating stat on md, full row on xl */}
         <div className="flex items-center gap-5 min-w-0">
           <span className="inline-flex items-center gap-1.5">

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -21,7 +21,7 @@ export function SubnetsCompareDrawer() {
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
-      <div className="max-w-[1400px] mx-auto px-4 md:px-10 pb-3">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
             "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_rgba(0,0,0,0.35)]",

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -96,6 +96,7 @@
   --spacing-nav: 3.5rem; /* app header height (h-nav in app-shell) */
   --spacing-sticky-offset: 6.5rem; /* nav + filter-bar height — sticky thead anchor */
   --spacing-section-gap: 4rem; /* between top-level page sections */
+  --spacing-shell-max: 1400px; /* page shell max width (max-w-shell-max) */
 }
 
 /* ============ LIGHT (default) — Bone + Ink ============ */


### PR DESCRIPTION
## What

The page-shell max width is hand-typed as `max-w-[1400px]` across five component files with no single source of truth, while `src/styles.css` already promotes exactly this kind of shared layout constant into `@theme` spacing tokens (`--spacing-section`, `--spacing-nav`, `--spacing-sticky-offset`, `--spacing-section-gap`). This PR gives the shell width the same treatment: one `--spacing-shell-max: 1400px` token alongside the existing spacing tokens, consumed as the bare `max-w-shell-max` utility - the exact consumption pattern the existing tokens use (`h-nav`, `top-sticky-offset`, `mt-section-gap`).

One scope note: the issue's prose says 9 occurrences, but its own enumerated list is 10 sites (`app-shell.tsx` has 6 - lines 130, 202, 264, 297, 351, 356) and that matches the grep on current `main`. All 10 are swapped; nothing else is touched.

## No visual change

Pure define-once refactor. With `@theme inline`, Tailwind emits `.max-w-shell-max{max-width:1400px}` in the built CSS - byte-equivalent to the `.max-w-\[1400px\]` rule it replaces (verified in `.output/public/assets/styles-*.css` after `npm run build --workspace=apps/ui`). Per the issue's acceptance criteria, no before/after screenshots are required for this change.

## Acceptance criteria

- [x] `src/styles.css` gains the shared shell-width token (`--spacing-shell-max`, placed with the other layout geometry tokens)
- [x] All enumerated occurrences across the 5 files reference the token instead of the literal
- [x] Visual rendering is completely unchanged (identical emitted CSS rule, value untouched)
- [x] `grep -rn "max-w-\[1400px\]" apps/ui/src` returns zero results

## Validation

- `npm run typecheck --workspace=apps/ui` (clean after a fresh `npm run build --workspace=packages/client`; the two pre-existing errors on a stale local client dist are unrelated to this diff)
- `npm run lint --workspace=apps/ui`
- `npm test --workspace=apps/ui` (521 tests)
- `npm run build --workspace=apps/ui` + inspection of the emitted CSS for the new utility
- `npx prettier --check` on all six changed files

Closes #3980