### PR TITLE
fix(api): reject out-of-range recycled netuids

### DIFF
--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18604,6 +18604,7 @@
         "description": "Live cumulative TAO recycled for registration on one subnet (#4339/8.4), queried from the chain's own RAORecycledForRegistration storage map at request time and cached for 600s. recycled_tao is null on RPC failure; a subnet with zero registrations reads back a real 0, not null.",
         "properties": {
           "netuid": {
+            "maximum": 65535,
             "minimum": 0,
             "type": "integer"
           },
@@ -47305,6 +47306,7 @@
             "name": "netuid",
             "required": true,
             "schema": {
+              "maximum": 65535,
               "minimum": 0,
               "type": "integer"
             }

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -18582,6 +18582,7 @@
         "description": "Live cumulative TAO recycled for registration on one subnet (#4339/8.4), queried from the chain's own RAORecycledForRegistration storage map at request time and cached for 600s. recycled_tao is null on RPC failure; a subnet with zero registrations reads back a real 0, not null.",
         "properties": {
           "netuid": {
+            "maximum": 65535,
             "minimum": 0,
             "type": "integer"
           },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -3530,7 +3530,7 @@
         "required": ["schema_version", "netuid"],
         "properties": {
           "schema_version": { "type": "integer" },
-          "netuid": { "type": "integer", "minimum": 0 },
+          "netuid": { "type": "integer", "minimum": 0, "maximum": 65535 },
           "recycled_tao": { "type": ["number", "null"] },
           "queried_at": { "type": ["string", "null"], "format": "date-time" }
         }

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2918,7 +2918,12 @@ export const API_ROUTES = [
     "short",
     ["subnets"],
     [],
-    [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+    [
+      {
+        name: "netuid",
+        schema: { type: "integer", minimum: 0, maximum: 65535 },
+      },
+    ],
   ),
   route(
     "blocks-feed",

--- a/src/subnet-recycled.mjs
+++ b/src/subnet-recycled.mjs
@@ -36,6 +36,7 @@
 export const RECYCLED_KV_TTL = 600; // seconds — a registration-count counter, not a live price
 export const RECYCLED_NEGATIVE_KV_TTL = 10; // seconds
 export const RECYCLED_RPC_TIMEOUT_MS = 5000;
+export const MAX_U16_NETUID = 65535;
 const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
 
 // twox128("SubtensorModule") ++ twox128("RAORecycledForRegistration").
@@ -44,9 +45,18 @@ const RECYCLED_STORAGE_KEY_PREFIX =
 
 // netuid (0..65535) as a u16, little-endian, 2 hex bytes — the Identity-hashed
 // map-key suffix appended to the fixed prefix above.
+export function isU16Netuid(netuid) {
+  return Number.isInteger(netuid) && netuid >= 0 && netuid <= MAX_U16_NETUID;
+}
+
 function netuidStorageKeySuffix(netuid) {
-  const lo = (netuid & 0xff).toString(16).padStart(2, "0");
-  const hi = ((netuid >> 8) & 0xff).toString(16).padStart(2, "0");
+  if (!isU16Netuid(netuid)) {
+    throw new RangeError("netuid must be an integer in the u16 range 0..65535");
+  }
+  const lo = (netuid % 256).toString(16).padStart(2, "0");
+  const hi = Math.floor(netuid / 256)
+    .toString(16)
+    .padStart(2, "0");
   return lo + hi;
 }
 
@@ -77,6 +87,10 @@ function raoToTao(rao) {
 // registrations reads back the chain's own 0x00...0 ValueQuery default,
 // decoding to a real 0, not null.
 export async function loadSubnetRecycled(env, netuid) {
+  if (!isU16Netuid(netuid)) {
+    throw new RangeError("netuid must be an integer in the u16 range 0..65535");
+  }
+
   const cacheKey = `recycled:${netuid}`;
   const kv = env?.METAGRAPH_CONTROL;
 

--- a/tests/subnet-recycled.test.mjs
+++ b/tests/subnet-recycled.test.mjs
@@ -196,6 +196,34 @@ describe("loadSubnetRecycled", () => {
     }
   });
 
+  test("rejects out-of-range netuids before KV or RPC work", async () => {
+    let kvReads = 0;
+    let fetchCalls = 0;
+    const env = {
+      METAGRAPH_CONTROL: {
+        get: async () => {
+          kvReads += 1;
+          return null;
+        },
+      },
+    };
+
+    await withFetchStub(
+      async () => {
+        fetchCalls += 1;
+        throw new Error("should not fetch");
+      },
+      async () => {
+        await assert.rejects(
+          () => loadSubnetRecycled(env, 65536),
+          /0\.\.65535/,
+        );
+        assert.equal(kvReads, 0);
+        assert.equal(fetchCalls, 0);
+      },
+    );
+  });
+
   test("KV cache key is scoped per netuid", async () => {
     let sawKey;
     const env = {
@@ -400,6 +428,65 @@ describe("GET /api/v1/subnets/{netuid}/recycled via the Worker", () => {
         assert.equal(res.status, 200);
         const body = await res.json();
         assert.equal(body.data.recycled_tao, null);
+      },
+    );
+  });
+
+  test("rejects out-of-range u16 netuids before rate limiting or RPC fetch", async () => {
+    let limiterCalls = 0;
+    let fetchCalls = 0;
+    const env = {
+      RPC_RATE_LIMITER: {
+        limit: async () => {
+          limiterCalls += 1;
+          return { success: true };
+        },
+      },
+    };
+
+    await withFetchStub(
+      async () => {
+        fetchCalls += 1;
+        throw new Error("should not fetch");
+      },
+      async () => {
+        const res = await handleRequest(
+          req("/api/v1/subnets/65536/recycled"),
+          env,
+          {},
+        );
+        assert.equal(res.status, 400);
+        const body = await res.json();
+        assert.equal(body.ok, false);
+        assert.equal(body.error.code, "invalid_netuid");
+        assert.match(body.error.message, /0\.\.65535/);
+        assert.equal(limiterCalls, 0);
+        assert.equal(fetchCalls, 0);
+      },
+    );
+  });
+
+  test("accepts the maximum u16 netuid", async () => {
+    let rpcStorageKey;
+    await withFetchStub(
+      async (_url, init) => {
+        const body = JSON.parse(init.body);
+        rpcStorageKey = body.params[0];
+        return {
+          ok: true,
+          json: async () => ({ result: GOLDEN_RAW_STORAGE }),
+        };
+      },
+      async () => {
+        const res = await handleRequest(
+          req("/api/v1/subnets/65535/recycled"),
+          {},
+          {},
+        );
+        assert.equal(res.status, 200);
+        const body = await res.json();
+        assert.equal(body.data.netuid, 65535);
+        assert.ok(rpcStorageKey.endsWith("ffff"));
       },
     );
   });

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -101,7 +101,7 @@ import {
   loadAccountBalance,
 } from "../../src/account-balance.mjs";
 import { loadSudoKey } from "../../src/sudo-key.mjs";
-import { loadSubnetRecycled } from "../../src/subnet-recycled.mjs";
+import { isU16Netuid, loadSubnetRecycled } from "../../src/subnet-recycled.mjs";
 import { loadRuntimeVersionHistory } from "../../src/runtime-versions.mjs";
 import { decodeCursor, encodeCursor } from "../../src/cursor.mjs";
 import {
@@ -3314,6 +3314,14 @@ export async function handleAccountBalance(request, env, ss58) {
 // ss58), so it shares that route's rate limiter rather than sudo-key's
 // no-limiter reasoning. recycled_tao is null on RPC failure (schema-stable).
 export async function handleSubnetRecycled(request, env, netuid) {
+  if (!isU16Netuid(netuid)) {
+    return errorResponse(
+      "invalid_netuid",
+      "netuid must be an integer in the u16 range 0..65535.",
+      400,
+    );
+  }
+
   if (env.RPC_RATE_LIMITER?.limit) {
     const { success } = await env.RPC_RATE_LIMITER.limit({
       key: `recycled:${resolveClientIp(request)}`,


### PR DESCRIPTION
### Motivation
- The `/api/v1/subnets/{netuid}/recycled` route accepted arbitrary decimal `netuid` values while the on-chain storage key uses a u16 suffix, allowing out-of-range aliases that bypass the intended per-subnet KV cache and confuse clients. 
- JavaScript bitwise operations silently truncated high bits when building the storage-key suffix, producing the wrong on-chain suffix for attacker-supplied out-of-range values. 
- The change must validate and reject non-integer / out-of-range netuids before any rate-limiter, KV, or RPC work to close the cache-bypass and integrity hole.

### Description
- Add a shared u16 guard: introduce `MAX_U16_NETUID = 65535` and `isU16Netuid(netuid)` in `src/subnet-recycled.mjs`, and make `netuidStorageKeySuffix` validate and throw on out-of-range inputs. 
- Enforce validation at the loader boundary by making `loadSubnetRecycled` reject non-u16 `netuid` values before touching KV or RPC. 
- Enforce validation at the Worker handler by returning `400 invalid_netuid` from `handleSubnetRecycled` before rate-limiter or RPC work in `workers/request-handlers/entities.mjs`. 
- Update the route/contract/schema/OpenAPI to document `netuid` as `integer` with `maximum: 65535` and regenerate artifacts (`src/contracts.mjs`, `schemas/components/05-subnets.schema.json`, `public/metagraph/openapi.json`).

### Testing
- Ran the unit tests for the feature with `npm test -- tests/subnet-recycled.test.mjs`, where the updated suite passed (`23 tests` passed). 
- Built the project with `npm run build`, and contract drift validation with `npm run validate:contract-drift` both succeeded. 
- Ran schema validation with `npm run validate:schemas` and formatting checks with `npm run format:check`, both of which passed. 
- Added regression tests covering loader-level rejection, route-level rejection before rate limiting/KV/RPC, and acceptance of the maximum u16 `netuid`, all exercised by the updated test file `tests/subnet-recycled.test.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5c89e96c832c92391c56eb1bb73e)