### PR TITLE
feat(registry): add SN89 InfiniteHash auction incentive data-artifact (#4116)

### DIFF
--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -1,25 +1,12 @@
 {
-  "schema_version": 1,
-  "netuid": 89,
-  "name": "InfiniteHash",
-  "slug": "sn-89",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-docs",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/backend-developers-ltd/InfiniteHash",
-  "docs_url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
-  "dashboard_url": "https://taomarketcap.com/subnets/89",
-  "notes": "Reviewed overlay for SN89 using the official InfiniteHash source repository, repository documentation, and universal TaoMarketCap dashboard. The repository homepage points to infinitehash.xyz, but that deployment currently returns HTTP 402 and is not promoted as a monitored website/API surface.",
+  "contact": "btc@infinitehash.xyz",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
-    "verified_at": "2026-06-08T09:25:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Project homepage currently returns HTTP 402.",
       "The subnet auction incentive mechanism is documented in the public source repository.",
@@ -27,47 +14,61 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T09:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/89",
+  "docs_url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
+  "name": "InfiniteHash",
+  "netuid": 89,
+  "notes": "Reviewed overlay for SN89 using the official InfiniteHash source repository, repository documentation, and universal TaoMarketCap dashboard. The repository homepage points to infinitehash.xyz, but that deployment currently returns HTTP 402 and is not promoted as a monitored website/API surface.",
+  "schema_version": 1,
+  "slug": "sn-89",
+  "source_repo": "https://github.com/backend-developers-ltd/InfiniteHash",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-89-infinitehash-source",
-      "name": "InfiniteHash source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/backend-developers-ltd/InfiniteHash",
-      "provider": "infinitehash",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/backend-developers-ltd/InfiniteHash"],
+      "id": "sn-89-infinitehash-source",
+      "kind": "source-repo",
+      "name": "InfiniteHash source repository",
+      "notes": "Official InfiniteHash source repository for SN89.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official InfiniteHash source repository for SN89."
+      "provider": "infinitehash",
+      "public_safe": true,
+      "source_urls": ["https://github.com/backend-developers-ltd/InfiniteHash"],
+      "url": "https://github.com/backend-developers-ltd/InfiniteHash"
     },
     {
-      "id": "sn-89-infinitehash-auction-docs",
-      "name": "InfiniteHash auction incentive documentation",
-      "kind": "docs",
-      "url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
-      "provider": "infinitehash",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-89-infinitehash-auction-docs",
+      "kind": "docs",
+      "name": "InfiniteHash auction incentive documentation",
+      "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "infinitehash",
       "public_safe": true,
       "source_urls": [
         "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
         "https://github.com/backend-developers-ltd/InfiniteHash"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism."
+      "url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md"
     },
     {
       "auth_required": false,
@@ -87,8 +88,26 @@
         "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/89"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-89-infinitehash-auction-incentive-docs",
+      "kind": "data-artifact",
+      "name": "InfiniteHash auction incentive mechanism documentation",
+      "notes": "Public no-auth Markdown specification of SN89's action-based auction incentive system and validator responsibilities, published in the official InfiniteHash source repository at docs/subnet_auction_incentive_system.md. Served as a static raw file (distinct from the GitHub blob docs surface) for machine-readable ingestion of the full incentive-mechanism write-up.",
+      "provider": "infinitehash",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "luciferlive112116"
+      },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/master/docs/subnet_auction_incentive_system.md"
     }
   ],
-  "website_url": "https://infinitehash.xyz/",
-  "contact": "btc@infinitehash.xyz"
+  "website_url": "https://infinitehash.xyz/"
 }


### PR DESCRIPTION
## Summary
- Adds a community-submitted `data-artifact` surface for SN89 InfiniteHash: the official `subnet_auction_incentive_system.md` specification published as a public raw Markdown file in the InfiniteHash source repository.
- Closes #4116.

## Verification
- `npm run surface:add` verified the raw URL is reachable and public-safe.
- `npm run validate:surface -- registry/subnets/infinitehash.json`

## Test plan
- [x] `npm run validate:surface -- registry/subnets/infinitehash.json`
- [ ] CI registry + public-safety gates