### PR TITLE
feat(registry): add SN63 Enigma min-compute-spec data-artifact surface (#4071)

### DIFF
--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -84,6 +84,25 @@
         "https://www.qbittensorlabs.com/"
       ],
       "url": "https://www.qbittensorlabs.com/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-63-enigma-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Enigma minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official qbittensor-labs/enigma repository as min_compute.yml. Documents SN63 operator CPU/GPU/memory/storage/network floors.",
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://github.com/qbittensor-labs/enigma/blob/main/min_compute.yml",
+        "https://github.com/qbittensor-labs/enigma"
+      ],
+      "url": "https://raw.githubusercontent.com/qbittensor-labs/enigma/main/min_compute.yml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/enigma.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 63
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/qbittensor-labs/enigma/main/min_compute.yml
- Source URL (proves the claim): https://github.com/qbittensor-labs/enigma/blob/main/min_compute.yml (the file itself, in the subnet's already-registered `authority: official` source repo), plus https://github.com/qbittensor-labs/enigma (the repo root)
- Provider slug: qbittensor-labs (already registered)

Live no-auth YAML file at the root of the official source repository documenting miner/validator minimum hardware requirements (CPU/GPU/memory/storage/network). Same `min_compute.yml`-as-`data-artifact` pattern already accepted elsewhere in the registry (e.g. `quantum-compute.json`, `djinn.json`, `talkhead.json` — the same qbittensor-labs org already has this pattern merged for its sibling SN48 Quantum Compute subnet). Fills this file's gap note "No verified standalone static data artifact yet."

Closes #4071

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4071`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/enigma.json` — passed (4 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/enigma.json` — passed