### PR TITLE
fix(api): replace node:crypto blake2b512 with @noble/hashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "packages/contract"
       ],
       "dependencies": {
+        "@noble/hashes": "^2.2.0",
         "graphql": "^17.0.2",
         "postgres": "^3.4.9",
         "workers-og": "^0.0.27"
@@ -2449,6 +2450,18 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
   },
   "dependencies": {
+    "@noble/hashes": "^2.2.0",
     "graphql": "^17.0.2",
     "postgres": "^3.4.9",
     "workers-og": "^0.0.27"

--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -1,7 +1,15 @@
 // Live finney account TAO balance (free + reserved) via RPC (#1818).
 // Shared by GET /api/v1/accounts/{ss58}/balance and MCP get_account_balance.
 
-import { createHash } from "node:crypto";
+// node:crypto's createHash("blake2b512") is NOT implemented in the Cloudflare
+// Workers runtime (confirmed live: throws "Error: Digest method not
+// supported" in workerd, even though the identical call works fine under
+// Node.js/vitest, which run this code against real Node -- the local/CI test
+// suite never caught this because it never runs against workerd). Web
+// Crypto's SubtleCrypto.digest() has no BLAKE2b algorithm either. @noble/hashes
+// is audited, zero-dependency, pure JS, and verified working in workerd
+// (wrangler dev) with output identical to node:crypto's blake2b512.
+import { blake2b } from "@noble/hashes/blake2.js";
 
 const SS58_BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -51,9 +59,10 @@ function verifyFinneySs58Checksum(decoded) {
   const checksum = decoded.subarray(
     decoded.length - FINNEY_SS58_CHECKSUM_LENGTH,
   );
-  const hash = createHash("blake2b512")
-    .update(Buffer.concat([Buffer.from(SS58_PREIMAGE), Buffer.from(body)]))
-    .digest();
+  const preimage = new Uint8Array(SS58_PREIMAGE.length + body.length);
+  preimage.set(SS58_PREIMAGE, 0);
+  preimage.set(body, SS58_PREIMAGE.length);
+  const hash = blake2b(preimage, { dkLen: 64 });
   return hash[0] === checksum[0] && hash[1] === checksum[1];
 }
 

--- a/src/sudo-key.mjs
+++ b/src/sudo-key.mjs
@@ -7,7 +7,14 @@
 // computed at runtime. Mirrors src/account-balance.mjs's live-RPC + KV-cache
 // shape for GET /api/v1/accounts/{ss58}/balance.
 
-import { createHash } from "node:crypto";
+// node:crypto's createHash("blake2b512") is NOT implemented in the Cloudflare
+// Workers runtime (confirmed live in production: this same call throws
+// "Error: Digest method not supported" in workerd -- account-balance.mjs's
+// GET /api/v1/accounts/{ss58}/balance, which had the identical pattern, was
+// 500ing on every request for exactly this reason). @noble/hashes is
+// audited, zero-dependency, pure JS, and verified working in workerd
+// (wrangler dev) with output identical to node:crypto's blake2b512.
+import { blake2b } from "@noble/hashes/blake2.js";
 
 const SUDO_KEY_STORAGE_KEY =
   "0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b";
@@ -42,16 +49,15 @@ function encodeBase58(bytes) {
 // bytes, checksum = blake2b512("SS58PRE" + payload)[0:2], address =
 // base58(payload + checksum). The exact inverse of account-balance.mjs's
 // verifyFinneySs58Checksum (decode direction) — golden-value-tested against
-// the live-confirmed 2026-07-08 Sudo key in tests/sudo-key.test.mjs. Uses
-// node:crypto's blake2b512 like account-balance.mjs — Web Crypto's
-// SubtleCrypto.digest() has no BLAKE2b algorithm.
+// the live-confirmed 2026-07-08 Sudo key in tests/sudo-key.test.mjs.
 function ss58Encode(accountIdBytes, prefix = FINNEY_SS58_PREFIX) {
   const payload = new Uint8Array(1 + accountIdBytes.length);
   payload[0] = prefix;
   payload.set(accountIdBytes, 1);
-  const hash = createHash("blake2b512")
-    .update(Buffer.concat([Buffer.from(SS58_PREIMAGE), Buffer.from(payload)]))
-    .digest();
+  const preimage = new Uint8Array(SS58_PREIMAGE.length + payload.length);
+  preimage.set(SS58_PREIMAGE, 0);
+  preimage.set(payload, SS58_PREIMAGE.length);
+  const hash = blake2b(preimage, { dkLen: 64 });
   const full = new Uint8Array(payload.length + 2);
   full.set(payload, 0);
   full[payload.length] = hash[0];


### PR DESCRIPTION
## Summary
- Adds `@noble/hashes` (audited, zero-dependency, pure JS) as a dependency
- `src/account-balance.mjs` and `src/sudo-key.mjs` both switch their SS58 checksum blake2b512 hashing from `node:crypto`'s `createHash` to `@noble/hashes/blake2.js`'s `blake2b`

## Root cause
Cloudflare Workers' `node:crypto` polyfill does not implement `blake2b512`. `GET /api/v1/accounts/{ss58}/balance` was 500ing on every single request in production — confirmed against multiple different addresses, 100% reproducible, not address-specific. `isFinneySs58Address` (called unguarded at the very top of the handler, before any try/catch) calls `verifyFinneySs58Checksum`, which calls `createHash("blake2b512")` — this throws synchronously in the real Workers runtime.

Confirmed the exact mechanism against the real runtime, not just theorized: built a minimal standalone Worker and ran it under `wrangler dev` (actual `workerd`, not Node/vitest). `createHash("blake2b512")` throws `Error: Digest method not supported` there, while the identical call works fine under plain Node.js — which is exactly why this was never caught: `vitest.config.ts` uses `environment: "node"`, so the existing test suite runs against real Node (where blake2b512 works via OpenSSL) and never exercises the actual Workers runtime.

`src/sudo-key.mjs` had the identical pattern — its own comment noted "Web Crypto's SubtleCrypto.digest() has no BLAKE2b algorithm" (correctly ruling out Web Crypto) but assumed `node:crypto` had it in Workers (it doesn't). `GET /api/v1/network/sudo-key` was broken the same way.

## Why `@noble/hashes`
Considered hand-rolling BLAKE2b (the rest of this codebase hand-rolls its own base58 encode/decode, deliberately avoiding heavy dependencies) but decided against it — a hand-written hash primitive under time pressure is exactly the kind of thing worth getting from an audited source instead. `@noble/hashes` is zero-dependency, small, and explicitly built to be portable across environments including Workers/edge runtimes.

## Test plan
- [x] Verified `@noble/hashes`'s `blake2b(..., { dkLen: 64 })` output is byte-identical to `node:crypto`'s `createHash("blake2b512")` for the same input
- [x] Verified in the real Workers runtime (`wrangler dev`, not Node): a minimal worker importing the fixed `account-balance.mjs` correctly validates a real SS58 address (`true`) and rejects a garbage string (`false`) — no crash
- [x] `npx vitest run tests/account-balance-loader.test.mjs tests/sudo-key.test.mjs` — 21/21 pass unchanged, confirming checksum output matches the old implementation (golden-value tested against a live-confirmed real address/sudo key)
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run worker:bundle:budget` — 952.7 KiB gzipped, still comfortably under the 1000 KiB fail threshold
