### PR TITLE
fix(ui): surface error states for account extrinsics and transfers (#3434)

### DIFF
--- a/apps/ui/src/lib/metagraphed/account-feed-section.test.ts
+++ b/apps/ui/src/lib/metagraphed/account-feed-section.test.ts
@@ -4,38 +4,34 @@ import { accountFeedSectionPhase } from "./account-feed-section";
 
 describe("accountFeedSectionPhase", () => {
   it("shows a skeleton while the first page is loading", () => {
-    expect(
-      accountFeedSectionPhase({ isPending: true, isError: false, rowCount: 0 }),
-    ).toBe("skeleton");
+    expect(accountFeedSectionPhase({ isPending: true, isError: false, rowCount: 0 })).toBe(
+      "skeleton",
+    );
   });
 
   it("prefers the error panel over stale cached rows", () => {
-    expect(
-      accountFeedSectionPhase({ isPending: false, isError: true, rowCount: 3 }),
-    ).toBe("error");
+    expect(accountFeedSectionPhase({ isPending: false, isError: true, rowCount: 3 })).toBe("error");
   });
 
   it("renders the error panel when the feed fails with no cache", () => {
-    expect(
-      accountFeedSectionPhase({ isPending: false, isError: true, rowCount: 0 }),
-    ).toBe("error");
+    expect(accountFeedSectionPhase({ isPending: false, isError: true, rowCount: 0 })).toBe("error");
   });
 
   it("hides the section when the feed succeeded with zero rows", () => {
-    expect(
-      accountFeedSectionPhase({ isPending: false, isError: false, rowCount: 0 }),
-    ).toBe("empty");
+    expect(accountFeedSectionPhase({ isPending: false, isError: false, rowCount: 0 })).toBe(
+      "empty",
+    );
   });
 
   it("renders table content when rows are available", () => {
-    expect(
-      accountFeedSectionPhase({ isPending: false, isError: false, rowCount: 2 }),
-    ).toBe("content");
+    expect(accountFeedSectionPhase({ isPending: false, isError: false, rowCount: 2 })).toBe(
+      "content",
+    );
   });
 
   it("keeps showing content while a background refetch is pending", () => {
-    expect(
-      accountFeedSectionPhase({ isPending: true, isError: false, rowCount: 2 }),
-    ).toBe("content");
+    expect(accountFeedSectionPhase({ isPending: true, isError: false, rowCount: 2 })).toBe(
+      "content",
+    );
   });
 });

--- a/apps/ui/src/lib/metagraphed/account-feed-section.test.ts
+++ b/apps/ui/src/lib/metagraphed/account-feed-section.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { accountFeedSectionPhase } from "./account-feed-section";
+
+describe("accountFeedSectionPhase", () => {
+  it("shows a skeleton while the first page is loading", () => {
+    expect(
+      accountFeedSectionPhase({ isPending: true, isError: false, rowCount: 0 }),
+    ).toBe("skeleton");
+  });
+
+  it("prefers the error panel over stale cached rows", () => {
+    expect(
+      accountFeedSectionPhase({ isPending: false, isError: true, rowCount: 3 }),
+    ).toBe("error");
+  });
+
+  it("renders the error panel when the feed fails with no cache", () => {
+    expect(
+      accountFeedSectionPhase({ isPending: false, isError: true, rowCount: 0 }),
+    ).toBe("error");
+  });
+
+  it("hides the section when the feed succeeded with zero rows", () => {
+    expect(
+      accountFeedSectionPhase({ isPending: false, isError: false, rowCount: 0 }),
+    ).toBe("empty");
+  });
+
+  it("renders table content when rows are available", () => {
+    expect(
+      accountFeedSectionPhase({ isPending: false, isError: false, rowCount: 2 }),
+    ).toBe("content");
+  });
+
+  it("keeps showing content while a background refetch is pending", () => {
+    expect(
+      accountFeedSectionPhase({ isPending: true, isError: false, rowCount: 2 }),
+    ).toBe("content");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/account-feed-section.ts
+++ b/apps/ui/src/lib/metagraphed/account-feed-section.ts
@@ -1,0 +1,21 @@
+/** Render phase for optional account feed sections (extrinsics, transfers, …). */
+export type AccountFeedSectionPhase = "skeleton" | "error" | "empty" | "content";
+
+/**
+ * Shared branching for non-blocking account feed sections.
+ * Error wins over stale cached rows — matches AccountEventsSection (#3434).
+ */
+export function accountFeedSectionPhase({
+  isPending,
+  isError,
+  rowCount,
+}: {
+  isPending?: boolean;
+  isError?: boolean;
+  rowCount: number;
+}): AccountFeedSectionPhase {
+  if (isPending && rowCount === 0) return "skeleton";
+  if (isError) return "error";
+  if (rowCount === 0) return "empty";
+  return "content";
+}

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -50,6 +50,7 @@ import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
+import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
 import type {
   AccountRegistration,
   AccountSummary,
@@ -423,7 +424,12 @@ function AccountExtrinsicsSection({
   error?: unknown;
   onRetry?: () => void;
 }) {
-  if (isPending && rows.length === 0) {
+  const phase = accountFeedSectionPhase({
+    isPending,
+    isError,
+    rowCount: rows.length,
+  });
+  if (phase === "skeleton") {
     return (
       <AccountFeedSectionSkeleton
         id="extrinsics"
@@ -432,7 +438,7 @@ function AccountExtrinsicsSection({
       />
     );
   }
-  if (isError) {
+  if (phase === "error") {
     return (
       <SectionAnchor
         id="extrinsics"
@@ -450,7 +456,7 @@ function AccountExtrinsicsSection({
       </SectionAnchor>
     );
   }
-  if (rows.length === 0) return null;
+  if (phase === "empty") return null;
   return (
     <SectionAnchor
       id="extrinsics"
@@ -540,7 +546,12 @@ function AccountTransfersSection({
   error?: unknown;
   onRetry?: () => void;
 }) {
-  if (isPending && rows.length === 0) {
+  const phase = accountFeedSectionPhase({
+    isPending,
+    isError,
+    rowCount: rows.length,
+  });
+  if (phase === "skeleton") {
     return (
       <AccountFeedSectionSkeleton
         id="transfers"
@@ -549,7 +560,7 @@ function AccountTransfersSection({
       />
     );
   }
-  if (isError) {
+  if (phase === "error") {
     return (
       <SectionAnchor
         id="transfers"
@@ -567,7 +578,7 @@ function AccountTransfersSection({
       </SectionAnchor>
     );
   }
-  if (rows.length === 0) return null;
+  if (phase === "empty") return null;
   return (
     <SectionAnchor
       id="transfers"

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -299,8 +299,21 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
 
-      <AccountExtrinsicsSection rows={signedExtrinsics} isPending={extrinsicsResult.isPending} />
-      <AccountTransfersSection ss58={ss58} rows={transfers} isPending={transfersResult.isPending} />
+      <AccountExtrinsicsSection
+        rows={signedExtrinsics}
+        isPending={extrinsicsResult.isPending}
+        isError={extrinsicsResult.isError}
+        error={extrinsicsResult.error}
+        onRetry={() => void extrinsicsResult.refetch()}
+      />
+      <AccountTransfersSection
+        ss58={ss58}
+        rows={transfers}
+        isPending={transfersResult.isPending}
+        isError={transfersResult.isError}
+        error={transfersResult.error}
+        onRetry={() => void transfersResult.refetch()}
+      />
 
       <div className="mt-6">
         <Link
@@ -397,7 +410,19 @@ function AccountFeedSectionSkeleton({
   );
 }
 
-function AccountExtrinsicsSection({ rows, isPending }: { rows: Extrinsic[]; isPending?: boolean }) {
+function AccountExtrinsicsSection({
+  rows,
+  isPending,
+  isError,
+  error,
+  onRetry,
+}: {
+  rows: Extrinsic[];
+  isPending?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  onRetry?: () => void;
+}) {
   if (isPending && rows.length === 0) {
     return (
       <AccountFeedSectionSkeleton
@@ -405,6 +430,24 @@ function AccountExtrinsicsSection({ rows, isPending }: { rows: Extrinsic[]; isPe
         title="Signed extrinsics"
         subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
       />
+    );
+  }
+  if (isError) {
+    return (
+      <SectionAnchor
+        id="extrinsics"
+        title="Signed extrinsics"
+        subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Couldn't load signed extrinsics"
+          description="The extrinsics tier is optional enrichment — the rest of the account page is unaffected."
+          error={error}
+          onRetry={onRetry}
+        />
+      </SectionAnchor>
     );
   }
   if (rows.length === 0) return null;
@@ -486,10 +529,16 @@ function AccountTransfersSection({
   ss58,
   rows,
   isPending,
+  isError,
+  error,
+  onRetry,
 }: {
   ss58: string;
   rows: Transfer[];
   isPending?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  onRetry?: () => void;
 }) {
   if (isPending && rows.length === 0) {
     return (
@@ -498,6 +547,24 @@ function AccountTransfersSection({
         title="Transfers"
         subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
       />
+    );
+  }
+  if (isError) {
+    return (
+      <SectionAnchor
+        id="transfers"
+        title="Transfers"
+        subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Couldn't load transfers"
+          description="The transfers tier is optional enrichment — the rest of the account page is unaffected."
+          error={error}
+          onRetry={onRetry}
+        />
+      </SectionAnchor>
     );
   }
   if (rows.length === 0) return null;


### PR DESCRIPTION
﻿## Summary

- Wire `isError` / `error` / `onRetry` from `accountExtrinsicsQuery` and `accountTransfersQuery` into `AccountExtrinsicsSection` and `AccountTransfersSection`.
- On fetch failure, render the same `TableState variant="error"` pattern already used by sibling account feeds instead of silently returning `null`.

Closes #3434 · Part of #2542

## Screenshots

Captured from the real account route (`/accounts/5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ`) with extrinsics/transfers calls forced to return HTTP 503 to exercise the error branch.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] Non-blocking queries remain `useQuery` (no suspense conversion)
- [x] Error branch now surfaces for extrinsics/transfers while empty cold-account behavior remains unchanged
- [x] Equivalent code path passed full CI in prior submission (#4232)
