### PR TITLE
feat(registry): add SN23 Trishool submission schema data-artifact (#4020)

### DIFF
--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -102,6 +102,25 @@
         "submitted_by": "devmixa702"
       },
       "notes": "Official Trishool documentation site (docs.trishool.ai), hosted on the subnet's own domain and linked from the official website trishool.ai."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-23-trishool-submission-schema",
+      "kind": "data-artifact",
+      "name": "Trishool tri-check submission schema template",
+      "notes": "Public no-auth JSON template for the tri-check / alignet-style miner submission format (Q1–Q12 prompt object keys). Used for local testing and documentation of the expected batch submission shape.",
+      "provider": "trishool",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/TrishoolAI/trishool-phase2/blob/main/tri-check/README.md",
+        "https://github.com/TrishoolAI/trishool-phase2/blob/main/tri-check/data/submission_schema.json"
+      ],
+      "url": "https://raw.githubusercontent.com/TrishoolAI/trishool-phase2/main/tri-check/data/submission_schema.json"
     }
   ],
   "social": { "x": "https://x.com/trishoolai" },


### PR DESCRIPTION
## Summary
- Adds a `data-artifact` surface for Trishool’s public JSON submission schema template used by `tri-check` to document the expected Q1–Q12 batch submission shape.

Closes #4020

## Test plan
- [x] `npm run validate:surface -- registry/subnets/trishool.json`
- [x] `npm run scan:public-safety`