### PR TITLE
feat(ui): surface serving + prometheus endpoint-announcement tiles in the operational panel (#3481)

### DIFF
--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -7,6 +7,8 @@ import {
   subnetHealthTrendsQuery,
   subnetEndpointsQuery,
   subnetAxonRemovalsQuery,
+  subnetServingQuery,
+  subnetPrometheusQuery,
   flattenSurfaceIncidents,
 } from "@/lib/metagraphed/queries";
 import type {
@@ -170,6 +172,8 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
             columns); #3481 (serving/prometheus) tiles wrap in alongside it. */}
           <div className="flex flex-wrap divide-x divide-border border-b border-border">
             <AxonRemovalsStat netuid={netuid} />
+            <ServingActivityStat netuid={netuid} />
+            <PrometheusActivityStat netuid={netuid} />
           </div>
 
           {!filter.isAll ? (
@@ -363,6 +367,50 @@ function AxonRemovalsStat({ netuid }: { netuid: number }) {
       value={value}
       tone={removals > 0 ? "warn" : "default"}
       hint={`Axon (serving-endpoint) removals for SN${netuid} over the ${win} window — ${removers} distinct ${removers === 1 ? "remover" : "removers"}. Source: /api/v1/subnets/{netuid}/axon-removals.`}
+    />
+  );
+}
+
+/**
+ * #3481: endpoint-announcement activity KPIs — serving (axon) and Prometheus
+ * endpoint announcements for this subnet over the trailing window, from the
+ * already-shipped subnetServingQuery / subnetPrometheusQuery (#3675). Each
+ * endpoint returns a flat window aggregate, so they render as single `Stat`
+ * tiles matching the health ribbon convention: "…" while pending, "—" on error,
+ * the distinct-announcer count otherwise.
+ */
+function ServingActivityStat({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetServingQuery(netuid));
+  const s = res?.data;
+  const servers = s?.distinct_servers ?? 0;
+  const win = s?.window ?? "30d";
+  const value = isError ? "—" : isPending && !s ? "…" : formatNumber(servers);
+  return (
+    <Stat
+      label={`Serving · ${win}`}
+      value={value}
+      tone={servers > 0 ? "ok" : "default"}
+      hint={`Distinct axon serving-endpoint announcers for SN${netuid} over the ${win} window — ${formatNumber(
+        s?.announcements ?? 0,
+      )} announcements. Source: /api/v1/subnets/{netuid}/serving.`}
+    />
+  );
+}
+
+function PrometheusActivityStat({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetPrometheusQuery(netuid));
+  const p = res?.data;
+  const exporters = p?.distinct_exporters ?? 0;
+  const win = p?.window ?? "30d";
+  const value = isError ? "—" : isPending && !p ? "…" : formatNumber(exporters);
+  return (
+    <Stat
+      label={`Prometheus · ${win}`}
+      value={value}
+      tone={exporters > 0 ? "ok" : "default"}
+      hint={`Distinct Prometheus exporter announcers for SN${netuid} over the ${win} window — ${formatNumber(
+        p?.announcements ?? 0,
+      )} announcements. Source: /api/v1/subnets/{netuid}/prometheus.`}
     />
   );
 }


### PR DESCRIPTION
## Summary

Closes #3481

Wires the already-shipped `subnetServingQuery` + `subnetPrometheusQuery` (#3675) into the subnet **Operational status** panel as two endpoint-announcement KPI tiles — **Serving** (distinct axon serving-endpoint announcers) and **Prometheus** (distinct exporter announcers) — in the same flex strip as the axon-removals teardown tile. Each mirrors the existing
`AxonRemovalsStat` convention (`…` while pending, `—` on error, the distinct-announcer count otherwise) and carries a tooltip citing its source endpoint.

**UI-only** — `queries.ts`/`types.ts` untouched (the typed data layer already shipped and is tested in #3675), per the issue's non-goals.

## Acceptance criteria
- [x] Consumes `subnetServingQuery` + `subnetPrometheusQuery` via `useQuery`
- [x] Renders serving + Prometheus endpoint-announcement KPI tiles in `operational-panel.tsx`
- [x] Loading (`…`) / error (`—`) states match the panel's health-ribbon convention

## Validation
- `npm run typecheck -w apps/ui` — pass
- `npm run lint` (changed file) — 0 errors
- `npm run test -w apps/ui` — 537 passed
- `npm run build -w apps/ui` — pass

Single-file, append-only diff (`apps/ui/src/components/metagraphed/operational-panel.tsx`, +48/-0); no generated artifacts touched.

## Screenshots

Subnet **Operational status** panel (SN64), same crop before/after. Before: `Teardowns` only.
After: `Teardowns · Serving · Prometheus`. 3 viewports (1280×800 / 768×1024 / 375×812, fixed) × 2 themes × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1442" height="696" alt="des-lg-be" src="https://github.com/user-attachments/assets/9b299358-51e9-4647-8b82-d8454c0b6354" /> | <img width="1394" height="689" alt="des-lg-af" src="https://github.com/user-attachments/assets/c1028623-46d8-4fd5-8d56-080a1b745a59" /> |
| Desktop · Dark | <img width="1394" height="686" alt="des-dk-be" src="https://github.com/user-attachments/assets/9ab68299-0266-44d2-848a-ca7b5dae66d8" /> | <img width="1374" height="689" alt="des-dk-af" src="https://github.com/user-attachments/assets/acf0629f-c3b0-4077-81a6-dd23aebe8bd3" /> |
| Tablet · Light | <img width="672" height="875" alt="tab-lg-be" src="https://github.com/user-attachments/assets/da6ff3e6-d992-467c-8922-32fbba821375" /> | <img width="652" height="885" alt="tab-lg-af" src="https://github.com/user-attachments/assets/3c21d68a-5511-42fa-b3c5-e3ef00ea2e57" /> |
| Tablet · Dark | <img width="688" height="877" alt="tab-dk-be" src="https://github.com/user-attachments/assets/391cff14-ca3d-40b3-b1ec-76c4db3b84f3" /> | <img width="663" height="862" alt="tab-dk-af" src="https://github.com/user-attachments/assets/610ed712-866f-40e8-a840-6b56cb79c268" /> |
| Mobile · Light | <img width="433" height="922" alt="mb-lg-be" src="https://github.com/user-attachments/assets/b6767855-d395-411a-92a5-ffdcafeaead6" /> | <img width="464" height="927" alt="mb-lg-af" src="https://github.com/user-attachments/assets/dfec2f7f-1458-4227-a374-61a291023eab" /> |
| Mobile · Dark | <img width="450" height="918" alt="mb-dk-be" src="https://github.com/user-attachments/assets/6a7a4979-bc4b-4733-ac72-d6001fcf1388" /> | <img width="425" height="927" alt="mb-dk-af" src="https://github.com/user-attachments/assets/68b68694-c185-4fcb-b19f-e19be5b77978" /> |
