### PR TITLE
feat(registry): add SN4 Targon miner-stats data-artifact surface

### DIFF
--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -172,6 +172,22 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Official Targon Stats dashboard (page title \"Targon Stats\"). Its first-party ownership is proven by the official manifold-inc/targon CLI source, which names https://stats.targon.com as a default endpoint host."
+    },
+    {
+      "id": "sn-4-targon-data-artifact",
+      "name": "Targon miner stats feed",
+      "kind": "data-artifact",
+      "url": "https://stats.targon.com/api/miners",
+      "provider": "targon",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": ["https://stats.targon.com/docs"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "notes": "Public no-auth JSON feed of live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), documented as 'Get All Miners' in the official Targon Stats HTTP API docs at stats.targon.com/docs. This is the data feed behind the already-registered Targon Stats dashboard surface — distinct from it by both URL and kind, and distinct from the registered inventory subnet-api."
     }
   ],
   "social": { "x": "https://x.com/targoncompute" },


### PR DESCRIPTION
## Summary

Adds the missing **data artifact** surface for **SN4 Targon**: the public per-miner stats feed at `https://stats.targon.com/api/miners`, filling the manifest's own gap note ("No verified standalone static data artifact yet").

- **`url`** — `https://stats.targon.com/api/miners`: fetches publicly with no auth (HTTP 200, `application/json`), returning live SN4 per-miner rows keyed by subnet UID: `{"data":[{"uid":"89","count":8,"payout":64,"cards":8,"compute_type":"TDX-BLACKWELL-NVIDIA-B300"}, ...]}` — payout, GPU card count, and confidential-compute type per miner.
- **`source_urls` proof** — `https://stats.targon.com/docs`: Targon's own Stats HTTP API documentation lists **"Get All Miners — GET https://stats.targon.com/api/miners"** with this exact response schema, and marks the sibling `attest/error` route as the one requiring Epistula auth headers (confirming this endpoint is the public one). The `stats.targon.com` host is already established as first-party in this manifest (the registered Targon Stats dashboard surface cites `manifold-inc/targon`'s CLI source, which defaults to this host).
- **Distinct from existing surfaces**: not the `stats.targon.com/` root (kind `dashboard`) and not `api.targon.com/tha/v2/inventory` (kind `subnet-api`) — different URL and different kind.

One file changed, append-only (existing surfaces and key order untouched): `registry/subnets/targon.json` gains one `authority: community` / `review.state: community-submitted` surface.

## Validation

- `npm run validate:surface -- registry/subnets/targon.json` — passed (8 surfaces)
- `npm run scan:public-safety` — no findings in the changed file
- `npx prettier --check registry/subnets/targon.json` — clean
- Re-verified the artifact fetches live (200, `application/json`) immediately before opening this PR

Closes #4001