### PR TITLE
feat(registry): add SN107 Minos min-compute-spec data-artifact surface (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Minos minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official minos-protocol/minos_subnet repository as min_compute.yml. Documents SN107 operator CPU/GPU/memory/storage requirements for the genomic variant-calling (GATK HaplotypeCaller / DeepVariant) workload.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml",
+        "https://github.com/minos-protocol/minos_subnet"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/minos.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 107
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml
- Source URL (proves the claim): https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml (the file itself, in the subnet's already-registered official source repo), plus https://github.com/minos-protocol/minos_subnet (the repo root)
- Provider slug: minos (already registered)

Live no-auth YAML file at the root of the official source repository documenting miner/validator minimum hardware requirements (CPU/GPU/memory/storage) for the genomic variant-calling (GATK HaplotypeCaller / DeepVariant) workload. Same `min_compute.yml`-as-`data-artifact` pattern already accepted elsewhere in the registry (e.g. `quantum-compute.json`, `enigma.json`, `tao-private-network.json`). Fills a real gap for this file, which previously had only one `subnet-api` surface.

Closes #4141

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4141`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/minos.json` — passed (2 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/minos.json` — passed
- [x] Live curl of the URL immediately before submission: `200`