### PR TITLE
feat(registry): add SN18 Zeus RMSE latitude-weighting array data artifact

### DIFF
--- a/registry/subnets/zeus.json
+++ b/registry/subnets/zeus.json
@@ -68,6 +68,24 @@
         "https://docs.zeussubnet.com/docs/introduction"
       ],
       "url": "https://api.zeussubnet.com/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-data-artifact",
+      "kind": "data-artifact",
+      "name": "Zeus latitude-weighting array for RMSE scoring",
+      "notes": "Public NumPy (.npy) array of per-latitude weights that SN18 Zeus applies to compute area-weighted RMSE when scoring miner weather/climate forecasts (correcting for grid-cell area shrinking toward the poles). Committed in the validator repository alongside its generator script. No-auth static file, pinned to an immutable commit.",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "source_urls": [
+        "https://github.com/Orpheus-AI/Zeus/blob/8b79e8ea117d085f959decd6fea9ae17da1b1494/zeus/data/weights/latitude_weights_for_rmse.npy"
+      ],
+      "url": "https://raw.githubusercontent.com/Orpheus-AI/Zeus/8b79e8ea117d085f959decd6fea9ae17da1b1494/zeus/data/weights/latitude_weights_for_rmse.npy"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest — `registry/subnets/zeus.json`. Append-only; no other field changed.

Closes #4015

## Summary

Registers **SN18 Zeus**'s public RMSE latitude-weighting array as a `data-artifact` surface.

- **url:** the `latitude_weights_for_rmse.npy` array, pinned to an immutable commit (`8b79e8e`) — public, no-auth, verified live.
- **What it is:** a NumPy array of per-latitude weights that Zeus applies to compute **area-weighted RMSE** when scoring miner weather/climate forecasts (correcting for grid-cell area shrinking toward the poles). Zeus is a weather/climate-prediction subnet, so its scoring-weight array is directly relevant integration data; the repo ships the `latitude_weights_for_rmse.py` generator alongside it.

## Surface

- Netuid: 18
- Kind: data-artifact
- Public URL: `raw.githubusercontent.com/Orpheus-AI/Zeus/8b79e8e…/zeus/data/weights/latitude_weights_for_rmse.npy`
- Source URL: the same file's GitHub blob in SN18's registered `source-repo` (`Orpheus-AI/Zeus`) — establishes ownership.
- Provider slug: `zeus` (already registered)

## Why it's safe to merge

- **One file, one surface** — appends a single `data-artifact` to `registry/subnets/zeus.json`; purely additive (+18 / −0), no existing field touched.
- **Not a duplicate** — SN18 had no `data-artifact` surface.
- **Ownership established** — hosted in `Orpheus-AI/Zeus`, SN18's already-registered `source-repo`.
- **Durable** — URL pinned to an immutable commit SHA rather than a moving branch ref.
- **Clean** — a numeric weights array; no secrets/keys/private material.
- Same accepted raw-GitHub-file pattern as the merged SN13 (#4272), SN87 (#4279), SN67 (#4381), and SN39 (#4391) data-artifacts.
- `validate:surface`, `validate`, `scan:public-safety`, `format:check`, and `build` all pass locally.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only.
- [x] `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, verified-live data hosted in the subnet's own source repo.
