### PR TITLE
feat(registry): add SN38 ChronoLLM submissions API surface (#4039)

### DIFF
--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -60,6 +60,25 @@
         "https://huggingface.co/manelalab"
       ],
       "url": "https://huggingface.co/datasets/manelalab/ChronoInstruct-SFT-v1"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-38-chronollm-submissions-api",
+      "kind": "subnet-api",
+      "name": "ChronoLLM round submissions API",
+      "notes": "Public no-auth endpoint on the official ChronoLLM backend returning a round's miner model submissions (uid -> per-year ChronoGPT model repo@commit pins). The chronollm/sn38 miner guide documents this API: curl https://api.chronollm.com/submissions/{round}/{uid}, with the round index from https://api.chronollm.com/rounds/current.",
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dalledajay-coder"
+      },
+      "source_urls": [
+        "https://github.com/chronollm/sn38/blob/main/docs/miner.md",
+        "https://github.com/chronollm/sn38"
+      ],
+      "url": "https://api.chronollm.com/submissions/2"
     }
   ],
   "source_repo": "https://github.com/chronollm/sn38",


### PR DESCRIPTION
## Add or update a subnet surface

Appends one `subnet-api` surface to `registry/subnets/chronollm.json` (SN38, ChronoLLM). Append-only — the three existing surfaces and every top-level field are unchanged.

## Surface

- Netuid: 38
- Kind: subnet-api
- Public URL: https://api.chronollm.com/submissions/2
- Source URL (proves the claim): https://github.com/chronollm/sn38/blob/main/docs/miner.md
- Provider slug: tao-colosseum

ChronoLLM runs a public, no-auth backend at `api.chronollm.com`. The `/submissions/{round}` endpoint returns that round's miner model submissions — `{ "round": 2, "submissions": { "<uid>": { "models": { "<year>": "<repo>@<sha>" } } } }` (200 JSON, ~114 KB, 114 submissions in the current round). The subnet's own miner guide documents this API (`curl https://api.chronollm.com/submissions/{round}/{uid}` and `https://api.chronollm.com/rounds/current`), and `api.chronollm.com` is a subdomain of the official ChronoLLM project (repo `chronollm/sn38`).

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file — append-only.
- [x] Surface carries `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (the three existing surfaces are docs + two HuggingFace data artifacts).
- [x] Links a tracked issue that is still OPEN (`Closes #4039`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/chronollm.json` → passed (4 surfaces across 1 file).
- [x] `npm run scan:public-safety` → passed.
- Verified live: `GET https://api.chronollm.com/submissions/2` → 200, valid JSON, no auth header, byte-identical across repeated calls.

Closes #4039
