### PR TITLE
feat(ui): add a chain-head tip to the home hero

### DIFF
--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -36,6 +36,7 @@ import { QuickActionsRow } from "@/components/metagraphed/quick-actions-row";
 import { ContinueExploring } from "@/components/metagraphed/continue-exploring";
 
 import {
+  blocksQuery,
   coverageQuery,
   freshnessQuery,
   healthQuery,
@@ -285,6 +286,25 @@ function OverviewPage() {
 
 /* ----------------------------- hero ----------------------------- */
 
+// #3372: a compact chain-head tip in the hero — "head #NNNN · N ago" from the
+// live /api/v1/blocks feed (limit 1), linking to that block. Plain useQuery so a
+// cold/failed fetch silently renders null and never disrupts the primary hero.
+function ChainHeadTip() {
+  const { data } = useQuery(blocksQuery({ limit: 1 }));
+  const head = data?.data?.[0];
+  if (!head || head.block_number == null) return null;
+  return (
+    <Link
+      to="/blocks/$ref"
+      params={{ ref: String(head.block_number) }}
+      className="mg-fade-in mg-fade-in-delay-3 mt-4 inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted hover:text-accent transition-colors"
+    >
+      <span className="mg-live-dot" />
+      head #{formatNumber(head.block_number)} · <TimeAgo at={head.observed_at} />
+    </Link>
+  );
+}
+
 function HomeHero() {
   return (
     <section className="mg-hero-slab relative overflow-hidden px-6 py-12 md:px-12 md:py-20">
@@ -316,6 +336,7 @@ function HomeHero() {
               Read the API
             </Link>
           </div>
+          <ChainHeadTip />
         </div>
         <div className="mg-fade-in mg-fade-in-delay-2 shrink-0">
           <HeroKpis />


### PR DESCRIPTION
## What

Adds a compact **chain-head tip** to the home hero — `● head #NNNN · N ago` — sourced from the live `/api/v1/blocks` feed (`limit 1`) and linking to that block's detail page. The hero already advertises "Live · Read-only" but surfaced no chain head; this shows it as a caption-style pointer below the CTAs, without competing with the Registry Pulse panel.

## How

- **`apps/ui/src/routes/index.tsx`** — new `ChainHeadTip` component using the existing `blocksQuery({ limit: 1 })` via plain `useQuery` (renders `null` on a cold/failed fetch, matching the hero-adjacent module convention), mounted right after the hero CTA row.

No data-layer change: `blocksQuery` / `normalizeBlock` / the `Block` type are reused as-is.

## Screenshots (home — live api.metagraph.sh)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-light-after.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-desktop-dark-after.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-light-after.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-tablet-dark-after.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-light-after.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/home-chainhead-mobile-dark-after.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] Diff touches `apps/ui/src/routes/index.tsx`
- [x] Component calls `blocksQuery` via `useQuery`
- [x] Renders `head #<block_number>` + `<TimeAgo>`, linking to `/blocks/$ref`
- [x] Loading/empty render `null` (silent); errors swallowed
- [x] No sparkline (#3383), no explorer.tsx (#3373), no polling infra (#3371), no data-layer change

## Gates

`npm run typecheck` ✓ · `eslint` (my code) ✓

Closes #3372