### PR TITLE
feat(registry): add SN26 Perturb burn-rate data-artifact surface (#4023)

### DIFF
--- a/registry/subnets/perturb.json
+++ b/registry/subnets/perturb.json
@@ -31,6 +31,31 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Public no-auth GET returning the Perturb (SN26) backend API health as JSON (status + server timestamp). Hosted on api.perturbai.io, the API subdomain of the subnet's registered website perturbai.io."
+    },
+    {
+      "id": "sn-26-perturb-data-artifact",
+      "name": "Perturb emission burn rate",
+      "kind": "data-artifact",
+      "url": "https://api.perturbai.io/api/v1/burn-rate",
+      "provider": "perturb",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/0xsigurd/Perturb/blob/8da57e5c6a43e29392f52fe9f22883859e7a230d/perturbnet/constants.py",
+        "https://www.perturbai.io/"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "notes": "Public no-auth GET returning SN26 Perturb's current emission burn rate as JSON ({\"burnRate\":0.5} observed at submission time). The endpoint is declared as BURN_RATE_ENDPOINT in the subnet's validator source (perturbnet/constants.py in the official repo, pinned above) and is served from api.perturbai.io, the same host as the already-registered health surface."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds one community **data-artifact** surface to `registry/subnets/perturb.json` (SN26): the subnet's public **emission burn-rate** feed at `https://api.perturbai.io/api/v1/burn-rate`, returning machine-readable JSON (`{"burnRate":0.5}` observed at submission time).

Closes #4023

## Validation

- `curl -s` with no auth: **HTTP 200**, `content-type: application/json; charset=utf-8`, 16 bytes, body `{"burnRate":0.5}`. Retested several times over a few minutes — identical response every time.
- First-party provenance: the endpoint is declared as `BURN_RATE_ENDPOINT` in the subnet's own validator source (`perturbnet/constants.py` in the official `0xsigurd/Perturb` repo — `source_urls[0]` is pinned to the exact commit for durable trace-to-source), and it is served from `api.perturbai.io`, the same host as the already-registered SN26 health surface.
- Provider slug `perturb` matches the existing surface in the file; a `probe` block (GET / expect json / 10s) is included to match the file's existing surface shape.
- Append-only single-file diff (+25): one new object at the end of `surfaces[]`; the existing surface and all top-level fields are byte-identical.
- Duplicate check: the file's only surface is the `/health` subnet-api — no data-artifact exists yet, and no open PR touches `perturb.json`.
