### PR TITLE
feat(ui): add a block-throughput sparkline to the blocks index page header

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -11,6 +11,7 @@ import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ListShell } from "@/components/metagraphed/list-shell";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import {
   PageSizeSelect,
   ResetFiltersButton,
@@ -19,7 +20,7 @@ import {
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
-import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
+import { blocksQuery, blocksSummaryQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
@@ -80,6 +81,18 @@ function BlocksPage() {
   const search = Route.useSearch();
   const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
 
+  // #3390: compact blocks-per-day sparkline in the page header, reusing the
+  // same chainActivityQuery data path explorer.tsx already proves out. Not a
+  // useSuspenseQuery — the hero's title/description render immediately, and
+  // the kpis strip simply appears once this non-blocking fetch settles
+  // (PageHero already renders nothing when `kpis` is undefined).
+  const activityResult = useQuery(chainActivityQuery());
+  const activityDays = activityResult.data?.data.days;
+  const chronoDays = activityDays ? [...activityDays].reverse() : [];
+  const dailyBlockCounts = chronoDays.map((d) => d.block_count);
+  const latestBlocksPerDay =
+    dailyBlockCounts.length > 0 ? dailyBlockCounts[dailyBlockCounts.length - 1]! : null;
+
   return (
     <AppShell>
       <PageHero
@@ -93,6 +106,28 @@ function BlocksPage() {
             <ShareButton />
           </>
         }
+        kpis={
+          dailyBlockCounts.length > 1
+            ? [
+                {
+                  label: "Blocks / day",
+                  value: latestBlocksPerDay != null ? formatNumber(latestBlocksPerDay) : "—",
+                  hint: "7d trend",
+                  chart: (
+                    <Sparkline
+                      values={dailyBlockCounts}
+                      points={dailyBlockCounts.map((v, i) => ({ t: chronoDays[i]?.day ?? "", v }))}
+                      width={140}
+                      height={28}
+                      color="var(--accent)"
+                      ariaLabel="Daily block count"
+                      formatValue={(v) => `${formatNumber(v)} blocks`}
+                    />
+                  ),
+                },
+              ]
+            : undefined
+        }
       />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-28 w-full mb-8" />}>
@@ -105,7 +140,7 @@ function BlocksPage() {
         </Suspense>
       </QueryErrorBoundary>
       <ApiSourceFooter
-        paths={["/api/v1/blocks", "/api/v1/blocks/summary"]}
+        paths={["/api/v1/blocks", "/api/v1/blocks/summary", "/api/v1/chain/activity"]}
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
       />
     </AppShell>


### PR DESCRIPTION
Closes #3390

## What
Adds a compact "Blocks / day" sparkline to the Blocks index page header, driven by `chainActivityQuery(...).data.data.days[].block_count` — the same data path `explorer.tsx` already proves out (its `totalBlocks` KPI sums this exact series).

## Changes
- `apps/ui/src/routes/blocks.index.tsx`: `BlocksPage` now calls `useQuery(chainActivityQuery())` (non-suspending — the hero's title/description still render immediately; the KPI strip simply appears once this fetch settles, since `PageHero` already renders nothing when `kpis` is `undefined`). Populates `PageHero`'s previously-unset `kpis` prop with one item — `{ label: "Blocks / day", value, hint: "7d trend", chart: <Sparkline .../> }` — using the existing `Sparkline` component (the same one `explorer.tsx`'s `MiniSeries` wraps), with the newest-first→chronological `[...days].reverse()` ordering `Sparkline` expects.
- `ApiSourceFooter`'s `paths` now also lists `/api/v1/chain/activity`.

## Note on screenshots
The live `/api/v1/chain/activity` endpoint currently returns zero `days` entries (verified via direct `curl` — a temporary data-pipeline gap, not a bug in this component or its query). The screenshots below mock a realistic 7-day `days[]` response — the same shape the real endpoint returns — via Playwright route interception, to demonstrate the feature against the actual component code rather than against empty live data.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-desktop-light.png" width="280">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-desktop-light.png" width="280">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-desktop-dark.png" width="280">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-desktop-dark.png" width="280">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-desktop-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-sparkline-3390/after-mobile-dark.png)<br><sub>after</sub> |

## Acceptance criteria
- [x] `blocks.index.tsx` shows a compact blocks-per-day sparkline in the page header
- [x] Reuses the existing `Sparkline` component and `chainActivityQuery` — no reimplementation
- [x] No backend/schema change — `/api/v1/chain/activity` already exists and is already consumed identically in `explorer.tsx`
- [x] `ApiSourceFooter`'s `paths` includes `/api/v1/chain/activity`
- [x] Loading/empty states match convention: the KPI simply doesn't render until data resolves (no fabricated placeholder)

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean (aside from pre-existing CRLF/fast-refresh noise unrelated to this change).
- Diff is 38 insertions / 3 deletions in a single file.
