### PR TITLE
feat(registry): add SN10 Swap NonfungiblePositionManager ABI data-artifact surface (#4006)

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -152,6 +152,25 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Public unauthenticated TaoFi (SN10 Swap) API — the servers host declared in the TaoFi OpenAPI schema. POST endpoints return live swap/bridge quotes and transaction call data (verified: getBuyQuote returned an HTTP 200 JSON quote). Documented at taofi-doc.web.app."
+    },
+    {
+      "id": "sn-10-swap-nfpm-abi",
+      "name": "Swap NonfungiblePositionManager contract ABI",
+      "kind": "data-artifact",
+      "url": "https://raw.githubusercontent.com/Swap-Subnet/swap-subnet/main/swap/abi/NonfungiblePositionManager.json",
+      "provider": "taofi",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Swap-Subnet/swap-subnet/blob/main/swap/abi/NonfungiblePositionManager.json",
+        "https://github.com/Swap-Subnet/swap-subnet"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "notes": "Public no-auth Uniswap-V3-style NonfungiblePositionManager contract ABI (46 entries) published in the official Swap-Subnet/swap-subnet repository at swap/abi/NonfungiblePositionManager.json. Used by SN10 Swap's on-chain liquidity-position logic; the same repo is already this file's registered source_repo."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/swap.json` (pure 19-line append, no other file, no reformatting).

## Surface

- Netuid: 10
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/Swap-Subnet/swap-subnet/main/swap/abi/NonfungiblePositionManager.json
- Source URL (proves the claim): https://github.com/Swap-Subnet/swap-subnet/blob/main/swap/abi/NonfungiblePositionManager.json (the file itself, in the subnet's already-registered official source repo), plus https://github.com/Swap-Subnet/swap-subnet (the repo root)
- Provider slug: taofi (already registered)

Live no-auth Uniswap-V3-style NonfungiblePositionManager contract ABI (46 entries, valid JSON) published in the official source repository, used by SN10 Swap's on-chain liquidity-position logic. Same contract-ABI-as-`data-artifact` pattern already accepted elsewhere in the registry (e.g. `tensorusd.json`'s vault ABI). Fills this file's gap note "No verified standalone static data artifact yet."

Closes #4006

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file, append-only (19-line insertion only).
- [x] Matches the existing file's format exactly — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove official ownership.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing surface (file previously had no `data-artifact` kind).
- [x] Links a tracked issue (`Closes #4006`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/swap.json` — passed (6 surfaces across 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/swap.json` — passed