### PR TITLE
feat(ui): auto-refresh the blocks index first page

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChevronLeft, ChevronRight, Timer, Activity, Users } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -156,7 +157,11 @@ function BlocksTable() {
   // Only send filters the user actually set, so an empty bar is the plain feed.
   const queryParams = blocksQueryParams(search);
 
-  const rows = (useSuspenseQuery(blocksQuery(queryParams)).data.data ?? []) as Block[];
+  // Blocks turn over fast (~12s/block) — poll the first page only, so paging
+  // through older blocks (offset > 0) isn't yanked or reflowed mid-read.
+  const refetchInterval = useRefetchInterval(15_000, search.offset === 0);
+  const rows = (useSuspenseQuery({ ...blocksQuery(queryParams), refetchInterval }).data.data ??
+    []) as Block[];
 
   // Offset pagination: the API returns newest-first pages with no total. A full
   // page (rows === limit) implies more may exist; a short page is the tail.


### PR DESCRIPTION
Closes #3374

`apps/ui/src/routes/blocks.index.tsx` fetched the blocks feed once via `useSuspenseQuery`, with no `refetchInterval` — so the page only updated on manual reload even though `PageHero` already renders `live`, and `GET /api/v1/blocks` already returns newest-first data from a live chain poller.

## What it does

Polls the first page every 15s via `useRefetchInterval` (`apps/ui/src/hooks/use-refetch-interval.ts`), gated on `search.offset === 0` so paging through older blocks isn't reflowed mid-read.

**Deviation from the issue's stated approach, worth flagging explicitly:** the issue was filed before a shared polling hook existed and explicitly said not to depend on one landing first — "inline `refetchInterval` directly... following the existing ad hoc pattern already used in `status.tsx`/`health.tsx`." Since then, `useRefetchInterval` (with its own test suite) has landed and is now the actual convention used in both of those files. I used the hook rather than inlining a raw `refetchInterval` literal, since duplicating what the hook already does (including its tab-visibility pause, which an inline value doesn't get for free) would be working against the current codebase rather than with it. Functionally this satisfies every acceptance criterion in the issue; happy to redo as a raw inline value if that's preferred.

## Verification

Verified the polling behavior directly via request-log capture (not just visually):
- First page (`offset=0`): **3 requests over 35s** — matches the 15s interval firing on schedule.
- Paginated page (`offset=50`): **exactly 1 request over 20s** (the initial load only) — confirms polling never fires off the first page.

Also hit a transient cold/empty live-data window mid-testing (`block_count: 0` on the production API) — confirmed via direct `curl` this was a real, momentary upstream data state unrelated to this change, and the existing `EmptyState` fallback handled it correctly; live data returned normally shortly after and renders correctly in the screenshots below.

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 537 passed
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

This change is behavior-only (polling timing, no markup/styling changes) — before/after are visually identical, included per the repo's rule that any `routes/` file change gets the screenshot table regardless of whether the diff is visually observable.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/blocks-after-mobile-dark.png)<br><sub>after</sub> |