### PR TITLE
feat(registry): add SN127 Astrid Arena dashboard surface

### DIFF
--- a/registry/subnets/astrid.json
+++ b/registry/subnets/astrid.json
@@ -46,6 +46,25 @@
         "https://github.com/astridintelligence/sn-127/blob/master/README.md"
       ],
       "url": "https://arena-api.astrid.global/public/competitions/190482a8-70b8-463d-b6c5-d1808bc7db9f/wallet-activity"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-127-astrid-arena-dashboard",
+      "kind": "dashboard",
+      "name": "Astrid Arena dashboard",
+      "notes": "Public no-auth Astrid Arena web dashboard for SN127 agent-trading competitions — the front end over the arena-api surfaces already in this manifest. The page self-identifies as SN127 (document title 'Astrid Arena · Agent Trading Competitions on Bittensor SN127') and is linked as 'Arena' from the official www.astrid.global homepage.",
+      "provider": "astrid",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://www.astrid.global/",
+        "https://github.com/astridintelligence/sn-127/blob/master/README.md"
+      ],
+      "url": "https://arena.astrid.global"
     }
   ],
   "source_repo": "https://github.com/astridintelligence/sn-127",


### PR DESCRIPTION
Closes #4180

## Summary
Registers **SN127 Astrid**'s public **Astrid Arena dashboard** — the web front end for the subnet's agent-trading competitions, which the registry didn't yet have.

## Surface
- kind: `dashboard`
- url: `https://arena.astrid.global`
- provider: `astrid` (existing)

## Proof of ownership (airtight)
- The page **self-identifies as SN127**: document title `Astrid Arena · Agent Trading Competitions on Bittensor SN127`.
- It is linked as **"Arena"** from the official `www.astrid.global` homepage (the registered `website_url`), and is the front end over the `arena-api.astrid.global` surfaces already in this manifest.
- `GET https://arena.astrid.global` → **HTTP 200**.
- `source_urls`: the official homepage + the `astridintelligence/sn-127` README.

## Scope note (#4180)
#4180 asks for SN127's OpenAPI/Swagger spec. Astrid's arena-api is a Node/TS service with no OpenAPI (`arena-api.astrid.global/openapi.json` → 404). This registers the subnet's public **dashboard** — its primary public human/agent entry point over the arena data.

## Non-duplication
Distinct from the existing `sn-127-astrid` API/data-artifact surfaces (the `arena-api.astrid.global` JSON endpoints) — this is the `arena.astrid.global` web dashboard (different host, different kind). No open PR targets SN127.

## Validation (local)
- `npx prettier --check registry/subnets/astrid.json` → clean
- `npm run validate:surface -- registry/subnets/astrid.json` → passes (3 surfaces)
- single file, 19-line pure append, no reordering, no generated artifacts.
