### PR TITLE
fix(api): align sudo CSV contract example

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -26738,8 +26738,8 @@ export interface operations {
                         data?: components["schemas"]["ExtrinsicsFeedArtifact"];
                     };
                     /**
-                     * @example extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at
-                     *     8454388-1,8454388,1,0xhash_sample,5SudoKey,Sudo,sudo,true,0.000123,0,2026-07-03T00:00:00.000Z
+                     * @example extrinsic_id,block_number,signer,call_module,call_function,success
+                     *     8454388-1,8454388,5SudoKey,Sudo,sudo,true
                      */
                     "text/csv": string;
                 };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -48850,7 +48850,7 @@
                 }
               },
               "text/csv": {
-                "example": "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at\r\n8454388-1,8454388,1,0xhash_sample,5SudoKey,Sudo,sudo,true,0.000123,0,2026-07-03T00:00:00.000Z",
+                "example": "extrinsic_id,block_number,signer,call_module,call_function,success\r\n8454388-1,8454388,5SudoKey,Sudo,sudo,true",
                 "schema": {
                   "type": "string"
                 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -26738,8 +26738,8 @@ export interface operations {
                         data?: components["schemas"]["ExtrinsicsFeedArtifact"];
                     };
                     /**
-                     * @example extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at
-                     *     8454388-1,8454388,1,0xhash_sample,5SudoKey,Sudo,sudo,true,0.000123,0,2026-07-03T00:00:00.000Z
+                     * @example extrinsic_id,block_number,signer,call_module,call_function,success
+                     *     8454388-1,8454388,5SudoKey,Sudo,sudo,true
                      */
                     "text/csv": string;
                 };

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -4138,8 +4138,8 @@ function csvExampleForRoute(entry) {
   }
   if (entry.id === "sudo-calls") {
     return [
-      "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
-      "8454388-1,8454388,1,0xhash_sample,5SudoKey,Sudo,sudo,true,0.000123,0,2026-07-03T00:00:00.000Z",
+      "extrinsic_id,block_number,signer,call_module,call_function,success",
+      "8454388-1,8454388,5SudoKey,Sudo,sudo,true",
     ].join("\r\n");
   }
   if (entry.id === "governance-config-changes") {

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -225,6 +225,10 @@ describe("public contract registry", () => {
         "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
       ],
       [
+        "/api/v1/sudo",
+        "extrinsic_id,block_number,signer,call_module,call_function,success",
+      ],
+      [
         "/api/v1/accounts/{ss58}/transfers",
         "block_number,event_index,from,to,amount_tao,direction,observed_at",
       ],

--- a/tests/sudo.test.mjs
+++ b/tests/sudo.test.mjs
@@ -159,6 +159,9 @@ test("GET /api/v1/sudo?format=csv downloads the filtered rows as CSV", async () 
   assert.equal(res.status, 200);
   assert.match(res.headers.get("content-type") || "", /text\/csv/);
   const text = await res.text();
-  assert.match(text, /call_module/);
+  assert.equal(
+    text.split("\r\n")[0],
+    "extrinsic_id,block_number,signer,call_module,call_function,success",
+  );
   assert.match(text, /Sudo,sudo/);
 });


### PR DESCRIPTION
### Motivation
- The `/api/v1/sudo` route reuses `extrinsicsToCsvRows` and `EXTRINSICS_CSV_COLUMNS` (a six-column CSV projection) while the published CSV example and generated OpenAPI/TS artifacts advertised eleven columns, producing an API contract mismatch for clients.
- Align the published contract/examples with the handler output so generated clients and documentation reflect the actual response shape.

### Description
- Update the canonical CSV example for the `sudo-calls` artifact in `src/contracts.mjs` to the six-column header `extrinsic_id,block_number,signer,call_module,call_function,success` to match `extrinsicsToCsvRows`.
- Regenerate the public contract artifacts so the published contract matches the canonical example, updating `public/metagraph/openapi.json`, `public/metagraph/types.d.ts`, and `packages/contract/index.d.ts`.
- Add regression coverage by updating `tests/contracts.test.mjs` to assert the OpenAPI CSV header for `/api/v1/sudo` and by tightening `tests/sudo.test.mjs` to assert the CSV response header returned by the route.
- Preserve the handler implementation (it still calls `extrinsicsToCsvRows(...)` and uses `EXTRINSICS_CSV_COLUMNS`) so runtime behavior is unchanged.

### Testing
- Ran `npm run build`, which regenerated the derived artifacts and completed successfully while warning about modified deploy-owned artifacts that should not be committed unchanged.
- Ran unit tests with `npm test -- tests/sudo.test.mjs tests/contracts.test.mjs`, and both test files passed.
- Ran contract/contract-drift checks with `npm run validate:contract-drift` and OpenAPI validation with `npm run validate:openapi`, and both validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f258d4194832cb00383d569b0e416)