### PR TITLE
feat(ui): surface a counterparties panel on the account detail page (#3340)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-counterparties.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-counterparties.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountCounterpartiesQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 addresses (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${ALICE}/counterparties`,
+  });
+}
+
+async function runQuery(ss58: string) {
+  const opts = accountCounterpartiesQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountCounterpartiesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the counterparties route and passes through a well-formed row", async () => {
+    resolveWith({
+      ss58: ALICE,
+      counterparty_count: 1,
+      transfers_scanned: 42,
+      scan_capped: false,
+      total_sent_tao: 10,
+      total_received_tao: 5,
+      counterparties: [
+        {
+          address: BOB,
+          sent_tao: 7,
+          received_tao: 3,
+          net_tao: -4,
+          transfer_count: 5,
+          last_block: 1234,
+        },
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/counterparties`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data).toMatchObject({
+      ss58: ALICE,
+      counterparty_count: 1,
+      transfers_scanned: 42,
+      scan_capped: false,
+      total_sent_tao: 10,
+      total_received_tao: 5,
+    });
+    expect(res.data.counterparties).toEqual([
+      {
+        address: BOB,
+        sent_tao: 7,
+        received_tao: 3,
+        net_tao: -4,
+        transfer_count: 5,
+        last_block: 1234,
+      },
+    ]);
+  });
+
+  it("drops rows with no address and coerces junk numeric cells to null (never NaN)", async () => {
+    resolveWith({
+      ss58: ALICE,
+      counterparties: [
+        { address: BOB, sent_tao: "nope", received_tao: {}, net_tao: null },
+        { sent_tao: 1 }, // no address → dropped
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(res.data.counterparties).toEqual([
+      {
+        address: BOB,
+        sent_tao: null,
+        received_tao: null,
+        net_tao: null,
+        transfer_count: null,
+        last_block: null,
+      },
+    ]);
+    // counterparty_count falls back to the surviving-row count when absent.
+    expect(res.data.counterparty_count).toBe(1);
+  });
+
+  it("degrades a cold / unknown account to an empty leaderboard (never throws)", async () => {
+    for (const raw of [{}, null, { counterparties: "not-an-array" }]) {
+      resolveWith(raw);
+      const res = await runQuery(ALICE);
+      expect(res.data.ss58).toBe(ALICE);
+      expect(res.data.counterparties).toEqual([]);
+      expect(res.data.counterparty_count).toBe(0);
+      expect(res.data.total_sent_tao).toBeNull();
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -44,6 +44,8 @@ import type {
   AccountDay,
   AccountEvent,
   AccountEventsPage,
+  AccountCounterparties,
+  AccountCounterparty,
   AccountHistory,
   AccountPortfolio,
   AccountStakeMoves,
@@ -2468,6 +2470,56 @@ export const accountSubnetsQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountSubnets>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3340: fund-flow leaderboard — the addresses this account transacts with most
+// (by volume), from the already-live /api/v1/accounts/{ss58}/counterparties
+// (list mode). Structured-object response, so it mirrors accountSubnetsQuery's
+// apiFetch + isRecord + per-row normalize shape (not a bare fetchList).
+function normalizeCounterparty(raw: unknown): AccountCounterparty | null {
+  if (!isRecord(raw)) return null;
+  const address = firstString(raw.address);
+  if (!address) return null;
+  return {
+    address,
+    sent_tao: firstFiniteNumber(raw.sent_tao) ?? null,
+    received_tao: firstFiniteNumber(raw.received_tao) ?? null,
+    net_tao: firstFiniteNumber(raw.net_tao) ?? null,
+    transfer_count: firstFiniteNumber(raw.transfer_count) ?? null,
+    last_block: firstFiniteNumber(raw.last_block) ?? null,
+  };
+}
+
+export const accountCounterpartiesQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-counterparties", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/counterparties`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const counterparties = Array.isArray(d.counterparties)
+        ? d.counterparties.flatMap((row) => {
+            const c = normalizeCounterparty(row);
+            return c ? [c] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          counterparty_count: firstFiniteNumber(d.counterparty_count) ?? counterparties.length,
+          transfers_scanned: firstFiniteNumber(d.transfers_scanned) ?? null,
+          scan_capped: booleanValue(d.scan_capped),
+          total_sent_tao: firstFiniteNumber(d.total_sent_tao) ?? null,
+          total_received_tao: firstFiniteNumber(d.total_received_tao) ?? null,
+          counterparties,
+        } as AccountCounterparties,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountCounterparties>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1258,6 +1258,29 @@ export interface AccountStakeMoves {
   subnets: AccountStakeMovesSubnet[];
   [key: string]: unknown;
 }
+/** One counterparty row in /api/v1/accounts/{ss58}/counterparties (list mode). */
+export interface AccountCounterparty {
+  address: string;
+  sent_tao: number | null;
+  received_tao: number | null;
+  net_tao: number | null;
+  transfer_count: number | null;
+  last_block: number | null;
+}
+/**
+ * #3340: /api/v1/accounts/{ss58}/counterparties (list mode) — the fund-flow
+ * leaderboard of the addresses this account transacts with, by volume.
+ */
+export interface AccountCounterparties {
+  ss58: string;
+  counterparty_count: number;
+  transfers_scanned: number | null;
+  scan_capped: boolean | null;
+  total_sent_tao: number | null;
+  total_received_tao: number | null;
+  counterparties: AccountCounterparty[];
+  [key: string]: unknown;
+}
 export interface AccountPortfolio {
   ss58: string;
   captured_at?: string | null;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -18,6 +18,7 @@ import {
   Unplug,
   UserMinus,
   UserPlus,
+  Users,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
@@ -36,6 +37,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountCounterpartiesQuery,
   accountPortfolioQuery,
   accountStakeMovesQuery,
   accountDeregistrationsQuery,
@@ -56,6 +58,7 @@ import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
 import type {
+  AccountCounterparty,
   AccountRegistration,
   AccountSummary,
   Extrinsic,
@@ -322,6 +325,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
         error={transfersResult.error}
         onRetry={() => void transfersResult.refetch()}
       />
+      {/* #3340: the aggregated fund-flow view over the same transfer data. */}
+      <AccountCounterpartiesSection ss58={ss58} />
 
       <div className="mt-6">
         <Link
@@ -344,6 +349,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
+            { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
             { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
             { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
           ]}
@@ -356,6 +362,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/history`,
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
+          `/api/v1/accounts/${sourceRef}/counterparties`,
           `/api/v1/accounts/${sourceRef}/serving`,
           `/api/v1/accounts/${sourceRef}/prometheus`,
         ]}
@@ -798,6 +805,155 @@ function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
       {subnets.length > rows.length ? (
         <p className="mt-3 font-mono text-[10px] text-ink-muted">
           Showing the {rows.length} most-active of {formatNumber(subnets.length)} subnets.
+        </p>
+      ) : null}
+    </SectionAnchor>
+  );
+}
+
+// #3340: fund-flow leaderboard for this account — the top addresses it transacts
+// with by volume, from accountCounterpartiesQuery. Self-contained + non-blocking
+// (same shape as AccountStakeMovesSection): while it loads or if it fails, the
+// rest of the account page is unaffected; a cold wallet renders nothing.
+function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountCounterpartiesQuery(ss58));
+  const c = result.data?.data;
+  const SUBTITLE =
+    "The addresses this account transacts with most, by volume — directional totals, net flow, transfer count, and last-active block.";
+
+  if (result.isPending && !c) {
+    return (
+      <AccountFeedSectionSkeleton id="counterparties" title="Counterparties" subtitle={SUBTITLE} />
+    );
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor id="counterparties" title="Counterparties" subtitle={SUBTITLE} tone="accent">
+        <TableState
+          variant="error"
+          title="Couldn't load counterparties"
+          description="The counterparties tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  const parties = c?.counterparties ?? [];
+  if (!c || parties.length === 0) return null;
+  const volume = (p: AccountCounterparty) => (p.sent_tao ?? 0) + (p.received_tao ?? 0);
+  const rows = [...parties].sort((a, b) => volume(b) - volume(a)).slice(0, 20);
+
+  return (
+    <SectionAnchor
+      id="counterparties"
+      title="Counterparties"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="Fund-flow leaderboard from /api/v1/accounts/{ss58}/counterparties — the top addresses by transfer volume, with sent/received/net totals and the last block each was active in."
+      right={
+        <SectionBadge tone="accent">{formatNumber(c.counterparty_count)} addresses</SectionBadge>
+      }
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile
+          icon={Users}
+          eyebrow="Counterparties"
+          tone="accent"
+          value={formatNumber(c.counterparty_count)}
+          hint="distinct addresses"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={TrendingUp}
+          eyebrow="Total sent"
+          value={fmtTaoCompact(c.total_sent_tao)}
+          hint="outflow"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="Total received"
+          value={fmtTaoCompact(c.total_received_tao)}
+          hint="inflow"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Activity}
+          eyebrow="Transfers scanned"
+          value={formatNumber(c.transfers_scanned ?? 0)}
+          hint={c.scan_capped ? "scan capped" : "in window"}
+          className={KPI_TILE}
+        />
+      </div>
+      <DataPanel>
+        <table className="w-full text-left text-sm">
+          <thead className="bg-surface/50">
+            <tr>
+              <th className={TH}>Address</th>
+              <th className={`${TH} text-right`}>Sent</th>
+              <th className={`${TH} text-right`}>Received</th>
+              <th className={`${TH} text-right`}>Net flow</th>
+              <th className={`${TH} text-right`}>Transfers</th>
+              <th className={`${TH} text-right`}>Last block</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((p, i) => (
+              <tr key={`${p.address}-${i}`} className="hover:bg-surface/30">
+                <td className="px-5 py-4 font-mono text-[11px] text-ink-muted" title={p.address}>
+                  {p.address !== ss58 ? (
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: p.address }}
+                      className="hover:text-accent hover:underline"
+                    >
+                      {shortHash(p.address)}
+                    </Link>
+                  ) : (
+                    (shortHash(p.address) ?? "—")
+                  )}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {p.sent_tao != null ? `${formatNumber(p.sent_tao)} τ` : "—"}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {p.received_tao != null ? `${formatNumber(p.received_tao)} τ` : "—"}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums">
+                  {p.net_tao == null ? (
+                    <span className="text-ink-muted">—</span>
+                  ) : (
+                    <span className={p.net_tao >= 0 ? "text-emerald-500" : "text-amber-500"}>
+                      {p.net_tao >= 0 ? "+" : ""}
+                      {formatNumber(p.net_tao)} τ
+                    </span>
+                  )}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {formatNumber(p.transfer_count ?? 0)}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[12px]">
+                  {p.last_block != null ? (
+                    <Link
+                      to="/blocks/$ref"
+                      params={{ ref: String(p.last_block) }}
+                      className="text-ink hover:text-accent hover:underline"
+                    >
+                      #{formatNumber(p.last_block)}
+                    </Link>
+                  ) : (
+                    <span className="text-ink-muted">—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </DataPanel>
+      {parties.length > rows.length ? (
+        <p className="mt-3 font-mono text-[10px] text-ink-muted">
+          Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
       ) : null}
     </SectionAnchor>


### PR DESCRIPTION
Closes #3340

## Summary

Adds a **Counterparties** panel to the account detail page — the fund-flow leaderboard of the addresses this account transacts with most (by volume), which the backend already computes at `GET /api/v1/accounts/{ss58}/counterparties` (list mode) but the UI never surfaced. Data-layer + UI in one PR; **no backend change**.

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `accountCounterpartiesQuery(ss58)` + a `normalizeCounterparty` helper, mirroring `accountSubnetsQuery`'s `apiFetch` + `isRecord` + per-row normalize shape (structured object, not a bare `fetchList`). Numeric cells coerce to `null` (never `NaN`), addressless rows drop, `counterparty_count` falls back to the surviving-row count.
- **`apps/ui/src/lib/metagraphed/types.ts`** — new `AccountCounterparties` + `AccountCounterparty` response types.
- **`apps/ui/src/routes/accounts.$ss58.tsx`** — new self-contained `AccountCounterpartiesSection({ ss58 })` (non-blocking `useQuery`, same shape as `AccountStakeMovesSection`): a summary `StatTile` row (counterparties · total sent · total received · transfers scanned) + a volume-ranked table — **Address** (→ its account page), **Sent**, **Received**, **Net flow** (signed + green/amber toned), **Transfers**, **Last block** (→ the block page). Rendered right after `AccountTransfersSection`; the new route is added to the `EndpointSnippet` rows and `ApiSourceFooter`.

## Scope (matches the issue's acceptance criteria)

- [x] Diff touches `apps/ui/src/routes/accounts.$ss58.tsx` (not just `queries.ts`/`types.ts`)
- [x] New `accountCounterpartiesQuery` (`queryOptions`/`apiFetch`/normalize) + a corresponding `types.ts` type
- [x] The section imports + calls it via `useQuery` (non-blocking — never `useSuspenseQuery` for this sub-resource)
- [x] Renders address (linked), sent/received/net TAO, transfer count, and last-seen block (linked)
- [x] Loading → shared skeleton; empty (`counterparties.length === 0`) → `return null`; error → `TableState` without blocking the rest of the page

## Non-goals respected

- No `?counterparty=<ss58>` two-party drilldown; no backend / `src/counterparties.mjs` change; sibling sections untouched beyond slotting the new one in.

## Local verification

- `npm run typecheck --workspace=apps/ui` ✓
- `npm test --workspace=apps/ui` ✓ — 85 files, **585 tests** (adds `accountCounterpartiesQuery` path/normalize/cold-account tests)
- `eslint` clean on the changed files (0 errors)

## Before / after screenshots — account detail page

> **Note on the data:** live `Balances.Transfer` volume is currently sparse network-wide (0 transfer pairs even at a 30-day window), so production accounts render this section's **graceful empty state** (the section returns `null` when `counterparties.length === 0`, covered by tests). To make the rendered component reviewable, the **`after`** captures use Playwright route-interception to serve a **representative** `/counterparties` payload (valid-format ss58 rows, realistic τ volumes). `before` = current production (same account) — the page has no counterparties panel.

| Viewport · Theme | Before (production — no panel) | After (new Counterparties panel, representative payload) |
| ---------------- | --- | --- |
| Desktop · Light  | ![account desktop light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-desktop-light-before.png) | ![account desktop light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-desktop-light-after.png) |
| Desktop · Dark   | ![account desktop dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-desktop-dark-before.png) | ![account desktop dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-desktop-dark-after.png) |
| Tablet · Light   | ![account tablet light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-tablet-light-before.png) | ![account tablet light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-tablet-light-after.png) |
| Tablet · Dark    | ![account tablet dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-tablet-dark-before.png) | ![account tablet dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-tablet-dark-after.png) |
| Mobile · Light   | ![account mobile light before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-mobile-light-before.png) | ![account mobile light after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-mobile-light-after.png) |
| Mobile · Dark    | ![account mobile dark before](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-mobile-dark-before.png) | ![account mobile dark after](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/account-mobile-dark-after.png) |

On mobile the summary `StatTile`s stack to one column and the table sits in the standard `DataPanel` horizontal-scroll container — values are compact (shortHash, τ amounts, block #), so no cell-wrap crowding.
