### PR TITLE
feat(ui): add /validators/$hotkey cross-subnet validator detail page

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -21,7 +21,7 @@ export function taoCompact(v?: number | null): string {
 }
 
 /** Format a 0..1 score (trust, consensus, incentive) to three decimals. */
-function scoreStr(v?: number | null): string {
+export function scoreStr(v?: number | null): string {
   if (v == null || !Number.isFinite(v)) return "—";
   return v.toFixed(3);
 }
@@ -197,15 +197,27 @@ export function NeuronTable({
                   </td>
                   <td className="px-3 py-2.5 font-mono text-[11px]">
                     {n.hotkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: n.hotkey }}
-                        className="text-ink-muted hover:text-ink hover:underline"
-                        onClick={(e) => e.stopPropagation()}
-                        title={n.hotkey}
-                      >
-                        {shortHash(n.hotkey) ?? n.hotkey}
-                      </Link>
+                      isValidator ? (
+                        <Link
+                          to="/validators/$hotkey"
+                          params={{ hotkey: n.hotkey }}
+                          className="text-ink-muted hover:text-ink hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                          title={n.hotkey}
+                        >
+                          {shortHash(n.hotkey) ?? n.hotkey}
+                        </Link>
+                      ) : (
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: n.hotkey }}
+                          className="text-ink-muted hover:text-ink hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                          title={n.hotkey}
+                        >
+                          {shortHash(n.hotkey) ?? n.hotkey}
+                        </Link>
+                      )
                     ) : (
                       "—"
                     )}

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
+import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { healthColorVar } from "@/lib/health-tokens";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import type { ValidatorHistoryPoint } from "@/lib/metagraphed/types";
+
+// Lowercase windows, matching the /history API's window enum.
+type Win = "7d" | "30d" | "90d" | "1y" | "all";
+const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+
+function taoStr(v?: number) {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
+}
+
+function rewardsStr(v?: number) {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${v.toFixed(4)} τ/1k`;
+}
+
+/** Staked-over-time + rewards-per-1000-TAO daily history for one validator
+ * (#4337/7.3), reusing the neuron_daily rollup. Mirrors subnet-history-chart.tsx's
+ * window selector + stacked HistoryRow pattern. Renders null-safe empty state when
+ * the validator has no history yet (e.g. a freshly-registered hotkey). */
+export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
+  const [win, setWin] = useState<Win>("90d");
+  const { data: res, isLoading } = useQuery(validatorHistoryQuery(hotkey, win));
+  const points = useMemo<ValidatorHistoryPoint[]>(
+    () => res?.data?.points ?? [],
+    [res?.data?.points],
+  );
+
+  const series = useMemo(() => {
+    const pick = (key: keyof ValidatorHistoryPoint) =>
+      points
+        .map((p) => p[key])
+        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    return {
+      stake: pick("total_stake_tao"),
+      rewards: pick("rewards_per_1000_tao"),
+    };
+  }, [points]);
+
+  const hasData = series.stake.length + series.rewards.length > 0;
+
+  const windowSelector = (
+    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          onClick={() => setWin(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">{windowSelector}</div>
+      {isLoading ? (
+        <Skeleton className="h-32 w-full" />
+      ) : !hasData ? (
+        <EmptyState
+          title="No history yet"
+          description="Daily snapshots will appear here once enough chain history has accumulated for this validator."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          {series.stake.length > 0 ? (
+            <HistoryRow
+              label="Staked"
+              series={series.stake}
+              color={healthColorVar("warn")}
+              format={taoStr}
+            />
+          ) : null}
+          {series.rewards.length > 0 ? (
+            <HistoryRow
+              label="Rewards / 1k τ"
+              series={series.rewards}
+              color="var(--accent, #00c899)"
+              format={rewardsStr}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HistoryRow({
+  label,
+  series,
+  color,
+  format,
+}: {
+  label: string;
+  series: number[];
+  color: string;
+  format?: (v: number) => string;
+}) {
+  const last = series[series.length - 1]!;
+  const display = format ? format(last) : Number.isFinite(last) ? formatNumber(last) : "—";
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
+        {label}
+      </span>
+      <div className="flex-1 min-w-0">
+        <Sparkline values={series} color={color} width={220} height={28} formatValue={format} />
+      </div>
+      <span className="w-20 shrink-0 text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
+        {display}
+      </span>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -1,0 +1,186 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { EmptyState } from "@/components/metagraphed/states";
+import { ListShell } from "@/components/metagraphed/list-shell";
+import {
+  PageSizeSelect,
+  ResetFiltersButton,
+  SearchInput,
+  SelectFilter,
+} from "@/components/metagraphed/table-controls";
+import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { TimeAgo } from "@/components/metagraphed/time-ago";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { validatorNominatorsQuery } from "@/lib/metagraphed/queries";
+import type { ValidatorNominatorEntry } from "@/lib/metagraphed/types";
+
+const WINDOWS = ["7d", "30d", "90d"] as const;
+const SORTS = [
+  { value: "net_staked", label: "Net staked" },
+  { value: "gross_staked", label: "Gross staked" },
+  { value: "last_activity", label: "Last activity" },
+] as const;
+
+export interface ValidatorNominatorsSearch {
+  window: "7d" | "30d" | "90d";
+  sort: "net_staked" | "gross_staked" | "last_activity";
+  limit: number;
+  offset: number;
+  coldkey: string;
+}
+
+interface Props {
+  queryOptions: ReturnType<typeof validatorNominatorsQuery>;
+  search: ValidatorNominatorsSearch;
+  setSearch: (patch: Partial<ValidatorNominatorsSearch>) => void;
+}
+
+/** Nominator list + search for a validator (#4336/7.2) — derived from
+ * stake-delegation account_events, no new capture. Embedded within
+ * /validators/$hotkey, mirroring how /sudo embeds CallModuleExtrinsicsTable. */
+export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Props) {
+  const rows = useSuspenseQuery(queryOptions).data.data ?? [];
+
+  const hasPrev = search.offset > 0;
+  const hasNext = rows.length === search.limit;
+
+  const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
+  const goNext = () => setSearch({ offset: search.offset + search.limit });
+
+  const filtersActive = Boolean(search.coldkey);
+
+  const filters = (
+    <>
+      <SearchInput
+        value={search.coldkey}
+        onChange={(v) => setSearch({ coldkey: v, offset: 0 })}
+        placeholder="Coldkey ss58…"
+      />
+      <SelectFilter
+        label="Window"
+        value={search.window}
+        onChange={(v) => setSearch({ window: v as ValidatorNominatorsSearch["window"], offset: 0 })}
+        options={WINDOWS.map((w) => ({ value: w, label: w }))}
+      />
+      <SelectFilter
+        label="Sort"
+        value={search.sort}
+        onChange={(v) => setSearch({ sort: v as ValidatorNominatorsSearch["sort"], offset: 0 })}
+        options={[...SORTS]}
+      />
+      <PageSizeSelect
+        value={search.limit}
+        onChange={(n) => setSearch({ limit: n, offset: 0 })}
+        options={[10, 20, 50, 100]}
+      />
+      <ResetFiltersButton
+        active={filtersActive}
+        onReset={() => setSearch({ coldkey: "", offset: 0 })}
+      />
+    </>
+  );
+
+  const emptyNode = (
+    <EmptyState
+      title="No nominators in this window"
+      description="Nominators are derived from stake-delegation events — widen the window or check back once new delegations land."
+    />
+  );
+
+  const footerNode = (
+    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted">
+      <span>
+        {rows.length
+          ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
+          : "0"}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={goPrev}
+          disabled={!hasPrev}
+          className="inline-flex items-center gap-1 rounded border border-border bg-card px-2.5 py-1.5 font-medium hover:border-ink/30 disabled:opacity-40 disabled:cursor-not-allowed min-h-9"
+        >
+          <ChevronLeft className="size-3" /> Prev
+        </button>
+        <button
+          type="button"
+          onClick={goNext}
+          disabled={!hasNext}
+          className="inline-flex items-center gap-1 rounded border border-border bg-card px-2.5 py-1.5 font-medium hover:border-ink/30 disabled:opacity-40 disabled:cursor-not-allowed min-h-9"
+        >
+          Next <ChevronRight className="size-3" />
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <ListShell
+      filters={filters}
+      isEmpty={rows.length === 0}
+      empty={emptyNode}
+      cards={rows.map((n) => (
+        <NominatorCard key={n.coldkey} n={n} />
+      ))}
+      table={
+        <table className="w-full text-left text-sm">
+          <thead className="sticky top-sticky-offset z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+            <tr>
+              <th className="px-4 py-2.5">Coldkey</th>
+              <th className="px-4 py-2.5 text-right">Net staked</th>
+              <th className="px-4 py-2.5 text-right">Gross staked</th>
+              <th className="px-4 py-2.5 text-right">Unstaked</th>
+              <th className="px-4 py-2.5 text-right">Events</th>
+              <th className="px-4 py-2.5 text-right">Last activity</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((n) => (
+              <tr key={n.coldkey} className="mg-row-accent hover:bg-surface/40">
+                <td className="px-4 py-2.5 font-mono text-[11px]">
+                  <CopyableCode value={n.coldkey} className="max-w-full" />
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                  {taoCompact(n.net_staked_tao)}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {taoCompact(n.gross_staked_tao)}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                  {taoCompact(n.unstaked_tao)}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                  {formatNumber(n.event_count)}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                  <TimeAgo at={n.last_observed_at} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      }
+      footer={footerNode}
+    />
+  );
+}
+
+function NominatorCard({ n }: { n: ValidatorNominatorEntry }) {
+  return (
+    <div className="block rounded border border-border bg-card p-3 min-h-11">
+      <div className="flex items-center justify-between gap-2">
+        <CopyableCode value={n.coldkey} className="max-w-[70%]" />
+        <span className="font-mono text-[11px] text-ink-muted shrink-0">
+          <TimeAgo at={n.last_observed_at} />
+        </span>
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+        <span>net {taoCompact(n.net_staked_tao)}</span>
+        <span>gross {taoCompact(n.gross_staked_tao)}</span>
+        <span>{formatNumber(n.event_count)} events</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -160,6 +160,11 @@ import type {
   GlobalValidators,
   GlobalValidatorSort,
   GlobalValidatorSubnet,
+  ValidatorDetail,
+  ValidatorDetailSubnet,
+  ValidatorNominatorEntry,
+  ValidatorHistory,
+  ValidatorHistoryPoint,
   SubnetNeuronSnapshot,
   ConcentrationMetrics,
   ScoreDistribution,
@@ -4634,6 +4639,150 @@ export const validatorsQuery = ({
         meta: res.meta,
         url: res.url,
       } as ApiResult<GlobalValidators>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeValidatorDetailSubnet(raw: unknown): ValidatorDetailSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  const uid = firstFiniteNumber(raw.uid);
+  if (netuid == null || uid == null) return null;
+  return {
+    netuid,
+    uid,
+    hotkey: firstString(raw.hotkey) ?? null,
+    coldkey: firstString(raw.coldkey) ?? null,
+    active: booleanValue(raw.active) ?? null,
+    validator_permit: booleanValue(raw.validator_permit) ?? false,
+    rank: firstFiniteNumber(raw.rank) ?? null,
+    trust: firstFiniteNumber(raw.trust) ?? null,
+    validator_trust: firstFiniteNumber(raw.validator_trust) ?? null,
+    consensus: firstFiniteNumber(raw.consensus) ?? null,
+    incentive: firstFiniteNumber(raw.incentive) ?? null,
+    dividends: firstFiniteNumber(raw.dividends) ?? null,
+    emission_tao: firstFiniteNumber(raw.emission_tao) ?? null,
+    stake_tao: firstFiniteNumber(raw.stake_tao) ?? null,
+    registered_at_block: firstFiniteNumber(raw.registered_at_block) ?? null,
+    is_immunity_period: booleanValue(raw.is_immunity_period) ?? null,
+    axon: firstString(raw.axon) ?? null,
+  };
+}
+
+/** Cross-subnet validator detail — a validator's rows joined across every subnet
+ * they operate in (#4335/7.1). Schema-stable: a cold/unknown hotkey resolves to
+ * a zeroed aggregate rather than an error, so this never throws on a bad hotkey. */
+export const validatorDetailQuery = (hotkey: string) =>
+  queryOptions({
+    queryKey: k("validator-detail", hotkey),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/validators/${ss58PathSegment(hotkey)}`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const subnets = Array.isArray(d.subnets)
+        ? d.subnets.flatMap((row) => {
+            const s = normalizeValidatorDetailSubnet(row);
+            return s ? [s] : [];
+          })
+        : [];
+      return {
+        data: {
+          hotkey: firstString(d.hotkey) ?? hotkey,
+          coldkey: firstString(d.coldkey) ?? null,
+          coldkey_count: firstFiniteNumber(d.coldkey_count) ?? 0,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? 0,
+          total_emission_tao: firstFiniteNumber(d.total_emission_tao) ?? 0,
+          avg_validator_trust: firstFiniteNumber(d.avg_validator_trust) ?? null,
+          max_validator_trust: firstFiniteNumber(d.max_validator_trust) ?? null,
+          captured_at: firstString(d.captured_at) ?? null,
+          block_number: firstFiniteNumber(d.block_number) ?? null,
+          subnets,
+        } as ValidatorDetail,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ValidatorDetail>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeValidatorNominator(raw: unknown): ValidatorNominatorEntry | null {
+  if (!isRecord(raw)) return null;
+  const coldkey = firstString(raw.coldkey);
+  if (!coldkey) return null;
+  return {
+    coldkey,
+    staked_tao: firstFiniteNumber(raw.staked_tao) ?? 0,
+    unstaked_tao: firstFiniteNumber(raw.unstaked_tao) ?? 0,
+    net_staked_tao: firstFiniteNumber(raw.net_staked_tao) ?? 0,
+    gross_staked_tao: firstFiniteNumber(raw.gross_staked_tao) ?? 0,
+    event_count: firstFiniteNumber(raw.event_count) ?? 0,
+    last_observed_at: firstString(raw.last_observed_at) ?? null,
+  };
+}
+
+/** Nominator list + search for one validator, derived from stake-delegation
+ * account_events (#4336/7.2). Offset-paginated, newest/largest-first per `sort`. */
+export const validatorNominatorsQuery = (hotkey: string, params?: QueryParams) =>
+  queryOptions({
+    queryKey: k("validator-nominators", hotkey, params ?? {}),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<unknown>(
+        `/api/v1/validators/${ss58PathSegment(hotkey)}/nominators`,
+        "nominators",
+        params,
+        signal,
+      );
+      const data = res.data.flatMap((row) => {
+        const n = normalizeValidatorNominator(row);
+        return n ? [n] : [];
+      });
+      return { ...res, data } as ApiResult<ValidatorNominatorEntry[]>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeValidatorHistoryPoint(raw: unknown): ValidatorHistoryPoint | null {
+  if (!isRecord(raw)) return null;
+  const snapshotDate = firstString(raw.snapshot_date);
+  if (!snapshotDate) return null;
+  return {
+    snapshot_date: snapshotDate,
+    subnet_count: firstFiniteNumber(raw.subnet_count) ?? null,
+    total_stake_tao: firstFiniteNumber(raw.total_stake_tao) ?? null,
+    total_emission_tao: firstFiniteNumber(raw.total_emission_tao) ?? null,
+    rewards_per_1000_tao: firstFiniteNumber(raw.rewards_per_1000_tao) ?? null,
+  };
+}
+
+/** Daily staked-over-time + rewards-per-1000-TAO series for one validator,
+ * reusing the neuron_daily rollup (#4337/7.3). */
+export const validatorHistoryQuery = (hotkey: string, window: string) =>
+  queryOptions({
+    queryKey: k("validator-history", hotkey, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/validators/${ss58PathSegment(hotkey)}/history`, {
+        params: { window },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const points = Array.isArray(d.points)
+        ? d.points.flatMap((row) => {
+            const p = normalizeValidatorHistoryPoint(row);
+            return p ? [p] : [];
+          })
+        : [];
+      return {
+        data: {
+          hotkey: firstString(d.hotkey) ?? hotkey,
+          window: firstString(d.window) ?? null,
+          point_count: firstFiniteNumber(d.point_count) ?? points.length,
+          points,
+        } as ValidatorHistory,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ValidatorHistory>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1716,6 +1716,74 @@ export interface GlobalValidators {
   validators: GlobalValidator[];
 }
 
+/** One per-subnet membership row from /api/v1/validators/{hotkey} (#4335, 7.1). */
+export interface ValidatorDetailSubnet {
+  netuid: number;
+  uid: number;
+  hotkey?: string | null;
+  coldkey?: string | null;
+  active?: boolean | null;
+  validator_permit: boolean;
+  rank?: number | null;
+  trust?: number | null;
+  validator_trust?: number | null;
+  consensus?: number | null;
+  incentive?: number | null;
+  dividends?: number | null;
+  emission_tao?: number | null;
+  stake_tao?: number | null;
+  registered_at_block?: number | null;
+  is_immunity_period?: boolean | null;
+  axon?: string | null;
+}
+
+/** Cross-subnet validator detail from GET /api/v1/validators/{hotkey} (#4335, 7.1).
+ * Schema-stable: a cold/unknown hotkey returns 200 with a zeroed aggregate, never 404. */
+export interface ValidatorDetail {
+  schema_version?: number;
+  hotkey: string;
+  coldkey: string | null;
+  coldkey_count: number;
+  subnet_count: number;
+  total_stake_tao: number;
+  total_emission_tao: number;
+  avg_validator_trust: number | null;
+  max_validator_trust: number | null;
+  captured_at?: string | null;
+  block_number?: number | null;
+  subnets: ValidatorDetailSubnet[];
+}
+
+/** One nominator row from /api/v1/validators/{hotkey}/nominators (#4336, 7.2). */
+export interface ValidatorNominatorEntry {
+  coldkey: string;
+  staked_tao: number;
+  unstaked_tao: number;
+  net_staked_tao: number;
+  gross_staked_tao: number;
+  event_count: number;
+  last_observed_at?: string | null;
+}
+
+/** One daily snapshot from /api/v1/validators/{hotkey}/history (#4337, 7.3). */
+export interface ValidatorHistoryPoint {
+  snapshot_date: string;
+  subnet_count?: number | null;
+  total_stake_tao?: number | null;
+  total_emission_tao?: number | null;
+  /** Null when stake is 0/absent for the day (division by zero avoided server-side). */
+  rewards_per_1000_tao?: number | null;
+}
+
+/** Daily stake/rewards history from GET /api/v1/validators/{hotkey}/history (#4337, 7.3). */
+export interface ValidatorHistory {
+  schema_version?: number;
+  hotkey: string;
+  window?: string | null;
+  point_count: number;
+  points: ValidatorHistoryPoint[];
+}
+
 /** A single neuron snapshot from /api/v1/subnets/{netuid}/neurons/{uid}. */
 export interface SubnetNeuronSnapshot {
   netuid: number;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
+import { Route as ValidatorsHotkeyRouteImport } from './routes/validators.$hotkey'
 import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
 import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
 import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
@@ -117,6 +118,11 @@ const AccountsIndexRoute = AccountsIndexRouteImport.update({
   path: '/accounts/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ValidatorsHotkeyRoute = ValidatorsHotkeyRouteImport.update({
+  id: '/validators/$hotkey',
+  path: '/validators/$hotkey',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SubnetsNetuidRoute = SubnetsNetuidRouteImport.update({
   id: '/subnets/$netuid',
   path: '/subnets/$netuid',
@@ -160,6 +166,7 @@ export interface FileRoutesByFullPath {
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts/': typeof AccountsIndexRoute
   '/blocks/': typeof BlocksIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
@@ -184,6 +191,7 @@ export interface FileRoutesByTo {
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts': typeof AccountsIndexRoute
   '/blocks': typeof BlocksIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
@@ -209,6 +217,7 @@ export interface FileRoutesById {
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts/': typeof AccountsIndexRoute
   '/blocks/': typeof BlocksIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
@@ -235,6 +244,7 @@ export interface FileRouteTypes {
     | '/extrinsics/$hash'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/validators/$hotkey'
     | '/accounts/'
     | '/blocks/'
     | '/extrinsics/'
@@ -259,6 +269,7 @@ export interface FileRouteTypes {
     | '/extrinsics/$hash'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/validators/$hotkey'
     | '/accounts'
     | '/blocks'
     | '/extrinsics'
@@ -283,6 +294,7 @@ export interface FileRouteTypes {
     | '/extrinsics/$hash'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/validators/$hotkey'
     | '/accounts/'
     | '/blocks/'
     | '/extrinsics/'
@@ -308,6 +320,7 @@ export interface RootRouteChildren {
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
   SubnetsNetuidRoute: typeof SubnetsNetuidRoute
+  ValidatorsHotkeyRoute: typeof ValidatorsHotkeyRoute
   AccountsIndexRoute: typeof AccountsIndexRoute
   BlocksIndexRoute: typeof BlocksIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
@@ -437,6 +450,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AccountsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/validators/$hotkey': {
+      id: '/validators/$hotkey'
+      path: '/validators/$hotkey'
+      fullPath: '/validators/$hotkey'
+      preLoaderRoute: typeof ValidatorsHotkeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/subnets/$netuid': {
       id: '/subnets/$netuid'
       path: '/subnets/$netuid'
@@ -492,6 +512,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
   SubnetsNetuidRoute: SubnetsNetuidRoute,
+  ValidatorsHotkeyRoute: ValidatorsHotkeyRoute,
   AccountsIndexRoute: AccountsIndexRoute,
   BlocksIndexRoute: BlocksIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -1,0 +1,316 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { Boxes, Coins, Gauge, Zap } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
+import { ShareButton } from "@/components/metagraphed/share-button";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { SectionAnchor } from "@/components/metagraphed/section-anchor";
+import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
+import {
+  ValidatorNominatorsTable,
+  type ValidatorNominatorsSearch,
+} from "@/components/metagraphed/validator-nominators-table";
+import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-table";
+import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphed/queries";
+import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { ValidatorDetailSubnet } from "@/lib/metagraphed/types";
+
+const validatorDetailSearchSchema = z.object({
+  window: fallback(z.enum(["7d", "30d", "90d"]), "30d").default("30d"),
+  sort: fallback(z.enum(["net_staked", "gross_staked", "last_activity"]), "net_staked").default(
+    "net_staked",
+  ),
+  limit: fallback(z.number().int().min(1).max(100), 20).default(20),
+  offset: fallback(z.number().int().min(0), 0).default(0),
+  coldkey: fallback(z.string(), "").default(""),
+});
+
+export const Route = createFileRoute("/validators/$hotkey")({
+  validateSearch: zodValidator(validatorDetailSearchSchema),
+  head: ({ params }) => {
+    const label = shortHash(params.hotkey) ?? params.hotkey;
+    return {
+      meta: [
+        { title: `Validator ${label} — Metagraphed` },
+        {
+          name: "description",
+          content: `Cross-subnet performance, nominators, and staking history for Bittensor validator ${label}.`,
+        },
+        { property: "og:title", content: `Validator ${label} — Metagraphed` },
+        {
+          property: "og:description",
+          content: "Cross-subnet validator performance, nominators, and staking history.",
+        },
+      ],
+    };
+  },
+  component: ValidatorDetailPage,
+});
+
+function ValidatorDetailPage() {
+  const { hotkey } = Route.useParams();
+  return (
+    <AppShell>
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+          <ValidatorDetailGate hotkey={hotkey} />
+        </Suspense>
+      </QueryErrorBoundary>
+    </AppShell>
+  );
+}
+
+function ValidatorDetailGate({ hotkey }: { hotkey: string }) {
+  if (!isValidSs58(hotkey)) {
+    return (
+      <>
+        <PageHeading
+          eyebrow="Explorer"
+          title="Invalid hotkey"
+          description="Validator hotkeys must be a valid ss58 (base58) string."
+        />
+        <EmptyState
+          title="Invalid hotkey"
+          description="Use a valid validator hotkey ss58 address."
+          action={{ label: "Back to validators", href: "/validators" }}
+        />
+      </>
+    );
+  }
+  return <ValidatorDetail hotkey={hotkey} />;
+}
+
+const TH = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
+
+function SubnetPerformanceTable({ subnets }: { subnets: ValidatorDetailSubnet[] }) {
+  if (subnets.length === 0) {
+    return (
+      <EmptyState
+        title="No active subnet memberships"
+        description="This hotkey isn't currently registered as a validator on any subnet."
+      />
+    );
+  }
+  const sorted = [...subnets].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0));
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-left text-sm">
+        <thead className="bg-surface/50">
+          <tr>
+            <th className={TH}>Subnet</th>
+            <th className={`${TH} text-right`}>UID</th>
+            <th className={`${TH} text-right`}>Stake τ</th>
+            <th className={`${TH} text-right`}>Emission τ</th>
+            <th className={`${TH} text-right`}>Dividends</th>
+            <th className={`${TH} text-right`}>Val trust</th>
+            <th className={`${TH} text-center`}>Permit</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {sorted.map((s) => (
+            <tr key={s.netuid} className="hover:bg-surface/40">
+              <td className="px-3 py-2 font-mono text-[11px]">
+                <Link
+                  to="/subnets/$netuid"
+                  params={{ netuid: s.netuid }}
+                  className="text-ink-strong hover:text-accent hover:underline"
+                >
+                  SN{s.netuid}
+                </Link>
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                {s.uid}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                {taoCompact(s.stake_tao)}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink">
+                {taoCompact(s.emission_tao)}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink">
+                {scoreStr(s.dividends)}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                {scoreStr(s.validator_trust)}
+              </td>
+              <td className="px-3 py-2 text-center">
+                {s.validator_permit ? (
+                  <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                    Yes
+                  </span>
+                ) : (
+                  <span className="font-mono text-[10px] text-ink-subtle-text">—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function nominatorsQueryParams(search: ValidatorNominatorsSearch): Record<string, string | number> {
+  const params: Record<string, string | number> = {
+    window: search.window,
+    sort: search.sort,
+    limit: search.limit,
+    offset: search.offset,
+  };
+  // Only a complete, valid ss58 is worth sending — the backend 400s on a partial
+  // match, and a partial/invalid value updates on every keystroke, so gating here
+  // keeps a mid-typing coldkey from ever reaching the API.
+  if (search.coldkey && isValidSs58(search.coldkey)) params.coldkey = search.coldkey;
+  return params;
+}
+
+function NominatorsSection({ hotkey }: { hotkey: string }) {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const setSearch = (patch: Partial<ValidatorNominatorsSearch>) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
+      resetScroll: false,
+    });
+
+  const normalizedSearch: ValidatorNominatorsSearch = {
+    window: search.window,
+    sort: search.sort,
+    limit: search.limit,
+    offset: search.offset,
+    coldkey: search.coldkey,
+  };
+
+  return (
+    <ValidatorNominatorsTable
+      queryOptions={validatorNominatorsQuery(hotkey, nominatorsQueryParams(normalizedSearch))}
+      search={normalizedSearch}
+      setSearch={setSearch}
+    />
+  );
+}
+
+function ValidatorDetail({ hotkey }: { hotkey: string }) {
+  const sourceRef = ss58PathSegment(hotkey);
+  const detail = useSuspenseQuery(validatorDetailQuery(hotkey)).data.data;
+
+  return (
+    <>
+      <PageHero
+        eyebrow="Explorer · validator"
+        live
+        title={shortHash(hotkey, 8) ?? "Validator"}
+        description={
+          // PageHero renders `description` inside a <p> — block elements (div/p)
+          // are invalid HTML there (triggers a hydration mismatch), so this uses
+          // block-styled <span>s instead of the <div>/<p> combo other detail pages
+          // use for the same "blurb + copyable chip" shape.
+          <span className="block space-y-4">
+            <span className="block max-w-2xl">
+              Cross-subnet performance, nominators, and staking history for one Bittensor validator
+              hotkey.
+            </span>
+            <span className="inline-flex max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+              <CopyableCode value={hotkey} truncate={false} />
+            </span>
+          </span>
+        }
+        actions={<ShareButton />}
+        caption="explorer / v1"
+      />
+
+      <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <StatTile
+          icon={Coins}
+          eyebrow="Total stake"
+          value={taoCompact(detail.total_stake_tao)}
+          hint="across all subnets"
+          tone="accent"
+          className="rounded-2xl border-accent/25 bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
+        />
+        <StatTile
+          icon={Zap}
+          eyebrow="Total emission"
+          value={taoCompact(detail.total_emission_tao)}
+          hint="across all subnets"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Active subnets"
+          value={formatNumber(detail.subnet_count)}
+          hint="validator memberships"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={Gauge}
+          eyebrow="Avg validator trust"
+          value={scoreStr(detail.avg_validator_trust)}
+          hint="mean across subnets"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+      </div>
+
+      <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
+        <SubnetPerformanceTable subnets={detail.subnets} />
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="history"
+        title="Stake & rewards over time"
+        subtitle="Daily snapshots"
+        tone="ink"
+      >
+        <ValidatorHistoryChart hotkey={hotkey} />
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="nominators"
+        title="Nominators"
+        subtitle="Derived from stake-delegation events"
+        tone="muted"
+      >
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+            <NominatorsSection hotkey={hotkey} />
+          </Suspense>
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="call"
+        title="Call this endpoint"
+        subtitle="Copy a ready-to-run request for this validator."
+      >
+        <EndpointSnippet
+          rows={[
+            { label: "summary", path: `/api/v1/validators/${sourceRef}` },
+            { label: "nominators", path: `/api/v1/validators/${sourceRef}/nominators` },
+            { label: "history", path: `/api/v1/validators/${sourceRef}/history` },
+          ]}
+        />
+      </SectionAnchor>
+
+      <ApiSourceFooter
+        paths={[
+          `/api/v1/validators/${sourceRef}`,
+          `/api/v1/validators/${sourceRef}/nominators`,
+          `/api/v1/validators/${sourceRef}/history`,
+        ]}
+      />
+    </>
+  );
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -168,8 +168,8 @@ function ValidatorsTable({
                 <tr key={v.hotkey} className="hover:bg-surface/40">
                   <td className="px-3 py-2 font-mono text-[11px]">
                     <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: v.hotkey }}
+                      to="/validators/$hotkey"
+                      params={{ hotkey: v.hotkey }}
                       className="text-ink-strong hover:text-accent hover:underline"
                       title={v.hotkey}
                     >


### PR DESCRIPTION
## Summary

- Deliverable 7.4 of the validator-detail epic (#4334), closing out 7/7 open items: wires the already-shipped 7.1-7.3 backend routes (`/api/v1/validators/{hotkey}`, `/nominators`, `/history`) to a new `/validators/$hotkey` detail page.
- This directly unblocks the Wave 3 (#2542) checklist item — "Add a per-validator detail page (/validators/$hotkey) — BLOCKED: no per-hotkey backend detail route exists yet" — which has sat blocked since that tracker was filed.

## What changed

- `apps/ui/src/routes/validators.$hotkey.tsx`: new detail page — hero + StatTile KPI grid (total stake, total emission, active subnets, avg validator trust), per-subnet performance table (all subnet memberships for this hotkey), staked-over-time + rewards-per-1000-TAO chart, a searchable/paginated nominator list, and a "Call this endpoint" snippet — following the `accounts.$ss58.tsx` entity-detail-page pattern (StatTile grid, SectionAnchor composition, EndpointSnippet + ApiSourceFooter) rather than the KPI-strip pattern used by list/overview pages.
- `apps/ui/src/components/metagraphed/validator-history-chart.tsx`, `validator-nominators-table.tsx`: new supporting components (window-selector chart mirroring `subnet-history-chart.tsx`; embedded searchable/paginated table mirroring `call-module-extrinsics-table.tsx`).
- `apps/ui/src/lib/metagraphed/queries.ts` / `types.ts`: `validatorDetailQuery`, `validatorNominatorsQuery`, `validatorHistoryQuery` + matching types, hand-normalized against the real backend response shapes.
- **Wiring**: `validators.index.tsx` and `neuron-table.tsx`'s validator hotkey links now point at `/validators/$hotkey` instead of the generic `/accounts/$ss58` — this is the actual "wire it up" deliverable, not just the new page existing in isolation.

## Maintainer PR — no screenshot table

Internal maintainer PR (own-repo, own-issue) — skipping the before/after screenshot table per direct call. Verified live against the production API (`api.metagraph.sh`) via a local dev server against a real validator hotkey with 113 subnet memberships and real nominator/history data — full page renders correctly end-to-end (hero, per-subnet table, history chart, paginated nominator list all confirmed with real data, not just empty states).

This PR went through an internal multi-dimension review pass (correctness / reuse-simplification / consistency-with-precedent) before push; confirmed findings that were fixed:
- A real bug: the nominator coldkey search filter had no client-side validation, so a partial/mid-typing value would 400 against the backend and crash the whole nominators section via the error boundary — now gated on `isValidSs58` before it ever reaches the API.
- Stale wiring: `neuron-table.tsx`'s per-subnet validators panel still linked hotkeys to `/accounts/$ss58` after this PR's own `validators.index.tsx` change — now consistent (validator rows go to `/validators/$hotkey`, non-validator/miner rows still go to `/accounts/$ss58`).
- Dead code (`ValidatorNominators` type) and an unsafe `as unknown as` cast, both removed.
- Missing `caption`/`EndpointSnippet` section that every sibling `$param` detail page has — added to match precedent.

## Validation (Path C)

- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (537 passed)
- [x] `npm run build --workspace=apps/ui`
- [x] Bundle-size budget: 261 KB / 300 KB gzipped initial load (unaffected — the new route is lazy-loaded, not part of the `/` cold-load chain)

Closes #4338