### PR TITLE
fix(ui): use the live window in subnet tile captions, not a hardcoded 30d

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -48,7 +48,7 @@ function StakeMovesTile({ netuid }: { netuid: number }) {
       chart={
         <SparkLegend
           metric="Stake moves"
-          source={`On-chain StakeMoved (re-delegation) events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          source={`On-chain StakeMoved (re-delegation) events for SN${netuid} over the trailing ${card?.window ?? "30d"} window — ${m.summary}.`}
           windowLabel={card?.window ?? "30d"}
           updatedAt={card?.observed_at ?? null}
           staleness="Counts settle as the chain-events indexer catches up; the bar hides when no re-delegations occurred in the window."
@@ -87,7 +87,7 @@ function StakeTransfersTile({ netuid }: { netuid: number }) {
       chart={
         <SparkLegend
           metric="Stake transfers"
-          source={`On-chain stake-transfer events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          source={`On-chain stake-transfer events for SN${netuid} over the trailing ${card?.window ?? "30d"} window — ${m.summary}.`}
           windowLabel={card?.window ?? "30d"}
           updatedAt={card?.observed_at ?? null}
           staleness="Counts settle as the chain-events indexer catches up; the bar hides when no transfers occurred in the window."

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -422,7 +422,7 @@ export function SubnetMasthead({
           label="Registrations"
           value={formatNumber(reg?.registrations)}
           hint={`${formatNumber(reg?.distinct_registrants ?? 0)} registrants`}
-          full="Neuron-registration events on this subnet over the trailing 30-day window."
+          full={`Neuron-registration events on this subnet over the trailing ${reg?.window ?? "30d"} window.`}
           updatedAt={reg?.observed_at ?? null}
           windowLabel={reg?.window ?? "30d"}
         />
@@ -430,7 +430,7 @@ export function SubnetMasthead({
           label="Deregistrations"
           value={formatNumber(dereg?.deregistrations)}
           hint={`${formatNumber(dereg?.distinct_deregistered_hotkeys ?? 0)} hotkeys`}
-          full="Neuron-deregistration (eviction) events on this subnet over the trailing 30-day window."
+          full={`Neuron-deregistration (eviction) events on this subnet over the trailing ${dereg?.window ?? "30d"} window.`}
           updatedAt={dereg?.observed_at ?? null}
           windowLabel={dereg?.window ?? "30d"}
         />


### PR DESCRIPTION
## Summary

Fixes #3949 — subnet-scoped tiles hardcoded "over the trailing **30-day** window" in their caption prose, even though each tile already receives (and separately renders) the *actual* window from its API response. When the API returns a window other than 30 days, the tile shows the real window in one place (`${windowLabel} window`) but the stale "30-day" in the caption — an internal contradiction on the same tile.

## Change

Interpolate the same window value the adjacent `windowLabel` prop already uses, so the caption can never disagree with what the tile renders:

- `economics-panel.tsx` — the two `SparkLegend` `source` strings (StakeMoves + stake-transfer tiles) → `over the trailing ${card?.window ?? "30d"} window`.
- `subnet-masthead.tsx` — the two `StatWithSpark` `full` captions (Registrations + Deregistrations) → interpolate `${reg?.window ?? "30d"}` / `${dereg?.window ?? "30d"}`.

Each uses exactly the expression already feeding the sibling `windowLabel` prop. With the default 30-day window there's no visible change; the fix only manifests when the API window differs. Mirrors the fix requested for the account-page equivalents in the sibling issue.

## Validation (local)

- `vitest run` — the full apps/ui suite passes, no regressions.
- `tsc --noEmit`, `eslint` (0 errors), and `prettier --check` are clean on both changed files.
- (No new unit test: this is caption prose inside component render code; apps/ui's vitest suite covers pure modules under `src/lib/metagraphed` — there are no component-render tests — so correctness is via the existing suite + typecheck.)

Closes #3949
