### PR TITLE
feat(ui): wire account entity hover-cards onto the blocks and extrinsics tables

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -20,11 +20,13 @@ import {
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
+import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { Block } from "@/lib/metagraphed/types";
 
@@ -362,7 +364,19 @@ function BlocksTable() {
                   className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
                   title={b.author ?? undefined}
                 >
-                  {shortHash(b.author) ?? "—"}
+                  {b.author && isValidSs58(b.author) ? (
+                    <EntityHoverCard kind="account" ss58={b.author}>
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: b.author }}
+                        className="hover:text-ink-strong"
+                      >
+                        {shortHash(b.author)}
+                      </Link>
+                    </EntityHoverCard>
+                  ) : (
+                    (shortHash(b.author) ?? "—")
+                  )}
                 </td>
                 <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
                   {formatNumber(b.extrinsic_count ?? 0)}

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -21,11 +21,13 @@ import { ShareButton } from "@/components/metagraphed/share-button";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
 import { CopyButton } from "@/components/metagraphed/copy-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
+import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import { extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { Extrinsic } from "@/lib/metagraphed/types";
 
@@ -288,7 +290,25 @@ function ExtrinsicsTable() {
                   {extrinsicCall(x.call_module, x.call_function)}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"}
+                  {x.signer && isValidSs58(x.signer) ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <EntityHoverCard kind="account" ss58={x.signer}>
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: x.signer }}
+                          className="hover:text-ink-strong"
+                          title={x.signer}
+                        >
+                          {shortHash(x.signer)}
+                        </Link>
+                      </EntityHoverCard>
+                      <CopyButton value={x.signer} label="signer" />
+                    </span>
+                  ) : x.signer ? (
+                    <CopyableCode value={x.signer} className="max-w-full" />
+                  ) : (
+                    "—"
+                  )}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">
                   <SuccessBadge success={x.success} />


### PR DESCRIPTION
Closes #3398

## What
The block-author cell (`blocks.index.tsx`) and extrinsic-signer cell (`extrinsics.index.tsx`) in the desktop tables are now `/accounts/$ss58` links wrapped in `EntityHoverCard` (`kind="account"`, from #3397), so hovering previews the account — event count, subnet count, last-seen — before navigating, matching the treatment subnets and providers already get elsewhere in the app (`routes/index.tsx`, `routes/providers.index.tsx`, `routes/subnets.index.tsx`).

## Changes
- **`apps/ui/src/routes/blocks.index.tsx`** — the author cell's plain `{shortHash(b.author) ?? "—"}` now renders `<EntityHoverCard kind="account" ss58={b.author}><Link to="/accounts/$ss58" .../></EntityHoverCard>` when `b.author` is a valid ss58 (via `isValidSs58`), falling back to the existing plain text otherwise. The `title={b.author}` tooltip on the `<td>` is unchanged.
- **`apps/ui/src/routes/extrinsics.index.tsx`** — the signer cell currently renders `CopyableCode` (a self-contained copy button, no navigation — the file has evolved since the issue was filed, which described a bare `shortHash` text). Added the same `EntityHoverCard`-wrapped `Link` alongside the existing `CopyButton` (mirroring the co-located link+copy-icon pattern already used for the extrinsic hash in this same file's mobile card, `HashCardOrLink`), so the signer is now both a navigable/previewable account link *and* still one-click copyable. Falls back to the original `CopyableCode`-only rendering when the signer isn't a valid ss58.
- Both mobile card layouts are untouched — `EntityHoverCard` is a no-op passthrough on coarse-pointer devices by design, and the issue scopes mobile out explicitly.

## Screenshots

Hovering an author/signer link now shows the account preview card:

| Page | Before | After (hover) |
| --- | --- | --- |
| Blocks | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/before-blocks.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/before-blocks.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/after-blocks.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/after-blocks.png)<br><sub>after</sub> |
| Extrinsics | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/before-extrinsics.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/before-extrinsics.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/after-extrinsics.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-entity-hover-cards-3398/after-extrinsics.png)<br><sub>after</sub> |

## Acceptance criteria
- [x] Author/signer cells in the Blocks and Extrinsics desktop tables are `/accounts/$ss58` links wrapped in `EntityHoverCard`
- [x] Existing `title={b.author}`/full-address tooltips preserved (extrinsics' signer link additionally carries `title={x.signer}`, matching the address-tooltip convention since the file's current `CopyableCode`-based markup didn't expose one at the `<td>` level)
- [x] `EntityHoverCard`'s existing `Props` union is consumed as-is, not forked or duplicated
- [x] No new `any` casts
- [x] Mobile card layouts unaffected (out of scope per the issue)

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on both changed files: clean (aside from pre-existing CRLF/fast-refresh noise unrelated to this change).
- Diff is 36 insertions / 4 deletions across exactly the two files the issue names.
