### PR TITLE
fix(data): reject partial hyperparameter snapshots

### DIFF
--- a/scripts/fetch-subnet-hyperparams.py
+++ b/scripts/fetch-subnet-hyperparams.py
@@ -127,12 +127,14 @@ def main():
     for netuid in netuids:
         try:
             hp = s.subnets.get_subnet_hyperparameters(netuid=netuid)
-        except Exception as exc:  # a single subnet's runtime call failing must
-            # not abort the whole fetch (matches fetch-native-subnets.py's
-            # per-netuid try/except around SubnetIdentitiesV3 storage reads).
+        except Exception as exc:
+            # This fetch feeds a full-snapshot loader that prunes absent netuids.
+            # A per-netuid failure must therefore fail the run instead of
+            # authenticating a partial snapshot as complete.
             errors.append(f"netuid={netuid}: {exc}")
             continue
         if hp is None:
+            errors.append(f"netuid={netuid}: empty hyperparameters response")
             continue
         block_number = int(getattr(s.substrate, "block_number", 0) or 0)
         rows.append(
@@ -217,7 +219,7 @@ def main():
     )
     for err in errors:
         sys.stderr.write(f"  {err}\n")
-    if not rows:
+    if errors or len(rows) != len(netuids):
         sys.exit(1)
 
 

--- a/scripts/test_fetch_subnet_hyperparams.py
+++ b/scripts/test_fetch_subnet_hyperparams.py
@@ -9,11 +9,16 @@ Runnable both ways:
 
 Loaded by path (hyphenated filename), same convention as
 test_fetch_metagraph_native.py. Does not import the real `bittensor` package —
-these are pure functions with no SDK dependency.
+main-path tests inject a tiny fake SDK module.
 """
 import importlib.util
+import json
 import os
+import sys
+import tempfile
+import types
 import unittest
+from unittest import mock
 
 _FSH_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "fetch-subnet-hyperparams.py"
@@ -28,6 +33,64 @@ u16_ratio = _fsh.u16_ratio
 rao_to_tao_exact = _fsh.rao_to_tao_exact
 to_flag = _fsh.to_flag
 to_float = _fsh.to_float
+
+
+class _Info:
+    def __init__(self, netuid, mechid=0):
+        self.netuid = netuid
+        self.mechid = mechid
+
+
+class _Hp:
+    tempo = 360
+
+
+class FetchCompletenessTest(unittest.TestCase):
+    def run_main(self, responses):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "hyperparams.json")
+
+            class _SubtensorApi:
+                def __init__(self, network):
+                    self.network = network
+                    self.substrate = types.SimpleNamespace(block_number=123)
+                    self.metagraphs = types.SimpleNamespace(
+                        get_all_metagraphs_info=lambda all_mechanisms: [
+                            _Info(1),
+                            _Info(2),
+                            _Info(99, mechid=1),
+                        ]
+                    )
+
+                    def get_subnet_hyperparameters(netuid):
+                        value = responses[netuid]
+                        if isinstance(value, Exception):
+                            raise value
+                        return value
+
+                    self.subnets = types.SimpleNamespace(
+                        get_subnet_hyperparameters=get_subnet_hyperparameters
+                    )
+
+            fake_bt = types.SimpleNamespace(SubtensorApi=_SubtensorApi)
+            with mock.patch.object(_fsh, "OUT", out):
+                with mock.patch.dict(sys.modules, {"bittensor": fake_bt}):
+                    with mock.patch.object(sys, "argv", ["fetch-subnet-hyperparams.py"]):
+                        with self.assertRaises(SystemExit) as cm:
+                            _fsh.main()
+            with open(out) as fh:
+                rows = json.load(fh)
+            return cm.exception.code, rows
+
+    def test_per_netuid_exception_fails_instead_of_signing_partial_snapshot(self):
+        code, rows = self.run_main({1: _Hp(), 2: RuntimeError("rpc failed")})
+        self.assertEqual(code, 1)
+        self.assertEqual([row["netuid"] for row in rows], [1])
+
+    def test_empty_hyperparameters_response_fails_instead_of_signing_partial_snapshot(self):
+        code, rows = self.run_main({1: _Hp(), 2: None})
+        self.assertEqual(code, 1)
+        self.assertEqual([row["netuid"] for row in rows], [1])
 
 
 class U16RatioTest(unittest.TestCase):

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -505,17 +505,17 @@ function validStagedSubnetHyperparamsRow(row) {
 // bounded, schema-valid rows through the METAGRAPH_HEALTH_DB binding (no
 // API-token D1 permission needed) with PARAMETERIZED inserts.
 //
-// Unlike loadStagedNeurons, every fetch covers ALL active subnets in one run
-// (get_subnet_hyperparameters has no bulk variant, but the fetch script loops
-// every netuid every time — no "refreshed_netuids" partial-coverage concept
-// needed here). ~129 rows today is far smaller than the neuron snapshot, so no
-// backup/rollback complexity: each upsert batch is independently an atomic D1
-// transaction and idempotent (INSERT OR REPLACE), so a failed batch leaves
-// only correctly-upserted rows behind — safe to leave as-is, since the staged
-// object is preserved (not deleted) on failure and the next cron retries the
-// same full snapshot. The prune (deleting a deregistered subnet's stale row)
-// runs only after every upsert batch succeeds, so it never fires against a
-// partially-loaded snapshot.
+// Unlike loadStagedNeurons, every successful fetch covers ALL active subnets in
+// one run (get_subnet_hyperparameters has no bulk variant, but the fetch script
+// loops every netuid every time and exits nonzero on any missing netuid — no
+// "refreshed_netuids" partial-coverage concept needed here). ~129 rows today is
+// far smaller than the neuron snapshot, so no backup/rollback complexity: each
+// upsert batch is independently an atomic D1 transaction and idempotent (INSERT
+// OR REPLACE), so a failed batch leaves only correctly-upserted rows behind —
+// safe to leave as-is, since the staged object is preserved (not deleted) on
+// failure and the next cron retries the same full snapshot. The prune (deleting
+// a deregistered subnet's stale row) runs only after every upsert batch succeeds,
+// so it never fires against a partial loader run.
 export async function loadStagedSubnetHyperparams(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;


### PR DESCRIPTION
### Motivation
- Prevent integrity/availability regression where a partially-failed `fetch-subnet-hyperparams.py` run could be signed/staged and then cause the D1 prune (`DELETE ... WHERE netuid NOT IN (...)`) to remove still-active subnet rows.
- Ensure the signed/staged snapshot truly covers every active netuid before the full-sync prune runs.

### Description
- Change `scripts/fetch-subnet-hyperparams.py` so any per-netuid exception or an empty `get_subnet_hyperparameters` response is recorded and the script exits nonzero when `errors` is non-empty or the number of rows does not equal the discovered `netuids` set.
- Update the `workers/request-handlers/staging.mjs` loader documentation to state the safety invariant that snapshots must be full (every active netuid) before the prune runs.
- Add regression tests in `scripts/test_fetch_subnet_hyperparams.py` that inject a fake SDK to verify the fetcher fails on per-netuid RPC exceptions and on empty responses.

### Testing
- Ran `npm test -- tests/load-staged-subnet-hyperparams.test.mjs` and the suite passed (all tests green).
- Ran `python3 scripts/test_fetch_subnet_hyperparams.py` and it passed, exercising the new completeness checks.
- Ran `npm run format:check`, `npm run lint`, `npm run validate:workflows`, and `npm run scan:public-safety`, and each check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f258f045c832ca5c208fbd24f1190)