### PR TITLE
feat(ui): show market-cap and FDV proxy tiles in the subnet economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -168,6 +168,8 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
       <StatTile eyebrow="Total stake" value={fmtTao(e.total_stake_tao)} />
       <StatTile eyebrow="Volume" value={fmtTao(e.subnet_volume_tao)} />
       <StatTile eyebrow="Max stake" value={fmtTao(e.max_stake_tao)} />
+      <StatTile eyebrow="Market cap" value={fmtTao(e.alpha_market_cap_tao)} hint="proxy" />
+      <StatTile eyebrow="FDV" value={fmtTao(e.alpha_fdv_tao)} hint="proxy" />
       <StatTile
         eyebrow="Registration"
         tone={e.registration_allowed === false ? "down" : "default"}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -273,6 +273,8 @@ function normalizeEconomicsSubnets(value: unknown): SubnetEconomics[] {
         max_stake_tao: optionalNumber(item.max_stake_tao),
         subnet_volume_tao: optionalNumber(item.subnet_volume_tao),
         registration_cost_tao: optionalNumber(item.registration_cost_tao),
+        alpha_market_cap_tao: optionalNumber(item.alpha_market_cap_tao),
+        alpha_fdv_tao: optionalNumber(item.alpha_fdv_tao),
         registration_allowed: booleanValue(item.registration_allowed),
       } satisfies SubnetEconomics,
     ];

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1216,6 +1216,9 @@ export interface SubnetEconomics {
   subnet_volume_tao?: number;
   registration_cost_tao?: number;
   registration_allowed?: boolean;
+  /** Proxy metrics (#3361): alpha_price × total_stake, and alpha_price × ALPHA_MAX_SUPPLY. */
+  alpha_market_cap_tao?: number;
+  alpha_fdv_tao?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## What

Adds **Market cap** and **FDV** tiles to the subnet economics panel, from `alpha_market_cap_tao` / `alpha_fdv_tao` — both already computed and served by `/api/v1/economics` but never surfaced in the UI. Both are **proxy** metrics per the backend (`alpha_market_cap_tao = alpha_price × total_stake`; `alpha_fdv_tao = alpha_price × ALPHA_MAX_SUPPLY`), so each tile carries a `proxy` hint so the number isn't read as an authoritative on-chain market cap.

## How

- **`apps/ui/src/lib/metagraphed/types.ts`** — declare `alpha_market_cap_tao?` / `alpha_fdv_tao?` on `SubnetEconomics` (previously only reachable via the catch-all index signature).
- **`apps/ui/src/lib/metagraphed/queries.ts`** — coerce both via `optionalNumber(...)` in `normalizeEconomicsSubnets`, matching every sibling numeric field.
- **`apps/ui/src/components/metagraphed/economics-panel.tsx`** — two `StatTile`s rendered with the panel's own `fmtTao()` helper, alongside the existing 8 tiles.

No backend change (`economicsQuery` is already wired and consumed by the panel).

## Screenshots

Live SN64 economics panel — the new Market cap (258.8k τ) and FDV (1.52M τ) tiles, both flagged `proxy`.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-econ-mcap-3361/before.png) | ![after](https://raw.githubusercontent.com/dhgoal/metagraphed/assets-econ-mcap-3361/after.png) |

## Acceptance criteria

- [x] Diff touches `economics-panel.tsx` (not just `queries.ts`/`types.ts`)
- [x] `SubnetEconomics` declares `alpha_fdv_tao?: number` and `alpha_market_cap_tao?: number`
- [x] `normalizeEconomicsSubnets` coerces both with `optionalNumber(...)`, matching the other fields
- [x] Panel renders a "Market cap" tile (`alpha_market_cap_tao`) and an "FDV" tile (`alpha_fdv_tao`), both via `fmtTao()`
- [x] Loading/empty covered by the existing `!e` / `isPending` branches; the new tiles don't crash before `e` is defined
- [x] Proxy caveat surfaced (`proxy` hint on both tiles)

## Non-goals respected

No alpha-price sparkline (that's #3362, same file), no backend/artifact change, no re-labeling these as literal market cap without the proxy caveat.

## Gates

`npm run typecheck` ✓ (exit 0) · `eslint` (my files) ✓

Closes #3361