### PR TITLE
feat(registry): add SN65 TAO Private Network min-compute-spec data-artifact surface (#4073)

### DIFF
--- a/registry/subnets/tao-private-network.json
+++ b/registry/subnets/tao-private-network.json
@@ -54,6 +54,25 @@
         "https://api.taoprivatenetwork.com/docs/getting-started/"
       ],
       "url": "https://api.taoprivatenetwork.com/api/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tpn-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "TAO Private Network minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official taofu-labs/tpn-subnet repository as min_compute.yml. Documents SN65 operator CPU/GPU/memory/storage/network floors.",
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://github.com/taofu-labs/tpn-subnet/blob/main/min_compute.yml",
+        "https://github.com/taofu-labs/tpn-subnet"
+      ],
+      "url": "https://raw.githubusercontent.com/taofu-labs/tpn-subnet/main/min_compute.yml"
     }
   ],
   "website_url": "https://tpn.taofu.xyz/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/tao-private-network.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 65
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/taofu-labs/tpn-subnet/main/min_compute.yml
- Source URL (proves the claim): https://github.com/taofu-labs/tpn-subnet/blob/main/min_compute.yml (the file itself, in the subnet's already-registered official source repo), plus https://github.com/taofu-labs/tpn-subnet (the repo root)
- Provider slug: taofu-labs (already registered, already used by this file's two existing `openapi`/`subnet-api` surfaces)

Live no-auth YAML file at the root of the official source repository documenting miner/validator minimum hardware requirements (CPU/GPU/memory/storage/network). Same `min_compute.yml`-as-`data-artifact` pattern already accepted elsewhere in the registry (e.g. `quantum-compute.json`, `enigma.json`, `djinn.json`, `talkhead.json`). Fills a real gap for this file, which previously had no `data-artifact` surface.

Closes #4073

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4073`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/tao-private-network.json` — passed (3 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/tao-private-network.json` — passed