### PR TITLE
feat(registry): add SN12 Compute Horde map contract ABI data-artifact

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -1,4 +1,9 @@
 {
+  "schema_version": 1,
+  "netuid": 12,
+  "name": "Compute Horde",
+  "slug": "sn-12",
+  "status": "active",
   "categories": [
     "baseline-curated",
     "compute",
@@ -7,7 +12,16 @@
     "official-website",
     "official-source-repo"
   ],
+  "website_url": "https://computehorde.io/",
+  "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
+  "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
+  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
   "curation": {
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:45:00.000Z",
+    "verified_at": "2026-06-08T15:45:00.000Z",
+    "source_count": 5,
     "gap_notes": [
       "Project-linked Grafana metagraph dashboard is verified live.",
       "No verified official docs URL yet.",
@@ -15,122 +29,109 @@
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ],
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:45:00.000Z",
-    "source_count": 5,
-    "verified_at": "2026-06-08T15:45:00.000Z"
+    ]
   },
-  "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
-  "name": "Compute Horde",
-  "netuid": 12,
-  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
-  "schema_version": 1,
-  "slug": "sn-12",
-  "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
-  "status": "active",
   "surfaces": [
     {
+      "id": "sn-12-compute-horde-website",
+      "name": "Compute Horde website",
+      "kind": "website",
+      "url": "https://computehorde.io/",
+      "provider": "compute-horde",
       "auth_required": false,
       "authority": "official",
-      "id": "sn-12-compute-horde-website",
-      "kind": "website",
-      "name": "Compute Horde website",
-      "notes": "Official Compute Horde website linked from Learn Bittensor.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://learnbittensor.org/subnets/12",
         "https://computehorde.io/"
       ],
-      "url": "https://computehorde.io/"
-    },
-    {
-      "auth_required": false,
-      "authority": "official",
-      "id": "sn-12-compute-horde-source",
-      "kind": "source-repo",
-      "name": "Compute Horde source repository",
-      "notes": "Official Compute Horde source repository.",
       "probe": {
         "enabled": true,
-        "expect": "any",
         "method": "HEAD",
+        "expect": "any",
         "timeout_ms": 10000
       },
+      "notes": "Official Compute Horde website linked from Learn Bittensor."
+    },
+    {
+      "id": "sn-12-compute-horde-source",
+      "name": "Compute Horde source repository",
+      "kind": "source-repo",
+      "url": "https://github.com/backend-developers-ltd/ComputeHorde",
       "provider": "compute-horde",
+      "auth_required": false,
+      "authority": "official",
       "public_safe": true,
       "source_urls": [
         "https://learnbittensor.org/subnets/12",
         "https://github.com/backend-developers-ltd/ComputeHorde"
       ],
-      "url": "https://github.com/backend-developers-ltd/ComputeHorde"
-    },
-    {
-      "auth_required": false,
-      "authority": "provider-claimed",
-      "id": "sn-12-compute-horde-grafana",
-      "kind": "dashboard",
-      "name": "Compute Horde Grafana dashboard",
-      "notes": "Project-linked public Grafana metagraph dashboard. The originally discovered bactensor.io URL redirects to bittensor.church.",
       "probe": {
         "enabled": true,
-        "expect": "html",
         "method": "HEAD",
+        "expect": "any",
         "timeout_ms": 10000
       },
+      "notes": "Official Compute Horde source repository."
+    },
+    {
+      "id": "sn-12-compute-horde-grafana",
+      "name": "Compute Horde Grafana dashboard",
+      "kind": "dashboard",
+      "url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
       "provider": "compute-horde",
+      "auth_required": false,
+      "authority": "provider-claimed",
       "public_safe": true,
       "source_urls": [
         "https://github.com/backend-developers-ltd/ComputeHorde",
         "https://grafana.bactensor.io/d/subnet/metagraph-subnet?var-subnet=12",
         "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
       ],
-      "url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "notes": "Project-linked public Grafana metagraph dashboard. The originally discovered bactensor.io URL redirects to bittensor.church."
     },
     {
+      "id": "sn-12-compute-horde-sdk",
+      "name": "Compute Horde Python SDK",
+      "kind": "sdk",
+      "url": "https://pypi.org/project/compute-horde-sdk/",
+      "provider": "compute-horde",
       "auth_required": false,
       "authority": "community",
-      "id": "sn-12-compute-horde-sdk",
-      "kind": "sdk",
-      "name": "Compute Horde Python SDK",
-      "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository.",
-      "provider": "compute-horde",
       "public_safe": true,
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/tree/master/compute_horde_sdk"
+      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "devmixa702"
       },
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/ComputeHorde/tree/master/compute_horde_sdk"
-      ],
-      "url": "https://pypi.org/project/compute-horde-sdk/"
+      "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository."
     },
     {
+      "id": "sn-12-compute-horde-subnet-api",
+      "name": "Compute Horde subnet-api",
+      "kind": "subnet-api",
+      "url": "https://facilitator.computehorde.io/auth/nonce",
+      "provider": "compute-horde",
       "auth_required": false,
       "authority": "community",
-      "id": "sn-12-compute-horde-subnet-api",
-      "kind": "subnet-api",
-      "name": "Compute Horde subnet-api",
-      "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login.",
-      "provider": "compute-horde",
       "public_safe": true,
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "galuis116"
-      },
       "source_urls": [
         "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py",
         "https://sdk.computehorde.io/"
       ],
-      "url": "https://facilitator.computehorde.io/auth/nonce"
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
     },
     {
       "auth_required": false,
@@ -157,6 +158,5 @@
       ],
       "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/86ebc5b8df46/compute_horde/compute_horde/smart_contracts/abi/map_abi.json"
     }
-  ],
-  "website_url": "https://computehorde.io/"
+  ]
 }

--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 12,
-  "name": "Compute Horde",
-  "slug": "sn-12",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "compute",
@@ -12,16 +7,7 @@
     "official-website",
     "official-source-repo"
   ],
-  "website_url": "https://computehorde.io/",
-  "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
-  "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
-  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:45:00.000Z",
-    "verified_at": "2026-06-08T15:45:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Project-linked Grafana metagraph dashboard is verified live.",
       "No verified official docs URL yet.",
@@ -29,109 +15,148 @@
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:45:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T15:45:00.000Z"
   },
+  "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
+  "name": "Compute Horde",
+  "netuid": 12,
+  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
+  "schema_version": 1,
+  "slug": "sn-12",
+  "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-12-compute-horde-website",
-      "name": "Compute Horde website",
-      "kind": "website",
-      "url": "https://computehorde.io/",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-12-compute-horde-website",
+      "kind": "website",
+      "name": "Compute Horde website",
+      "notes": "Official Compute Horde website linked from Learn Bittensor.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://learnbittensor.org/subnets/12",
         "https://computehorde.io/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Compute Horde website linked from Learn Bittensor."
+      "url": "https://computehorde.io/"
     },
     {
-      "id": "sn-12-compute-horde-source",
-      "name": "Compute Horde source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/backend-developers-ltd/ComputeHorde",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-12-compute-horde-source",
+      "kind": "source-repo",
+      "name": "Compute Horde source repository",
+      "notes": "Official Compute Horde source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://learnbittensor.org/subnets/12",
         "https://github.com/backend-developers-ltd/ComputeHorde"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Compute Horde source repository."
+      "url": "https://github.com/backend-developers-ltd/ComputeHorde"
     },
     {
-      "id": "sn-12-compute-horde-grafana",
-      "name": "Compute Horde Grafana dashboard",
-      "kind": "dashboard",
-      "url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-12-compute-horde-grafana",
+      "kind": "dashboard",
+      "name": "Compute Horde Grafana dashboard",
+      "notes": "Project-linked public Grafana metagraph dashboard. The originally discovered bactensor.io URL redirects to bittensor.church.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://github.com/backend-developers-ltd/ComputeHorde",
         "https://grafana.bactensor.io/d/subnet/metagraph-subnet?var-subnet=12",
         "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Project-linked public Grafana metagraph dashboard. The originally discovered bactensor.io URL redirects to bittensor.church."
+      "url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
     },
     {
-      "id": "sn-12-compute-horde-sdk",
-      "name": "Compute Horde Python SDK",
-      "kind": "sdk",
-      "url": "https://pypi.org/project/compute-horde-sdk/",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-12-compute-horde-sdk",
+      "kind": "sdk",
+      "name": "Compute Horde Python SDK",
+      "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository.",
+      "provider": "compute-horde",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/ComputeHorde/tree/master/compute_horde_sdk"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "devmixa702"
       },
-      "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository."
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/tree/master/compute_horde_sdk"
+      ],
+      "url": "https://pypi.org/project/compute-horde-sdk/"
     },
     {
-      "id": "sn-12-compute-horde-subnet-api",
-      "name": "Compute Horde subnet-api",
-      "kind": "subnet-api",
-      "url": "https://facilitator.computehorde.io/auth/nonce",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-12-compute-horde-subnet-api",
+      "kind": "subnet-api",
+      "name": "Compute Horde subnet-api",
+      "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login.",
+      "provider": "compute-horde",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py",
-        "https://sdk.computehorde.io/"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "galuis116"
       },
-      "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py",
+        "https://sdk.computehorde.io/"
+      ],
+      "url": "https://facilitator.computehorde.io/auth/nonce"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-12-compute-horde-map-abi",
+      "kind": "data-artifact",
+      "name": "Compute Horde map contract ABI",
+      "notes": "Public no-auth JSON ABI for the Compute Horde map smart contract, published in the official ComputeHorde repository at compute_horde/smart_contracts/abi/map_abi.json. Loaded at runtime by get_contract_abi() in smart_contracts/utils.py and used by map_contract.py to instantiate the on-chain map contract.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde/compute_horde/smart_contracts/map_contract.py",
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde/compute_horde/smart_contracts/utils.py"
+      ],
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/86ebc5b8df46/compute_horde/compute_horde/smart_contracts/abi/map_abi.json"
     }
-  ]
+  ],
+  "website_url": "https://computehorde.io/"
 }


### PR DESCRIPTION
## Summary

- Append a `data-artifact` surface to `registry/subnets/compute-horde.json` for the public map smart-contract ABI JSON published in the official ComputeHorde repository.
- URL pinned to commit `86ebc5b8df46`; proof in `map_contract.py` (loads `map_abi.json` via `get_contract_abi()`) and `smart_contracts/utils.py`.

Closes #4010

## Why

SN12 already lists website, source repo, Grafana dashboard, Python SDK, and Facilitator API surfaces. This fills the remaining standalone public data-artifact gap with the on-chain map contract ABI the subnet code loads at runtime.

## Validation

```sh
npm run validate:surface -- registry/subnets/compute-horde.json
npm run scan:public-safety
```

- Artifact URL resolves and returns JSON ABI payload.
- Only `registry/subnets/compute-horde.json` changed (+25 lines, append-only).

## Test plan

- [x] `validate:surface` passes
- [x] `scan:public-safety` passes
- [x] `source_urls` cite official ComputeHorde smart-contract loader code
- [x] No screenshots required (registry-only change)


Made with [Cursor](https://cursor.com)