### PR TITLE
fix(smoke): harden rollup counters

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -405,7 +405,7 @@ export function reconcileRollups(summary, detail, fieldsToKeys) {
   for (const [rollupKey, field] of Object.entries(fieldsToKeys)) {
     const rollup = summary?.[rollupKey];
     if (!rollup || typeof rollup !== "object") continue;
-    const actual = {};
+    const actual = Object.create(null);
     for (const row of detail) {
       const value = row?.[field];
       if (value === undefined || value === null) continue;

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -418,7 +418,7 @@ export function reconcileRollups(summary, detail, fieldsToKeys) {
       (key) => rollup[key] === actual[key],
     );
     if (!keysMatch || !countsMatch) {
-      mismatches.push({ rollupKey, expected: rollup, actual });
+      mismatches.push({ rollupKey, expected: rollup, actual: { ...actual } });
     }
   }
   return mismatches;

--- a/tests/reconcile-rollups.test.mjs
+++ b/tests/reconcile-rollups.test.mjs
@@ -78,4 +78,14 @@ describe("reconcileRollups", () => {
     });
     assert.deepEqual(mismatches, []);
   });
+
+  test("counts rollup keys that collide with Object prototype properties", () => {
+    const mismatches = reconcileRollups(
+      { by_provider: { constructor: 1, "has-own-property": 1 } },
+      [{ provider: "constructor" }, { provider: "has-own-property" }],
+      { by_provider: "provider" },
+    );
+
+    assert.deepEqual(mismatches, []);
+  });
 });


### PR DESCRIPTION
### Motivation
- The live rollup/detail reconciliation used a plain object as a counter, which miscounts valid keys that collide with `Object.prototype` properties (e.g. a provider slug of `constructor`) and can cause the publish smoke check to falsely fail.

### Description
- Replace the counter `const actual = {}` with a prototype-free object via `Object.create(null)` in `scripts/smoke-live-api.mjs` so rollup keys are treated as own data properties; add a regression test in `tests/reconcile-rollups.test.mjs` that verifies keys like `constructor` are counted correctly.

### Testing
- Ran `npm run lint` and `npm run format:check` against the changed files, both succeeded. 
- Attempted `npm test -- tests/reconcile-rollups.test.mjs` but the test run was blocked by dependency installation errors (`npm install` failed with a 403 fetching `playwright-core` and `vitest` reported `Cannot find package '@noble/hashes/blake2.js'`), so full test execution could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f6273f52c832cb59a051f03d72428)