### PR TITLE
feat(registry): add SN89 InfiniteHash mining-pool worker metrics data artifact

### DIFF
--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -68,6 +68,24 @@
         "timeout_ms": 10000
       },
       "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism."
+    },
+    {
+      "id": "sn-89-infinitehash-data-artifact",
+      "name": "InfiniteHash mining-pool worker metrics",
+      "kind": "data-artifact",
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/1a4f32d1efb053efd6d1a64d48d67680081ee744/app/src/infinite_hashes/validator/tests/data/pool-workers-2025-08-21.csv",
+      "provider": "infinitehash",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/1a4f32d1efb053efd6d1a64d48d67680081ee744/app/src/infinite_hashes/validator/tests/data/pool-workers-2025-08-21.csv"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "notes": "Public snapshot of SN89 InfiniteHash mining-pool worker performance metrics — per-worker hashrate, efficiency, and stale/rejected share rates with last-share timestamps and status — committed in the validator repository. No-auth static CSV, pinned to an immutable commit."
     }
   ],
   "website_url": "https://infinitehash.xyz/",


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest — `registry/subnets/infinitehash.json`. Append-only; no other field changed.

Closes #4116

## Summary

Registers **SN89 InfiniteHash**'s public mining-pool worker metrics as a `data-artifact` surface.

- **url:** a CSV snapshot of pool worker metrics, pinned to an immutable commit (`1a4f32d`) — public, no-auth, verified live.
- **What it is:** per-worker performance metrics — hashrate, efficiency, stale/rejected share rates, last-share timestamp, and status — for the SN89 InfiniteHash mining pool, committed in the validator repository. InfiniteHash scores miners on contributed hashrate, so this is directly relevant operational data.

## Surface

- Netuid: 89
- Kind: data-artifact
- Public URL: `raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/1a4f32d…/…/pool-workers-2025-08-21.csv`
- Source URL: the same file's GitHub blob in SN89's registered `source-repo` (`backend-developers-ltd/InfiniteHash`) — establishes ownership.
- Provider slug: `infinitehash` (already registered)

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` to `registry/subnets/infinitehash.json`; purely additive (+18 / −0), no existing field touched.
- **Not a duplicate** — SN89 had no `data-artifact` surface.
- **Ownership established** — hosted in `backend-developers-ltd/InfiniteHash`, SN89's already-registered `source-repo`.
- **Durable** — URL pinned to an immutable commit SHA rather than a moving branch ref.
- **Clean** — no secrets/keys/private material (the file holds only public metrics and public on-chain worker identifiers).
- Same accepted raw-GitHub-file pattern as the merged SN13 (#4272), SN87 (#4279), SN67 (#4381), and SN39 (#4391) data-artifacts.
- `validate:surface`, `validate`, `scan:public-safety`, `format:check`, and `build` all pass locally.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, verified-live data hosted in the subnet's own source repo.
