### PR TITLE
feat(ui): add a /runtime spec-version upgrade history page (#4318)

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -19,6 +19,7 @@ import {
   ExternalLink,
   FileJson,
   Gauge,
+  GitBranch,
   Hash,
   KeyRound,
   Layers,
@@ -151,6 +152,13 @@ const ROUTE_INDEX: Array<{
     to: "/admin-changes",
     hint: "AdminUtils config-change feed",
     icon: SlidersHorizontal,
+    scope: "route",
+  },
+  {
+    label: "Runtime",
+    to: "/runtime",
+    hint: "Spec-version upgrade history",
+    icon: GitBranch,
     scope: "route",
   },
 ];

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -71,6 +71,7 @@ export const MEGA_PANELS: MegaPanel[] = [
       { to: "/accounts", label: "Accounts", hint: "Hotkey / coldkey lookup" },
       { to: "/sudo", label: "Sudo", hint: "Root-origin calls + current key" },
       { to: "/admin-changes", label: "Admin changes", hint: "AdminUtils config-change feed" },
+      { to: "/runtime", label: "Runtime", hint: "Spec-version upgrade history" },
     ],
     filters: [],
   },

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -86,6 +86,8 @@ import type {
   Extrinsic,
   ExtrinsicCallArg,
   SudoKey,
+  RuntimeTransition,
+  RuntimeVersionHistory,
   Transfer,
   Candidate,
   Compare,
@@ -2088,6 +2090,47 @@ export const sudoKeyQuery = () =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<SudoKey>;
+    },
+    staleTime: STALE_LONG,
+  });
+
+function normalizeRuntimeTransition(raw: unknown): RuntimeTransition | null {
+  if (!isRecord(raw)) return null;
+  const specVersion = firstFiniteNumber(raw.spec_version);
+  const blockNumber = firstFiniteNumber(raw.block_number);
+  if (specVersion == null || blockNumber == null) return null;
+  return {
+    spec_version: specVersion,
+    block_number: blockNumber,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+/** Spec-version upgrade timeline from the `blocks` D1 tier (#4316/3.1). Small,
+ * bounded dataset (runtime upgrades are rare) — no pagination params. */
+export const runtimeVersionHistoryQuery = () =>
+  queryOptions({
+    queryKey: k("runtime-version-history"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/runtime", { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      const transitions = Array.isArray(d.transitions)
+        ? d.transitions.flatMap((row) => {
+            const t = normalizeRuntimeTransition(row);
+            return t ? [t] : [];
+          })
+        : [];
+      return {
+        data: {
+          transitions,
+          transition_count: firstFiniteNumber(d.transition_count) ?? transitions.length,
+          current_spec_version: firstFiniteNumber(d.current_spec_version) ?? null,
+          coverage_from_block: firstFiniteNumber(d.coverage_from_block) ?? null,
+          coverage_from_at: firstString(d.coverage_from_at) ?? null,
+        } as RuntimeVersionHistory,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<RuntimeVersionHistory>;
     },
     staleTime: STALE_LONG,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1323,6 +1323,24 @@ export interface SudoKey {
   queried_at?: string | null;
 }
 
+/** One spec-version transition from /api/v1/runtime (#4316/3.1). */
+export interface RuntimeTransition {
+  spec_version: number | null;
+  block_number: number | null;
+  observed_at: string | null;
+}
+
+/** Spec-version upgrade history from /api/v1/runtime. See that route's own docs
+ * for coverage_from_*'s "earliest reading this endpoint can see" caveat — it is
+ * not a guarantee the network never upgraded before that point. */
+export interface RuntimeVersionHistory {
+  transitions: RuntimeTransition[];
+  transition_count: number;
+  current_spec_version: number | null;
+  coverage_from_block: number | null;
+  coverage_from_at: string | null;
+}
+
 /** Per-subnet on-chain economics from /api/v1/economics. */
 export interface SubnetEconomics {
   netuid: number;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as ValidatorsIndexRouteImport } from './routes/validators.index'
 import { Route as SudoIndexRouteImport } from './routes/sudo.index'
 import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
+import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
@@ -105,6 +106,11 @@ const SubnetsIndexRoute = SubnetsIndexRouteImport.update({
   path: '/subnets/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RuntimeIndexRoute = RuntimeIndexRouteImport.update({
+  id: '/runtime/',
+  path: '/runtime/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProvidersIndexRoute = ProvidersIndexRouteImport.update({
   id: '/providers/',
   path: '/providers/',
@@ -184,6 +190,7 @@ export interface FileRoutesByFullPath {
   '/blocks/': typeof BlocksIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
+  '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
   '/sudo/': typeof SudoIndexRoute
   '/validators/': typeof ValidatorsIndexRoute
@@ -211,6 +218,7 @@ export interface FileRoutesByTo {
   '/blocks': typeof BlocksIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
   '/providers': typeof ProvidersIndexRoute
+  '/runtime': typeof RuntimeIndexRoute
   '/subnets': typeof SubnetsIndexRoute
   '/sudo': typeof SudoIndexRoute
   '/validators': typeof ValidatorsIndexRoute
@@ -239,6 +247,7 @@ export interface FileRoutesById {
   '/blocks/': typeof BlocksIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
+  '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
   '/sudo/': typeof SudoIndexRoute
   '/validators/': typeof ValidatorsIndexRoute
@@ -268,6 +277,7 @@ export interface FileRouteTypes {
     | '/blocks/'
     | '/extrinsics/'
     | '/providers/'
+    | '/runtime/'
     | '/subnets/'
     | '/sudo/'
     | '/validators/'
@@ -295,6 +305,7 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/extrinsics'
     | '/providers'
+    | '/runtime'
     | '/subnets'
     | '/sudo'
     | '/validators'
@@ -322,6 +333,7 @@ export interface FileRouteTypes {
     | '/blocks/'
     | '/extrinsics/'
     | '/providers/'
+    | '/runtime/'
     | '/subnets/'
     | '/sudo/'
     | '/validators/'
@@ -350,6 +362,7 @@ export interface RootRouteChildren {
   BlocksIndexRoute: typeof BlocksIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
+  RuntimeIndexRoute: typeof RuntimeIndexRoute
   SubnetsIndexRoute: typeof SubnetsIndexRoute
   SudoIndexRoute: typeof SudoIndexRoute
   ValidatorsIndexRoute: typeof ValidatorsIndexRoute
@@ -455,6 +468,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SubnetsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/runtime/': {
+      id: '/runtime/'
+      path: '/runtime'
+      fullPath: '/runtime/'
+      preLoaderRoute: typeof RuntimeIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/providers/': {
       id: '/providers/'
       path: '/providers'
@@ -558,6 +578,7 @@ const rootRouteChildren: RootRouteChildren = {
   BlocksIndexRoute: BlocksIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,
+  RuntimeIndexRoute: RuntimeIndexRoute,
   SubnetsIndexRoute: SubnetsIndexRoute,
   SudoIndexRoute: SudoIndexRoute,
   ValidatorsIndexRoute: ValidatorsIndexRoute,

--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -1,0 +1,160 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, type ReactNode } from "react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ShareButton } from "@/components/metagraphed/share-button";
+import { TableState } from "@/components/metagraphed/table-state";
+import { TimeAgo } from "@/components/metagraphed/time-ago";
+import { runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { RuntimeVersionHistory } from "@/lib/metagraphed/types";
+
+export const Route = createFileRoute("/runtime/")({
+  head: () => ({
+    meta: [
+      { title: "Runtime — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Spec-version upgrade history for the Bittensor chain — every runtime upgrade observed, newest first.",
+      },
+      { property: "og:title", content: "Runtime — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Spec-version upgrade history for the Bittensor chain — every runtime upgrade observed, newest first.",
+      },
+    ],
+  }),
+  component: RuntimePage,
+});
+
+function RuntimePage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Explorer"
+        live
+        title="Runtime"
+        description="Spec-version upgrade history for the Bittensor chain, tracked from the first-party blocks tier — every observed runtime upgrade, newest first."
+        actions={<ShareButton />}
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+          <RuntimeContent />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/runtime"]} artifacts={["/metagraph/runtime.json"]} />
+    </AppShell>
+  );
+}
+
+function RuntimeContent() {
+  const { data: res } = useSuspenseQuery(runtimeVersionHistoryQuery());
+  const history = res.data;
+  // Backend orders transitions ascending by block_number (earliest first);
+  // display newest first, matching every other timeline view on this site.
+  const rows = [...history.transitions].reverse();
+
+  return (
+    <>
+      <PageHeroKpis history={history} />
+      {rows.length === 0 ? (
+        <TableState
+          variant="empty"
+          title="No runtime upgrades observed yet"
+          description="This tracks forward from when spec_version capture began — an upgrade before that point won't appear here."
+          generatedAt={history.coverage_from_at ?? undefined}
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+                <tr>
+                  <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
+                    Spec Version
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
+                    Block
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
+                    Observed
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr
+                    key={`${row.spec_version}-${row.block_number}`}
+                    className="mg-row-hover border-t border-border/60"
+                  >
+                    <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
+                      {formatNumber(row.spec_version)}
+                    </td>
+                    <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums">
+                      {row.block_number != null ? (
+                        <Link
+                          to="/blocks/$ref"
+                          params={{ ref: String(row.block_number) }}
+                          className="text-ink hover:underline"
+                        >
+                          #{formatNumber(row.block_number)}
+                        </Link>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-muted">
+                      {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function PageHeroKpis({ history }: { history: RuntimeVersionHistory }) {
+  return (
+    <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-3">
+      <KpiTile label="Current spec version" value={formatNumber(history.current_spec_version)} />
+      <KpiTile label="Transitions tracked" value={formatNumber(history.transition_count)} />
+      <KpiTile
+        label="Coverage from"
+        value={
+          history.coverage_from_block != null ? (
+            <Link
+              to="/blocks/$ref"
+              params={{ ref: String(history.coverage_from_block) }}
+              className="hover:underline"
+            >
+              #{formatNumber(history.coverage_from_block)}
+            </Link>
+          ) : (
+            "—"
+          )
+        }
+        hint={history.coverage_from_at ? <TimeAgo at={history.coverage_from_at} /> : undefined}
+      />
+    </div>
+  );
+}
+
+function KpiTile({ label, value, hint }: { label: string; value: ReactNode; hint?: ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border bg-card px-4 py-3">
+      <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">{label}</div>
+      <div className="mt-1 font-mono text-lg text-ink-strong tabular-nums">{value}</div>
+      {hint ? <div className="mt-0.5 text-xs text-ink-muted">{hint}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Standalone `/runtime` page over `GET /api/v1/runtime` (#4317), mirroring `/sudo` and `/admin-changes`' structure: `PageHero` + KPI strip (current spec version, transitions tracked, coverage-from block) + a compact table of every observed spec-version transition, newest first, each block number linking to its block detail page.

No pagination — spec-version upgrades are rare (3 observed in the live dataset as of writing), so the whole dataset is small and bounded; the backend route itself takes no query params.

Wired into the mega-menu's Blocks section and the command palette alongside the existing Sudo/Admin changes entries.

Closes #4318

## Validation

- `npm run lint` / `npm run typecheck` / `npx vitest run` (apps/ui) — all clean
- Visually verified live via the local dev server against production data: KPIs and table render correctly with real spec-version transitions (424/423/422), block links navigate to `/blocks/{ref}`, no console errors beyond a pre-existing app-wide dev-mode SSR hydration warning also reproduced on the existing `/sudo` page (confirmed unrelated to this change)

Maintainer PR — no screenshot table.