### PR TITLE
feat(registry): add SN28 gm miner Envoy data-plane config data-artifact surface (#4027)

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -81,6 +81,25 @@
       },
       "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
       "url": "https://saygm.com/healthz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-28-gm-envoy-config",
+      "kind": "data-artifact",
+      "name": "gm miner Envoy data-plane configuration",
+      "notes": "Public no-auth machine-readable Envoy configuration for the SN28 gm miner data plane, committed in the official taostat/gm-miner repository (its README identifies the repo as the gm Bittensor subnet, netuid 28 mainnet, and links the registered saygm.com website). It is the canonical definition of the gm miner data plane: the provider routing table (Anthropic/OpenAI/Gemini/Chutes plus a benchmark route keyed on the x-gm-provider header), the inbound node-key auth Lua filter, HTTP local rate-limiting and load-shedding, the Prometheus metrics listener, and the RA-TLS attestation ingress listener. No secrets are present (keys and the node secret are rendered from container env at start).",
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/taostat/gm-miner",
+        "https://github.com/taostat/gm-miner/blob/main/image/envoy.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Registers **SN28 gm**'s public **miner data-plane Envoy configuration** as a `data-artifact` surface — a standalone, no-auth, machine-readable file the registry did not yet capture for this subnet. It is the canonical definition of the gm miner data plane and the concrete public data artifact issue #4027 asks for.

## Surface

- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml`
- **provider:** `gm` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url`: `https://github.com/taostat/gm-miner` — the repo registered as SN28's `source_repo`. Its README states verbatim: *"Miner image and CLI for the [gm](https://saygm.com) Bittensor subnet (**netuid 28 mainnet**, 482 testnet)"* and links **saygm.com**, which is SN28's registered `website_url`. So the artifact is unambiguously SN28's.
- Second `source_url` points at the file itself on GitHub (`.../blob/main/image/envoy.yaml`).

## Verified live + public + safe

- `GET https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml` → **HTTP 200**, `text/plain; charset=utf-8`, ~55 KB, **no auth**.
- Real payload: the miner data-plane Envoy config — the provider routing table (Anthropic/OpenAI/Gemini/Chutes plus a benchmark route keyed on the `x-gm-provider` header), the inbound node-key auth Lua filter, HTTP local rate-limiting/load-shedding, the Prometheus metrics listener, and the RA-TLS attestation ingress listener.
- **No secrets present:** every key/secret reference is a comment or an env placeholder (e.g. `__GM_NODE_SECRET__`, `ANTHROPIC_API_KEY` referenced by name only); credentials are rendered from container env at start.

## Non-duplication

Distinct from gm's three existing surfaces (`sn-28-gm-openapi`, `sn-28-gm-subnet-api` = `/v1/models`, `sn-28-gm-health` = `/healthz`), which are all on the `saygm.com`/`api.saygm.com` host. This is a different `kind` (`data-artifact`), a different host (`raw.githubusercontent.com`), and a different URL — gm has no `data-artifact` surface yet. No other open PR targets SN28 / gm.

## Scope note (relative to #4027)

#4027 asks for SN28's public **data artifact**. gm exposes no downloadable dataset (it is a TEE LLM-inference marketplace; its model catalog is already the `subnet-api` surface). Its one genuine standalone static machine-readable data file is this canonical data-plane config, committed in the official repo — the concrete public data surface behind the issue's intent, matching the accepted deployment/config data-artifact pattern.

## Validation (local)

- `npm run validate:surface -- registry/subnets/gm.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/gm.json` → clean
- `git diff --stat` → single file `registry/subnets/gm.json`, a 19-line pure append (no top-level metadata, other surfaces, or generated artifacts touched)

## Template Used

- Subnet surface

Closes #4027
