### PR TITLE
fix(ui): consolidate the remaining copy-pasted TAO formatting into the shared formatTao helper (#3947)

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -3,18 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
 type Win = "7d" | "30d" | "90d" | "1y" | "all";
 const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
-
-function taoStr(v?: number) {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
-}
 
 function scoreStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";
@@ -88,14 +81,19 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
           {series.stake.length > 0 ? (
-            <HistoryRow label="Stake" series={series.stake} color="var(--accent)" format={taoStr} />
+            <HistoryRow
+              label="Stake"
+              series={series.stake}
+              color="var(--accent)"
+              format={formatTao}
+            />
           ) : null}
           {series.emission.length > 0 ? (
             <HistoryRow
               label="Emission"
               series={series.emission}
               color="var(--health-warn)"
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
           {series.incentive.length > 0 ? (

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -4,21 +4,13 @@ import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
 
 // Lowercase windows, mirroring the /history API + the inline toggle conventions
 // used by health-trends.tsx. "all" maps to the API's widest supported window.
 type Win = "7d" | "30d" | "90d" | "1y" | "all";
 const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
-
-function taoStr(v?: number) {
-  if (v == null || !Number.isFinite(v)) return "—";
-  // Stake/emission can span a wide range; keep it compact and readable.
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
-}
 
 /**
  * Per-subnet on-chain history (#1302). A window selector drives a daily snapshot
@@ -96,7 +88,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               label="Total stake"
               series={series.stake}
               color={healthColorVar("warn")}
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
           {series.emission.length > 0 ? (
@@ -104,7 +96,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               label="Total emission"
               series={series.emission}
               color="var(--accent, #00c899)"
-              format={taoStr}
+              format={formatTao}
             />
           ) : null}
         </div>

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -50,7 +50,7 @@ import {
   accountSubnetsQuery,
   accountTransfersQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
@@ -132,14 +132,6 @@ function AccountDetail({ ss58 }: { ss58: string }) {
   return <ValidAccountDetail ss58={ss58} />;
 }
 
-// Compact TAO formatter — mirrors the economics panel's fmtTao convention.
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
-}
-
 function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const sourceRef = ss58PathSegment(ss58);
   const account = useSuspenseQuery(accountQuery(ss58)).data.data as AccountSummary;
@@ -157,7 +149,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const balanceValue = balanceResult.isPending ? (
     <span className="text-ink-muted">…</span>
   ) : balance?.balance_tao != null ? (
-    fmtTao(balance.balance_tao)
+    formatTao(balance.balance_tao)
   ) : (
     "—"
   );

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -30,7 +30,7 @@ import {
   chainTransferPairsQuery,
   economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type {
@@ -76,13 +76,7 @@ function sum(values: number[]): number {
 }
 
 function fmtTaoSigned(v: number): string {
-  return v < 0 ? `-${fmtTao(-v)}` : `+${fmtTao(v)}`;
-}
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
+  return v < 0 ? `-${formatTao(-v)}` : `+${formatTao(v)}`;
 }
 
 function ExplorerPage() {
@@ -366,9 +360,9 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
               value={fmtTaoSigned(net.net_flow_tao)}
               tone={net.net_flow_tao >= 0 ? "ok" : "down"}
             />
-            <StakeFlowMetric label="Gross flow" value={fmtTao(net.gross_flow_tao)} />
-            <StakeFlowMetric label="Staked" value={fmtTao(net.total_staked_tao)} />
-            <StakeFlowMetric label="Unstaked" value={fmtTao(net.total_unstaked_tao)} />
+            <StakeFlowMetric label="Gross flow" value={formatTao(net.gross_flow_tao)} />
+            <StakeFlowMetric label="Staked" value={formatTao(net.total_staked_tao)} />
+            <StakeFlowMetric label="Unstaked" value={formatTao(net.total_unstaked_tao)} />
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[10px] uppercase tracking-widest">
             <span className="text-health-ok">{formatNumber(net.gaining)} gaining</span>
@@ -635,14 +629,14 @@ function EconomicsTrendsSection({ trends }: { trends: EconomicsTrends }) {
             days={chrono.map((d) => d.snapshot_date)}
             values={chrono.map((d) => d.total_stake_tao ?? 0)}
             color="var(--accent)"
-            formatValue={fmtTao}
+            formatValue={formatTao}
           />
           <MiniSeries
             label="Alpha price"
             days={chrono.map((d) => d.snapshot_date)}
             values={chrono.map((d) => d.alpha_price_tao_weighted ?? 0)}
             color="var(--chart-1)"
-            formatValue={fmtTao}
+            formatValue={formatTao}
           />
           <MiniSeries
             label="Emission share"
@@ -778,11 +772,11 @@ function ExplorerDashboard() {
           value={formatNumber(totalEvents)}
           hint={`${win} total`}
         />
-        <StatTile icon={Coins} eyebrow="Fees" value={fmtTao(totalFees)} hint={`${win} total`} />
+        <StatTile icon={Coins} eyebrow="Fees" value={formatTao(totalFees)} hint={`${win} total`} />
         <StatTile
           icon={Coins}
           eyebrow="Tips"
-          value={fmtTao(totalTips)}
+          value={formatTao(totalTips)}
           hint={`${win} total`}
           tone={totalTips > 0 ? "ok" : "default"}
         />
@@ -863,28 +857,28 @@ function ExplorerDashboard() {
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.total_fee_tao)}
                 color="var(--accent)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Avg fee"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.avg_fee_tao ?? 0)}
                 color="var(--chart-3)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Total tips"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.total_tip_tao)}
                 color="var(--chart-6)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
               <MiniSeries
                 label="Avg tip"
                 days={feeChrono.map((d) => d.day)}
                 values={feeChrono.map((d) => d.avg_tip_tao ?? 0)}
                 color="var(--chart-1)"
-                formatValue={fmtTao}
+                formatValue={formatTao}
               />
             </div>
           ) : (
@@ -925,10 +919,10 @@ function ExplorerDashboard() {
                       </Link>
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                      {fmtTao(p.total_fee_tao)}
+                      {formatTao(p.total_fee_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(p.total_tip_tao)}
+                      {formatTao(p.total_tip_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                       {formatNumber(p.extrinsic_count)}
@@ -986,10 +980,10 @@ function ExplorerDashboard() {
                       {formatNumber(s.tx_count)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(s.total_fee_tao)}
+                      {formatTao(s.total_fee_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(s.total_tip_tao)}
+                      {formatTao(s.total_tip_tao)}
                     </td>
                     <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                       {s.last_tx_block != null ? (
@@ -1103,7 +1097,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
           {pairs ? (
             <p className="mt-1 font-mono text-[11px] text-ink-muted">
               {formatNumber(pairs.unique_pairs)} sender→receiver corridors ·{" "}
-              {fmtTao(pairs.total_volume_tao)} moved
+              {formatTao(pairs.total_volume_tao)} moved
             </p>
           ) : null}
         </div>
@@ -1174,7 +1168,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
                     </Link>
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {fmtTao(p.volume_tao)}
+                    {formatTao(p.volume_tao)}
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                     {formatNumber(p.transfer_count)}

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -14,7 +14,7 @@ import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import {
   extrinsicCall,
@@ -203,12 +203,12 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           </FieldRow>
           <FieldRow label="Inclusion fee">
             <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.fee_tao != null ? fmtTao(extrinsic.fee_tao) : "—"}
+              {extrinsic.fee_tao != null ? formatTao(extrinsic.fee_tao) : "—"}
             </span>
           </FieldRow>
           <FieldRow label="Tip">
             <span className="font-mono text-sm text-ink-strong">
-              {extrinsic.tip_tao != null ? fmtTao(extrinsic.tip_tao) : "—"}
+              {extrinsic.tip_tao != null ? formatTao(extrinsic.tip_tao) : "—"}
             </span>
           </FieldRow>
           <FieldRow label="Observed at">
@@ -337,13 +337,6 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
       />
     </>
   );
-}
-
-function fmtTao(v: number): string {
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
-  return `${v.toFixed(4)} τ`;
 }
 
 function renderCallArgs(callArgs: unknown) {


### PR DESCRIPTION
## Summary

Continues the consolidation already started for `economics-panel.tsx` (landed via #4456 for #3364): the shared `formatTao` in `lib/metagraphed/format.ts` already covers the majority `≥1→2dp, <1→4dp` convention.

This PR wires up the five remaining sites the issue names — `explorer.tsx`, `accounts.$ss58.tsx`, `extrinsics.$hash.tsx`, `subnet-history-chart.tsx`, and `neuron-history-chart.tsx` — to import and use the shared `formatTao` instead of their own hand-duplicated local copies (`fmtTao` / `taoStr`).

The two chart files (`subnet-history-chart.tsx`, `neuron-history-chart.tsx`) previously used a divergent `v < 10 → 3dp` / `v >= 10 → 2dp` convention, so a value like 5 TAO rendered as `"5.000 τ"` on a subnet/neuron history chart but `"5.00 τ"` everywhere else on the same subnet's page. All six sites now agree.

`accounts.$ss58.tsx`'s separate `fmtTaoCompact` helper (a different, out-of-scope function used only for validator-leaderboard tiles) is untouched.

## Screenshots

Verified against a real subnet page (SN64) with a controlled 5.5 TAO value routed through both the Economics panel and the Network history chart, to make the previously-divergent precision band (`< 10 TAO`) visible:

| Before | After |
| --- | --- |
| [<img src="https://gist.githubusercontent.com/galuis116/16784eb17745e0b8be8784406a8799a8/raw/7a2b8456b45beea068ebcd2b534685b7f42dee4b/before-tao.png" width="420">](https://gist.githubusercontent.com/galuis116/16784eb17745e0b8be8784406a8799a8/raw/7a2b8456b45beea068ebcd2b534685b7f42dee4b/before-tao.png)<br><sub>Economics panel shows "5.50 τ"; Network history chart shows "5.500 τ" — mismatched</sub> | [<img src="https://gist.githubusercontent.com/galuis116/16784eb17745e0b8be8784406a8799a8/raw/7a2b8456b45beea068ebcd2b534685b7f42dee4b/after-tao.png" width="420">](https://gist.githubusercontent.com/galuis116/16784eb17745e0b8be8784406a8799a8/raw/7a2b8456b45beea068ebcd2b534685b7f42dee4b/after-tao.png)<br><sub>Both panels now show "5.50 τ" — identical</sub> |

Closes #3947

## Acceptance criteria

- [x] `src/lib/metagraphed/format.ts` already has the shared TAO-formatting function (landed via #4456)
- [x] All six listed files now import and use the shared function instead of their local copies (`economics-panel.tsx` already did; this PR covers the remaining five)
- [x] The same input value produces the same formatted string across all six call sites — `format.test.ts` (already on main) asserts the 1 TAO and 10 TAO boundary values explicitly, and the screenshots above confirm it visually for a value inside the previously-divergent `< 10` band
- [x] No visible change to the majority convention's rendering (explorer, accounts, extrinsics) — only the two chart files' precision changes to match
- [x] Before/after screenshot table included above

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm run lint --workspace=apps/ui` — 0 errors (pre-existing unrelated warnings only)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 588/588 tests passing (85/85 files)
- [x] `npm run build --workspace=apps/ui` — builds cleanly