### PR TITLE
fix(ui): use shared EmptyState for the extrinsic emitted-events empty case

### DIFF
--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -277,9 +277,10 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             </table>
           </div>
         ) : (
-          <p className="rounded border border-border bg-card/40 px-4 py-6 text-sm text-ink-muted">
-            No emitted events were indexed for this extrinsic.
-          </p>
+          <EmptyState
+            title="No emitted events"
+            description="No emitted events were indexed for this extrinsic."
+          />
         )}
       </SectionAnchor>
 


### PR DESCRIPTION
Closes #3969

## What
`extrinsics.$hash.tsx`'s "Emitted events" section now uses the shared `EmptyState` component for its empty case, matching the two other empty cases already in the same file (invalid-hash and not-found, both using `EmptyState`).

## Why
The "Emitted events" section fell back to a plain `<p>` for its empty case while every other empty case in this file correctly uses the shared `EmptyState` (icon + title + description), so the same underlying situation ("nothing to show here") looked inconsistent depending on which section hit it.

## Changes
- `apps/ui/src/routes/extrinsics.$hash.tsx`: replaced the plain paragraph fallback in the "Emitted events" section with `<EmptyState title="No emitted events" description="No emitted events were indexed for this extrinsic." />`, matching the existing `EmptyState` usage pattern already in this file.

## Screenshots

An extrinsic with zero emitted events (`commit_timelocked_mechanism_weights`), both themes:

| Theme | Before | After |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/before-events-light.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/before-events-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/after-events-light.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/after-events-light.png)<br><sub>after</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/before-events-dark.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/before-events-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/after-events-dark.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-extrinsic-events-3969/after-events-dark.png)<br><sub>after</sub> |

## Acceptance criteria
- [x] `extrinsics.$hash.tsx` appears in the diff
- [x] The "Emitted events" empty case now uses the shared component, consistent with its siblings in the same file
- [x] Populated-events rendering is unaffected (the `events.length > 0` branch is untouched)
- [x] Before/after screenshot table, both themes

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean (pre-existing fast-refresh warnings on this route file are unrelated to this change).
- Diff is 4 insertions / 3 deletions in a single file.
