### PR TITLE
feat(ui): add registration-activity summary to the account detail page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -30,6 +30,8 @@ import type {
   AccountAxonRemovals,
   AccountAxonRemovalsSubnet,
   AccountDeregistrations,
+  AccountRegistrations,
+  AccountRegistrationsSubnet,
   AccountDeregistrationsSubnet,
   AccountWeightSetters,
   AccountWeightSettersSubnet,
@@ -2524,6 +2526,59 @@ export const accountAxonRemovalsQuery = (ss58: string, window = "30d") =>
       );
       return {
         data: normalizeAccountAxonRemovals(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountRegistrationsSubnet(raw: unknown): AccountRegistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    registrations: firstFiniteNumber(raw.registrations) ?? 0,
+    first_registered_at: firstString(raw.first_registered_at) ?? null,
+    last_registered_at: firstString(raw.last_registered_at) ?? null,
+  };
+}
+
+// Per-account registration (NeuronRegistered) footprint over a 7d/30d/90d window
+// (#3730). A flat summary card — total registrations + distinct subnets — from the
+// account_events NeuronRegistered stream. Coerces defensively: counts fall through
+// to 0 and concentration to null on a cold store or junk.
+export function normalizeAccountRegistrations(ss58: string, raw: unknown): AccountRegistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((row) => {
+        const normalized = normalizeAccountRegistrationsSubnet(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    address: firstString(rec.address) ?? ss58,
+    window: firstString(rec.window) ?? null,
+    total_registrations: firstFiniteNumber(rec.total_registrations) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    concentration: firstFiniteNumber(rec.concentration) ?? null,
+    dominant_netuid: firstFiniteNumber(rec.dominant_netuid) ?? null,
+    subnets,
+  };
+}
+
+export const accountRegistrationsQuery = (ss58: string, window = "30d") =>
+  queryOptions({
+    queryKey: k("account-registrations", ss58, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountRegistrations>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/registrations`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeAccountRegistrations(ss58, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1047,6 +1047,25 @@ export interface AccountDeregistrations {
   subnets: AccountDeregistrationsSubnet[];
 }
 
+export interface AccountRegistrationsSubnet {
+  netuid: number;
+  registrations: number;
+  first_registered_at: string | null;
+  last_registered_at: string | null;
+}
+
+/** Per-account registration (NeuronRegistered) footprint over a window (#3730). */
+export interface AccountRegistrations {
+  schema_version: number;
+  address: string;
+  window: string | null;
+  total_registrations: number;
+  subnet_count: number;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnets: AccountRegistrationsSubnet[];
+}
+
 /** Per-subnet WeightsSet row in /api/v1/accounts/{ss58}/weight-setters. */
 export interface AccountWeightSettersSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -17,6 +17,7 @@ import {
   Scale,
   Unplug,
   UserMinus,
+  UserPlus,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
@@ -37,6 +38,7 @@ import {
   accountPortfolioQuery,
   accountStakeMovesQuery,
   accountDeregistrationsQuery,
+  accountRegistrationsQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
   accountEventsQuery,
@@ -263,6 +265,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <AccountTeardownActivitySection ss58={ss58} />
 
+      <AccountRegistrationActivitySection ss58={ss58} />
       <AccountDeregistrationActivitySection ss58={ss58} />
 
       <AccountWeightSettingSection ss58={ss58} />
@@ -1001,6 +1004,74 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
  * count + distinct-subnet summary from /deregistrations. Non-blocking: while the
  * dedicated query loads (or if it fails), the section never stalls the page.
  */
+function AccountRegistrationActivitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountRegistrationsQuery(ss58));
+  const card = result.data?.data;
+  const windowLabel = card?.window ?? "30d";
+
+  if (result.isPending && !card) {
+    return (
+      <AccountFeedSectionSkeleton
+        id="registrations"
+        title="Registration activity"
+        subtitle="Neuron registrations (NeuronRegistered) for this account over the trailing 30-day window."
+      />
+    );
+  }
+
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="registrations"
+        title="Registration activity"
+        subtitle="Neuron registrations (NeuronRegistered) for this account over the trailing 30-day window."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load registration activity"
+          description="The registrations tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const registrations = card?.total_registrations ?? 0;
+  const distinctSubnets = card?.subnet_count ?? 0;
+  if (registrations === 0 && distinctSubnets === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="registrations"
+      title="Registration activity"
+      subtitle="Neuron registrations (NeuronRegistered) for this account over the trailing 30-day window."
+      tone="accent"
+      info="The account-level companion to subnet registration activity — counts how often this hotkey was registered into a subnet, and on how many distinct subnets."
+      right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
+    >
+      <div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Registrations"
+          tone="accent"
+          value={formatNumber(registrations)}
+          hint={`NeuronRegistered · ${windowLabel}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Distinct subnets"
+          value={formatNumber(distinctSubnets)}
+          hint="subnets with registration"
+          className={KPI_TILE}
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
 function AccountDeregistrationActivitySection({ ss58 }: { ss58: string }) {
   const result = useQuery(accountDeregistrationsQuery(ss58));
   const card = result.data?.data;


### PR DESCRIPTION
## What

Adds a **registration-activity summary** to the account detail page — a KPI card showing this account's NeuronRegistered footprint (registration count + distinct-subnet count) over the trailing window, from `GET /api/v1/accounts/{ss58}/registrations`. It's the account-level twin of the existing deregistration / teardown activity sections; the endpoint had no frontend consumer.

## How

- **`queries.ts`** — `accountRegistrationsQuery(ss58, window="30d")` + a coerce-safe `normalizeAccountRegistrations` (cold/junk store degrades to a zeroed card, never NaN), mirroring `accountDeregistrationsQuery`.
- **`types.ts`** — `AccountRegistrations` / `AccountRegistrationsSubnet`.
- **`accounts.$ss58.tsx`** — `AccountRegistrationActivitySection`: two `StatTile`s (Registrations, Distinct subnets) with loading/error/empty states, mirroring the deregistration-activity section it sits beside.

## Screenshots (account 5E2LP6…TKeZ5u — live api.metagraph.sh)

> The registration section is net-new, so the **before** frame is anchored on the adjacent Weight-setting section (what occupied that area before); the **after** shows the new Registration activity section.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-light-after.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-desktop-dark-after.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-light-after.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-tablet-dark-after.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-light-after.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-registrations-mobile-dark-after.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] Diff touches `accounts.$ss58.tsx` (not just queries.ts/types.ts)
- [x] New `accountRegistrationsQuery` added AND consumed via `useQuery` in the same PR
- [x] Renders the registration count (and distinct-subnet count) for the account
- [x] Loading/empty/error states match the page's existing section convention

## Non-goals respected

- Doesn't touch the subnet-level version (#3483)

## Gates

`npm run typecheck` ✓ (exit 0) · `eslint` (my files) ✓

Closes #3730