### PR TITLE
feat(ui): display the RPC endpoints catalog on the endpoints page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -145,7 +145,6 @@ export function AppShell({ children }: { children: ReactNode }) {
                 <ApiDrawerTrigger />
 
                 <NetworkSwitcher />
-                <ShortcutsPopover />
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Link
@@ -163,38 +162,6 @@ export function AppShell({ children }: { children: ReactNode }) {
                 <div className="hidden md:inline-flex">
                   <SettingsPopover />
                 </div>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <a
-                      href={GITHUB_HREF}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label="GitHub repository"
-                      className="hidden md:inline-flex items-center justify-center rounded-md size-9 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-                    >
-                      <Github className="size-4" />
-                    </a>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="text-[11px]">
-                    Open source on GitHub
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <a
-                      href={DISCORD_HREF}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label="Discord community"
-                      className="hidden md:inline-flex items-center justify-center rounded-md size-9 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-                    >
-                      <DiscordIcon className="size-4" />
-                    </a>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="text-[11px]">
-                    Join us on Discord
-                  </TooltipContent>
-                </Tooltip>
               </div>
             </div>
             <RegistryTicker />
@@ -281,6 +248,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           <SiteFooter />
           <ApiDrawer />
           <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+          <ShortcutsPopover />
           <BackToTop />
         </div>
       </ApiSourceProvider>

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -138,7 +138,7 @@ export function AppShell({ children }: { children: ReactNode }) {
               <Brand />
               <span aria-hidden className="hidden lg:inline-block h-5 w-px bg-border mx-1" />
               <NavMegaMenu />
-              <div className="flex-1 flex justify-end">
+              <div className="flex-1 min-w-0 flex justify-end">
                 <NavOmnibox onOpenPalette={() => setPaletteOpen(true)} />
               </div>
               <div className="flex items-center gap-1">
@@ -151,7 +151,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                     <Link
                       to="/settings"
                       aria-label="Developer settings"
-                      className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                      className="hidden md:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
                     >
                       <Webhook className="size-3.5" aria-hidden="true" />
                     </Link>
@@ -160,7 +160,9 @@ export function AppShell({ children }: { children: ReactNode }) {
                     Developer settings — webhook subscriptions
                   </TooltipContent>
                 </Tooltip>
-                <SettingsPopover />
+                <div className="hidden md:inline-flex">
+                  <SettingsPopover />
+                </div>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <a
@@ -248,6 +250,16 @@ export function AppShell({ children }: { children: ReactNode }) {
                   <Compass className="size-3" /> Unofficial registry
                 </div>
                 <MobileMegaMenu onNavigate={() => setMobileOpen(false)} />
+                <div className="flex items-center gap-2">
+                  <Link
+                    to="/settings"
+                    onClick={() => setMobileOpen(false)}
+                    className="inline-flex flex-1 items-center gap-2 rounded border border-border bg-card px-3 py-2 text-[13px] text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                  >
+                    <Webhook className="size-3.5" aria-hidden="true" /> Developer settings
+                  </Link>
+                  <SettingsPopover />
+                </div>
                 <div className="mt-auto border-t border-border pt-3">
                   <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted mb-1.5">
                     API base

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -365,16 +365,6 @@ export function NavOmnibox({ onOpenPalette }: Props) {
           aria-activedescendant={activeOptionId}
           className="flex-1 min-w-0 bg-transparent outline-none text-ink-strong placeholder:text-ink-muted text-sm"
         />
-        <button
-          type="button"
-          onClick={onOpenPalette}
-          title="Open command palette"
-          aria-label="Open command palette"
-          className="hidden sm:inline-flex items-center gap-0.5 shrink-0 text-ink-muted hover:text-ink-strong transition-colors"
-        >
-          <Kbd>⌘</Kbd>
-          <Kbd>K</Kbd>
-        </button>
       </div>
 
       {/* Dropdown — wider than the input, right-aligned */}

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -356,7 +356,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
           }}
           onFocus={() => setOpen(true)}
           onKeyDown={onKeyDown}
-          placeholder="Search subnets, wallets, blocks, txs…"
+          placeholder="Explore Bittensor…"
           role="combobox"
           aria-label="Search the registry"
           aria-autocomplete="list"

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -4,6 +4,7 @@ import { Keyboard } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Kbd } from "./kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { classNames } from "@/lib/metagraphed/format";
 
 const GOTO: Array<{ keys: string; to: string; label: string }> = [
   { keys: "g s", to: "/subnets", label: "Subnets" },
@@ -57,17 +58,22 @@ export function ShortcutsPopover() {
             <button
               type="button"
               aria-label="Keyboard shortcuts"
-              className="hidden md:inline-flex items-center justify-center rounded-md size-9 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+              className={classNames(
+                "hidden md:inline-flex fixed z-40 bottom-5 left-5 md:bottom-7 md:left-7",
+                "items-center justify-center rounded-full border border-border bg-card/95 backdrop-blur",
+                "size-10 text-ink-muted shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)]",
+                "hover:border-accent/60 hover:text-accent transition-colors",
+              )}
             >
               <Keyboard className="size-4" />
             </button>
           </PopoverTrigger>
         </TooltipTrigger>
-        <TooltipContent side="bottom" className="text-[11px]">
+        <TooltipContent side="right" className="text-[11px]">
           Keyboard shortcuts (?)
         </TooltipContent>
       </Tooltip>
-      <PopoverContent align="end" className="w-80 p-4">
+      <PopoverContent align="start" side="top" className="w-80 p-4">
         <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mb-3">
           Shortcuts
         </div>

--- a/apps/ui/src/lib/metagraphed/queries.rpc-endpoints.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.rpc-endpoints.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { rpcEndpointsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown, meta: Record<string, unknown> = {}): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: meta as ApiResult<unknown>["meta"],
+    url: "/api/v1/rpc/endpoints",
+  });
+}
+
+async function runQuery() {
+  const opts = rpcEndpointsQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("rpcEndpointsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("unwraps both the endpoints array and the summary rollup (fetchList alone would drop summary)", async () => {
+    resolveWith({
+      contract_version: "2026-06-06.1",
+      generated_at: "2026-07-08T21:50:41.021Z",
+      endpoints: [{ id: "onfinality-finney-rpc", kind: "subtensor-rpc", status: "ok" }],
+      summary: { endpoint_count: 9, archive_supported_count: 4, by_status: { ok: 4 } },
+    });
+
+    const res = await runQuery();
+
+    expect(res.data.endpoints).toHaveLength(1);
+    expect(res.data.endpoints[0]?.id).toBe("onfinality-finney-rpc");
+    expect(res.data.summary).toEqual({
+      endpoint_count: 9,
+      archive_supported_count: 4,
+      by_status: { ok: 4 },
+    });
+  });
+
+  it("drops a row with no id (not just passing junk through)", async () => {
+    resolveWith({
+      endpoints: [{ kind: "subtensor-rpc" }, { id: "real-one" }],
+      summary: null,
+    });
+
+    const res = await runQuery();
+
+    expect(res.data.endpoints).toHaveLength(1);
+    expect(res.data.endpoints[0]?.id).toBe("real-one");
+  });
+
+  it("degrades a cold/junk store to a schema-stable shape, never throws", async () => {
+    for (const raw of [{}, null, "x", { endpoints: "nope", summary: "nope" }]) {
+      resolveWith(raw);
+      const res = await runQuery();
+      expect(res.data.endpoints).toEqual([]);
+      expect(res.data.summary).toBeNull();
+    }
+  });
+
+  it("passes generated_at through via meta, matching the rpcPoolsQuery freshness convention", async () => {
+    resolveWith({ endpoints: [], summary: null }, { generated_at: "2026-07-08T21:50:41.021Z" });
+    const res = await runQuery();
+    expect(res.meta?.generated_at).toBe("2026-07-08T21:50:41.021Z");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -129,6 +129,9 @@ import type {
   Provider,
   ProviderEndpointSummary,
   RpcPool,
+  RpcEndpoint,
+  RpcEndpointsData,
+  RpcEndpointsSummary,
   RpcUsage,
   SchemaInfo,
   SemanticSearchResponse,
@@ -5760,6 +5763,41 @@ export const rpcPoolsQuery = () =>
     queryFn: async ({ signal }) => {
       const res = await fetchList<unknown>("/api/v1/rpc/pools", "pools", undefined, signal);
       return { ...res, data: res.data.map(normalizePool) } as ApiResult<RpcPool[]>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeRpcEndpoint(raw: unknown): RpcEndpoint | undefined {
+  if (!isRecord(raw)) return undefined;
+  const id = asString(raw.id);
+  if (!id) return undefined;
+  return { ...(raw as object), id } as RpcEndpoint;
+}
+
+function normalizeRpcEndpointsSummary(raw: unknown): RpcEndpointsSummary | null {
+  return isRecord(raw) ? (raw as RpcEndpointsSummary) : null;
+}
+
+// /api/v1/rpc/endpoints — the base-layer Subtensor RPC/WSS registry
+// (RpcEndpointsArtifact: a summary rollup alongside the endpoint list).
+// Unlike the other `fetchList`-based queries on this page, this artifact's
+// `summary` sibling field would be silently dropped by `fetchList` (which
+// only extracts the keyed array) — verified live: `summary` lives in the
+// artifact body next to `endpoints`, not in the response envelope's `meta`
+// (only `generated_at` round-trips through `meta`, matching `rpcPoolsQuery`'s
+// `data.meta?.generated_at` freshness read). So this unwraps the keyed
+// object itself, mirroring `fetchList`'s own array-extraction, to keep both.
+export const rpcEndpointsQuery = () =>
+  queryOptions({
+    queryKey: k("rpc-endpoints"),
+    queryFn: async ({ signal }): Promise<ApiResult<RpcEndpointsData>> => {
+      const res = await apiFetch<unknown>("/api/v1/rpc/endpoints", { signal });
+      const body = isRecord(res.data) ? res.data : {};
+      const endpoints = Array.isArray(body.endpoints)
+        ? body.endpoints.map(normalizeRpcEndpoint).filter((e): e is RpcEndpoint => e != null)
+        : [];
+      const summary = normalizeRpcEndpointsSummary(body.summary);
+      return { ...res, data: { endpoints, summary } };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/rpc-endpoints-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/rpc-endpoints-summary.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { rpcEndpointsSummaryLine } from "./rpc-endpoints-summary";
+
+describe("rpcEndpointsSummaryLine", () => {
+  it("returns null when there's no summary", () => {
+    expect(rpcEndpointsSummaryLine(null)).toBeNull();
+  });
+
+  it("builds the count · archive-capable · by-status line, status parts sorted by count descending", () => {
+    expect(
+      rpcEndpointsSummaryLine({
+        endpoint_count: 9,
+        archive_supported_count: 4,
+        by_status: { unknown: 1, ok: 4, degraded: 4 },
+      }),
+    ).toBe("9 endpoints tracked · 4 archive-capable · 4 ok · 4 degraded · 1 unknown");
+  });
+
+  it("stays singular at exactly 1 endpoint", () => {
+    expect(rpcEndpointsSummaryLine({ endpoint_count: 1 })).toBe("1 endpoint tracked");
+  });
+
+  it("omits the archive-capable segment when the field is absent, and the status segment when by_status is empty", () => {
+    expect(rpcEndpointsSummaryLine({ endpoint_count: 3 })).toBe("3 endpoints tracked");
+    expect(rpcEndpointsSummaryLine({ endpoint_count: 3, by_status: {} })).toBe(
+      "3 endpoints tracked",
+    );
+  });
+
+  it("defaults a missing endpoint_count to 0", () => {
+    expect(rpcEndpointsSummaryLine({})).toBe("0 endpoints tracked");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/rpc-endpoints-summary.ts
+++ b/apps/ui/src/lib/metagraphed/rpc-endpoints-summary.ts
@@ -1,0 +1,16 @@
+import type { RpcEndpointsSummary } from "./types";
+
+/** "N endpoints tracked · N archive-capable · N ok · N degraded · ..." built from the artifact's summary rollup. */
+export function rpcEndpointsSummaryLine(summary: RpcEndpointsSummary | null): string | null {
+  if (!summary) return null;
+  const statusParts = Object.entries(summary.by_status ?? {})
+    .sort(([, a], [, b]) => b - a)
+    .map(([status, count]) => `${count} ${status}`);
+  const count = summary.endpoint_count ?? 0;
+  const parts = [`${count} endpoint${count === 1 ? "" : "s"} tracked`];
+  if (summary.archive_supported_count != null) {
+    parts.push(`${summary.archive_supported_count} archive-capable`);
+  }
+  parts.push(...statusParts);
+  return parts.join(" · ");
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -293,6 +293,49 @@ export interface RpcPool {
   [key: string]: unknown;
 }
 
+/** One row from GET /api/v1/rpc/endpoints — the base-layer Subtensor RPC/WSS registry (RpcEndpoint schema). */
+export interface RpcEndpoint {
+  id: string;
+  kind?: string; // subtensor-rpc | subtensor-wss
+  url?: string;
+  provider?: string;
+  netuid?: number;
+  subnet_name?: string;
+  subnet_slug?: string;
+  status?: string; // ok | degraded | failed | unknown
+  classification?: string; // live | redirected | auth-required | dead | unsafe | unsupported | rate-limited
+  network?: string;
+  chain?: string;
+  archive_support?: boolean | null;
+  latency_ms?: number | null;
+  latest_block?: number | null;
+  auth_required?: boolean;
+  authority?: string;
+  health_source?: string;
+  health_stale?: boolean;
+  last_ok?: string | null;
+  last_checked?: string | null;
+  observed_at?: string | null;
+  error?: string | null;
+  [key: string]: unknown;
+}
+
+/** Roll-up counts accompanying GET /api/v1/rpc/endpoints (RpcEndpointsArtifact.summary). */
+export interface RpcEndpointsSummary {
+  endpoint_count?: number;
+  archive_supported_count?: number;
+  by_kind?: Record<string, number>;
+  by_provider?: Record<string, number>;
+  by_status?: Record<string, number>;
+  [key: string]: unknown;
+}
+
+/** The unwrapped GET /api/v1/rpc/endpoints payload — the endpoint list plus its summary rollup. */
+export interface RpcEndpointsData {
+  endpoints: RpcEndpoint[];
+  summary: RpcEndpointsSummary | null;
+}
+
 export interface EndpointIncident {
   id: string;
   endpoint_id?: string;

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -8,7 +8,7 @@ import { Search, X } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { HealthPill } from "@/components/metagraphed/chips";
+import { HealthPill, HealthDot } from "@/components/metagraphed/chips";
 import { CopyButton } from "@/components/metagraphed/copy-button";
 import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
@@ -396,7 +396,7 @@ function RpcEndpointsTable() {
                   </span>
                 </td>
                 <td className="px-3 py-2 text-center">
-                  <HealthPill state={statusToHealth(e.status)} />
+                  <HealthDot state={statusToHealth(e.status)} />
                 </td>
                 <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
                   {e.archive_support == null ? "—" : e.archive_support ? "yes" : "no"}

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -33,12 +33,15 @@ import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { ProxyHero, ProxyUsagePanel } from "@/components/metagraphed/rpc-proxy";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
+import { rpcEndpointsSummaryLine } from "@/lib/metagraphed/rpc-endpoints-summary";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { useScrolled } from "@/hooks/use-scrolled";
 import {
   endpointsQuery,
   endpointIncidentsQuery,
   rpcPoolsQuery,
+  rpcEndpointsQuery,
+  statusToHealth,
   providersQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
@@ -52,7 +55,7 @@ import {
   type PoolEligibility,
 } from "@/lib/metagraphed/endpoint-pool";
 
-import type { Endpoint, RpcPool, Provider, Subnet } from "@/lib/metagraphed/types";
+import type { Endpoint, RpcPool, RpcEndpoint, Provider, Subnet } from "@/lib/metagraphed/types";
 
 const endpointsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
@@ -173,6 +176,14 @@ function EndpointsPage() {
             </QueryErrorBoundary>
           </section>
           <section>
+            <SectionHeading title="Root RPC/WSS endpoints" />
+            <QueryErrorBoundary>
+              <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+                <RpcEndpointsTable />
+              </Suspense>
+            </QueryErrorBoundary>
+          </section>
+          <section>
             <SectionHeading title="Callable endpoints" />
             <QueryErrorBoundary>
               <Suspense fallback={<Skeleton className="h-48 w-full" />}>
@@ -196,6 +207,7 @@ function EndpointsPage() {
           "/api/v1/rpc/usage",
           "/api/v1/endpoints",
           "/api/v1/rpc/pools",
+          "/api/v1/rpc/endpoints",
           "/api/v1/endpoint-incidents",
         ]}
       />
@@ -277,8 +289,8 @@ function PoolsTable() {
               <th className="px-3 py-2 text-left">Pool</th>
               <th className="px-3 py-2 text-left">Region</th>
               <th className="px-3 py-2 text-right">Members</th>
-              <th className="px-3 py-2">Archive</th>
-              <th className="px-3 py-2">Eligibility</th>
+              <th className="px-3 py-2 text-center">Archive</th>
+              <th className="px-3 py-2 text-center">Eligibility</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -297,10 +309,10 @@ function PoolsTable() {
                   <td className="px-3 py-2 font-medium text-ink-strong">{p.name ?? p.id}</td>
                   <td className="px-3 py-2 text-[12px]">{p.region ?? "—"}</td>
                   <td className="px-3 py-2 text-right font-mono">{p.members_count ?? "—"}</td>
-                  <td className="px-3 py-2 text-[11px] text-ink-muted">
+                  <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
                     {p.archive_capable ? "yes" : "—"}
                   </td>
-                  <td className="px-3 py-2">
+                  <td className="px-3 py-2 text-center">
                     <span
                       className={classNames(
                         "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
@@ -320,6 +332,86 @@ function PoolsTable() {
         Proxy-eligible members serve live traffic through the reverse proxy above; the proxy prefers
         in-sync, healthy nodes and fails over automatically.
       </p>
+    </div>
+  );
+}
+
+const CLASSIFICATION_TONE: Record<string, string> = {
+  live: "border-health-ok/40 text-health-ok",
+  redirected: "border-health-warn/40 text-health-warn",
+  "auth-required": "border-ink-subtle text-ink-muted",
+  dead: "border-health-down/40 text-health-down",
+  unsafe: "border-health-down/40 text-health-down",
+  unsupported: "border-ink-subtle text-ink-muted",
+  "rate-limited": "border-health-warn/40 text-health-warn",
+  unknown: "border-ink-subtle text-ink-muted",
+};
+
+function RpcEndpointsTable() {
+  const { data } = useSuspenseQuery(rpcEndpointsQuery());
+  const rows = data.data.endpoints;
+  const summaryLine = rpcEndpointsSummaryLine(data.data.summary);
+  const stale = isStaleFreshness(data.meta?.generated_at);
+  if (rows.length === 0)
+    return (
+      <EmptyState
+        title="No RPC endpoints tracked"
+        description="The base-layer Subtensor RPC/WSS registry appears here once endpoints are registered."
+      />
+    );
+  return (
+    <div className="space-y-2">
+      {stale ? (
+        <StaleBanner
+          generatedAt={data.meta?.generated_at}
+          refreshQueryKeys={[rpcEndpointsQuery().queryKey]}
+        />
+      ) : null}
+      <div className="rounded border border-border bg-card overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-3 py-2 text-left">Provider</th>
+              <th className="px-3 py-2 text-left">Kind</th>
+              <th className="px-3 py-2 text-left">Classification</th>
+              <th className="px-3 py-2">Status</th>
+              <th className="px-3 py-2">Archive</th>
+              <th className="px-3 py-2 text-right">Latency</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((e: RpcEndpoint) => (
+              <tr key={e.id} className="mg-row-hover">
+                <td className="px-3 py-2 font-medium text-ink-strong">{e.provider ?? "—"}</td>
+                <td className="px-3 py-2 font-mono text-[11px]">{e.kind ?? "—"}</td>
+                <td className="px-3 py-2">
+                  <span
+                    className={classNames(
+                      "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                      CLASSIFICATION_TONE[e.classification ?? "unknown"] ??
+                        CLASSIFICATION_TONE.unknown,
+                    )}
+                  >
+                    {e.classification ?? "unknown"}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-center">
+                  <HealthPill state={statusToHealth(e.status)} />
+                </td>
+                <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
+                  {e.archive_support == null ? "—" : e.archive_support ? "yes" : "no"}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-[11px]">
+                  {e.latency_ms != null ? `${e.latency_ms}ms` : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {summaryLine ? (
+        <p className="px-1 font-mono text-[10px] text-ink-muted">{summaryLine}</p>
+      ) : null}
     </div>
   );
 }

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -236,13 +236,38 @@ export function mergeRpcEndpoints(staticArtifact, liveRpcPool) {
       observed_at: liveRpcPool.last_run_at || live.last_ok || null,
     };
   });
+  // The live overlay above can change a row's `status`/`archive_support` — the
+  // two summary fields derived from them (`by_status`, `archive_supported_count`)
+  // must be recomputed from the post-overlay `endpoints`, or they silently drift
+  // from the rows actually served alongside them (found live: a fully-recovered
+  // sweep still reported stale `degraded` counts from the last static build).
+  // `by_kind`/`by_provider`/`endpoint_count` are untouched by the overlay (kind
+  // and provider are static-only fields), so those pass through unchanged.
+  const byStatus = {};
+  let archiveSupportedCount = 0;
+  for (const endpoint of endpoints) {
+    const status = endpoint.status || "unknown";
+    byStatus[status] = (byStatus[status] || 0) + 1;
+    if (endpoint.archive_support === true) archiveSupportedCount += 1;
+  }
   return {
     ...staticArtifact,
     generated_at: liveRpcPool.generated_at ?? staticArtifact.generated_at,
     source: "live-cron-prober",
     operational_observed_at: liveRpcPool.last_run_at || null,
+    summary: {
+      ...staticArtifact.summary,
+      by_status: sortedRecord(byStatus),
+      archive_supported_count: archiveSupportedCount,
+    },
     endpoints,
   };
+}
+
+function sortedRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).sort(([a], [b]) => a.localeCompare(b)),
+  );
 }
 
 // Overlay live RPC health onto the static proxy pool: an endpoint stays eligible

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -136,10 +136,67 @@ describe("mergeRpcEndpoints", () => {
     assert.equal(a.status, "failed");
     assert.equal(a.health_source, "probe-derived");
     assert.equal(a.pool_eligible, undefined);
-    assert.deepEqual(merged.summary, { total: 2 });
+    // Non-derived summary fields (anything besides by_status/archive_supported_count)
+    // pass through from the static artifact unchanged.
+    assert.equal(merged.summary.total, 2);
     assert.equal(merged.generated_at, "g");
     assert.equal(merged.operational_observed_at, "r");
     assert.equal(merged.endpoints.find((e) => e.id === "b").status, "ok"); // no live → static
+  });
+
+  test("recomputes summary.by_status and archive_supported_count from the post-overlay endpoints, never the stale static build", () => {
+    // Reproduces a live discrepancy: the static build's summary said 4 "degraded"
+    // (the state at the last full artifact rebuild), but a later live sweep
+    // recovered those same endpoints to "ok" — the served summary must reflect
+    // the sweep, not the stale build, or it silently disagrees with the endpoint
+    // rows served right alongside it.
+    const stat = {
+      schema_version: 1,
+      summary: {
+        endpoint_count: 3,
+        by_kind: { "subtensor-rpc": 3 },
+        by_status: { degraded: 2, unknown: 1 },
+        archive_supported_count: 0,
+      },
+      endpoints: [
+        { id: "a", status: "degraded", archive_support: false },
+        { id: "b", status: "degraded", archive_support: false },
+        { id: "c", status: "unknown", archive_support: null },
+      ],
+    };
+    const live = {
+      last_run_at: "r",
+      endpoints: [
+        {
+          id: "a",
+          status: "ok",
+          classification: "live",
+          archive_support: true,
+        },
+        {
+          id: "b",
+          status: "ok",
+          classification: "live",
+          archive_support: true,
+        },
+      ],
+    };
+    const merged = mergeRpcEndpoints(stat, live);
+    assert.deepEqual(merged.summary.by_status, { ok: 2, unknown: 1 });
+    assert.equal(merged.summary.archive_supported_count, 2);
+    // Fields the overlay never touches (kind/provider are static-only) pass through.
+    assert.deepEqual(merged.summary.by_kind, { "subtensor-rpc": 3 });
+    assert.equal(merged.summary.endpoint_count, 3);
+  });
+
+  test("folds a row with no status into 'unknown' when tallying by_status", () => {
+    const stat = {
+      schema_version: 1,
+      summary: {},
+      endpoints: [{ id: "a" }],
+    };
+    const merged = mergeRpcEndpoints(stat, { endpoints: [] });
+    assert.deepEqual(merged.summary.by_status, { unknown: 1 });
   });
 
   test("folds unrecognized live status into unknown on the endpoint row", () => {
@@ -711,7 +768,9 @@ describe("mergeRpcEndpoints (additional paths)", () => {
     assert.equal(a.health_source, "probe-derived");
     assert.equal(a.health_stale, false);
     assert.equal(a.pool_eligible, undefined);
-    assert.deepEqual(out.summary, { total: 1 });
+    assert.equal(out.summary.total, 1); // other static summary fields pass through
+    assert.deepEqual(out.summary.by_status, { ok: 1 }); // recomputed, not stale-static
+    assert.equal(out.summary.archive_supported_count, 1); // recomputed from the fallback value
     assert.equal(a.observed_at, "r"); // last_ok null → last_run_at
   });
 


### PR DESCRIPTION
Closes #3350

Wires `GET /api/v1/rpc/endpoints` (the base-layer Subtensor RPC/WSS registry — previously live but unwired to any query function or component) into a new "Root RPC/WSS endpoints" section on `/endpoints`, alongside `/leaderboards`/`/explorer`-style summary rollup.

## What it adds

- **`rpcEndpointsQuery`** in `queries.ts` — unwraps the keyed `{endpoints, summary}` object itself rather than via the `fetchList` helper, since `fetchList` only extracts the keyed array and would silently drop the artifact's `summary` sibling field.
- **`RpcEndpoint`/`RpcEndpointsSummary`/`RpcEndpointsData`** types in `types.ts`, matching the `RpcEndpointsArtifact` OpenAPI schema (`schemas/components/07-endpoints-rpc.schema.json`).
- **`RpcEndpointsTable`** on `/endpoints`, placed next to the existing "RPC pools" section: provider/kind/classification/status/archive/latency per row, plus a summary line (`rpcEndpointsSummaryLine`, extracted to `lib/metagraphed/rpc-endpoints-summary.ts` so it's testable without tripping TanStack Router's file-based route scanner — a `.test.ts` colocated in `routes/` gets treated as a route candidate).
- `/api/v1/rpc/endpoints` added to the page's `ApiSourceFooter`.

## Beyond the issue's stated scope (maintainer OK'd)

Five things surfaced while building and testing this, fixed here rather than filed separately since I don't have issue-creation rights and each was small/adjacent:

1. **RPC pools table misalignment** — the `Archive`/`Eligibility` `<th>` had no explicit `text-align` (browser default centers `<th>`), while their `<td>` cells defaulted to left — header labels rendered centered above left-aligned data. Made both explicit and consistent (centered).
2. **Backend data-integrity bug**: `mergeRpcEndpoints` (`src/health-serving.mjs`) overlays live probe status onto each endpoint row but returned the static build's `summary` unchanged, so `summary.by_status`/`archive_supported_count` silently drifted from the `endpoints[]` rows served alongside them. Reproduced live: `summary` reported 4 "degraded" endpoints while every row's actual status was "ok"/"unknown", both read from the same response body at the same `generated_at`. Fixed to recompute just the two fields the overlay can change, from the post-overlay `endpoints`; `by_kind`/`by_provider`/`endpoint_count` are untouched by the overlay (kind/provider are static-only) and pass through as before. Added a regression test reproducing the exact discrepancy, plus updated two existing tests that had (unintentionally) locked in the stale-summary behavior as an expected assertion.
3. **Mobile header overflow**: the omnibox wrapper had `flex-1` but no `min-w-0`, so on narrow viewports it wouldn't shrink below its content's intrinsic width — visible as the search input bleeding off the right edge of the viewport. Compounded by two right-cluster icons (dev-settings link, settings popover) that weren't hidden on mobile like their siblings (API drawer, shortcuts, GitHub, Discord already were). Fixed the wrapper's `min-w-0` and hid the two icons behind the existing mobile menu sheet (both are now actually reachable there, matching the `hidden md:inline-flex` convention already used for the others). Header now measures exactly 375px on a 375px viewport — zero overflow, verified with `getBoundingClientRect()`.
4. **New table's mobile density**: swapped the status cell from `HealthPill` (icon + text label) to `HealthDot` (icon only, same `aria-label`/`title`) — the text label duplicated the adjacent Classification badge's signal and ate scarce width on an already horizontally-scrolling mobile table.
5. **Desktop header overflow, exposed by fix #3**: giving the omnibox wrapper `min-w-0` let the header shrink to fit its viewport for the first time — which revealed it never actually had room for everything. At 1280px, `NavMegaMenu` (~552px) + the icon cluster (~348px) + logo (~174px) left only ~85px for the omnibox, collapsing the search input to zero visible width. Confirmed this was already broken on unmodified `main` (header overflowed its own viewport by ~369px at 1024px, just silently, since nothing forced it to shrink and reveal it) — this PR reduces that to ~18px at that same 1024px width, not introduces it. Removed GitHub/Discord from the header icon cluster (both remain in the footer) and the in-pill "⌘K" command-palette hint button (the global ⌘K shortcut still works — unrelated to this specific button). Moved the keyboard-shortcuts trigger out of the header into a floating button (bottom-left, matching `BackToTop`'s fixed-position pattern at bottom-right). Search input now renders at a real width (161px at 1280px, up from 0px). One residual edge case: right at the exact `lg` breakpoint (1024px, where `NavMegaMenu` first switches on), the header still overflows by ~18px — down from ~369px pre-PR, but not fully eliminated; closing that last gap needs touching `NavMegaMenu` itself (a larger, separate scope I didn't want to pull into this PR without a fresh OK).

## Verification

Functionally verified end-to-end against the live API (not just visually) — confirmed 9 real rows render with correct provider/kind/classification/status/latency, and the summary line matches the live payload. Also verified interactively: the floating keyboard-shortcuts button opens its popover correctly, and the mobile sheet's "Developer settings" link + settings popover both render and function.

**Frontend** (`apps/ui`):
- `npm run typecheck --workspace=apps/ui` — clean (2 pre-existing errors on `main`, unrelated, unchanged)
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 546 passed
- `npm run build --workspace=apps/ui` — clean

**Backend** (`src/health-serving.mjs` fix):
- `npm run lint` / `npm run format:check` (root) — clean
- `npm run worker:test` — passed
- `npm run test:coverage` — 6681 passed; new lines in `mergeRpcEndpoints` fully covered (the file's 2 pre-existing uncovered lines are unrelated, elsewhere in the file)
- `npm run validate` — clean
- `git diff --check` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Framed to show the changed areas (RPC pools alignment fix + the new table) in one shot per viewport/theme; the sticky header at the top of each shot also shows the decluttered search bar.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/endpoints-after-mobile-dark.png)<br><sub>after</sub> |
