### PR TITLE
feat(data): add subnet hyperparameters refresh workflow + D1 loader

### DIFF
--- a/.github/workflows/refresh-subnet-hyperparams.yml
+++ b/.github/workflows/refresh-subnet-hyperparams.yml
@@ -1,0 +1,116 @@
+name: Refresh Subnet Hyperparameters
+
+# Fetches every active subnet's hyperparameter set FIRST-PARTY via the Bittensor
+# SDK (#4303/1.2 — chain-direct, no Taostats, no API key) and loads it into the
+# metagraphed-health D1 `subnet_hyperparams` table (#4303/1.3). Powers
+# /api/v1/subnets/{netuid}/hyperparameters (#4307/1.4). Daily (hyperparameters
+# change rarely — could even be weekly, but daily costs nothing extra and keeps
+# staleness bounded). The snapshot is signed (sign-staged-neurons.mjs, reused
+# unchanged — same bare-array envelope shape as a legacy neuron snapshot) before
+# staging to R2; the Worker authenticates + bounds it before loading into D1 via
+# its binding (loadStagedSubnetHyperparams) — no API-token D1 permission
+# required. Mirrors refresh-metagraph.yml's fetch/sign-and-stage split exactly.
+on:
+  schedule:
+    - cron: "13 6 * * *" # daily 06:13 UTC — distinct minute from refresh-metagraph's 05:23
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: refresh-subnet-hyperparams
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30 # ~129 individual get_subnet_hyperparameters calls, one per subnet
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+
+      # First-party chain-direct fetch (pinned bittensor, matching refresh-metagraph):
+      # one get_all_metagraphs_info call to discover the active netuid set, then one
+      # get_subnet_hyperparameters(netuid) call per subnet (no bulk variant exists
+      # for this call — see scripts/fetch-subnet-hyperparams.py's docstring).
+      - name: Fetch subnet hyperparameters (Bittensor SDK)
+        run: uvx --from bittensor==10.4.0 python scripts/fetch-subnet-hyperparams.py
+        env:
+          # Same hidden chain-RPC secret as the metagraph/events fetches (ADR 0012).
+          # Unset → the script defaults to "finney"; set it to the private node URL
+          # to route the fetch through our own infra without exposing it.
+          SUBTENSOR_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL }}
+
+      - name: Upload unsigned hyperparameters snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: subnet-hyperparams-unsigned
+          path: dist/metagraph-subnet-hyperparams.json
+          if-no-files-found: error
+          retention-days: 1
+
+  sign-and-stage:
+    needs: fetch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Keep the secret-bearing job in a fresh workspace. The unpinned PyPI
+      # execution boundary above can only pass the JSON data artifact forward, not
+      # mutated repository scripts, shell startup files, or node_modules.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+
+      - name: Install
+        run: npm ci
+
+      - name: Download unsigned hyperparameters snapshot
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: subnet-hyperparams-unsigned
+          path: dist
+
+      # scripts/sign-staged-neurons.mjs is generic over any bare-array snapshot
+      # (no neuron-specific logic) — reused unchanged rather than duplicating it.
+      - name: Sign staged hyperparameters snapshot
+        run: node scripts/sign-staged-neurons.mjs dist/metagraph-subnet-hyperparams.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
+
+      # Stage the signed snapshot to R2 (the token's existing R2 permission); the
+      # Worker authenticates + bounds it before loading into D1 via its binding.
+      - name: Stage hyperparameters to R2 for the Worker to load into D1
+        run: npx wrangler r2 object put metagraphed-artifacts/metagraph/subnet-hyperparams-pending.json --file=dist/metagraph-subnet-hyperparams.json --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  notify-on-failure:
+    needs: [fetch, sign-and-stage]
+    if: ${{ always() && (needs.fetch.result == 'failure' || needs.sign-and-stage.result == 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Notify on failure
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -z "$METAGRAPH_ALERT_WEBHOOK_URL" ]; then
+            exit 0
+          fi
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed refresh-subnet-hyperparams FAILED — the subnet_hyperparams D1 tier may go stale."}'

--- a/migrations/0036_subnet_hyperparams.sql
+++ b/migrations/0036_subnet_hyperparams.sql
@@ -1,0 +1,60 @@
+-- Subnet hyperparameters (#4303, epic #4301): the largest confirmed capture gap
+-- found in the 2026-07-08 block-explorer research pass
+-- (docs/block-explorer-data-model.md). One row per netuid, refreshed daily-or-
+-- weekly by the refresh-subnet-hyperparams workflow (hyperparameters change
+-- rarely) — latest-only, REPLACE-on-conflict, so the table stays tiny (~129
+-- rows) and never grows unbounded. Powers
+-- /api/v1/subnets/{netuid}/hyperparameters (#4307).
+--
+-- Field mapping + units verified live against finney, 2026-07-08 (research spike
+-- #4304; full detail in scripts/fetch-subnet-hyperparams.py's docstring):
+--   *_ratio columns          = on-chain U16 (0..65535) / 65535
+--   min_burn_tao/max_burn_tao = on-chain rao / 1e9 (exact-split, not float-lossy)
+--   burn_increase_mult / alpha_sigmoid_steepness = already float-decoded
+--     fixed-point on the SDK side
+--   bonds_moving_avg_raw     = RAW on-chain integer, deliberately NOT scaled to
+--     a ratio — the spike could not confirm its exact scaling constant against
+--     the pallet source
+--   *_enabled / *_allowed / subnet_is_active = 0/1 booleans
+-- rho/difficulty/min_difficulty/max_difficulty/adjustment_interval/
+-- adjustment_alpha are OMITTED — confirmed None (dead PoW-era fields) on every
+-- probed netuid; no columns for these.
+CREATE TABLE IF NOT EXISTS subnet_hyperparams (
+  netuid                       INTEGER NOT NULL,
+  kappa_ratio                  REAL,
+  immunity_period               INTEGER,
+  min_allowed_weights           INTEGER,
+  max_weight_limit_ratio        REAL,
+  tempo                        INTEGER,
+  weights_version               INTEGER,
+  weights_rate_limit            INTEGER,
+  activity_cutoff               INTEGER,
+  activity_cutoff_factor        INTEGER,
+  registration_allowed          INTEGER,    -- 0/1
+  target_regs_per_interval      INTEGER,
+  min_burn_tao                 REAL,
+  max_burn_tao                 REAL,
+  burn_half_life                INTEGER,
+  burn_increase_mult            REAL,
+  bonds_moving_avg_raw           INTEGER,    -- raw on-chain integer, not a ratio
+  max_regs_per_block            INTEGER,
+  serving_rate_limit            INTEGER,
+  max_validators                INTEGER,
+  commit_reveal_period          INTEGER,
+  commit_reveal_enabled         INTEGER,    -- 0/1
+  alpha_high_ratio              REAL,
+  alpha_low_ratio               REAL,
+  liquid_alpha_enabled          INTEGER,    -- 0/1
+  alpha_sigmoid_steepness       REAL,
+  yuma_version                  INTEGER,
+  subnet_is_active              INTEGER,    -- 0/1
+  transfers_enabled             INTEGER,    -- 0/1
+  bonds_reset_enabled           INTEGER,    -- 0/1
+  user_liquidity_enabled        INTEGER,    -- 0/1
+  owner_cut_enabled             INTEGER,    -- 0/1
+  owner_cut_auto_lock_enabled   INTEGER,    -- 0/1
+  min_childkey_take_ratio       REAL,
+  block_number                 INTEGER,    -- chain height at capture
+  captured_at                  INTEGER NOT NULL, -- epoch milliseconds
+  PRIMARY KEY (netuid)
+);

--- a/src/subnet-hyperparams.mjs
+++ b/src/subnet-hyperparams.mjs
@@ -1,0 +1,45 @@
+// Subnet hyperparameters (#4303, epic #4301): one row per netuid, latest-only.
+// Field mapping documented in scripts/fetch-subnet-hyperparams.py's docstring
+// and migrations/0036_subnet_hyperparams.sql. Mirrors NEURON_INSERT_COLUMNS's
+// role in src/metagraph-neurons.mjs — the full column set written by the
+// staged-load path (loadStagedSubnetHyperparams) and read by the serving
+// route (#4307/1.4).
+
+export const SUBNET_HYPERPARAMS_INSERT_COLUMNS = [
+  "netuid",
+  "kappa_ratio",
+  "immunity_period",
+  "min_allowed_weights",
+  "max_weight_limit_ratio",
+  "tempo",
+  "weights_version",
+  "weights_rate_limit",
+  "activity_cutoff",
+  "activity_cutoff_factor",
+  "registration_allowed",
+  "target_regs_per_interval",
+  "min_burn_tao",
+  "max_burn_tao",
+  "burn_half_life",
+  "burn_increase_mult",
+  "bonds_moving_avg_raw",
+  "max_regs_per_block",
+  "serving_rate_limit",
+  "max_validators",
+  "commit_reveal_period",
+  "commit_reveal_enabled",
+  "alpha_high_ratio",
+  "alpha_low_ratio",
+  "liquid_alpha_enabled",
+  "alpha_sigmoid_steepness",
+  "yuma_version",
+  "subnet_is_active",
+  "transfers_enabled",
+  "bonds_reset_enabled",
+  "user_liquidity_enabled",
+  "owner_cut_enabled",
+  "owner_cut_auto_lock_enabled",
+  "min_childkey_take_ratio",
+  "block_number",
+  "captured_at",
+];

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -1,0 +1,487 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { test, vi } from "vitest";
+import { loadStagedSubnetHyperparams } from "../workers/api.mjs";
+
+const STAGED_KEY = "metagraph/subnet-hyperparams-pending.json";
+const SIGNING_KEY = "test-staged-subnet-hyperparams-secret";
+
+function hyperparamsRow(netuid) {
+  return {
+    netuid,
+    kappa_ratio: 0.5,
+    immunity_period: 4096,
+    min_allowed_weights: 8,
+    max_weight_limit_ratio: 1,
+    tempo: 360,
+    weights_version: 0,
+    weights_rate_limit: 100,
+    activity_cutoff: 5000,
+    activity_cutoff_factor: 1,
+    registration_allowed: 1,
+    target_regs_per_interval: 2,
+    min_burn_tao: 0.000001,
+    max_burn_tao: 100,
+    burn_half_life: 43200,
+    burn_increase_mult: 1.5,
+    bonds_moving_avg_raw: 900000,
+    max_regs_per_block: 1,
+    serving_rate_limit: 50,
+    max_validators: 64,
+    commit_reveal_period: 1,
+    commit_reveal_enabled: 0,
+    alpha_high_ratio: 0.9,
+    alpha_low_ratio: 0.7,
+    liquid_alpha_enabled: 0,
+    alpha_sigmoid_steepness: 10,
+    yuma_version: 2,
+    subnet_is_active: 1,
+    transfers_enabled: 1,
+    bonds_reset_enabled: 0,
+    user_liquidity_enabled: 0,
+    owner_cut_enabled: 1,
+    owner_cut_auto_lock_enabled: 0,
+    min_childkey_take_ratio: 0,
+    block_number: 5_000_000,
+    captured_at: 1_750_000_000_000,
+  };
+}
+
+function signedEnvelope(rows, key = SIGNING_KEY) {
+  return {
+    schema_version: 1,
+    hmac_sha256: createHmac("sha256", key)
+      .update(JSON.stringify(rows))
+      .digest("hex"),
+    rows,
+  };
+}
+
+function mockEnv({
+  rows,
+  bad = false,
+  failBatch = false,
+  failPrune = false,
+  getCalls = [],
+  deleted = [],
+  prepared = [],
+  batches = [],
+  runs = [],
+  size,
+}) {
+  const jsonCalls = [];
+  return {
+    env: {
+      METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          getCalls.push(key);
+          if (rows == null) return null;
+          return {
+            size: size ?? JSON.stringify(rows).length,
+            async json() {
+              jsonCalls.push(1);
+              if (bad) throw new Error("bad json");
+              return rows;
+            },
+          };
+        },
+        async delete(key) {
+          deleted.push(key);
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          prepared.push(sql);
+          return {
+            bind: (...v) => ({
+              sql,
+              v,
+              async run() {
+                runs.push({ sql, v });
+                if (
+                  failPrune &&
+                  sql.startsWith("DELETE FROM subnet_hyperparams")
+                ) {
+                  throw new Error("simulated prune failure");
+                }
+                return {
+                  meta: {
+                    changes: sql.startsWith("DELETE FROM subnet_hyperparams")
+                      ? 1
+                      : 0,
+                  },
+                };
+              },
+            }),
+          };
+        },
+        async batch(stmts) {
+          batches.push(stmts.length);
+          if (failBatch) throw new Error("simulated D1 batch failure");
+          return stmts.map(() => ({ meta: { changes: 0 } }));
+        },
+      },
+    },
+    getCalls,
+    deleted,
+    prepared,
+    batches,
+    runs,
+    jsonCalls,
+  };
+}
+
+test("loadStagedSubnetHyperparams loads JSON via parameterized batches + deletes it (#4306)", async () => {
+  const rows = Array.from({ length: 5 }, (_, i) => hyperparamsRow(i + 1));
+  const m = mockEnv({ rows: signedEnvelope(rows) });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, 5);
+  assert.deepEqual(m.getCalls, [STAGED_KEY]);
+  // 5 rows / 2 per statement = 3 upsert statements in one db.batch() call.
+  assert.deepEqual(m.batches, [3]);
+  // SQL is parameterized — the structure is fixed and values are bound, never
+  // interpolated, so a tampered staged file cannot inject SQL.
+  assert.ok(
+    m.prepared[0].startsWith("INSERT OR REPLACE INTO subnet_hyperparams ("),
+  );
+  assert.ok(m.prepared[0].includes("VALUES (?"));
+  assert.ok(
+    m.prepared.some((s) =>
+      s.startsWith("DELETE FROM subnet_hyperparams WHERE netuid NOT IN"),
+    ),
+  );
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams no-ops when nothing is staged", async () => {
+  const m = mockEnv({ rows: null });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "none");
+  assert.equal(m.batches.length, 0);
+  assert.equal(m.deleted.length, 0);
+});
+
+test("loadStagedSubnetHyperparams deletes + bails on unparseable JSON", async () => {
+  const m = mockEnv({ rows: [], bad: true });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.reason, "parse_failed");
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams is a safe no-op without bindings", async () => {
+  const r = await loadStagedSubnetHyperparams({});
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unavailable");
+});
+
+test("loadStagedSubnetHyperparams rejects unsigned or tampered staged payloads", async () => {
+  const m = mockEnv({ rows: [hyperparamsRow(1)] }); // bare array, no envelope shape
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+
+  const tampered = signedEnvelope([hyperparamsRow(1)]);
+  tampered.rows[0].tempo = 999;
+  const m2 = mockEnv({ rows: tampered });
+  const r2 = await loadStagedSubnetHyperparams(m2.env);
+  assert.equal(r2.reason, "unauthenticated");
+  assert.equal(m2.batches.length, 0);
+});
+
+test("loadStagedSubnetHyperparams rejects an oversized staged file without reading it", async () => {
+  const warn = vi.spyOn(console, "warn");
+  const m = mockEnv({
+    rows: signedEnvelope([hyperparamsRow(1)]),
+    size: 2_000_001,
+  });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.reason, "too_large");
+  assert.equal(r.size, 2_000_001);
+  assert.equal(m.batches.length, 0);
+  assert.equal(
+    m.jsonCalls.length,
+    0,
+    "oversized payloads must return before object.json()",
+  );
+  assert.equal(warn.mock.calls.length, 1);
+  assert.match(String(warn.mock.calls[0][0]), /2000001/);
+  assert.deepEqual(
+    m.deleted,
+    [],
+    "must NOT delete — that would drop staged rows, next cron retries",
+  );
+  warn.mockRestore();
+});
+
+test("loadStagedSubnetHyperparams rejects a payload with more rows than the cap", async () => {
+  const bigRows = Array.from({ length: 1_001 }, (_, i) => hyperparamsRow(i));
+  const m = mockEnv({ rows: signedEnvelope(bigRows), size: 1 });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "too_many_rows");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams deletes an empty-rows payload without loading", async () => {
+  const m = mockEnv({ rows: signedEnvelope([]) });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.reason, "invalid");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams rejects rows that fail per-field bounding", async () => {
+  // Each case is a correctly-signed row that still fails one of the guards in
+  // validStagedSubnetHyperparamsRow — the column allow-list, finiteness, the
+  // number-or-null type rule, and the netuid range/integer check.
+  const cases = {
+    unknown_column: { ...hyperparamsRow(1), evil_extra: 1 },
+    non_finite_number: { ...hyperparamsRow(1), kappa_ratio: Infinity },
+    boolean_value: { ...hyperparamsRow(1), registration_allowed: true },
+    string_value: { ...hyperparamsRow(1), tempo: "360" },
+    out_of_range_netuid: { ...hyperparamsRow(1), netuid: 999_999 },
+    non_integer_netuid: { ...hyperparamsRow(1), netuid: 1.5 },
+    negative_netuid: { ...hyperparamsRow(1), netuid: -1 },
+    non_object_row: null,
+    array_row: [],
+  };
+  for (const [name, row] of Object.entries(cases)) {
+    const m = mockEnv({ rows: signedEnvelope([row]) });
+    const r = await loadStagedSubnetHyperparams(m.env);
+    assert.equal(r.ok, false, `${name} must be rejected`);
+    assert.equal(r.reason, "invalid", `${name} must be rejected as invalid`);
+    assert.equal(m.batches.length, 0, `${name} must never reach a D1 write`);
+    assert.deepEqual(m.deleted, [STAGED_KEY]);
+  }
+});
+
+test("loadStagedSubnetHyperparams keeps the staged object when the upsert batch fails (safety)", async () => {
+  const rows = [hyperparamsRow(1), hyperparamsRow(2)];
+  const m = mockEnv({ rows: signedEnvelope(rows), failBatch: true });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  assert.equal(
+    m.runs.length,
+    0,
+    "prune must never run after a failed upsert batch",
+  );
+  assert.deepEqual(
+    m.deleted,
+    [],
+    "staged object must be preserved for the next cron retry",
+  );
+});
+
+test("loadStagedSubnetHyperparams returns purge_failed when upserts commit but the prune fails", async () => {
+  const rows = [hyperparamsRow(1)];
+  const m = mockEnv({ rows: signedEnvelope(rows), failPrune: true });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "purge_failed");
+  assert.ok(
+    m.batches.length > 0,
+    "upserts already committed before the prune ran",
+  );
+  assert.deepEqual(
+    m.deleted,
+    [],
+    "staged object kept so the next cron re-prunes",
+  );
+});
+
+// A stateful D1 mock (a real Map keyed on netuid) honoring the two SQL shapes
+// loadStagedSubnetHyperparams issues — INSERT OR REPLACE (upsert by PK) and
+// DELETE ... WHERE netuid NOT IN (full-sync prune, no partial-coverage concept
+// since every fetch covers all active subnets). Proves a deregistered
+// subnet's row is actually gone, not merely that a DELETE was prepared.
+function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
+  const deleted = [];
+  function applyUpsert(sql, values) {
+    const cols = sql.slice(sql.indexOf("(") + 1, sql.indexOf(")")).split(",");
+    const perRow = cols.length;
+    for (let i = 0; i < values.length; i += perRow) {
+      const row = {};
+      cols.forEach((c, j) => (row[c.trim()] = values[i + j]));
+      table.set(row.netuid, row);
+    }
+  }
+  function applyPrune(keepNetuids) {
+    const keep = new Set(keepNetuids);
+    let changes = 0;
+    for (const netuid of [...table.keys()]) {
+      if (!keep.has(netuid)) {
+        table.delete(netuid);
+        changes += 1;
+      }
+    }
+    return changes;
+  }
+  return {
+    env: {
+      METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
+      METAGRAPH_ARCHIVE: {
+        _staged: null,
+        async get() {
+          return this._staged == null
+            ? null
+            : {
+                size: JSON.stringify(this._staged).length,
+                json: async () => this._staged,
+              };
+        },
+        async delete(key) {
+          deleted.push(key);
+          this._staged = null;
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind: (...v) => ({
+              sql,
+              v,
+              async run() {
+                if (sql.startsWith("DELETE FROM subnet_hyperparams")) {
+                  if (failPrune) throw new Error("simulated prune failure");
+                  return { meta: { changes: applyPrune(v) } };
+                }
+                return { meta: { changes: 0 } };
+              },
+            }),
+          };
+        },
+        async batch(stmts) {
+          if (failBatch) throw new Error("simulated batch failure");
+          for (const stmt of stmts) {
+            if (
+              stmt.sql.startsWith("INSERT OR REPLACE INTO subnet_hyperparams")
+            ) {
+              applyUpsert(stmt.sql, stmt.v);
+            }
+          }
+          return stmts.map(() => ({ meta: { changes: 0 } }));
+        },
+      },
+    },
+    deleted,
+    table,
+  };
+}
+
+test("loadStagedSubnetHyperparams prunes a deregistered subnet's row on the next full snapshot", async () => {
+  const table = new Map();
+  table.set(1, { ...hyperparamsRow(1) });
+  table.set(2, { ...hyperparamsRow(2) }); // subnet 2 will deregister
+  const m = statefulEnv(table);
+
+  // Every fetch covers ALL active subnets (no partial-coverage concept) — subnet
+  // 2 is simply absent from this snapshot because it deregistered.
+  const snapshot = [{ ...hyperparamsRow(1), tempo: 720 }];
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snapshot);
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 1, "exactly the deregistered subnet 2 row is pruned");
+  assert.deepEqual([...table.keys()], [1]);
+  assert.equal(table.get(1).tempo, 720);
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams keeps every current subnet when none deregistered", async () => {
+  const table = new Map();
+  table.set(1, { ...hyperparamsRow(1) });
+  table.set(2, { ...hyperparamsRow(2) });
+  const m = statefulEnv(table);
+
+  const snapshot = [
+    { ...hyperparamsRow(1), tempo: 720 },
+    { ...hyperparamsRow(2), tempo: 100 },
+  ];
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snapshot);
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+  assert.deepEqual([...table.keys()].sort(), [1, 2]);
+});
+
+test("loadStagedSubnetHyperparams treats a missing object.size as zero bytes", async () => {
+  const envelope = signedEnvelope([hyperparamsRow(1)]);
+  const getCalls = [];
+  const env = {
+    METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        getCalls.push(key);
+        return {
+          async json() {
+            return envelope;
+          },
+        }; // no .size field at all
+      },
+      async delete() {},
+    },
+    METAGRAPH_HEALTH_DB: mockEnv({ rows: envelope }).env.METAGRAPH_HEALTH_DB,
+  };
+  const r = await loadStagedSubnetHyperparams(env);
+  assert.equal(
+    r.ok,
+    true,
+    "a missing size must fall back to 0, not throw or reject",
+  );
+  assert.deepEqual(getCalls, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams rejects a schema_version:1 payload with no hmac field at all", async () => {
+  // Distinct from the tampered-payload case: here hmac_sha256 is entirely
+  // absent (not just wrong), which only the `envelope?.hmac_sha256 || ""`
+  // fallback inside the format check can catch.
+  const rows = [hyperparamsRow(1)];
+  const m = mockEnv({ rows: { schema_version: 1, rows } });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, [STAGED_KEY]);
+});
+
+test("loadStagedSubnetHyperparams substitutes null for a row's omitted optional columns", async () => {
+  const table = new Map();
+  const m = statefulEnv(table);
+  const partial = { netuid: 5, tempo: 360 }; // every other optional column omitted
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope([partial]);
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(table.get(5).tempo, 360);
+  assert.equal(
+    table.get(5).kappa_ratio,
+    null,
+    "an omitted column must bind as NULL, not undefined",
+  );
+});
+
+test("loadStagedSubnetHyperparams treats a prune result with no meta.changes as zero purged", async () => {
+  const rows = [hyperparamsRow(1)];
+  const m = mockEnv({ rows: signedEnvelope(rows) });
+  const basePrepare = m.env.METAGRAPH_HEALTH_DB.prepare;
+  m.env.METAGRAPH_HEALTH_DB.prepare = (sql) => {
+    if (!sql.startsWith("DELETE FROM subnet_hyperparams")) {
+      return basePrepare(sql);
+    }
+    return {
+      bind: () => ({
+        async run() {
+          return {};
+        },
+      }),
+    };
+  };
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -78,6 +78,7 @@ import {
   loadStagedEvents,
   loadStagedBlocks,
   loadStagedExtrinsics,
+  loadStagedSubnetHyperparams,
 } from "./request-handlers/staging.mjs";
 import {
   handleSubnetMetagraph,
@@ -441,6 +442,7 @@ export {
   loadStagedEvents,
   loadStagedBlocks,
   loadStagedExtrinsics,
+  loadStagedSubnetHyperparams,
 };
 
 // The RPC-proxy subsystem now lives in request-handlers/rpc-proxy.mjs (#1763).
@@ -858,11 +860,13 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
     //   - loadStagedNeurons: token-free per-UID metagraph load (#1303)
     //   - loadStagedEvents:  token-free chain-event load (#1346)
     //   - loadStagedBlocks / loadStagedExtrinsics: block-explorer hot window (#1345)
+    //   - loadStagedSubnetHyperparams: token-free subnet hyperparams load (#4303/1.3)
     await Promise.allSettled([
       loadStagedNeurons(env),
       loadStagedEvents(env),
       loadStagedBlocks(env),
       loadStagedExtrinsics(env),
+      loadStagedSubnetHyperparams(env),
     ]);
     return { ok: true, fast_load: true };
   }

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -27,6 +27,7 @@ import {
   NEURON_SNAPSHOT_PRUNE_RETRIES,
 } from "../config.mjs";
 import { NEURON_INSERT_COLUMNS } from "../../src/metagraph-neurons.mjs";
+import { SUBNET_HYPERPARAMS_INSERT_COLUMNS } from "../../src/subnet-hyperparams.mjs";
 import {
   eventInsertStatements,
   validEventRows,
@@ -54,6 +55,14 @@ const MAX_STAGED_NEURON_STRING_BYTES = 512;
 const MAX_STAGED_NETUID = 65_535;
 const MAX_STAGED_UID = 65_535;
 const MAX_STAGED_REFRESHED_NETUIDS = 256;
+
+// Subnet hyperparameters (#4303/1.3): a much smaller, much-less-frequent staged
+// snapshot (~129 rows today, one per active subnet) than the per-UID neuron
+// snapshot above — bounds are correspondingly tighter.
+const STAGED_SUBNET_HYPERPARAMS_KEY =
+  "metagraph/subnet-hyperparams-pending.json";
+const MAX_STAGED_SUBNET_HYPERPARAMS_BYTES = 2_000_000;
+const MAX_STAGED_SUBNET_HYPERPARAMS_ROWS = 1_000;
 
 function neuronStagingSignPayload(rows, refreshed_netuids, captured_at) {
   if (refreshed_netuids == null && captured_at == null) {
@@ -464,6 +473,149 @@ export async function loadStagedNeurons(env) {
     }
   }
   await bucket.delete(STAGED_NEURONS_KEY);
+  return { ok: true, rows: rows.length, purged };
+}
+
+function subnetHyperparamsStagingSignPayload(rows) {
+  return JSON.stringify(rows);
+}
+
+function validStagedSubnetHyperparamsRow(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  if (
+    !Number.isInteger(row.netuid) ||
+    row.netuid < 0 ||
+    row.netuid > MAX_STAGED_NETUID
+  )
+    return false;
+  for (const [key, value] of Object.entries(row)) {
+    if (!SUBNET_HYPERPARAMS_INSERT_COLUMNS.includes(key)) return false;
+    if (typeof value === "number" && !Number.isFinite(value)) return false;
+    if (value !== null && typeof value !== "number") return false;
+  }
+  return true;
+}
+
+// Load a staged subnet-hyperparameters snapshot from R2 into D1 (#4303/1.3). The
+// refresh-subnet-hyperparams CI job fetches every active subnet's hyperparameter
+// set first-party (#4305), signs the bare-array snapshot with
+// scripts/sign-staged-neurons.mjs (reused unchanged — same bare-array envelope
+// shape as a legacy neuron snapshot), and writes it to R2
+// (metagraph/subnet-hyperparams-pending.json). We load only authenticated,
+// bounded, schema-valid rows through the METAGRAPH_HEALTH_DB binding (no
+// API-token D1 permission needed) with PARAMETERIZED inserts.
+//
+// Unlike loadStagedNeurons, every fetch covers ALL active subnets in one run
+// (get_subnet_hyperparameters has no bulk variant, but the fetch script loops
+// every netuid every time — no "refreshed_netuids" partial-coverage concept
+// needed here). ~129 rows today is far smaller than the neuron snapshot, so no
+// backup/rollback complexity: each upsert batch is independently an atomic D1
+// transaction and idempotent (INSERT OR REPLACE), so a failed batch leaves
+// only correctly-upserted rows behind — safe to leave as-is, since the staged
+// object is preserved (not deleted) on failure and the next cron retries the
+// same full snapshot. The prune (deleting a deregistered subnet's stale row)
+// runs only after every upsert batch succeeds, so it never fires against a
+// partially-loaded snapshot.
+export async function loadStagedSubnetHyperparams(env) {
+  const bucket = env.METAGRAPH_ARCHIVE;
+  const db = env.METAGRAPH_HEALTH_DB;
+  const signingKey = env.METAGRAPH_STAGING_SIGNING_KEY;
+  if (!bucket?.get || !db?.prepare || !signingKey) {
+    return { ok: false, reason: "unavailable" };
+  }
+  const object = await bucket.get(STAGED_SUBNET_HYPERPARAMS_KEY);
+  if (!object) return { ok: false, reason: "none" };
+  if (Number(object.size || 0) > MAX_STAGED_SUBNET_HYPERPARAMS_BYTES) {
+    console.warn(
+      `loadStagedSubnetHyperparams: staged file ${object.size} bytes exceeds ${MAX_STAGED_SUBNET_HYPERPARAMS_BYTES}; skipping (next cron self-heals)`,
+    );
+    return { ok: false, reason: "too_large", size: Number(object.size) };
+  }
+  let envelope;
+  try {
+    envelope = await object.json();
+  } catch {
+    await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
+    return { ok: false, reason: "parse_failed" };
+  }
+  const rows = Array.isArray(envelope?.rows) ? envelope.rows : [];
+  if (
+    envelope?.schema_version !== 1 ||
+    !/^[a-f0-9]{64}$/.test(String(envelope?.hmac_sha256 || ""))
+  ) {
+    await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  if (rows.length > MAX_STAGED_SUBNET_HYPERPARAMS_ROWS) {
+    await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
+    return { ok: false, reason: "too_many_rows" };
+  }
+  if (
+    !rows.length ||
+    rows.some((row) => !validStagedSubnetHyperparamsRow(row))
+  ) {
+    await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
+    return { ok: false, reason: "invalid" };
+  }
+  const expected = await hmacHex(
+    signingKey,
+    subnetHyperparamsStagingSignPayload(rows),
+  );
+  if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
+    await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  const cols = SUBNET_HYPERPARAMS_INSERT_COLUMNS;
+  const colList = cols.join(",");
+  // Matches loadStagedNeurons's proven-in-production per-statement/per-batch
+  // sizing (5 rows x 18 columns = 90 bound params/statement, 50 statements/
+  // batch) scaled down for this table's larger column count (36): 2 rows x 36
+  // columns = 72 bound params/statement, same 50-statement batch size.
+  const ROWS_PER_STMT = 2;
+  const STMTS_PER_BATCH = 50;
+  const statements = [];
+  for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
+    const chunk = rows.slice(i, i + ROWS_PER_STMT);
+    const tuples = chunk
+      .map(() => `(${cols.map(() => "?").join(",")})`)
+      .join(",");
+    const values = chunk.flatMap((row) => cols.map((c) => row[c] ?? null));
+    statements.push(
+      db
+        .prepare(
+          `INSERT OR REPLACE INTO subnet_hyperparams (${colList}) VALUES ${tuples}`,
+        )
+        .bind(...values),
+    );
+  }
+  try {
+    for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
+      await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
+    }
+  } catch {
+    // Staged object intentionally preserved: the next cron retries the full
+    // (idempotent) snapshot rather than leaving a partial load unrecovered.
+    return { ok: false, reason: "load_failed" };
+  }
+  const netuidsInSnapshot = rows.map((row) => row.netuid);
+  let purged;
+  try {
+    const result = await db
+      .prepare(
+        `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${netuidsInSnapshot
+          .map(() => "?")
+          .join(",")})`,
+      )
+      .bind(...netuidsInSnapshot)
+      .run();
+    purged = result?.meta?.changes ?? 0;
+  } catch {
+    // Upserts already committed; only the stale-subnet prune failed. Keep the
+    // staged object so the next cron retries (a redundant but harmless
+    // re-upsert either way).
+    return { ok: false, reason: "purge_failed" };
+  }
+  await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
   return { ok: true, rows: rows.length, purged };
 }
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/refresh-subnet-hyperparams.yml`: daily (06:13 UTC) chain-direct fetch via `scripts/fetch-subnet-hyperparams.py` (#4304/#4305, merged in #4420), signed with the existing `sign-staged-neurons.mjs` (reused unchanged), staged to R2.
- Adds `migrations/0036_subnet_hyperparams.sql`: a `subnet_hyperparams` D1 table, one row per netuid, `PRIMARY KEY (netuid)`.
- Adds `src/subnet-hyperparams.mjs`: `SUBNET_HYPERPARAMS_INSERT_COLUMNS`, the 36-column insert order shared by the loader and the future serving route.
- Adds `loadStagedSubnetHyperparams` to `workers/request-handlers/staging.mjs`, wired into the existing `*/3` `EVENTS_LOAD_CRON` drain in `workers/api.mjs` (no new cron trigger needed).

## Design notes
- Every fetch covers **all** active subnets in one run (no bulk hyperparameters RPC exists, but the fetch script loops every netuid every time) — so unlike `loadStagedNeurons`'s partial-coverage snapshot-replace, the prune here is a full-sync `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (...)` against the current snapshot's netuid set. This table is ~129 rows and changes rarely, so the elaborate backup/rollback/partial-refresh machinery `loadStagedNeurons` needs at metagraph scale isn't proportionate here: each upsert batch is independently atomic and idempotent (`INSERT OR REPLACE`), and the staged R2 object is preserved (not deleted) on any failure so the next cron retries the same full snapshot.
- HMAC verification, byte/row caps, and per-field row validation follow the same trust contract as the other three loaders in this file.

## Test plan
- `npm run validate:migrations` — 36 migration files, prefixes unique and sequential.
- `npm run validate:workflows` — 23 workflow files valid.
- `npm run lint` / `npx prettier --check` — clean.
- `npm run scan:public-safety` — clean.
- `npm run test:coverage` (full unsharded) — 234/234 files, 6530/6530 tests green; `coverage/lcov.info` cross-checked line-by-line for `loadStagedSubnetHyperparams` — zero uncovered branches remain in the new code (the 4 initial gaps found this way were closed with targeted tests: missing `object.size`, a schema_version:1 payload with no `hmac_sha256` field, a row omitting optional columns, and a prune result with no `meta.changes`).
- `npm run validate` (full registry+API+OpenAPI suite) — clean.
- `git diff --check` — clean.
- No `schemas/`, OpenAPI, or client-SDK files touched — contract-drift/client-sdk-sync regeneration doesn't apply to this PR.

Closes #4306