### PR TITLE
feat(api): add live rollup/detail self-consistency check

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -319,6 +319,61 @@ async function runLiveSmoke() {
     }
   }
 
+  // Rollup/detail self-consistency: a real, once-live bug had
+  // /api/v1/endpoints' summary.by_status silently drift from the actual
+  // endpoints[] rows in the SAME response -- schema-valid on both sides, the
+  // values just didn't reconcile with each other, which no shape validator
+  // catches. Recompute each rollup independently from the response's own
+  // detail array and assert they still agree. Checked unpaginated (no
+  // `?limit`) -- a rollup describing a total across pages while the detail
+  // array is one page is normal pagination, not drift, so this must never
+  // run against a limited request.
+  const endpointsGlobal = await fetchJson(`${baseUrl}/api/v1/endpoints`);
+  assert.equal(
+    endpointsGlobal.status,
+    200,
+    "/api/v1/endpoints: expected HTTP 200",
+  );
+  const globalEndpoints = endpointsGlobal.body?.data?.endpoints;
+  assert.ok(
+    Array.isArray(globalEndpoints),
+    "/api/v1/endpoints: expected data.endpoints array",
+  );
+  assertRollupsReconcile(
+    "/api/v1/endpoints",
+    endpointsGlobal.body?.data?.summary,
+    globalEndpoints,
+    { by_status: "status", by_kind: "kind", by_provider: "provider" },
+  );
+
+  // Second, distinct artifact with the same rollup+detail shape (not just a
+  // second field on the same response) -- generalizes the check rather than
+  // hardcoding one endpoint.
+  const sampleProvider = Object.keys(
+    endpointsGlobal.body?.data?.summary?.by_provider ?? {},
+  )[0];
+  if (sampleProvider) {
+    const providerEndpoints = await fetchJson(
+      `${baseUrl}/api/v1/providers/${sampleProvider}/endpoints`,
+    );
+    assert.equal(
+      providerEndpoints.status,
+      200,
+      `/api/v1/providers/${sampleProvider}/endpoints: expected HTTP 200`,
+    );
+    const scopedEndpoints = providerEndpoints.body?.data?.endpoints;
+    assert.ok(
+      Array.isArray(scopedEndpoints),
+      `/api/v1/providers/${sampleProvider}/endpoints: expected data.endpoints array`,
+    );
+    assertRollupsReconcile(
+      `/api/v1/providers/${sampleProvider}/endpoints`,
+      providerEndpoints.body?.data?.summary,
+      scopedEndpoints,
+      { by_status: "status", by_kind: "kind" },
+    );
+  }
+
   console.log(
     JSON.stringify(
       {
@@ -335,6 +390,46 @@ async function runLiveSmoke() {
       null,
       2,
     ),
+  );
+}
+
+// Recomputes each named rollup from `detail` (tallying `detail[row][field]`)
+// and asserts it exactly matches `summary[rollupKey]` -- same key set, same
+// counts. Deliberately limited to plain single-field count rollups
+// (by_status/by_kind/by_provider): a derived/composite rollup (e.g.
+// by_publication_state, which folds in auth/pool-eligibility rules) would
+// need its derivation logic reimplemented here to check safely, which is
+// its own bug surface -- skip those rather than guess.
+export function reconcileRollups(summary, detail, fieldsToKeys) {
+  const mismatches = [];
+  for (const [rollupKey, field] of Object.entries(fieldsToKeys)) {
+    const rollup = summary?.[rollupKey];
+    if (!rollup || typeof rollup !== "object") continue;
+    const actual = {};
+    for (const row of detail) {
+      const value = row?.[field];
+      if (value === undefined || value === null) continue;
+      actual[value] = (actual[value] || 0) + 1;
+    }
+    const keysMatch =
+      Object.keys(rollup).sort().join(",") ===
+      Object.keys(actual).sort().join(",");
+    const countsMatch = Object.keys(rollup).every(
+      (key) => rollup[key] === actual[key],
+    );
+    if (!keysMatch || !countsMatch) {
+      mismatches.push({ rollupKey, expected: rollup, actual });
+    }
+  }
+  return mismatches;
+}
+
+function assertRollupsReconcile(routeLabel, summary, detail, fieldsToKeys) {
+  const mismatches = reconcileRollups(summary, detail, fieldsToKeys);
+  assert.deepEqual(
+    mismatches,
+    [],
+    `${routeLabel}: summary rollup(s) don't reconcile against this response's own detail array: ${JSON.stringify(mismatches)}`,
   );
 }
 

--- a/tests/reconcile-rollups.test.mjs
+++ b/tests/reconcile-rollups.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { reconcileRollups } from "../scripts/smoke-live-api.mjs";
+
+// Offline unit coverage for the rollup/detail self-consistency check added for
+// #4503 -- a real, once-live bug had summary.by_status silently drift from the
+// endpoints[] rows in the SAME /api/v1/endpoints response (schema-valid on
+// both sides, the values just didn't reconcile). The live-network assertion
+// itself lives in smoke-live-api.mjs's runLiveSmoke() (only runs against
+// production, not in CI); this covers reconcileRollups' own logic against
+// fixed, offline inputs.
+describe("reconcileRollups", () => {
+  const detail = [
+    { status: "ok", kind: "docs" },
+    { status: "ok", kind: "docs" },
+    { status: "degraded", kind: "dashboard" },
+  ];
+  const consistentSummary = {
+    by_status: { ok: 2, degraded: 1 },
+    by_kind: { docs: 2, dashboard: 1 },
+  };
+
+  test("reports no mismatches when the rollup matches the detail array", () => {
+    const mismatches = reconcileRollups(consistentSummary, detail, {
+      by_status: "status",
+      by_kind: "kind",
+    });
+    assert.deepEqual(mismatches, []);
+  });
+
+  test("catches a count drift (rollup says one more than the detail array has)", () => {
+    const drifted = {
+      ...consistentSummary,
+      by_status: { ...consistentSummary.by_status, ok: 3 },
+    };
+    const mismatches = reconcileRollups(drifted, detail, {
+      by_status: "status",
+    });
+    assert.equal(mismatches.length, 1);
+    assert.equal(mismatches[0].rollupKey, "by_status");
+    assert.deepEqual(mismatches[0].expected, { ok: 3, degraded: 1 });
+    assert.deepEqual(mismatches[0].actual, { ok: 2, degraded: 1 });
+  });
+
+  test("catches a rollup key with no matching rows in the detail array", () => {
+    const withPhantomKey = {
+      by_status: { ...consistentSummary.by_status, unknown: 1 },
+    };
+    const mismatches = reconcileRollups(withPhantomKey, detail, {
+      by_status: "status",
+    });
+    assert.equal(mismatches.length, 1);
+    assert.equal(mismatches[0].rollupKey, "by_status");
+  });
+
+  test("catches a detail-array value missing from the rollup entirely", () => {
+    const missingKey = { by_kind: { docs: 2 } }; // dashboard row exists in detail but not here
+    const mismatches = reconcileRollups(missingKey, detail, {
+      by_kind: "kind",
+    });
+    assert.equal(mismatches.length, 1);
+    assert.equal(mismatches[0].rollupKey, "by_kind");
+  });
+
+  test("skips a rollup field the summary doesn't carry, rather than failing", () => {
+    const mismatches = reconcileRollups(consistentSummary, detail, {
+      by_status: "status",
+      by_provider: "provider", // not present in consistentSummary
+    });
+    assert.deepEqual(mismatches, []);
+  });
+
+  test("ignores detail rows where the field is null/undefined instead of miscounting them", () => {
+    const withGaps = [...detail, { status: null, kind: undefined }];
+    const mismatches = reconcileRollups(consistentSummary, withGaps, {
+      by_status: "status",
+      by_kind: "kind",
+    });
+    assert.deepEqual(mismatches, []);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `reconcileRollups()` to `scripts/smoke-live-api.mjs` — recomputes each named summary rollup independently from a response's own detail array and asserts it still agrees
- Wired into `runLiveSmoke()` against two distinct artifacts sharing the rollup+detail shape: `/api/v1/endpoints` (by_status/by_kind/by_provider) and a per-provider-scoped `/api/v1/providers/{slug}/endpoints` (by_status/by_kind)
- Adds `tests/reconcile-rollups.test.mjs` — offline unit coverage for the reconciliation logic itself (6 cases: consistent, count drift, phantom rollup key, missing rollup key, unrelated rollup field skipped, null/undefined detail fields ignored)

Closes #4503.

## Background
A real, once-live bug had `/api/v1/endpoints`' `summary.by_status` silently drift from the actual `endpoints[]` rows in the *same* response — schema-valid on both sides, the values just didn't reconcile with each other. `npm run validate` checks shape; nothing checked whether two sibling fields in the same artifact agree with each other.

## Why this lives in `smoke-live-api.mjs`, not `npm run validate`
The issue's original suggestion was a post-build or live-smoke check; I went with live-smoke specifically after checking the build-time code path (`scripts/lib/endpoint-artifacts.mjs`) and the live-serving overlay path (`src/health-serving.mjs`) — both already derive `by_status` directly from the same `endpoints` array they serialize (`countRecord(endpoints, ...)` / `countEndpointStatuses(endpoints)`), so a build-time check on committed/staged artifacts would only ever tautologically pass. The bug the contributor found was via live testing, so the check needs to run against the live serving layer to have a chance of catching the same class of drift again. `smoke-live-api.mjs` already runs post-deploy in `publish-cloudflare.yml` — this reuses that existing wiring rather than adding a new live-network dependency to every contributor PR's `validate` step.

## Test plan
- [x] Verified live against production right now: `/api/v1/endpoints` (1545 rows, unpaginated) and a per-provider scoped endpoint both currently reconcile cleanly — confirms the bug that motivated this is already fixed, and this is now regression protection
- [x] Confirmed the check actually catches drift: temporarily injected a synthetic `+1` count mismatch and a deleted rollup key against the live response outside the committed code, observed both fail with a clear, actionable diff (`expected` vs `actual`)
- [x] `npx vitest run tests/reconcile-rollups.test.mjs` — 6/6 pass, offline, no network
- [x] Full local suite: `npx vitest run` — 244 files / 6698 tests pass
- [x] `npm run lint && npm run format:check` clean

## Unrelated finding along the way
`npm run smoke:live`'s full run currently fails on an *existing*, unrelated check: `GET /api/v1/accounts/{ss58}/balance` for the canonical smoke-test address returns a live HTTP 500. Confirmed via `curl`, not a side effect of this change (my new checks run later in the same function and were verified in isolation). Flagged separately, not fixed here.
