### PR TITLE
feat(registry): add SN83 CliqueAI min-compute data-artifact surface (#4106)

### DIFF
--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -27,6 +27,24 @@
         "https://github.com/toptensor/CliqueAI/blob/main/docs/wandb_logging.md"
       ],
       "url": "https://wandb.ai/toptensor-ai/CliqueAI/table"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-cliqueai-min-compute",
+      "kind": "data-artifact",
+      "name": "CliqueAI minimum compute requirements",
+      "notes": "Public no-auth static YAML data file committed at the root of SN83 CliqueAI's official toptensor/CliqueAI repository — the subnet's minimum/recommended compute specification (per-role miner and validator CPU, GPU/VRAM, memory, storage, OS, and network bandwidth requirements) used by operators to provision hardware. Served read-only via raw.githubusercontent from the same official repo.",
+      "provider": "cliqueai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "source_urls": [
+        "https://github.com/toptensor/CliqueAI/blob/main/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/toptensor/CliqueAI/main/min_compute.yml"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends **one** community surface to exactly one subnet manifest — `registry/subnets/cliqueai.json`. Append-only; no other field or surface changed.

Closes #4106

## Summary

Registers SN83 CliqueAI's public, no-auth **minimum compute requirements** data file — filling the manifest's documented data-artifact gap. `min_compute.yml` is committed at the root of the subnet's official `toptensor/CliqueAI` repository and specifies the per-role (miner / validator) hardware requirements: CPU cores/speed, GPU/VRAM and CUDA capability, memory, storage/IOPS, OS, and network bandwidth.

- **url:** `https://raw.githubusercontent.com/toptensor/CliqueAI/main/min_compute.yml` — HTTP 200, `text/plain` YAML, no auth.
- **source_url:** the file's GitHub blob in the same official repo.

Public-safe: hardware-requirement reference values only — no credentials.

## Validation

- `npm run validate:surface -- registry/subnets/cliqueai.json` → passed
- `npm run scan:public-safety` → passed
