### PR TITLE
feat(api): add account_position_daily capture pipeline

### DIFF
--- a/migrations/0037_account_position_daily.sql
+++ b/migrations/0037_account_position_daily.sql
@@ -1,0 +1,54 @@
+-- Per-account daily position HISTORY (block-explorer Tier-1, epic #4329/6.1).
+--
+-- The refresh-metagraph cron lands the LATEST per-UID snapshot in `neurons`
+-- (migration 0007, overwrite-on-conflict — no history is kept). A dedicated daily
+-- rollup (rollupAccountPositionDaily, src/account-position-history.mjs) copies the
+-- current snapshot into this append-only DATED table, keyed by
+-- (account, netuid, snapshot_date) instead of neuron_daily's (netuid, uid,
+-- snapshot_date) — giving /accounts/{addr}/portfolio's positions a per-account
+-- time-series (the "Alpha Holdings chart", #4329) the same way neuron_daily gives
+-- per-UID metagraph time-series (#1302). account = hotkey ss58, matching
+-- loadAccountPortfolio's own "WHERE hotkey = ?" framing (src/account-portfolio.mjs).
+--
+-- Columns mirror ACCOUNT_PORTFOLIO_READ_COLUMNS plus coldkey for ownership display
+-- — not the full neuron row (no axon/registered_at_block/is_immunity_period,
+-- point-in-time metagraph facts, not portfolio economics). Simple retention prune
+-- (ACCOUNT_POSITION_DAILY_RETENTION_DAYS, no cold-archive tier) — unproven at
+-- scale; add archival later if row growth demands it, following neuron_daily's
+-- own later evolution (PR-A2) rather than building it preemptively.
+--
+-- Known overlap with neuron_daily (#4330's own issue text mandates this new
+-- table regardless — see src/account-position-history.mjs's header for the
+-- full tradeoff writeup): every column here already exists in neuron_daily,
+-- which already has a purpose-built idx_neuron_daily_hotkey_date index for
+-- much the same read pattern. This doubles daily write volume onto the same
+-- D1 database that has already hit its capacity limit once. Also: "position"
+-- here is a hotkey's own registered-neuron stake, not a coldkey's aggregate
+-- nominator/delegated stake — a real scope limitation given epic #4329 frames
+-- this as matching taostats.io's (coldkey-centric) "Alpha Holdings" feature.
+CREATE TABLE IF NOT EXISTS account_position_daily (
+  account               TEXT    NOT NULL,  -- hotkey ss58
+  netuid                INTEGER NOT NULL,
+  snapshot_date         TEXT    NOT NULL,  -- YYYY-MM-DD (UTC) derived from captured_at
+  uid                   INTEGER,
+  coldkey               TEXT,
+  active                INTEGER,           -- 0/1
+  validator_permit      INTEGER,           -- 0/1
+  rank                  REAL,
+  trust                 REAL,
+  incentive             REAL,
+  dividends             REAL,
+  stake_tao             REAL,
+  emission_tao          REAL,
+  captured_at           INTEGER NOT NULL,  -- epoch ms — the single consistent snapshot stamp
+  updated_at            INTEGER NOT NULL,  -- epoch ms when this daily row was (re)rolled
+  PRIMARY KEY (account, netuid, snapshot_date)
+);
+
+-- Per-subnet as-of / cross-account snapshot on a date.
+CREATE INDEX IF NOT EXISTS idx_account_position_daily_netuid_date
+  ON account_position_daily (netuid, snapshot_date);
+
+-- Lets the retention prune SEEK the old-day tail instead of full-scanning.
+CREATE INDEX IF NOT EXISTS idx_account_position_daily_date
+  ON account_position_daily (snapshot_date);

--- a/src/account-position-history.mjs
+++ b/src/account-position-history.mjs
@@ -1,0 +1,139 @@
+// Per-account daily position HISTORY (block-explorer Tier-1, epic #4329/6.1).
+//
+// The refresh-metagraph cron lands the LATEST per-UID snapshot in `neurons`
+// (overwrite-on-conflict — no history is kept). This daily rollup copies the
+// current snapshot into the append-only `account_position_daily` table, keyed by
+// (account, netuid, snapshot_date) instead of neuron_daily's (netuid, uid,
+// snapshot_date) — giving /accounts/{addr}/portfolio's positions a per-account
+// time-series (the "Alpha Holdings chart") the same way neuron_daily gives
+// per-UID metagraph time-series. Same source table as neuron_daily, so both
+// rollups fire from the SAME cron tick for a consistent snapshot stamp.
+// account = hotkey ss58, matching loadAccountPortfolio's own "WHERE hotkey = ?"
+// framing (src/account-portfolio.mjs). Pure + injectable for tests; the Worker
+// runs the D1 I/O.
+//
+// Known overlap with neuron_daily (#4330's own issue text mandates this new
+// table regardless — flagging the tradeoff here, not silently accepting or
+// re-litigating it): every column this table stores already exists in
+// neuron_daily, which already carries a `hotkey` column and a purpose-built
+// `idx_neuron_daily_hotkey_date` index ("Point-in-time account history: which
+// UID a hotkey held on a date" — migrations/0011_neuron_daily.sql) that could
+// serve most of this same read pattern (`WHERE hotkey = ? ORDER BY
+// snapshot_date`) with no new table. This rollup doubles daily write volume
+// onto the same D1 database that has already hit its capacity limit once
+// (neuron_daily's own 400d->90d retention cut, src/neuron-history.mjs) — worth
+// weighing before #4331's read route builds on top of this table, and before
+// assuming this data couldn't instead be served from neuron_daily directly.
+//
+// Known scope limitation: "position"/stake_tao here is a HOTKEY's own
+// registered-neuron stake (for a validator hotkey, the FULL pool delegated to
+// it by every nominator — migrations/0007_neurons.sql's stake_tao comment),
+// not a coldkey's aggregate nominator/delegated stake across OTHER people's
+// validators. A wallet that only delegates (never registers its own hotkey)
+// will show near-zero history here despite genuinely holding alpha — that
+// delegated-stake concept only exists as an account_events log today (would
+// need balance reconstruction, out of scope for this issue). Matches
+// loadAccountPortfolio's existing, equally-unqualified "WHERE hotkey = ?"
+// framing (src/account-portfolio.mjs) — not a new gap, but worth restating
+// here since epic #4329 explicitly frames this as taostats.io's (coldkey-
+// centric) "Alpha Holdings" feature.
+
+// Columns written to account_position_daily by the rollup — the load contract,
+// positionally aligned with NEURONS_SELECT_COLUMNS below.
+const ROLLUP_COLUMNS = [
+  "account",
+  "netuid",
+  "uid",
+  "coldkey",
+  "active",
+  "validator_permit",
+  "rank",
+  "trust",
+  "incentive",
+  "dividends",
+  "stake_tao",
+  "emission_tao",
+  "captured_at",
+];
+
+// The `neurons` columns snapshotted into account_position_daily — mirrors
+// ACCOUNT_PORTFOLIO_READ_COLUMNS (src/account-portfolio.mjs) plus coldkey for
+// ownership display, not the full neuron row (no axon/registered_at_block/
+// is_immunity_period — point-in-time metagraph facts, not portfolio economics).
+const NEURONS_SELECT_COLUMNS =
+  "hotkey AS account, netuid, uid, coldkey, active, validator_permit, rank, " +
+  "trust, incentive, dividends, stake_tao, emission_tao, captured_at";
+
+// Retention window for the simple prune below. Mirrors EVENT_RETENTION_MS's
+// plain-DELETE approach (src/account-events.mjs), not neuron_daily's cold-archive
+// tier — account_position_daily is new and unproven at scale; add archival later
+// if row growth demands it, following neuron_daily's own later evolution (PR-A2)
+// rather than building it preemptively.
+export const ACCOUNT_POSITION_DAILY_RETENTION_DAYS = 90;
+
+function accountPositionDailyRetentionCutoff(now) {
+  return new Date(now - ACCOUNT_POSITION_DAILY_RETENTION_DAYS * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+// Daily rollup: snapshot the current `neurons` table into
+// `account_position_daily` for the captured UTC day. Same atomic INSERT...SELECT
+// shape as rollupNeuronDaily (src/neuron-history.mjs):
+//  - WHERE captured_at = MAX(captured_at): one consistent snapshot stamp, so a
+//    concurrent partial load can't bleed two stamps into a single day.
+//  - AND hotkey IS NOT NULL: `account` is NOT NULL and part of the primary key,
+//    but neurons.hotkey is nullable — an unfiltered SELECT would abort the
+//    WHOLE INSERT (every account/subnet for the day, not just the offending
+//    row) the moment any one neuron row lacked a hotkey.
+//  - snapshot_date = the UTC day of that captured_at, computed in SQL.
+//  - ON CONFLICT(account, netuid, snapshot_date) DO UPDATE: intra-day re-runs
+//    are idempotent (the row reflects the last capture that UTC day).
+// Returns {rolled, rows} for cron observability; the caller .catch-isolates it
+// so a failure never affects the rest of the scheduled run.
+export async function rollupAccountPositionDaily(
+  env,
+  { now = Date.now() } = {},
+) {
+  const db = env?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { rolled: false, reason: "no-db" };
+  const cols = ROLLUP_COLUMNS.join(", ");
+  const setClause = ROLLUP_COLUMNS.filter(
+    (c) => c !== "account" && c !== "netuid",
+  )
+    .map((c) => `${c} = excluded.${c}`)
+    .concat("updated_at = excluded.updated_at")
+    .join(", ");
+  const sql =
+    `INSERT INTO account_position_daily (${cols}, snapshot_date, updated_at) ` +
+    `SELECT ${NEURONS_SELECT_COLUMNS}, date(captured_at / 1000, 'unixepoch'), ? ` +
+    `FROM neurons WHERE captured_at = (SELECT MAX(captured_at) FROM neurons) ` +
+    `AND hotkey IS NOT NULL ` +
+    `ON CONFLICT(account, netuid, snapshot_date) DO UPDATE SET ${setClause}`;
+  const res = await db.prepare(sql).bind(now).run();
+  return { rolled: true, rows: res?.meta?.changes ?? null };
+}
+
+// Prune rows older than the retention window — a plain DELETE, no cold-archive
+// tier (mirrors pruneAccountEvents, src/account-events.mjs). Returns
+// {pruned, changes} for cron observability. The D1 call is try/caught, but the
+// retention-cutoff computation just above it is NOT — a non-finite `now` would
+// still throw there; every current caller passes now = Date.now(), so that's
+// not reachable today, but this function is not unconditionally exception-free.
+export async function pruneAccountPositionDaily(
+  env,
+  { now = Date.now() } = {},
+) {
+  const db = env?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { pruned: false, reason: "no-db" };
+  const cutoff = accountPositionDailyRetentionCutoff(now);
+  try {
+    const result = await db
+      .prepare("DELETE FROM account_position_daily WHERE snapshot_date < ?")
+      .bind(cutoff)
+      .run();
+    return { pruned: true, cutoff, changes: result?.meta?.changes ?? null };
+  } catch {
+    return { pruned: false };
+  }
+}

--- a/tests/account-position-history.test.mjs
+++ b/tests/account-position-history.test.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  rollupAccountPositionDaily,
+  pruneAccountPositionDaily,
+  ACCOUNT_POSITION_DAILY_RETENTION_DAYS,
+} from "../src/account-position-history.mjs";
+import { handleScheduled } from "../workers/api.mjs";
+import { NEURON_HISTORY_ROLLUP_CRON } from "../workers/config.mjs";
+
+const ctx = { waitUntil: (p) => p };
+
+describe("rollupAccountPositionDaily", () => {
+  test("issues a single INSERT...SELECT with a consistent captured_at snapshot + idempotent upsert", async () => {
+    const captured = {};
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          captured.sql = sql;
+          return {
+            bind(...params) {
+              captured.params = params;
+              return { run: () => Promise.resolve({ meta: { changes: 42 } }) };
+            },
+          };
+        },
+      },
+    };
+    const res = await rollupAccountPositionDaily(env, {
+      now: 1_780_000_000_001,
+    });
+    assert.deepEqual(res, { rolled: true, rows: 42 });
+    // One consistent snapshot stamp (WHERE captured_at = MAX), dated in SQL.
+    assert.match(captured.sql, /INSERT INTO account_position_daily/);
+    assert.match(captured.sql, /hotkey AS account/);
+    assert.match(captured.sql, /SELECT MAX\(captured_at\) FROM neurons/);
+    assert.match(captured.sql, /date\(captured_at \/ 1000, 'unixepoch'\)/);
+    // account is NOT NULL + part of the primary key, but neurons.hotkey is
+    // nullable — an unfiltered SELECT would abort the whole INSERT on any one
+    // null-hotkey row (see the function's own docstring).
+    assert.match(captured.sql, /AND hotkey IS NOT NULL/);
+    // Idempotent intra-day re-run.
+    assert.match(
+      captured.sql,
+      /ON CONFLICT\(account, netuid, snapshot_date\) DO UPDATE/,
+    );
+    assert.deepEqual(captured.params, [1_780_000_000_001]);
+  });
+
+  test("no-ops cleanly without a DB binding (cron isolation)", async () => {
+    assert.deepEqual(await rollupAccountPositionDaily({}), {
+      rolled: false,
+      reason: "no-db",
+    });
+  });
+
+  test("reports rows:null when the run result omits meta.changes", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return { bind: () => ({ run: () => Promise.resolve({}) }) };
+        },
+      },
+    };
+    const res = await rollupAccountPositionDaily(env, { now: 1 });
+    assert.equal(res.rolled, true);
+    assert.equal(res.rows, null);
+  });
+});
+
+describe("pruneAccountPositionDaily", () => {
+  test("deletes below the retention cutoff", async () => {
+    let boundCutoff;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind: (cutoff) => {
+              boundCutoff = cutoff;
+              return { run: async () => ({ meta: { changes: 7 } }) };
+            },
+          };
+        },
+      },
+    };
+    const now = new Date("2026-07-09T00:00:00.000Z").getTime();
+    const res = await pruneAccountPositionDaily(env, { now });
+    assert.equal(res.pruned, true);
+    assert.equal(res.changes, 7);
+    const expectedCutoff = new Date(
+      now - ACCOUNT_POSITION_DAILY_RETENTION_DAYS * 86_400_000,
+    )
+      .toISOString()
+      .slice(0, 10);
+    assert.equal(boundCutoff, expectedCutoff);
+    assert.equal(res.cutoff, expectedCutoff);
+  });
+
+  test("no-ops cleanly without a DB binding", async () => {
+    assert.deepEqual(await pruneAccountPositionDaily({}), {
+      pruned: false,
+      reason: "no-db",
+    });
+  });
+
+  test("reports changes:null when the run result omits meta.changes", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return { bind: () => ({ run: () => Promise.resolve({}) }) };
+        },
+      },
+    };
+    const res = await pruneAccountPositionDaily(env, { now: 1 });
+    assert.equal(res.pruned, true);
+    assert.equal(res.changes, null);
+  });
+
+  test("returns pruned:false when D1 throws", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind: () => ({
+              run: async () => {
+                throw new Error("d1 down");
+              },
+            }),
+          };
+        },
+      },
+    };
+    const res = await pruneAccountPositionDaily(env, { now: 1 });
+    assert.equal(res.pruned, false);
+  });
+});
+
+describe("handleScheduled rollup cron wiring (#4329/6.1)", () => {
+  test("isolates a rollup failure from the rest of the NEURON_HISTORY_ROLLUP_CRON tick", async () => {
+    // account_position_daily's INSERT throws; every other statement (neuron_daily's
+    // rollup/archive-read/prune) resolves emptily, so the surrounding cron tick
+    // completes and the failure stays isolated to accountPositionRolled.
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind: () => ({
+              run: () => {
+                if (sql.includes("account_position_daily")) {
+                  return Promise.reject(new Error("d1 down"));
+                }
+                return Promise.resolve({ meta: { changes: 0 } });
+              },
+              all: () => Promise.resolve({ results: [] }),
+            }),
+          };
+        },
+      },
+    };
+    const result = await handleScheduled(
+      { cron: NEURON_HISTORY_ROLLUP_CRON },
+      env,
+      ctx,
+    );
+    assert.equal(result.accountPositionRolled.rolled, false);
+  });
+
+  test("rolls up and prunes account_position_daily on the same cron tick", async () => {
+    const calls = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          calls.push(sql);
+          return {
+            bind: () => ({
+              run: () => Promise.resolve({ meta: { changes: 3 } }),
+              all: () => Promise.resolve({ results: [] }),
+            }),
+          };
+        },
+      },
+    };
+    const result = await handleScheduled(
+      { cron: NEURON_HISTORY_ROLLUP_CRON },
+      env,
+      ctx,
+    );
+    assert.equal(result.accountPositionRolled.rolled, true);
+    assert.equal(result.accountPositionPruned.pruned, true);
+    assert.ok(
+      calls.some((sql) => sql.includes("INSERT INTO account_position_daily")),
+    );
+    assert.ok(
+      calls.some((sql) => sql.includes("DELETE FROM account_position_daily")),
+    );
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -253,6 +253,10 @@ import {
   validNeuronDailyRows,
 } from "../src/neuron-history.mjs";
 import {
+  rollupAccountPositionDaily,
+  pruneAccountPositionDaily,
+} from "../src/account-position-history.mjs";
+import {
   eventInsertStatements,
   pruneAccountEvents,
   rollupAccountEventsDaily,
@@ -948,7 +952,26 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
             days: archivedPrunable.complete ? undefined : archivedPrunable.days,
           }).catch(() => ({ pruned: false }))
         : { pruned: false, reason: "archive-not-confirmed" };
-    return { rolled, archived, archivedPrunable, pruned };
+    // Per-account position history (#4329/6.1): same source `neurons` table and
+    // cron tick as neuron_daily, so both stay snapshot-consistent. Simple prune,
+    // no cold-archive tier (see src/account-position-history.mjs).
+    // pruneAccountPositionDaily already self-catches its own D1 errors (unlike
+    // rollupAccountPositionDaily, which has no internal try/catch), so it needs
+    // no wrapper .catch() here.
+    const accountPositionRolled = await rollupAccountPositionDaily(env).catch(
+      () => ({ rolled: false }),
+    );
+    const accountPositionPruned = await pruneAccountPositionDaily(env, {
+      now,
+    });
+    return {
+      rolled,
+      archived,
+      archivedPrunable,
+      pruned,
+      accountPositionRolled,
+      accountPositionPruned,
+    };
   }
   return runHealthProber(env, ctx);
 }


### PR DESCRIPTION
## Summary

Adds the `account_position_daily` table + daily rollup job (#4329/6.1) — a per-account time-series companion to `/accounts/{addr}/portfolio`'s positions, cloning `rollupNeuronDaily`'s `INSERT...SELECT` pattern (`src/neuron-history.mjs` / `migrations/0011_neuron_daily.sql`) but keyed by `(account, netuid, snapshot_date)` instead of `(netuid, uid, snapshot_date)`, per the issue's own explicit instruction. **Capture-only** — no REST route in this PR; #4331 (6.2, "Depends on 6.1") is the separate, dependent route sub-task.

## What changed

- `migrations/0037_account_position_daily.sql` (new) — table + 2 indexes (`netuid+date` for cross-account-on-a-date reads, `date` for the retention-prune seek).
- `src/account-position-history.mjs` (new) — `rollupAccountPositionDaily` (same atomic `INSERT...SELECT WHERE captured_at = MAX(captured_at)` + `ON CONFLICT DO UPDATE` shape as `rollupNeuronDaily`) and `pruneAccountPositionDaily` (simple `DELETE`, 90-day retention, no cold-archive tier — deliberately simpler than `neuron_daily`'s archive-integrated prune since this table is new and unproven at scale).
- `workers/api.mjs` — wired into the same `NEURON_HISTORY_ROLLUP_CRON` tick as `rollupNeuronDaily`, right after its existing archive/prune block, so both stay snapshot-consistent.
- `tests/account-position-history.test.mjs` (new) — unit tests for both functions plus a `handleScheduled` integration block proving a rollup failure stays isolated from `neuron_daily`'s own rollup/archive/prune in the same tick.

## A bug found and fixed by adversarial review

`account` is `NOT NULL` and part of the primary key, but its sole source column, `neurons.hotkey`, is **nullable** in real data (confirmed: `scripts/fetch-metagraph.mjs`'s `normalizeNeuron` maps a missing hotkey to `null`; several existing call sites elsewhere already guard `hotkey IS NOT NULL` before hotkey-keyed work). An unfiltered `INSERT...SELECT` would hit a `NOT NULL` constraint violation and **abort the entire statement** — not just the offending row — silently zeroing that day's rollup across every account and every subnet. Reproduced empirically against the actual schema before fixing. Fixed with `AND hotkey IS NOT NULL` on the source `SELECT`.

## Design notes — two tensions worth your explicit sign-off

This issue explicitly asks for a **new** table cloning the `neuron_daily` pattern, which is what's built here. But adversarial review surfaced two real tensions with that design that are worth flagging rather than silently shipping:

1. **Overlap with `neuron_daily`**: every column `account_position_daily` stores already exists in `neuron_daily`, which already has a `hotkey` column and a purpose-built `idx_neuron_daily_hotkey_date` index (comment: *"Point-in-time account history: which UID a hotkey held on a date"*) — i.e. `SELECT ... FROM neuron_daily WHERE hotkey = ? ORDER BY snapshot_date` already serves close to the same read pattern #4331 would build, with real R2 cold-archival already in place, and no new write stream. This PR doubles daily write volume onto the same D1 database that has already hit its 10GB capacity limit once (`neuron_daily`'s own 400d→90d retention cut). I built the new table because the issue is explicit about wanting one, but this tradeoff deserves your sign-off before #4331 builds a read route on top of it — worth a quick "yes, still want the separate table" or "actually just read `neuron_daily` by hotkey" call before that lands.
2. **Scope**: "position"/`stake_tao` here is a **hotkey's own registered-neuron stake** — for a validator hotkey, that's the full pool delegated to it by *every* nominator, not one coldkey's share. This table has no way to represent a coldkey's aggregate nominator/delegated stake across *other* validators (that only exists as an `account_events` log, needing balance reconstruction — out of scope here). Epic #4329 frames this feature as matching taostats.io's "Alpha Holdings," which for most real users is coldkey-centric delegated stake — so a wallet that only delegates (never registers its own hotkey) will show near-zero history despite genuinely holding alpha. Documented directly in the code now; flagging here too since #4331's route/response and any UI built on it will inherit this same limitation.

Both are now documented directly in `src/account-position-history.mjs`'s and `migrations/0037`'s header comments.

## Maintainer PR — no screenshot table

Backend-only change, no visual output.

## Validation checklist

- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm test` — 6598/6598 passing
- [x] `npm run test:coverage` — `src/account-position-history.mjs` 100% lines/branches/functions
- [x] `npm run validate` green
- [x] No contract/schema files touched (capture-only, no route) — `validate:contract-drift` not applicable
- [x] Adversarial review workflow run across 3 dimensions (correctness / design-scope / reuse-simplification); the confirmed null-hotkey bug fixed, both design tensions documented transparently above

Closes #4330