### PR TITLE
feat(ui): add truncation notices to the extrinsic detail page

### DIFF
--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -93,6 +93,17 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
   const extrinsic = useSuspenseQuery(extrinsicQuery(hash)).data.data;
   const callArgs = extrinsic?.call_args;
   const events = (extrinsic?.events ?? []).slice(0, 100);
+  // #3423: the events/call-args lists are sliced to bound render cost on an
+  // already-fetched payload; surface how many rows were clipped so a viewer can
+  // tell a complete record from a truncated one.
+  const eventsTotal = extrinsic?.events?.length ?? 0;
+  const eventsOmitted = Math.max(0, eventsTotal - events.length);
+  const callArgsTotal = Array.isArray(callArgs)
+    ? callArgs.length
+    : callArgs && typeof callArgs === "object"
+      ? Object.keys(callArgs).length
+      : 0;
+  const callArgsOmitted = Math.max(0, callArgsTotal - 64);
 
   if (!extrinsic) {
     return (
@@ -215,6 +226,12 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         subtitle="The decoded parameters passed to this extrinsic."
       >
         {renderCallArgs(callArgs)}
+        {callArgsOmitted > 0 ? (
+          <p className="mt-2 font-mono text-[11px] text-ink-muted">
+            Showing 64 of {formatNumber(callArgsTotal)} call args — {formatNumber(callArgsOmitted)}{" "}
+            more omitted.
+          </p>
+        ) : null}
       </SectionAnchor>
 
       <SectionAnchor id="events" title="Emitted events" tone="accent">
@@ -282,6 +299,12 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             description="No emitted events were indexed for this extrinsic."
           />
         )}
+        {eventsOmitted > 0 ? (
+          <p className="mt-2 font-mono text-[11px] text-ink-muted">
+            Showing 100 of {formatNumber(eventsTotal)} events — {formatNumber(eventsOmitted)} more
+            omitted.
+          </p>
+        ) : null}
       </SectionAnchor>
 
       <div className="mt-6">


### PR DESCRIPTION
## Summary

Closes #3423

The extrinsic detail page slices emitted events to 100 and decoded call-args to 64 to bound render cost — but gave no indication when the record was clipped. This adds a small muted "Showing X of Y — N more omitted" notice under the **Emitted events** and **Call arguments** sections whenever the fetched payload exceeds the cap. Static notice only (no pagination / load-more — the caps bound render of an already-fetched payload).

## Validation
- `npm run typecheck -w apps/ui` — pass
- `prettier --check` (changed file) — clean
- `npm run test -w apps/ui` — pass
- `npm run build -w apps/ui` — pass

Add-only diff (+23, 0 deletions); single file.

## Screenshots

Extrinsic detail page with a truncated events (or call-args) list. Before: table stops at the cap with no indicator. After: a "Showing 100 of Y — N more omitted" notice under the section.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1406" height="746" alt="dek-lg-be" src="https://github.com/user-attachments/assets/3c13e6e2-60ff-4bc4-990e-56d30d350bf8" /> | <img width="1393" height="707" alt="dek-lg-af" src="https://github.com/user-attachments/assets/cd49b6ef-f463-4478-ae2b-45e8244d764c" /> |
| Desktop · Dark |<img width="1419" height="732" alt="dek-dk-be" src="https://github.com/user-attachments/assets/ed4621aa-ab5d-483a-90c1-94145898fd1e" /> | <img width="1411" height="744" alt="dek-dk-af" src="https://github.com/user-attachments/assets/bf564b06-f3a9-446e-8f52-16e170983a56" /> |
| Tablet · Light | <img width="651" height="889" alt="tab-lg-be" src="https://github.com/user-attachments/assets/f11ea96f-b00e-4b58-9c87-e03eab8012c2" /> | <img width="641" height="892" alt="tab-lg-af" src="https://github.com/user-attachments/assets/4e4d0c58-9b23-436d-9094-f6700b65be3d" /> |
| Tablet · Dark | <img width="638" height="898" alt="tab-dk-be" src="https://github.com/user-attachments/assets/9ea42b99-8496-4d54-9c92-7c78a7b5e9c6" /> | <img width="637" height="883" alt="tab-dk-af" src="https://github.com/user-attachments/assets/aa3b812a-a9e3-4c0e-bcb3-6a1b0f7da856" /> |
| Mobile · Light | <img width="440" height="916" alt="mb-lg-be" src="https://github.com/user-attachments/assets/366032b1-082f-49e9-a98e-2e65275124fb" /> | <img width="429" height="925" alt="mb-lg-af" src="https://github.com/user-attachments/assets/aa381b6c-001c-4da0-8b64-186046a9676e" /> |
| Mobile · Dark | <img width="459" height="923" alt="mb-dk-be" src="https://github.com/user-attachments/assets/0c6d3f01-f908-4242-a45d-879c65f9d67a" /> | <img width="437" height="931" alt="mb-dk-af" src="https://github.com/user-attachments/assets/8a161250-b273-4dce-a7d3-31b367465305" /> |
