### PR TITLE
feat(registry): add SN88 Investing KYM no-code miner app dashboard

### DIFF
--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -154,6 +154,30 @@
         "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
       ],
       "url": "https://api.investing88.ai/days"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-investing-kym-app",
+      "kind": "dashboard",
+      "name": "Investing KYM (Know Your Miner) app",
+      "notes": "Public no-auth 'Know Your Miner' (KYM) web app for SN88 Investing at kym.investing88.ai — the no-code mining/onboarding interface documented as the 'KYM app' in the official mobiusfund/investing README. Served on the same investing88.ai domain as the already-registered dashboard and data APIs; distinct from the db.investing88.ai performance dashboard.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/README.md"
+      ],
+      "url": "https://kym.investing88.ai/"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4113

## Summary

Registers **SN88 Investing**'s public **KYM ("Know Your Miner") app** — the no-code mining/onboarding interface at `kym.investing88.ai`, the one README-documented public surface the registry didn't yet have.

## Surface

- kind: `dashboard`
- url: `https://kym.investing88.ai/`
- provider: `mobiusfund` (existing)

## Proof of ownership (airtight)

- The official SN88 repo `mobiusfund/investing` (netuid 88 confirmed in its README) lists `https://kym.investing88.ai` as the **"KYM app"** in the README. That README is the `source_url`.
- Served on the same `investing88.ai` domain as the already-registered `investing88.ai` website, `db.investing88.ai` dashboard, and `api.investing88.ai/*` data APIs.

## Verified live + public

- `GET https://kym.investing88.ai/` → **HTTP 200** (`text/html`), no auth.

## Scope note (relative to #4113)

#4113 asks for SN88's OpenAPI/Swagger spec. Investing exposes no OpenAPI (verified: `api.investing88.ai/openapi.json` → 404) — its APIs are plain JSON routes and its user surfaces are web apps. This registers the remaining README-documented public app (KYM), the concrete public surface behind the issue's enrichment intent.

## Non-duplication

Distinct from the existing `sn-88-investing-dashboard` (`db.investing88.ai` performance dashboard) and the `api.investing88.ai/{assets,ratio,days}` data/API surfaces — KYM is a different host (`kym.investing88.ai`), a different app (no-code miner onboarding), and a different URL. No existing surface references `kym.investing88.ai`; no open PR targets SN88.

## Validation (local)

- `npm run validate:surface -- registry/subnets/investing.json` → passes (7 surfaces)
- `npm run scan:public-safety` → passes
- `git diff --stat` → single file `registry/subnets/investing.json`, a 24-line pure append (no reordering, no other surfaces/fields touched), no generated artifacts.
