### PR TITLE
feat(registry): add SN113 TensorUSD docs llms.txt data-artifact

### DIFF
--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -127,6 +127,25 @@
         "https://github.com/TensorUSD/subnet/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/TensorUSD/subnet/main/tensorusd/common/abis/tusdt_vault.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-113-tensorusd-llms-txt",
+      "kind": "data-artifact",
+      "name": "TensorUSD docs llms.txt index",
+      "notes": "Public no-auth machine-readable llms.txt index of the official SN113 TensorUSD documentation, served at the docs.tensorusd.com domain the official TensorUSD/subnet README links (README confirms netuid 113). Provides an agent-consumable Markdown map of the TensorUSD docs (introduction, components, contracts) for LLM/agent ingestion; content begins '# TensorUSD'.",
+      "provider": "tensorusd",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/TensorUSD/subnet/blob/main/README.md",
+        "https://docs.tensorusd.com/"
+      ],
+      "url": "https://docs.tensorusd.com/llms.txt"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4151

## Summary
Registers **SN113 TensorUSD**'s public machine-readable **`llms.txt` documentation index** — an agent-consumable Markdown map of the official TensorUSD docs the registry didn't yet have.

## Surface
- kind: `data-artifact`
- url: `https://docs.tensorusd.com/llms.txt`
- provider: `tensorusd` (existing)

## Proof of ownership (airtight)
- Served on **docs.tensorusd.com**, the official docs domain the `TensorUSD/subnet` README links; that README confirms **netuid 113** (multiple references).
- `GET https://docs.tensorusd.com/llms.txt` → **HTTP 200**, `text/markdown`, content begins `# TensorUSD`.
- `source_urls`: the official README + the docs site.

## Scope note (#4151)
#4151 asks for TensorUSD's OpenAPI/Swagger spec. The subnet exposes no OpenAPI (`api.tensorusd.com/openapi.json` → 404) — its logic is on-chain contracts. This registers the subnet's public machine-readable **docs index** (`llms.txt`), the concrete agent-consumable public artifact available.

## Non-duplication
Distinct from the existing `sn-113-tensorusd-docs` (HTML docs page), `sn-113-tensorusd-health` (API liveness), and `sn-113-tensorusd-vault-abi` (contract ABI) surfaces — different URL and payload (the LLM/agent docs index). No open PR targets SN113.

## Validation (local)
- `npx prettier --check registry/subnets/tensorusd.json` → clean
- `npm run validate:surface -- registry/subnets/tensorusd.json` → passes (6 surfaces)
- `npm run scan:public-safety` → passes
- single file, 19-line pure append, no reordering, no generated artifacts.
