### PR TITLE
fix(staging): refuse to prune D1 on partial subnet-hyperparams snapshots

### DIFF
--- a/scripts/fetch-subnet-hyperparams.py
+++ b/scripts/fetch-subnet-hyperparams.py
@@ -94,6 +94,11 @@ def to_flag(value):
     return 1 if value else 0
 
 
+def coverage_snapshot_complete(rows_count, netuids_count, errors):
+    """True only when every active netuid produced a hyperparameter row."""
+    return not errors and rows_count == netuids_count
+
+
 def main():
     import bittensor as bt  # lazy: keeps this module loadable (e.g. for unit
     # tests) without the heavy SDK installed, matching fetch-events.py's/
@@ -209,14 +214,33 @@ def main():
         )
 
     os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    # Every staged snapshot is a full-sync replacement: the Worker prunes any
+    # netuid absent from the signed rows. A partial fetch (per-netuid RPC
+    # failures or missing hyperparameters for an active netuid) must not be
+    # written — mirror fetch-metagraph.mjs's coverage-collapse guard.
+    if not coverage_snapshot_complete(len(rows), len(netuids), errors):
+        if errors:
+            sys.stderr.write(
+                f"aborting: {len(errors)}/{len(netuids)} subnet hyperparameter fetch(es) failed\n",
+            )
+            for err in errors:
+                sys.stderr.write(f"  {err}\n")
+        else:
+            sys.stderr.write(
+                f"aborting: expected {len(netuids)} row(s) but got {len(rows)} "
+                f"(active netuid without hyperparameters)\n",
+            )
+        sys.exit(1)
+    payload = {
+        "rows": rows,
+        "expected_netuid_count": len(netuids),
+        "captured_at": captured_at,
+    }
     with open(OUT, "w") as fh:
-        json.dump(rows, fh)
+        json.dump(payload, fh)
     sys.stderr.write(
-        f"wrote {len(rows)} subnet hyperparameter row(s) "
-        f"({len(errors)} error(s)) -> {OUT}\n"
+        f"wrote {len(rows)} subnet hyperparameter row(s) -> {OUT}\n",
     )
-    for err in errors:
-        sys.stderr.write(f"  {err}\n")
     if not rows:
         sys.exit(1)
 

--- a/scripts/sign-staged-neurons.mjs
+++ b/scripts/sign-staged-neurons.mjs
@@ -14,6 +14,7 @@ const parsed = JSON.parse(readFileSync(inputPath, "utf8"));
 let rows;
 let refreshed_netuids;
 let captured_at;
+let expected_netuid_count;
 let payload;
 if (Array.isArray(parsed)) {
   rows = parsed;
@@ -22,10 +23,16 @@ if (Array.isArray(parsed)) {
   rows = parsed.rows;
   refreshed_netuids = parsed.refreshed_netuids;
   captured_at = parsed.captured_at;
+  expected_netuid_count = parsed.expected_netuid_count;
   if (!Array.isArray(rows)) {
     throw new Error("staged payload rows must be a JSON array");
   }
-  payload = JSON.stringify({ rows, refreshed_netuids, captured_at });
+  payload = JSON.stringify({
+    rows,
+    refreshed_netuids,
+    captured_at,
+    expected_netuid_count,
+  });
 } else {
   throw new Error("staged payload must be a JSON array or staging object");
 }
@@ -35,4 +42,6 @@ const envelope = { schema_version: 1, hmac_sha256, rows };
 if (refreshed_netuids !== undefined)
   envelope.refreshed_netuids = refreshed_netuids;
 if (captured_at !== undefined) envelope.captured_at = captured_at;
+if (expected_netuid_count !== undefined)
+  envelope.expected_netuid_count = expected_netuid_count;
 writeFileSync(outputPath, `${JSON.stringify(envelope)}\n`);

--- a/scripts/test_fetch_subnet_hyperparams.py
+++ b/scripts/test_fetch_subnet_hyperparams.py
@@ -28,6 +28,7 @@ u16_ratio = _fsh.u16_ratio
 rao_to_tao_exact = _fsh.rao_to_tao_exact
 to_flag = _fsh.to_flag
 to_float = _fsh.to_float
+coverage_snapshot_complete = _fsh.coverage_snapshot_complete
 
 
 class U16RatioTest(unittest.TestCase):
@@ -92,6 +93,17 @@ class ToFloatTest(unittest.TestCase):
 
     def test_non_numeric_returns_none(self):
         self.assertIsNone(to_float("not-a-number"))
+
+
+class CoverageSnapshotCompleteTest(unittest.TestCase):
+    def test_complete_when_all_netuids_succeeded(self):
+        self.assertTrue(coverage_snapshot_complete(129, 129, []))
+
+    def test_incomplete_when_any_fetch_failed(self):
+        self.assertFalse(coverage_snapshot_complete(128, 129, ["netuid=8: timeout"]))
+
+    def test_incomplete_when_row_count_short(self):
+        self.assertFalse(coverage_snapshot_complete(128, 129, []))
 
 
 if __name__ == "__main__":

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -419,10 +419,14 @@ test("loadStagedSubnetHyperparams skips prune when expected_netuid_count is zero
   table.set(2, { ...hyperparamsRow(2) });
   const m = statefulEnv(table);
 
-  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope([hyperparamsRow(1)], SIGNING_KEY, {
-    expected_netuid_count: 0,
-    captured_at: 1_750_000_000_000,
-  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(
+    [hyperparamsRow(1)],
+    SIGNING_KEY,
+    {
+      expected_netuid_count: 0,
+      captured_at: 1_750_000_000_000,
+    },
+  );
   const r = await loadStagedSubnetHyperparams(m.env);
   assert.equal(r.ok, true);
   assert.equal(r.purged, 0);

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -47,14 +47,27 @@ function hyperparamsRow(netuid) {
   };
 }
 
-function signedEnvelope(rows, key = SIGNING_KEY) {
-  return {
+function signedEnvelope(
+  rows,
+  key = SIGNING_KEY,
+  { expected_netuid_count, captured_at } = {},
+) {
+  const payload =
+    expected_netuid_count == null && captured_at == null
+      ? JSON.stringify(rows)
+      : JSON.stringify({ rows, expected_netuid_count, captured_at });
+  const envelope = {
     schema_version: 1,
-    hmac_sha256: createHmac("sha256", key)
-      .update(JSON.stringify(rows))
-      .digest("hex"),
+    hmac_sha256: createHmac("sha256", key).update(payload).digest("hex"),
     rows,
   };
+  if (expected_netuid_count != null) {
+    envelope.expected_netuid_count = expected_netuid_count;
+  }
+  if (captured_at != null) {
+    envelope.captured_at = captured_at;
+  }
+  return envelope;
 }
 
 function mockEnv({
@@ -93,7 +106,7 @@ function mockEnv({
       METAGRAPH_HEALTH_DB: {
         prepare(sql) {
           prepared.push(sql);
-          return {
+          const stmt = {
             bind: (...v) => ({
               sql,
               v,
@@ -113,8 +126,21 @@ function mockEnv({
                   },
                 };
               },
+              async first() {
+                if (sql.includes("COUNT(*)")) {
+                  return { c: 0 };
+                }
+                return null;
+              },
             }),
+            async first() {
+              if (sql.includes("COUNT(*)")) {
+                return { c: 0 };
+              }
+              return null;
+            },
           };
+          return stmt;
         },
         async batch(stmts) {
           batches.push(stmts.length);
@@ -354,7 +380,19 @@ function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
                 }
                 return { meta: { changes: 0 } };
               },
+              async first() {
+                if (sql.includes("COUNT(*)")) {
+                  return { c: table.size };
+                }
+                return null;
+              },
             }),
+            async first() {
+              if (sql.includes("COUNT(*)")) {
+                return { c: table.size };
+              }
+              return null;
+            },
           };
         },
         async batch(stmts) {
@@ -374,6 +412,30 @@ function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
     table,
   };
 }
+
+test("loadStagedSubnetHyperparams keeps stale rows when completeness contract is unmet", async () => {
+  const table = new Map();
+  table.set(1, { ...hyperparamsRow(1) });
+  table.set(2, { ...hyperparamsRow(2) });
+  table.set(3, { ...hyperparamsRow(3) });
+  const m = statefulEnv(table);
+
+  const snapshot = [
+    { ...hyperparamsRow(1), tempo: 720 },
+    { ...hyperparamsRow(3), tempo: 100 },
+  ];
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snapshot, SIGNING_KEY, {
+    expected_netuid_count: 3,
+    captured_at: 1_750_000_000_000,
+  });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+  assert.equal(r.prune_skipped, true);
+  assert.deepEqual([...table.keys()].sort(), [1, 2, 3]);
+  assert.equal(table.get(1).tempo, 720);
+  assert.equal(table.get(3).tempo, 100);
+});
 
 test("loadStagedSubnetHyperparams prunes a deregistered subnet's row on the next full snapshot", async () => {
   const table = new Map();

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -413,6 +413,44 @@ function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
   };
 }
 
+test("loadStagedSubnetHyperparams returns purge_failed when legacy count lookup fails", async () => {
+  const env = {
+    METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          size: 100,
+          async json() {
+            return signedEnvelope([hyperparamsRow(1)]);
+          },
+        };
+      },
+      async delete() {},
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind: (...v) => ({
+            async run() {
+              return { meta: { changes: 0 } };
+            },
+          }),
+          async first() {
+            if (sql.includes("COUNT(*)")) throw new Error("count failed");
+            return null;
+          },
+        };
+      },
+      async batch() {
+        return [{ meta: { changes: 0 } }];
+      },
+    },
+  };
+  const r = await loadStagedSubnetHyperparams(env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "purge_failed");
+});
+
 test("loadStagedSubnetHyperparams skips legacy prune when row count collapsed vs D1", async () => {
   const table = new Map();
   for (let i = 1; i <= 4; i++) table.set(i, { ...hyperparamsRow(i) });

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { createHmac } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test, vi } from "vitest";
 import { loadStagedSubnetHyperparams } from "../workers/api.mjs";
 
@@ -55,7 +59,12 @@ function signedEnvelope(
   const payload =
     expected_netuid_count == null && captured_at == null
       ? JSON.stringify(rows)
-      : JSON.stringify({ rows, expected_netuid_count, captured_at });
+      : JSON.stringify({
+          rows,
+          refreshed_netuids: undefined,
+          captured_at,
+          expected_netuid_count,
+        });
   const envelope = {
     schema_version: 1,
     hmac_sha256: createHmac("sha256", key).update(payload).digest("hex"),
@@ -157,6 +166,36 @@ function mockEnv({
     jsonCalls,
   };
 }
+
+test("loadStagedSubnetHyperparams accepts envelopes signed by sign-staged-neurons.mjs", async () => {
+  const table = new Map();
+  const m = statefulEnv(table);
+  const row = hyperparamsRow(1);
+  const dir = mkdtempSync(path.join(tmpdir(), "hyperparams-sign-roundtrip-"));
+  const input = path.join(dir, "in.json");
+  const output = path.join(dir, "out.json");
+  writeFileSync(
+    input,
+    JSON.stringify({
+      rows: [row],
+      expected_netuid_count: 1,
+      captured_at: row.captured_at,
+    }),
+  );
+  execFileSync(
+    process.execPath,
+    ["scripts/sign-staged-neurons.mjs", input, output],
+    {
+      env: { ...process.env, METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY },
+    },
+  );
+  m.env.METAGRAPH_STAGING_SIGNING_KEY = SIGNING_KEY;
+  m.env.METAGRAPH_ARCHIVE._staged = JSON.parse(readFileSync(output, "utf8"));
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, 1);
+  assert.equal(r.purged, 0);
+});
 
 test("loadStagedSubnetHyperparams loads JSON via parameterized batches + deletes it (#4306)", async () => {
   const rows = Array.from({ length: 5 }, (_, i) => hyperparamsRow(i + 1));

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -430,7 +430,7 @@ test("loadStagedSubnetHyperparams returns purge_failed when legacy count lookup 
     METAGRAPH_HEALTH_DB: {
       prepare(sql) {
         return {
-          bind: (...v) => ({
+          bind: (..._v) => ({
             async run() {
               return { meta: { changes: 0 } };
             },

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -413,6 +413,23 @@ function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
   };
 }
 
+test("loadStagedSubnetHyperparams skips prune when expected_netuid_count is zero", async () => {
+  const table = new Map();
+  table.set(1, { ...hyperparamsRow(1) });
+  table.set(2, { ...hyperparamsRow(2) });
+  const m = statefulEnv(table);
+
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope([hyperparamsRow(1)], SIGNING_KEY, {
+    expected_netuid_count: 0,
+    captured_at: 1_750_000_000_000,
+  });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+  assert.equal(r.prune_skipped, true);
+  assert.deepEqual([...table.keys()].sort(), [1, 2]);
+});
+
 test("loadStagedSubnetHyperparams returns purge_failed when legacy count lookup fails", async () => {
   const env = {
     METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -413,6 +413,37 @@ function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
   };
 }
 
+test("loadStagedSubnetHyperparams skips legacy prune when row count collapsed vs D1", async () => {
+  const table = new Map();
+  for (let i = 1; i <= 4; i++) table.set(i, { ...hyperparamsRow(i) });
+  const m = statefulEnv(table);
+
+  const snapshot = [{ ...hyperparamsRow(1), tempo: 720 }];
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snapshot);
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+  assert.equal(r.prune_skipped, true);
+  assert.deepEqual([...table.keys()].sort(), [1, 2, 3, 4]);
+});
+
+test("loadStagedSubnetHyperparams prunes when expected_netuid_count matches snapshot rows", async () => {
+  const table = new Map();
+  table.set(1, { ...hyperparamsRow(1) });
+  table.set(2, { ...hyperparamsRow(2) });
+  const m = statefulEnv(table);
+
+  const snapshot = [{ ...hyperparamsRow(1), tempo: 720 }];
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snapshot, SIGNING_KEY, {
+    expected_netuid_count: 1,
+    captured_at: 1_750_000_000_000,
+  });
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 1);
+  assert.deepEqual([...table.keys()], [1]);
+});
+
 test("loadStagedSubnetHyperparams keeps stale rows when completeness contract is unmet", async () => {
   const table = new Map();
   table.set(1, { ...hyperparamsRow(1) });

--- a/tests/load-staged-subnet-hyperparams.test.mjs
+++ b/tests/load-staged-subnet-hyperparams.test.mjs
@@ -452,6 +452,24 @@ function statefulEnv(table, { failBatch = false, failPrune = false } = {}) {
   };
 }
 
+test("loadStagedSubnetHyperparams legacy envelope still prunes when shrink is below collapse threshold", async () => {
+  const table = new Map();
+  table.set(1, { ...hyperparamsRow(1) });
+  table.set(2, { ...hyperparamsRow(2) });
+  table.set(3, { ...hyperparamsRow(3) });
+  const m = statefulEnv(table);
+
+  const snapshot = [
+    { ...hyperparamsRow(1), tempo: 720 },
+    { ...hyperparamsRow(2), tempo: 100 },
+  ];
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snapshot);
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 1);
+  assert.deepEqual([...table.keys()].sort(), [1, 2]);
+});
+
 test("loadStagedSubnetHyperparams skips prune when expected_netuid_count is zero", async () => {
   const table = new Map();
   table.set(1, { ...hyperparamsRow(1) });
@@ -471,6 +489,45 @@ test("loadStagedSubnetHyperparams skips prune when expected_netuid_count is zero
   assert.equal(r.purged, 0);
   assert.equal(r.prune_skipped, true);
   assert.deepEqual([...table.keys()].sort(), [1, 2]);
+});
+
+test("loadStagedSubnetHyperparams verifies HMAC when captured_at is set without expected_netuid_count", async () => {
+  const table = new Map();
+  const m = statefulEnv(table);
+  const row = hyperparamsRow(1);
+  const captured_at = 1_750_000_000_000;
+  const payload = JSON.stringify({ rows: [row], captured_at });
+  m.env.METAGRAPH_ARCHIVE._staged = {
+    schema_version: 1,
+    rows: [row],
+    captured_at,
+    hmac_sha256: createHmac("sha256", SIGNING_KEY)
+      .update(payload)
+      .digest("hex"),
+  };
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, 1);
+});
+
+test("loadStagedSubnetHyperparams legacy envelope treats missing COUNT c as zero prior rows", async () => {
+  const table = new Map();
+  const m = statefulEnv(table);
+  const basePrepare = m.env.METAGRAPH_HEALTH_DB.prepare;
+  m.env.METAGRAPH_HEALTH_DB.prepare = (sql) => {
+    const stmt = basePrepare(sql);
+    if (!sql.includes("COUNT(*)")) return stmt;
+    return {
+      bind: (...v) => stmt.bind(...v),
+      async first() {
+        return {};
+      },
+    };
+  };
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope([hyperparamsRow(1)]);
+  const r = await loadStagedSubnetHyperparams(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
 });
 
 test("loadStagedSubnetHyperparams returns purge_failed when legacy count lookup fails", async () => {

--- a/tests/sign-staged-neurons.test.mjs
+++ b/tests/sign-staged-neurons.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+
+test("sign-staged-neurons.mjs signs expected_netuid_count on hyperparams payloads", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "sign-hyperparams-"));
+  const input = path.join(dir, "in.json");
+  const output = path.join(dir, "out.json");
+  writeFileSync(
+    input,
+    JSON.stringify({
+      rows: [{ netuid: 1, tempo: 360 }],
+      expected_netuid_count: 1,
+      captured_at: 1_750_000_000_000,
+    }),
+  );
+  execFileSync(process.execPath, ["scripts/sign-staged-neurons.mjs", input, output], {
+    env: { ...process.env, METAGRAPH_STAGING_SIGNING_KEY: "test-sign-key" },
+  });
+  const envelope = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(envelope.schema_version, 1);
+  assert.equal(envelope.expected_netuid_count, 1);
+  assert.equal(envelope.captured_at, 1_750_000_000_000);
+  assert.match(envelope.hmac_sha256, /^[a-f0-9]{64}$/);
+});

--- a/tests/sign-staged-neurons.test.mjs
+++ b/tests/sign-staged-neurons.test.mjs
@@ -17,9 +17,13 @@ test("sign-staged-neurons.mjs signs expected_netuid_count on hyperparams payload
       captured_at: 1_750_000_000_000,
     }),
   );
-  execFileSync(process.execPath, ["scripts/sign-staged-neurons.mjs", input, output], {
-    env: { ...process.env, METAGRAPH_STAGING_SIGNING_KEY: "test-sign-key" },
-  });
+  execFileSync(
+    process.execPath,
+    ["scripts/sign-staged-neurons.mjs", input, output],
+    {
+      env: { ...process.env, METAGRAPH_STAGING_SIGNING_KEY: "test-sign-key" },
+    },
+  );
   const envelope = JSON.parse(readFileSync(output, "utf8"));
   assert.equal(envelope.schema_version, 1);
   assert.equal(envelope.expected_netuid_count, 1);

--- a/tests/sign-staged-neurons.test.mjs
+++ b/tests/sign-staged-neurons.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHmac } from "node:crypto";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -9,12 +10,13 @@ test("sign-staged-neurons.mjs signs expected_netuid_count on hyperparams payload
   const dir = mkdtempSync(path.join(tmpdir(), "sign-hyperparams-"));
   const input = path.join(dir, "in.json");
   const output = path.join(dir, "out.json");
+  const captured_at = 1_750_000_000_000;
   writeFileSync(
     input,
     JSON.stringify({
       rows: [{ netuid: 1, tempo: 360 }],
       expected_netuid_count: 1,
-      captured_at: 1_750_000_000_000,
+      captured_at,
     }),
   );
   execFileSync(
@@ -27,6 +29,15 @@ test("sign-staged-neurons.mjs signs expected_netuid_count on hyperparams payload
   const envelope = JSON.parse(readFileSync(output, "utf8"));
   assert.equal(envelope.schema_version, 1);
   assert.equal(envelope.expected_netuid_count, 1);
-  assert.equal(envelope.captured_at, 1_750_000_000_000);
+  assert.equal(envelope.captured_at, captured_at);
   assert.match(envelope.hmac_sha256, /^[a-f0-9]{64}$/);
+  const payload = JSON.stringify({
+    rows: envelope.rows,
+    captured_at,
+    expected_netuid_count: 1,
+  });
+  assert.equal(
+    envelope.hmac_sha256,
+    createHmac("sha256", "test-sign-key").update(payload).digest("hex"),
+  );
 });

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -614,8 +614,7 @@ export async function loadStagedSubnetHyperparams(env) {
   const hasCompletenessContract = Number.isInteger(expectedNetuidCount);
   let canPrune = true;
   if (hasCompletenessContract) {
-    canPrune =
-      expectedNetuidCount > 0 && rows.length === expectedNetuidCount;
+    canPrune = expectedNetuidCount > 0 && rows.length === expectedNetuidCount;
     if (!canPrune) {
       console.warn(
         `loadStagedSubnetHyperparams: incomplete snapshot (${rows.length}/${expectedNetuidCount}); skipping prune`,

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -476,8 +476,15 @@ export async function loadStagedNeurons(env) {
   return { ok: true, rows: rows.length, purged };
 }
 
-function subnetHyperparamsStagingSignPayload(rows) {
-  return JSON.stringify(rows);
+function subnetHyperparamsStagingSignPayload(
+  rows,
+  expected_netuid_count,
+  captured_at,
+) {
+  if (expected_netuid_count == null && captured_at == null) {
+    return JSON.stringify(rows);
+  }
+  return JSON.stringify({ rows, expected_netuid_count, captured_at });
 }
 
 function validStagedSubnetHyperparamsRow(row) {
@@ -505,10 +512,11 @@ function validStagedSubnetHyperparamsRow(row) {
 // bounded, schema-valid rows through the METAGRAPH_HEALTH_DB binding (no
 // API-token D1 permission needed) with PARAMETERIZED inserts.
 //
-// Unlike loadStagedNeurons, every fetch covers ALL active subnets in one run
-// (get_subnet_hyperparameters has no bulk variant, but the fetch script loops
-// every netuid every time — no "refreshed_netuids" partial-coverage concept
-// needed here). ~129 rows today is far smaller than the neuron snapshot, so no
+// Unlike loadStagedNeurons, every successful fetch is expected to cover ALL
+// active subnets in one run. The fetch script stamps expected_netuid_count on
+// the signed envelope; loadStagedSubnetHyperparams refuses to prune when that
+// completeness contract is unmet (or, for legacy bare-array envelopes, when
+// row count collapsed vs the live table).
 // backup/rollback complexity: each upsert batch is independently an atomic D1
 // transaction and idempotent (INSERT OR REPLACE), so a failed batch leaves
 // only correctly-upserted rows behind — safe to leave as-is, since the staged
@@ -559,7 +567,11 @@ export async function loadStagedSubnetHyperparams(env) {
   }
   const expected = await hmacHex(
     signingKey,
-    subnetHyperparamsStagingSignPayload(rows),
+    subnetHyperparamsStagingSignPayload(
+      rows,
+      envelope.expected_netuid_count,
+      envelope.captured_at,
+    ),
   );
   if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
     await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
@@ -598,25 +610,62 @@ export async function loadStagedSubnetHyperparams(env) {
     return { ok: false, reason: "load_failed" };
   }
   const netuidsInSnapshot = rows.map((row) => row.netuid);
-  let purged;
-  try {
-    const result = await db
-      .prepare(
-        `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${netuidsInSnapshot
-          .map(() => "?")
-          .join(",")})`,
-      )
-      .bind(...netuidsInSnapshot)
-      .run();
-    purged = result?.meta?.changes ?? 0;
-  } catch {
-    // Upserts already committed; only the stale-subnet prune failed. Keep the
-    // staged object so the next cron retries (a redundant but harmless
-    // re-upsert either way).
-    return { ok: false, reason: "purge_failed" };
+  const expectedNetuidCount = envelope.expected_netuid_count;
+  const hasCompletenessContract = Number.isInteger(expectedNetuidCount);
+  let canPrune = true;
+  if (hasCompletenessContract) {
+    canPrune =
+      expectedNetuidCount > 0 && rows.length === expectedNetuidCount;
+    if (!canPrune) {
+      console.warn(
+        `loadStagedSubnetHyperparams: incomplete snapshot (${rows.length}/${expectedNetuidCount}); skipping prune`,
+      );
+    }
+  } else {
+    // Legacy bare-array envelopes lack a completeness marker — refuse to prune
+    // when coverage collapsed vs the live table (mirrors fetch-metagraph.mjs).
+    let priorCount = 0;
+    try {
+      const countRow = await db
+        .prepare(`SELECT COUNT(*) AS c FROM subnet_hyperparams`)
+        .first();
+      priorCount = Number(countRow?.c ?? 0);
+    } catch {
+      return { ok: false, reason: "purge_failed" };
+    }
+    if (priorCount > 0 && rows.length < priorCount / 2) {
+      canPrune = false;
+      console.warn(
+        `loadStagedSubnetHyperparams: legacy snapshot row count collapsed (${rows.length}/${priorCount}); skipping prune`,
+      );
+    }
+  }
+  let purged = 0;
+  if (canPrune) {
+    try {
+      const result = await db
+        .prepare(
+          `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${netuidsInSnapshot
+            .map(() => "?")
+            .join(",")})`,
+        )
+        .bind(...netuidsInSnapshot)
+        .run();
+      purged = result?.meta?.changes ?? 0;
+    } catch {
+      // Upserts already committed; only the stale-subnet prune failed. Keep the
+      // staged object so the next cron retries (a redundant but harmless
+      // re-upsert either way).
+      return { ok: false, reason: "purge_failed" };
+    }
   }
   await bucket.delete(STAGED_SUBNET_HYPERPARAMS_KEY);
-  return { ok: true, rows: rows.length, purged };
+  return {
+    ok: true,
+    rows: rows.length,
+    purged,
+    ...(canPrune ? {} : { prune_skipped: true }),
+  };
 }
 
 // Load a staged chain-event batch from R2 into D1 (#1346, epic #1345). The

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -623,8 +623,8 @@ export async function loadStagedSubnetHyperparams(env) {
   const hasCompletenessContract = Number.isInteger(expectedNetuidCount);
   let canPrune = true;
   if (hasCompletenessContract) {
-    canPrune = expectedNetuidCount > 0 && rows.length === expectedNetuidCount;
-    if (!canPrune) {
+    if (expectedNetuidCount <= 0 || rows.length !== expectedNetuidCount) {
+      canPrune = false;
       console.warn(
         `loadStagedSubnetHyperparams: incomplete snapshot (${rows.length}/${expectedNetuidCount}); skipping prune`,
       );

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -484,7 +484,16 @@ function subnetHyperparamsStagingSignPayload(
   if (expected_netuid_count == null && captured_at == null) {
     return JSON.stringify(rows);
   }
-  return JSON.stringify({ rows, expected_netuid_count, captured_at });
+  // Property order must match scripts/sign-staged-neurons.mjs (rows,
+  // refreshed_netuids, captured_at, expected_netuid_count) — undefined keys
+  // are omitted by JSON.stringify but captured_at must precede
+  // expected_netuid_count or the HMAC will not verify.
+  return JSON.stringify({
+    rows,
+    refreshed_netuids: undefined,
+    captured_at,
+    expected_netuid_count,
+  });
 }
 
 function validStagedSubnetHyperparamsRow(row) {

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -624,7 +624,7 @@ export async function loadStagedSubnetHyperparams(env) {
   } else {
     // Legacy bare-array envelopes lack a completeness marker — refuse to prune
     // when coverage collapsed vs the live table (mirrors fetch-metagraph.mjs).
-    let priorCount = 0;
+    let priorCount;
     try {
       const countRow = await db
         .prepare(`SELECT COUNT(*) AS c FROM subnet_hyperparams`)


### PR DESCRIPTION
## Summary

Partial subnet-hyperparameters fetches could corrupt the `subnet_hyperparams` D1 tier: the fetch script tolerated per-netuid RPC failures and still staged a snapshot, while `loadStagedSubnetHyperparams` always ran a full-sync `DELETE ... WHERE netuid NOT IN (...)` prune — deleting rows for still-active subnets missing from the partial file.

## Root cause

- `scripts/fetch-subnet-hyperparams.py` continued on per-netuid errors and exited 0 with a partial row set.
- `loadStagedSubnetHyperparams` treated every staged snapshot as a complete replacement of all active subnets.

## Fix

**Producer:** abort before writing when any fetch fails or row count != active netuid count; emit `expected_netuid_count` on the signed envelope.

**Loader:** skip the prune unless `rows.length === expected_netuid_count`; for legacy bare-array envelopes, skip prune when row count collapsed vs the live table (>50% drop).

**Signing:** `sign-staged-neurons.mjs` passes `expected_netuid_count` through the HMAC envelope.

## Impact

- Prevents silent loss of `/api/v1/subnets/{netuid}/hyperparameters` data after transient RPC blips during the daily refresh workflow.
- Full successful refreshes still prune deregistered subnets as before.

## Risks / tradeoffs

- A partial daily fetch now fails CI instead of staging bad data (intentional).
- Legacy staged files without `expected_netuid_count` keep the old prune path but gain a coverage-collapse guard.

## Test plan

- [x] `python scripts/test_fetch_subnet_hyperparams.py`
- [x] `npm test -- tests/load-staged-subnet-hyperparams.test.mjs`
- [x] CI Validate workflow (pending)