### PR TITLE
fix(nav): point mega-menu "Curated" link at a real curation level

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
@@ -49,6 +49,29 @@ describe("MEGA_PANELS catalogue", () => {
       }
     }
   });
+
+  it("only links to real curation levels in subnet filters", () => {
+    // /subnets filters on the curation levels enumerated in chips.tsx's
+    // `curationLabel`. A mega-menu link carrying a value outside this set
+    // (e.g. the old "verified") matches zero rows and silently renders the
+    // full unfiltered list instead of a curated one.
+    const CURATION_LEVELS = new Set([
+      "native",
+      "candidate-discovered",
+      "community-seeded",
+      "machine-verified",
+      "maintainer-reviewed",
+      "adapter-backed",
+    ]);
+    for (const p of MEGA_PANELS) {
+      for (const l of [...p.browse, ...p.filters]) {
+        const curation = l.search?.curation;
+        if (curation !== undefined) {
+          expect(CURATION_LEVELS.has(curation)).toBe(true);
+        }
+      }
+    }
+  });
 });
 
 describe("storage helpers (SSR/node-safe)", () => {

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -31,7 +31,7 @@ export const MEGA_PANELS: MegaPanel[] = [
       { to: "/subnets", label: "All subnets", hint: "Browse every active netuid" },
       {
         to: "/subnets",
-        search: { curation: "verified" },
+        search: { curation: "maintainer-reviewed" },
         label: "Curated",
         hint: "Maintainer-reviewed",
       },


### PR DESCRIPTION
## Summary

Fixes the primary nav mega-menu's **"Curated"** subnets link, which pointed at a curation level that doesn't exist.

`nav-mega-menu-data.ts` linked the "Curated" item to `/subnets?curation=verified`, but `verified` is not one of the real curation levels the `/subnets` route filters on — `chips.tsx`'s `curationLabel` enumerates them as `native` · `candidate-discovered` · `community-seeded` · `machine-verified` · `maintainer-reviewed` · `adapter-backed`. Because `verified` matches zero rows, clicking "Curated" silently rendered the **full, unfiltered** subnet list instead of the reviewed subset — while the adjacent "Machine-verified" link (`curation=machine-verified`, a real value) worked correctly.

The item's own hint already reads "Maintainer-reviewed", so the intended value is `maintainer-reviewed`.

## Change

- `nav-mega-menu-data.ts`: `curation: "verified"` → `curation: "maintainer-reviewed"` for the "Curated" link.
- `nav-mega-menu-data.test.ts`: adds a regression test asserting every mega-menu subnet-filter link uses a real curation level — it fails against the old `verified` value and passes on the fix.

## Validation (local)

- `vitest run` — 75 files / 522 tests pass, including the new guard (verified to fail before the one-line fix and pass after).
- `tsc --noEmit`, `eslint`, and `prettier --check` are all clean on the changed files.

Closes #3974
