### PR TITLE
fix(nav): point Endpoints mega-menu filters at params the route reads

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
@@ -72,6 +72,43 @@ describe("MEGA_PANELS catalogue", () => {
       }
     }
   });
+
+  it("only links to route-consumed filter params/values on /endpoints", () => {
+    // /endpoints (routes/endpoints.tsx) reads category / health / eligibility;
+    // its facet chips enumerate the allowed values. A mega-menu link carrying a
+    // param the route never reads (the old kind / archive / pool / incidents /
+    // stale) matches zero rows and silently renders the unfiltered list. Pin
+    // every /endpoints filter link to a param+value the route actually accepts.
+    const SCHEMA_KEYS = new Set([
+      "q",
+      "category",
+      "provider",
+      "health",
+      "netuid",
+      "region",
+      "eligibility",
+      "callable",
+      "sort",
+      "order",
+      "page",
+      "pageSize",
+      "view",
+    ]);
+    const FACET_VALUES: Record<string, Set<string>> = {
+      category: new Set(["all", "rpc", "wss", "api", "sse", "data", "other"]),
+      health: new Set(["ok", "warn", "down", "unknown"]),
+      eligibility: new Set(["proxy-enabled", "pool-member", "archive-capable", "unassigned"]),
+    };
+    const endpoints = MEGA_PANELS.find((p) => p.key === "endpoints");
+    expect(endpoints).toBeDefined();
+    for (const l of [...endpoints!.browse, ...endpoints!.filters]) {
+      for (const [param, value] of Object.entries(l.search ?? {})) {
+        expect(SCHEMA_KEYS.has(param)).toBe(true);
+        const allowed = FACET_VALUES[param];
+        if (allowed) expect(allowed.has(value)).toBe(true);
+      }
+    }
+  });
 });
 
 describe("storage helpers (SSR/node-safe)", () => {

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -104,14 +104,14 @@ export const MEGA_PANELS: MegaPanel[] = [
     apiPath: "/api/v1/endpoints",
     browse: [
       { to: "/endpoints", label: "All endpoints" },
-      { to: "/endpoints", search: { kind: "rpc" }, label: "Root RPC" },
-      { to: "/endpoints", search: { kind: "wss" }, label: "WSS" },
-      { to: "/endpoints", search: { archive: "1" }, label: "Archive-capable" },
-      { to: "/endpoints", search: { pool: "eligible" }, label: "Pool-eligible" },
+      { to: "/endpoints", search: { category: "rpc" }, label: "Root RPC" },
+      { to: "/endpoints", search: { category: "wss" }, label: "WSS" },
+      { to: "/endpoints", search: { eligibility: "archive-capable" }, label: "Archive-capable" },
+      { to: "/endpoints", search: { eligibility: "pool-member" }, label: "Pool-eligible" },
     ],
     filters: [
-      { to: "/endpoints", search: { incidents: "recent" }, label: "Recent incidents" },
-      { to: "/endpoints", search: { stale: "1" }, label: "Stale probes" },
+      { to: "/endpoints", search: { health: "down" }, label: "Recent incidents" },
+      { to: "/endpoints", search: { health: "unknown" }, label: "Stale probes" },
     ],
   },
   {


### PR DESCRIPTION
## Problem

The primary-nav **Endpoints** mega-panel builds six "quick filter" links whose search params the `/endpoints` route schema never defines, so every one is a silent no-op — the page loads with default filters regardless of which was clicked (`nav-mega-menu-data.ts`, the endpoints panel):

| Link (label) | Old param | `endpointsSearchSchema` reads it? |
| --- | --- | --- |
| Root RPC | `kind=rpc` | no — the field is `category` |
| WSS | `kind=wss` | no — the field is `category` |
| Archive-capable | `archive=1` | no |
| Pool-eligible | `pool=eligible` | no |
| Recent incidents | `incidents=recent` | no |
| Stale probes | `stale=1` | no |

`endpointsSearchSchema` (`routes/endpoints.tsx`) exposes `category` / `health` / `eligibility` (not `kind`/`archive`/`pool`/`incidents`/`stale`), and the facet chips enumerate the real values. This is the same class as the already-merged `curation=verified` mega-menu fix.

## Fix

Repoint each link to a param + value the route actually consumes. **Only the `search` params change — every visible `label` is untouched**, so this is a pure data correction with no rendered-text change.

- `kind: "rpc"` → `category: "rpc"`, `kind: "wss"` → `category: "wss"` — `category` enum is `["all","rpc","wss","api","sse","data","other"]`.
- `archive: "1"` → `eligibility: "archive-capable"`, `pool: "eligible"` → `eligibility: "pool-member"` — these are the **exact** values `endpointEligibility()` derives from `e.archive` and `e.pool_eligible` (`lib/metagraphed/endpoint-pool.ts`).
- `incidents: "recent"` → `health: "down"`, `stale: "1"` → `health: "unknown"` — there is no dedicated incidents/stale *filter* on `/endpoints` (incidents render in a separate timeline section; staleness drives the `probed` sort, not a filter), so these map to the nearest real `health` facet: `down` = currently-failing (active incident), `unknown` = no fresh probe-derived health (stale). If you'd rather add first-class `incidents`/`stale` filters to `endpointsSearchSchema`, I'm happy to follow up with that route change separately — I kept this PR data-only.

## Test

Extends `nav-mega-menu-data.test.ts` with a guard that every `/endpoints` browse/filter link uses a param in `endpointsSearchSchema` and a value in that facet's allowed set. It fails on the pre-fix data (`kind`/`archive`/`pool`/`incidents`/`stale` are not schema keys) and passes after.

Local: `vitest run` (6 passed), `tsc --noEmit` (clean), `eslint` (0), `prettier --check` (clean).

Closes #3972
