### PR TITLE
fix(ui): use the real maintainer-reviewed curation value in the "Curated" mega-menu link

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
@@ -49,6 +49,29 @@ describe("MEGA_PANELS catalogue", () => {
       }
     }
   });
+
+  it("every curation filter link targets a real curation level", () => {
+    // The only curation values subnets.index.tsx actually matches are the
+    // levels enumerated in chips.tsx `curationLabel`. A link with any other
+    // value (e.g. the former "verified") matches zero rows and silently
+    // renders the full unfiltered list instead of filtering.
+    const VALID_CURATION_LEVELS = new Set([
+      "native",
+      "candidate-discovered",
+      "community-seeded",
+      "machine-verified",
+      "maintainer-reviewed",
+      "adapter-backed",
+    ]);
+    for (const p of MEGA_PANELS) {
+      for (const l of [...p.browse, ...p.filters]) {
+        const curation = l.search?.curation;
+        if (curation !== undefined) {
+          expect(VALID_CURATION_LEVELS.has(curation)).toBe(true);
+        }
+      }
+    }
+  });
 });
 
 describe("storage helpers (SSR/node-safe)", () => {

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -31,7 +31,7 @@ export const MEGA_PANELS: MegaPanel[] = [
       { to: "/subnets", label: "All subnets", hint: "Browse every active netuid" },
       {
         to: "/subnets",
-        search: { curation: "verified" },
+        search: { curation: "maintainer-reviewed" },
         label: "Curated",
         hint: "Maintainer-reviewed",
       },


### PR DESCRIPTION
## Summary

The primary nav mega-menu's "Curated" link pointed at `/subnets?curation=verified`, but `verified` is not one of the real curation levels (`native` / `candidate-discovered` / `community-seeded` / `machine-verified` / `maintainer-reviewed` / `adapter-backed`). As a result the link matched **0 of 129** subnets — clicking "Curated" produced an empty list — while the adjacent "Machine-verified" link (which uses a real value) worked correctly.

This points the "Curated" link at the real `maintainer-reviewed` value (the level whose chip label is "Reviewed"), so it now filters `/subnets` to the maintainer-reviewed subnets. One-line value change plus a small regression test.

## What changed

- `apps/ui/src/components/metagraphed/nav-mega-menu-data.ts` — the "Curated" browse link's `curation` search value: `verified` → `maintainer-reviewed`. The adjacent "Machine-verified" link is untouched.
- `apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts` — a new test asserting every mega-menu `curation` filter link targets a real curation level (mirrors `chips.tsx`'s `curationLabel`), so an invalid value like `verified` can't silently regress.

## Screenshots

Before = the old link's target (`?curation=verified`) → **0 of 129** (empty). After = the fixed link's target (`?curation=maintainer-reviewed`) → the subnets, each shown as **REVIEWED**.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-light.png)<br><sub>0 of 129</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-light.png)<br><sub>reviewed</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-desktop-dark.png)<br><sub>0 of 129</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-desktop-dark.png)<br><sub>reviewed</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-light.png)<br><sub>0 of 129</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-light.png)<br><sub>reviewed</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-tablet-dark.png)<br><sub>0 of 129</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-tablet-dark.png)<br><sub>reviewed</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-light.png)<br><sub>0 of 129</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-light.png)<br><sub>reviewed</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/before-mobile-dark.png)<br><sub>0 of 129</sub> | [<img src="https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dalledajay-coder/metagraphed/screenshots/after-mobile-dark.png)<br><sub>reviewed</sub> |

## Validation

Scoped to `apps/ui`, ran locally (Node 22):

- `npm run lint --workspace=apps/ui` — 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean (after `npm run build --workspace=packages/client`)
- `npm test --workspace=apps/ui` — the new assertion passes
- `npm run build --workspace=apps/ui` — succeeds

Closes #3974
