### PR TITLE
feat(ui): add transfer-pairs flow view to the explorer page (#3476)

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useMemo, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -25,6 +25,7 @@ import {
   chainSignersQuery,
   chainStakeFlowQuery,
   chainStakeTransfersQuery,
+  chainTransferPairsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -723,6 +724,8 @@ function ExplorerDashboard() {
         </section>
       </div>
 
+      <TransferPairsSection win={win} />
+
       <StakeFlowSection flow={stakeFlow} />
 
       {/* stake-transfer leaderboard */}
@@ -784,6 +787,128 @@ function ExplorerDashboard() {
       </section>
       <PalletEventMixSection stats={eventMix} />
     </div>
+  );
+}
+
+// Ranked sender→receiver native-TAO transfer corridors (#3476). Uses a plain
+// useQuery (not the page's suspense queries) so the volume/count sort toggle can
+// swap the ranking in place without re-suspending the whole dashboard.
+function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
+  const [sort, setSort] = useState<"volume" | "count">("volume");
+  const pairsQ = useQuery(chainTransferPairsQuery(win, 25, sort));
+  const pairs = pairsQ.data?.data;
+  const rows = pairs?.pairs ?? [];
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Transfer pairs
+          </h2>
+          {pairs ? (
+            <p className="mt-1 font-mono text-[11px] text-ink-muted">
+              {formatNumber(pairs.unique_pairs)} sender→receiver corridors ·{" "}
+              {fmtTao(pairs.total_volume_tao)} moved
+            </p>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1.5" role="group" aria-label="Sort transfer pairs by">
+          {(["volume", "count"] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              aria-pressed={s === sort}
+              onClick={() => setSort(s)}
+              className={
+                s === sort
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
+                  : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
+              }
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {pairsQ.isPending ? (
+        <Skeleton className="h-64 w-full" />
+      ) : pairsQ.error ? (
+        <ErrorState
+          error={pairsQ.error}
+          onRetry={() => pairsQ.refetch()}
+          context="transfer pairs"
+        />
+      ) : rows.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={`${TH} text-right`}>#</th>
+                <th className={TH}>From</th>
+                <th className={TH}>To</th>
+                <th className={`${TH} text-right`}>Volume</th>
+                <th className={`${TH} text-right`}>Transfers</th>
+                <th className={`${TH} text-right`}>Last block</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rows.map((p, i) => (
+                <tr key={`${p.from}-${p.to}`} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {i + 1}
+                  </td>
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: p.from }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                      title={p.from}
+                    >
+                      {shortHash(p.from) ?? p.from}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: p.to }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                      title={p.to}
+                    >
+                      {shortHash(p.to) ?? p.to}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {fmtTao(p.volume_tao)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(p.transfer_count)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {p.last_block != null ? (
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: String(p.last_block) }}
+                        className="hover:text-accent hover:underline"
+                      >
+                        #{formatNumber(p.last_block)}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">
+          No transfer pairs in this window yet.
+        </p>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #3476

Adds a ranked **sender→receiver native-TAO transfer-pairs** section to `/explorer`. It consumes the already-shipped `chainTransferPairsQuery` (#3683) via `useQuery`, with a **volume/count sort toggle** that re-ranks in place, and renders a ranked table (rank, from, to, volume, transfers, last block). Loading/empty/error states follow the page's existing top-payers convention. The section sits between "Most active accounts" and "Stake flow".

**UI-only** — `queries.ts`/`types.ts` untouched (data layer already shipped + tested in #3683), per the issue's non-goals.

## Acceptance criteria
- [x] Diff touches `explorer.tsx` (not queries.ts/types.ts)
- [x] Calls `chainTransferPairsQuery` via `useQuery`
- [x] Ranked sender→receiver table with a volume/count sort toggle
- [x] Loading (`Skeleton`) / empty (muted note) / error (`ErrorState` + retry) match the page convention

## Validation
- `npm run typecheck -w apps/ui` — pass
- `npm run lint` (changed file) — 0 errors
- `npm run test -w apps/ui` — 521 passed
- `npm run build -w apps/ui` — pass

Single-file change (`apps/ui/src/routes/explorer.tsx`); no generated artifacts touched.

## Screenshots

3 viewports (375×812 / 768×1024 / 1280×800, fixed viewport) × 2 themes (`mg-theme` forced) × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1386" height="564" alt="desk-lg" src="https://github.com/user-attachments/assets/6611f49c-2090-461e-bb1b-860b1af9be3d" /> | <img width="1364" height="689" alt="desk-dk" src="https://github.com/user-attachments/assets/1adf54f6-349c-4bf0-b63c-0999a76f8224" /> |
| Desktop · Dark | <img width="1353" height="536" alt="desk-dk-before" src="https://github.com/user-attachments/assets/464e5fdd-e866-4f85-8068-fe8b20df1e7c" /> | <img width="1376" height="684" alt="desk-dk-after" src="https://github.com/user-attachments/assets/7a372c8a-e043-4d1c-8d92-e38ec9448232" /> |
| Tablet · Light | <img width="676" height="886" alt="tab-lg-before" src="https://github.com/user-attachments/assets/60832e8f-62fa-44fd-b029-a64f5cfa6154" /> | <img width="661" height="886" alt="tab-lg-after" src="https://github.com/user-attachments/assets/dd1af525-1557-417f-83af-c411a840c4d7" /> |
| Tablet · Dark | <img width="650" height="857" alt="tab-dk-before" src="https://github.com/user-attachments/assets/ed0d4655-ca70-4677-9439-259060ae506f" /> | <img width="674" height="869" alt="tab-dk-after" src="https://github.com/user-attachments/assets/bbc127dd-0784-44d9-b0e5-6a12a25de43d" /> |
| Mobile · Light | <img width="446" height="854" alt="mb-lg-be" src="https://github.com/user-attachments/assets/6c282926-6055-4218-b5c2-a3b248c0e3ea" /> | <img width="459" height="874" alt="mb-lg-af" src="https://github.com/user-attachments/assets/c33afe0f-0863-4597-98b3-f0424f226c25" /> |
| Mobile · Dark | <img width="441" height="928" alt="mb-dk-be" src="https://github.com/user-attachments/assets/947a23b2-e458-4fa4-88f1-2a0706dbfc65" /> | <img width="448" height="930" alt="mb-dk-af" src="https://github.com/user-attachments/assets/dfd9d7c8-66ed-4124-85a8-3ff7a0617a7a" /> |
