### PR TITLE
feat(ui): surface the enrichment-evidence queue on the gaps page (#3354)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.enrichment-evidence.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.enrichment-evidence.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { reviewEnrichmentEvidenceQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/review/enrichment-evidence",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (mirrors the sibling query tests).
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+describe("reviewEnrichmentEvidenceQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits /api/v1/review/enrichment-evidence and reads the `entries` collection", async () => {
+    resolveWith({
+      entries: [
+        {
+          netuid: 12,
+          name: "Foo",
+          slug: "foo",
+          lane: "candidate",
+          evidence_action: "verify-openapi",
+          missing_kinds: ["openapi", "sdk"],
+          direct_submission_kinds: ["docs"],
+          priority_score: 87.4,
+          extra_ignored_field: "x",
+        },
+      ],
+    });
+    const res = await runQuery(reviewEnrichmentEvidenceQuery());
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/review/enrichment-evidence",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data).toEqual([
+      {
+        netuid: 12,
+        name: "Foo",
+        slug: "foo",
+        lane: "candidate",
+        evidence_action: "verify-openapi",
+        missing_kinds: ["openapi", "sdk"],
+        direct_submission_kinds: ["docs"],
+        priority_score: 87.4,
+      },
+    ]);
+  });
+
+  it("defaults kind arrays to [] and score to undefined for sparse rows (never NaN/undefined leaks)", async () => {
+    resolveWith({ entries: [{ netuid: 3 }] });
+    const res = await runQuery(reviewEnrichmentEvidenceQuery());
+    expect(res.data[0]).toMatchObject({
+      netuid: 3,
+      missing_kinds: [],
+      direct_submission_kinds: [],
+      priority_score: undefined,
+    });
+  });
+
+  it("coerces non-array kind fields to [] rather than passing them through", async () => {
+    resolveWith({ entries: [{ netuid: 5, missing_kinds: "openapi", direct_submission_kinds: null }] });
+    const res = await runQuery(reviewEnrichmentEvidenceQuery());
+    expect(res.data[0].missing_kinds).toEqual([]);
+    expect(res.data[0].direct_submission_kinds).toEqual([]);
+  });
+
+  it("returns an empty list when the artifact has no entries", async () => {
+    resolveWith({});
+    const res = await runQuery(reviewEnrichmentEvidenceQuery());
+    expect(res.data).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.enrichment-evidence.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.enrichment-evidence.test.ts
@@ -85,7 +85,9 @@ describe("reviewEnrichmentEvidenceQuery", () => {
   });
 
   it("coerces non-array kind fields to [] rather than passing them through", async () => {
-    resolveWith({ entries: [{ netuid: 5, missing_kinds: "openapi", direct_submission_kinds: null }] });
+    resolveWith({
+      entries: [{ netuid: 5, missing_kinds: "openapi", direct_submission_kinds: null }],
+    });
     const res = await runQuery(reviewEnrichmentEvidenceQuery());
     expect(res.data[0].missing_kinds).toEqual([]);
     expect(res.data[0].direct_submission_kinds).toEqual([]);

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6418,6 +6418,42 @@ export const reviewEnrichmentQueueQuery = () =>
     staleTime: STALE_LONG,
   });
 
+// #3354: detailed per-subnet evidence behind the enrichment queue — one level
+// down from reviewEnrichmentQueueQuery's summary. Distinct endpoint/artifact
+// (collection key "entries"); mirrors the fetchList + .map() normalization the
+// two review siblings above use.
+export const reviewEnrichmentEvidenceQuery = () =>
+  queryOptions({
+    queryKey: k("review-enrichment-evidence"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/enrichment-evidence",
+        "entries",
+        undefined,
+        signal,
+      );
+      // API rows (enrichmentEvidenceEntry, scripts/lib/enrichment-queue-artifacts.mjs):
+      // { netuid, name, slug, lane, evidence_action, missing_kinds,
+      // direct_submission_kinds, priority_score, ... }. Kind arrays default to []
+      // and the score to undefined so the UI never renders NaN/undefined.
+      const rows = res.data.map((r) => ({
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        slug: r.slug as string | undefined,
+        lane: r.lane as string | undefined,
+        evidence_action: r.evidence_action as string | undefined,
+        missing_kinds: Array.isArray(r.missing_kinds) ? (r.missing_kinds as string[]) : [],
+        direct_submission_kinds: Array.isArray(r.direct_submission_kinds)
+          ? (r.direct_submission_kinds as string[])
+          : [],
+        priority_score:
+          typeof r.priority_score === "number" ? (r.priority_score as number) : undefined,
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
 function normalizeSchema(raw: unknown): SchemaInfo {
   if (!raw || typeof raw !== "object") return raw as SchemaInfo;
   const s = raw as Record<string, unknown>;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -29,6 +29,7 @@ import {
   reviewProfileCompletenessQuery,
   reviewAdapterCandidatesQuery,
   reviewEnrichmentQueueQuery,
+  reviewEnrichmentEvidenceQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
@@ -201,6 +202,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="enrichment-evidence"
+          eyebrow="Evidence"
+          title="Enrichment evidence"
+          description="Detailed per-subnet evidence behind the enrichment queue — the review lane, recommended action, and the surface kinds still missing."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <EnrichmentEvidence />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -209,6 +223,7 @@ function GapsPage() {
           "/api/v1/review/profile-completeness",
           "/api/v1/review/adapter-candidates",
           "/api/v1/review/enrichment-queue",
+          "/api/v1/review/enrichment-evidence",
         ]}
       />
     </AppShell>
@@ -997,6 +1012,74 @@ function EnrichmentQueue() {
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// #3354: detailed per-subnet evidence behind the enrichment queue. Same list
+// shape and table idiom as EnrichmentQueue above, but the granular evidence view
+// (lane / recommended action / missing + direct-submission kinds / priority),
+// sourced from the distinct reviewEnrichmentEvidenceQuery.
+function EnrichmentEvidence() {
+  const { data } = useSuspenseQuery(reviewEnrichmentEvidenceQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No enrichment evidence"
+        description="Detailed evidence rows appear once the enrichment queue has candidates with recorded gaps."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-4 py-2.5 text-left">Netuid</th>
+              <th className="px-4 py-2.5 text-left">Lane</th>
+              <th className="px-4 py-2.5 text-left">Evidence action</th>
+              <th className="px-4 py-2.5 text-left">Missing kinds</th>
+              <th className="px-4 py-2.5 text-left">Direct submission</th>
+              <th className="px-4 py-2.5 text-right">Priority</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r, i) => (
+              <tr key={`${r.netuid ?? r.slug ?? r.name ?? "row"}-${i}`} className="mg-row-hover">
+                <td className="px-4 py-2.5 font-mono text-[11px]">
+                  {r.netuid != null ? (
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="hover:text-accent"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink">{r.lane ?? "—"}</td>
+                <td className="px-4 py-2.5 text-[12px] text-ink">{r.evidence_action ?? "—"}</td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                  {r.missing_kinds.length > 0 ? r.missing_kinds.join(", ") : "—"}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                  {r.direct_submission_kinds.length > 0 ? r.direct_submission_kinds.join(", ") : "—"}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                  {r.priority_score != null ? Math.round(r.priority_score) : "—"}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -1075,7 +1075,9 @@ function EnrichmentEvidence() {
                   {r.missing_kinds.length > 0 ? r.missing_kinds.join(", ") : "—"}
                 </td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">
-                  {r.direct_submission_kinds.length > 0 ? r.direct_submission_kinds.join(", ") : "—"}
+                  {r.direct_submission_kinds.length > 0
+                    ? r.direct_submission_kinds.join(", ")
+                    : "—"}
                 </td>
                 <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
                   {r.priority_score != null ? Math.round(r.priority_score) : "—"}


### PR DESCRIPTION
Closes #3354

## Summary

Adds the missing `reviewEnrichmentEvidenceQuery` data-layer function for the already-live `GET /api/v1/review/enrichment-evidence` endpoint and renders its per-subnet evidence rows in a new **Enrichment evidence** `PageSection` on `/gaps` — the *detailed* view one level down from the existing Enrichment queue summary. **No backend/schema change** — the endpoint was already serving data.

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `reviewEnrichmentEvidenceQuery`, mirroring the `reviewEnrichmentQueueQuery` / `reviewAdapterCandidatesQuery` siblings exactly: `fetchList<Record<string, unknown>>("/api/v1/review/enrichment-evidence", "entries", undefined, signal)` + `.map()` normalization of `netuid, name, slug, lane, evidence_action, missing_kinds, direct_submission_kinds, priority_score`, wrapped in `queryOptions({ queryKey: k("review-enrichment-evidence"), staleTime: STALE_LONG })`. Kind arrays default to `[]` and the score to `undefined` so the UI never renders `NaN`/`undefined`.
- **`apps/ui/src/routes/gaps.tsx`** — new `<PageSection id="enrichment-evidence">` between the `enrichment-queue` section and `</main>`, wrapped in the same `QueryErrorBoundary` + `Suspense fallback={<Skeleton/>}` convention as every other section. A new `EnrichmentEvidence` component renders the table (netuid → `/subnets/$netuid`, lane, evidence_action, missing_kinds, direct_submission_kinds, priority_score) with a `TableState variant="empty"` empty state. The new route path is appended to `ApiSourceFooter`.
- **`apps/ui/src/lib/metagraphed/queries.enrichment-evidence.test.ts`** — tests for the query: `entries` collection-key read, field normalization (sparse rows → `[]`/`undefined`; non-array kinds coerced to `[]`), and empty-artifact handling.

## Scope (matches the issue's acceptance criteria)

- [x] Diff touches `apps/ui/src/routes/gaps.tsx` in addition to `queries.ts`
- [x] `reviewEnrichmentEvidenceQuery` calls `fetchList` against `/api/v1/review/enrichment-evidence` (collection key `entries`), following the `reviewEnrichmentQueueQuery`/`reviewAdapterCandidatesQuery` pattern
- [x] `gaps.tsx` imports + calls it via `useSuspenseQuery` in a new component mounted in a new `PageSection`
- [x] Rows show netuid (linked to `/subnets/$netuid`), lane, evidence_action, missing_kinds, direct_submission_kinds, priority_score
- [x] `/api/v1/review/enrichment-evidence` added to `ApiSourceFooter paths`
- [x] Loading (`Suspense`/`Skeleton`), empty (`TableState variant="empty"`), and error (`QueryErrorBoundary`) states handled, matching the sibling `AdapterCandidates`/`EnrichmentQueue` components
- [x] No backend/schema change; the existing `reviewEnrichmentQueueQuery` and its section are untouched — this is additive and adjacent (`id="enrichment-evidence"`)

## Non-goals respected

- Does not wire `/api/v1/review/enrichment-targets` (#3355) or the global `/api/v1/review/gaps` queue (#3356)
- Does not modify the existing `reviewEnrichmentQueueQuery` or its `EnrichmentQueue` section
- No filtering/sorting UI beyond the sibling sections' parity

## Local verification

- `npm run typecheck --workspace=apps/ui` ✓
- `npm test --workspace=apps/ui` ✓ — 79 files, **541 tests** (adds the `reviewEnrichmentEvidenceQuery` tests)
- `npm run format:check` ✓ on the changed files

## Before / after screenshots — `/gaps`

`before` = current production (`metagraph.sh`, unchanged `main`) — the page's last content section is **Enrichment queue**. `after` = this branch's new **Enrichment evidence** section (rendered against the same live `api.metagraph.sh` data, 129 entries). Fixed viewport captures, theme forced via `localStorage['mg-theme']`.

| Viewport · Theme | Before (production — ends at Enrichment queue) | After (new Enrichment evidence section) |
| ---------------- | --- | --- |
| Desktop · Light  | ![gaps desktop light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-desktop-light-before.png) | ![gaps desktop light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-desktop-light-after.png) |
| Desktop · Dark   | ![gaps desktop dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-desktop-dark-before.png) | ![gaps desktop dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-desktop-dark-after.png) |
| Tablet · Light   | ![gaps tablet light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-tablet-light-before.png) | ![gaps tablet light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-tablet-light-after.png) |
| Tablet · Dark    | ![gaps tablet dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-tablet-dark-before.png) | ![gaps tablet dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-tablet-dark-after.png) |
| Mobile · Light   | ![gaps mobile light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-mobile-light-before.png) | ![gaps mobile light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-mobile-light-after.png) |
| Mobile · Dark    | ![gaps mobile dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-mobile-dark-before.png) | ![gaps mobile dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/gaps-mobile-dark-after.png) |
