### PR TITLE
feat(registry): add SN111 oneoneone config and protocol data-artifacts (#4148)

### DIFF
--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -76,7 +76,7 @@
       "id": "sn-111-oneoneone-node-validator-config",
       "kind": "data-artifact",
       "name": "oneoneone Node.js validator configuration",
-      "notes": "Public no-auth JavaScript configuration for the SN111 oneoneone Node.js validator layer. Defines synapse timeouts, spot-check counts, supported job types (Google Maps reviews and X tweets), Apify actor IDs, Chutes/OpenRouter model lists, and place-type allowlists. Imported at runtime by node/validator.js via the package.json #config alias.",
+      "notes": "Public no-auth JavaScript configuration for the SN111 oneoneone Node.js validator layer. Defines synapse timeouts, spot-check counts, supported job types (Google Maps reviews and X tweets), Apify actor IDs, Chutes/OpenRouter model lists, and place-type allowlists. Imported at runtime by node/validator.js via the package.json #config alias. Pinned to an immutable commit.",
       "provider": "oneoneone",
       "public_safe": true,
       "review": {
@@ -84,11 +84,11 @@
         "submitted_by": "petermilord"
       },
       "source_urls": [
-        "https://github.com/oneoneone-io/subnet-111/blob/main/node/validator.js",
-        "https://github.com/oneoneone-io/subnet-111/blob/main/node/package.json",
-        "https://github.com/oneoneone-io/subnet-111/blob/main/README.md"
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/node/validator.js",
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/node/package.json",
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/README.md"
       ],
-      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/main/node/config.js"
+      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/node/config.js"
     },
     {
       "auth_required": false,
@@ -96,7 +96,7 @@
       "id": "sn-111-oneoneone-python-subnet-config",
       "kind": "data-artifact",
       "name": "oneoneone Python subnet configuration",
-      "notes": "Public no-auth Python constants for the SN111 oneoneone Bittensor validator loop: MAX_MINER_COUNT, SYNAPSE_WAIT_TIME, VALIDATOR_MIN_STAKE, and VALIDATOR_API_TIMEOUT. Consumed by oneoneone/validator/forward.py when querying miners and pacing validation rounds.",
+      "notes": "Public no-auth Python constants for the SN111 oneoneone Bittensor validator loop: MAX_MINER_COUNT, SYNAPSE_WAIT_TIME, VALIDATOR_MIN_STAKE, and VALIDATOR_API_TIMEOUT. Consumed by oneoneone/validator/forward.py when querying miners and pacing validation rounds. Pinned to an immutable commit.",
       "provider": "oneoneone",
       "public_safe": true,
       "review": {
@@ -104,10 +104,10 @@
         "submitted_by": "petermilord"
       },
       "source_urls": [
-        "https://github.com/oneoneone-io/subnet-111/blob/main/oneoneone/validator/forward.py",
-        "https://github.com/oneoneone-io/subnet-111/blob/main/README.md"
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/oneoneone/validator/forward.py",
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/README.md"
       ],
-      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/main/oneoneone/config.py"
+      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/oneoneone/config.py"
     },
     {
       "auth_required": false,
@@ -115,7 +115,7 @@
       "id": "sn-111-oneoneone-generic-synapse-protocol",
       "kind": "data-artifact",
       "name": "oneoneone GenericSynapse protocol definition",
-      "notes": "Public no-auth Bittensor synapse protocol for SN111 oneoneone miner–validator communication. Defines the GenericSynapse request/response shape (type_id, metadata, timeout, responses) used by the validator forward pass to dispatch data-fetch tasks to miners.",
+      "notes": "Public no-auth Bittensor synapse protocol for SN111 oneoneone miner–validator communication. Defines the GenericSynapse request/response shape (type_id, metadata, timeout, responses) used by the validator forward pass to dispatch data-fetch tasks to miners. Pinned to an immutable commit.",
       "provider": "oneoneone",
       "public_safe": true,
       "review": {
@@ -123,10 +123,10 @@
         "submitted_by": "petermilord"
       },
       "source_urls": [
-        "https://github.com/oneoneone-io/subnet-111/blob/main/oneoneone/validator/forward.py",
-        "https://github.com/oneoneone-io/subnet-111/blob/main/README.md"
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/oneoneone/validator/forward.py",
+        "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/README.md"
       ],
-      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/main/oneoneone/protocol.py"
+      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/oneoneone/protocol.py"
     }
   ],
   "contact": "support@oneoneone.io"

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -69,6 +69,64 @@
         "timeout_ms": 10000
       },
       "notes": "Official oneoneone source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-111-oneoneone-node-validator-config",
+      "kind": "data-artifact",
+      "name": "oneoneone Node.js validator configuration",
+      "notes": "Public no-auth JavaScript configuration for the SN111 oneoneone Node.js validator layer. Defines synapse timeouts, spot-check counts, supported job types (Google Maps reviews and X tweets), Apify actor IDs, Chutes/OpenRouter model lists, and place-type allowlists. Imported at runtime by node/validator.js via the package.json #config alias.",
+      "provider": "oneoneone",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/oneoneone-io/subnet-111/blob/main/node/validator.js",
+        "https://github.com/oneoneone-io/subnet-111/blob/main/node/package.json",
+        "https://github.com/oneoneone-io/subnet-111/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/main/node/config.js"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-111-oneoneone-python-subnet-config",
+      "kind": "data-artifact",
+      "name": "oneoneone Python subnet configuration",
+      "notes": "Public no-auth Python constants for the SN111 oneoneone Bittensor validator loop: MAX_MINER_COUNT, SYNAPSE_WAIT_TIME, VALIDATOR_MIN_STAKE, and VALIDATOR_API_TIMEOUT. Consumed by oneoneone/validator/forward.py when querying miners and pacing validation rounds.",
+      "provider": "oneoneone",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/oneoneone-io/subnet-111/blob/main/oneoneone/validator/forward.py",
+        "https://github.com/oneoneone-io/subnet-111/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/main/oneoneone/config.py"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-111-oneoneone-generic-synapse-protocol",
+      "kind": "data-artifact",
+      "name": "oneoneone GenericSynapse protocol definition",
+      "notes": "Public no-auth Bittensor synapse protocol for SN111 oneoneone miner–validator communication. Defines the GenericSynapse request/response shape (type_id, metadata, timeout, responses) used by the validator forward pass to dispatch data-fetch tasks to miners.",
+      "provider": "oneoneone",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/oneoneone-io/subnet-111/blob/main/oneoneone/validator/forward.py",
+        "https://github.com/oneoneone-io/subnet-111/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/main/oneoneone/protocol.py"
     }
   ],
   "contact": "support@oneoneone.io"


### PR DESCRIPTION
## Summary
- Adds three `data-artifact` surfaces from the official oneoneone-io/subnet-111 repo:
  - Node.js validator config (`node/config.js`)
  - Python subnet timing/stake constants (`oneoneone/config.py`)
  - GenericSynapse protocol definition (`oneoneone/protocol.py`)
- Each artifact is loaded at runtime by the subnet’s validator code and documented in the official README.

Closes #4148

## Test plan
- [x] `npm run validate:surface -- registry/subnets/oneoneone.json`
- [x] `npm run scan:public-safety`
- [x] Only `registry/subnets/oneoneone.json` changed