### PR TITLE
feat(ui): add a network-wide validator-turnover section to the chain explorer

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -57,6 +57,9 @@ import type {
   ChainStakeFlowNetwork,
   ChainStakeFlowSubnet,
   ChainStakeMoves,
+  ChainTurnover,
+  ChainTurnoverNetwork,
+  ChainTurnoverSubnet,
   ChainStakeMovesDistribution,
   ChainStakeMovesNetwork,
   ChainStakeMovesSubnet,
@@ -209,6 +212,7 @@ const MAX_CHAIN_ACTIVITY_DAYS = 31;
 const MAX_CHAIN_CALLS = 12;
 const MAX_STAKE_FLOW_SUBNETS = 24;
 const MAX_STAKE_MOVES_SUBNETS = 24;
+const MAX_TURNOVER_SUBNETS = 24;
 // The endpoint returns the top 100 pallet.method groups, busiest first.
 const MAX_CHAIN_EVENT_GROUPS = 100;
 const DEFAULT_CHAIN_EVENT_BLOCKS = 1000;
@@ -3227,6 +3231,64 @@ export const chainStakeMovesQuery = (window: ChainWindow = "7d") =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainStakeMoves>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeChainTurnoverNetwork(raw: unknown): ChainTurnoverNetwork | null {
+  if (!isRecord(raw)) return null;
+  return {
+    validators_start: coerceFiniteNumber(raw.validators_start) ?? 0,
+    validators_end: coerceFiniteNumber(raw.validators_end) ?? 0,
+    validators_entered: coerceFiniteNumber(raw.validators_entered) ?? 0,
+    validators_exited: coerceFiniteNumber(raw.validators_exited) ?? 0,
+    validator_retention: coerceFiniteNumber(raw.validator_retention) ?? null,
+    stability_score: coerceFiniteNumber(raw.stability_score) ?? null,
+  };
+}
+
+function normalizeChainTurnoverSubnet(raw: unknown): ChainTurnoverSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    validators_start: coerceFiniteNumber(raw.validators_start) ?? 0,
+    validators_end: coerceFiniteNumber(raw.validators_end) ?? 0,
+    validators_entered: coerceFiniteNumber(raw.validators_entered) ?? 0,
+    validators_exited: coerceFiniteNumber(raw.validators_exited) ?? 0,
+    validator_retention: coerceFiniteNumber(raw.validator_retention) ?? null,
+    stability_score: coerceFiniteNumber(raw.stability_score) ?? null,
+  };
+}
+
+export const chainTurnoverQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-turnover", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/turnover", {
+        params: { window },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: 1,
+          window,
+          start_date: firstString(d.start_date) ?? null,
+          end_date: firstString(d.end_date) ?? null,
+          comparable: d.comparable === true,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          network: normalizeChainTurnoverNetwork(d.network),
+          subnets: normalizeChainRows(
+            d.subnets,
+            MAX_TURNOVER_SUBNETS,
+            normalizeChainTurnoverSubnet,
+          ),
+        } as ChainTurnover,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainTurnover>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1961,6 +1961,33 @@ export interface ChainStakeFlow {
   net_flow_distribution: ChainStakeFlowDistribution | null;
   subnets: ChainStakeFlowSubnet[];
 }
+export interface ChainTurnoverNetwork {
+  validators_start: number;
+  validators_end: number;
+  validators_entered: number;
+  validators_exited: number;
+  validator_retention: number | null;
+  stability_score: number | null;
+}
+export interface ChainTurnoverSubnet {
+  netuid: number;
+  validators_start: number;
+  validators_end: number;
+  validators_entered: number;
+  validators_exited: number;
+  validator_retention: number | null;
+  stability_score: number | null;
+}
+export interface ChainTurnover {
+  schema_version: number;
+  window: string;
+  start_date: string | null;
+  end_date: string | null;
+  comparable: boolean;
+  subnet_count: number;
+  network: ChainTurnoverNetwork | null;
+  subnets: ChainTurnoverSubnet[];
+}
 export interface ChainStakeMovesNetwork {
   distinct_movers: number;
   movements: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -25,6 +25,7 @@ import {
   chainSignersQuery,
   chainStakeFlowQuery,
   chainStakeMovesQuery,
+  chainTurnoverQuery,
   chainStakeTransfersQuery,
   chainTransferPairsQuery,
 } from "@/lib/metagraphed/queries";
@@ -37,6 +38,7 @@ import type {
   ChainEventsStats,
   ChainStakeFlow,
   ChainStakeMoves,
+  ChainTurnover,
 } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
@@ -105,6 +107,7 @@ function ExplorerPage() {
           "/api/v1/chain/signers",
           "/api/v1/chain/stake-flow",
           "/api/v1/chain/stake-moves",
+          "/api/v1/chain/turnover",
           "/api/v1/chain/stake-transfers",
           "/api/v1/chain-events",
           "/api/v1/chain-events/stats",
@@ -509,6 +512,103 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
   );
 }
 
+/**
+ * Network-wide validator-set turnover (#3473) — how much each subnet's validator
+ * set churned over the window (entered / exited, retention, stability), plus the
+ * most volatile subnets. Chain-direct: GET /api/v1/chain/turnover. Placed here
+ * alongside the sibling network-chain sections; the issue names /leaderboards,
+ * which does not exist yet.
+ */
+function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
+  const net = turnover.network;
+  // Most volatile first (lowest stability score); bar width ~ total churn.
+  const volatile = [...turnover.subnets]
+    .sort((a, b) => (a.stability_score ?? 100) - (b.stability_score ?? 100))
+    .slice(0, 12);
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Validator turnover
+        </h2>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(turnover.subnet_count)} subnets
+        </span>
+      </div>
+
+      {net ? (
+        <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <StakeFlowMetric
+            label="Retention"
+            value={
+              net.validator_retention != null
+                ? `${(net.validator_retention * 100).toFixed(1)}%`
+                : "—"
+            }
+            tone="ok"
+          />
+          <StakeFlowMetric label="Entered" value={formatNumber(net.validators_entered)} />
+          <StakeFlowMetric label="Exited" value={formatNumber(net.validators_exited)} />
+          <StakeFlowMetric
+            label="Stability"
+            value={net.stability_score != null ? `${formatNumber(net.stability_score)}/100` : "—"}
+          />
+        </div>
+      ) : null}
+
+      {volatile.length > 0 ? (
+        <div>
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Most volatile subnets
+          </div>
+          <ul className="space-y-1.5">
+            {volatile.map((s) => {
+              const pct = Math.max(
+                2,
+                Math.round((s.validator_retention != null ? 1 - s.validator_retention : 0) * 100),
+              );
+              return (
+                <li key={s.netuid}>
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: s.netuid }}
+                    className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
+                  >
+                    <span className="truncate font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                      SN{s.netuid}
+                    </span>
+                    <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
+                      <span
+                        className="absolute inset-y-0 left-0 rounded-full"
+                        style={{ width: `${pct}%`, background: "var(--health-warn)" }}
+                      />
+                    </span>
+                    <span className="text-right font-mono text-[10px] tabular-nums text-ink-strong">
+                      {s.validator_retention != null
+                        ? `${Math.round(s.validator_retention * 100)}% kept`
+                        : "—"}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">No turnover in this window yet.</p>
+      )}
+
+      {net ? (
+        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+          Validator set {formatNumber(net.validators_start)} to {formatNumber(net.validators_end)}{" "}
+          over {turnover.window}, across {formatNumber(turnover.subnet_count)} subnets.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -520,6 +620,7 @@ function ExplorerDashboard() {
   const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
   const stakeFlow = useSuspenseQuery(chainStakeFlowQuery(win)).data.data;
   const stakeMoves = useSuspenseQuery(chainStakeMovesQuery(win)).data.data;
+  const turnover = useSuspenseQuery(chainTurnoverQuery(win)).data.data;
   const stakeTransfers = useSuspenseQuery(chainStakeTransfersQuery(win)).data.data;
   const eventMix = useSuspenseQuery(chainEventsStatsQuery()).data.data;
 
@@ -812,6 +913,8 @@ function ExplorerDashboard() {
       <StakeFlowSection flow={stakeFlow} />
 
       <StakeMovesSection moves={stakeMoves} />
+
+      <ValidatorTurnoverSection turnover={turnover} />
 
       {/* stake-transfer leaderboard */}
       <section className="rounded-lg border border-border bg-card p-5">


### PR DESCRIPTION
Closes #3473

Adds a network-wide **Validator turnover** section (the "most volatile validator sets" view) to the chain explorer, mirroring the existing `StakeFlowSection` / `StakeMovesSection` in the same file. Wires the live `GET /api/v1/chain/turnover` aggregate.

## What it adds
- **Data layer** — `ChainTurnover` (+ `…Network` / `…Subnet`) in `types.ts`, and `chainTurnoverQuery` + normalizers in `queries.ts`, following the exact `chainStakeMovesQuery` pattern.
- **UI** — a `ValidatorTurnoverSection` in `explorer.tsx`, fetched with `useSuspenseQuery(chainTurnoverQuery(win))` and rendered after Stake moves:
  - network **retention**, **entered**, **exited**, and a **stability score**,
  - a **most-volatile-subnets** bar list (ranked by lowest retention; the bar length is the volatility, `1 − retention`, so it tracks the ranking), each linking to the subnet,
  - a footnote with the network validator-count delta over the window.

Honors the `7d` / `30d` window toggle. No changes outside these three files. Reuses the file's `StakeFlowMetric`.

> **Placement note:** the issue names `/leaderboards`, which doesn't exist in the route tree yet. I've placed this network-wide turnover section on the explorer alongside its sibling network-chain aggregates (Stake flow, Stake moves) as the natural current home — happy to move it to `/leaderboards` if/when that route lands.

## Verification
`tsc --noEmit` clean · `eslint .` clean (no new warnings) · `prettier --check` clean (prettier 3.9.4, per lockfile) · `vite build` clean.

## Screenshots

> **Note on the data shown.** As with the sibling Stake flow / Stake moves sections, the `/api/v1/chain/*` family is served an empty edge-cache variant to browser clients (`vary: Accept, Accept-Encoding`, `cf-cache-status: HIT`), so these render empty in a live browser today. Server-side, `GET /api/v1/chain/turnover` returns a full payload (129 subnets, 1019→1041 validators, 66 entered / 44 exited). The populated shots below render the section against that live payload (captured server-side, injected via a Playwright route mock); the empty state is included last.

### Populated (live `/chain/turnover` payload) — desktop / tablet / mobile × light + dark

| | Light | Dark |
|---|---|---|
| **Desktop** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/data-desktop-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/data-desktop-dark.png) |
| **Tablet** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/data-tablet-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/data-tablet-dark.png) |
| **Mobile** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/data-mobile-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/data-mobile-dark.png) |

### Empty state (what a live browser renders today)

| Light | Dark |
|---|---|
| ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/empty-desktop-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/turnover-shots/empty-desktop-dark.png) |
