### PR TITLE
fix(subnet-detail): route the #activity hash link to the Activity tab

### DIFF
--- a/apps/ui/src/lib/metagraphed/subnet-detail-tabs.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-detail-tabs.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+
+import { TABS, SECTION_TO_TAB } from "./subnet-detail-tabs";
+
+describe("subnet-detail tab routing", () => {
+  const tabIds = new Set<string>(TABS.map((t) => t.id));
+
+  it("routes the #activity anchor to the Activity tab", () => {
+    // Without this mapping, /subnets/N#activity — including the Activity panel's
+    // own "copy link" button — silently fails to switch tabs (#3978).
+    expect(SECTION_TO_TAB.activity).toBe("activity");
+  });
+
+  it("maps every section anchor to a declared tab", () => {
+    // A section anchor pointing at a tab id that isn't in TABS can never be
+    // resolved by useHashScroll, so its deep link is dead on arrival.
+    for (const [section, tab] of Object.entries(SECTION_TO_TAB)) {
+      expect(tabIds.has(tab), `section "${section}" → unknown tab "${tab}"`).toBe(true);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-detail-tabs.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-detail-tabs.ts
@@ -1,0 +1,52 @@
+// Pure config for the subnet-detail route (`subnets.$netuid.tsx`): the tab bar
+// definition and the section-anchor → owning-tab routing that drives cross-tab
+// deep links (a `/subnets/N#section` hash resolves to the tab that owns the
+// section and scrolls to it). Kept framework-free (no React) so the deep-link
+// routing table can be unit tested — every section anchor must resolve to a
+// real tab, or its hash link (including the panels' own "copy link" buttons)
+// silently fails to switch tabs.
+
+export const TABS = [
+  { id: "overview", label: "Overview" },
+  { id: "metagraph", label: "Metagraph" },
+  { id: "validators", label: "Validators" },
+  { id: "activity", label: "Activity" },
+  { id: "identity", label: "Identity history" },
+  { id: "hyperparameters", label: "Hyperparameters" },
+  { id: "services", label: "Callable services" },
+  { id: "surfaces", label: "Surfaces" },
+  { id: "endpoints", label: "Endpoints" },
+  { id: "schemas", label: "Schemas" },
+  { id: "candidates", label: "Candidates" },
+  { id: "gaps", label: "Gaps" },
+  { id: "evidence", label: "Evidence" },
+  { id: "api", label: "API" },
+] as const;
+
+// Which tab does each section anchor live under? Drives cross-tab deep links.
+export const SECTION_TO_TAB: Record<string, string> = {
+  "endpoints-glance": "overview",
+  "health-trends": "overview",
+  incidents: "overview",
+  economics: "overview",
+  reliability: "overview",
+  lineage: "overview",
+  evidence: "overview",
+  metagraph: "metagraph",
+  neuron: "metagraph",
+  concentration: "metagraph",
+  yield: "metagraph",
+  turnover: "metagraph",
+  validators: "validators",
+  activity: "activity",
+  identity: "identity",
+  hyperparameters: "hyperparameters",
+  services: "services",
+  "agent-readiness": "services",
+  surfaces: "surfaces",
+  endpoints: "endpoints",
+  "schema-drift": "schemas",
+  candidates: "candidates",
+  gaps: "gaps",
+  api: "api",
+};

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { TABS, SECTION_TO_TAB } from "@/lib/metagraphed/subnet-detail-tabs";
 import { TableState } from "@/components/metagraphed/table-state";
 import type {
   AccountEvent,
@@ -145,50 +146,6 @@ export const Route = createFileRoute("/subnets/$netuid")({
     </AppShell>
   ),
 });
-
-const TABS = [
-  { id: "overview", label: "Overview" },
-  { id: "metagraph", label: "Metagraph" },
-  { id: "validators", label: "Validators" },
-  { id: "activity", label: "Activity" },
-  { id: "identity", label: "Identity history" },
-  { id: "hyperparameters", label: "Hyperparameters" },
-  { id: "services", label: "Callable services" },
-  { id: "surfaces", label: "Surfaces" },
-  { id: "endpoints", label: "Endpoints" },
-  { id: "schemas", label: "Schemas" },
-  { id: "candidates", label: "Candidates" },
-  { id: "gaps", label: "Gaps" },
-  { id: "evidence", label: "Evidence" },
-  { id: "api", label: "API" },
-] as const;
-
-// Which tab does each section anchor live under? Drives cross-tab deep links.
-const SECTION_TO_TAB: Record<string, string> = {
-  "endpoints-glance": "overview",
-  "health-trends": "overview",
-  incidents: "overview",
-  economics: "overview",
-  reliability: "overview",
-  lineage: "overview",
-  evidence: "overview",
-  metagraph: "metagraph",
-  neuron: "metagraph",
-  concentration: "metagraph",
-  yield: "metagraph",
-  turnover: "metagraph",
-  validators: "validators",
-  identity: "identity",
-  hyperparameters: "hyperparameters",
-  services: "services",
-  "agent-readiness": "services",
-  surfaces: "surfaces",
-  endpoints: "endpoints",
-  "schema-drift": "schemas",
-  candidates: "candidates",
-  gaps: "gaps",
-  api: "api",
-};
 
 function SubnetDetailPage() {
   const { netuid } = Route.useParams();


### PR DESCRIPTION
## Summary

Fixes #3978 — following a `/subnets/N#activity` hash link (including the one the Activity panel's own "copy link" button generates) silently failed to switch to the Activity tab.

`subnets.$netuid.tsx`'s `SECTION_TO_TAB` map — which `useHashScroll` uses to resolve an incoming hash to its owning tab — had no `activity` entry, even though the page defines an `activity` tab and wraps `ActivityPanel` in `<SectionAnchor id="activity">`. So that anchor couldn't resolve to a tab, and the deep link was dead on arrival.

## Change

- Adds the missing `activity: "activity"` mapping.
- Extracts the tab table (`TABS`) and section→tab routing (`SECTION_TO_TAB`) out of the route component into a framework-free module, `lib/metagraphed/subnet-detail-tabs.ts`, so the deep-link routing can be unit-tested — the suite is explicitly designed for "pure modules under `src/lib/metagraphed`" and Codecov gates patch coverage. The route imports them unchanged (no behavior change beyond the added mapping).
- Adds `subnet-detail-tabs.test.ts`: asserts the `#activity` anchor resolves to the Activity tab (fails without the mapping), and — to guard the whole class of dead deep links — that every section anchor maps to a declared tab.

## Validation (local)

- `vitest run` — 76 files / 524 tests pass, including the two new guards (verified to fail before the mapping is added).
- `tsc --noEmit`, `eslint` (0 errors), and `prettier --check` are clean on the changed files.

Closes #3978
