### PR TITLE
feat(ui): add a stake-flow scorecard to the subnet Activity tab

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -148,6 +148,7 @@ import type {
   SubnetNeuronHistoryPoint,
   SubnetStakeTransfers,
   SubnetRegistrations,
+  SubnetStakeFlow,
   SubnetMovers,
   SubnetMover,
   MetagraphNeuron,
@@ -3567,6 +3568,36 @@ export const subnetHealthQuery = (netuid: number) =>
  * newest first, from the account_events tier filtered by netuid. Schema-stable
  * zero for a cold/unknown subnet.
  */
+// #3342: per-subnet stake-flow scorecard — net capital movement (staked in /
+// unstaked out / signed net) over the window. A cold store returns all-zero
+// totals (never 404); the normalizer coerces every numeric to 0, never NaN.
+export function normalizeSubnetStakeFlow(netuid: number, raw: unknown): SubnetStakeFlow {
+  const d = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    window: firstString(d.window) ?? "30d",
+    total_staked_tao: coerceFiniteNumber(d.total_staked_tao) ?? 0,
+    total_unstaked_tao: coerceFiniteNumber(d.total_unstaked_tao) ?? 0,
+    net_flow_tao: coerceFiniteNumber(d.net_flow_tao) ?? 0,
+    stake_events: firstFiniteNumber(d.stake_events) ?? 0,
+    unstake_events: firstFiniteNumber(d.unstake_events) ?? 0,
+  };
+}
+
+export const subnetStakeFlowQuery = (netuid: number, window = "30d") =>
+  queryOptions({
+    queryKey: k("subnet-stake-flow", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetStakeFlow>>(`/api/v1/subnets/${netuid}/stake-flow`, {
+        params: { window },
+        signal,
+      });
+      return { data: normalizeSubnetStakeFlow(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
 export const subnetEventsQuery = (netuid: number) =>
   queryOptions({
     queryKey: k("subnet-events", netuid),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1491,6 +1491,18 @@ export interface SubnetRegistrations {
   registrations_per_registrant: number | null;
 }
 
+/** Per-subnet stake-flow scorecard from /api/v1/subnets/{netuid}/stake-flow (#3342). */
+export interface SubnetStakeFlow {
+  schema_version: number;
+  netuid: number;
+  window: string;
+  total_staked_tao: number;
+  total_unstaked_tao: number;
+  net_flow_tao: number;
+  stake_events: number;
+  unstake_events: number;
+}
+
 /** One subnet's movement over the comparison window on the /subnets/movers board. */
 export interface SubnetMover {
   netuid: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, Waves, Activity } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CandidateChip, CurationChip, ReviewChip } from "@/components/metagraphed/chips";
 import { ExternalLink } from "@/components/metagraphed/external-link";
@@ -18,6 +18,8 @@ import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { SchemaDriftSummary } from "@/components/metagraphed/schema-drift";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
 import { SurfaceFixture } from "@/components/metagraphed/surface-fixture";
@@ -48,6 +50,7 @@ import {
   subnetWeightSettersQuery,
   subnetWeightsQuery,
   subnetIdentityHistoryQuery,
+  subnetStakeFlowQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -543,6 +546,43 @@ function SurfacesPanel({ netuid }: { netuid: number }) {
 
 // On-chain activity stream (#1345): first-party SubtensorModule events for this
 // subnet, decoded direct from finney and served from /api/v1/subnets/{netuid}/events.
+function StakeFlowScorecard({ netuid }: { netuid: number }) {
+  const { data: res } = useQuery(subnetStakeFlowQuery(netuid));
+  const card = res?.data;
+  if (!card) return null;
+  const net = card.net_flow_tao;
+  const netTone: "ok" | "down" | "default" = net > 0 ? "ok" : net < 0 ? "down" : "default";
+  return (
+    <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatTile
+        icon={ArrowDownToLine}
+        eyebrow="Staked in"
+        value={`${taoCompact(card.total_staked_tao)} τ`}
+        hint={`${formatNumber(card.stake_events)} stake events`}
+      />
+      <StatTile
+        icon={ArrowUpFromLine}
+        eyebrow="Unstaked out"
+        value={`${taoCompact(card.total_unstaked_tao)} τ`}
+        hint={`${formatNumber(card.unstake_events)} unstake events`}
+      />
+      <StatTile
+        icon={Waves}
+        eyebrow="Net flow"
+        tone={netTone}
+        value={`${taoCompact(net)} τ`}
+        hint={net > 0 ? "net inflow" : net < 0 ? "net outflow" : "balanced"}
+      />
+      <StatTile
+        icon={Activity}
+        eyebrow="Total events"
+        value={formatNumber(card.stake_events + card.unstake_events)}
+        hint={`over ${card.window}`}
+      />
+    </div>
+  );
+}
+
 function ActivityPanel({ netuid }: { netuid: number }) {
   return (
     <SectionAnchor
@@ -551,6 +591,7 @@ function ActivityPanel({ netuid }: { netuid: number }) {
       subtitle="First-party chain events for this subnet, newest first."
       info="Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
     >
+      <StakeFlowScorecard netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
           <ActivityTableLoader netuid={netuid} />


### PR DESCRIPTION
## What

Adds a **stake-flow scorecard** to the subnet Activity tab — per-subnet net capital movement (staked in / unstaked out / signed net flow) over the trailing 30-day window, from `GET /api/v1/subnets/{netuid}/stake-flow`. It sits above the existing raw event table; the endpoint had no frontend consumer.

## How

- **`queries.ts`** — `subnetStakeFlowQuery(netuid, window="30d")` + `normalizeSubnetStakeFlow` (a cold store returns all-zero totals, never 404; the normalizer coerces every numeric to 0, never NaN).
- **`types.ts`** — `SubnetStakeFlow`.
- **`subnets.$netuid.tsx`** — `StakeFlowScorecard`: a `StatTile` grid inside the `activity` `SectionAnchor`, above `ActivityTableLoader`:
  - **Staked in** (`total_staked_tao`), **Unstaked out** (`total_unstaked_tao`)
  - **Net flow** (`net_flow_tao`) — `ok`/`down` tone by sign so inflow/outflow reads at a glance
  - **Total events** (`stake_events` + `unstake_events`)

The existing per-event table (`ActivityTableLoader` / `subnetEventsQuery`) is untouched.

## Screenshots (subnet 64 — Chutes, live api.metagraph.sh)

Both frames anchored on the `#activity` section — the **after** shows the new scorecard above the event table; the **before** shows the same section without it.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-light-after.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-desktop-dark-after.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-light-after.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-tablet-dark-after.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-light-after.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/subnet-stakeflow-mobile-dark-after.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] Diff touches `subnets.$netuid.tsx` (not just queries.ts/types.ts)
- [x] `subnetStakeFlowQuery` calls `GET /api/v1/subnets/{netuid}/stake-flow`, following the `queryOptions`/`apiFetch`/normalize idiom
- [x] `ActivityPanel` calls it via `useQuery`
- [x] Scorecard shows `total_staked_tao`, `total_unstaked_tao`, `net_flow_tao` with sign-distinct tone, via `StatTile`
- [x] Cold/zeroed response renders zeros (not an error); loading/error handled per the file's convention

## Non-goals respected

No changes to `ActivityTableLoader`/the event table; no account-level stake-flow; no window/direction selector (fixed 30d default).

## Gates

`npm run typecheck` ✓ (exit 0) · `eslint` (my files) ✓

Closes #3342