### PR TITLE
fix(ui): consolidate copy-pasted TAO formatting into a shared formatTao helper (#3947)

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -10,20 +10,12 @@ import { MiniStack } from "@/components/metagraphed/charts/stat-with-spark";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
 import { Sparkline, type SparklinePoint } from "@/components/metagraphed/charts/sparkline";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
 
 // #1112: per-subnet on-chain economics (emission share, alpha price, stake,
 // validators, volume) from the previously-unused /api/v1/economics. The artifact
 // carries all subnets; we fetch once (shared cache) and find this netuid.
-
-function fmtTao(v?: number): string {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
-}
 
 function Notice({ children }: { children: string }) {
   return (
@@ -169,11 +161,11 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
         value={formatNumber(e.miner_count)}
         hint={e.max_uids ? `${e.max_uids} max UIDs` : undefined}
       />
-      <StatTile eyebrow="Total stake" value={fmtTao(e.total_stake_tao)} />
-      <StatTile eyebrow="Volume" value={fmtTao(e.subnet_volume_tao)} />
-      <StatTile eyebrow="Max stake" value={fmtTao(e.max_stake_tao)} />
-      <StatTile eyebrow="Market cap" value={fmtTao(e.alpha_market_cap_tao)} hint="proxy" />
-      <StatTile eyebrow="FDV" value={fmtTao(e.alpha_fdv_tao)} hint="proxy" />
+      <StatTile eyebrow="Total stake" value={formatTao(e.total_stake_tao)} />
+      <StatTile eyebrow="Volume" value={formatTao(e.subnet_volume_tao)} />
+      <StatTile eyebrow="Max stake" value={formatTao(e.max_stake_tao)} />
+      <StatTile eyebrow="Market cap" value={formatTao(e.alpha_market_cap_tao)} hint="proxy" />
+      <StatTile eyebrow="FDV" value={formatTao(e.alpha_fdv_tao)} hint="proxy" />
       <StatTile
         eyebrow="Registration"
         tone={e.registration_allowed === false ? "down" : "default"}

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -3,18 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
 type Win = "7d" | "30d" | "90d" | "1y" | "all";
 const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
-
-function taoStr(v?: number) {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
-}
 
 function scoreStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";
@@ -88,14 +81,19 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
           {series.stake.length > 0 ? (
-            <HistoryRow label="Stake" series={series.stake} color="var(--accent)" format={taoStr} />
+            <HistoryRow
+              label="Stake"
+              series={series.stake}
+              color="var(--accent)"
+              format={formatTao}
+            />
           ) : null}
           {series.emission.length > 0 ? (
             <HistoryRow
               label="Emission"
               series={series.emission}
               color="var(--health-warn)"
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
           {series.incentive.length > 0 ? (

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -4,21 +4,13 @@ import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
 
 // Lowercase windows, mirroring the /history API + the inline toggle conventions
 // used by health-trends.tsx. "all" maps to the API's widest supported window.
 type Win = "7d" | "30d" | "90d" | "1y" | "all";
 const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
-
-function taoStr(v?: number) {
-  if (v == null || !Number.isFinite(v)) return "—";
-  // Stake/emission can span a wide range; keep it compact and readable.
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
-}
 
 /**
  * Per-subnet on-chain history (#1302). A window selector drives a daily snapshot
@@ -96,7 +88,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               label="Total stake"
               series={series.stake}
               color={healthColorVar("warn")}
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
           {series.emission.length > 0 ? (
@@ -104,7 +96,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               label="Total emission"
               series={series.emission}
               color="var(--accent, #00c899)"
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
         </div>

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -5,6 +5,7 @@ import {
   durationLabel,
   formatRelative,
   isStaleFreshness,
+  formatTao,
 } from "./format";
 
 describe("isUsableTimestamp", () => {
@@ -130,5 +131,43 @@ describe("isStaleFreshness", () => {
   it("honours a custom threshold", () => {
     const oneHourAgo = new Date(Date.now() - 3_600_000).toISOString();
     expect(isStaleFreshness(oneHourAgo, 30 * 60_000)).toBe(true);
+  });
+});
+
+describe("formatTao", () => {
+  it("returns the fallback for nullish / non-finite input", () => {
+    expect(formatTao(null)).toBe("—");
+    expect(formatTao(undefined)).toBe("—");
+    expect(formatTao(Number.NaN)).toBe("—");
+    expect(formatTao(Infinity)).toBe("—");
+    expect(formatTao(null, "n/a")).toBe("n/a");
+  });
+
+  it("formats sub-1-TAO values to 4 decimal places", () => {
+    expect(formatTao(0.5)).toBe("0.5000 τ");
+    expect(formatTao(0)).toBe("0.0000 τ");
+  });
+
+  it("formats 1 TAO and above to 2 decimal places, the same regardless of which call site produced it", () => {
+    // The exact boundary the issue's two divergent conventions disagreed on:
+    // the majority convention (>=1 -> 2dp) vs. the chart-only convention
+    // (<10 -> 3dp). formatTao must now produce one answer for every caller.
+    expect(formatTao(1)).toBe("1.00 τ");
+    expect(formatTao(5)).toBe("5.00 τ");
+    expect(formatTao(9.999)).toBe("10.00 τ");
+  });
+
+  it("formats 10 TAO and above the same as just under 10 (both use 2dp)", () => {
+    expect(formatTao(9.5)).toBe("9.50 τ");
+    expect(formatTao(10)).toBe("10.00 τ");
+  });
+
+  it("compacts thousands and millions with a k/M suffix", () => {
+    expect(formatTao(1_500)).toBe("1.5k τ");
+    expect(formatTao(2_500_000)).toBe("2.50M τ");
+  });
+
+  it("uses the magnitude for negative values, matching the sign-aware callers", () => {
+    expect(formatTao(-5)).toBe("-5.00 τ");
   });
 });

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -5,6 +5,20 @@ export function formatNumber(n: number | undefined | null, fallback = "—"): st
 }
 
 /**
+ * Compact TAO amount formatter — the single source of truth for the
+ * `Nk`/`NM` compaction + decimal-place thresholds previously hand-duplicated
+ * across economics-panel.tsx, explorer.tsx, accounts.$ss58.tsx,
+ * extrinsics.$hash.tsx, subnet-history-chart.tsx, and neuron-history-chart.tsx.
+ */
+export function formatTao(v: number | undefined | null, fallback = "—"): string {
+  if (v === undefined || v === null || !Number.isFinite(v)) return fallback;
+  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  if (Math.abs(v) >= 1) return `${v.toFixed(2)} τ`;
+  return `${v.toFixed(4)} τ`;
+}
+
+/**
  * The upstream registry frequently emits "1970-01-01T00:00:00.000Z" as a
  * placeholder when an artifact hasn't been timestamped yet. Treat any
  * pre-2000 date as "unknown" so the UI doesn't claim freshness/staleness

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -49,7 +49,7 @@ import {
   accountSubnetsQuery,
   accountTransfersQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
@@ -131,14 +131,6 @@ function AccountDetail({ ss58 }: { ss58: string }) {
   return <ValidAccountDetail ss58={ss58} />;
 }
 
-// Compact TAO formatter — mirrors the economics panel's fmtTao convention.
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
-}
-
 function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const sourceRef = ss58PathSegment(ss58);
   const account = useSuspenseQuery(accountQuery(ss58)).data.data as AccountSummary;
@@ -156,7 +148,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const balanceValue = balanceResult.isPending ? (
     <span className="text-ink-muted">…</span>
   ) : balance?.balance_tao != null ? (
-    fmtTao(balance.balance_tao)
+    formatTao(balance.balance_tao)
   ) : (
     "—"
   );

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -29,7 +29,7 @@ import {
   chainStakeTransfersQuery,
   chainTransferPairsQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type {
@@ -74,13 +74,7 @@ function sum(values: number[]): number {
 }
 
 function fmtTaoSigned(v: number): string {
-  return v < 0 ? `-${fmtTao(-v)}` : `+${fmtTao(v)}`;
-}
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
+  return v < 0 ? `-${formatTao(-v)}` : `+${formatTao(v)}`;
 }
 
 function ExplorerPage() {
@@ -363,9 +357,9 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
               value={fmtTaoSigned(net.net_flow_tao)}
               tone={net.net_flow_tao >= 0 ? "ok" : "down"}
             />
-            <StakeFlowMetric label="Gross flow" value={fmtTao(net.gross_flow_tao)} />
-            <StakeFlowMetric label="Staked" value={fmtTao(net.total_staked_tao)} />
-            <StakeFlowMetric label="Unstaked" value={fmtTao(net.total_unstaked_tao)} />
+            <StakeFlowMetric label="Gross flow" value={formatTao(net.gross_flow_tao)} />
+            <StakeFlowMetric label="Staked" value={formatTao(net.total_staked_tao)} />
+            <StakeFlowMetric label="Unstaked" value={formatTao(net.total_unstaked_tao)} />
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[10px] uppercase tracking-widest">
             <span className="text-health-ok">{formatNumber(net.gaining)} gaining</span>
@@ -676,11 +670,11 @@ function ExplorerDashboard() {
           value={formatNumber(totalEvents)}
           hint={`${win} total`}
         />
-        <StatTile icon={Coins} eyebrow="Fees" value={fmtTao(totalFees)} hint={`${win} total`} />
+        <StatTile icon={Coins} eyebrow="Fees" value={formatTao(totalFees)} hint={`${win} total`} />
         <StatTile
           icon={Coins}
           eyebrow="Tips"
-          value={fmtTao(totalTips)}
+          value={formatTao(totalTips)}
           hint={`${win} total`}
           tone={totalTips > 0 ? "ok" : "default"}
         />
@@ -761,28 +755,28 @@ function ExplorerDashboard() {
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.total_fee_tao)}
                 color="var(--accent)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Avg fee"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.avg_fee_tao ?? 0)}
                 color="var(--chart-3)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Total tips"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.total_tip_tao)}
                 color="var(--chart-6)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Avg tip"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.avg_tip_tao ?? 0)}
                 color="var(--chart-1)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
             </div>
           ) : (
@@ -823,10 +817,10 @@ function ExplorerDashboard() {
                       </Link>
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                      {fmtTao(p.total_fee_tao)}
+                      {formatTao(p.total_fee_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(p.total_tip_tao)}
+                      {formatTao(p.total_tip_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                       {formatNumber(p.extrinsic_count)}
@@ -880,10 +874,10 @@ function ExplorerDashboard() {
                       {formatNumber(s.tx_count)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(s.total_fee_tao)}
+                      {formatTao(s.total_fee_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(s.total_tip_tao)}
+                      {formatTao(s.total_tip_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                       {s.last_tx_block != null ? (
@@ -997,7 +991,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
           {pairs ? (
             <p className="mt-1 font-mono text-[11px] text-ink-muted">
               {formatNumber(pairs.unique_pairs)} sender→receiver corridors ·{" "}
-              {fmtTao(pairs.total_volume_tao)} moved
+              {formatTao(pairs.total_volume_tao)} moved
             </p>
           ) : null}
         </div>
@@ -1068,7 +1062,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
                     </Link>
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {fmtTao(p.volume_tao)}
+                    {formatTao(p.volume_tao)}
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                     {formatNumber(p.transfer_count)}

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -13,7 +13,7 @@ import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import {
   extrinsicCall,
@@ -190,12 +190,12 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           </FieldRow>
           <FieldRow label="Inclusion fee">
             <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.fee_tao != null ? fmtTao(extrinsic.fee_tao) : "—"}
+              {extrinsic.fee_tao != null ? formatTao(extrinsic.fee_tao) : "—"}
             </span>
           </FieldRow>
           <FieldRow label="Tip">
             <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.tip_tao != null ? fmtTao(extrinsic.tip_tao) : "—"}
+              {extrinsic.tip_tao != null ? formatTao(extrinsic.tip_tao) : "—"}
             </span>
           </FieldRow>
           <FieldRow label="Observed at">
@@ -312,13 +312,6 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
       />
     </>
   );
-}
-
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
 }
 
 function renderCallArgs(callArgs: unknown) {


### PR DESCRIPTION
## Summary

The same compact-TAO-formatting logic (`Nk`/`NM` compaction plus decimal-place thresholds) was hand-duplicated into six files, and the copies had drifted apart:

- `economics-panel.tsx`, `explorer.tsx`, `accounts.$ss58.tsx`, `extrinsics.$hash.tsx` used `v >= 1 → toFixed(2)`, `v < 1 → toFixed(4)`
- `subnet-history-chart.tsx`, `neuron-history-chart.tsx` used `v < 10 → toFixed(3)`, `v >= 10 → toFixed(2)`

A value like 1.226 TAO rendered as `"1.23 τ"` on the majority of pages but `"1.226 τ"` on the subnet/neuron history chart — the same kind of value, visibly different precision depending on which panel a user happens to be looking at.

## What changed

- Added a single `formatTao` function to `src/lib/metagraphed/format.ts`, alongside the existing `formatNumber`/`formatRelative`/`humaniseSeconds`, using the majority convention (`≥1 → 2dp`, `<1 → 4dp`) as canonical.
- Replaced all six local copies with imports of the shared function. `fmtTaoCompact` in `accounts.$ss58.tsx` (a different, differently-named helper not covered by the issue) was left untouched.
- A 5 TAO value — or any other value — now renders identically regardless of which of these six components displays it.

## Screenshots

Verified live against real production data (SN12 UID 11, stake ≈1.226 TAO — a value that lands exactly in the range where the two conventions disagreed):

| Page / Feature | Before | After |
| --- | --- | --- |
| `/subnets/12?tab=metagraph&uid=11` — neuron history chart | [<img src="https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/73af4c8903caeb2011f08b0f90e13d436de4c02f/before-history.png" width="320">](https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/73af4c8903caeb2011f08b0f90e13d436de4c02f/before-history.png)<br><sub>before: "1.226 τ" (chart-only 3dp convention)</sub> | [<img src="https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/8362104010b7e0e41e64eab09c4c7d8fcf8f4d93/after-history.png" width="320">](https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/8362104010b7e0e41e64eab09c4c7d8fcf8f4d93/after-history.png)<br><sub>after: "1.23 τ" (matches every other page's convention)</sub> |

No visible change to the majority convention's rendering (economics panel, explorer, accounts, extrinsics) — only the two chart files' precision changed to match.

Closes #3947

## Acceptance criteria

- [x] `src/lib/metagraphed/format.ts` gains the new shared TAO-formatting function
- [x] All six listed files import and use the shared function instead of their local copies
- [x] The same input value produces the same formatted string across all six call sites — unit tests added asserting boundary values (1 TAO, 10 TAO, and the two conventions' actual disagreement point) in `format.test.ts`
- [x] No visible change to the majority convention's rendering — verified above
- [x] Before/after screenshot table showing the same TAO value on the chart before and after, confirming they now match

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — no new errors (2 pre-existing baseline errors unrelated to this change)
- [x] `npm run lint --workspace=apps/ui` — clean
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 543/543 tests passing (78/78 files), including 8 new `formatTao` tests
- [x] `npm run build --workspace=apps/ui` — builds cleanly
- [x] Manually verified against live production data via a local dev server + headless browser, both before and after the fix