### PR TITLE
feat(ui): add a registration-cost column to the subnets table view (#3364)

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -10,20 +10,14 @@ import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { Sparkline, type SparklinePoint } from "@/components/metagraphed/charts/sparkline";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
 // validators, volume) from the previously-unused /api/v1/economics. The artifact
 // carries all subnets; we fetch once (shared cache) and find this netuid.
-
-function fmtTao(v?: number): string {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
-}
+// #3364: the tiered τ formatter now lives in lib/format (formatTao) so this
+// panel and the /subnets table Registration column share one source of truth.
 
 function Notice({ children }: { children: string }) {
   return (
@@ -169,11 +163,11 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         value={formatNumber(e.miner_count)}
         hint={e.max_uids ? `${e.max_uids} max UIDs` : undefined}
       />
-      <StatTile eyebrow="Total stake" value={fmtTao(e.total_stake_tao)} />
-      <StatTile eyebrow="Volume" value={fmtTao(e.subnet_volume_tao)} />
-      <StatTile eyebrow="Max stake" value={fmtTao(e.max_stake_tao)} />
-      <StatTile eyebrow="Market cap" value={fmtTao(e.alpha_market_cap_tao)} hint="proxy" />
-      <StatTile eyebrow="FDV" value={fmtTao(e.alpha_fdv_tao)} hint="proxy" />
+      <StatTile eyebrow="Total stake" value={formatTao(e.total_stake_tao)} />
+      <StatTile eyebrow="Volume" value={formatTao(e.subnet_volume_tao)} />
+      <StatTile eyebrow="Max stake" value={formatTao(e.max_stake_tao)} />
+      <StatTile eyebrow="Market cap" value={formatTao(e.alpha_market_cap_tao)} hint="proxy" />
+      <StatTile eyebrow="FDV" value={formatTao(e.alpha_fdv_tao)} hint="proxy" />
       <StatTile
         eyebrow="Registration"
         tone={e.registration_allowed === false ? "down" : "default"}

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -5,6 +5,7 @@ import {
   durationLabel,
   formatRelative,
   isStaleFreshness,
+  formatTao,
 } from "./format";
 
 describe("isUsableTimestamp", () => {
@@ -130,5 +131,35 @@ describe("isStaleFreshness", () => {
   it("honours a custom threshold", () => {
     const oneHourAgo = new Date(Date.now() - 3_600_000).toISOString();
     expect(isStaleFreshness(oneHourAgo, 30 * 60_000)).toBe(true);
+  });
+});
+
+describe("formatTao", () => {
+  it("returns the em-dash fallback for nullish / non-finite input", () => {
+    expect(formatTao(undefined)).toBe("—");
+    expect(formatTao(null)).toBe("—");
+    expect(formatTao(Number.NaN)).toBe("—");
+    expect(formatTao(Infinity)).toBe("—");
+    expect(formatTao(-Infinity)).toBe("—");
+  });
+
+  it("keeps 4 decimals for zero and sub-unit amounts (< 1)", () => {
+    expect(formatTao(0)).toBe("0.0000 τ");
+    expect(formatTao(0.5)).toBe("0.5000 τ");
+    expect(formatTao(0.48213)).toBe("0.4821 τ");
+  });
+
+  it("uses 2 decimals for whole-unit amounts in [1, 1e3)", () => {
+    expect(formatTao(1)).toBe("1.00 τ"); // lower boundary — 2dp, not k-tier
+    expect(formatTao(256.5)).toBe("256.50 τ");
+    expect(formatTao(999.994)).toBe("999.99 τ");
+  });
+
+  it("switches to the k-tier at 1e3 and the M-tier at 1e6 (inclusive)", () => {
+    expect(formatTao(1_000)).toBe("1.0k τ"); // lower boundary of k-tier
+    expect(formatTao(12_345)).toBe("12.3k τ");
+    expect(formatTao(999_999)).toBe("1000.0k τ"); // still < 1e6 → k-tier
+    expect(formatTao(1_000_000)).toBe("1.00M τ"); // lower boundary of M-tier
+    expect(formatTao(2_500_000)).toBe("2.50M τ");
   });
 });

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -5,6 +5,22 @@ export function formatNumber(n: number | undefined | null, fallback = "—"): st
 }
 
 /**
+ * Format a TAO (τ) amount for compact display, tiering the precision by
+ * magnitude so both dust and whole-subnet aggregates stay readable in a
+ * single cell: ≥1e6 → "1.23M τ", ≥1e3 → "1.2k τ", ≥1 → "1.23 τ", and
+ * sub-unit values keep 4 decimals ("0.5000 τ"). Nullish / non-finite input
+ * renders the em-dash fallback. Shared by the per-subnet EconomicsPanel tiles
+ * and the /subnets table Registration column so the two never drift.
+ */
+export function formatTao(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  if (v >= 1) return `${v.toFixed(2)} τ`;
+  return `${v.toFixed(4)} τ`;
+}
+
+/**
  * The upstream registry frequently emits "1970-01-01T00:00:00.000Z" as a
  * placeholder when an artifact hasn't been timestamped yet. Treat any
  * pre-2000 date as "unknown" so the UI doesn't claim freshness/staleness

--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { joinHealth, matchesQuery, sortBy, paginate } from "./url-state";
+import { joinEconomics, joinHealth, matchesQuery, sortBy, paginate } from "./url-state";
 
 describe("matchesQuery", () => {
   it("matches everything for an empty needle", () => {
@@ -101,6 +101,52 @@ describe("joinHealth", () => {
     const rows = [{ netuid: 1, updated_at: null as string | null }];
     joinHealth(rows, { 1: { health: "ok", last_checked: "probe-time" } });
     expect(rows[0].updated_at).toBeNull();
+  });
+});
+
+describe("joinEconomics", () => {
+  it("attaches registration cost + allowed flag from a matching entry", () => {
+    const rows = [{ netuid: 1 }, { netuid: 2 }];
+    const out = joinEconomics(rows, {
+      1: { registration_cost_tao: 256, registration_allowed: true },
+    });
+    expect(out[0]).toMatchObject({
+      netuid: 1,
+      registration_cost_tao: 256,
+      registration_allowed: true,
+    });
+  });
+
+  it("carries a closed (registration_allowed: false) entry through", () => {
+    const rows = [{ netuid: 5 }];
+    const out = joinEconomics(rows, {
+      5: { registration_cost_tao: 0.5, registration_allowed: false },
+    });
+    expect(out[0]).toMatchObject({ registration_cost_tao: 0.5, registration_allowed: false });
+  });
+
+  it("passes rows with no economics entry through by reference (unchanged)", () => {
+    const rows = [{ netuid: 9 }];
+    const out = joinEconomics(rows, { 1: { registration_cost_tao: 10 } });
+    // No entry for netuid 9 → same object reference, so its cell renders "—".
+    expect(out[0]).toBe(rows[0]);
+    expect(out[0]).not.toHaveProperty("registration_cost_tao");
+  });
+
+  it("attaches undefined fields when the entry exists but omits them", () => {
+    const rows = [{ netuid: 3 }];
+    const out = joinEconomics(rows, { 3: {} });
+    // The row is cloned (entry present) but both fields are undefined — the
+    // column must not misread this as "registration open".
+    expect(out[0]).not.toBe(rows[0]);
+    expect((out[0] as { registration_cost_tao?: number }).registration_cost_tao).toBeUndefined();
+    expect((out[0] as { registration_allowed?: boolean }).registration_allowed).toBeUndefined();
+  });
+
+  it("does not mutate the input rows", () => {
+    const rows = [{ netuid: 1 }];
+    joinEconomics(rows, { 1: { registration_cost_tao: 42, registration_allowed: true } });
+    expect(rows[0]).not.toHaveProperty("registration_cost_tao");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -79,3 +79,30 @@ export function joinHealth<
     return h ? { ...s, health: h.health, updated_at: s.updated_at ?? h.last_checked } : s;
   });
 }
+
+/**
+ * #3364: join a list of rows with a per-netuid economics map, overlaying the
+ * `registration_cost_tao` + `registration_allowed` fields so the /subnets
+ * table's Registration column (and its sort) can read them straight off the
+ * row. Mirrors `joinHealth`/the catalog join: a row with no economics entry
+ * passes through unchanged (same reference), so its cell renders "—". Pure +
+ * allocation-light so callers can memoize it.
+ */
+export function joinEconomics<
+  T extends { netuid: number },
+  E extends { registration_cost_tao?: number; registration_allowed?: boolean },
+>(
+  rows: T[],
+  economicsMap: Record<number, E | undefined>,
+): Array<T | (T & { registration_cost_tao?: number; registration_allowed?: boolean })> {
+  return rows.map((s) => {
+    const e = economicsMap[s.netuid];
+    return e
+      ? {
+          ...s,
+          registration_cost_tao: e.registration_cost_tao,
+          registration_allowed: e.registration_allowed,
+        }
+      : s;
+  });
+}

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -40,12 +40,19 @@ import {
   healthQuery,
   subnetHealthMapQuery,
   agentCatalogMapQuery,
+  economicsQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { joinHealth, matchesQuery, sortBy, tableSearchSchema } from "@/lib/metagraphed/url-state";
+import {
+  joinEconomics,
+  joinHealth,
+  matchesQuery,
+  sortBy,
+  tableSearchSchema,
+} from "@/lib/metagraphed/url-state";
 import { API_BASE } from "@/lib/metagraphed/config";
-import type { AgentCatalogSummary, Subnet } from "@/lib/metagraphed/types";
+import type { AgentCatalogSummary, Subnet, SubnetEconomics } from "@/lib/metagraphed/types";
 
 // #9: a list row enriched with its agent-catalog capability fields (flattened
 // from the netuid-keyed catalog map so client-side sort/filter can read them).
@@ -55,6 +62,10 @@ type SubnetRow = Subnet & {
   integration_readiness?: number;
   readiness_tier?: string;
   service_count?: number;
+  // #3364: on-chain registration economics joined from /api/v1/economics by
+  // netuid so the Registration column (and its sort) can read them off the row.
+  registration_cost_tao?: number;
+  registration_allowed?: boolean;
 };
 
 function joinCatalog(
@@ -269,6 +280,17 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   const catalogMapRaw = useSuspenseQuery(agentCatalogMapQuery()).data.data;
   const catalogMap = useMemo(() => catalogMapRaw ?? {}, [catalogMapRaw]);
 
+  // #3364: per-subnet on-chain economics — already fetched once per session for
+  // the detail EconomicsPanel, so this reuses that shared cache (no new endpoint,
+  // no backend change). Indexed by netuid into a map and joined the same way as
+  // health/catalog so the Registration column + its sort resolve off the row.
+  const economicsRaw = useSuspenseQuery(economicsQuery()).data.data;
+  const economicsMap = useMemo(() => {
+    const map: Record<number, SubnetEconomics> = {};
+    for (const e of economicsRaw ?? []) map[e.netuid] = e;
+    return map;
+  }, [economicsRaw]);
+
   const pages = data.pages as Array<(typeof data.pages)[number] & { cursorInvalid?: boolean }>;
   const lastPage = pages[pages.length - 1];
   const cursorInvalid = !!lastPage?.cursorInvalid;
@@ -277,14 +299,17 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   // re-renders the route doesn't re-flatten and re-clone every row.
   const all = useMemo(
     () =>
-      joinCatalog(
-        joinHealth(
-          pages.flatMap((p) => (p.data ?? []) as Subnet[]),
-          healthMap,
+      joinEconomics(
+        joinCatalog(
+          joinHealth(
+            pages.flatMap((p) => (p.data ?? []) as Subnet[]),
+            healthMap,
+          ),
+          catalogMap,
         ),
-        catalogMap,
+        economicsMap,
       ),
-    [pages, healthMap, catalogMap],
+    [pages, healthMap, catalogMap, economicsMap],
   );
   const total = pages[0]?.meta?.pagination?.total ?? pages[0]?.meta?.total;
 
@@ -623,6 +648,19 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                     align="right"
                   />
                 </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
+                >
+                  <SortHeader
+                    label="Registration"
+                    field="registration_cost_tao"
+                    active={search.sort === "registration_cost_tao"}
+                    order={search.order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
                 <th className={cellPad}>Health</th>
                 <th
                   className={classNames(cellPad, "text-right")}
@@ -698,6 +736,26 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       tier={s.readiness_tier}
                       kinds={s.service_kinds}
                     />
+                  </td>
+                  <td
+                    className={classNames(
+                      cellPad,
+                      "text-right font-mono text-[11px] tabular-nums",
+                      // #3364: dim the cost only when registration is explicitly
+                      // closed. `registration_allowed === undefined` (economics
+                      // entry present but flag absent, or no entry at all) keeps
+                      // the neutral tone — do NOT read it as "open".
+                      s.registration_allowed === false ? "text-ink-muted" : "text-ink",
+                    )}
+                    title={
+                      s.registration_allowed === false
+                        ? "Registration currently closed"
+                        : s.registration_allowed === true
+                          ? "Registration open"
+                          : undefined
+                    }
+                  >
+                    {formatTao(s.registration_cost_tao)}
                   </td>
                   <td className={cellPad}>
                     <HealthPill state={s.health} />


### PR DESCRIPTION
Closes #3364

## Summary

Adds a right-aligned, sortable **Registration** column (`registration_cost_tao`, in τ) to the `/subnets` **table** view (`SubnetsTable`), between the Readiness and Health columns. The value is joined by `netuid` from the already-fetched `/api/v1/economics` artifact via `economicsQuery()` — **no new endpoint, no backend/schema change**. Missing values render `—`; `registration_allowed` drives a subtle cell tone + title (open/closed). Sorting works through the existing `SortHeader`/`sortBy` mechanism.

## What changed

- **`apps/ui/src/routes/subnets.index.tsx`** — new `useSuspenseQuery(economicsQuery())` + memoized `netuid → SubnetEconomics` map, folded into the same `all` memo alongside `joinHealth`/`joinCatalog` (dependency array updated). New `SortHeader label="Registration" field="registration_cost_tao"` `<th>` and a matching right-aligned `<td>` rendering `formatTao(...)`. `SubnetRow` extended with the two optional fields.
- **`apps/ui/src/lib/metagraphed/url-state.ts`** — new generic `joinEconomics()` helper next to `joinHealth()` (same shape: pure, allocation-light, non-matching rows pass through by reference so their cell renders `—`).
- **`apps/ui/src/lib/metagraphed/format.ts`** — extracted the tiered τ formatter `fmtTao` (previously duplicated in `economics-panel.tsx`) into a shared, documented `formatTao()`.
- **`apps/ui/src/components/metagraphed/economics-panel.tsx`** — now imports `formatTao` instead of defining a local copy (behaviour-preserving; the per-subnet Registration tile output is unchanged).

## Scope (matches the issue's acceptance criteria)

- [x] New "Registration" `<th>`/`<td>` in `SubnetsTable`, from `SubnetEconomics.registration_cost_tao` joined by `netuid`
- [x] Uses the existing `economicsQuery()` + `useSuspenseQuery` + memoized join (same as `healthMap`/`catalogMap`); no new fetch/endpoint
- [x] Sortable via the existing `SortHeader`/`onSort` (`?sort=registration_cost_tao&order=`) — `sortBy` reads the field off the row, no `tableSearchSchema` change
- [x] Null/missing renders `—` (never `undefined`/`NaN`/blank)
- [x] No `schemas/` / `registry/` / backend/Worker changes — frontend-only join of already-served data
- [x] `SubnetGrid` / `SubnetMatrix` and the per-subnet `EconomicsPanel` tile left untouched (table-view-only column)

## Notes for review

- **Search/filter path:** the table's free-text filter is `matchesQuery([s.netuid, s.name, s.symbol], search.q)` — numeric joined fields (`service_count`, `integration_readiness`) are already excluded from that haystack, and `registration_cost_tao` follows the same rule (sort-only, not searched). No filter-helper change needed.
- **`registration_allowed === undefined`** (economics entry present but flag absent, or no entry) intentionally keeps the neutral `text-ink` tone with no tooltip — commented inline so it isn't misread as "open".

## Local verification

- `npm run typecheck --workspace=apps/ui` ✓
- `npm test --workspace=apps/ui` ✓ — 78 files, **546 tests** (adds `formatTao` boundary tests + `joinEconomics` tests)
- `npm run lint` / `npm run format:check` ✓ on the changed files

## Before / after screenshots — `/subnets` table view

`before` = current production (`metagraph.sh`, unchanged `main`) · `after` = this branch's local dev build against the same live `api.metagraph.sh` data. Fixed viewport captures, theme forced via `localStorage['mg-theme']`.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | ![desktop light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/desktop-light-before.png)<br><sub>columns end …Readiness · Health · Updated</sub> | ![desktop light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/desktop-light-after.png)<br><sub>new sortable **Registration** (τ) column between Readiness and Health</sub> |
| Desktop · Dark   | ![desktop dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/desktop-dark-before.png)<br><sub>before</sub> | ![desktop dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light   | ![tablet light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/tablet-light-before.png)<br><sub>before</sub> | ![tablet light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/tablet-light-after.png)<br><sub>after — see note</sub> |
| Tablet · Dark    | ![tablet dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/tablet-dark-before.png)<br><sub>before</sub> | ![tablet dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/tablet-dark-after.png)<br><sub>after</sub> |

**Tablet note:** at `md`/768px the table's `overflow-x-clip` (ListShell `stickyHeader`) clips the right-hand columns; Health and Updated are already off-screen on `main`, so the new Registration column lands in that same already-clipped region and the visible portion is unchanged before/after.

**Mobile (< `md`) intentionally omitted:** below the `md` breakpoint `ListShell` renders the tap-friendly **card** fallback (`md:hidden`), not the `<table>` (`hidden md:block`). This change adds a table column only and does not touch the cards, so the mobile view is provably unaffected.
