### PR TITLE
fix(ui): auto-build packages/client before typecheck

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -15,6 +15,7 @@
     "build:dev": "vite build --mode development",
     "preview": "vite preview",
     "lint": "eslint .",
+    "pretypecheck": "npm run build:client",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary
- Adds a `pretypecheck` script to `apps/ui/package.json` (`npm run build:client`, reusing the existing script) so `npm run typecheck` is self-sufficient regardless of what ran before it.

Closes #4504 (the `.nvmrc` half of this issue already shipped in #4505; this is the remaining typecheck half).

## What I found — one root cause, not two bugs
The issue as filed described two "pre-existing typecheck errors." Root-caused before fixing anything: `apps/ui` imports types from `@jsonbored/metagraphed`, but only that package's runtime JS is committed — `packages/client/dist/index.d.ts` is gitignored by design (regenerated by `npm run build --workspace=packages/client`). Without that build having run, `tsc` can't resolve the import at all, which cascades into two seemingly-unrelated errors: a missing-declaration-file error on the import itself, and an implicit-any indexing error wherever that type gets used downstream (`HEALTH_STATUS_TO_STATE[status]` in `queries.ts`).

Confirmed by building `packages/client` and re-running typecheck (clean, 0 errors), then deleting `dist/index.d.ts` again and confirming both errors reappear identically. There's no actual type error in the source — CI never sees this because the `ui` job's "Build packages/client (drift check)" step always runs before "Typecheck." A contributor running `npm run typecheck --workspace=apps/ui` locally without already knowing to build `packages/client` first does.

## Why a `pretypecheck` hook instead of just documenting the prerequisite
Docs get skipped. This makes the actual failure mode structurally impossible instead of relying on a contributor having read the right paragraph first.

## Test plan
- [x] Deleted `packages/client/dist/index.d.ts` + `index.d.cts` (simulating a fresh clone before anyone's built it) — `npm run typecheck --workspace=apps/ui` from repo root auto-rebuilds and passes clean
- [x] Same test run directly from within `apps/ui/` (`cd apps/ui && npm run typecheck`) — also self-heals and passes
- [x] `npm run lint` / `npm run format:check` (`apps/ui`) clean — 0 errors (196 pre-existing warnings, untouched)
- [x] `git status` after the rebuild confirms no unintended diff — `packages/client/dist`'s committed runtime files (`index.js`/`index.cjs`) are byte-identical after rebuild; only `index.d.ts`/`index.d.cts` regenerate, and those are gitignored
