### PR TITLE
fix(ui): balance the endpoints toolbar's wrapped control row

### DIFF
--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -748,7 +748,7 @@ function EndpointsTable() {
               : "Showing all endpoints, including directory links"
           }
           className={classNames(
-            "ml-auto inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+            "inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
             search.callable
               ? "border-accent/40 bg-accent/10 text-accent"
               : "border-border bg-card text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
## What

The `/endpoints` sticky filter toolbar is a single `flex-wrap` row. Once the Download CSV button (#3817) was added, the trailing view controls — the callable-only toggle, the table/grid switch, and the result count — still carried an `ml-auto` that pinned them to the far right. So as soon as the filters filled the first line, those controls wrapped onto a second line **pushed hard to the right, leaving a large empty gap on the left** that read as lopsided at desktop and tablet widths.

Closes #3992

## Fix

Drop the `ml-auto` on the view-controls group so it packs left with the rest of the row instead of being pinned right. When the row wraps, those controls now sit flush-left as a coherent group and the toolbar reads as evenly balanced at every width. No control's behavior changes — one-line, layout-only.

## Checks

`eslint` + `tsc --noEmit` clean. UI-only, no schema/contract change.

## Screenshots

Exact viewports — mobile 375×812, tablet 768×1024, desktop 1280×800 — light + dark, before/after. Before: the callable/view/count controls are shoved to the right edge with an empty left gap; after: they pack flush-left as a group.

| viewport / theme | before | after |
|---|---|---|
| **mobile · light** | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-mobile-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-tablet-dark-after.png)<br><sub>after</sub> |
| **desktop · light** | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/ep-toolbar-desktop-dark-after.png)<br><sub>after</sub> |
