### PR TITLE
feat(ui): fetch the composed overview artifact in the subnet Overview tab

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-overview.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-overview.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetOverview, subnetOverviewQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+describe("normalizeSubnetOverview", () => {
+  it("passes a well-formed overview artifact through", () => {
+    const overview = normalizeSubnetOverview(
+      {
+        netuid: 1,
+        name: "Apex",
+        slug: "sn-1",
+        status: "active",
+        profile: { symbol: "α" },
+        health: { status: "unknown", surface_count: 0 },
+        curation: { level: "maintainer-reviewed" },
+        gaps: { missing_kinds: ["sse"] },
+        counts: { surfaces: 16, endpoints: 16, candidates: 14 },
+        gap_priorities: [{ suggested_next_action: "evaluate for subnet-specific adapter" }],
+      },
+      1,
+    );
+    expect(overview.netuid).toBe(1);
+    expect(overview.name).toBe("Apex");
+    expect(overview.status).toBe("active");
+    expect(overview.health).toEqual({ status: "unknown", surface_count: 0 });
+    expect(overview.curation).toEqual({ level: "maintainer-reviewed" });
+    expect(overview.counts).toEqual({ surfaces: 16, endpoints: 16, candidates: 14 });
+    expect(overview.gap_priorities).toEqual([
+      { suggested_next_action: "evaluate for subnet-specific adapter" },
+    ]);
+  });
+
+  it("degrades a cold/junk store to a schema-stable shape, never throws", () => {
+    for (const raw of [{}, null, "x", { counts: "nope", gap_priorities: "nope" }]) {
+      const overview = normalizeSubnetOverview(raw, 7);
+      expect(overview.netuid).toBe(7);
+      expect(overview.counts).toEqual({ surfaces: 0, endpoints: 0, candidates: 0 });
+      expect(overview.gap_priorities).toEqual([]);
+      expect(overview.health).toBeUndefined();
+      expect(overview.curation).toBeUndefined();
+    }
+  });
+
+  it("falls back to the passed netuid when the payload omits it", () => {
+    expect(normalizeSubnetOverview({ status: "active" }, 42).netuid).toBe(42);
+  });
+});
+
+describe("subnetOverviewQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches the per-netuid overview route and normalizes the response", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: { netuid: 5, status: "active", counts: { surfaces: 3, endpoints: 2, candidates: 1 } },
+      meta: {} as ApiResult<unknown>["meta"],
+      url: "/api/v1/subnets/5/overview",
+    });
+
+    const opts = subnetOverviewQuery(5);
+    if (!opts.queryFn) throw new Error("expected a queryFn");
+    const res = await opts.queryFn({
+      signal: new AbortController().signal,
+      queryKey: opts.queryKey,
+      meta: undefined,
+    } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/5/overview",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(res.data.counts).toEqual({ surfaces: 3, endpoints: 2, candidates: 1 });
+    expect(res.data.status).toBe("active");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -182,6 +182,7 @@ import type {
   YieldHistoryPoint,
   SubnetYieldHistory,
   SubnetProfile,
+  SubnetOverview,
   Surface,
   SurfaceLatencyPercentiles,
   SurfaceSla,
@@ -6472,6 +6473,45 @@ export const subnetGapsQuery = (netuid: number) =>
       const data = normalizeSubnetGaps(res.data);
       if (!data) throw new Error("Invalid subnet gaps response");
       return { ...res, data };
+    },
+    staleTime: STALE_MED,
+  });
+
+// The composed SubnetOverviewArtifact's sub-objects (profile/health/curation/
+// gaps) are already reviewed, schema-valid payloads in their own right — this
+// only needs enough fidelity to render the summary strip (#3346), not a full
+// re-typed mirror of each sub-schema, so profile/health/curation/gaps pass
+// through as loose records (matching the existing SubnetOverview interface).
+export function normalizeSubnetOverview(raw: unknown, netuid: number): SubnetOverview {
+  const root = isRecord(raw) ? raw : {};
+  const counts = isRecord(root.counts) ? root.counts : {};
+  return {
+    netuid: optionalNumber(root.netuid) ?? netuid,
+    name: optionalString(root.name),
+    slug: optionalString(root.slug),
+    status: optionalString(root.status),
+    profile: isRecord(root.profile) ? root.profile : undefined,
+    health: isRecord(root.health) ? root.health : undefined,
+    curation: isRecord(root.curation) ? root.curation : undefined,
+    gaps: isRecord(root.gaps) ? root.gaps : undefined,
+    gap_priorities: Array.isArray(root.gap_priorities) ? root.gap_priorities : [],
+    counts: {
+      surfaces: optionalNumber(counts.surfaces) ?? 0,
+      endpoints: optionalNumber(counts.endpoints) ?? 0,
+      candidates: optionalNumber(counts.candidates) ?? 0,
+    },
+  };
+}
+
+export const subnetOverviewQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-overview", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/subnets/${netuid}/overview`, { signal });
+      return {
+        ...res,
+        data: normalizeSubnetOverview(res.data, netuid),
+      } as ApiResult<SubnetOverview>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -44,6 +44,7 @@ import {
   subnetCandidatesQuery,
   subnetEventsQuery,
   subnetGapsQuery,
+  subnetOverviewQuery,
   fixturesIndexQuery,
   lineageQuery,
   agentCatalogDetailQuery,
@@ -325,6 +326,16 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
   const subnetGaps = gapsResult?.data;
   return (
     <div className="space-y-6">
+      {/* 0 — Composed overview summary strip (#3346): counts + status +
+          curation from the single server-composed /overview route, at a
+          glance before the more detailed sub-panels below. Each of those
+          sub-panels owns its own deeper backend route and stays as-is. */}
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+          <OverviewSummaryStrip netuid={netuid} />
+        </Suspense>
+      </QueryErrorBoundary>
+
       {/* 1 — Readiness scorecard: the "can I build on this, where do I start?"
           answer, up top before the operational/resource detail. */}
       <ReadinessScorecard profile={profile} />
@@ -405,6 +416,47 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
       (subnetGaps?.gap_notes.length ?? 0) > 0 ||
       (profile?.gap_notes?.length ?? 0) > 0 ? (
         <GapsPanel netuid={netuid} compact />
+      ) : null}
+    </div>
+  );
+}
+
+// #3346: the server-composed summary — counts + lifecycle status + curation
+// level + (if any) the top gap-priority hint — sourced from the one dedicated
+// /overview route instead of re-deriving equivalent state from the several
+// separate calls the sub-panels below already make. `status` here is the
+// subnet's on-chain lifecycle (e.g. "active"/"deregistered"), a different
+// vocabulary than health.status's probe-derived ok/warn/down/unknown — so it
+// renders as a plain badge rather than through HealthPill, which only knows
+// the probe vocabulary and would otherwise mislabel e.g. "active" as
+// "Unknown". health.status (when present) uses HealthPill correctly.
+function OverviewSummaryStrip({ netuid }: { netuid: number }) {
+  const { data } = useSuspenseQuery(subnetOverviewQuery(netuid));
+  const overview = data.data;
+  const health = overview.health as Record<string, unknown> | undefined;
+  const curation = overview.curation as Record<string, unknown> | undefined;
+  const topGap = overview.gap_priorities?.[0] as Record<string, unknown> | undefined;
+  const topGapHint =
+    typeof topGap?.suggested_next_action === "string" ? topGap.suggested_next_action : undefined;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {overview.status ? (
+          <span className="inline-flex items-center rounded border border-border bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            {overview.status}
+          </span>
+        ) : null}
+        {typeof health?.status === "string" ? <HealthPill state={health.status} /> : null}
+        {typeof curation?.level === "string" ? <CurationChip level={curation.level} /> : null}
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        <StatTile eyebrow="Surfaces" value={formatNumber(overview.counts?.surfaces ?? 0)} />
+        <StatTile eyebrow="Endpoints" value={formatNumber(overview.counts?.endpoints ?? 0)} />
+        <StatTile eyebrow="Candidates" value={formatNumber(overview.counts?.candidates ?? 0)} />
+      </div>
+      {topGapHint ? (
+        <p className="font-mono text-[11px] text-ink-muted">Top gap: {topGapHint}</p>
       ) : null}
     </div>
   );


### PR DESCRIPTION
Closes #3346

`OverviewPanel` hand-assembles ~10 separate sub-panels from their own individual backend routes instead of calling the single dedicated `GET /api/v1/subnets/{netuid}/overview` route that already composes this data server-side. That route is live; nothing in the frontend called it. The `SubnetOverview` interface (`types.ts`) was already declared but was dead code — confirmed zero other references anywhere in `apps/ui/src`.

## What it adds

- **`subnetOverviewQuery` + `normalizeSubnetOverview`** in `queries.ts`, following the `queryOptions`/`apiFetch`/`normalize*` pattern of its siblings (`subnetProfileQuery`, `subnetGapsQuery`).
- **`OverviewSummaryStrip`**, rendered as the very first child of `OverviewPanel` (before `ReadinessScorecard`): `counts.surfaces`/`endpoints`/`candidates` as `StatTile`s, the composed status + curation level as chips, and (when present) the top gap-priority's suggested next action as a one-line hint. None of the existing ~10 sub-panels (`ReadinessScorecard`, `OperationalPanel`, `EconomicsPanel`, etc.) are touched or replaced — each still owns its own more detailed dedicated route, exactly per the issue's non-goals.
- Wrapped in `QueryErrorBoundary` + `Suspense`/`Skeleton`, matching the file's existing convention for every other sub-panel in this component.

## Deliberate deviation from the issue's literal wording (worth a reviewer's attention)

The issue says to render the composed `status` via `HealthPill`. The artifact's top-level `status` is the subnet's **on-chain lifecycle** (e.g. `"active"`/`"deregistered"`) — a different vocabulary than `health.status`'s probe-derived `ok`/`warn`/`down`/`unknown`, which is what `HealthPill` actually renders. Passing `"active"` through `HealthPill` would silently normalize it to `"Unknown"` (`HealthPill` falls back to `"unknown"` styling for any state string it doesn't recognize from its own vocabulary) — mislabeling an active subnet as unknown-status.

Verified live against netuid 1 (Apex): rendering the two fields separately shows an honest `ACTIVE` lifecycle badge next to the correctly-labeled `Unknown` health pill and `REVIEWED` curation chip — three distinct, accurate pieces of information — instead of a confusing `Unknown` `Unknown` pair had I forced `status` through `HealthPill` as literally written. `health.status` (when present) does go through `HealthPill`, matching the issue's actual intent for that field.

## Verification

Functionally verified against the live API, not just visually — loaded `/subnets/1` and confirmed the strip renders real data matching a direct `curl` of the endpoint: `ACTIVE` / `Unknown` / `REVIEWED` chips, `16`/`16`/`14` surfaces/endpoints/candidates, and `Top gap: evaluate for subnet-specific adapter` (from `gap_priorities[0].suggested_next_action`). No console errors.

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 541 passed (4 new, covering `normalizeSubnetOverview`'s well-formed/cold-store/missing-netuid paths + `subnetOverviewQuery`'s fetch)
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Framed on the `/subnets/1` Overview tab so the new strip (or its absence, in "before") is directly visible above the pre-existing "Integration Readiness" section.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/subnet-overview-after-mobile-dark.png)<br><sub>after</sub> |