### PR TITLE
fix(api): cache runtime HEAD requests

### DIFF
--- a/tests/runtime-versions.test.mjs
+++ b/tests/runtime-versions.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { afterEach, describe, test } from "vitest";
 
 import {
   buildRuntimeVersionHistory,
@@ -169,6 +169,12 @@ function runtimeEnv(
   captured.calls = calls;
   return {
     ...createLocalArtifactEnv(),
+    METAGRAPH_CONTROL: {
+      async get(key, options) {
+        if (key !== "health:meta" || options?.type !== "json") return null;
+        return { last_run_at: "2026-07-09T00:00:00.000Z" };
+      },
+    },
     METAGRAPH_HEALTH_DB: {
       prepare(sql) {
         return {
@@ -182,6 +188,30 @@ function runtimeEnv(
     },
   };
 }
+
+function installRuntimeCache() {
+  const store = new Map();
+  const puts = [];
+  const matches = [];
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        matches.push(request.url);
+        return store.get(request.url)?.clone();
+      },
+      async put(request, response) {
+        puts.push(request.url);
+        store.set(request.url, response.clone());
+      },
+    },
+  };
+  return { matches, puts, store };
+}
+
+let originalCaches;
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
 
 describe("GET /api/v1/runtime via the Worker", () => {
   test("returns the transition timeline for a warm D1", async () => {
@@ -248,6 +278,52 @@ describe("GET /api/v1/runtime via the Worker", () => {
       ctx,
     );
     assert.equal(res.status, 400);
+  });
+
+  test("HEAD shares and warms the GET edge cache before stripping the body", async () => {
+    originalCaches = globalThis.caches;
+    const cache = installRuntimeCache();
+    const captured = {};
+    const env = runtimeEnv(
+      [transitionRow()],
+      [{ spec_version: 218 }],
+      captured,
+    );
+
+    const first = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/runtime", {
+        method: "HEAD",
+      }),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    assert.equal(await first.text(), "");
+    assert.equal(captured.calls.length, 2);
+    assert.equal(cache.matches.length, 1);
+    assert.equal(cache.puts.length, 1);
+
+    const second = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/runtime", {
+        method: "HEAD",
+      }),
+      env,
+      ctx,
+    );
+    assert.equal(second.status, 200);
+    assert.equal(await second.text(), "");
+    assert.equal(captured.calls.length, 2);
+    assert.equal(cache.matches.length, 2);
+
+    const get = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/runtime"),
+      env,
+      ctx,
+    );
+    const body = await get.json();
+    assert.equal(body.data.current_spec_version, 218);
+    assert.equal(captured.calls.length, 2);
   });
 
   test("testnet has no variant (mainnet-only blocks D1 tier)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2301,9 +2301,23 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       return handleGovernanceConfigChanges(request, env, resolved.url);
     }
     if (RUNTIME_VERSIONS_PATH_PATTERN.test(resolved.url.pathname)) {
-      return withEdgeCache(request, ctx, env, "runtime-versions", () =>
-        handleRuntime(request, env, resolved.url),
+      const cacheRequest =
+        request.method === "HEAD"
+          ? new Request(request, { method: "GET" })
+          : request;
+      const response = await withEdgeCache(
+        cacheRequest,
+        ctx,
+        env,
+        "runtime-versions",
+        () => handleRuntime(cacheRequest, env, resolved.url),
       );
+      return request.method === "HEAD"
+        ? new Response(null, {
+            status: response.status,
+            headers: response.headers,
+          })
+        : response;
     }
     if (resolved.url.pathname === "/api/v1/incidents") {
       return withEdgeCache(request, ctx, env, "global-incidents", () =>


### PR DESCRIPTION
### Motivation
- The public `GET /api/v1/runtime` handler executed an unbounded D1 `GROUP BY` on every uncached request and `HEAD` requests bypassed the edge cache, allowing repeated HEAD polling to re-run the expensive aggregate and amplify D1 cost/availability pressure.

### Description
- Normalize `HEAD` requests for the runtime route by converting them to a `GET` for the `withEdgeCache` path so the edge cache is used and warmed when appropriate, then strip the body to preserve `HEAD` semantics; change localized in `workers/api.mjs` using a `cacheRequest` passed to `withEdgeCache` and `handleRuntime`.
- Add a test-time cache stub and health metadata fixture so runtime cache behavior is testable, and add a regression test that asserts a first `HEAD` warms the cache, subsequent `HEAD`s hit the cache and do not increase D1 calls, and a later `GET` reuses the cached payload; changes in `tests/runtime-versions.test.mjs`.
- No changes to the runtime query SQL or runtime loader were made; the fix bounds the public surface by ensuring `HEAD` requests reuse the same edge-cache entry as `GET`.

### Testing
- Ran `npm test -- tests/runtime-versions.test.mjs` and the runtime test suite passed (all tests in that file succeeded). 
- Ran `npm run lint` and `git diff --check` locally with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3ea82b70832cb201ef71d0bda156)