### PR TITLE
fix(ui): parallelize explorer's 9 suspense queries, fixing a ~33s page load

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useInfiniteQuery, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useSuspenseQueries } from "@tanstack/react-query";
 import { Suspense, useMemo, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -614,15 +614,47 @@ function ExplorerDashboard() {
   const navigate = useNavigate({ from: Route.fullPath });
   const win = search.window;
 
-  const activity = useSuspenseQuery(chainActivityQuery(win)).data.data;
-  const fees = useSuspenseQuery(chainFeesQuery(win)).data.data;
-  const calls = useSuspenseQuery(chainCallsQuery(win)).data.data;
-  const signers = useSuspenseQuery(chainSignersQuery(win)).data.data;
-  const stakeFlow = useSuspenseQuery(chainStakeFlowQuery(win)).data.data;
-  const stakeMoves = useSuspenseQuery(chainStakeMovesQuery(win)).data.data;
-  const turnover = useSuspenseQuery(chainTurnoverQuery(win)).data.data;
-  const stakeTransfers = useSuspenseQuery(chainStakeTransfersQuery(win)).data.data;
-  const eventMix = useSuspenseQuery(chainEventsStatsQuery()).data.data;
+  // A single batched useSuspenseQueries, not 9 individual useSuspenseQuery
+  // calls: each individual call suspends the component separately, so on a
+  // cold cache (in particular during SSR) React re-renders and re-suspends
+  // once per query, resolving them in a serial waterfall instead of parallel
+  // -- 9 queries at ~5s each measured as a genuine ~33s page load in
+  // production, not a hang (confirmed by testing each endpoint standalone,
+  // all fast, and the full page eventually completing at ~33s with a longer
+  // timeout). useSuspenseQueries fires all 9 fetches concurrently and
+  // suspends once, so the page waits on the slowest single query, not the sum.
+  const [
+    { data: activityRes },
+    { data: feesRes },
+    { data: callsRes },
+    { data: signersRes },
+    { data: stakeFlowRes },
+    { data: stakeMovesRes },
+    { data: turnoverRes },
+    { data: stakeTransfersRes },
+    { data: eventMixRes },
+  ] = useSuspenseQueries({
+    queries: [
+      chainActivityQuery(win),
+      chainFeesQuery(win),
+      chainCallsQuery(win),
+      chainSignersQuery(win),
+      chainStakeFlowQuery(win),
+      chainStakeMovesQuery(win),
+      chainTurnoverQuery(win),
+      chainStakeTransfersQuery(win),
+      chainEventsStatsQuery(),
+    ],
+  });
+  const activity = activityRes.data;
+  const fees = feesRes.data;
+  const calls = callsRes.data;
+  const signers = signersRes.data;
+  const stakeFlow = stakeFlowRes.data;
+  const stakeMoves = stakeMovesRes.data;
+  const turnover = turnoverRes.data;
+  const stakeTransfers = stakeTransfersRes.data;
+  const eventMix = eventMixRes.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
   const chrono = [...activity.days].reverse();

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -42,5 +42,13 @@
   ],
   "/settings@768": ["DIV:flex items-center gap-1"],
   "/settings@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],
-  "/settings@1280": ["DIV:flex items-center gap-1"]
+  "/settings@1280": ["DIV:flex items-center gap-1"],
+  "/explorer@375": [
+    "DIV:flex items-center gap-1",
+    "DIV:flex items-center gap-1.5",
+    "DIV:flex-1 flex justify-end"
+  ],
+  "/explorer@768": ["DIV:flex items-center gap-1"],
+  "/explorer@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],
+  "/explorer@1280": ["DIV:flex items-center gap-1"]
 }

--- a/apps/ui/tests/e2e/overflow-check.config.js
+++ b/apps/ui/tests/e2e/overflow-check.config.js
@@ -1,12 +1,7 @@
 // Shared between responsive-overflow.spec.ts and generate-overflow-baseline.mjs
 // so the two can't silently drift apart.
 //
-// /explorer deliberately excluded: its default query params
-// (?window=7d&pallet=&method=&events_cursor=) never return a response at all
-// in local dev (confirmed with curl and Playwright's earliest "commit"
-// navigation signal, both hang past 15-45s) -- a real, separate finding, not
-// something this check can route around. Re-add once that's resolved.
-export const ROUTES = ["/", "/subnets/1", "/endpoints", "/status", "/settings"];
+export const ROUTES = ["/", "/subnets/1", "/endpoints", "/status", "/settings", "/explorer"];
 
 export const VIEWPORTS = [
   { name: "mobile", width: 375, height: 812 },


### PR DESCRIPTION
## Summary
- `apps/ui/src/routes/explorer.tsx`: replaces 9 individual `useSuspenseQuery` calls with a single batched `useSuspenseQueries` call
- Re-adds `/explorer` to the #4502 responsive-overflow e2e route list (it was excluded there specifically because of this bug — see that PR's history) and regenerates the baseline now that the route actually loads

No visual change — same data, same rendered output, only the loading behavior changes. Not applicable: before/after screenshot table.

## What I found
Investigating a reported "`/explorer` never responds, even a 45s curl times out" finding from building #4502. Confirmed it reproduces in **production** too (`metagraph.sh/explorer`), not just local dev — this was a real, live bug, not a dev-server artifact.

Traced it: `explorer.tsx` has no route `loader` (so it's not blocking SSR the way a loader would), but `ExplorerDashboard` calls 9 separate `useSuspenseQuery` hooks back-to-back (`chainActivityQuery`, `chainFeesQuery`, `chainCallsQuery`, `chainSignersQuery`, `chainStakeFlowQuery`, `chainStakeMovesQuery`, `chainTurnoverQuery`, `chainStakeTransfersQuery`, `chainEventsStatsQuery`). Each one suspends the component individually — on a cold cache (in particular during SSR), React re-renders and re-suspends once per query as each prior one resolves, resolving them in a serial waterfall rather than concurrently. This is a well-known React Query pitfall with multiple sibling `useSuspenseQuery` calls in one component.

Verified every step of this rather than assuming:
- Every one of the 9 underlying `/api/v1/chain/*` endpoints responds fine standalone (0.5–7s each, tested directly)
- It's not actually infinite: `curl --max-time 120` against production completes in **33.5s**. Every shorter timeout I'd tried during investigation (15s, 30s, 45s) looked identical to a hang from outside, which is why it initially got reported as "never responds"
- 9 sequential ~5s calls ≈ the ~33s measured — consistent with a waterfall, not a stuck/dead request

## Fix
`useSuspenseQueries({ queries: [...] })` fires all 9 fetches concurrently and suspends the component once, bounded by the slowest single query instead of their sum.

## Test plan
- [x] `npm run typecheck --workspace=apps/ui` clean
- [x] Local dev, before the fix: page load ~consistent with the production waterfall pattern. After the fix: **10.4s** (some of the remaining gap vs. an ideal ~7s is local-network-to-live-API variance, not part of this fix)
- [x] `npm run test:e2e --workspace=apps/ui` — 24/24 pass, including 4 new `/explorer` cases (re-added to the route list now that it loads; each completes in ~8s, well within Playwright's defaults)
- [x] `npm run lint && npm run format:check` (`apps/ui`) clean
