### PR TITLE
feat(registry): add SN123 MANTIS historical datalog data-artifact

### DIFF
--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -89,6 +89,24 @@
         "submitted_by": "dev-miro26"
       },
       "notes": "Public no-auth JSON data artifact of asset prices and funding rates published by the SN123 MANTIS validator — the PRICE_DATA_URL declared in the official repo's config.py (line 63). Freshness/uptime are probe-derived and not asserted here."
+    },
+    {
+      "id": "sn-123-mantis-datalog-archive",
+      "name": "MANTIS historical datalog archive",
+      "kind": "data-artifact",
+      "url": "https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db",
+      "provider": "mantis",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://raw.githubusercontent.com/Barbariandev/MANTIS/main/config.py"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public no-auth downloadable SQLite datalog of the SN123 MANTIS validator's full historical multi-asset signal/price time series — the DATALOG_ARCHIVE_URL declared in the official repo's config.py, distinct from and complementary to the latest_prices.json snapshot (this is the complete historical archive, served as a SQLite database file). Verified as a live SQLite artifact (magic bytes 'SQLite format 3'). Freshness/size are probe-derived and not asserted here."
     }
   ]
 }


### PR DESCRIPTION
Closes #4173

## Summary

Registers **SN123 MANTIS**'s full historical **datalog archive** — a public, no-auth data endpoint the registry didn't yet have. MANTIS ("The Ultimate Signal Machine") publishes its data over public Cloudflare R2 endpoints rather than a REST API; this adds the complete historical time-series datalog, complementing the already-registered `latest_prices.json` snapshot.

## Surface

- kind: `data-artifact`
- url: `https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db`
- provider: `mantis` (existing)

## Proof of ownership (airtight)

- The official MANTIS source repo `Barbariandev/MANTIS` hardcodes this exact URL in `config.py`:
  `DATALOG_ARCHIVE_URL = "https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db"` — that file is the `source_url`.
- The repo README declares it "Bittensor Subnet 123, The Ultimate Signal Machine." Same repo already backs the registered `latest_prices.json` surface (via `PRICE_DATA_URL` in the same `config.py`).

## Verified live + public

- `GET` (range request) → **HTTP 206**, body begins with the magic bytes **`SQLite format 3`** — a genuine, downloadable SQLite database, no auth.

## Relation to the linked issue (#4173)

#4173 asks for SN123's public **API endpoint**. MANTIS exposes no REST API or OpenAPI — its machine-usable data is served as public R2 files. This registers the subnet's primary **public historical-data endpoint** (the datalog archive), which is the concrete public data surface behind #4173's intent.

## Non-duplication

Distinct from the existing `sn-123-mantis-price-feed` surface: that is the current-snapshot `latest_prices.json`; this is the full historical `datalog.db` (a different URL, different format, different purpose). No other surface references `datalog.db`; no open PR targets SN123.

## Validation (local)

- `npm run validate:surface -- registry/subnets/mantis.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `git diff --stat` → single file `registry/subnets/mantis.json`, an 18-line pure append (no reordering, no other surfaces/fields touched), no generated artifacts.
