### PR TITLE
feat(registry): add SN89 InfiniteHash pool-workers dataset data-artifact surface (#4116)

### DIFF
--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -87,6 +87,25 @@
         "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/89"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-89-infinitehash-pool-workers-dataset",
+      "kind": "data-artifact",
+      "name": "InfiniteHash pool-workers dataset",
+      "notes": "Public no-auth CSV snapshot of SN89 InfiniteHash mining-pool workers, published in the official backend-developers-ltd/InfiniteHash repository. Each row is a real worker keyed by hotkey.ASIC-workerID with its Firmware, Hashrate (TH/PH), Efficiency, Stale/Rejected share rates, Last Share Time, and Status — the concrete form of the hotkey-in-workerID hash-contribution data the README states validators score. Machine-readable reference data for the subnet's Bitcoin-mining output.",
+      "provider": "infinitehash",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md",
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/app/src/infinite_hashes/validator/tests/data/pool-workers-2025-08-21.csv"
+      ],
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/refs/heads/master/app/src/infinite_hashes/validator/tests/data/pool-workers-2025-08-21.csv"
     }
   ],
   "website_url": "https://infinitehash.xyz/",


### PR DESCRIPTION
## Summary

Registers **SN89 InfiniteHash**'s public **pool-workers dataset** as a `data-artifact` surface — a no-auth CSV of the subnet's mining-pool worker performance data the registry did not yet capture. It is the concrete public data artifact issue #4116 asks for.

## Surface

- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/refs/heads/master/app/src/infinite_hashes/validator/tests/data/pool-workers-2025-08-21.csv`
- **provider:** `infinitehash` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md` — the registry's registered `source_repo`; its first line reads **"InfiniteHash Subnet (SN89)"** and states *"Validators score your hash contribution based on your hotkey in the ASIC workerID."*
- `source_url` 2: the file blob itself in that same official repo.
- The dataset is the concrete form of exactly that scored data: each row is keyed by `hotkey.workerID`.

## Verified live + public + safe

- `GET` the raw URL → **HTTP 200**, `text/plain; charset=utf-8`, ~41 KB, **no auth**.
- Real payload — header `Worker Name,Subaccount,Firmware,Hashrate,Efficiency,Stale Shares,Rejected Shares,Last Share Time (UTC),Status`; rows are real workers (`<SS58-hotkey>.0x0x…`, e.g. `MicroBT Stock, 129.641 TH, 100.00%, … Active`).
- Public-safe: only public on-chain data (SS58 hotkeys) and mining telemetry; no secrets.

## Non-duplication

Distinct from InfiniteHash's existing surfaces — `source-repo`, `docs` (auction incentive doc), and the `subnet-api` (TaoMarketCap indexed snapshot). This is the subnet's own first-party machine-readable dataset at a new URL/kind; SN89 has no `data-artifact` surface yet. No open PR targets this.

## Scope note

The file lives under the repo's `validator/tests/data/` path but is a genuine dated snapshot of real SN89 pool-worker hash-contribution data (real hotkeys, real hashrates) committed to the official repo and served publicly — the representative reference dataset for the subnet's Bitcoin-mining output, which is the public data #4116 seeks.

## Validation (local)

- `npm run validate:surface -- registry/subnets/infinitehash.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/infinitehash.json` → clean
- `git diff --stat` → single file, 19-line pure append (no top-level metadata or other surfaces touched)

## Template Used

- Subnet surface

Closes #4116
