### PR TITLE
feat(ui): wire the economics-trends time-series into an explorer trend chart

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.economics-trends.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.economics-trends.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { economicsTrendsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/economics/trends",
+  });
+}
+
+async function runQuery(window?: "7d" | "30d") {
+  const opts = window == null ? economicsTrendsQuery() : economicsTrendsQuery(window);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("economicsTrendsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the window param and normalizes chronological-descending rows", async () => {
+    resolveWith({
+      window: "30d",
+      day_count: 2,
+      days: [
+        {
+          snapshot_date: "2026-07-08",
+          subnet_count: 129,
+          total_stake_tao: 12_500_000,
+          alpha_price_tao_weighted: 0.045,
+          alpha_price_tao_median: 0.041,
+          validator_count: 4200,
+          miner_count: 15800,
+          mean_emission_share: 0.00775,
+        },
+        {
+          snapshot_date: "2026-07-07",
+          subnet_count: 128,
+          total_stake_tao: 12_300_000,
+          alpha_price_tao_weighted: 0.044,
+          alpha_price_tao_median: 0.04,
+          validator_count: 4190,
+          miner_count: 15750,
+          mean_emission_share: 0.00776,
+        },
+      ],
+    });
+    const res = await runQuery("30d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/economics/trends",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+    expect(res.data.window).toBe("30d");
+    expect(res.data.day_count).toBe(2);
+    expect(res.data.days).toHaveLength(2);
+    expect(res.data.days[0]).toEqual({
+      snapshot_date: "2026-07-08",
+      subnet_count: 129,
+      total_stake_tao: 12_500_000,
+      alpha_price_tao_weighted: 0.045,
+      alpha_price_tao_median: 0.041,
+      validator_count: 4200,
+      miner_count: 15800,
+      mean_emission_share: 0.00775,
+    });
+  });
+
+  it("defaults to a 7d window", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/economics/trends",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+  });
+
+  it("degrades a cold / junk store to a schema-stable empty card", async () => {
+    for (const raw of [{}, null, "x", { day_count: "nope", days: "nope" }]) {
+      resolveWith(raw);
+      const res = await runQuery("30d");
+      expect(res.data.day_count).toBe(0);
+      expect(res.data.days).toEqual([]);
+      // window falls through to the requested window on a cold store, matching
+      // the sibling chain-analytics queries' cold-store behavior.
+      expect(res.data.window).toBe("30d");
+    }
+  });
+
+  it("drops a row missing snapshot_date or subnet_count, keeping per-metric nulls", async () => {
+    resolveWith({
+      day_count: 3,
+      days: [
+        { subnet_count: 129, total_stake_tao: 100 }, // no snapshot_date -> dropped
+        { snapshot_date: "2026-07-06", subnet_count: "nope" }, // junk count -> dropped
+        {
+          // no subnet reported a price or validator/miner count this day, but the
+          // row itself is well-formed -> kept, with every optional metric null.
+          snapshot_date: "2026-07-05",
+          subnet_count: 3,
+          total_stake_tao: null,
+          alpha_price_tao_weighted: null,
+          alpha_price_tao_median: null,
+          validator_count: null,
+          miner_count: null,
+          mean_emission_share: null,
+        },
+      ],
+    });
+    const res = await runQuery();
+    expect(res.data.days).toHaveLength(1);
+    expect(res.data.days[0]).toEqual({
+      snapshot_date: "2026-07-05",
+      subnet_count: 3,
+      total_stake_tao: null,
+      alpha_price_tao_weighted: null,
+      alpha_price_tao_median: null,
+      validator_count: null,
+      miner_count: null,
+      mean_emission_share: null,
+    });
+  });
+
+  it("caps the rendered rows at 31 days", async () => {
+    resolveWith({
+      day_count: 60,
+      days: Array.from({ length: 60 }, (_, i) => ({
+        snapshot_date: `2026-07-${String(i + 1).padStart(2, "0")}`,
+        subnet_count: 129,
+      })),
+    });
+    const res = await runQuery();
+    expect(res.data.days).toHaveLength(31);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -56,6 +56,8 @@ import type {
   Block,
   ChainActivity,
   ChainActivityDay,
+  EconomicsTrends,
+  EconomicsTrendsDay,
   ChainCalls,
   ChainStakeFlow,
   ChainStakeFlowDistribution,
@@ -230,6 +232,7 @@ const MAX_ACCOUNT_STAKE_MOVES_SUBNETS = 128;
 const MAX_ACCOUNT_HISTORY_DAYS = 180;
 const MAX_ACCOUNT_DAY_EVENT_KINDS = 32;
 const MAX_CHAIN_ACTIVITY_DAYS = 31;
+const MAX_ECONOMICS_TRENDS_DAYS = 31;
 const MAX_CHAIN_CALLS = 12;
 const MAX_STAKE_FLOW_SUBNETS = 24;
 const MAX_STAKE_MOVES_SUBNETS = 24;
@@ -2902,6 +2905,27 @@ function normalizeChainActivityDay(raw: unknown): ChainActivityDay | null {
   };
 }
 
+// #3365: network-wide economics rollup day. Distinct source (subnet_snapshots)
+// from the chain-indexer days above, so only `snapshot_date` is required —
+// every metric is independently null-able (a day can have subnets reporting
+// counts but no price, etc.), mirroring the backend's per-metric null-safety.
+function normalizeEconomicsTrendsDay(raw: unknown): EconomicsTrendsDay | null {
+  if (!isRecord(raw)) return null;
+  const snapshotDate = firstString(raw.snapshot_date);
+  const subnetCount = coerceFiniteNumber(raw.subnet_count);
+  if (!snapshotDate || subnetCount == null) return null;
+  return {
+    snapshot_date: snapshotDate,
+    subnet_count: subnetCount,
+    total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? null,
+    alpha_price_tao_weighted: coerceFiniteNumber(raw.alpha_price_tao_weighted) ?? null,
+    alpha_price_tao_median: coerceFiniteNumber(raw.alpha_price_tao_median) ?? null,
+    validator_count: coerceFiniteNumber(raw.validator_count) ?? null,
+    miner_count: coerceFiniteNumber(raw.miner_count) ?? null,
+    mean_emission_share: coerceFiniteNumber(raw.mean_emission_share) ?? null,
+  };
+}
+
 function normalizeChainCallEntry(raw: unknown): ChainCallEntry | null {
   if (!isRecord(raw)) return null;
   const callModule = firstString(raw.call_module);
@@ -3011,6 +3035,34 @@ export const chainActivityQuery = (window: ChainWindow = "7d") =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainActivity>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+// #3365: network-wide economics rollup (GET /api/v1/economics/trends), a distinct
+// data source (subnet_snapshots) from the chain-indexer series above. The endpoint
+// itself accepts a wider window vocabulary (7d/30d/90d/1y/all); this reuses
+// ChainWindow ("7d" | "30d") to match the explorer page's existing window toggle
+// rather than introducing a second, unused range.
+export const economicsTrendsQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("economics-trends", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/economics/trends", {
+        params: { window },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: 1,
+          window: firstString(d.window) ?? window,
+          day_count: firstFiniteNumber(d.day_count) ?? 0,
+          days: normalizeChainRows(d.days, MAX_ECONOMICS_TRENDS_DAYS, normalizeEconomicsTrendsDay),
+        } as EconomicsTrends,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<EconomicsTrends>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2145,6 +2145,24 @@ export interface ChainActivity {
   day_count: number;
   days: ChainActivityDay[];
 }
+// #3365: network-wide economics rollup (subnet_snapshots, not the chain-indexer
+// tables the rest of the explorer page reads from).
+export interface EconomicsTrendsDay {
+  snapshot_date: string;
+  subnet_count: number;
+  total_stake_tao: number | null;
+  alpha_price_tao_weighted: number | null;
+  alpha_price_tao_median: number | null;
+  validator_count: number | null;
+  miner_count: number | null;
+  mean_emission_share: number | null;
+}
+export interface EconomicsTrends {
+  schema_version: number;
+  window: string | null;
+  day_count: number;
+  days: EconomicsTrendsDay[];
+}
 export interface ChainCallEntry {
   call_module: string;
   call_function: string | null;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -28,6 +28,7 @@ import {
   chainTurnoverQuery,
   chainStakeTransfersQuery,
   chainTransferPairsQuery,
+  economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -39,6 +40,7 @@ import type {
   ChainStakeFlow,
   ChainStakeMoves,
   ChainTurnover,
+  EconomicsTrends,
 } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
@@ -111,6 +113,7 @@ function ExplorerPage() {
           "/api/v1/chain/stake-transfers",
           "/api/v1/chain-events",
           "/api/v1/chain-events/stats",
+          "/api/v1/economics/trends",
         ]}
       />
     </AppShell>
@@ -609,20 +612,84 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
   );
 }
 
+/**
+ * Network-wide economics trend (#3365) — the subnet_snapshots rollup (stake,
+ * alpha price, validator/miner counts, emission share), a distinct data source
+ * from every other section on this page (which reads the chain indexer). Reuses
+ * the page's MiniSeries idiom for consistency with "Daily activity"/"Daily fees".
+ */
+function EconomicsTrendsSection({ trends }: { trends: EconomicsTrends }) {
+  const chrono = [...trends.days].reverse();
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Network economics trend
+        </h2>
+        <span className="font-mono text-[11px] text-ink-muted">{trends.day_count} days</span>
+      </div>
+      {chrono.length > 0 ? (
+        <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2 xl:grid-cols-3">
+          <MiniSeries
+            label="Total stake"
+            days={chrono.map((d) => d.snapshot_date)}
+            values={chrono.map((d) => d.total_stake_tao ?? 0)}
+            color="var(--accent)"
+            formatValue={fmtTao}
+          />
+          <MiniSeries
+            label="Alpha price"
+            days={chrono.map((d) => d.snapshot_date)}
+            values={chrono.map((d) => d.alpha_price_tao_weighted ?? 0)}
+            color="var(--chart-1)"
+            formatValue={fmtTao}
+          />
+          <MiniSeries
+            label="Emission share"
+            days={chrono.map((d) => d.snapshot_date)}
+            values={chrono.map((d) => (d.mean_emission_share ?? 0) * 100)}
+            color="var(--chart-6)"
+            formatValue={(v) => `${v.toFixed(3)}%`}
+          />
+          <MiniSeries
+            label="Validators"
+            days={chrono.map((d) => d.snapshot_date)}
+            values={chrono.map((d) => d.validator_count ?? 0)}
+            color="var(--chart-3)"
+            formatValue={(v) => formatNumber(v)}
+          />
+          <MiniSeries
+            label="Miners"
+            days={chrono.map((d) => d.snapshot_date)}
+            values={chrono.map((d) => d.miner_count ?? 0)}
+            color="var(--chart-1)"
+            formatValue={(v) => formatNumber(v)}
+          />
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">
+          No economics snapshots in this window yet.
+        </p>
+      )}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const win = search.window;
 
-  // A single batched useSuspenseQueries, not 9 individual useSuspenseQuery
-  // calls: each individual call suspends the component separately, so on a
+  // A single batched useSuspenseQueries, not one useSuspenseQuery call per
+  // endpoint: each individual call suspends the component separately, so on a
   // cold cache (in particular during SSR) React re-renders and re-suspends
   // once per query, resolving them in a serial waterfall instead of parallel
-  // -- 9 queries at ~5s each measured as a genuine ~33s page load in
-  // production, not a hang (confirmed by testing each endpoint standalone,
+  // -- the original 9 queries at ~5s each measured as a genuine ~33s page load
+  // in production, not a hang (confirmed by testing each endpoint standalone,
   // all fast, and the full page eventually completing at ~33s with a longer
-  // timeout). useSuspenseQueries fires all 9 fetches concurrently and
-  // suspends once, so the page waits on the slowest single query, not the sum.
+  // timeout). useSuspenseQueries fires all fetches concurrently and suspends
+  // once, so the page waits on the slowest single query, not the sum. #3365
+  // adds a 10th (economics/trends, a different data source entirely).
   const [
     { data: activityRes },
     { data: feesRes },
@@ -633,6 +700,7 @@ function ExplorerDashboard() {
     { data: turnoverRes },
     { data: stakeTransfersRes },
     { data: eventMixRes },
+    { data: trendsRes },
   ] = useSuspenseQueries({
     queries: [
       chainActivityQuery(win),
@@ -644,6 +712,7 @@ function ExplorerDashboard() {
       chainTurnoverQuery(win),
       chainStakeTransfersQuery(win),
       chainEventsStatsQuery(),
+      economicsTrendsQuery(win),
     ],
   });
   const activity = activityRes.data;
@@ -655,6 +724,7 @@ function ExplorerDashboard() {
   const turnover = turnoverRes.data;
   const stakeTransfers = stakeTransfersRes.data;
   const eventMix = eventMixRes.data;
+  const trends = trendsRes.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
   const chrono = [...activity.days].reverse();
@@ -874,6 +944,10 @@ function ExplorerDashboard() {
           )}
         </section>
       </div>
+
+      {/* network-wide economics trend (#3365) — subnet_snapshots rollup, a
+          different data source from the chain-indexer sections above/below */}
+      <EconomicsTrendsSection trends={trends} />
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* call mix */}

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -24,9 +24,9 @@
     "SPAN:",
     "TABLE:w-full text-sm"
   ],
-  "/endpoints@768": ["DIV:flex items-center gap-1", "TABLE:w-full text-sm"],
-  "/endpoints@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],
-  "/endpoints@1280": ["DIV:flex items-center gap-1"],
+  "/endpoints@768": ["DIV:flex items-center gap-1", "SPAN:", "TABLE:w-full text-sm"],
+  "/endpoints@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end", "SPAN:"],
+  "/endpoints@1280": ["DIV:flex items-center gap-1", "SPAN:"],
   "/status@375": [
     "DIV:flex items-center gap-1",
     "DIV:flex items-center gap-1.5",


### PR DESCRIPTION
Closes #3365

`explorer.tsx` reads five chain-indexer series (`chainActivityQuery`, `chainFeesQuery`, `chainCallsQuery`, `chainSignersQuery`, plus the stake-flow/turnover/transfer sections) but had no query at all for `GET /api/v1/economics/trends` — a distinct data source (`subnet_snapshots`, the network-wide economics rollup: stake, alpha price, validator/miner counts, emission share) that was already live and routed but entirely unconsumed by the UI.

## What changed

- **`apps/ui/src/lib/metagraphed/types.ts`** — new `EconomicsTrendsDay`/`EconomicsTrends` types, mirroring the shape of `ChainActivityDay`/`ChainActivity`.
- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `economicsTrendsQuery(window)` following the existing `queryOptions`/`apiFetch`/normalize pattern (closest sibling: `chainFeesQuery`). Reuses the page's own `ChainWindow` (`"7d" | "30d"`) rather than the endpoint's wider `7d/30d/90d/1y/all` vocabulary, so it matches the explorer page's existing window toggle instead of introducing a second, unused range. `normalizeEconomicsTrendsDay` requires only `snapshot_date` + `subnet_count`; every other metric is independently null-able, mirroring the backend's per-metric null-safety in `buildEconomicsTrends()`.
- **`apps/ui/src/routes/explorer.tsx`** — added `economicsTrendsQuery(win)` as a 10th entry in the page's existing batched `useSuspenseQueries` call (not a 10th separate `useSuspenseQuery`, which would reintroduce the serial-waterfall SSR problem the existing code comment already documents), and a new `EconomicsTrendsSection` reusing the page's `MiniSeries` sparkline component as-is (no new chart primitive) for total stake, alpha price, emission share, validators, and miners. Mounted as its own full-width card between the fees/top-payers grid and the call-mix/signers grid, visually distinct from the chain-indexer sections since it's a different data source. Added `/api/v1/economics/trends` to the page's `ApiSourceFooter`.

## Coordination note (per the issue's own instruction)

The issue flags **#3345** as a near-duplicate targeting the same endpoint, same file, same deliverable, with instructions that whichever PR lands first should close the other. As of opening this PR, #3345 has no open PR against it (checked via `gh pr list` immediately before pushing) — if one appears afterward, the later PR should be closed as superseded per the issue's guidance.

## Verification

- Confirmed the query/render wiring end-to-end against the **live production API** (`https://api.metagraph.sh`), not a mock: the section correctly issues `GET /api/v1/economics/trends?window=30d` and renders. **Production's `subnet_snapshots` table is currently empty across every window** (`7d` through `all` all return `day_count: 0`), so the live screenshots below show the section's empty state (`No economics snapshots in this window yet.`) — this is the backend's real current data state, not a rendering bug. That's a data-population gap outside this PR's scope (the endpoint itself, as the issue states, is "live and unconsumed" — not "live and populated").
- To demonstrate the sparklines/formatting actually work once the backend has data, I additionally captured **one extra screenshot with the API response mocked** (14 synthetic days, via Playwright route interception) — included below, clearly labeled. It confirms correct formatting: `12.59M τ` (stake), `0.0462 τ` (alpha price), `0.762%` (emission share), `4,228`/`15,886` (validators/miners).
- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 new warnings (explorer.tsx's 2 pre-existing `react-refresh/only-export-components` warnings are unchanged, confirmed via a before/after diff of the lint output)
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 588 passed, including 5 new tests in `queries.economics-trends.test.ts` covering the window param, chronological normalization, a cold/junk-store degrade path, dropped-malformed-row handling, and the 31-day cap
- `npm run test:e2e --workspace=apps/ui` (responsive-overflow check) — 24/24 passed, including `/explorer` at all 4 viewports with the new section present
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-after-mobile-dark.png)<br><sub>after</sub> |

**Bonus — section with populated data (API response mocked for this one screenshot only, since production has no snapshots yet):**

[<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-demo-mocked-data-desktop-light.png" width="420">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/explorer-demo-mocked-data-desktop-light.png)
