### PR TITLE
feat(ui): surface account stake-moves activity on the account detail page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -43,6 +43,8 @@ import type {
   AccountEventsPage,
   AccountHistory,
   AccountPortfolio,
+  AccountStakeMoves,
+  AccountStakeMovesSubnet,
   AccountRegistration,
   AccountSubnets,
   AccountSummary,
@@ -203,6 +205,7 @@ const MAX_EXTRINSIC_COLLECTION_ENTRIES = 64;
 const MAX_EXTRINSIC_STRING_LENGTH = 2_000;
 const MAX_ACCOUNT_REGISTRATIONS = 100;
 const MAX_ACCOUNT_POSITIONS = 256;
+const MAX_ACCOUNT_STAKE_MOVES_SUBNETS = 128;
 const MAX_ACCOUNT_HISTORY_DAYS = 180;
 const MAX_ACCOUNT_DAY_EVENT_KINDS = 32;
 const MAX_CHAIN_ACTIVITY_DAYS = 31;
@@ -2394,6 +2397,50 @@ export const accountSubnetsQuery = (ss58: string) =>
 // #3491: the economics-rich companion to accountSubnetsQuery — every neuron
 // position under this hotkey with stake/emission/yield, plus wallet aggregates.
 // Non-blocking on the entity page; a cold wallet returns an empty positions[].
+function normalizeAccountStakeMovesSubnet(raw: unknown): AccountStakeMovesSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    movements: coerceFiniteNumber(raw.movements) ?? 0,
+    first_moved_at: firstString(raw.first_moved_at) ?? null,
+    last_moved_at: firstString(raw.last_moved_at) ?? null,
+  };
+}
+
+export const accountStakeMovesQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-stake-moves", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/stake-moves`, {
+        params: { window: "30d" },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const subnets = Array.isArray(d.subnets)
+        ? d.subnets.slice(0, MAX_ACCOUNT_STAKE_MOVES_SUBNETS).flatMap((row) => {
+            const n = normalizeAccountStakeMovesSubnet(row);
+            return n ? [n] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.address) ?? ss58,
+          window: firstString(d.window) ?? "30d",
+          total_movements: firstFiniteNumber(d.total_movements) ?? 0,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? subnets.length,
+          concentration: firstFiniteNumber(d.concentration) ?? null,
+          dominant_netuid: firstFiniteNumber(d.dominant_netuid) ?? null,
+          subnets,
+        } as AccountStakeMoves,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountStakeMoves>;
+    },
+    staleTime: STALE_MED,
+  });
+
 export const accountPortfolioQuery = (ss58: string) =>
   queryOptions({
     queryKey: k("account-portfolio", ss58),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1141,6 +1141,22 @@ export interface PortfolioConcentration {
  * counts, overall return, stake concentration). Richer than the registrations-only
  * AccountSubnets footprint.
  */
+export interface AccountStakeMovesSubnet {
+  netuid: number;
+  movements: number;
+  first_moved_at?: string | null;
+  last_moved_at?: string | null;
+}
+export interface AccountStakeMoves {
+  ss58: string;
+  window: string;
+  total_movements: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountStakeMovesSubnet[];
+  [key: string]: unknown;
+}
 export interface AccountPortfolio {
   ss58: string;
   captured_at?: string | null;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -35,6 +35,7 @@ import { AccountHistoryChart } from "@/components/metagraphed/account-history-ch
 import {
   accountAxonRemovalsQuery,
   accountPortfolioQuery,
+  accountStakeMovesQuery,
   accountDeregistrationsQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
@@ -257,6 +258,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
 
       <AccountPortfolioSection ss58={ss58} />
+      <AccountStakeMovesSection ss58={ss58} />
 
       <AccountTeardownActivitySection ss58={ss58} />
 
@@ -603,6 +605,122 @@ function fmtTaoCompact(v?: number | null): string {
 // per-subnet position table (netuid, role, stake, emission, incentive). Non-
 // blocking: while it loads or if it fails, the rest of the account page is
 // unaffected.
+function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountStakeMovesQuery(ss58));
+  const m = result.data?.data;
+
+  if (result.isPending && !m) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="stake-moves"
+        title="Stake moves"
+        subtitle="Where this account re-delegated stake over the window: total movements, the subnets it moved across, and the per-subnet breakdown."
+      />
+    );
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="stake-moves"
+        title="Stake moves"
+        subtitle="Where this account re-delegated stake over the window: total movements, the subnets it moved across, and the per-subnet breakdown."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load stake moves"
+          description="The stake-moves tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  const subnets = m?.subnets ?? [];
+  if (!m || subnets.length === 0) return null;
+  const rows = [...subnets].sort((a, b) => b.movements - a.movements).slice(0, 20);
+
+  return (
+    <SectionAnchor
+      id="stake-moves"
+      title="Stake moves"
+      subtitle="Where this account re-delegated stake over the window: total movements, the subnets it moved across, and the per-subnet breakdown."
+      tone="accent"
+      info="Re-delegation activity for this account, from /api/v1/accounts/{ss58}/stake-moves — total movements over the window, how concentrated they are, the dominant subnet, and the per-subnet breakdown."
+      right={<SectionBadge tone="accent">{formatNumber(m.subnet_count)} subnets</SectionBadge>}
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile
+          icon={Activity}
+          eyebrow="Movements"
+          tone="accent"
+          value={formatNumber(m.total_movements)}
+          hint={`over ${m.window}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Subnets moved"
+          value={formatNumber(m.subnet_count)}
+          hint="distinct subnets"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Scale}
+          eyebrow="Concentration"
+          value={m.concentration != null ? m.concentration.toFixed(4) : "—"}
+          hint="0 = spread, 1 = single"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Sparkles}
+          eyebrow="Dominant subnet"
+          value={m.dominant_netuid != null ? `SN${m.dominant_netuid}` : "—"}
+          hint="most-moved"
+          className={KPI_TILE}
+        />
+      </div>
+      <DataPanel>
+        <table className="w-full text-left text-sm">
+          <thead className="bg-surface/50">
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={`${TH} text-right`}>Movements</th>
+              <th className={`${TH} text-right`}>Last moved</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((s) => (
+              <tr key={s.netuid} className="hover:bg-surface/30">
+                <td className="px-5 py-4 font-mono text-[12px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: s.netuid }}
+                    className="text-ink hover:text-accent hover:underline"
+                  >
+                    SN{s.netuid}
+                  </Link>
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {formatNumber(s.movements)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
+                  {s.last_moved_at ? <TimeAgo at={s.last_moved_at} /> : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </DataPanel>
+      {subnets.length > rows.length ? (
+        <p className="mt-3 font-mono text-[10px] text-ink-muted">
+          Showing the {rows.length} most-active of {formatNumber(subnets.length)} subnets.
+        </p>
+      ) : null}
+    </SectionAnchor>
+  );
+}
+
 function AccountPortfolioSection({ ss58 }: { ss58: string }) {
   const result = useQuery(accountPortfolioQuery(ss58));
   const p = result.data?.data;


### PR DESCRIPTION
Closes #3732

Surfaces per-account **stake-moves (re-delegation) activity** on the account detail page, mirroring the existing `AccountPortfolioSection` in the same file. Wires the live `GET /api/v1/accounts/{ss58}/stake-moves` aggregate.

## What it adds
- **Data layer** — `AccountStakeMoves` (+ `AccountStakeMovesSubnet`) in `types.ts`, and `accountStakeMovesQuery` + normalizer in `queries.ts`, following the exact `accountPortfolioQuery` pattern (`ss58PathSegment`, `apiFetch`, `isRecord`/`coerceFiniteNumber` normalize).
- **UI** — an `AccountStakeMovesSection` on `accounts.$ss58.tsx`, rendered after the Portfolio section, with the same loading / error / empty-→null behaviour:
  - KPI tiles: **total movements**, **subnets moved**, **concentration**, and the **dominant subnet**,
  - a per-subnet table (movements + last-moved), **capped to the 20 most-active** with a "showing N of M" note so it stays compact on high-activity accounts,
  - degrades to `null` when the account has no moves in the window (optional enrichment tier, doesn't affect the rest of the page).

No changes outside these three files. Reuses the file's `AccountFeedSectionSkeleton` / `SectionAnchor` / `SectionBadge` / `DataPanel` / `KPI_TILE` / `TimeAgo`.

## Verification
`tsc --noEmit` clean · `eslint .` clean (no new warnings) · `prettier --check` clean (prettier 3.9.4, per lockfile) · `vite build` clean.

## Screenshots
Real renders against a live account with re-delegation activity (`5E9fVY1jexCNVMjd2rdBsAxeamFGEMfzHcyTn2fHgdHeYc5p` — 234 movements across 89 subnets). Section element, desktop / tablet / mobile × light + dark, all under 2000px.

| | Light | Dark |
|---|---|---|
| **Desktop** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/acct-stakemoves-shots/data-desktop-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/acct-stakemoves-shots/data-desktop-dark.png) |
| **Tablet** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/acct-stakemoves-shots/data-tablet-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/acct-stakemoves-shots/data-tablet-dark.png) |
| **Mobile** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/acct-stakemoves-shots/data-mobile-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/acct-stakemoves-shots/data-mobile-dark.png) |
