### PR TITLE
feat(ui): add network axon-churn leaderboard to the explorer page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-axon-removals.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-axon-removals.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainAxonRemovalsQuery, normalizeChainAxonRemovals } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/axon-removals",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainAxonRemovalsQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainAxonRemovals", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainAxonRemovals({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: { distinct_removers: 5, removals: 70, removals_per_remover: 14 },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          { netuid: 1, distinct_removers: 4, removals: 40, removals_per_remover: 10 },
+          { netuid: 2, distinct_removers: 2, removals: 30, removals_per_remover: 15 },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: { distinct_removers: 5, removals: 70, removals_per_remover: 14 },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        { netuid: 1, distinct_removers: 4, removals: 40, removals_per_remover: 10 },
+        { netuid: 2, distinct_removers: 2, removals: 30, removals_per_remover: 15 },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainAxonRemovals(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+      expect(card.network).toEqual({
+        distinct_removers: 0,
+        removals: 0,
+        removals_per_remover: null,
+      });
+      expect(card.intensity_distribution).toBeNull();
+    }
+  });
+
+  it("drops malformed subnet rows and coerces a junk removals_per_remover to null", () => {
+    const card = normalizeChainAxonRemovals({
+      network: { removals_per_remover: { pct: 1 } },
+      subnets: [{ distinct_removers: 4 }, { netuid: 2, removals: 30 }],
+    });
+    expect(card.subnets).toHaveLength(1);
+    expect(card.subnets[0]?.netuid).toBe(2);
+    expect(card.subnets[0]?.removals_per_remover).toBeNull();
+    expect(card.network.removals_per_remover).toBeNull();
+  });
+});
+
+describe("chainAxonRemovalsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the leaderboard", async () => {
+    resolveWith({
+      window: "30d",
+      subnet_count: 1,
+      network: { distinct_removers: 4, removals: 40, removals_per_remover: 10 },
+      subnets: [{ netuid: 1, distinct_removers: 4, removals: 40, removals_per_remover: 10 }],
+    });
+    const res = await runQuery("30d", 5);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/axon-removals",
+      expect.objectContaining({ params: { window: "30d", limit: 5 } }),
+    );
+    expect(res.data.subnet_count).toBe(1);
+    expect(res.data.subnets).toHaveLength(1);
+  });
+
+  it("defaults to the 7d window and limit 20", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/axon-removals",
+      expect.objectContaining({ params: { window: "7d", limit: 20 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -72,6 +72,8 @@ import type {
   ChainTransferPairs,
   ChainStakeTransfers,
   ChainStakeTransferSubnet,
+  ChainAxonRemovals,
+  ChainAxonRemovalSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -222,6 +224,7 @@ const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
+const MAX_CHAIN_AXON_REMOVALS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3133,6 +3136,61 @@ export const chainStakeTransfersQuery = (window = "7d", limit = 20) =>
       });
       return {
         data: normalizeChainStakeTransfers(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainAxonRemovalSubnet(raw: unknown): ChainAxonRemovalSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_removers: firstFiniteNumber(raw.distinct_removers) ?? 0,
+    removals: firstFiniteNumber(raw.removals) ?? 0,
+    removals_per_remover: firstFiniteNumber(raw.removals_per_remover) ?? null,
+  };
+}
+
+// #3464: network-wide axon-teardown ("churn") leaderboard over a 7d/30d window —
+// the teardown-side complement of the serving leaderboard. Every numeric cell
+// coerces defensively: counts fall through to 0, averages to null (never NaN),
+// and malformed subnet rows are dropped on a cold store or junk.
+export function normalizeChainAxonRemovals(raw: unknown): ChainAxonRemovals {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_removers: firstFiniteNumber(networkRec.distinct_removers) ?? 0,
+      removals: firstFiniteNumber(networkRec.removals) ?? 0,
+      removals_per_remover: firstFiniteNumber(networkRec.removals_per_remover) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_AXON_REMOVALS,
+      normalizeChainAxonRemovalSubnet,
+    ),
+  };
+}
+
+export const chainAxonRemovalsQuery = (window = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-axon-removals", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainAxonRemovals>>("/api/v1/chain/axon-removals", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainAxonRemovals(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -578,7 +578,11 @@ export interface Lineage {
 
 /** The five D1-computed registry leaderboards from /api/v1/registry/leaderboards. */
 export type LeaderboardBoardKey =
-  "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing";
+  | "healthiest"
+  | "fastest-rpc"
+  | "most-complete"
+  | "most-enriched"
+  | "fastest-growing";
 
 /**
  * One ranked subnet in a leaderboard. Every row carries netuid/slug/name; only
@@ -2137,6 +2141,39 @@ export interface ChainStakeTransfers {
   network: ChainStakeTransferNetwork;
   intensity_distribution: ChainIntensityDistribution | null;
   subnets: ChainStakeTransferSubnet[];
+}
+
+/** One subnet's row on the network-wide axon-teardown ("churn") leaderboard (#3464). */
+export interface ChainAxonRemovalSubnet {
+  netuid: number;
+  distinct_removers: number;
+  removals: number;
+  removals_per_remover: number | null;
+}
+
+/** Network-wide axon-teardown rollup — true distinct-remover count (not a per-subnet sum) + total removals. */
+export interface ChainAxonRemovalNetwork {
+  distinct_removers: number;
+  removals: number;
+  removals_per_remover: number | null;
+}
+
+/**
+ * Network-wide axon-teardown ("churn") leaderboard over a 7d/30d window (#3464),
+ * from GET /api/v1/chain/axon-removals — the teardown-side complement of the
+ * serving leaderboard: subnets ranked by AxonInfoRemoved event count, plus the
+ * true network-wide distinct-remover rollup and a distribution summary of the
+ * per-subnet teardown intensity. Zeroed with an empty subnets list when the
+ * store is cold.
+ */
+export interface ChainAxonRemovals {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainAxonRemovalNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainAxonRemovalSubnet[];
 }
 
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -26,6 +26,7 @@ import {
   chainStakeFlowQuery,
   chainStakeMovesQuery,
   chainStakeTransfersQuery,
+  chainAxonRemovalsQuery,
   chainTransferPairsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -37,6 +38,7 @@ import type {
   ChainEventsStats,
   ChainStakeFlow,
   ChainStakeMoves,
+  ChainAxonRemovals,
 } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
@@ -106,6 +108,7 @@ function ExplorerPage() {
           "/api/v1/chain/stake-flow",
           "/api/v1/chain/stake-moves",
           "/api/v1/chain/stake-transfers",
+          "/api/v1/chain/axon-removals",
           "/api/v1/chain-events",
           "/api/v1/chain-events/stats",
         ]}
@@ -509,6 +512,73 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
   );
 }
 
+/**
+ * #3464: network-wide axon-teardown ("churn") leaderboard — the teardown-side
+ * complement of the serving/stake-transfer boards, from the newly-wired
+ * chainAxonRemovalsQuery. Network rollup line + per-subnet table, mirroring the
+ * stake-transfer leaderboard treatment on this page.
+ */
+function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Axon churn leaderboard
+          </h2>
+          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+            {formatNumber(churn.network.removals)} axon teardowns across{" "}
+            {formatNumber(churn.network.distinct_removers)} removers network-wide
+          </p>
+        </div>
+        <span className="font-mono text-[11px] text-ink-muted">{churn.subnets.length} subnets</span>
+      </div>
+      {churn.subnets.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={`${TH} text-right`}>Teardowns</th>
+                <th className={`${TH} text-right`}>Distinct removers</th>
+                <th className={`${TH} text-right`}>Teardowns per remover</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {churn.subnets.map((s) => (
+                <tr key={s.netuid} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: s.netuid }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{s.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(s.removals)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(s.distinct_removers)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {s.removals_per_remover != null ? s.removals_per_remover.toFixed(2) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">
+          No axon teardowns in this window yet.
+        </p>
+      )}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -521,6 +591,7 @@ function ExplorerDashboard() {
   const stakeFlow = useSuspenseQuery(chainStakeFlowQuery(win)).data.data;
   const stakeMoves = useSuspenseQuery(chainStakeMovesQuery(win)).data.data;
   const stakeTransfers = useSuspenseQuery(chainStakeTransfersQuery(win)).data.data;
+  const axonChurn = useSuspenseQuery(chainAxonRemovalsQuery(win)).data.data;
   const eventMix = useSuspenseQuery(chainEventsStatsQuery()).data.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
@@ -870,6 +941,9 @@ function ExplorerDashboard() {
           </p>
         )}
       </section>
+
+      <AxonChurnSection churn={axonChurn} />
+
       <PalletEventMixSection stats={eventMix} />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #3464

Wires `GET /api/v1/chain/axon-removals` into the frontend and renders it as a new **Axon churn leaderboard** section on `/explorer` — the teardown-side complement of the stake-transfer / serving boards. Shows a network teardown rollup (total teardowns across N distinct removers) plus a per-subnet table (teardowns, distinct removers, teardowns/remover),
over the same 7d/30d window as the rest of the explorer dashboard.

Per the issue, this adds the data layer **and** the UI in one PR (a data-layer-only PR is the failure mode the issue calls out):
- `chainAxonRemovalsQuery` + `ChainAxonRemovals` / `ChainAxonRemovalSubnet` / `ChainAxonRemovalNetwork`
  types, modeled on the existing `chainStakeTransfersQuery` sibling (same `ChainWindow` param,   `apiFetch` + defensive normalizer idiom, `staleTime`).
- A normalizer unit test (`queries.chain-axon-removals.test.ts`) mirroring the stake-transfers test.
- The `AxonChurnSection` on `/explorer`, matching the stake-transfer leaderboard treatment.

## Acceptance criteria
- [x] Adds the typed query function **and** the UI wiring in one PR
- [x] Network-wide churn panel on `/explorer` (distinct removers, total removals, per-remover, per-subnet leaderboard)
- [x] Same 7d/30d window as the rest of the explorer dashboard

## Validation
- `npm run typecheck -w apps/ui` — pass
- `npm run lint` (changed files) — 0 errors
- `npm run test -w apps/ui` — 542 passed (incl. 5 new)
- `npm run build -w apps/ui` — pass

## Screenshots

New **Axon churn leaderboard** section on `/explorer` (below the Stake-transfer leaderboard),
same crop before/after. 3 viewports (1280×800 / 768×1024 / 375×812, fixed) × 2 themes × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1472" height="834" alt="dek-lg-be" src="https://github.com/user-attachments/assets/b207048f-5ea3-4739-842e-fa56d6af998a" /> | <img width="1443" height="753" alt="dek-lg-af" src="https://github.com/user-attachments/assets/9beefb03-310b-4881-baa6-870fcf503e31" /> |
| Desktop · Dark | <img width="1425" height="816" alt="dek-dk-be" src="https://github.com/user-attachments/assets/4a2bba15-79ad-4b4d-9c17-7217f5aaa0b4" /> | <img width="1437" height="752" alt="dek-dk-af" src="https://github.com/user-attachments/assets/97bf605b-1394-4c74-877c-2f8be6eba462" /> |
| Tablet · Light | <img width="675" height="905" alt="tab-lg-be" src="https://github.com/user-attachments/assets/86840cce-ada1-4e20-ab8d-b226743546fb" /> | <img width="673" height="880" alt="tab-lg-af" src="https://github.com/user-attachments/assets/2e5de949-7d50-400d-837c-0a896db851cc" /> |
| Tablet · Dark | <img width="670" height="882" alt="tab-dk-be" src="https://github.com/user-attachments/assets/9420f3eb-531d-4122-a23b-1b07d7f1602e" /> | <img width="657" height="876" alt="tab-dk-af" src="https://github.com/user-attachments/assets/65fa9cc8-aa52-4945-9633-3f0f9795cb1b" /> |
| Mobile · Light | <img width="506" height="930" alt="mb-lg-be" src="https://github.com/user-attachments/assets/0369fa55-a98f-40af-9ee0-68221cfbebee" /> | <img width="491" height="921" alt="mb-lg-af" src="https://github.com/user-attachments/assets/bd2c83df-9fec-4f06-99a4-eb45100b622f" /> |
| Mobile · Dark | <img width="450" height="927" alt="mb-dk-be" src="https://github.com/user-attachments/assets/4432ec34-dc05-44c6-8cff-d6fb20148450" /> | <img width="445" height="922" alt="mb-dk-af" src="https://github.com/user-attachments/assets/3c29ad2d-27aa-4e67-93e5-eb4eac678f07" /> |
