### PR TITLE
feat(registry): add SN78 Vocence llms.txt documentation index

### DIFF
--- a/registry/subnets/vocence.json
+++ b/registry/subnets/vocence.json
@@ -49,6 +49,25 @@
         "https://github.com/vocence-78/vocence/blob/master/vocence/gateway/http/service/app.py"
       ],
       "url": "https://api.vocence.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-78-vocence-llms-txt",
+      "kind": "data-artifact",
+      "name": "Vocence documentation index",
+      "notes": "Public no-auth machine-readable llms.txt documentation index published by the official Vocence website (www.vocence.ai). Catalogs SN78 Vocence Studio guides, Developer API reference, Python SDK, CLI, subnet miner/validator setup docs, and links the hosted OpenAPI spec at api.vocence.ai/openapi.json plus llms-full.txt for full-doc ingestion.",
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://www.vocence.ai/",
+        "https://github.com/vocence-78/vocence/blob/master/README.md"
+      ],
+      "url": "https://www.vocence.ai/llms.txt"
     }
   ],
   "source_repo": "https://github.com/vocence-78/vocence",


### PR DESCRIPTION
## Summary

- Adds a `data-artifact` surface for SN78 Vocence: the official `https://www.vocence.ai/llms.txt` machine-readable documentation index.
- The file catalogs Vocence Studio guides, Developer API reference, Python SDK/CLI docs, subnet miner/validator setup, and links the hosted OpenAPI spec at `api.vocence.ai/openapi.json`.

Closes #4095

## Test plan

- [x] `npm run validate:surface -- registry/subnets/vocence.json`
- [x] `npm run scan:public-safety`
- [x] Confirmed `url` resolves (HTTP 200)
- [x] Confirmed `source_urls` prove official SN78 Vocence publication (website + README)
- [x] Single-file diff: `registry/subnets/vocence.json` only

Made with [Cursor](https://cursor.com)