### PR TITLE
fix(ui): make HoverPreview keyboard-reachable for non-link evidence items

### DIFF
--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -167,6 +167,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
             {items.slice(0, 24).map((item) => (
               <li key={item.id}>
                 <HoverPreview
+                  focusable={!item.url}
                   content={
                     <div className="space-y-1.5">
                       <div className="mg-label">

--- a/apps/ui/src/components/metagraphed/hover-preview.tsx
+++ b/apps/ui/src/components/metagraphed/hover-preview.tsx
@@ -5,16 +5,24 @@ interface Props {
   children: ReactNode;
   content: ReactNode;
   className?: string;
+  /**
+   * Set when `children` isn't itself a focusable element (e.g. a plain
+   * `<span>` fallback rather than a link/button) — makes the wrapper a tab
+   * stop so keyboard users can still reach the preview on focus, not only
+   * on hover.
+   */
+  focusable?: boolean;
 }
 
 /**
  * Lightweight hover/focus popover (no portal, no deps). Anchored bottom-left.
  */
-export function HoverPreview({ children, content, className }: Props) {
+export function HoverPreview({ children, content, className, focusable }: Props) {
   const [open, setOpen] = useState(false);
   return (
     <span
       className={classNames("relative inline-flex", className)}
+      tabIndex={focusable ? 0 : undefined}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
       onFocus={() => setOpen(true)}


### PR DESCRIPTION
Closes #3957

## What
`HoverPreview` now accepts a `focusable` prop that puts `tabIndex={0}` on its wrapper span, and `evidence-panel.tsx` passes `focusable={!item.url}` — so evidence items with no underlying link (rendered as a plain `<span>` fallback, not an `<a>`) are keyboard-reachable, matching link-based items which were already focusable through their `<ExternalLink>` anchor.

## Why
`HoverPreview`'s wrapper already listens for `onFocus`/`onBlur` correctly — the bug was that non-link evidence items render as a plain `<span>` with no `tabindex`, so Tab navigation skips over them entirely and the wrapper's `onFocus` handler never fires for that item. Link items were unaffected since their `<ExternalLink>` anchor is natively focusable.

## Design choice
Rather than hardcoding `tabIndex={0}` unconditionally on `HoverPreview`'s wrapper (which would create a redundant second tab stop when the child is already focusable, e.g. a link), the new `focusable` prop lets each caller opt in only when its own child isn't already interactive — `evidence-panel.tsx` computes this per item (`!item.url`), so link items keep exactly one tab stop (the link itself) and non-link items gain exactly one (the wrapper).

## Screen recordings

The live evidence ledger currently has zero rows to demonstrate against (nothing to Tab to), so these recordings mock a realistic `/api/v1/evidence` response with one link item and one non-link item ("demo-2", a maintainer-verified identity claim with no source URL) — the same shape the real endpoint returns, exercising the actual component code. Both recordings walk real `Tab` keypresses from a neutral point on the page.

**Before** — 80 Tab presses never land on the non-link chip; focus moves elsewhere entirely, the preview is never reachable:
https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-evidence-hover-preview-3957/before.webm

![before](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-evidence-hover-preview-3957/before.png)

**After** — Tab reaches the "demo-2" chip directly, the focus ring appears, and the preview reveals on focus exactly like hover:
https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-evidence-hover-preview-3957/after.webm

![after](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-evidence-hover-preview-3957/after.png)

## Acceptance criteria
- [x] Both `evidence-panel.tsx` and `hover-preview.tsx` appear in the diff
- [x] Tabbing to a non-link evidence item reveals its preview content, matching hover behavior
- [x] Link-based evidence items (already focusable via `<ExternalLink>`) are unaffected — no second tab stop introduced
- [x] Before/after screen recording demonstrating keyboard focus revealing a non-link item's preview

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on both changed files: clean (aside from pre-existing CRLF-only diffs unrelated to this change).
- Diff is 10 insertions / 1 deletion across exactly the two files the issue names.
