### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -6,7 +6,7 @@
   "status": "active",
   "categories": ["baseline-curated", "identity-reviewed"],
   "source_repo": null,
-  "website_url": null,
+  "website_url": "https://www.heraldmedia.ai/",
   "docs_url": null,
   "dashboard_url": null,
   "notes": "Reviewed overlay for SN69 ain. Public directories and analytics pages list the subnet, but no official team, website, source repository, API, OpenAPI schema, or docs site has been verified.",

--- a/registry/subnets/astrid.json
+++ b/registry/subnets/astrid.json
@@ -47,5 +47,7 @@
       ],
       "url": "https://arena-api.astrid.global/public/competitions/190482a8-70b8-463d-b6c5-d1808bc7db9f/wallet-activity"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/astridintelligence/sn-127",
+  "website_url": "https://www.astrid.global/"
 }

--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -70,7 +70,7 @@
       "url": "https://beamcore.b1m.ai/config/uid-ranges"
     }
   ],
-  "source_repo": null,
+  "source_repo": "https://github.com/orgs/Beam-Network/repositories",
   "website_url": "https://b1m.ai/",
   "contact": "info@b1m.ai"
 }

--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -69,5 +69,7 @@
       ],
       "url": "https://bitsec.ai/api/projects/known-solutions"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/Bitsec-AI/sandbox",
+  "website_url": "https://bitsec.ai/"
 }

--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -63,5 +63,9 @@
     }
   ],
   "source_repo": "https://github.com/chronollm/sn38",
-  "contact": "crew@crunchdao.com"
+  "contact": "crew@crunchdao.com",
+  "website_url": "https://chronollm.crunchdao.com/",
+  "social": {
+    "x": "https://x.com/chronollm"
+  }
 }

--- a/registry/subnets/chunking.json
+++ b/registry/subnets/chunking.json
@@ -28,7 +28,7 @@
   "notes": "Reviewed overlay for SN40 Chunking. Multiple public directories identify VectorChat as the team and subnet.chunking.com as the official website, but the website currently has an expired TLS certificate and the historical VectorChat/chunking_subnet repository returns 404.",
   "schema_version": 1,
   "slug": "chunking",
-  "source_repo": null,
+  "source_repo": "https://github.com/RalphLabsAI/ralph",
   "status": "active",
   "surfaces": [
     {

--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -28,5 +28,7 @@
       ],
       "url": "https://wandb.ai/toptensor-ai/CliqueAI/table"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/toptensor/CliqueAI",
+  "website_url": "https://cliqueai.toptensor.ai/"
 }

--- a/registry/subnets/coldint.json
+++ b/registry/subnets/coldint.json
@@ -176,5 +176,8 @@
       },
       "notes": "Public no-auth GET competitions.json on the official SN29 dynamic-configuration repository (github.com/coldint/sn29). Validators poll this URL on COMPETITIONS_URL in constants/__init__.py via requests.get to load live competition parameters without restart."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/cacheon_ai"
+  }
 }

--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -308,5 +308,8 @@
       "url": "https://handshake58.com/api/validator/registry"
     }
   ],
-  "website_url": "https://handshake58.com"
+  "website_url": "https://handshake58.com",
+  "social": {
+    "x": "https://x.com/greevils_ai"
+  }
 }

--- a/registry/subnets/liquidity.json
+++ b/registry/subnets/liquidity.json
@@ -46,5 +46,7 @@
       ],
       "url": "https://77.creativebuilds.io/weights"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/creativebuilds/sn77",
+  "website_url": "https://sn77.xyz/"
 }

--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -68,5 +68,7 @@
       ],
       "url": "https://api.synthdata.co/validation/scores/latest"
     }
-  ]
+  ],
+  "source_repo": "https://github.com/mode-network/synth-subnet",
+  "website_url": "https://synthdata.co/"
 }


### PR DESCRIPTION
## Summary

Third-party taostats gap-fills for human review — these values come from the [Taostats subnet identity API](https://api.taostats.io/api/subnet/identity/v1) and have been sanitized through the repo's own `normalizePublicHttpUrl` + `isPlaceholderIdentityUrl` helpers. Only empty fields are filled; no existing values are overwritten.

**Provenance:** taostats (community/third-party), not chain-native or maintainer-verified.

## Subnets touched (11)

| SN | Name | Field(s) added |
|----|------|----------------|
| 29 | Coldint | `social.x` → @cacheon_ai |
| 38 | ChronoLLM | `website_url`, `social.x` → @chronollm |
| 40 | Chunking | `source_repo` → RalphLabsAI/ralph |
| 50 | Synth | `source_repo`, `website_url` |
| 58 | Handshake58 | `social.x` → @greevils_ai |
| 60 | Bitsec | `source_repo`, `website_url` |
| 69 | ain | `website_url` |
| 77 | Liquidity | `source_repo`, `website_url` |
| 83 | CliqueAI | `source_repo`, `website_url` |
| 105 | Beam | `source_repo` (org repos page) |
| 127 | Astrid | `source_repo`, `website_url` |

**Excluded:** SN80 (dogelayer) — taostats data pointed to generic `opentensor/subtensor` + `bittensor.com`, not subnet-specific.

Schema validation passes (`validate:schemas`). Lint clean. Prettier clean on changed files.