### PR TITLE
fix(ui): keep header actions on-screen when the omnibox is present

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -138,10 +138,10 @@ export function AppShell({ children }: { children: ReactNode }) {
               <Brand />
               <span aria-hidden className="hidden lg:inline-block h-5 w-px bg-border mx-1" />
               <NavMegaMenu />
-              <div className="flex-1 flex justify-end">
+              <div className="flex-1 flex justify-end min-w-0">
                 <NavOmnibox onOpenPalette={() => setPaletteOpen(true)} />
               </div>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 shrink-0">
                 <ApiDrawerTrigger />
 
                 <NetworkSwitcher />


### PR DESCRIPTION
## What

On pages that render the full header action row (e.g. `/settings`), the trailing action group — network switcher, shortcuts, developer-settings link, settings popover, GitHub, Discord — was pushed past the right edge of the viewport at **1280px desktop** and **768px tablet**. The settings gear and GitHub link ended up off-screen and unreachable.

Closes #3985

## Root cause

The omnibox wrapper is `flex-1` but had no `min-w-0`, so it couldn't shrink below its content's intrinsic width; the action group had no shrink guard. Under width pressure the row overflowed instead of the omnibox yielding.

## Fix

Two classes in `apps/ui/src/components/metagraphed/app-shell.tsx`:
- add `min-w-0` to the omnibox wrapper so it can shrink,
- add `shrink-0` to the action group so it's never compressed or pushed off.

The omnibox now yields width first (collapsing to a compact search pill when space is tight) and **every action stays fully visible and clickable**. No icon is removed; wider viewports are unchanged. Verified on `/settings` **and** the home page.

## Checks

`eslint` + `tsc` clean. UI-only, no schema/contract change. 2-line diff.

## Screenshots

Exact viewports — mobile 375×812, tablet 768×1024, desktop 1280×800 — light + dark, before/after. At **desktop and tablet** the before shows the gear/GitHub/Discord clipped past the right edge; the after shows the full action group on-screen. Mobile (header collapses to the menu button) is unaffected.

| viewport / theme | before | after |
|---|---|---|
| **mobile · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-mobile-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-tablet-dark-after.png)<br><sub>after</sub> |
| **desktop · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/header-overflow-desktop-dark-after.png)<br><sub>after</sub> |
