### PR TITLE
feat(ui): add a validator × subnet stake heatmap to the validators page

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { validatorsQuery } from "@/lib/metagraphed/queries";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { classNames } from "@/lib/metagraphed/format";
+
+// #3495: validator (row) × subnet (column) participation matrix from the global
+// validators payload, cells shaded by relative stake. Pure consumer of
+// validatorsQuery() — no new query/route. The payload is server-capped (top ~20
+// validators, top 10 subnets by stake per validator), so the matrix is a
+// concentration snapshot, not exhaustive coverage — the header says so.
+
+const MAX_VALIDATORS = 15;
+
+function stakeTone(ratio: number | null): string {
+  if (ratio == null) return "bg-ink-subtle/10"; // non-participating (or beyond top-10)
+  if (ratio >= 0.66) return "bg-accent/80";
+  if (ratio >= 0.33) return "bg-accent/50";
+  if (ratio > 0) return "bg-accent/20";
+  return "bg-ink-subtle/10";
+}
+
+export function ValidatorSubnetHeatmap() {
+  const validators = useSuspenseQuery(
+    validatorsQuery({ sort: "total_stake", limit: MAX_VALIDATORS }),
+  ).data.data.validators;
+
+  const { rows, netuids, maxStake } = useMemo(() => {
+    const rows = validators.slice(0, MAX_VALIDATORS);
+    const set = new Set<number>();
+    let maxStake = 0;
+    for (const v of rows) {
+      for (const s of v.subnets ?? []) {
+        set.add(s.netuid);
+        if (s.stake_tao > maxStake) maxStake = s.stake_tao;
+      }
+    }
+    return { rows, netuids: [...set].sort((a, b) => a - b), maxStake };
+  }, [validators]);
+
+  if (rows.length === 0 || netuids.length === 0) {
+    return (
+      <div className="rounded border border-border bg-card p-4 text-xs text-ink-muted">
+        No validator participation data yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2.5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Validator × subnet · stake intensity
+        </div>
+        <div className="flex flex-wrap items-center gap-2.5 font-mono text-[9.5px] text-ink-muted">
+          <span>top {rows.length} validators · top 10 subnets each (server-capped)</span>
+          <span className="inline-flex items-center gap-1">
+            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-accent/20" />
+            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-accent/50" />
+            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-accent/80" />
+            more stake
+          </span>
+        </div>
+      </div>
+      <div className="w-full overflow-x-auto [scrollbar-gutter:stable]">
+        <table className="w-full min-w-[640px] text-[11px] font-mono">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 border-b border-border bg-card px-3 py-2 text-left text-[10px] uppercase tracking-widest text-ink-muted">
+                Validator
+              </th>
+              {netuids.map((n) => (
+                <th
+                  key={n}
+                  className="border-b border-border px-1.5 py-2 text-[10px] tabular-nums text-ink-muted"
+                >
+                  {n}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((v) => {
+              const byNet = new Map((v.subnets ?? []).map((s) => [s.netuid, s]));
+              return (
+                <tr key={v.hotkey} className="border-b border-border last:border-b-0">
+                  <td className="sticky left-0 z-10 border-r border-border bg-card px-3 py-1.5 text-ink-strong">
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: v.hotkey }}
+                      className="block max-w-[12ch] truncate hover:text-accent"
+                      title={v.hotkey}
+                    >
+                      {shortHash(v.hotkey) ?? v.hotkey}
+                    </Link>
+                  </td>
+                  {netuids.map((n) => {
+                    const s = byNet.get(n);
+                    const ratio = s && maxStake > 0 ? s.stake_tao / maxStake : null;
+                    return (
+                      <td key={n} className="p-0.5">
+                        <div
+                          className={classNames("h-6 rounded-sm", stakeTone(ratio))}
+                          title={
+                            s
+                              ? `${shortHash(v.hotkey)} · SN${n}\nstake ${taoCompact(s.stake_tao)} τ · emission ${taoCompact(s.emission_tao)} τ · trust ${s.validator_trust ?? "—"}`
+                              : `SN${n} · not in this validator's top-10 subnets`
+                          }
+                        />
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -12,6 +12,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
@@ -89,6 +90,13 @@ function ValidatorsPage() {
           />
         </Suspense>
       </QueryErrorBoundary>
+      <div className="mt-6" id="validator-subnet-heatmap">
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+            <ValidatorSubnetHeatmap />
+          </Suspense>
+        </QueryErrorBoundary>
+      </div>
       <ApiSourceFooter paths={["/api/v1/validators"]} />
     </AppShell>
   );


### PR DESCRIPTION
## What

Adds a **validator × subnet stake-intensity heatmap** to the `/validators` page, mounted below the existing directory table. Each row is a top validator, each column a subnet; cells are shaded by that validator's relative stake on the subnet, with per-cell stake / emission / trust on hover. It surfaces cross-subnet validator footprint and stake concentration — a view the page didn't have anywhere.

Closes #3495

## How

- **New** `apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx` — a pure consumer of the existing `validatorsQuery({ sort: "total_stake", limit: 15 })`; **no new query, route, or type**. Sticky validator column (links to `/accounts/$ss58`), subnet columns as the union of netuids across the top validators, stake-shaded cells (`bg-accent/{20,50,80}`), native-title tooltips. The header states the server caps (top ~15 validators, top 10 subnets each) so the matrix never reads as exhaustive.
- `apps/ui/src/routes/validators.index.tsx` — mount it below the table.

## Data

Live from `/api/v1/validators` — the screenshots show real chain-direct stake for the current top validators. Degrades to an empty-state card if the payload has no participation rows.

## Checks

`eslint .` clean on the changed files, `tsc` typecheck clean. UI-only; no schema/contract change.

## Screenshots

Exact viewports — mobile 375×812, tablet 768×1024, desktop 1280×800 — each in light + dark, before/after.

| viewport / theme | before | after |
|---|---|---|
| **mobile · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-mobile-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-tablet-dark-after.png)<br><sub>after</sub> |
| **desktop · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/validator-subnet-heatmap-desktop-dark-after.png)<br><sub>after</sub> |