### PR TITLE
feat(registry): add SN84 ansuz ChipForge llms.txt data-artifact (#4107)

### DIFF
--- a/registry/subnets/ansuz.json
+++ b/registry/subnets/ansuz.json
@@ -91,6 +91,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official ChipForge source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-84-chipforge-llms-txt",
+      "kind": "data-artifact",
+      "name": "ChipForge documentation index",
+      "notes": "Public no-auth machine-readable llms.txt documentation index published by the official ChipForge docs site (docs.chipforge.io). Catalogs SN84 ansuz API reference endpoints (active challenge, test-case download, submission/scoring routes) and links the hosted OpenAPI spec at /api-reference/openapi.json. Referenced from the docs root as the discovery file for agents and integrators.",
+      "provider": "chipforge",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://docs.chipforge.io/",
+        "https://github.com/TatsuProject/ChipForge_SN84/blob/master/README.md"
+      ],
+      "url": "https://docs.chipforge.io/llms.txt"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Appends a community data-artifact surface to registry/subnets/ansuz.json for SN84 ansuz (ChipForge).
- Registers the public no-auth llms.txt documentation index at https://docs.chipforge.io/llms.txt, which catalogs ChipForge API reference endpoints (active challenge, test-case download, submission/scoring) and links the hosted OpenAPI spec.

Closes #4107

## Surface

| Field | Value |
|-------|-------|
| kind | data-artifact |
| url | https://docs.chipforge.io/llms.txt |
| source_urls | https://docs.chipforge.io/, https://github.com/TatsuProject/ChipForge_SN84/blob/master/README.md |
| provider | chipforge |

## Test plan

- [x] npm run validate:surface -- registry/subnets/ansuz.json
- [x] npm run scan:public-safety
- [x] Verified URL returns 200 text/plain with API endpoint catalog
- [x] PR touches exactly one subnet file (append-only)

