### PR TITLE
feat(ui): show market-cap and FDV proxy tiles in the subnet economics panel

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -168,6 +168,8 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
       <StatTile eyebrow="Total stake" value={fmtTao(e.total_stake_tao)} />
       <StatTile eyebrow="Volume" value={fmtTao(e.subnet_volume_tao)} />
       <StatTile eyebrow="Max stake" value={fmtTao(e.max_stake_tao)} />
+      <StatTile eyebrow="Market cap" value={fmtTao(e.alpha_market_cap_tao)} hint="proxy" />
+      <StatTile eyebrow="FDV" value={fmtTao(e.alpha_fdv_tao)} hint="proxy" />
       <StatTile
         eyebrow="Registration"
         tone={e.registration_allowed === false ? "down" : "default"}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -278,6 +278,8 @@ function normalizeEconomicsSubnets(value: unknown): SubnetEconomics[] {
         max_stake_tao: optionalNumber(item.max_stake_tao),
         subnet_volume_tao: optionalNumber(item.subnet_volume_tao),
         registration_cost_tao: optionalNumber(item.registration_cost_tao),
+        alpha_market_cap_tao: optionalNumber(item.alpha_market_cap_tao),
+        alpha_fdv_tao: optionalNumber(item.alpha_fdv_tao),
         registration_allowed: booleanValue(item.registration_allowed),
       } satisfies SubnetEconomics,
     ];

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1252,6 +1252,9 @@ export interface SubnetEconomics {
   subnet_volume_tao?: number;
   registration_cost_tao?: number;
   registration_allowed?: boolean;
+  /** Proxy metrics (#3361): alpha_price × total_stake, and alpha_price × ALPHA_MAX_SUPPLY. */
+  alpha_market_cap_tao?: number;
+  alpha_fdv_tao?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## What

Adds **Market cap** and **FDV** tiles to the subnet economics panel, from `alpha_market_cap_tao` / `alpha_fdv_tao` — already computed and served by `/api/v1/economics` but never surfaced in the UI. Both are **proxy** metrics per the backend (`alpha_price × total_stake`; `alpha_price × ALPHA_MAX_SUPPLY`), so each tile carries a `proxy` hint.

> Resubmission of #4417 (closed) with screenshots in the AI-skill format — 3 viewports × 2 themes, before/after. Thanks for the pointer to #3922.

## How

- **`types.ts`** — declare `alpha_market_cap_tao?` / `alpha_fdv_tao?` on `SubnetEconomics`.
- **`queries.ts`** — coerce both via `optionalNumber(...)` in `normalizeEconomicsSubnets`, matching the sibling fields.
- **`economics-panel.tsx`** — two `StatTile`s rendered with the panel's `fmtTao()` helper, alongside the existing tiles.

No backend change (`economicsQuery` already wired and consumed by the panel).

## Screenshots (subnet 64 — Chutes, live api.metagraph.sh)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-light-after.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-desktop-dark-after.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-light-after.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-tablet-dark-after.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-light-after.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/econ-mcap-fdv-mobile-dark-after.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] Diff touches `economics-panel.tsx` (not just `queries.ts`/`types.ts`)
- [x] `SubnetEconomics` declares `alpha_fdv_tao?: number` and `alpha_market_cap_tao?: number`
- [x] `normalizeEconomicsSubnets` coerces both with `optionalNumber(...)`
- [x] Panel renders a "Market cap" tile (`alpha_market_cap_tao`) and an "FDV" tile (`alpha_fdv_tao`) via `fmtTao()`
- [x] Proxy caveat surfaced (`proxy` hint on both tiles)

## Gates

`npm run typecheck` ✓ · `eslint` (my files) ✓

Closes #3361