### PR TITLE
feat(registry): add SN4 Targon miner-stats subnet-api surface

### DIFF
--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -172,6 +172,28 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Official Targon Stats dashboard (page title \"Targon Stats\"). Its first-party ownership is proven by the official manifold-inc/targon CLI source, which names https://stats.targon.com as a default endpoint host."
+    },
+    {
+      "id": "sn-4-targon-miner-stats-api",
+      "name": "Targon miner stats API",
+      "kind": "subnet-api",
+      "url": "https://stats.targon.com/api/miners",
+      "provider": "targon",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": ["https://stats.targon.com/docs"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "notes": "Public no-auth JSON endpoint returning live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), documented as 'Get All Miners' in the official Targon Stats HTTP API docs."
     }
   ],
   "social": { "x": "https://x.com/targoncompute" },


### PR DESCRIPTION
## Summary

Resubmission of #4416 with **both requested fixes applied verbatim**:

1. **Kind corrected to `subnet-api`** — `https://stats.targon.com/api/miners` is a dynamic, queryable JSON endpoint, so it now follows the same kind convention as the existing `sn-4-targon-subnet-api` (`api.targon.com/tha/v2/inventory`) instead of `data-artifact`.
2. **Standard probe block added** (`GET` / `json` / `timeout_ms: 10000`) so the build's health verification covers this live endpoint exactly like the sibling `sn-4-targon-subnet-api`, `sn-4-targon-sdk`, and `sn-4-targon-stats-dashboard` surfaces.

Also applied the review nit: the `notes` field is trimmed to facts only.

The surface itself: live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), fetching publicly with no auth (HTTP 200, `application/json`), documented as **"Get All Miners — GET https://stats.targon.com/api/miners"** in Targon's own Stats HTTP API docs (`https://stats.targon.com/docs`, which marks the sibling `attest/error` route as the auth-protected one). Distinct by URL from the registered inventory subnet-api and stats dashboard.

One file changed, append-only: `registry/subnets/targon.json` (existing surfaces and key order untouched).

## Validation

- `npm run validate:surface -- registry/subnets/targon.json` — passed (8 surfaces)
- `npx prettier --check registry/subnets/targon.json` — clean
- Endpoint re-verified live immediately before opening (200, `application/json`)

Closes #4001