### PR TITLE
fix(registry): wrap registry-sync writes in a single Postgres transaction

### DIFF
--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -7,28 +7,43 @@ const sqlCalls = vi.hoisted(() => []);
 const surfaceResult = vi.hoisted(() => ({ current: [{ inserted: true }] }));
 const deleteResult = vi.hoisted(() => ({ surfaces: [], subnets: [] }));
 const failure = vi.hoisted(() => ({ error: null }));
+const transaction = vi.hoisted(() => ({ began: 0, rolledBack: 0 }));
 
 vi.mock("postgres", () => ({
   default: () => {
-    const sql = (strings, ...values) => {
-      const text = Array.from(strings).join("?");
-      sqlCalls.push({ text, values });
-      if (failure.error && /INSERT INTO providers/.test(text)) {
-        return Promise.reject(failure.error);
-      }
-      if (/INSERT INTO surfaces/.test(text)) {
-        return Promise.resolve(surfaceResult.current);
-      }
-      if (/DELETE FROM surfaces/.test(text)) {
-        return Promise.resolve(deleteResult.surfaces);
-      }
-      if (/DELETE FROM subnets/.test(text)) {
-        return Promise.resolve(deleteResult.subnets);
-      }
-      return Promise.resolve([]);
+    const makeSql = () => {
+      const sql = (strings, ...values) => {
+        const text = Array.from(strings).join("?");
+        sqlCalls.push({ text, values });
+        if (failure.error && /INSERT INTO providers/.test(text)) {
+          return Promise.reject(failure.error);
+        }
+        if (/INSERT INTO surfaces/.test(text)) {
+          return Promise.resolve(surfaceResult.current);
+        }
+        if (/DELETE FROM surfaces/.test(text)) {
+          return Promise.resolve(deleteResult.surfaces);
+        }
+        if (/DELETE FROM subnets/.test(text)) {
+          return Promise.resolve(deleteResult.subnets);
+        }
+        return Promise.resolve([]);
+      };
+      sql.json = (value) => value;
+      return sql;
     };
-    sql.json = (value) => value;
+    const sql = makeSql();
     sql.end = () => Promise.resolve();
+    sql.begin = async (fn) => {
+      transaction.began += 1;
+      const tx = makeSql();
+      try {
+        return await fn(tx);
+      } catch (err) {
+        transaction.rolledBack += 1;
+        throw err;
+      }
+    };
     return sql;
   },
 }));
@@ -86,6 +101,8 @@ beforeEach(() => {
   deleteResult.surfaces = [];
   deleteResult.subnets = [];
   failure.error = null;
+  transaction.began = 0;
+  transaction.rolledBack = 0;
 });
 
 test("rejects non-POST (405)", async () => {
@@ -489,6 +506,18 @@ test("does not delete a subnet that is also upserted in the same request", async
   expect(text).not.toMatch(/DELETE FROM subnets/);
 });
 
+test("wraps all registry mutations in a single postgres transaction", async () => {
+  await worker.fetch(
+    post(
+      { providers: [provider()], subnets: [subnet()], surfaces: [surface()] },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+  expect(transaction.began).toBe(1);
+});
+
 test("maps a DB failure to a clean 502 instead of throwing", async () => {
   failure.error = new Error("connection reset");
   const res = await worker.fetch(
@@ -498,4 +527,5 @@ test("maps a DB failure to a clean 502 instead of throwing", async () => {
   );
   expect(res.status).toBe(502);
   expect((await res.json()).error).toBe("write failed");
+  expect(transaction.rolledBack).toBe(1);
 });

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -116,152 +116,157 @@ export default {
       subnets_deleted: 0,
     };
     try {
-      await sql`SET statement_timeout = '10000ms'`;
+      // All registry mutations run in one transaction so a mid-batch failure
+      // (timeout, constraint error, transient Hyperdrive blip) cannot leave
+      // prune/delete commits visible without the matching inserts.
+      await sql.begin(async (tx) => {
+        await tx`SET statement_timeout = '10000ms'`;
 
-      for (const p of providers) {
-        if (!p.id || !p.overlay || !p.source_commit) continue;
-        await sql`
-          INSERT INTO providers (id, overlay, source_commit)
-          VALUES (${p.id}, ${sql.json(p.overlay)}, ${p.source_commit})
-          ON CONFLICT (id) DO UPDATE SET
-            overlay = EXCLUDED.overlay,
-            source_commit = EXCLUDED.source_commit,
-            updated_at = now()
-          WHERE providers.overlay IS DISTINCT FROM EXCLUDED.overlay`;
-        summary.providers_written += 1;
-      }
-
-      const writtenSubnetNetuids = new Set();
-      for (const s of subnets) {
-        if (
-          !Number.isInteger(s.netuid) ||
-          !s.slug ||
-          !s.name ||
-          !s.overlay ||
-          !s.source_commit
-        )
-          continue;
-        await sql`
-          INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
-          VALUES (${s.netuid}, ${s.slug}, ${s.name}, ${s.source || "community"}, ${sql.json(s.overlay)}, ${s.source_commit})
-          ON CONFLICT (netuid) DO UPDATE SET
-            slug = EXCLUDED.slug,
-            name = EXCLUDED.name,
-            source = EXCLUDED.source,
-            overlay = EXCLUDED.overlay,
-            source_commit = EXCLUDED.source_commit,
-            updated_at = now()`;
-        summary.subnets_written += 1;
-        writtenSubnetNetuids.add(s.netuid);
-      }
-
-      for (const prune of pruneSurfaces) {
-        if (
-          !Number.isInteger(prune.subnet_netuid) ||
-          !Array.isArray(prune.current_surfaces) ||
-          !prune.source_commit
-        )
-          continue;
-        const keepKeys = prune.current_surfaces
-          .filter((surface) => surface?.kind && surface?.url)
-          .map((surface) => `${surface.kind}\u001f${surface.url}`);
-        // `authority_scope: "community"` (set by the merge-triggered fast path,
-        // scripts/sync-registry-to-postgres.mjs) bounds this prune to ONLY the
-        // community-authority rows for the subnet -- the fast path's
-        // current_surfaces comes from a single registry/subnets/<slug>.json file
-        // and has no visibility into machine-generated/candidate-promoted
-        // surfaces (authority: "registry-observed") the same subnet may also
-        // carry, so without this scope it would delete those rows on every
-        // merge that touches the file. The scheduled full resync
-        // (scripts/backfill-registry-postgres.mjs) computes current_surfaces
-        // from the complete baseline-augmented view and omits authority_scope,
-        // so it keeps pruning across every authority as before. Passed as a
-        // plain boolean parameter (not spliced SQL) so the condition is a
-        // no-op OR branch when unscoped, rather than composing raw fragments.
-        const scopeToCommunity = prune.authority_scope === "community";
-        const deleted = keepKeys.length
-          ? await sql`
-              DELETE FROM surfaces
-              WHERE subnet_netuid = ${prune.subnet_netuid}
-                AND (NOT ${scopeToCommunity} OR authority = ${"community"})
-                AND NOT (kind || ${"\u001f"} || url = ANY(${keepKeys}))
-              RETURNING id, subnet_netuid, overlay`
-          : await sql`
-              DELETE FROM surfaces
-              WHERE subnet_netuid = ${prune.subnet_netuid}
-                AND (NOT ${scopeToCommunity} OR authority = ${"community"})
-              RETURNING id, subnet_netuid, overlay`;
-        for (const row of deleted) {
-          await sql`
-            INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
-            VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${sql.json(row.overlay)}, ${prune.source_commit})`;
-          summary.surfaces_deleted += 1;
+        for (const p of providers) {
+          if (!p.id || !p.overlay || !p.source_commit) continue;
+          await tx`
+            INSERT INTO providers (id, overlay, source_commit)
+            VALUES (${p.id}, ${tx.json(p.overlay)}, ${p.source_commit})
+            ON CONFLICT (id) DO UPDATE SET
+              overlay = EXCLUDED.overlay,
+              source_commit = EXCLUDED.source_commit,
+              updated_at = now()
+            WHERE providers.overlay IS DISTINCT FROM EXCLUDED.overlay`;
+          summary.providers_written += 1;
         }
-      }
 
-      for (const deletion of deleteSubnets) {
-        if (!Number.isInteger(deletion.netuid) || !deletion.source_commit)
-          continue;
-        if (writtenSubnetNetuids.has(deletion.netuid)) continue;
-        const deletedSurfaces = await sql`
-          DELETE FROM surfaces
-          WHERE subnet_netuid = ${deletion.netuid}
-          RETURNING id, subnet_netuid, overlay`;
-        for (const row of deletedSurfaces) {
-          await sql`
-            INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
-            VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${sql.json(row.overlay)}, ${deletion.source_commit})`;
-          summary.surfaces_deleted += 1;
-        }
-        const deletedSubnets = await sql`
-          DELETE FROM subnets
-          WHERE netuid = ${deletion.netuid}
-          RETURNING netuid`;
-        summary.subnets_deleted += deletedSubnets.length;
-      }
-
-      for (const surf of surfaces) {
-        if (
-          !Number.isInteger(surf.subnet_netuid) ||
-          !surf.surface_key ||
-          !surf.kind ||
-          !surf.url ||
-          !surf.overlay ||
-          !surf.source_commit
-        )
-          continue;
-        const result = await sql`
-          INSERT INTO surfaces (
-            subnet_netuid, provider_id, surface_key, kind, url,
-            authority, review_state, probe_eligible, public_safe,
-            overlay, source_commit
+        const writtenSubnetNetuids = new Set();
+        for (const s of subnets) {
+          if (
+            !Number.isInteger(s.netuid) ||
+            !s.slug ||
+            !s.name ||
+            !s.overlay ||
+            !s.source_commit
           )
-          VALUES (
-            ${surf.subnet_netuid}, ${surf.provider_id ?? null}, ${surf.surface_key}, ${surf.kind}, ${surf.url},
-            ${surf.authority || "community"}, ${surf.review_state || "community-submitted"},
-            ${Boolean(surf.probe_eligible)}, ${surf.public_safe !== false},
-            ${sql.json(surf.overlay)}, ${surf.source_commit}
-          )
-          ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
-            provider_id = EXCLUDED.provider_id,
-            surface_key = EXCLUDED.surface_key,
-            authority = EXCLUDED.authority,
-            review_state = EXCLUDED.review_state,
-            probe_eligible = EXCLUDED.probe_eligible,
-            public_safe = EXCLUDED.public_safe,
-            overlay = EXCLUDED.overlay,
-            source_commit = EXCLUDED.source_commit,
-            updated_at = now()
-          WHERE surfaces.overlay IS DISTINCT FROM EXCLUDED.overlay
-          RETURNING (xmax = 0) AS inserted`;
-        if (result.length) {
-          const action = result[0].inserted ? "insert" : "update";
-          await sql`
-            INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
-            VALUES (${surf.subnet_netuid}, ${action}, ${sql.json(surf.overlay)}, ${surf.source_commit})`;
-          summary.surfaces_written += 1;
+            continue;
+          await tx`
+            INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
+            VALUES (${s.netuid}, ${s.slug}, ${s.name}, ${s.source || "community"}, ${tx.json(s.overlay)}, ${s.source_commit})
+            ON CONFLICT (netuid) DO UPDATE SET
+              slug = EXCLUDED.slug,
+              name = EXCLUDED.name,
+              source = EXCLUDED.source,
+              overlay = EXCLUDED.overlay,
+              source_commit = EXCLUDED.source_commit,
+              updated_at = now()`;
+          summary.subnets_written += 1;
+          writtenSubnetNetuids.add(s.netuid);
         }
-      }
+
+        for (const prune of pruneSurfaces) {
+          if (
+            !Number.isInteger(prune.subnet_netuid) ||
+            !Array.isArray(prune.current_surfaces) ||
+            !prune.source_commit
+          )
+            continue;
+          const keepKeys = prune.current_surfaces
+            .filter((surface) => surface?.kind && surface?.url)
+            .map((surface) => `${surface.kind}\u001f${surface.url}`);
+          // `authority_scope: "community"` (set by the merge-triggered fast path,
+          // scripts/sync-registry-to-postgres.mjs) bounds this prune to ONLY the
+          // community-authority rows for the subnet -- the fast path's
+          // current_surfaces comes from a single registry/subnets/<slug>.json file
+          // and has no visibility into machine-generated/candidate-promoted
+          // surfaces (authority: "registry-observed") the same subnet may also
+          // carry, so without this scope it would delete those rows on every
+          // merge that touches the file. The scheduled full resync
+          // (scripts/backfill-registry-postgres.mjs) computes current_surfaces
+          // from the complete baseline-augmented view and omits authority_scope,
+          // so it keeps pruning across every authority as before. Passed as a
+          // plain boolean parameter (not spliced SQL) so the condition is a
+          // no-op OR branch when unscoped, rather than composing raw fragments.
+          const scopeToCommunity = prune.authority_scope === "community";
+          const deleted = keepKeys.length
+            ? await tx`
+                DELETE FROM surfaces
+                WHERE subnet_netuid = ${prune.subnet_netuid}
+                  AND (NOT ${scopeToCommunity} OR authority = ${"community"})
+                  AND NOT (kind || ${"\u001f"} || url = ANY(${keepKeys}))
+                RETURNING id, subnet_netuid, overlay`
+            : await tx`
+                DELETE FROM surfaces
+                WHERE subnet_netuid = ${prune.subnet_netuid}
+                  AND (NOT ${scopeToCommunity} OR authority = ${"community"})
+                RETURNING id, subnet_netuid, overlay`;
+          for (const row of deleted) {
+            await tx`
+              INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
+              VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${tx.json(row.overlay)}, ${prune.source_commit})`;
+            summary.surfaces_deleted += 1;
+          }
+        }
+
+        for (const deletion of deleteSubnets) {
+          if (!Number.isInteger(deletion.netuid) || !deletion.source_commit)
+            continue;
+          if (writtenSubnetNetuids.has(deletion.netuid)) continue;
+          const deletedSurfaces = await tx`
+            DELETE FROM surfaces
+            WHERE subnet_netuid = ${deletion.netuid}
+            RETURNING id, subnet_netuid, overlay`;
+          for (const row of deletedSurfaces) {
+            await tx`
+              INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
+              VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${tx.json(row.overlay)}, ${deletion.source_commit})`;
+            summary.surfaces_deleted += 1;
+          }
+          const deletedSubnets = await tx`
+            DELETE FROM subnets
+            WHERE netuid = ${deletion.netuid}
+            RETURNING netuid`;
+          summary.subnets_deleted += deletedSubnets.length;
+        }
+
+        for (const surf of surfaces) {
+          if (
+            !Number.isInteger(surf.subnet_netuid) ||
+            !surf.surface_key ||
+            !surf.kind ||
+            !surf.url ||
+            !surf.overlay ||
+            !surf.source_commit
+          )
+            continue;
+          const result = await tx`
+            INSERT INTO surfaces (
+              subnet_netuid, provider_id, surface_key, kind, url,
+              authority, review_state, probe_eligible, public_safe,
+              overlay, source_commit
+            )
+            VALUES (
+              ${surf.subnet_netuid}, ${surf.provider_id ?? null}, ${surf.surface_key}, ${surf.kind}, ${surf.url},
+              ${surf.authority || "community"}, ${surf.review_state || "community-submitted"},
+              ${Boolean(surf.probe_eligible)}, ${surf.public_safe !== false},
+              ${tx.json(surf.overlay)}, ${surf.source_commit}
+            )
+            ON CONFLICT (subnet_netuid, kind, url) DO UPDATE SET
+              provider_id = EXCLUDED.provider_id,
+              surface_key = EXCLUDED.surface_key,
+              authority = EXCLUDED.authority,
+              review_state = EXCLUDED.review_state,
+              probe_eligible = EXCLUDED.probe_eligible,
+              public_safe = EXCLUDED.public_safe,
+              overlay = EXCLUDED.overlay,
+              source_commit = EXCLUDED.source_commit,
+              updated_at = now()
+            WHERE surfaces.overlay IS DISTINCT FROM EXCLUDED.overlay
+            RETURNING (xmax = 0) AS inserted`;
+          if (result.length) {
+            const action = result[0].inserted ? "insert" : "update";
+            await tx`
+              INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
+              VALUES (${surf.subnet_netuid}, ${action}, ${tx.json(surf.overlay)}, ${surf.source_commit})`;
+            summary.surfaces_written += 1;
+          }
+        }
+      });
 
       return json({ ok: true, ...summary });
     } catch (err) {


### PR DESCRIPTION
## Summary

Registry sync mutations (provider/subnet upserts, surface prunes/deletes, surface inserts + history) previously ran as independent auto-committed statements. A mid-batch failure (statement timeout, constraint error, transient Hyperdrive blip) could leave prune/delete commits visible while later inserts never ran, corrupting the production registry catalog until the next successful sync.

## Root cause

`workers/registry-sync-api.mjs` is the sole write path into registry Postgres. Its write loop issued many separate `await sql\`...\`` calls inside one `try` block but without a transaction boundary, so Postgres committed each statement immediately.

## Fix

Wrap the entire mutation block in `sql.begin()` and route all writes through the transaction handle (`tx`). On any error, postgres.js rolls back the whole batch and the handler still returns a clean 502.

## Impact

- Prevents partial registry state after failed CI merge-triggered syncs and scheduled resyncs
- No API contract change; success/error shapes unchanged
- Adds unit coverage that mutations run inside exactly one transaction and that failures trigger rollback

## Risks / tradeoffs

- A failed sync now rolls back entirely instead of leaving partial progress. This is intentional: partial progress was the bug. Retries remain safe because upserts are idempotent.

## Test plan

- [x] `npm test -- tests/registry-sync-api.test.mjs`
- [x] CI Validate workflow (pending)