### PR TITLE
fix(ui): distinguish a partial endpoint-announcement fetch failure from a real zero

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1232,9 +1232,15 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
     );
   }
 
+  // Each source can fail independently while the other succeeds — the
+  // combined section must not render the failed half's count as if it were
+  // a genuine zero.
+  const servingFailed = servingResult.isError && !serving;
+  const prometheusFailed = prometheusResult.isError && !prometheus;
   const servingCount = serving?.total_announcements ?? 0;
   const prometheusCount = prometheus?.total_announcements ?? 0;
-  const isEmpty = servingCount === 0 && prometheusCount === 0;
+  const isEmpty =
+    !servingFailed && !prometheusFailed && servingCount === 0 && prometheusCount === 0;
 
   return (
     <SectionAnchor
@@ -1255,16 +1261,25 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
           <StatTile
             icon={Radar}
             eyebrow="Axon serving"
-            tone="accent"
-            value={formatNumber(servingCount)}
-            hint={`AxonServed · ${windowLabel}`}
+            tone={servingFailed ? "warn" : "accent"}
+            value={servingFailed ? "—" : formatNumber(servingCount)}
+            hint={
+              servingFailed
+                ? "fetch failed · showing Prometheus only"
+                : `AxonServed · ${windowLabel}`
+            }
             className={KPI_TILE}
           />
           <StatTile
             icon={Gauge}
             eyebrow="Prometheus"
-            value={formatNumber(prometheusCount)}
-            hint={`PrometheusServed · ${windowLabel}`}
+            tone={prometheusFailed ? "warn" : "default"}
+            value={prometheusFailed ? "—" : formatNumber(prometheusCount)}
+            hint={
+              prometheusFailed
+                ? "fetch failed · showing Axon only"
+                : `PrometheusServed · ${windowLabel}`
+            }
             className={KPI_TILE}
           />
         </div>


### PR DESCRIPTION
Closes #3970

## What
`AccountEndpointAnnouncementSection` (`apps/ui/src/routes/accounts.$ss58.tsx`) now tracks each of its two underlying sources' (axon serving, Prometheus) fetch state independently, and shows a visible "fetch failed" indicator on whichever tile's source errored, instead of rendering that half as a plain `0`.

## Why
The section combines two independent queries (`accountServingQuery`, `accountPrometheusQuery`). If one fails while the other succeeds, `bothError` (which requires *both* to fail) is false, so the code fell through to the normal render path — where a failed query's `total_announcements ?? 0` reads identically to a subnet that genuinely had zero announcements. A user has no way to tell "zero activity" apart from "we don't know."

## Changes
- `apps/ui/src/routes/accounts.$ss58.tsx`:
  - Added `servingFailed`/`prometheusFailed` flags (`result.isError && !data`) that track each source's failure independently.
  - The `isEmpty` check (which renders the "No endpoint announcements" empty state) now excludes the case where either source failed — a partial failure is not "confirmed empty," so it must still render the tiles.
  - Each `StatTile` shows `—` with `tone="warn"` and a "fetch failed · showing \{other\} only" hint when its own source failed, instead of a plain formatted count.

## Screenshots

An account with Prometheus data (42 announcements) but a failed serving fetch, both themes:

| Theme | Before (serving shows `0`, indistinguishable from real zero) | After (serving shows `—` with a visible failure indicator) |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/before-light.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/before-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/after-light.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/after-light.png)<br><sub>after</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/before-dark.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/before-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/after-dark.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-endpoint-partial-failure-3970/after-dark.png)<br><sub>after</sub> |

Captured by mocking the two account endpoints (one 503, one a realistic success payload) since no live account currently has both sources with divergent states — same response shape the real endpoints return.

## Acceptance criteria
- [x] `accounts.$ss58.tsx` appears in the diff, specifically `AccountEndpointAnnouncementSection`
- [x] A simulated partial failure shows a visible indicator distinguishing it from a genuine zero
- [x] Both sources succeeding, or both legitimately reading zero, renders exactly as it does today (the `isEmpty`/normal-render branches are otherwise unchanged)
- [x] Before/after screenshot table, both themes

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean (aside from pre-existing CRLF/fast-refresh noise unrelated to this change).
- Diff is 21 insertions / 6 deletions in a single file.
