### PR TITLE
feat(ui): add a /leaderboards route with a network-wide registrations leaderboard

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -58,6 +58,10 @@ import type {
   ChainStakeFlowDistribution,
   ChainStakeFlowNetwork,
   ChainStakeFlowSubnet,
+  ChainRegistrations,
+  ChainRegistrationsDistribution,
+  ChainRegistrationsNetwork,
+  ChainRegistrationsSubnet,
   ChainStakeMoves,
   ChainStakeMovesDistribution,
   ChainStakeMovesNetwork,
@@ -214,6 +218,7 @@ const MAX_CHAIN_ACTIVITY_DAYS = 31;
 const MAX_CHAIN_CALLS = 12;
 const MAX_STAKE_FLOW_SUBNETS = 24;
 const MAX_STAKE_MOVES_SUBNETS = 24;
+const MAX_REGISTRATIONS_SUBNETS = 24;
 // The endpoint returns the top 100 pallet.method groups, busiest first.
 const MAX_CHAIN_EVENT_GROUPS = 100;
 const DEFAULT_CHAIN_EVENT_BLOCKS = 1000;
@@ -3276,6 +3281,73 @@ export const chainStakeMovesQuery = (window: ChainWindow = "7d") =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainStakeMoves>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeChainRegistrationsNetwork(raw: unknown): ChainRegistrationsNetwork | null {
+  if (!isRecord(raw)) return null;
+  return {
+    distinct_registrants: coerceFiniteNumber(raw.distinct_registrants) ?? 0,
+    registrations: coerceFiniteNumber(raw.registrations) ?? 0,
+    registrations_per_registrant: coerceFiniteNumber(raw.registrations_per_registrant) ?? 0,
+  };
+}
+
+function normalizeChainRegistrationsDistribution(
+  raw: unknown,
+): ChainRegistrationsDistribution | null {
+  if (!isRecord(raw)) return null;
+  return {
+    count: coerceFiniteNumber(raw.count) ?? 0,
+    mean: coerceFiniteNumber(raw.mean) ?? null,
+    min: coerceFiniteNumber(raw.min) ?? null,
+    p25: coerceFiniteNumber(raw.p25) ?? null,
+    median: coerceFiniteNumber(raw.median) ?? null,
+    p75: coerceFiniteNumber(raw.p75) ?? null,
+    p90: coerceFiniteNumber(raw.p90) ?? null,
+    max: coerceFiniteNumber(raw.max) ?? null,
+  };
+}
+
+function normalizeChainRegistrationsSubnet(raw: unknown): ChainRegistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_registrants: coerceFiniteNumber(raw.distinct_registrants) ?? 0,
+    registrations: coerceFiniteNumber(raw.registrations) ?? 0,
+    registrations_per_registrant: coerceFiniteNumber(raw.registrations_per_registrant) ?? 0,
+  };
+}
+
+export const chainRegistrationsQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-registrations", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/registrations", {
+        params: { window },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: 1,
+          window,
+          observed_at: firstString(d.observed_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          network: normalizeChainRegistrationsNetwork(d.network),
+          intensity_distribution: normalizeChainRegistrationsDistribution(d.intensity_distribution),
+          subnets: normalizeChainRows(
+            d.subnets,
+            MAX_REGISTRATIONS_SUBNETS,
+            normalizeChainRegistrationsSubnet,
+          ),
+        } as ChainRegistrations,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainRegistrations>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1997,6 +1997,36 @@ export interface ChainStakeFlow {
   net_flow_distribution: ChainStakeFlowDistribution | null;
   subnets: ChainStakeFlowSubnet[];
 }
+export interface ChainRegistrationsNetwork {
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number;
+}
+export interface ChainRegistrationsDistribution {
+  count: number;
+  mean: number | null;
+  min: number | null;
+  p25: number | null;
+  median: number | null;
+  p75: number | null;
+  p90: number | null;
+  max: number | null;
+}
+export interface ChainRegistrationsSubnet {
+  netuid: number;
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number;
+}
+export interface ChainRegistrations {
+  schema_version: number;
+  window: string;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainRegistrationsNetwork | null;
+  intensity_distribution: ChainRegistrationsDistribution | null;
+  subnets: ChainRegistrationsSubnet[];
+}
 export interface ChainStakeMovesNetwork {
   distinct_movers: number;
   movements: number;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
+import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as ExplorerRouteImport } from './routes/explorer'
@@ -50,6 +51,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SchemasRoute = SchemasRouteImport.update({
   id: '/schemas',
   path: '/schemas',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LeaderboardsRoute = LeaderboardsRouteImport.update({
+  id: '/leaderboards',
+  path: '/leaderboards',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HealthRoute = HealthRouteImport.update({
@@ -151,6 +157,7 @@ export interface FileRoutesByFullPath {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -175,6 +182,7 @@ export interface FileRoutesByTo {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -200,6 +208,7 @@ export interface FileRoutesById {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -226,6 +235,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -250,6 +260,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -274,6 +285,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -299,6 +311,7 @@ export interface RootRouteChildren {
   ExplorerRoute: typeof ExplorerRoute
   GapsRoute: typeof GapsRoute
   HealthRoute: typeof HealthRoute
+  LeaderboardsRoute: typeof LeaderboardsRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
@@ -344,6 +357,13 @@ declare module '@tanstack/react-router' {
       path: '/schemas'
       fullPath: '/schemas'
       preLoaderRoute: typeof SchemasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/leaderboards': {
+      id: '/leaderboards'
+      path: '/leaderboards'
+      fullPath: '/leaderboards'
+      preLoaderRoute: typeof LeaderboardsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/health': {
@@ -483,6 +503,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExplorerRoute: ExplorerRoute,
   GapsRoute: GapsRoute,
   HealthRoute: HealthRoute,
+  LeaderboardsRoute: LeaderboardsRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -1,0 +1,179 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { ShareButton } from "@/components/metagraphed/share-button";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { chainRegistrationsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { ChainRegistrations } from "@/lib/metagraphed/types";
+
+const leaderboardsSearchSchema = z.object({
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+});
+
+export const Route = createFileRoute("/leaderboards")({
+  validateSearch: zodValidator(leaderboardsSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Leaderboards — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Network-wide Bittensor leaderboards — the busiest subnets by registration activity, computed live from the chain-direct tiers.",
+      },
+      { property: "og:title", content: "Leaderboards — Metagraphed" },
+    ],
+  }),
+  component: LeaderboardsPage,
+});
+
+function LeaderboardMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 font-mono text-sm tabular-nums text-ink-strong">{value}</div>
+    </div>
+  );
+}
+
+/**
+ * Network-wide registrations leaderboard (#3465) — the busiest subnets by UID
+ * registration activity over the window: distinct registrants, total
+ * registrations, and the per-subnet breakdown. Chain-direct: GET
+ * /api/v1/chain/registrations.
+ */
+function RegistrationsLeaderboard({ reg }: { reg: ChainRegistrations }) {
+  const net = reg.network;
+  const dist = reg.intensity_distribution;
+  const rows = [...reg.subnets].sort((a, b) => b.registrations - a.registrations).slice(0, 12);
+  const cap = Math.max(1, ...rows.map((s) => s.registrations));
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Registrations
+        </h2>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(reg.subnet_count)} subnets
+        </span>
+      </div>
+
+      {net ? (
+        <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <LeaderboardMetric
+            label="Distinct registrants"
+            value={formatNumber(net.distinct_registrants)}
+          />
+          <LeaderboardMetric label="Registrations" value={formatNumber(net.registrations)} />
+          <LeaderboardMetric
+            label="Regs / registrant"
+            value={net.registrations_per_registrant.toFixed(2)}
+          />
+        </div>
+      ) : null}
+
+      {rows.length > 0 ? (
+        <div>
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Busiest subnets
+          </div>
+          <ul className="space-y-1.5">
+            {rows.map((s) => {
+              const pct = Math.max(2, Math.round((s.registrations / cap) * 100));
+              return (
+                <li key={s.netuid}>
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: s.netuid }}
+                    className="grid w-full grid-cols-[3.5rem_1fr_6rem] items-center gap-2 text-left hover:opacity-80"
+                  >
+                    <span className="truncate font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                      SN{s.netuid}
+                    </span>
+                    <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
+                      <span
+                        className="absolute inset-y-0 left-0 rounded-full"
+                        style={{ width: `${pct}%`, background: "var(--accent)" }}
+                      />
+                    </span>
+                    <span className="text-right font-mono text-[10px] tabular-nums text-ink-strong">
+                      {formatNumber(s.registrations)}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">No registrations in this window yet.</p>
+      )}
+
+      {dist ? (
+        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+          Median {(dist.median ?? 0).toFixed(2)} registrations per registrant, up to{" "}
+          {(dist.max ?? 0).toFixed(2)} in the most concentrated subnet, across{" "}
+          {formatNumber(dist.count)} subnets.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function LeaderboardsDashboard() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const win = search.window;
+  const reg = useSuspenseQuery(chainRegistrationsQuery(win)).data.data;
+
+  return (
+    <div className="space-y-10">
+      <div className="flex items-center gap-2">
+        {(["7d", "30d"] as const).map((w) => (
+          <button
+            key={w}
+            type="button"
+            onClick={() => navigate({ search: { window: w } })}
+            className={
+              w === win
+                ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
+                : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
+            }
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+      <RegistrationsLeaderboard reg={reg} />
+    </div>
+  );
+}
+
+function LeaderboardsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Leaderboards"
+        live
+        title="Leaderboards"
+        description="Network-wide Bittensor leaderboards — the busiest subnets by registration activity, computed live from the chain-direct tiers."
+        actions={<ShareButton />}
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-[40rem] w-full" />}>
+          <LeaderboardsDashboard />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/chain/registrations"]} />
+    </AppShell>
+  );
+}


### PR DESCRIPTION
Closes #3465

Creates the **`/leaderboards` route** — the page the leaderboard issues (#3465/#3466/#3469/#3470/#3473) all target but which didn't exist yet — and lands its first section: a **network-wide registrations leaderboard**.

## What it adds
- **New route** `apps/ui/src/routes/leaderboards.tsx` (`/leaderboards`) — `AppShell` + `PageHero` + a `7d`/`30d` window toggle + `ApiSourceFooter`, following the explorer page shell. Registered in `routeTree.gen.ts`.
- **Registrations leaderboard section** — distinct registrants, total registrations, registrations-per-registrant, and the busiest subnets by registration count (bar list linking to each subnet), plus a per-registrant intensity footnote. Mirrors the explorer's stake-flow / stake-moves sections.
- **Data layer** — `ChainRegistrations` (+ `…Network` / `…Distribution` / `…Subnet`) in `types.ts`, and `chainRegistrationsQuery` + normalizers in `queries.ts`, following the `chainStakeMovesQuery` pattern. Adds `/api/v1/chain/registrations` to the footer.

This establishes `/leaderboards` as the home for the network-wide leaderboards; further leaderboards (deregistrations, weight-setters, turnover, …) can be added as sibling sections as their data tiers populate.

## Verification
`tsc --noEmit` clean · `eslint .` clean (no new warnings) · `prettier --check` clean (prettier 3.9.4, per lockfile) · `vite build` clean (route tree regenerated). `/api/v1/chain/registrations` returns live data (3,411 registrants / 3,875 registrations across 95 subnets), and it renders live in the browser — the shots below are real renders.

## Screenshots — desktop / tablet / mobile × light + dark

| | Light | Dark |
|---|---|---|
| **Desktop** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/leaderboards-shots/data-desktop-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/leaderboards-shots/data-desktop-dark.png) |
| **Tablet** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/leaderboards-shots/data-tablet-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/leaderboards-shots/data-tablet-dark.png) |
| **Mobile** | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/leaderboards-shots/data-mobile-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/leaderboards-shots/data-mobile-dark.png) |
