### PR TITLE
docs: note pretypecheck auto-build + missing test:e2e step

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -432,7 +432,7 @@ bundle-size-budget check, in that order — run the same locally before pushing:
 
 ```sh
 npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui
-npm run typecheck --workspace=apps/ui
+npm run typecheck --workspace=apps/ui  # auto-builds packages/client first (pretypecheck) -- no separate step needed
 npm test --workspace=apps/ui
 npm run test:e2e --workspace=apps/ui   # needs a Chromium browser: npx playwright install --with-deps chromium (once)
 npm run build --workspace=apps/ui

--- a/apps/ui/CONTRIBUTING.md
+++ b/apps/ui/CONTRIBUTING.md
@@ -24,8 +24,9 @@ all pass:
 
 ```bash
 npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui
-npm run typecheck --workspace=apps/ui
+npm run typecheck --workspace=apps/ui  # auto-builds packages/client first (pretypecheck) -- no separate step needed
 npm test --workspace=apps/ui
+npm run test:e2e --workspace=apps/ui   # needs a Chromium browser: npx playwright install --with-deps chromium (once)
 npm run build --workspace=apps/ui
 ```
 


### PR DESCRIPTION
## Summary
Small follow-up gap found while auditing doc coverage after #4502/#4513:

- `apps/ui/CONTRIBUTING.md`'s pre-PR checklist never mentioned `test:e2e` (added in #4502) even though CI's `ui` job runs it between `test` and `build` — a contributor following that checklist exactly would think they were done after `npm run build`.
- Neither `apps/ui/CONTRIBUTING.md` nor the `metagraphed` skill's `SKILL.md` mentioned the `pretypecheck` auto-build behavior (added in #4513) — not required for correctness (it's silent/automatic by design), but worth a one-line note so it's not a surprise if someone's debugging why `packages/client` rebuilds during typecheck.

## Test plan
- [x] `npx prettier --check .claude/skills/metagraphed/SKILL.md apps/ui/CONTRIBUTING.md` clean
