### PR TITLE
feat(ui): add a "No matches" quick-actions block to the command palette empty state (#3401)

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -560,6 +560,33 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
           </div>
         ) : null}
 
+        {/* #3401: richer zero-result state — a debounced query that matches nothing
+          across hits/routes/nav targets gets recovery chips instead of a dead-end
+          "No matches." Mirrors the empty-query "Try" row so both states offer a way
+          forward. Co-exists with the terse <CommandEmpty> above. */}
+        {debounced &&
+        hits.length === 0 &&
+        filteredRoutes.length === 0 &&
+        navigateTargets.length === 0 ? (
+          <div className="px-3 py-3 space-y-2 border-b border-border">
+            <div className="mg-label">No matches for &ldquo;{debounced}&rdquo;</div>
+            <p className="text-[11px] text-ink-muted">Try one of these instead:</p>
+            <ul className="flex flex-wrap gap-1">
+              {SUGGESTED_QUERIES.map((s) => (
+                <li key={s}>
+                  <button
+                    type="button"
+                    onClick={() => setQ(s)}
+                    className="rounded-full border border-dashed border-ink-subtle bg-paper px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                  >
+                    {s}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
         {navigateTargets.length > 0 ? (
           <CommandGroup heading="Go to">
             {navigateTargets.map((n) => {


### PR DESCRIPTION
## Summary

Closes #3401

When a debounced query yields **zero** results across `hits`, `filteredRoutes`, and `navigateTargets`, the command palette now renders a recovery block — a restated "No matches for \"{query}\"" line plus clickable `SUGGESTED_QUERIES` chips (reusing the
existing `setQ` pattern) — instead of a dead-end "No matches." It mirrors the empty-query "Try" row so both empty states offer a way forward, and co-exists with the terse `<CommandEmpty>` above it.

**UI-only, add-only** — single file (`command-palette-body.tsx`); no data layer, no shared
primitives touched.

## Acceptance criteria
- [x] Rendered when `debounced` is truthy and `hits.length === 0 && filteredRoutes.length === 0 && navigateTargets.length === 0`
- [x] Restated "No matches for \"{debounced}\"" message
- [x] Quick-action chips for `SUGGESTED_QUERIES`, reusing the `setQ(s)` pattern from the suggestions block

## Validation
- `npm run typecheck -w apps/ui` — pass
- `npm run lint` / `prettier --check` (changed file) — clean
- `npm run test -w apps/ui` — 537 passed
- `npm run build -w apps/ui` — pass

Single-file, append-only diff (+27, 0 deletions); no generated artifacts touched.

## Screenshots

Command palette (⌘/Ctrl-K) with a no-match query (e.g. `zzzzz`). Before: plain "No matches."
After: "No matches for …" + a **Try one of these instead** chip row. Same crop before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1428" height="821" alt="dsk-lg-be" src="https://github.com/user-attachments/assets/e663eefa-f23e-4413-be18-cc08f257b76a" /> | <img width="1431" height="774" alt="dsk-lg-af" src="https://github.com/user-attachments/assets/24347921-7785-4d7c-a439-75f3d109b835" /> |
| Desktop · Dark | <img width="1431" height="839" alt="dsk-dk-be" src="https://github.com/user-attachments/assets/00ab7736-5136-4a45-945e-e013290e044d" /> | <img width="1438" height="825" alt="dsk-dk-af" src="https://github.com/user-attachments/assets/3ffbe03b-0547-4653-a2f7-e3102b912859" /> |
| Tablet · Light | <img width="668" height="884" alt="tab-lg-be" src="https://github.com/user-attachments/assets/34930a6e-c541-4b3e-bac8-959658bfc22c" /> | <img width="639" height="879" alt="tab-lg-af" src="https://github.com/user-attachments/assets/06faaf7e-790b-4524-b45e-4e74dad99724" /> |
| Tablet · Dark | <img width="628" height="880" alt="tab-dk-be" src="https://github.com/user-attachments/assets/90817cfd-0305-4839-8f97-ab0f5169205d" /> | <img width="643" height="878" alt="tab-dk-af" src="https://github.com/user-attachments/assets/a4772e4d-8f7f-404b-8ab1-831b74b079ec" /> |
| Mobile · Light | <img width="417" height="928" alt="mb-lg-be" src="https://github.com/user-attachments/assets/723dce14-b701-49cf-8e1f-34cb0c32c93d" /> | <img width="440" height="920" alt="mb-lg-af" src="https://github.com/user-attachments/assets/aa725933-0d81-4c0c-981c-561a2630ef30" /> |
| Mobile · Dark | <img width="432" height="913" alt="mb-dk-be" src="https://github.com/user-attachments/assets/0d1f859f-561d-48e3-884c-2342ede10797" /> | <img width="440" height="914" alt="mb-dk-af" src="https://github.com/user-attachments/assets/d64554ed-b5ab-444e-9aba-f3fb83e3a0d7" /> |
