### PR TITLE
feat(registry): add SN76 Byzantium validator weights subnet-api surface (#4090)

### DIFF
--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -85,6 +85,25 @@
         "https://github.com/byzantiumaitao-arch/byzantium/blob/main/ai-agent-kit/byzantium.config.json"
       ],
       "url": "https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/ai-agent-kit/byzantium.config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-76-byzantium-validator-weights-api",
+      "kind": "subnet-api",
+      "name": "Byzantium validator weights API",
+      "notes": "Public no-auth JSON endpoint exposing SN76 Byzantium's current weight-copy validator data: per-miner score_sum, scored_clicks, computed weight, payout hotkey, and burn flag, alongside the weighting formula and the 24h reveal delay. Served from link.byzantiumai.net (a subdomain of the official byzantiumai.net website); its source is link-service/app/api/validator/weights/route.ts in the official byzantiumaitao-arch/byzantium repository, whose doc-comment designates it the sole public validator endpoint (the sibling /api/clicks route is admin-gated, returning HTTP 401).",
+      "provider": "byzantium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/byzantiumaitao-arch/byzantium/blob/main/link-service/app/api/validator/weights/route.ts",
+        "https://www.byzantiumai.net/"
+      ],
+      "url": "https://link.byzantiumai.net/api/validator/weights"
     }
   ],
   "website_url": "https://www.byzantiumai.net/"


### PR DESCRIPTION
## Summary

Registers **SN76 Byzantium**'s public **validator weights API** as a `subnet-api` surface — a live, no-auth JSON endpoint the registry did not yet capture. It is the subnet's sole public validator data feed, exactly the public API endpoint issue #4090 asks for.

## Surface

- **kind:** `subnet-api`
- **url:** `https://link.byzantiumai.net/api/validator/weights`
- **provider:** `byzantium` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://github.com/byzantiumaitao-arch/byzantium/blob/main/link-service/app/api/validator/weights/route.ts` — the endpoint's source in the official Byzantium repo (the same repo the registry's existing `sn-76-byzantium-agent-config` data-artifact is drawn from). Its doc-comment designates this **the sole public validator endpoint**.
- `source_url` 2: `https://www.byzantiumai.net/` — SN76's registered `website_url`; the endpoint host `link.byzantiumai.net` is a subdomain of it.

## Verified live + public + safe

- `GET https://link.byzantiumai.net/api/validator/weights` → **HTTP 200**, `Content-Type: application/json`, **no auth** (verified with no credentials).
- Real payload: `{ generated_at, reveal_delay_hours: 24, realtime, formula, burn_note, count, weights: [ { miner, score_sum, scored_clicks, weight, hotkey, burn }, … ] }` — the current weight-copy validator table.
- Public-safe: only public on-chain data (SS58 hotkeys, scores, weights); no secrets. The sibling admin route `/api/clicks` returns 401 and is deliberately **not** registered — this is the correct public route.

## Non-duplication

Distinct from Byzantium's three existing surfaces — `website` (byzantiumai.net), `source-repo` (safe-scan-ai/cancer-ai), and `data-artifact` (the static `byzantium.config.json`). This is a **live dynamic `subnet-api`** at a new host/URL/kind; no other open PR targets SN76.

## Validation (local)

- `npm run validate:surface -- registry/subnets/byzantium.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/byzantium.json` → clean
- `git diff --stat` → single file `registry/subnets/byzantium.json`, a 19-line pure append (no top-level metadata, other surfaces, or generated artifacts touched)

## Template Used

- Subnet surface

Closes #4090
