### PR TITLE
feat(registry): add SN80 DogeLayer PoolInfo SCALE type registry

### DIFF
--- a/registry/subnets/dogelayer.json
+++ b/registry/subnets/dogelayer.json
@@ -27,6 +27,26 @@
         "https://github.com/dogelayer-ai/dogelayer/blob/main/README.md"
       ],
       "url": "https://github.com/dogelayer-ai/dogelayer/blob/main/docs/proxy-api.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-80-dogelayer-poolinfo-types",
+      "kind": "data-artifact",
+      "name": "DogeLayer PoolInfo SCALE type registry",
+      "notes": "Public no-auth JSON PortableRegistry schema defining the SN80 DogeLayer PoolInfo on-chain commitment structure (pool_index, ip, port, domain, username, password, high_diff_port). Published in the official dogelayer-ai/dogelayer repository and loaded by dogelayer/core/chain_data/pool_info.py for encode_pool_info/decode_pool_info when validators publish stratum pool metadata to the chain.",
+      "provider": "dogelayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://github.com/dogelayer-ai/dogelayer/blob/main/dogelayer/core/chain_data/types.json",
+        "https://github.com/dogelayer-ai/dogelayer/blob/main/dogelayer/core/chain_data/pool_info.py",
+        "https://github.com/dogelayer-ai/dogelayer/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/dogelayer-ai/dogelayer/main/dogelayer/core/chain_data/types.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a `data-artifact` surface for SN80 DogeLayer: the official `dogelayer/core/chain_data/types.json` PortableRegistry schema in the `dogelayer-ai/dogelayer` repository.
- This JSON artifact defines the `PoolInfo` on-chain commitment structure (pool_index, ip, port, domain, username, password, high_diff_port) and is loaded by `pool_info.py` for `encode_pool_info` / `decode_pool_info` when validators publish stratum pool metadata to the chain.
- `dogelayer.ai` OpenAPI/health endpoints currently return 530 from this environment; the GitHub-hosted schema is the verified first-party public artifact.

Closes #4099

## Test plan

- [x] `npm run validate:surface -- registry/subnets/dogelayer.json`
- [x] `npm run scan:public-safety`
- [x] Confirmed `url` resolves (raw GitHub JSON, HTTP 200)
- [x] Confirmed `source_urls` prove official SN80 DogeLayer publication (types.json, pool_info.py, README)
- [x] Single-file diff: `registry/subnets/dogelayer.json` only

