### PR TITLE
fix(decentralization): disambiguate the Emission Gini tile Nakamoto hint

### DIFF
--- a/apps/ui/src/lib/metagraphed/network-decentralization.test.ts
+++ b/apps/ui/src/lib/metagraphed/network-decentralization.test.ts
@@ -100,6 +100,13 @@ describe("networkDecentralizationModel", () => {
     expect(nakamoto?.value).toBe("105");
     expect(nakamoto?.tone).toBe("ok");
 
+    // The Emission Gini tile carries the *emission* Nakamoto (118) in its hint;
+    // it must be domain-prefixed so it can't be misread as a second value for
+    // the stake "Nakamoto" tile (105) above.
+    const emissionGini = findTile(model, "emission-gini");
+    expect(emissionGini?.value).toBe("0.899");
+    expect(emissionGini?.hint).toBe("emission Nakamoto 118");
+
     // Shares render as percentages.
     const top1 = findTile(model, "stake-top1");
     expect(top1?.value).toBe("44.1%");

--- a/apps/ui/src/lib/metagraphed/network-decentralization.ts
+++ b/apps/ui/src/lib/metagraphed/network-decentralization.ts
@@ -143,7 +143,10 @@ function concentrationTiles(
       key: "emission-gini",
       label: "Emission Gini",
       value: numStr(emission?.gini),
-      hint: emissionNakamoto == null ? undefined : `Nakamoto ${Math.round(emissionNakamoto)}`,
+      // Domain-prefix the emission Nakamoto coefficient so it doesn't read as a
+      // second, conflicting value for the separate stake "Nakamoto" tile.
+      hint:
+        emissionNakamoto == null ? undefined : `emission Nakamoto ${Math.round(emissionNakamoto)}`,
       tone: giniTone(emission?.gini),
     },
   ];


### PR DESCRIPTION
## Summary

Fixes the Network Decentralization scorecard's **Emission Gini** tile, whose hint read `Nakamoto 118` — the same number-label pair as the separate **Nakamoto** tile (`105`) two tiles over, so the panel showed two different figures both labelled "Nakamoto."

The hint carries the *emission* Nakamoto coefficient — a real, distinct metric with no tile of its own — so the value isn't wrong, but the bare "Nakamoto" label is ambiguous next to the stake Nakamoto tile. Domain-prefix it to `emission Nakamoto 118`, matching the sibling **Stake Gini** tile's existing `emission 0.899` hint convention.

## Change

- `network-decentralization.ts`: the emission-gini tile hint `` `Nakamoto ${n}` `` → `` `emission Nakamoto ${n}` ``.
- `network-decentralization.test.ts`: asserts the emission-gini tile's value + disambiguated hint (fails on the old `Nakamoto 118`, passes on the fix).

## Validation (local)

- `vitest run` — 75 files / 522 tests pass, including the new assertion (verified to fail before the one-line fix).
- `tsc --noEmit`, `eslint`, and `prettier --check` are clean on the changed files.

Closes #3950
