### PR TITLE
feat(mcp): add get_validator_history tool mirroring GET /api/v1/validators/{hotkey}/history

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -416,6 +416,7 @@ import {
   NEURON_DAILY_READ_COLUMNS,
   parseHistoryWindow,
 } from "./neuron-history.mjs";
+import { buildValidatorHistory } from "./validator-history.mjs";
 import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
 import {
@@ -714,8 +715,10 @@ export const MCP_INSTRUCTIONS =
   "distribution) over a 7d/30d window, get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
   "list_subnet_validators its validators ranked by stake, list_global_validators " +
-  "the network-wide validator leaderboard grouped by hotkey, and get_neuron one " +
-  "UID — use these to decide where to mine or validate. For wallet lookup, " +
+  "the network-wide validator leaderboard grouped by hotkey, get_validator_history " +
+  "a validator hotkey's cross-subnet staked-over-time and rewards-per-1000-TAO " +
+  "daily history, and get_neuron one UID — use these to decide where to mine or " +
+  "validate. For wallet lookup, " +
   "get_account summarizes what one hotkey or coldkey does across the network, " +
   "get_account_balance its live native-TAO balance (free+reserved) from finney RPC, " +
   "get_account_events returns its chain-event history (optional kind filter), and " +
@@ -1170,6 +1173,27 @@ async function loadNeuronHistory(ctx, netuid, uid, { label, days }) {
   return buildNeuronHistory(rows, netuid, uid, { window: label });
 }
 
+// Cross-subnet daily history for one validator hotkey — mirrors
+// handleValidatorHistory: GROUP BY snapshot_date over neuron_daily rows where
+// validator_permit = 1, newest first, bounded by MAX_HISTORY_POINTS, shaped by
+// buildValidatorHistory. Cold D1 → point_count:0.
+async function loadValidatorHistory(ctx, hotkey, { label, days }) {
+  const run = mcpD1Runner(ctx);
+  const params = [hotkey];
+  let sql =
+    "SELECT snapshot_date, COUNT(DISTINCT netuid) AS subnet_count, " +
+    "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
+    "FROM neuron_daily WHERE hotkey = ? AND validator_permit = 1";
+  if (days != null) {
+    sql += " AND snapshot_date >= ?";
+    params.push(historyCutoff(days));
+  }
+  sql += " GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(MAX_HISTORY_POINTS);
+  const rows = await run(sql, params);
+  return buildValidatorHistory(rows, hotkey, { window: label });
+}
+
 // One provider's detail + (optionally) its endpoints, mirroring GET
 // /api/v1/providers/{slug}{,/endpoints}. Both are artifact-backed; the endpoints
 // artifact is optional (a provider may have no endpoints artifact), so a missing
@@ -1487,6 +1511,17 @@ function requireSs58(args) {
     throw toolError(
       "invalid_params",
       "Argument `ss58` must be a valid SS58 account address (base58, 47-48 chars).",
+    );
+  }
+  return value;
+}
+
+function requireHotkey(args) {
+  const value = requireString(args, "hotkey");
+  if (!SS58_ADDRESS_PATTERN.test(value)) {
+    throw toolError(
+      "invalid_params",
+      "Argument `hotkey` must be a valid SS58 validator hotkey (base58, 47-48 chars).",
     );
   }
   return value;
@@ -4156,6 +4191,39 @@ export const MCP_TOOLS = [
       const netuid = requireNetuid(args);
       const uid = requireNonNegativeInt(args, "uid");
       return loadNeuronHistory(ctx, netuid, uid, requireHistoryWindow(args));
+    },
+  },
+  {
+    name: "get_validator_history",
+    title: "Get a validator's cross-subnet daily history",
+    description:
+      "Fetch one validator hotkey's cross-subnet daily history from the " +
+      "neuron_daily rollup: active subnet count, total stake (TAO), total " +
+      "emission (TAO), and a rewards-per-1000-TAO rate per snapshot_date, " +
+      "newest first. Each point sums across every subnet the hotkey validates " +
+      "that day. Choose the window (7d, 30d, 90d, 1y, all; default 30d). " +
+      "Use it to chart how a validator's stake and reward rate have moved over " +
+      "time across the network. Mirrors GET /api/v1/validators/{hotkey}/history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        hotkey: {
+          type: "string",
+          pattern: SS58_PATTERN_SOURCE,
+          description: "Validator hotkey (SS58 address).",
+        },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d", "1y", "all"],
+          description: "History window (default 30d).",
+        },
+      },
+      required: ["hotkey"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const hotkey = requireHotkey(args);
+      return loadValidatorHistory(ctx, hotkey, requireHistoryWindow(args));
     },
   },
   {
@@ -9193,6 +9261,24 @@ const TOOL_OUTPUT_SCHEMAS = {
       window: NULLABLE_STRING,
       point_count: { type: "integer" },
       points: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_validator_history: {
+    type: "object",
+    additionalProperties: true,
+    required: ["hotkey", "point_count", "points"],
+    properties: {
+      schema_version: { type: "integer" },
+      hotkey: { type: "string" },
+      window: NULLABLE_STRING,
+      point_count: { type: "integer" },
+      points: objectItems({
+        snapshot_date: NULLABLE_STRING,
+        subnet_count: NULLABLE_INT,
+        total_stake_tao: ANY,
+        total_emission_tao: ANY,
+        rewards_per_1000_tao: ANY,
+      }),
     },
   },
   get_subnet_events: {

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -1052,6 +1052,45 @@ describe("analytics edge cache", () => {
     );
   });
 
+  test("validator-history ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const hotkey = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+    const base = `/api/v1/validators/${hotkey}/history`;
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=30d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=30d&`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "?window=30d& hits cache of ?window=30d",
+    );
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=30d",
+    );
+  });
+
   test("economics-trends ?window variants share a single cache entry (canonical key)", async () => {
     const queries = [];
     const cache = mockCaches();

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13403,6 +13403,87 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     assert.match(res.body.result.content[0].text, /uid/);
   });
 
+  test("get_validator_history returns cross-subnet per-day aggregates newest-first", async () => {
+    const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+    const capture = [];
+    const env = parityD1(
+      {
+        dailyAgg: [
+          {
+            snapshot_date: "2026-06-26",
+            subnet_count: 3,
+            total_stake_tao: 12_000,
+            total_emission_tao: 60,
+          },
+          {
+            snapshot_date: "2026-06-25",
+            subnet_count: 2,
+            total_stake_tao: 10_000,
+            total_emission_tao: 50,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_validator_history",
+      { hotkey: HOTKEY, window: "7d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.hotkey, HOTKEY);
+    assert.equal(out.window, "7d");
+    assert.equal(out.point_count, 2);
+    assert.equal(out.points[0].snapshot_date, "2026-06-26");
+    assert.equal(out.points[0].subnet_count, 3);
+    assert.equal(out.points[0].rewards_per_1000_tao, 5);
+    const q = capture.find(
+      (c) => /hotkey = \? AND validator_permit = 1/.test(c.sql),
+    );
+    assert.ok(q);
+    assert.ok(q.params.includes(HOTKEY));
+    assert.ok(q.params.some((p) => /^\d{4}-\d{2}-\d{2}$/.test(p)));
+  });
+
+  test("get_validator_history (all) omits the date cutoff bind", async () => {
+    const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+    const capture = [];
+    const env = parityD1({ dailyAgg: [] }, capture);
+    const res = await callTool(
+      "get_validator_history",
+      { hotkey: HOTKEY, window: "all" },
+      { env },
+    );
+    assert.equal(res.body.result.structuredContent.window, "all");
+    const q = capture.find(
+      (c) => /hotkey = \? AND validator_permit = 1/.test(c.sql),
+    );
+    assert.equal(q.params.length, 2);
+    assert.ok(!q.params.some((p) => /^\d{4}-\d{2}-\d{2}$/.test(p)));
+  });
+
+  test("get_validator_history defaults to the 30d window when omitted", async () => {
+    const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+    const env = parityD1({ dailyAgg: [] });
+    const res = await callTool("get_validator_history", { hotkey: HOTKEY }, { env });
+    assert.equal(res.body.result.structuredContent.window, "30d");
+  });
+
+  test("get_validator_history rejects an unknown window", async () => {
+    const res = await callTool("get_validator_history", {
+      hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+      window: "400d",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_validator_history requires a valid hotkey", async () => {
+    const res = await callTool("get_validator_history", { hotkey: "not-ss58" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /hotkey/);
+  });
+
   test("get_subnet_concentration_history builds the per-day trend", async () => {
     const env = parityD1({
       concentrationRows: [
@@ -13611,6 +13692,11 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
       uid: 0,
     });
     assert.equal(neuronHistory.body.result.structuredContent.point_count, 0);
+
+    const validatorHistory = await callTool("get_validator_history", {
+      hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+    });
+    assert.equal(validatorHistory.body.result.structuredContent.point_count, 0);
 
     const concentration = await callTool("get_subnet_concentration_history", {
       netuid: 1,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -13437,8 +13437,8 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     assert.equal(out.points[0].snapshot_date, "2026-06-26");
     assert.equal(out.points[0].subnet_count, 3);
     assert.equal(out.points[0].rewards_per_1000_tao, 5);
-    const q = capture.find(
-      (c) => /hotkey = \? AND validator_permit = 1/.test(c.sql),
+    const q = capture.find((c) =>
+      /hotkey = \? AND validator_permit = 1/.test(c.sql),
     );
     assert.ok(q);
     assert.ok(q.params.includes(HOTKEY));
@@ -13455,8 +13455,8 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
       { env },
     );
     assert.equal(res.body.result.structuredContent.window, "all");
-    const q = capture.find(
-      (c) => /hotkey = \? AND validator_permit = 1/.test(c.sql),
+    const q = capture.find((c) =>
+      /hotkey = \? AND validator_permit = 1/.test(c.sql),
     );
     assert.equal(q.params.length, 2);
     assert.ok(!q.params.some((p) => /^\d{4}-\d{2}-\d{2}$/.test(p)));
@@ -13465,7 +13465,11 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   test("get_validator_history defaults to the 30d window when omitted", async () => {
     const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
     const env = parityD1({ dailyAgg: [] });
-    const res = await callTool("get_validator_history", { hotkey: HOTKEY }, { env });
+    const res = await callTool(
+      "get_validator_history",
+      { hotkey: HOTKEY },
+      { env },
+    );
     assert.equal(res.body.result.structuredContent.window, "30d");
   });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -57,6 +57,7 @@ import {
   handleExtrinsics,
   handleExtrinsic,
   canonicalSubnetHistoryCachePath,
+  canonicalValidatorHistoryCachePath,
   canonicalSubnetTurnoverCachePath,
   canonicalSubnetStakeFlowCachePath,
   canonicalSubnetWeightsCachePath,
@@ -6258,6 +6259,29 @@ describe("canonicalSubnetHistoryCachePath", () => {
   test("falls back to raw url when window value is invalid", () => {
     const raw = "/api/v1/subnets/7/history?window=invalid";
     assert.equal(canonicalSubnetHistoryCachePath(url(raw)), raw);
+  });
+});
+
+describe("canonicalValidatorHistoryCachePath", () => {
+  const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+  test("returns canonical key for valid window param", () => {
+    assert.equal(
+      canonicalValidatorHistoryCachePath(
+        url(`/api/v1/validators/${HOTKEY}/history?window=90d`),
+      ),
+      `/api/v1/validators/${HOTKEY}/history?window=90d`,
+    );
+  });
+
+  test("falls back to raw url when unknown query param is present", () => {
+    const raw = `/api/v1/validators/${HOTKEY}/history?window=30d&extra=junk`;
+    assert.equal(canonicalValidatorHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw url when window value is invalid", () => {
+    const raw = `/api/v1/validators/${HOTKEY}/history?window=invalid`;
+    assert.equal(canonicalValidatorHistoryCachePath(url(raw)), raw);
   });
 });
 


### PR DESCRIPTION
Closes #4451

## Summary

`GET /api/v1/validators/{hotkey}/history` (shipped in #4415) exposes cross-subnet daily validator history — staked-over-time and rewards-per-1000-TAO — but there is no matching MCP tool for agent workflows.

Sibling history routes already have MCP parity from #2221 (`get_subnet_history`, `get_neuron_history`).

## Proposed change

- Add `get_validator_history` MCP tool mirroring the REST route.
- Reuse `buildValidatorHistory` and the same `neuron_daily` GROUP BY `snapshot_date` query with `validator_permit = 1`.
- Support `window` values `7d|30d|90d|1y|all` (default `30d`).
- Add MCP integration tests plus `canonicalValidatorHistoryCachePath` / edge-cache parity tests.

## Acceptance

- [ ] MCP tool registered with output schema matching `buildValidatorHistory`
- [ ] `loadValidatorHistory` follows the same pattern as `loadNeuronHistory` / `loadSubnetHistory`
- [ ] Unit + MCP integration tests cover cold D1, happy path, invalid window, `all` window, invalid hotkey
- [ ] `npm run validate:mcp` smoke call for the new tool