### PR TITLE
Enrich SN89 InfiniteHash — add public API endpoint

### DIFF
--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -68,6 +68,25 @@
         "timeout_ms": 10000
       },
       "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-89-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "InfiniteHash TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/89 on api.taomarketcap.com returning machine-readable JSON for SN89 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. InfiniteHash's official infinitehash.xyz deployment currently returns HTTP 402 (Payment required), and no other first-party public API is verified; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/89"
     }
   ],
   "website_url": "https://infinitehash.xyz/",


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/infinitehash.json` (SN89, InfiniteHash). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 89
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/89
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md
- **Provider slug:** `taomarketcap`

InfiniteHash's official `infinitehash.xyz` deployment currently returns HTTP 402 (Payment required), and no other first-party public API is verified. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 89.

## Test plan

- [x] `npm run surface:add` — OK reachable + public-safe
- [x] `npm run scan:public-safety`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/89` returns HTTP 200 with valid JSON (`netuid: 89`)

Closes #4114