### PR TITLE
feat(registry): add SN48 Quantum Compute min-compute-spec data-artifact surface (#4053)

### DIFF
--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -85,6 +85,25 @@
         "https://www.qbittensorlabs.com/"
       ],
       "url": "https://www.qbittensorlabs.com/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-48-quantum-compute-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Quantum Compute minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official qbittensor-labs/quantum-compute repository as min_compute.yml. Documents SN48 operator CPU/GPU/memory/storage/network floors.",
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute/blob/main/min_compute.yml",
+        "https://github.com/qbittensor-labs/quantum-compute"
+      ],
+      "url": "https://raw.githubusercontent.com/qbittensor-labs/quantum-compute/main/min_compute.yml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/quantum-compute.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 48
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/qbittensor-labs/quantum-compute/main/min_compute.yml
- Source URL (proves the claim): https://github.com/qbittensor-labs/quantum-compute/blob/main/min_compute.yml (the file itself, in the subnet's own official, already-registered source repo), plus https://github.com/qbittensor-labs/quantum-compute (the repo root)
- Provider slug: qbittensor-labs (already registered)

Live no-auth YAML file at the root of the official source repository documenting miner/validator minimum hardware requirements (CPU/GPU/memory/storage/network). This is the same `min_compute.yml`-as-`data-artifact` pattern already accepted elsewhere in the registry (e.g. `djinn.json`, `talkhead.json`). Fills this file's gap note "No verified standalone static data artifact yet."

Closes #4053

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4053`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/quantum-compute.json` — passed (4 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/quantum-compute.json` — passed