### PR TITLE
feat(registry): add SN12 Compute Horde health-probe alert-rules data-artifact surface (#4010)

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -132,6 +132,25 @@
         "submitted_by": "galuis116"
       },
       "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
+    },
+    {
+      "id": "sn-12-compute-horde-data-artifact",
+      "name": "Compute Horde health probe alert rules",
+      "kind": "data-artifact",
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/af0956585f957ad05f856b2680673f0fffbe517a/health_probe/envs/dev/rules/ch_health.yml",
+      "provider": "compute-horde",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/health_probe/envs/dev/rules/ch_health.yml",
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/health_probe/README.md"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "notes": "Public no-auth YAML rule set for the official Compute Horde health probe (health_probe/ in the SN12 registered source repository): Prometheus alerting rules (SubnetBusyWarning, SubnetBusyCritical, SubnetBroken) defining when the subnet counts as busy or failing, based on the probe's periodic organic tasks. URL pinned to the immutable commit that last touched the file."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds one community **data-artifact** surface to `registry/subnets/compute-horde.json` (SN12): the official Compute Horde **health probe alert rules** (`ch_health.yml`) from the subnet's registered source repository (`backend-developers-ltd/ComputeHorde`, `health_probe/`). The rules define when the subnet counts as busy or failing (SubnetBusyWarning / SubnetBusyCritical / SubnetBroken) based on the probe's periodic organic tasks — a compact, machine-readable description of the subnet's own health semantics.

Closes #4010

## Validation

- `curl -sI` on the pinned URL: **HTTP 200**, `content-type: text/plain; charset=utf-8`, **1720 bytes**, no auth of any kind. Fetched twice with an identical checksum both times.
- URL is pinned to the immutable commit that last touched the file (`af09565`, 2025-06-20 — stable for over a year); `source_urls` point at the same file on `master` plus the `health_probe/` README that documents it.
- First-party provenance: the file lives in the manifest's registered `source_repo` for SN12; provider slug `compute-horde` matches every existing surface in the file.
- Append-only single-file diff (+19): one new object at the end of `surfaces[]`; existing entries and top-level fields are byte-identical (verified by JSON-diff before committing).
- Duplicate check: the file has website / source-repo / dashboard / sdk / subnet-api surfaces — no data-artifact yet, and no open PR touches `compute-horde.json`.

Artifact snippet for reference:

```
groups:
  - name: Compute Horde Health Probe
    rules:
      - alert: SubnetBusyWarning
        ...
```
