### PR TITLE
feat(registry): add SN103 Djinn genius track-record leaderboard data-artifact

### DIFF
--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -116,9 +116,7 @@
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "source_urls": [
-        "https://github.com/Djinn-Inc/djinn/blob/main/README.md"
-      ],
+      "source_urls": ["https://github.com/Djinn-Inc/djinn/blob/main/README.md"],
       "url": "https://www.djinn.gg/api/leaderboard"
     }
   ],

--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -102,6 +102,24 @@
         "https://github.com/Djinn-Inc/djinn/blob/main/CONTRIBUTING.md"
       ],
       "url": "https://raw.githubusercontent.com/Djinn-Inc/djinn/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-103-djinn-genius-leaderboard",
+      "kind": "data-artifact",
+      "name": "Djinn genius track-record leaderboard",
+      "notes": "Public no-auth JSON leaderboard of SN103 Djinn 'Genius' analysts served from the official djinn.gg site, exposing each genius's on-chain track record (totalSignals, totalPurchases, totalVolume, totalFeesEarned, aggregateQualityScore, collateralDeposited, totalSlashed, favorable/unfavorable/void counts). This is the machine-readable form of the publicly-verifiable track records the official Djinn-Inc/djinn README describes (\"Track records are publicly verifiable on-chain\"), served on the README's official djinn.gg domain.",
+      "provider": "djinn",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn/blob/main/README.md"
+      ],
+      "url": "https://www.djinn.gg/api/leaderboard"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4133

## Summary

Registers **SN103 Djinn**'s public **genius track-record leaderboard** — a live, no-auth JSON data endpoint the registry didn't yet have. It exposes the on-chain, publicly-verifiable performance records that are core to the Djinn protocol.

## Surface

- kind: `data-artifact`
- url: `https://www.djinn.gg/api/leaderboard`
- provider: `djinn` (existing)

## Proof of ownership (airtight)

- Served on **djinn.gg**, the official SN103 site linked in the `Djinn-Inc/djinn` README (which is the registered `source_repo`, netuid 103 confirmed in that README).
- The README states: *"Track records are publicly verifiable on-chain"* and *"Idiots purchase signals based on verifiable track records."* This endpoint is the machine-readable form of exactly those records — `source_url` is the README.

## Verified live + public

- `GET https://www.djinn.gg/api/leaderboard` → **HTTP 200**, `application/json`, no auth. Real payload: `{"geniuses":[ … 8 entries … ]}` with per-genius fields `totalSignals, activeSignals, totalPurchases, totalVolume, totalFeesEarned, aggregateQualityScore, totalAudits, collateralDeposited, totalSlashed, totalFavorable, totalUnfavorable, totalVoid`.

## Scope note (relative to #4133)

#4133 asks for SN103's OpenAPI/Swagger spec. Djinn exposes no OpenAPI (verified: `djinn.gg/openapi.json` → 404) — its public machine-usable data is served as JSON routes on djinn.gg. This registers the subnet's primary public **data endpoint** (the genius leaderboard), the concrete public data surface behind the issue's intent.

## Non-duplication

Distinct from the existing `sn-103-djinn-health` (subnet-api liveness) and `sn-103-djinn-min-compute-spec` (YAML hardware spec) surfaces — this is a different URL, kind, and payload (the analyst track-record dataset). No other surface references `/api/leaderboard`; no open PR targets SN103.

## Validation (local)

- `npm run validate:surface -- registry/subnets/djinn.json` → passes (5 surfaces)
- `npm run scan:public-safety` → passes
- `git diff --stat` → single file `registry/subnets/djinn.json`, an 18-line pure append (no reordering, no other surfaces/fields touched), no generated artifacts.
