### PR TITLE
feat(ui): add Share deep-link buttons to block, extrinsic, and account detail pages (#3399)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -26,6 +26,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { TableState } from "@/components/metagraphed/table-state";
 import { PageHero } from "@/components/metagraphed/page-hero";
+import { ShareButton } from "@/components/metagraphed/share-button";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
 import { SelectFilter } from "@/components/metagraphed/table-controls";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
@@ -183,6 +184,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
         }
         actions={
           <>
+            <ShareButton />
             <a
               href="#history"
               className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/15"

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -8,6 +8,7 @@ import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, ErrorState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
+import { ShareButton } from "@/components/metagraphed/share-button";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
@@ -127,6 +128,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         live
         title={`#${formatNumber(block.block_number)}`}
         description={<span className="font-mono text-sm break-all">{block.block_hash || "—"}</span>}
+        actions={<ShareButton />}
         caption="explorer / v1"
       />
 

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -8,6 +8,7 @@ import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
+import { ShareButton } from "@/components/metagraphed/share-button";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
@@ -128,6 +129,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
           </span>
         }
+        actions={<ShareButton />}
         caption="explorer / v1"
       />
 


### PR DESCRIPTION
## Summary

Closes #3399

Adds `<ShareButton />` to the `PageHero` `actions` slot on the three entity **detail** pages —`blocks.$ref.tsx`, `extrinsics.$hash.tsx`, and `accounts.$ss58.tsx` — so visitors can copy a canonical deep link to the block, extrinsic, or account they're viewing. Reuses the existing `ShareButton` already wired into the list/index pages (blocks, extrinsics, explorer, subnets,
surfaces). UI-only, add-only.

## Validation
- `npm run typecheck -w apps/ui` — pass
- `prettier --check` (changed files) — clean
- `npm run test -w apps/ui` — pass
- `npm run build -w apps/ui` — pass

Add-only diff (+6, 0 deletions) across 3 files; no generated artifacts touched.

## Screenshots

Share button in the header of each detail page. Before: no Share button. After: a Share button
in the `actions` row. 3 viewports (1280×800 / 768×1024 / 375×812, fixed) × 2 themes × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1414" height="714" alt="dek-lg-be" src="https://github.com/user-attachments/assets/9912adab-53d5-4722-954d-6411feb6552d" /> | <img width="1407" height="714" alt="dek-lg-af" src="https://github.com/user-attachments/assets/dfced807-2542-4e0f-99d0-db26870269e5" /> |
| Desktop · Dark | <img width="1411" height="666" alt="dek-dk-be" src="https://github.com/user-attachments/assets/d9e49b9b-e059-486f-a29a-4c1d766c5662" /> | <img width="1422" height="654" alt="dek-dk-af" src="https://github.com/user-attachments/assets/2054cbe3-3d4c-416d-961a-2ea81f4e3658" /> |
| Tablet · Light | <img width="649" height="885" alt="tab-lg-be" src="https://github.com/user-attachments/assets/c7180041-0cb6-44a3-b017-9ab78cedcc82" /> | <img width="652" height="883" alt="tab-lg-af" src="https://github.com/user-attachments/assets/068bab22-2221-4b8d-af44-b2b8240660b5" /> |
| Tablet · Dark | <img width="644" height="875" alt="tab-dk-be" src="https://github.com/user-attachments/assets/06257a7a-0aa8-4262-838e-1579bf7889a5" /> | <img width="631" height="878" alt="tab-dk-af" src="https://github.com/user-attachments/assets/286cdb05-bf1b-4ba3-ac57-4a587f9c81e6" /> |
| Mobile · Light | <img width="418" height="912" alt="mb-lg-be" src="https://github.com/user-attachments/assets/9898f48c-1ab7-4e42-8fde-ecd6665ff8d5" /> | <img width="447" height="923" alt="mb-lg-af" src="https://github.com/user-attachments/assets/ee441355-9edd-4724-8676-10c2935bb728" /> |
| Mobile · Dark | <img width="434" height="917" alt="mb-dk-be" src="https://github.com/user-attachments/assets/bde457ef-bbd6-41c0-b414-9193b1969094" /> | <img width="425" height="909" alt="mb-dk-af" src="https://github.com/user-attachments/assets/853b8516-1ade-4592-a4ea-a824dfaffa0a" /> |
