### PR TITLE
feat(registry): add SN107 Minos chr20 reference FAI data-artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -1,5 +1,6 @@
 {
   "categories": [],
+  "contact": "contact@theminos.ai",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
@@ -13,7 +14,6 @@
   },
   "source_repo": "https://github.com/minos-protocol/minos_subnet",
   "status": "active",
-  "website_url": "https://theminos.ai/",
   "surfaces": [
     {
       "auth_required": false,
@@ -38,7 +38,32 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-data-artifact",
+      "kind": "data-artifact",
+      "name": "Minos chr20 reference FAI index",
+      "notes": "Public no-auth GET for the chr20 FASTA index (.fai) served via the Minos Platform reference redirect at api.theminos.ai/reference/.... Used as REF_HEALTH_URL in the official minos_subnet status checks and documented in the README as the canonical way operators download reference genomics files.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/neurons/status.py",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/reference/chr20/chr20.fa.fai"
     }
   ],
-  "contact": "contact@theminos.ai"
+  "website_url": "https://theminos.ai/"
 }


### PR DESCRIPTION
## Summary

- Append a `data-artifact` surface to `registry/subnets/minos.json` for the public chr20 FASTA index at `https://api.theminos.ai/reference/chr20/chr20.fa.fai`.
- Proof: `REF_HEALTH_URL` in the official `minos-protocol/minos_subnet` `neurons/status.py`, plus README documentation of the `api.theminos.ai/reference/...` redirect pattern for reference genomics files.

Closes #4141

## Why

SN107 already registers the Minos Platform health API; this fills the remaining standalone public data-artifact gap with a no-auth reference file the subnet operators actually download and health-check against.

## Validation

```sh
npm run validate:surface -- registry/subnets/minos.json
npm run scan:public-safety
```

- URL resolves (GET → 302 → 200) and returns the chr20 `.fai` index text.
- Only `registry/subnets/minos.json` changed (append-only surface add).

## Test plan

- [x] `validate:surface` passes for the updated manifest
- [x] `scan:public-safety` passes
- [x] `source_urls` point to official minos_subnet code documenting this exact URL
- [x] No screenshots required (registry-only, non-visual change)

