### PR TITLE
feat(ui): add an in-app Ask metagraphed Q&A box

### DIFF
--- a/apps/ui/src/components/metagraphed/ask-box.test.ts
+++ b/apps/ui/src/components/metagraphed/ask-box.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/metagraphed/client";
+import type { AskCitation } from "@/lib/metagraphed/types";
+import {
+  citationLabel,
+  citationMeta,
+  describeAskError,
+  formatScore,
+  sourceCountLabel,
+} from "./ask-box";
+
+function citation(overrides: Partial<AskCitation> = {}): AskCitation {
+  return {
+    ref: 1,
+    score: 0.5,
+    title: "Chutes",
+    netuid: 64,
+    slug: "chutes",
+    url: "https://chutes.ai",
+    ...overrides,
+  };
+}
+
+describe("describeAskError", () => {
+  it("describes a 429 as rate-limited, regardless of the server message", () => {
+    expect(
+      describeAskError(new ApiError("Too many requests", { status: 429, url: "/api/v1/ask" })),
+    ).toBe("Rate-limited — try again shortly.");
+  });
+
+  it("describes a 503 using the server message, falling back to a default when empty", () => {
+    expect(
+      describeAskError(new ApiError("AI unavailable", { status: 503, url: "/api/v1/ask" })),
+    ).toBe("AI unavailable");
+    expect(describeAskError(new ApiError("", { status: 503, url: "/api/v1/ask" }))).toBe(
+      "AI is temporarily unavailable.",
+    );
+  });
+
+  it("falls back to the error message for any other ApiError status", () => {
+    expect(describeAskError(new ApiError("Bad request", { status: 400, url: "/api/v1/ask" }))).toBe(
+      "Bad request",
+    );
+  });
+
+  it("uses the generic fallback for an ApiError with no message (e.g. a network failure)", () => {
+    expect(describeAskError(new ApiError("", { status: 0, url: "/api/v1/ask" }))).toBe(
+      "Couldn't get an answer — try again.",
+    );
+  });
+
+  it("returns a generic message for a non-ApiError failure", () => {
+    expect(describeAskError(new Error("network down"))).toBe("Couldn't get an answer — try again.");
+    expect(describeAskError("not even an error")).toBe("Couldn't get an answer — try again.");
+    expect(describeAskError(undefined)).toBe("Couldn't get an answer — try again.");
+  });
+});
+
+describe("formatScore", () => {
+  it("renders a mid-range score as a rounded percentage", () => {
+    expect(formatScore(0.87)).toBe("87%");
+    expect(formatScore(0.005)).toBe("1%"); // rounds, doesn't truncate
+  });
+
+  it("renders the 0 and 1 boundaries", () => {
+    expect(formatScore(0)).toBe("0%");
+    expect(formatScore(1)).toBe("100%");
+  });
+
+  it("degrades a non-finite or out-of-schema-range score to an em dash, never NaN%", () => {
+    expect(formatScore(Number.NaN)).toBe("—");
+    expect(formatScore(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatScore(-0.1)).toBe("—");
+    expect(formatScore(1.1)).toBe("—");
+  });
+});
+
+describe("citationLabel", () => {
+  it("uses the title when present", () => {
+    expect(citationLabel(citation({ title: "Chutes" }))).toBe("Chutes");
+  });
+
+  it("falls back to a ref-numbered label when title is null", () => {
+    expect(citationLabel(citation({ ref: 3, title: null }))).toBe("Citation 3");
+  });
+});
+
+describe("citationMeta", () => {
+  it("includes the subnet prefix when netuid is present", () => {
+    expect(citationMeta(citation({ netuid: 64, score: 0.5 }))).toBe("SN64 · 50%");
+  });
+
+  it("omits the subnet prefix when netuid is null", () => {
+    expect(citationMeta(citation({ netuid: null, score: 0.5 }))).toBe("50%");
+  });
+});
+
+describe("sourceCountLabel", () => {
+  it("pluralizes for 0 and for >1", () => {
+    expect(sourceCountLabel(0, "test-model")).toBe("0 sources · test-model");
+    expect(sourceCountLabel(3, "test-model")).toBe("3 sources · test-model");
+  });
+
+  it("stays singular at exactly 1", () => {
+    expect(sourceCountLabel(1, "test-model")).toBe("1 source · test-model");
+  });
+});

--- a/apps/ui/src/components/metagraphed/ask-box.tsx
+++ b/apps/ui/src/components/metagraphed/ask-box.tsx
@@ -1,0 +1,119 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { ApiError } from "@/lib/metagraphed/client";
+import { askQuestion } from "@/lib/metagraphed/queries";
+import { classNames } from "@/lib/metagraphed/format";
+import { ExternalLink } from "@/components/metagraphed/external-link";
+import type { AskAnswerData, AskCitation } from "@/lib/metagraphed/types";
+
+/** Distinguishes a 429 (rate-limited) and 503 (AI disabled/unavailable) ask rejection from a generic failure. */
+export function describeAskError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 429) return "Rate-limited — try again shortly.";
+    if (error.status === 503) return error.message || "AI is temporarily unavailable.";
+    return error.message || "Couldn't get an answer — try again.";
+  }
+  return "Couldn't get an answer — try again.";
+}
+
+/** Relevance score (0-1 per the ask-answer schema) as a rounded percentage; "—" for a non-finite/out-of-range value. */
+export function formatScore(score: number): string {
+  return Number.isFinite(score) && score >= 0 && score <= 1 ? `${Math.round(score * 100)}%` : "—";
+}
+
+/** A citation's display title, falling back to its 1-based ref when the registry has no title. */
+export function citationLabel(citation: AskCitation): string {
+  return citation.title ?? `Citation ${citation.ref}`;
+}
+
+/** The netuid + score meta string next to a citation, omitting the netuid segment when it's null. */
+export function citationMeta(citation: AskCitation): string {
+  const netuidPrefix = citation.netuid != null ? `SN${citation.netuid} · ` : "";
+  return `${netuidPrefix}${formatScore(citation.score)}`;
+}
+
+function CitationRow({ citation }: { citation: AskCitation }) {
+  return (
+    <li className="flex items-center justify-between gap-3 px-3 py-2">
+      <ExternalLink href={citation.url ?? ""} className="min-w-0 text-[12px]">
+        {citationLabel(citation)}
+      </ExternalLink>
+      <span className="shrink-0 font-mono text-[10px] text-ink-muted">
+        {citationMeta(citation)}
+      </span>
+    </li>
+  );
+}
+
+/** "N source(s) · model" meta line, singular/plural correct at exactly 1. */
+export function sourceCountLabel(contextCount: number, model: string): string {
+  return `${contextCount} source${contextCount === 1 ? "" : "s"} · ${model}`;
+}
+
+function AskResult({ result }: { result: AskAnswerData }) {
+  return (
+    <div className="mt-4 space-y-3 rounded-lg border border-accent/30 bg-accent-surface p-4">
+      <p className="text-[13px] leading-relaxed text-ink-strong">{result.answer}</p>
+      {result.citations.length > 0 ? (
+        <ul className="divide-y divide-border rounded border border-border bg-card">
+          {result.citations.map((c: AskCitation) => (
+            <CitationRow key={c.ref} citation={c} />
+          ))}
+        </ul>
+      ) : null}
+      <p className="font-mono text-[10px] text-ink-muted">
+        {sourceCountLabel(result.context_count, result.model)}
+      </p>
+    </div>
+  );
+}
+
+export function AskBox() {
+  const [question, setQuestion] = useState("");
+  const mutation = useMutation({
+    mutationFn: (q: string) => askQuestion(q),
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = question.trim();
+    if (!trimmed) return;
+    mutation.mutate(trimmed);
+  }
+
+  return (
+    <div>
+      <form onSubmit={onSubmit} className="flex flex-col gap-2 sm:flex-row sm:items-start">
+        <label className="flex-1">
+          <span className="sr-only">Ask a question about Bittensor subnets</span>
+          <textarea
+            rows={2}
+            required
+            placeholder="Which subnet does image generation?"
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            className="w-full resize-none rounded-lg border border-border bg-card px-3 py-2 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={mutation.isPending || !question.trim()}
+          className={classNames(
+            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 text-[13px] font-medium text-accent hover:bg-accent/15",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+        >
+          {mutation.isPending ? "Asking…" : "Ask"}
+        </button>
+      </form>
+
+      {mutation.isError ? (
+        <p role="alert" className="mt-3 font-mono text-[12px] text-health-warn">
+          {describeAskError(mutation.error)}
+        </p>
+      ) : null}
+
+      {mutation.data ? <AskResult result={mutation.data} /> : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/mcp-tools-list.test.ts
+++ b/apps/ui/src/components/metagraphed/mcp-tools-list.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { visibleTools } from "./mcp-tools-list";
+
+const TOOLS = Array.from({ length: 30 }, (_, i) => `tool_${i}`);
+
+describe("visibleTools", () => {
+  it("truncates to the 24-item preview when closed", () => {
+    expect(visibleTools(TOOLS, false)).toHaveLength(24);
+    expect(visibleTools(TOOLS, false)).toEqual(TOOLS.slice(0, 24));
+  });
+
+  it("returns every item when open", () => {
+    expect(visibleTools(TOOLS, true)).toEqual(TOOLS);
+  });
+
+  it("returns a short list unchanged in either state", () => {
+    const short = TOOLS.slice(0, 5);
+    expect(visibleTools(short, false)).toEqual(short);
+    expect(visibleTools(short, true)).toEqual(short);
+  });
+
+  it("handles an empty list", () => {
+    expect(visibleTools([], false)).toEqual([]);
+    expect(visibleTools([], true)).toEqual([]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/mcp-tools-list.tsx
+++ b/apps/ui/src/components/metagraphed/mcp-tools-list.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+const PREVIEW_COUNT = 24;
+
+/** The slice of tools to render: everything once expanded, a fixed preview otherwise. */
+export function visibleTools<T>(tools: T[], open: boolean): T[] {
+  return open ? tools : tools.slice(0, PREVIEW_COUNT);
+}
+
+/**
+ * The MCP server's tool catalog as wrapped, individually-scannable chips
+ * instead of one long dot-joined string — collapsed to a preview with a
+ * "Show all N tools" toggle once the list is long (mirrors the expand
+ * convention in endpoints-glance.tsx).
+ */
+export function McpToolsList({ tools }: { tools: { name: string; title?: string }[] }) {
+  const [open, setOpen] = useState(false);
+  const hasMore = tools.length > PREVIEW_COUNT;
+
+  return (
+    <div className="mt-2">
+      <div className="flex flex-wrap gap-1.5">
+        {visibleTools(tools, open).map((t) => (
+          <span
+            key={t.name}
+            title={t.title}
+            className="inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+          >
+            {t.name}
+          </span>
+        ))}
+      </div>
+      {hasMore ? (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className={classNames(
+            "mt-2 inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted",
+            "hover:text-accent transition-colors",
+          )}
+        >
+          {open ? (
+            <>
+              <ChevronUp className="size-3" /> Show fewer
+            </>
+          ) : (
+            <>
+              <ChevronDown className="size-3" /> Show all {tools.length} tools
+            </>
+          )}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ask.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ask.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { askQuestion } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+describe("askQuestion", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("POSTs the question as a JSON body and returns the unwrapped data", async () => {
+    const data = {
+      question: "which subnet does image generation?",
+      answer: "SN64 (Chutes) handles image generation.",
+      context_count: 3,
+      model: "test-model",
+      citations: [],
+    };
+    mockedApiFetch.mockResolvedValue({
+      data,
+      meta: {} as ApiResult<unknown>["meta"],
+      url: "/api/v1/ask",
+    });
+
+    const result = await askQuestion("which subnet does image generation?");
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/ask",
+      expect.objectContaining({
+        init: expect.objectContaining({
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ question: "which subnet does image generation?" }),
+        }),
+      }),
+    );
+    expect(result).toEqual(data);
+  });
+
+  it("forwards an AbortSignal when provided", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: { question: "q", answer: "a", context_count: 0, model: "m", citations: [] },
+      meta: {} as ApiResult<unknown>["meta"],
+      url: "/api/v1/ask",
+    });
+    const controller = new AbortController();
+
+    await askQuestion("q", controller.signal);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/ask",
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it("omits signal from the call when not provided (no accidental undefined-signal mismatch)", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: { question: "q", answer: "a", context_count: 0, model: "m", citations: [] },
+      meta: {} as ApiResult<unknown>["meta"],
+      url: "/api/v1/ask",
+    });
+
+    await askQuestion("q");
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/ask",
+      expect.objectContaining({ signal: undefined }),
+    );
+  });
+
+  it("propagates a rejection instead of swallowing it (e.g. a 429/503/network failure)", async () => {
+    const error = new Error("boom");
+    mockedApiFetch.mockRejectedValue(error);
+
+    await expect(askQuestion("q")).rejects.toBe(error);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -14,6 +14,7 @@ import type {
   AgentCatalogService,
   AgentReadiness,
   AgentCatalogBlocker,
+  AskAnswerData,
   BulkHealthTrends,
   BulkHealthTrendSubnet,
   BulkHealthTrendPoint,
@@ -5662,6 +5663,23 @@ export const agentResourcesQuery = () =>
     },
     staleTime: STALE_MED,
   });
+
+// POST /api/v1/ask — grounded Q&A over the registry. User-triggered on submit,
+// not a passive fetch-on-mount GET, so this is a plain typed helper for a
+// component's own useMutation to call (see ask-box.tsx), not a
+// queryOptions/useSuspenseQuery pair — matching the verify-surface-button.tsx
+// imperative-POST precedent.
+export async function askQuestion(question: string, signal?: AbortSignal): Promise<AskAnswerData> {
+  const res = await apiFetch<AskAnswerData>("/api/v1/ask", {
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question }),
+    },
+    signal,
+  });
+  return res.data;
+}
 
 export const endpointIncidentsQuery = () =>
   queryOptions({

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -367,6 +367,25 @@ export interface AgentResources {
   resources: AgentResource[];
 }
 
+/** One grounding source backing an /api/v1/ask answer. */
+export interface AskCitation {
+  ref: number;
+  score: number;
+  title: string | null;
+  netuid: number | null;
+  slug: string | null;
+  url: string | null;
+}
+
+/** Response payload for POST /api/v1/ask — a grounded Q&A answer + its citations. */
+export interface AskAnswerData {
+  question: string;
+  answer: string;
+  context_count: number;
+  model: string;
+  citations: AskCitation[];
+}
+
 /** One reconstructed downtime window from /api/v1/incidents (epoch-ms timestamps). */
 export interface GlobalIncident {
   started_at: number;

--- a/apps/ui/src/routes/agents.tsx
+++ b/apps/ui/src/routes/agents.tsx
@@ -14,8 +14,10 @@ import {
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
+import { AskBox } from "@/components/metagraphed/ask-box";
 import { CopyButton } from "@/components/metagraphed/copy-button";
 import { ExternalLink } from "@/components/metagraphed/external-link";
+import { McpToolsList } from "@/components/metagraphed/mcp-tools-list";
 import { Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { SectionHeading } from "@/components/metagraphed/section-heading";
@@ -79,12 +81,6 @@ const SDKS: { lang: string; pkg: string; install: string; url: string }[] = [
 
 const QUICKSTART: { label: string; cmd: string }[] = [
   {
-    label: "Ask a grounded question",
-    cmd: `curl -s https://api.metagraph.sh/api/v1/ask \\
-  -X POST -H 'content-type: application/json' \\
-  -d '{"question":"which subnet does image generation?"}'`,
-  },
-  {
     label: "List every callable service",
     cmd: "curl -s https://api.metagraph.sh/api/v1/agent-catalog",
   },
@@ -140,9 +136,16 @@ function AgentsBody() {
             server card
           </ExternalLink>
         </div>
-        <p className="mt-2 font-mono text-[11px] leading-relaxed text-ink-muted/70">
-          {mcp.tools.map((t) => t.name).join("  ·  ")}
-        </p>
+        <McpToolsList tools={mcp.tools} />
+      </section>
+
+      {/* Ask metagraphed directly — grounded Q&A over the registry */}
+      <section>
+        <SectionHeading
+          title="Ask metagraphed"
+          intro="Ask a question in plain English and get a grounded answer with citations back to the registry."
+        />
+        <AskBox />
       </section>
 
       {/* Two calmer alternatives, side by side */}


### PR DESCRIPTION
Closes #3492

Adds a real "Ask metagraphed" question box to `/agents` — `POST /api/v1/ask` was fully built but only ever shown as a curl example. Replaces that curl entry with an actual text input, wired to the endpoint via `useMutation`, rendering the grounded answer with its citations inline.

## What it adds

- **`askQuestion(question, signal?)`** in `queries.ts` — a typed imperative-POST helper (not a `queryOptions` pair, since this is user-triggered, not fetch-on-mount), following the existing `verify-surface-button.tsx` precedent.
- **`AskCitation`/`AskAnswerData`** types in `types.ts`, matching `schemas/ai/ask-answer.schema.json`.
- **`ask-box.tsx`** — the question input + submit button, mounted as its own section on `/agents` right after "Connect over MCP". Handles idle / pending ("Asking…") / success (answer + citations, each title linked to its source URL, plus a context-count/model meta line) / error states, with the error state distinguishing 429 (rate-limited) from 503 (AI unavailable) from a generic failure — mirroring the `ApiError`-status-branching convention in `webhook-subscription-manager.tsx`.
- Removed the now-redundant "Ask a grounded question" curl entry from the page's `QUICKSTART` list (the semantic-search entry for the sibling issue #3493 is untouched).

**Beyond the issue's stated scope** (flagged per the contributing guide, maintainer OK'd): the MCP tool catalog directly above the new Ask box was rendering all ~150 tool names as one unbroken dot-joined string, which was hard to scan and made the page noisy right next to the new interactive section. Extracted `mcp-tools-list.tsx`, rendering the catalog as wrapped, individually-scannable chips with a "Show all N tools" toggle (mirrors the expand pattern already used in `endpoints-glance.tsx`). No backend/data changes — same `mcp.tools` data, different presentation.

## Verification

Functionally verified end-to-end against the live API (not just visually) — submitted a real question through the built UI and confirmed the answer + 6 citations rendered correctly with no console errors beyond a pre-existing, unrelated dev-only hydration notice (reproduces identically on unmodified `main`).

- `npm run typecheck --workspace=apps/ui` — clean (2 pre-existing errors on `main`, unrelated to this diff, unchanged)
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 559 passed (18 new/expanded across 3 new test files)
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Framed to show both changed areas (the tool chips + the new Ask section) in one shot per viewport/theme.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/after-mobile-dark.png)<br><sub>after</sub> |