### PR TITLE
feat(registry): add SN8 Vanta OpenAPI 3.1 spec surface

### DIFF
--- a/registry/subnets/vanta.json
+++ b/registry/subnets/vanta.json
@@ -186,6 +186,31 @@
         "submitted_by": "rust-toml"
       },
       "notes": "Public no-auth static JSON dataset slippage_estimates.json committed in the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Distinct from the model-coefficients surface: this is the precomputed per-asset, per-trade-size empirical slippage lookup table (e.g. crypto BTCUSDC/ETHUSDC long/short across notional buckets). The path is resolved in vali_objects/utils/vali_bkp_utils.py and loaded by the PriceSlippageModel in vali_objects/utils/price_slippage_model.py to estimate execution slippage when scoring miner positions. Whitelisted for commit in .gitignore, so it is intentionally published."
+    },
+    {
+      "id": "sn-8-vanta-openapi",
+      "name": "Vanta API OpenAPI 3.1 spec",
+      "kind": "openapi",
+      "url": "https://api.staging.vantanetwork.io/openapi.json",
+      "provider": "vanta",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/taoshidev/vanta-starter/blob/main/README.md",
+        "https://github.com/taoshidev/vanta-starter/blob/main/lib/docs/api-catalog.ts"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "notes": "Public no-auth OpenAPI 3.1 document (openapi 3.1.0, 91 paths) for the Vanta API, self-describing as the REST surface over the SN8 Vanta Network (github.com/taoshidev/vanta-network) and Hyperscaled SDK. It is the team's officially-documented hosted deployment: taoshidev/vanta-starter README names api.staging.vantanetwork.io as the hosted platform API, and its lib/docs/api-catalog.ts documents GET /openapi.json as the public OpenAPI 3.1 specification. The spec document itself fetches with no auth (the per-endpoint API calls require a partner key; the spec does not). Same taoshidev org and vanta provider as the registered source-repo and model-parameter surfaces."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds the missing **OpenAPI/Swagger spec** surface for **SN8 Vanta**: the public no-auth OpenAPI 3.1 document at `https://api.staging.vantanetwork.io/openapi.json`.

- **`url`** — fetches publicly with no auth: `HTTP 200`, `application/json`, ~135 KB, a valid OpenAPI 3.1 document (`"openapi":"3.1.0"`, `info.title:"Vanta API"`, 91 paths). Its own `info.description` self-identifies: *"REST surface over the [Vanta Network](https://github.com/taoshidev/vanta-network) and [Hyperscaled SDK]…"* — i.e. SN8's REST surface. Companion `/docs` (Swagger UI) and `/health` also return 200.
- **`source_urls` proof** — `taoshidev/vanta-starter` (the official Taoshi org, same org as the registered SN8 source-repo) `README.md` names the hosted deployment: *"The platform API this app talks to — local (`http://localhost:8000`) or the hosted deployment at api.staging.vantanetwork.io."* Its `lib/docs/api-catalog.ts` documents `GET /openapi.json` as the *"OpenAPI 3.1 specification"* with `auth: public`.
- **Distinct** from the existing surfaces (website, dashboard, docs×2, source-repo, subnet-api model-parameters, data-artifact slippage) by both URL and `kind: openapi`. Same `vanta` provider.

**Transparency note:** Vanta's production host `api.vantanetwork.io` does not yet resolve; `api.staging.vantanetwork.io` is currently the team's only live, officially-documented public deployment (named as such in their own README). The spec document itself is public and no-auth, which is exactly the `openapi` surface requirement. Flagging this openly so the classification is an informed one.

One file changed, append-only: `registry/subnets/vanta.json` (existing surfaces and key order untouched).

## Validation

- `npm run validate:surface -- registry/subnets/vanta.json` — passed (8 surfaces)
- `npm run scan:public-safety` — no findings in the changed file
- `npx prettier --check registry/subnets/vanta.json` — clean
- Re-verified the spec fetches live (200, valid OpenAPI 3.1) immediately before opening

Closes #4004