### PR TITLE
Enrich SN86 Subnet 86 — add public API endpoint

### DIFF
--- a/registry/subnets/subnet-86.json
+++ b/registry/subnets/subnet-86.json
@@ -50,6 +50,25 @@
         "https://backprop.finance/dtao/subnets/86-subnet-86"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/86"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-86-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "SN86 TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/86 on api.taomarketcap.com returning machine-readable JSON for SN86 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. SN86 exposes no first-party API, repository, or docs site; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/86-subnet-86"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/86"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/subnet-86.json` (SN86). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 86
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/86
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://backprop.finance/dtao/subnets/86-subnet-86
- **Provider slug:** `taomarketcap`

SN86 has no first-party website, repository, or public API. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 86.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/86` returns HTTP 200 with valid JSON (`netuid: 86`)

Closes #4108

Made with [Cursor](https://cursor.com)