### PR TITLE
fix(api): bound validator nominator queries

### DIFF
--- a/migrations/0037_account_events_hotkey_kind_observed_index.sql
+++ b/migrations/0037_account_events_hotkey_kind_observed_index.sql
@@ -1,0 +1,3 @@
+-- Bound validator nominator flow queries by hotkey, stake kind, and time window.
+CREATE INDEX IF NOT EXISTS idx_account_events_hotkey_kind_observed
+  ON account_events (hotkey, event_kind, observed_at, coldkey);

--- a/src/validator-nominators.mjs
+++ b/src/validator-nominators.mjs
@@ -58,9 +58,10 @@ function sortValue(nominator, sort) {
   return nominator.net_staked_tao;
 }
 
-// Shape a hotkey's per-(coldkey, event_kind) StakeAdded/StakeRemoved aggregate
-// into a ranked nominator list. `rows` is the GROUP BY coldkey, event_kind
-// result. Null-safe: no rows (cold store / empty window / no nominators)
+// Shape a hotkey's StakeAdded/StakeRemoved aggregate into a ranked nominator
+// list. `rows` can be either the legacy GROUP BY coldkey,event_kind shape used
+// by unit tests or the SQL-paginated GROUP BY coldkey shape returned by the D1
+// read path. Null-safe: no rows (cold store / empty window / no nominators)
 // yields a zeroed, empty list — never throws, matching the sibling account
 // tiers (stake-flow, counterparties).
 export function buildValidatorNominators(
@@ -71,6 +72,7 @@ export function buildValidatorNominators(
     sort = DEFAULT_NOMINATOR_SORT,
     limit = NOMINATOR_LIMIT_DEFAULT,
     offset = 0,
+    totalCount,
   } = {},
 ) {
   const normalizedSort = NOMINATOR_SORTS.includes(sort)
@@ -90,15 +92,8 @@ export function buildValidatorNominators(
       typeof row?.coldkey === "string" && row.coldkey.length > 0
         ? row.coldkey
         : null;
+    if (!coldkey) continue;
     const kind = row?.event_kind;
-    if (
-      !coldkey ||
-      (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND)
-    ) {
-      continue;
-    }
-    const tao = nullableTao(row?.total_tao);
-    if (tao == null) continue;
     const bucket = perColdkey.get(coldkey) ?? {
       coldkey,
       staked_tao: 0,
@@ -106,8 +101,21 @@ export function buildValidatorNominators(
       event_count: 0,
       last_observed_ms: null,
     };
-    if (kind === STAKE_ADDED_KIND) bucket.staked_tao += tao;
-    else bucket.unstaked_tao += tao;
+    if (kind == null) {
+      const staked = nullableTao(row?.staked_tao);
+      const unstaked = nullableTao(row?.unstaked_tao);
+      if (staked == null && unstaked == null) continue;
+      bucket.staked_tao += staked ?? 0;
+      bucket.unstaked_tao += unstaked ?? 0;
+    } else {
+      if (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND) {
+        continue;
+      }
+      const tao = nullableTao(row?.total_tao);
+      if (tao == null) continue;
+      if (kind === STAKE_ADDED_KIND) bucket.staked_tao += tao;
+      else bucket.unstaked_tao += tao;
+    }
     bucket.event_count += Math.max(
       0,
       Math.trunc(Number(row?.event_count) || 0),
@@ -148,11 +156,14 @@ export function buildValidatorNominators(
     sort: normalizedSort,
     limit: normalizedLimit,
     offset: normalizedOffset,
-    nominator_count: nominators.length,
-    nominators: nominators.slice(
-      normalizedOffset,
-      normalizedOffset + normalizedLimit,
-    ),
+    nominator_count:
+      totalCount == null
+        ? nominators.length
+        : Math.max(0, Math.trunc(Number(totalCount))) || 0,
+    nominators:
+      totalCount == null
+        ? nominators.slice(normalizedOffset, normalizedOffset + normalizedLimit)
+        : nominators,
   };
 }
 
@@ -170,18 +181,58 @@ export async function loadValidatorNominators(
     NOMINATOR_WINDOWS[windowLabel] ??
     NOMINATOR_WINDOWS[DEFAULT_NOMINATOR_WINDOW];
   const cutoff = Date.now() - days * DAY_MS;
-  const params = [hotkey, STAKE_ADDED_KIND, STAKE_REMOVED_KIND, cutoff];
-  let sql =
-    "SELECT coldkey, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, " +
-    "COUNT(*) AS event_count, MAX(observed_at) AS last_observed " +
-    "FROM account_events INDEXED BY idx_account_events_hotkey " +
+  const normalizedSort = NOMINATOR_SORTS.includes(sort)
+    ? sort
+    : DEFAULT_NOMINATOR_SORT;
+  const flooredLimit = Math.floor(Number(limit));
+  const normalizedLimit = Number.isFinite(flooredLimit)
+    ? Math.max(0, Math.min(flooredLimit, NOMINATOR_LIMIT_MAX))
+    : NOMINATOR_LIMIT_DEFAULT;
+  const flooredOffset = Math.floor(Number(offset));
+  const normalizedOffset =
+    Number.isFinite(flooredOffset) && flooredOffset > 0 ? flooredOffset : 0;
+  const whereParams = [hotkey, STAKE_ADDED_KIND, STAKE_REMOVED_KIND, cutoff];
+  let whereSql =
     "WHERE hotkey = ? AND event_kind IN (?, ?) AND observed_at >= ?";
   if (coldkey) {
-    sql += " AND coldkey = ?";
-    params.push(coldkey);
+    whereSql += " AND coldkey = ?";
+    whereParams.push(coldkey);
   }
-  sql += " GROUP BY coldkey, event_kind";
-  const rows = await d1(sql, params);
+  const countRows = await d1(
+    "SELECT COUNT(DISTINCT coldkey) AS nominator_count " +
+      "FROM account_events INDEXED BY idx_account_events_hotkey_kind_observed " +
+      whereSql,
+    whereParams,
+  );
+  const totalCount = Math.max(
+    0,
+    Math.trunc(Number(countRows?.[0]?.nominator_count) || 0),
+  );
+  const orderBy = {
+    net_staked: "net_staked_tao DESC, coldkey ASC",
+    gross_staked: "gross_staked_tao DESC, coldkey ASC",
+    last_activity: "last_observed DESC, coldkey ASC",
+  }[normalizedSort];
+  const sql =
+    "SELECT coldkey, " +
+    "COALESCE(SUM(CASE WHEN event_kind = ? THEN amount_tao ELSE 0 END), 0) AS staked_tao, " +
+    "COALESCE(SUM(CASE WHEN event_kind = ? THEN amount_tao ELSE 0 END), 0) AS unstaked_tao, " +
+    "COUNT(*) AS event_count, MAX(observed_at) AS last_observed, " +
+    "COALESCE(SUM(CASE WHEN event_kind = ? THEN amount_tao ELSE -amount_tao END), 0) AS net_staked_tao, " +
+    "COALESCE(SUM(amount_tao), 0) AS gross_staked_tao " +
+    "FROM account_events INDEXED BY idx_account_events_hotkey_kind_observed " +
+    whereSql +
+    " GROUP BY coldkey ORDER BY " +
+    orderBy +
+    " LIMIT ? OFFSET ?";
+  const rows = await d1(sql, [
+    STAKE_ADDED_KIND,
+    STAKE_REMOVED_KIND,
+    STAKE_ADDED_KIND,
+    ...whereParams,
+    normalizedLimit,
+    normalizedOffset,
+  ]);
   let latestObserved = null;
   for (const row of Array.isArray(rows) ? rows : []) {
     const observed = coerceEpochMs(row?.last_observed);
@@ -198,6 +249,7 @@ export async function loadValidatorNominators(
       sort,
       limit,
       offset,
+      totalCount,
     }),
     generatedAt: toIso(latestObserved),
   };

--- a/tests/validator-nominators.test.mjs
+++ b/tests/validator-nominators.test.mjs
@@ -74,6 +74,43 @@ describe("buildValidatorNominators", () => {
     assert.equal(d.nominators[0].coldkey, "ck-a");
   });
 
+  test("folds SQL-paginated per-coldkey aggregate rows", () => {
+    const d = buildValidatorNominators(
+      [
+        {
+          coldkey: "ck-a",
+          staked_tao: 50,
+          unstaked_tao: null,
+          event_count: 2,
+          last_observed: 5000,
+        },
+        {
+          coldkey: "ck-b",
+          staked_tao: null,
+          unstaked_tao: 5,
+          event_count: 1,
+          last_observed: 4000,
+        },
+        {
+          coldkey: "ck-empty",
+          staked_tao: null,
+          unstaked_tao: null,
+          event_count: 1,
+        },
+      ],
+      HOTKEY,
+      { totalCount: 5, limit: 2, offset: 2 },
+    );
+    assert.equal(d.nominator_count, 5);
+    assert.deepEqual(
+      d.nominators.map((n) => [n.coldkey, n.staked_tao, n.unstaked_tao]),
+      [
+        ["ck-a", 50, 0],
+        ["ck-b", 0, 5],
+      ],
+    );
+  });
+
   test("skips a non-stake event_kind (e.g. Transfer rows sharing the same query)", () => {
     const d = buildValidatorNominators(
       [row("ck-a", "Transfer", 100, 1, 1000), added("ck-a", 25)],
@@ -268,12 +305,16 @@ describe("loadValidatorNominators", () => {
       windowLabel: "30d",
     });
     assert.match(calls[0].sql, /FROM account_events/);
-    assert.match(calls[0].sql, /INDEXED BY idx_account_events_hotkey/);
+    assert.match(
+      calls[0].sql,
+      /INDEXED BY idx_account_events_hotkey_kind_observed/,
+    );
     assert.match(calls[0].sql, /WHERE hotkey = \?/);
-    assert.match(calls[0].sql, /GROUP BY coldkey, event_kind/);
-    assert.equal(calls[0].params[0], HOTKEY);
-    assert.equal(calls[0].params[1], STAKE_ADDED_KIND);
-    assert.equal(calls[0].params[2], STAKE_REMOVED_KIND);
+    assert.match(calls[1].sql, /GROUP BY coldkey/);
+    assert.match(calls[1].sql, /LIMIT \? OFFSET \?/);
+    assert.equal(calls[1].params[3], HOTKEY);
+    assert.equal(calls[1].params[4], STAKE_ADDED_KIND);
+    assert.equal(calls[1].params[5], STAKE_REMOVED_KIND);
     assert.equal(d.data.nominators[0].net_staked_tao, 70);
     assert.equal(d.generatedAt, new Date(6000).toISOString());
   });
@@ -289,12 +330,26 @@ describe("loadValidatorNominators", () => {
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
     let cutoff;
     const d1 = async (sql, params) => {
-      cutoff = params[3];
+      cutoff ??= params[3];
       return [];
     };
     await loadValidatorNominators(d1, HOTKEY, { windowLabel: "bogus" });
     assert.equal(cutoff, Date.now() - 30 * 24 * 60 * 60 * 1000);
     vi.useRealTimers();
+  });
+
+  test("pushes normalized fallback pagination into SQL", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [];
+    };
+    await loadValidatorNominators(d1, HOTKEY, {
+      limit: "bogus",
+      offset: -1,
+    });
+    assert.equal(calls[1].params.at(-2), 20);
+    assert.equal(calls[1].params.at(-1), 0);
   });
 
   test("coldkey narrows the query to one nominator's own flow", async () => {
@@ -352,8 +407,8 @@ describe("loadValidatorNominators", () => {
   });
 });
 
-// A minimal D1 mock scoped to this route's exact SQL shape (GROUP BY coldkey,
-// event_kind), self-contained rather than extending the broader multi-purpose
+// A minimal D1 mock scoped to this route's exact SQL shape (COUNT DISTINCT and
+// GROUP BY coldkey), self-contained rather than extending the broader multi-purpose
 // account-routes.test.mjs dispatcher.
 function accountEventsD1(rows) {
   return {
@@ -362,15 +417,53 @@ function accountEventsD1(rows) {
         bind(...params) {
           return {
             all() {
-              if (!/GROUP BY coldkey, event_kind/.test(sql)) {
-                return Promise.resolve({ results: [] });
-              }
-              let r = rows.filter((x) => x.hotkey === params[0]);
+              const whereOffset = sql.startsWith("SELECT coldkey") ? 3 : 0;
+              let r = rows.filter((x) => x.hotkey === params[whereOffset]);
               if (sql.includes("AND coldkey = ?")) {
-                const coldkeyParam = params[params.length - 1];
+                const coldkeyParam = params[whereOffset + 4];
                 r = r.filter((x) => x.coldkey === coldkeyParam);
               }
-              return Promise.resolve({ results: r });
+              if (/COUNT\(DISTINCT coldkey\)/.test(sql)) {
+                return Promise.resolve({
+                  results: [
+                    {
+                      nominator_count: new Set(r.map((x) => x.coldkey)).size,
+                    },
+                  ],
+                });
+              }
+              if (!/GROUP BY coldkey/.test(sql)) {
+                return Promise.resolve({ results: [] });
+              }
+              const buckets = new Map();
+              for (const event of r) {
+                const bucket = buckets.get(event.coldkey) ?? {
+                  coldkey: event.coldkey,
+                  staked_tao: 0,
+                  unstaked_tao: 0,
+                  event_count: 0,
+                  last_observed: null,
+                };
+                if (event.event_kind === STAKE_ADDED_KIND) {
+                  bucket.staked_tao += event.total_tao;
+                } else if (event.event_kind === STAKE_REMOVED_KIND) {
+                  bucket.unstaked_tao += event.total_tao;
+                }
+                bucket.event_count += event.event_count;
+                bucket.last_observed = Math.max(
+                  bucket.last_observed ?? 0,
+                  event.last_observed,
+                );
+                buckets.set(event.coldkey, bucket);
+              }
+              const results = [...buckets.values()].sort(
+                (a, b) =>
+                  b.staked_tao -
+                    b.unstaked_tao -
+                    (a.staked_tao - a.unstaked_tao) ||
+                  a.coldkey.localeCompare(b.coldkey),
+              );
+              return Promise.resolve({ results });
             },
           };
         },


### PR DESCRIPTION
### Motivation
- The public GET `/api/v1/validators/{hotkey}/nominators` route previously aggregated all matching `account_events` rows in Worker memory and applied pagination in JavaScript, enabling expensive D1 scans and a potential cost/availability amplification vector. 
- The intent is to cap per-request database work at SQL level and preserve service availability while keeping the existing response shape and behavior.

### Description
- Change `loadValidatorNominators` to push normalized pagination and sorting into SQL by adding a `COUNT(DISTINCT coldkey)` pre-query and a second paginated `SELECT ... GROUP BY coldkey ORDER BY ... LIMIT ? OFFSET ?` query, and pass `totalCount` through to the shaper. (`src/validator-nominators.mjs`).
- Extend `buildValidatorNominators` to accept SQL-paginated per-coldkey aggregate rows and an optional `totalCount`, preserving legacy per-event-kind shaping and making `nominator_count` and `nominators` consistent with SQL pagination. (`src/validator-nominators.mjs`).
- Add a migration to create an index tailored to the bounded query shape: `idx_account_events_hotkey_kind_observed` on `(hotkey, event_kind, observed_at, coldkey)`. (`migrations/0037_account_events_hotkey_kind_observed_index.sql`).
- Update tests and the D1 mock to cover SQL-paginated aggregate rows, assert the bounded SQL contains `LIMIT ? OFFSET ?`, and verify normalized fallback pagination and total-count plumbing. (`tests/validator-nominators.test.mjs`).

### Testing
- Ran the route unit tests with `npm test -- tests/validator-nominators.test.mjs`, and all tests passed (31 tests). 
- Ran migration validation with `npm run validate:migrations` and `validate:migrations` completed successfully. 
- Ran the linter (`npm run lint`) which completed with no errors; a targeted `npm run test:coverage` showed the updated tests pass but the repo-wide coverage thresholds caused the overall coverage job to fail (coverage gate is global and remains red).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f223c6870832c808e06956fe3d54d)