### PR TITLE
feat(registry): add SN73 MetaHash validator weights data-artifact (#4089)

### DIFF
--- a/registry/providers/metahash.json
+++ b/registry/providers/metahash.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/clementblaise/metahash",
+  "id": "metahash",
+  "kind": "subnet-team",
+  "name": "MetaHash",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://github.com/clementblaise/metahash"
+}

--- a/registry/subnets/metahash.json
+++ b/registry/subnets/metahash.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 73,
-  "name": "MetaHash",
-  "slug": "metahash",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "defi",
@@ -11,17 +6,7 @@
     "otc",
     "treasury"
   ],
-  "source_repo": null,
-  "website_url": null,
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed identity overlay for SN73. Native chain identity currently reports Parked, while public subnet directories identify SN73 as MetaHash. Official-looking docs and source URLs discovered from public directories currently do not resolve or return 404, so they are not promoted.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T14:15:00.000Z",
-    "verified_at": "2026-06-08T14:15:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Native chain name currently reports as Parked; multiple public directories identify SN73 as MetaHash.",
       "Official-looking docs domain docs.metahash73.com currently does not resolve from simple probes.",
@@ -32,7 +17,43 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T14:15:00.000Z"
   },
-  "surfaces": []
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "MetaHash",
+  "netuid": 73,
+  "notes": "Reviewed identity overlay for SN73. Native chain identity currently reports Parked, while public subnet directories identify SN73 as MetaHash. Official-looking docs and source URLs discovered from public directories currently do not resolve or return 404, so they are not promoted.",
+  "schema_version": 1,
+  "slug": "metahash",
+  "source_repo": null,
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-73-metahash-data-artifact",
+      "kind": "data-artifact",
+      "name": "MetaHash validator subnet-weights configuration",
+      "notes": "Public no-auth YAML subnet-weight map used by SN73 MetaHash validators (weights.yml). Documents per-subnet weight overrides including disabling SN73 self-weight (73: 0). Pinned to immutable commit in the publicly accessible metahash repository fork; the on-chain-listed fx-integral/metahash source repo currently returns 404.",
+      "provider": "metahash",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsdevninja"
+      },
+      "source_urls": [
+        "https://github.com/clementblaise/metahash/blob/e1c0fac75438b62619380a0155c22a4b6cbebd34/weights.yml",
+        "https://github.com/clementblaise/metahash/blob/main/docs/validator.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
+      ],
+      "url": "https://raw.githubusercontent.com/clementblaise/metahash/e1c0fac75438b62619380a0155c22a4b6cbebd34/weights.yml"
+    }
+  ],
+  "website_url": null
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to `registry/subnets/metahash.json` and debuts the `metahash` provider stub (`registry/providers/metahash.json`). Append-only surface addition; provider scaffold required because no registered slug existed.

Closes #4089

## Summary

Registers **SN73 MetaHash**'s public validator subnet-weights configuration as a `data-artifact` surface.

- **url:** `weights.yml` pinned to immutable commit `e1c0fac` in the publicly accessible `clementblaise/metahash` repository — public, no-auth, verified live.
- **What it is:** the YAML subnet-weight map SN73 MetaHash validators use to set per-subnet weight overrides (including `73: 0` to disable self-weight). Documented in the subnet's validator setup guide.

## Surface

- Netuid: 73
- Kind: data-artifact
- Public URL: `https://raw.githubusercontent.com/clementblaise/metahash/e1c0fac75438b62619380a0155c22a4b6cbebd34/weights.yml`
- Source URLs (prove the claim):
  - `https://github.com/clementblaise/metahash/blob/e1c0fac…/weights.yml` — the artifact file itself
  - `https://github.com/clementblaise/metahash/blob/main/docs/validator.md` — validator guide explicitly documents `weights.yml` as the subnet-weight configuration
  - `https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json` — cross-reference identifying SN73 as MetaHash
- Provider slug: `metahash` (debut — `registry/providers/metahash.json` scaffolded in this PR)

## Context

The on-chain-listed official source repository (`fx-integral/metahash`) and operator domains (`metahash73.com`, `docs.metahash73.com`) currently return 404 / fail DNS resolution. The `clementblaise/metahash` fork is publicly accessible, documents SN73 in its validator guide, and hosts the `weights.yml` configuration file referenced by operator documentation.

## Checklist

- [x] Subnet manifest append-only surface addition (+ debut provider stub required for validation).
- [x] Generated with `npm run surface:add` — `authority: community` + `review.state: community-submitted`.
- [x] Public, no-auth, verified-live YAML configuration hosted in a reachable SN73 metahash repository.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing surface (manifest had zero surfaces).
- [x] Links tracked issue `Closes #4089`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/metahash.json` — passed (1 surface across 1 file)
- [x] `npm run scan:public-safety` — passed
