### PR TITLE
fix(api): gate validator drill-in routes as mainnet-only

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -318,6 +318,12 @@ describe("multi-network routing prefix (Phase 1)", () => {
       "/api/v1/testnet/subnets/7/metagraph",
       "/api/v1/testnet/subnets/7/hyperparameters",
       "/api/v1/testnet/subnets/7/validators",
+      // Cross-subnet validator drill-in routes read the same mainnet-only
+      // neurons D1 tier as /api/v1/validators — must not fall through to a
+      // testnet R2 read either.
+      `/api/v1/testnet/validators/${SS58}`,
+      `/api/v1/testnet/validators/${SS58}/nominators`,
+      `/api/v1/testnet/validators/${SS58}/history`,
       "/api/v1/testnet/subnets/7/events",
       "/api/v1/testnet/subnets/7/health",
       // D1-backed per-subnet analytics: also mainnet-only, must not fall through

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2400,6 +2400,9 @@ function isMainnetOnlyApiPath(pathname) {
     pathname === "/api/v1/graphql" ||
     pathname === "/api/v1/search/semantic" ||
     pathname === "/api/v1/validators" ||
+    VALIDATOR_DETAIL_PATH_PATTERN.test(pathname) ||
+    VALIDATOR_NOMINATORS_PATH_PATTERN.test(pathname) ||
+    VALIDATOR_HISTORY_PATH_PATTERN.test(pathname) ||
     pathname === "/api/v1/registry/leaderboards" ||
     pathname === "/api/v1/compare" ||
     pathname === "/api/v1/subnets/movers" ||


### PR DESCRIPTION
## Summary
- `VALIDATOR_DETAIL_PATH_PATTERN` (`GET /api/v1/validators/{hotkey}`), `VALIDATOR_NOMINATORS_PATH_PATTERN` (`.../nominators`), and `VALIDATOR_HISTORY_PATH_PATTERN` (`.../history`) — added in #4356/#4410/#4415 — read the same mainnet-only `neurons` D1 tier as `/api/v1/validators` and every `SUBNET_*_PATH_PATTERN` route, all of which are already gated in `isMainnetOnlyApiPath`.
- These three were never added to that allowlist. Under a `/{network}/` prefix (e.g. `/testnet/api/v1/validators/{hotkey}`), a request fell through instead of 404ing with the clean "only available on mainnet" contract — the same class of bug the existing `SUBNET_NEURON_PATH_PATTERN` entry guards against.
- Self-discovered while wiring the new `/api/v1/subnets/{netuid}/hyperparameters` route's own mainnet-only gating (#4445) — no tracked issue.

## Test plan
- Extended `tests/network-routing.test.mjs`'s existing mainnet-only-routes list with all three validator routes.
- Confirmed the new assertions actually fail without the fix (temporarily reverted `workers/api.mjs`, reran — the test caught it with a clear diff), then pass with the fix restored.
- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` — clean.
- `npm test` — 235/235 files, 6549/6549 tests green; `coverage/lcov.info` cross-checked around the changed lines — no new gaps.
- `npm run validate` — clean.
- No `schemas/`/OpenAPI/client files touched — verified `validate:contract-drift` and `validate:client-sdk-sync` report N/A, confirming no `npm run build` regeneration is needed for this pure route-gating fix.