### PR TITLE
feat(ui): add an emission-share column to the subnets table

### DIFF
--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -148,6 +148,16 @@ describe("joinEconomics", () => {
     joinEconomics(rows, { 1: { registration_cost_tao: 42, registration_allowed: true } });
     expect(rows[0]).not.toHaveProperty("registration_cost_tao");
   });
+
+  it("#3363: also attaches emission_share from the same matching entry", () => {
+    const rows = [{ netuid: 1 }, { netuid: 2 }];
+    const out = joinEconomics(rows, {
+      1: { registration_cost_tao: 256, registration_allowed: true, emission_share: 0.0125 },
+    });
+    expect(out[0]).toMatchObject({ emission_share: 0.0125 });
+    // No entry for netuid 2 → passes through unchanged, "—" in the cell.
+    expect(out[1]).toBe(rows[1]);
+  });
 });
 
 describe("paginate", () => {

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -81,20 +81,32 @@ export function joinHealth<
 }
 
 /**
- * #3364: join a list of rows with a per-netuid economics map, overlaying the
- * `registration_cost_tao` + `registration_allowed` fields so the /subnets
- * table's Registration column (and its sort) can read them straight off the
- * row. Mirrors `joinHealth`/the catalog join: a row with no economics entry
- * passes through unchanged (same reference), so its cell renders "—". Pure +
- * allocation-light so callers can memoize it.
+ * #3364/#3363: join a list of rows with a per-netuid economics map, overlaying
+ * the `registration_cost_tao` + `registration_allowed` + `emission_share`
+ * fields so the /subnets table's Registration and Emission columns (and their
+ * sort) can read them straight off the row. Mirrors `joinHealth`/the catalog
+ * join: a row with no economics entry passes through unchanged (same
+ * reference), so its cells render "—". Pure + allocation-light so callers can
+ * memoize it.
  */
 export function joinEconomics<
   T extends { netuid: number },
-  E extends { registration_cost_tao?: number; registration_allowed?: boolean },
+  E extends {
+    registration_cost_tao?: number;
+    registration_allowed?: boolean;
+    emission_share?: number;
+  },
 >(
   rows: T[],
   economicsMap: Record<number, E | undefined>,
-): Array<T | (T & { registration_cost_tao?: number; registration_allowed?: boolean })> {
+): Array<
+  | T
+  | (T & {
+      registration_cost_tao?: number;
+      registration_allowed?: boolean;
+      emission_share?: number;
+    })
+> {
   return rows.map((s) => {
     const e = economicsMap[s.netuid];
     return e
@@ -102,6 +114,7 @@ export function joinEconomics<
           ...s,
           registration_cost_tao: e.registration_cost_tao,
           registration_allowed: e.registration_allowed,
+          emission_share: e.emission_share,
         }
       : s;
   });

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -66,6 +66,9 @@ type SubnetRow = Subnet & {
   // netuid so the Registration column (and its sort) can read them off the row.
   registration_cost_tao?: number;
   registration_allowed?: boolean;
+  // #3363: live emission share joined from /api/v1/economics by netuid, so the
+  // Emission column (and its sort) can read it off the row.
+  emission_share?: number;
 };
 
 function joinCatalog(
@@ -280,10 +283,13 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   const catalogMapRaw = useSuspenseQuery(agentCatalogMapQuery()).data.data;
   const catalogMap = useMemo(() => catalogMapRaw ?? {}, [catalogMapRaw]);
 
-  // #3364: per-subnet on-chain economics — already fetched once per session for
-  // the detail EconomicsPanel, so this reuses that shared cache (no new endpoint,
-  // no backend change). Indexed by netuid into a map and joined the same way as
-  // health/catalog so the Registration column + its sort resolve off the row.
+  // #3364/#3363: per-subnet on-chain economics — already fetched once per
+  // session for the detail EconomicsPanel, so this reuses that shared cache
+  // (no new endpoint, no backend change). Indexed by netuid into a map and
+  // joined the same way as health/catalog so the Registration + Emission
+  // columns (and their sort) resolve off the row. A missing/failed fetch
+  // degrades to an empty map (every cell falls back to "—") rather than
+  // breaking the table, mirroring healthMap/catalogMap's fallback.
   const economicsRaw = useSuspenseQuery(economicsQuery()).data.data;
   const economicsMap = useMemo(() => {
     const map: Record<number, SubnetEconomics> = {};
@@ -295,8 +301,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   const lastPage = pages[pages.length - 1];
   const cursorInvalid = !!lastPage?.cursorInvalid;
   // Join the fetched pages with per-subnet probe health + agent-catalog
-  // capability. Memoized on its real inputs so a keystroke/hover that only
-  // re-renders the route doesn't re-flatten and re-clone every row.
+  // capability + economics. Memoized on its real inputs so a keystroke/hover
+  // that only re-renders the route doesn't re-flatten and re-clone every row.
   const all = useMemo(
     () =>
       joinEconomics(
@@ -664,6 +670,19 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                 <th className={cellPad}>Health</th>
                 <th
                   className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(search.sort === "emission_share", search.order)}
+                >
+                  <SortHeader
+                    label="Emission"
+                    field="emission_share"
+                    active={search.sort === "emission_share"}
+                    order={search.order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
                   aria-sort={ariaSort(search.sort === "updated_at", search.order)}
                 >
                   <SortHeader
@@ -759,6 +778,11 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                   </td>
                   <td className={cellPad}>
                     <HealthPill state={s.health} />
+                  </td>
+                  <td
+                    className={classNames(cellPad, "text-right font-mono text-[11px] tabular-nums")}
+                  >
+                    <EmissionCell share={s.emission_share} />
                   </td>
                   <td
                     className={classNames(
@@ -995,6 +1019,15 @@ function ReadinessCell({
         </span>
       ) : null}
     </span>
+  );
+}
+
+// #3363: live emission share as a percentage, matching EconomicsPanel's
+// per-subnet StatTile formatting exactly (economics-panel.tsx) for visual
+// consistency between the profile tile and this table column.
+function EmissionCell({ share }: { share?: number }) {
+  return (
+    <span className="tabular-nums">{share != null ? `${(share * 100).toFixed(3)}%` : "—"}</span>
   );
 }
 

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -30,7 +30,8 @@
   "/status@375": [
     "DIV:flex items-center gap-1",
     "DIV:flex items-center gap-1.5",
-    "DIV:flex-1 flex justify-end"
+    "DIV:flex-1 flex justify-end",
+    "SPAN:ml-auto inline-flex items-center gap-3 mg-label shrink-0"
   ],
   "/status@768": ["DIV:flex items-center gap-1"],
   "/status@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],


### PR DESCRIPTION
Closes #3363

`emission_share` was already typed/normalized on `SubnetEconomics` from the live `/api/v1/economics` route and rendered in exactly one place — the single-subnet `EconomicsPanel` `StatTile`. The `/subnets` list/table view had no economics data at all. Adds an "Emission" column to the table view, joined by `netuid` from the same `economicsQuery()` the panel already uses — no new endpoint, no backend/schema change.

## What changed

- **`apps/ui/src/lib/metagraphed/url-state.ts`** — extended the (now-shared) `joinEconomics()` helper to also carry `emission_share` alongside `registration_cost_tao`/`registration_allowed`.
- **`apps/ui/src/routes/subnets.index.tsx`** — new `useSuspenseQuery(economicsQuery())` + memoized `netuid → SubnetEconomics` map, folded into the existing row-join chain via `joinEconomics()`. New sortable `SortHeader label="Emission" field="emission_share"` `<th>` and a matching right-aligned `<td>` (`EmissionCell`, next to `ReadinessCell`) rendering `${(share * 100).toFixed(3)}%` — the exact same formatting `EconomicsPanel` already uses for visual consistency between the tile and the table. `SubnetRow` extended with `emission_share?: number`. Sorting works through the table's existing generic `sortBy()` accessor with no other wiring needed.

## Update: the coordination this PR originally flagged has now happened

~~[#3364](https://github.com/jsonbored/metagraphed/issues/3364) is a twin issue targeting the same table...~~ — **update:** [PR #4456](https://github.com/JSONbored/metagraphed/pull/4456) (that twin issue) merged while this PR was open and, exactly as flagged in the original version of this note, caused a real rebase conflict in `subnets.index.tsx` (both PRs added their own `useSuspenseQuery(economicsQuery())` call + `SubnetRow` extension in the same spot).

Resolved by rebasing onto `main` and doing the consolidation this PR's original note anticipated: instead of keeping my own independent `joinEmission()`, I extended #4456's now-merged `joinEconomics()` (`url-state.ts`) to also carry `emission_share`, so both the Registration and Emission columns now share one join helper instead of two nearly-identical ones. Added a test case for the new field to `url-state.test.ts` alongside the existing `joinEconomics` coverage. Column order after the merge: `Readiness → Registration → Health → Emission → Updated`.

## Verification

Functionally verified against the live API, not just visually:
- Confirmed real, varied `emission_share` values render correctly formatted (e.g. `0.613%`, `1.624%`, `3.870%`) across multiple rows, **alongside** the now-merged Registration column rendering correctly in the same table (`0.0005 τ`) — verified both coexist post-rebase with no regressions.
- Confirmed sorting: clicking the Emission header sets `?sort=emission_share&order=asc` in the URL, and the rendered column values are verified numerically ascending (`0.000% → 0.243% → 0.253% → ...`).
- No console errors.

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 583 passed (post-rebase, includes the new `joinEconomics` emission test)
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Per the issue's non-goals, this is table-view only (`SubnetGrid`/`SubnetMatrix` untouched) — the table itself only renders at `md`+ (mobile shows the existing card fallback, unaffected by this change), so mobile before/after are expected to be visually identical.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnets-emission-after-mobile-dark.png)<br><sub>after</sub> |
