### PR TITLE
fix(ui): use significant-figure precision for the yield leaderboard so distinct validator yields stop collapsing to the same string (#3946)

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/yield-panel.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { fmtYield } from "./yield-panel";
+
+describe("fmtYield", () => {
+  it("returns the em-dash fallback for nullish / non-finite input", () => {
+    expect(fmtYield(null)).toBe("—");
+    expect(fmtYield(undefined)).toBe("—");
+    expect(fmtYield(Number.NaN)).toBe("—");
+    expect(fmtYield(Infinity)).toBe("—");
+  });
+
+  it("renders exactly zero as a plain 0%", () => {
+    expect(fmtYield(0)).toBe("0%");
+  });
+
+  it("uses 2 decimal places once the percentage reaches 1%", () => {
+    expect(fmtYield(0.5)).toBe("50.00%");
+    expect(fmtYield(0.01)).toBe("1.00%");
+  });
+
+  it("does not collapse distinct validator-scale yields to the same string (#3946)", () => {
+    // Real values observed on-chain for SN64 validators — under the previous
+    // toFixed(4) formatting these all rounded to "0.0041%" or "0.0042%"
+    // despite differing, making a ranked leaderboard look identical/broken.
+    const raw = [
+      4.1721e-5, 4.1529e-5, 4.1496e-5, 4.1425e-5, 4.1359e-5, 4.1306e-5, 4.1225e-5, 4.1128e-5,
+      4.0711e-5, 4.056e-5,
+    ];
+    const formatted = raw.map((v) => fmtYield(v));
+    expect(new Set(formatted).size).toBe(formatted.length);
+  });
+
+  it("falls back to exponential notation below the 0.001% precision floor", () => {
+    expect(fmtYield(0.0000001)).toBe("1.00e-5%");
+  });
+});

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -19,12 +19,19 @@ const TOP_N = 15;
 
 // Yield is an emission/stake return rate — tiny fractions (~1e-5..1e-1). Render
 // as a percentage with adaptive precision; null/non-finite collapses to em-dash.
-function fmtYield(v?: number | null): string {
+//
+// The 0.001-1% band uses significant-figure precision (toPrecision), not a
+// fixed decimal count (toFixed) — validator yields in this subnet-scale range
+// commonly cluster within a few percent of each other (e.g. 0.0041529% vs
+// 0.0041496% vs 0.0041425%), and a fixed toFixed(4) rounds several of them to
+// the exact same displayed string even though the underlying values genuinely
+// differ, making an otherwise-ranked leaderboard look like a data bug.
+export function fmtYield(v?: number | null): string {
   if (v == null || !Number.isFinite(v)) return "—";
   if (v === 0) return "0%";
   const pct = v * 100;
   if (Math.abs(pct) >= 1) return `${pct.toFixed(2)}%`;
-  if (Math.abs(pct) >= 0.001) return `${pct.toFixed(4)}%`;
+  if (Math.abs(pct) >= 0.001) return `${pct.toPrecision(5)}%`;
   return `${pct.toExponential(2)}%`;
 }
 


### PR DESCRIPTION
## Summary

Traced the reported bug ("eight validators with wildly different stake all show the identical 0.0016% yield") back to source: the raw per-UID yield values returned by `GET /api/v1/subnets/{netuid}/yield` are already correct and genuinely distinct — this was never a calculation bug. It's a **display-precision** bug in `fmtYield` (`yield-panel.tsx`).

Validator yields at subnet scale commonly cluster within a fraction of a percent of each other (real example, SN64 validators): `0.0041721%`, `0.0041529%`, `0.0041496%`, `0.0041425%`. The `0.001%–1%` formatting band used a fixed `toFixed(4)`, which rounds several of these to the exact same string (`"0.0041%"` / `"0.0042%"`) even though the underlying values genuinely differ — making a *ranked* leaderboard look like duplicate/broken data.

## What changed

- `fmtYield`'s `0.001 ≤ |pct| < 1` band now uses `toPrecision(5)` (significant-figure precision, which scales resolution with magnitude) instead of `toFixed(4)` (a fixed decimal count, which loses resolution as the magnitude shrinks).
- Exported `fmtYield` and added a dedicated test file (`yield-panel.test.ts`) with a regression test asserting that a real cluster of previously-colliding validator yields now all format to distinct strings.

## Screenshots

Verified live against real production data (SN64, the exact subnet named in the original bug report):

| Page / Feature | Before | After |
| --- | --- | --- |
| `/subnets/64?tab=metagraph` — yield leaderboard (last 4 rows, all validators) | [<img src="https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/69c7b9b5b4299fccecae23b65e247bbf0d343e82/before-yield.png" width="360">](https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/69c7b9b5b4299fccecae23b65e247bbf0d343e82/before-yield.png)<br><sub>before: UID 6 & UID 1 both "0.0042%"; UID 234 & UID 46 both "0.0041%"</sub> | [<img src="https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/3ce55957747487b9030474f746e27b8a0857359a/after-yield.png" width="360">](https://gist.githubusercontent.com/galuis116/cf209d23e4415033790444d20bc9616a/raw/3ce55957747487b9030474f746e27b8a0857359a/after-yield.png)<br><sub>after: all four rows show distinct values (0.0041721%, 0.0041529%, 0.0041496%, 0.0041425%)</sub> |

Closes #3946

## Investigation (per the issue's acceptance criteria)

- **Root cause identified**: display formatting precision, not a denominator/floor/clamp bug in the calculation — documented above and in the code comment at the fix site.
- **Same sample validators now show varied values, proportional to their actual stake/emission** — confirmed above with live SN64 data.
- **Regression test added**: `yield-panel.test.ts` asserts a real previously-colliding value set now formats to distinct strings.

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — no new errors (2 pre-existing baseline errors unrelated to this change)
- [x] `npm run lint --workspace=apps/ui` — clean
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 542/542 tests passing (79/79 files), including 5 new `fmtYield` tests
- [x] `npm run build --workspace=apps/ui` — builds cleanly
- [x] Manually verified against live production data via a local dev server + headless browser, both before and after the fix