### PR TITLE
fix(scripts): fail empty hyperparameter discovery

### DIFF
--- a/scripts/fetch-subnet-hyperparams.py
+++ b/scripts/fetch-subnet-hyperparams.py
@@ -124,6 +124,11 @@ def main():
     captured_at = int(time.time() * 1000)
     rows = []
     errors = []
+    if not netuids:
+        # The downstream loader rejects empty snapshots; treat empty active-subnet
+        # discovery as a fetch failure so the refresh workflow alerts instead of
+        # signing and staging an unusable artifact.
+        errors.append("no active netuids discovered")
     for netuid in netuids:
         try:
             hp = s.subnets.get_subnet_hyperparameters(netuid=netuid)

--- a/scripts/test_fetch_subnet_hyperparams.py
+++ b/scripts/test_fetch_subnet_hyperparams.py
@@ -46,7 +46,7 @@ class _Hp:
 
 
 class FetchCompletenessTest(unittest.TestCase):
-    def run_main(self, responses):
+    def run_main(self, responses, infos=None):
         with tempfile.TemporaryDirectory() as tmp:
             out = os.path.join(tmp, "hyperparams.json")
 
@@ -54,12 +54,13 @@ class FetchCompletenessTest(unittest.TestCase):
                 def __init__(self, network):
                     self.network = network
                     self.substrate = types.SimpleNamespace(block_number=123)
+                    discovered_infos = (
+                        [_Info(1), _Info(2), _Info(99, mechid=1)]
+                        if infos is None
+                        else infos
+                    )
                     self.metagraphs = types.SimpleNamespace(
-                        get_all_metagraphs_info=lambda all_mechanisms: [
-                            _Info(1),
-                            _Info(2),
-                            _Info(99, mechid=1),
-                        ]
+                        get_all_metagraphs_info=lambda all_mechanisms: discovered_infos
                     )
 
                     def get_subnet_hyperparameters(netuid):
@@ -91,6 +92,11 @@ class FetchCompletenessTest(unittest.TestCase):
         code, rows = self.run_main({1: _Hp(), 2: None})
         self.assertEqual(code, 1)
         self.assertEqual([row["netuid"] for row in rows], [1])
+
+    def test_empty_active_netuid_discovery_fails_instead_of_signing_empty_snapshot(self):
+        code, rows = self.run_main({}, infos=[])
+        self.assertEqual(code, 1)
+        self.assertEqual(rows, [])
 
 
 class U16RatioTest(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- A recent change allowed an empty active-netuid discovery to write an empty JSON array and exit 0, which lets the workflow upload/sign/stage an unusable empty hyperparameter snapshot instead of alerting a failure. 
- The refresh job and downstream loader treat empty snapshots as invalid, so the fetcher should surface empty discovery as a fetch failure to trigger CI/alerts rather than silently succeed.

### Description
- In `scripts/fetch-subnet-hyperparams.py` add a guard that records an error when `netuids` is empty so the script exits non-zero instead of succeeding with `[]`.
- In `scripts/test_fetch_subnet_hyperparams.py` make the fake SDK discovery injectable and add a regression `test_empty_active_netuid_discovery_fails_instead_of_signing_empty_snapshot` that asserts the fetcher fails and writes an empty rows array.

### Testing
- Ran the unit tests with `python3 scripts/test_fetch_subnet_hyperparams.py` and `pytest`, and all tests passed. 
- Per-file diff/format checks (`git diff --check`) were run and showed no issues. 
- The new regression test verifies the zero-netuid discovery path and the existing partial-snapshot failure tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5e76eecc832c9a3d43d4e5673807)