### PR TITLE
feat(ui): add an RSS feed discovery link to the site footer (#3351)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Compass, Github, Menu, Webhook, X } from "lucide-react";
+import { ChevronRight, Compass, Github, Menu, Rss, Webhook, X } from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -307,6 +307,20 @@ function SiteFooter() {
               className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
             >
               <DiscordIcon className="size-4" />
+            </a>
+            {/* #3351: discoverable RSS/Atom feed for the registry-changes feed
+                (/api/v1/feeds/registry, content-negotiated; .rss for a predictable
+                browser click). Same guarded external-link pattern as the openapi
+                link and the GitHub/Discord icons above. */}
+            <a
+              href={safeExternalUrl(`${API_BASE}/api/v1/feeds/registry.rss`)}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Registry changes RSS feed"
+              title="Subscribe to the registry-changes feed (RSS)"
+              className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+            >
+              <Rss className="size-4" />
             </a>
           </div>
         </div>


### PR DESCRIPTION
Closes #3351

## Summary

Adds a discoverable **RSS feed link** to `SiteFooter` so a human visiting the site (not just an agent reading the homepage `<link>` tags or the `Link` header) can find and subscribe to the registry-changes feed. A single `Rss` icon-link is added to the footer's existing social-icon row (beside GitHub/Discord), pointing at the already-live `${API_BASE}/api/v1/feeds/registry.rss`. **UI-only, one file, no query/backend change.**

## What changed

- **`apps/ui/src/components/metagraphed/app-shell.tsx`** — import `Rss` from `lucide-react`; add one `<a>` to `SiteFooter`'s social-icon row, built through the same `safeExternalUrl()` guard + `target="_blank" rel="noopener noreferrer"` pattern as the adjacent GitHub/Discord icons and the `openapi` link, with `aria-label="Registry changes RSS feed"` and a `title`.

## Scope (matches the issue's acceptance criteria)

- [x] Diff touches only `app-shell.tsx` (not `queries.ts`/`types.ts` — none needed)
- [x] `SiteFooter` renders a new `<a>` → `${API_BASE}/api/v1/feeds/registry.rss`, built through `safeExternalUrl()` like every other external href in the file
- [x] Opens in a new tab (`target="_blank" rel="noopener noreferrer"`), matching the GitHub/Discord/openapi links
- [x] Discernible accessible name (`aria-label` + `title`), matching the existing icon-link convention
- [x] No data-fetching/loading/empty/error states — a static discovery link, no `useQuery` machinery

## Non-goals respected

- Does not touch `apps/ui/src/routes/status.tsx` (that's #3352)
- No `queries.ts`/`types.ts` entry and no `src/feeds.mjs` / `workers/api.mjs` change — the backend route is already live

## Local verification

- `npm run typecheck --workspace=apps/ui` ✓
- `eslint` clean on the changed file (0 errors)
- Feed endpoint verified live: `GET /api/v1/feeds/registry.rss` → `200`, `content-type: application/rss+xml`

> Note: the `ui` job's `test:e2e` step is currently red from a pre-existing `/status` overflow-baseline regression on `main` (main's own `ui` check is red today), unrelated to this footer-only change — this PR adds no `/status` or overflow-affecting markup.

## Before / after screenshots — site footer

`before` = current production (`metagraph.sh`) — footer shows GitHub · Discord. `after` = this branch — GitHub · Discord · **RSS**. Homepage footer, fixed viewport captures, theme forced via `localStorage['mg-theme']`.

| Viewport · Theme | Before | After |
| ---------------- | --- | --- |
| Desktop · Light  | ![footer desktop light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-desktop-light-before.png) | ![footer desktop light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-desktop-light-after.png) |
| Desktop · Dark   | ![footer desktop dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-desktop-dark-before.png) | ![footer desktop dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-desktop-dark-after.png) |
| Tablet · Light   | ![footer tablet light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-tablet-light-before.png) | ![footer tablet light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-tablet-light-after.png) |
| Tablet · Dark    | ![footer tablet dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-tablet-dark-before.png) | ![footer tablet dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-tablet-dark-after.png) |
| Mobile · Light   | ![footer mobile light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-mobile-light-before.png) | ![footer mobile light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-mobile-light-after.png) |
| Mobile · Dark    | ![footer mobile dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-mobile-dark-before.png) | ![footer mobile dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/footer-mobile-dark-after.png) |
