### PR TITLE
fix(ui): flex-wrap the economics panel tile grid so trailing rows stretch to fill

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -132,7 +132,11 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
   if (!e) return <Notice>No on-chain economic data for this subnet.</Notice>;
 
   return (
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    // Flex-wrap (not grid) so a trailing partial row's tiles stretch to fill
+    // the row instead of leaving empty column slots — grid tracks are shared
+    // across every row, but flex lines size independently (same pattern as
+    // the stat spine in subnet-masthead.tsx / operational-panel.tsx).
+    <div className="flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[200px]">
       <StatTile
         eyebrow="Emission share"
         tone="accent"


### PR DESCRIPTION
Closes #3986

## What
Replaces the economics panel's fixed `grid sm:grid-cols-2 lg:grid-cols-4` tile layout with a flex-wrap layout (`flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[200px]`) so a trailing partial row's tiles stretch to fill the row instead of leaving empty column slots.

## Why
With 10 tiles today (8 base + `StakeMovesTile` + `StakeTransfersTile`), the old `lg:grid-cols-4` grid left a mostly-empty final row on desktop, and `sm:grid-cols-2` did the same at tablet width — a fixed column count doesn't evenly divide an arbitrary, growing tile count. This is the exact same problem already solved elsewhere in this codebase: `subnet-masthead.tsx`'s stat spine and `operational-panel.tsx`'s flex strips both use flex-wrap with `grow`/`basis` instead of CSS grid for this reason (grid tracks are shared across every row; flex lines size independently, so a short trailing row's items grow to fill it). This PR applies the same established pattern to the economics panel.

## Why this is robust to future tile-count changes
Flex-wrap with `grow`/`basis` naturally distributes remaining row width across however many tiles land in the last row — it doesn't special-case any particular count (5, 6, 10, whatever). Adding an 11th tile tomorrow can't reintroduce the sparse-row problem, unlike a fix that just changed the grid's column count to divide evenly for exactly today's count.

## Screenshots

SN7's Economics panel, desktop (1280×800) and tablet (768×1024), both themes:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-economics-panel-3986/after-tablet-dark.png)<br><sub>after</sub> |

## Acceptance criteria
- [x] `economics-panel.tsx` appears in the diff
- [x] With 10 tiles (current count), the grid no longer leaves a sparse, mostly-empty final row at desktop or tablet width
- [x] The fix is robust to future tile-count changes (flex-wrap grow/basis, not a hardcoded column-count tweak for exactly 10 tiles)
- [x] Before/after screenshot table at desktop and tablet, both themes

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean (aside from pre-existing CRLF-only diffs unrelated to this change).
- Diff is 5 insertions / 1 deletion in a single file — only the container's layout classes changed, no tile content/logic touched.
