### PR TITLE
feat(registry): add SN5 Hone training-projects data-artifact surface (#4003)

### DIFF
--- a/registry/subnets/hone.json
+++ b/registry/subnets/hone.json
@@ -159,6 +159,31 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Public no-auth GET returning the Hone (SN5) backend API health as JSON ({\"status\":\"ok\"}). Served on the api.hone.training subdomain of the subnet's registered website hone.training — a live API host distinct from the website-host /health path noted as 404 in this file. Fills the noted missing public-API-endpoint gap."
+    },
+    {
+      "id": "sn-5-hone-projects-json",
+      "name": "Hone training projects data",
+      "kind": "data-artifact",
+      "url": "https://www.hone.training/api/proxy/runs/projects",
+      "provider": "hone",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://www.hone.training/projects",
+        "https://github.com/manifold-inc/hone"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "notes": "Public no-auth GET returning the Hone (SN5) training projects catalog as JSON (project, version, modelSize, runCount, lastSeen fields; 46 release entries observed at submission time). This is the machine-readable feed behind the registered hone.training /projects dashboard surface, served from the same first-party hone.training host as the subnet's registered website."
     }
   ],
   "contact": "devs@manifold.inc"


### PR DESCRIPTION
## Summary

Adds one community **data-artifact** surface to `registry/subnets/hone.json` (SN5): the machine-readable **training projects catalog** at `https://www.hone.training/api/proxy/runs/projects` — the JSON feed behind the already-registered `hone.training/projects` dashboard surface. The file's `curation.gap_notes` explicitly notes no standalone public data artifact is registered yet; this fills that gap.

Closes #4003

## Validation

- `curl -s` with no auth: **HTTP 200**, `content-type: application/json`, **5398 bytes**, valid JSON — 46 release entries with `project`, `version`, `modelSize`, `runCount`, `lastSeen` fields (counts observed at submission time). Fetched twice, byte-identical both times.
- First-party provenance: served from `www.hone.training`, the same host as the subnet's registered website/dashboard surfaces; `source_urls` point at the registered `/projects` dashboard the feed powers and the subnet's registered source repo (`manifold-inc/hone`).
- Provider slug `hone` matches every existing surface in the file; a `probe` block (GET / expect json / 10s) matches the file's existing shape.
- Append-only single-file diff (+25): one new object at the end of `surfaces[]`; all existing entries and top-level fields are byte-identical (JSON-diff-verified before committing). `id` is `sn-5-hone-projects-json` to stay distinct from the existing `sn-5-hone-projects` dashboard entry.
- Duplicate check: the file has website / dashboard ×3 / source-repo / subnet-api surfaces — no data-artifact yet, and no open PR touches `hone.json` or references #4003.

Sample of the artifact:

```json
{"projects":[{"project":"genesis_moe","version":"0.1.56","modelSize":"8B-A1B","lastSeen":"2026-05-08T20:19:59.000Z","runCount":3}, ...]}
```
