### PR TITLE
feat(ui): display base-layer RPC catalog on endpoints page (#3350)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.rpc-endpoints.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.rpc-endpoints.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  normalizeRpcEndpoint,
+  normalizeRpcEndpointsSummary,
+  rpcEndpointsQuery,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown, meta: ApiResult<unknown>["meta"] = {}): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta,
+    url: "/api/v1/rpc/endpoints",
+  });
+}
+
+function runQuery() {
+  const opts = rpcEndpointsQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never);
+}
+
+describe("normalizeRpcEndpointsSummary", () => {
+  it("maps rollup counts from the artifact summary block", () => {
+    const summary = normalizeRpcEndpointsSummary({
+      endpoint_count: 12,
+      archive_supported_count: 4,
+      by_kind: { "subtensor-rpc": 8, "subtensor-wss": 4 },
+      by_provider: { "opentensor": 6 },
+      by_status: { ok: 10, degraded: 2 },
+    });
+    expect(summary).toEqual({
+      endpoint_count: 12,
+      archive_supported_count: 4,
+      by_kind: { "subtensor-rpc": 8, "subtensor-wss": 4 },
+      by_provider: { opentensor: 6 },
+      by_status: { ok: 10, degraded: 2 },
+    });
+  });
+});
+
+describe("normalizeRpcEndpoint", () => {
+  it("maps wire status to UI health and preserves RPC-specific fields", () => {
+    const row = normalizeRpcEndpoint({
+      id: "finney-rpc-1",
+      netuid: 0,
+      chain: "bittensor",
+      kind: "subtensor-rpc",
+      url: "https://rpc.example",
+      provider: "opentensor",
+      status: "degraded",
+      classification: "live",
+      authority: "official",
+      latency_ms: 120,
+      latest_block: 4_200_000,
+      archive_support: true,
+      methods_supported: { chain_getBlock: true },
+    });
+    expect(row.health).toBe("warn");
+    expect(row.latest_block).toBe(4_200_000);
+    expect(row.archive_support).toBe(true);
+  });
+});
+
+describe("rpcEndpointsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("unwraps endpoints and summary from the keyed artifact payload", async () => {
+    resolveWith(
+      {
+        endpoints: [
+          {
+            id: "wss-1",
+            netuid: 0,
+            chain: "bittensor",
+            kind: "subtensor-wss",
+            url: "wss://entrypoint.example",
+            provider: "community",
+            status: "ok",
+          },
+        ],
+        summary: {
+          endpoint_count: 1,
+          archive_supported_count: 0,
+          by_status: { ok: 1 },
+        },
+        generated_at: "2026-07-08T00:00:00.000Z",
+      },
+      { generated_at: "2026-07-08T00:00:00.000Z", source: "live-cron-prober" },
+    );
+
+    const res = await runQuery();
+    expect(res.data).toHaveLength(1);
+    expect(res.data[0]?.kind).toBe("subtensor-wss");
+    expect(res.summary?.endpoint_count).toBe(1);
+    expect(res.summary?.by_status?.ok).toBe(1);
+    expect(res.meta?.source).toBe("live-cron-prober");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.rpc-endpoints.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.rpc-endpoints.test.ts
@@ -1,11 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
-import {
-  normalizeRpcEndpoint,
-  normalizeRpcEndpointsSummary,
-  rpcEndpointsQuery,
-} from "./queries";
+import { normalizeRpcEndpoint, normalizeRpcEndpointsSummary, rpcEndpointsQuery } from "./queries";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -38,7 +34,7 @@ describe("normalizeRpcEndpointsSummary", () => {
       endpoint_count: 12,
       archive_supported_count: 4,
       by_kind: { "subtensor-rpc": 8, "subtensor-wss": 4 },
-      by_provider: { "opentensor": 6 },
+      by_provider: { opentensor: 6 },
       by_status: { ok: 10, degraded: 2 },
     });
     expect(summary).toEqual({

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -118,6 +118,8 @@ import type {
   ReadinessSummary,
   Provider,
   ProviderEndpointSummary,
+  RpcEndpoint,
+  RpcEndpointsSummary,
   RpcPool,
   RpcUsage,
   SchemaInfo,
@@ -5290,6 +5292,89 @@ export const rpcPoolsQuery = () =>
     queryFn: async ({ signal }) => {
       const res = await fetchList<unknown>("/api/v1/rpc/pools", "pools", undefined, signal);
       return { ...res, data: res.data.map(normalizePool) } as ApiResult<RpcPool[]>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function countMap(raw: unknown): Record<string, number> | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+export function normalizeRpcEndpointsSummary(raw: unknown): RpcEndpointsSummary | null {
+  if (!raw || typeof raw !== "object") return null;
+  const s = raw as Record<string, unknown>;
+  return {
+    endpoint_count: optionalNumber(s.endpoint_count),
+    archive_supported_count: optionalNumber(s.archive_supported_count),
+    by_kind: countMap(s.by_kind),
+    by_provider: countMap(s.by_provider),
+    by_status: countMap(s.by_status),
+  };
+}
+
+export function normalizeRpcEndpoint(raw: unknown): RpcEndpoint {
+  if (!raw || typeof raw !== "object") return raw as RpcEndpoint;
+  const e = raw as Record<string, unknown>;
+  return {
+    ...(e as object),
+    id: asString(e.id) ?? "",
+    netuid: optionalNumber(e.netuid) ?? 0,
+    chain: (e.chain as "bittensor") ?? "bittensor",
+    kind: (e.kind as RpcEndpoint["kind"]) ?? "subtensor-rpc",
+    url: asString(e.url) ?? "",
+    provider: asString(e.provider) ?? "",
+    status: asString(e.status) ?? "unknown",
+    health: statusToHealth(e.status) ?? "unknown",
+    latency_ms: optionalNumber(e.latency_ms) ?? null,
+    latest_block: optionalNumber(e.latest_block) ?? null,
+    archive_support: booleanValue(e.archive_support) ?? null,
+    auth_required: booleanValue(e.auth_required),
+    observed_at: asString(e.observed_at) ?? null,
+    last_checked: asString(e.last_checked) ?? null,
+    last_ok: asString(e.last_ok) ?? null,
+    error: asString(e.error) ?? null,
+    rate_limit_notes: asString(e.rate_limit_notes) ?? null,
+    classification: asString(e.classification) ?? (e.classification as string | undefined),
+    authority: asString(e.authority) ?? (e.authority as string | undefined),
+    health_source: e.health_source as RpcEndpoint["health_source"],
+    health_stale: booleanValue(e.health_stale),
+    methods_supported: (e.methods_supported as RpcEndpoint["methods_supported"]) ?? null,
+    subnet_name: asString(e.subnet_name),
+    subnet_slug: asString(e.subnet_slug),
+    network: asString(e.network),
+  } as RpcEndpoint;
+}
+
+export type RpcEndpointsQueryResult = ApiResult<RpcEndpoint[]> & {
+  summary: RpcEndpointsSummary | null;
+};
+
+export const rpcEndpointsQuery = () =>
+  queryOptions({
+    queryKey: k("rpc-endpoints"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/rpc/endpoints", { signal });
+      const payload = res.data;
+      let endpoints: unknown[] = [];
+      let summary: RpcEndpointsSummary | null = null;
+      if (Array.isArray(payload)) {
+        endpoints = payload;
+      } else if (payload && typeof payload === "object") {
+        const obj = payload as Record<string, unknown>;
+        if (Array.isArray(obj.endpoints)) endpoints = obj.endpoints;
+        summary = normalizeRpcEndpointsSummary(obj.summary);
+      }
+      return {
+        data: endpoints.map(normalizeRpcEndpoint),
+        summary,
+        meta: res.meta,
+        url: res.url,
+      } as RpcEndpointsQueryResult;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -293,6 +293,47 @@ export interface RpcPool {
   [key: string]: unknown;
 }
 
+/** Base-layer Subtensor RPC/WSS row from GET /api/v1/rpc/endpoints (RpcEndpointsArtifact). */
+export interface RpcEndpoint {
+  id: string;
+  netuid: number;
+  chain: "bittensor";
+  kind: "subtensor-rpc" | "subtensor-wss";
+  url: string;
+  provider: string;
+  status: HealthStatus | string;
+  classification?: Classification | string;
+  authority?: Authority | string;
+  latency_ms?: number | null;
+  latest_block?: number | null;
+  archive_support?: boolean | null;
+  auth_required?: boolean;
+  methods_supported?: Record<string, boolean> | string[] | null;
+  health_source?: "probe-derived" | "missing-probe" | "not-monitored";
+  health_stale?: boolean;
+  last_checked?: string | null;
+  last_ok?: string | null;
+  observed_at?: string | null;
+  error?: string | null;
+  rate_limit_notes?: string | null;
+  subnet_name?: string;
+  subnet_slug?: string;
+  network?: string;
+  /** UI health chip mapped from wire `status`. */
+  health?: HealthState;
+  [key: string]: unknown;
+}
+
+/** Roll-up counts across the base-layer RPC endpoint catalog. */
+export interface RpcEndpointsSummary {
+  endpoint_count?: number;
+  archive_supported_count?: number;
+  by_kind?: Record<string, number>;
+  by_provider?: Record<string, number>;
+  by_status?: Record<string, number>;
+  [key: string]: unknown;
+}
+
 export interface EndpointIncident {
   id: string;
   endpoint_id?: string;

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -376,7 +376,12 @@ function RpcEndpointsTable() {
         />
       ) : null}
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-        <StatTile icon={Radio} eyebrow="Catalog endpoints" value={endpointCount} hint="base-layer" />
+        <StatTile
+          icon={Radio}
+          eyebrow="Catalog endpoints"
+          value={endpointCount}
+          hint="base-layer"
+        />
         <StatTile icon={ShieldCheck} eyebrow="Archive-capable" value={archiveCount} />
         <StatTile
           icon={Activity}
@@ -403,7 +408,11 @@ function RpcEndpointsTable() {
             {rows.map((row) => {
               const methodCount = rpcMethodsCount(row.methods_supported);
               return (
-                <tr key={row.id} id={`rpc-endpoint-${row.id}`} className="mg-row-hover scroll-mt-24">
+                <tr
+                  key={row.id}
+                  id={`rpc-endpoint-${row.id}`}
+                  className="mg-row-hover scroll-mt-24"
+                >
                   <td className="px-3 py-2 font-mono text-[11px]">{row.kind}</td>
                   <td className="px-3 py-2 text-[12px]">{row.provider}</td>
                   <td className="px-3 py-2 font-mono text-[11px] max-w-[36ch]">

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -350,8 +350,9 @@ function formatStatusRollup(byStatus: Record<string, number> | undefined): strin
 }
 
 function RpcEndpointsTable() {
-  const { data, summary } = useSuspenseQuery(rpcEndpointsQuery());
+  const { data } = useSuspenseQuery(rpcEndpointsQuery());
   const rows = (data.data ?? []) as RpcEndpoint[];
+  const summary = data.summary;
   const stale = isStaleFreshness(data.meta?.generated_at);
   const statusHint = formatStatusRollup(summary?.by_status);
   const endpointCount = summary?.endpoint_count ?? rows.length;

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -38,6 +38,7 @@ import { useScrolled } from "@/hooks/use-scrolled";
 import {
   endpointsQuery,
   endpointIncidentsQuery,
+  rpcEndpointsQuery,
   rpcPoolsQuery,
   providersQuery,
   subnetsQuery,
@@ -52,7 +53,7 @@ import {
   type PoolEligibility,
 } from "@/lib/metagraphed/endpoint-pool";
 
-import type { Endpoint, RpcPool, Provider, Subnet } from "@/lib/metagraphed/types";
+import type { Endpoint, RpcEndpoint, RpcPool, Provider, Subnet } from "@/lib/metagraphed/types";
 
 const endpointsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
@@ -173,6 +174,14 @@ function EndpointsPage() {
             </QueryErrorBoundary>
           </section>
           <section>
+            <SectionHeading title="Base-layer RPC catalog" />
+            <QueryErrorBoundary>
+              <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+                <RpcEndpointsTable />
+              </Suspense>
+            </QueryErrorBoundary>
+          </section>
+          <section>
             <SectionHeading title="Callable endpoints" />
             <QueryErrorBoundary>
               <Suspense fallback={<Skeleton className="h-48 w-full" />}>
@@ -195,6 +204,7 @@ function EndpointsPage() {
           "/rpc/v1/finney",
           "/api/v1/rpc/usage",
           "/api/v1/endpoints",
+          "/api/v1/rpc/endpoints",
           "/api/v1/rpc/pools",
           "/api/v1/endpoint-incidents",
         ]}
@@ -319,6 +329,127 @@ function PoolsTable() {
       <p className="px-1 font-mono text-[10px] text-ink-muted">
         Proxy-eligible members serve live traffic through the reverse proxy above; the proxy prefers
         in-sync, healthy nodes and fails over automatically.
+      </p>
+    </div>
+  );
+}
+
+function rpcMethodsCount(methods: RpcEndpoint["methods_supported"]): number | null {
+  if (methods == null) return null;
+  if (Array.isArray(methods)) return methods.length;
+  if (typeof methods === "object") return Object.keys(methods).length;
+  return null;
+}
+
+function formatStatusRollup(byStatus: Record<string, number> | undefined): string | undefined {
+  if (!byStatus || !Object.keys(byStatus).length) return undefined;
+  return Object.entries(byStatus)
+    .sort((a, b) => b[1] - a[1])
+    .map(([status, count]) => `${status}: ${count}`)
+    .join(" · ");
+}
+
+function RpcEndpointsTable() {
+  const { data, summary } = useSuspenseQuery(rpcEndpointsQuery());
+  const rows = (data.data ?? []) as RpcEndpoint[];
+  const stale = isStaleFreshness(data.meta?.generated_at);
+  const statusHint = formatStatusRollup(summary?.by_status);
+  const endpointCount = summary?.endpoint_count ?? rows.length;
+  const archiveCount =
+    summary?.archive_supported_count ?? rows.filter((row) => row.archive_support).length;
+  const okCount = summary?.by_status?.ok;
+
+  if (rows.length === 0)
+    return (
+      <EmptyState
+        title="No base-layer RPC endpoints tracked"
+        description="The rpc-endpoints artifact returned no rows — the catalog may be temporarily unavailable."
+      />
+    );
+
+  return (
+    <div className="space-y-2">
+      {stale ? (
+        <StaleBanner
+          generatedAt={data.meta?.generated_at}
+          refreshQueryKeys={[rpcEndpointsQuery().queryKey]}
+        />
+      ) : null}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <StatTile icon={Radio} eyebrow="Catalog endpoints" value={endpointCount} hint="base-layer" />
+        <StatTile icon={ShieldCheck} eyebrow="Archive-capable" value={archiveCount} />
+        <StatTile
+          icon={Activity}
+          eyebrow="Healthy (ok)"
+          value={okCount ?? "—"}
+          hint={statusHint ?? "status rollup"}
+        />
+      </div>
+      <div className="rounded border border-border bg-card overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-3 py-2 text-left">Kind</th>
+              <th className="px-3 py-2 text-left">Provider</th>
+              <th className="px-3 py-2 text-left">URL</th>
+              <th className="px-3 py-2 text-center">Status</th>
+              <th className="px-3 py-2 text-right">Latency</th>
+              <th className="px-3 py-2 text-right">Block</th>
+              <th className="px-3 py-2 text-center">Archive</th>
+              <th className="px-3 py-2 text-left">Authority</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((row) => {
+              const methodCount = rpcMethodsCount(row.methods_supported);
+              return (
+                <tr key={row.id} id={`rpc-endpoint-${row.id}`} className="mg-row-hover scroll-mt-24">
+                  <td className="px-3 py-2 font-mono text-[11px]">{row.kind}</td>
+                  <td className="px-3 py-2 text-[12px]">{row.provider}</td>
+                  <td className="px-3 py-2 font-mono text-[11px] max-w-[36ch]">
+                    {row.url ? (
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <ExternalLink href={row.url} className="truncate text-[11px]">
+                          {row.url}
+                        </ExternalLink>
+                        <CopyButton value={row.url} label="URL" />
+                      </div>
+                    ) : (
+                      "—"
+                    )}
+                    {methodCount != null ? (
+                      <div className="mt-0.5 text-[10px] text-ink-muted">
+                        {methodCount} method{methodCount === 1 ? "" : "s"}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="px-3 py-2 text-center">
+                    <HealthPill state={row.health ?? row.status} />
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px]">
+                    {row.latency_ms != null ? `${row.latency_ms}ms` : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px]">
+                    {row.latest_block != null ? row.latest_block.toLocaleString() : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
+                    {row.archive_support ? "yes" : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-[11px] text-ink-muted">
+                    <div>{row.authority ?? "—"}</div>
+                    {row.classification ? (
+                      <div className="font-mono text-[10px]">{row.classification}</div>
+                    ) : null}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p className="px-1 font-mono text-[10px] text-ink-muted">
+        Chain-scoped Subtensor RPC/WSS endpoints from the base-layer catalog — distinct from the
+        cross-subnet callable directory below.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #3350

Wires the existing `GET /api/v1/rpc/endpoints` base-layer catalog into the `/endpoints` page — a frontend-only gap; no backend changes.

- Adds `rpcEndpointsQuery`, `RpcEndpoint`, and `RpcEndpointsSummary` types mirroring the `RpcEndpointsArtifact` OpenAPI schema.
- Renders a new **Base-layer RPC catalog** section (between RPC pools and Callable endpoints) with summary stat tiles (`endpoint_count`, `archive_supported_count`, `by_status` rollup) and a per-endpoint table.
- Adds `/api/v1/rpc/endpoints` to the page `ApiSourceFooter`.

## Screenshots

| Before | After |
| --- | --- |
| `/endpoints` showed stat strip, RPC pools, and callable endpoints only — no section for the base-layer `rpc-endpoints` artifact. | New **Base-layer RPC catalog** section appears after RPC pools: three summary tiles (catalog count, archive-capable, healthy/ok + status mix hint) and a table of chain-scoped `subtensor-rpc` / `subtensor-wss` rows (kind, provider, URL, status, latency, block, archive, authority/classification). |

## Test plan

- [x] `npm run test --workspace=apps/ui -- src/lib/metagraphed/queries.rpc-endpoints.test.ts`
- [ ] Load `/endpoints` locally and confirm the new section renders with live API data
- [ ] Verify `ApiSourceFooter` lists `/api/v1/rpc/endpoints`

## Non-goals (per issue)

- No backend / `src/contracts.mjs` changes
- No endpoint-pools composition section (#3349)
- No extra filter/sort/pagination on the new table
