### PR TITLE
feat(ui): add network axon-churn leaderboard to the explorer page (#3464)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-axon-removals.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-axon-removals.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainAxonRemovalsQuery, normalizeChainAxonRemovals } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/axon-removals",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainAxonRemovalsQuery(window, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainAxonRemovals", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainAxonRemovals({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: { distinct_removers: 5, removals: 70, removals_per_remover: 14 },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          { netuid: 1, distinct_removers: 4, removals: 40, removals_per_remover: 10 },
+          { netuid: 2, distinct_removers: 2, removals: 30, removals_per_remover: 15 },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: { distinct_removers: 5, removals: 70, removals_per_remover: 14 },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        { netuid: 1, distinct_removers: 4, removals: 40, removals_per_remover: 10 },
+        { netuid: 2, distinct_removers: 2, removals: 30, removals_per_remover: 15 },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainAxonRemovals(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+      expect(card.network).toEqual({
+        distinct_removers: 0,
+        removals: 0,
+        removals_per_remover: null,
+      });
+      expect(card.intensity_distribution).toBeNull();
+    }
+  });
+
+  it("drops malformed subnet rows and coerces a junk removals_per_remover to null", () => {
+    const card = normalizeChainAxonRemovals({
+      network: { removals_per_remover: { pct: 1 } },
+      subnets: [{ distinct_removers: 4 }, { netuid: 2, removals: 30 }],
+    });
+    expect(card.subnets).toHaveLength(1);
+    expect(card.subnets[0]?.netuid).toBe(2);
+    expect(card.subnets[0]?.removals_per_remover).toBeNull();
+    expect(card.network.removals_per_remover).toBeNull();
+  });
+});
+
+describe("chainAxonRemovalsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window and limit params and normalizes the leaderboard", async () => {
+    resolveWith({
+      window: "30d",
+      subnet_count: 1,
+      network: { distinct_removers: 4, removals: 40, removals_per_remover: 10 },
+      subnets: [{ netuid: 1, distinct_removers: 4, removals: 40, removals_per_remover: 10 }],
+    });
+    const res = await runQuery("30d", 5);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/axon-removals",
+      expect.objectContaining({ params: { window: "30d", limit: 5 } }),
+    );
+    expect(res.data.subnet_count).toBe(1);
+    expect(res.data.subnets).toHaveLength(1);
+  });
+
+  it("defaults to the 7d window and limit 20", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/axon-removals",
+      expect.objectContaining({ params: { window: "7d", limit: 20 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -80,6 +80,8 @@ import type {
   ChainTransferPairs,
   ChainStakeTransfers,
   ChainStakeTransferSubnet,
+  ChainAxonRemovals,
+  ChainAxonRemovalSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -245,6 +247,7 @@ const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
+const MAX_CHAIN_AXON_REMOVALS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3314,6 +3317,61 @@ export const chainStakeTransfersQuery = (window = "7d", limit = 20) =>
       });
       return {
         data: normalizeChainStakeTransfers(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainAxonRemovalSubnet(raw: unknown): ChainAxonRemovalSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_removers: firstFiniteNumber(raw.distinct_removers) ?? 0,
+    removals: firstFiniteNumber(raw.removals) ?? 0,
+    removals_per_remover: firstFiniteNumber(raw.removals_per_remover) ?? null,
+  };
+}
+
+// #3464: network-wide axon-teardown ("churn") leaderboard over a 7d/30d window —
+// the teardown-side complement of the serving leaderboard. Every numeric cell
+// coerces defensively: counts fall through to 0, averages to null (never NaN),
+// and malformed subnet rows are dropped on a cold store or junk.
+export function normalizeChainAxonRemovals(raw: unknown): ChainAxonRemovals {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_removers: firstFiniteNumber(networkRec.distinct_removers) ?? 0,
+      removals: firstFiniteNumber(networkRec.removals) ?? 0,
+      removals_per_remover: firstFiniteNumber(networkRec.removals_per_remover) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_AXON_REMOVALS,
+      normalizeChainAxonRemovalSubnet,
+    ),
+  };
+}
+
+export const chainAxonRemovalsQuery = (window = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-axon-removals", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainAxonRemovals>>("/api/v1/chain/axon-removals", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainAxonRemovals(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2403,6 +2403,39 @@ export interface ChainStakeTransfers {
   subnets: ChainStakeTransferSubnet[];
 }
 
+/** One subnet's row on the network-wide axon-teardown ("churn") leaderboard (#3464). */
+export interface ChainAxonRemovalSubnet {
+  netuid: number;
+  distinct_removers: number;
+  removals: number;
+  removals_per_remover: number | null;
+}
+
+/** Network-wide axon-teardown rollup — true distinct-remover count (not a per-subnet sum) + total removals. */
+export interface ChainAxonRemovalNetwork {
+  distinct_removers: number;
+  removals: number;
+  removals_per_remover: number | null;
+}
+
+/**
+ * Network-wide axon-teardown ("churn") leaderboard over a 7d/30d window (#3464),
+ * from GET /api/v1/chain/axon-removals — the teardown-side complement of the
+ * serving leaderboard: subnets ranked by AxonInfoRemoved event count, plus the
+ * true network-wide distinct-remover rollup and a distribution summary of the
+ * per-subnet teardown intensity. Zeroed with an empty subnets list when the
+ * store is cold.
+ */
+export interface ChainAxonRemovals {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainAxonRemovalNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainAxonRemovalSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -27,6 +27,7 @@ import {
   chainStakeMovesQuery,
   chainTurnoverQuery,
   chainStakeTransfersQuery,
+  chainAxonRemovalsQuery,
   chainTransferPairsQuery,
   economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
@@ -41,6 +42,7 @@ import type {
   ChainStakeMoves,
   ChainTurnover,
   EconomicsTrends,
+  ChainAxonRemovals,
 } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
@@ -111,6 +113,7 @@ function ExplorerPage() {
           "/api/v1/chain/stake-moves",
           "/api/v1/chain/turnover",
           "/api/v1/chain/stake-transfers",
+          "/api/v1/chain/axon-removals",
           "/api/v1/chain-events",
           "/api/v1/chain-events/stats",
           "/api/v1/economics/trends",
@@ -516,6 +519,73 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
 }
 
 /**
+ * #3464: network-wide axon-teardown ("churn") leaderboard — the teardown-side
+ * complement of the serving/stake-transfer boards, from the newly-wired
+ * chainAxonRemovalsQuery. Network rollup line + per-subnet table, mirroring the
+ * stake-transfer leaderboard treatment on this page.
+ */
+function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Axon churn leaderboard
+          </h2>
+          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+            {formatNumber(churn.network.removals)} axon teardowns across{" "}
+            {formatNumber(churn.network.distinct_removers)} removers network-wide
+          </p>
+        </div>
+        <span className="font-mono text-[11px] text-ink-muted">{churn.subnets.length} subnets</span>
+      </div>
+      {churn.subnets.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={`${TH} text-right`}>Teardowns</th>
+                <th className={`${TH} text-right`}>Distinct removers</th>
+                <th className={`${TH} text-right`}>Teardowns per remover</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {churn.subnets.map((s) => (
+                <tr key={s.netuid} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: s.netuid }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{s.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(s.removals)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(s.distinct_removers)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {s.removals_per_remover != null ? s.removals_per_remover.toFixed(2) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">
+          No axon teardowns in this window yet.
+        </p>
+      )}
+    </section>
+  );
+}
+
+/**
  * Network-wide validator-set turnover (#3473) — how much each subnet's validator
  * set churned over the window (entered / exited, retention, stability), plus the
  * most volatile subnets. Chain-direct: GET /api/v1/chain/turnover. Placed here
@@ -699,6 +769,7 @@ function ExplorerDashboard() {
     { data: stakeMovesRes },
     { data: turnoverRes },
     { data: stakeTransfersRes },
+    { data: axonChurnRes },
     { data: eventMixRes },
     { data: trendsRes },
   ] = useSuspenseQueries({
@@ -711,6 +782,7 @@ function ExplorerDashboard() {
       chainStakeMovesQuery(win),
       chainTurnoverQuery(win),
       chainStakeTransfersQuery(win),
+      chainAxonRemovalsQuery(win),
       chainEventsStatsQuery(),
       economicsTrendsQuery(win),
     ],
@@ -723,6 +795,7 @@ function ExplorerDashboard() {
   const stakeMoves = stakeMovesRes.data;
   const turnover = turnoverRes.data;
   const stakeTransfers = stakeTransfersRes.data;
+  const axonChurn = axonChurnRes.data;
   const eventMix = eventMixRes.data;
   const trends = trendsRes.data;
 
@@ -1079,6 +1152,9 @@ function ExplorerDashboard() {
           </p>
         )}
       </section>
+
+      <AxonChurnSection churn={axonChurn} />
+
       <PalletEventMixSection stats={eventMix} />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #3464

Wires `GET /api/v1/chain/axon-removals` into the frontend and renders it as a new **Axon churn leaderboard** section on `/explorer` — the teardown-side complement of the stake-transfer / serving boards. Shows a network teardown rollup (total teardowns across N distinct removers) plus a per-subnet table (teardowns, distinct removers, teardowns/remover),
over the same 7d/30d window as the rest of the dashboard.

Adds the data layer **and** UI in one PR:
- `chainAxonRemovalsQuery` + `ChainAxonRemovals` types, modeled on `chainStakeTransfersQuery`.
- A normalizer unit test (`queries.chain-axon-removals.test.ts`).
- The `AxonChurnSection` on `/explorer`.

## Validation
- `npm run typecheck -w apps/ui` — pass
- `prettier --check` (changed files) — clean
- `npm run test -w apps/ui` — 593 passed (incl. 5 new)
- `npm run build -w apps/ui` — pass

## Screenshots

New **Axon churn leaderboard** section on `/explorer` (below the Stake-transfer leaderboard).
Before: absent. After: present. 3 viewports × 2 themes × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1388" height="729" alt="dsk-lg-be" src="https://github.com/user-attachments/assets/4a87a7fc-98bf-42cc-9417-f8abaead88a7" /> | <img width="1388" height="803" alt="dsk-lg-af" src="https://github.com/user-attachments/assets/03d9e9a5-842a-4a8b-b4e4-d04e6e65b135" /> |
| Desktop · Dark | <img width="1385" height="709" alt="dsk-dk-be" src="https://github.com/user-attachments/assets/a1275849-3852-49c9-82cf-32a8da2ac3cd" /> | <img width="1373" height="743" alt="dsk-dk-af" src="https://github.com/user-attachments/assets/d2946bf5-9f52-48c2-b023-899e7613e1fe" /> |
| Tablet · Light | <img width="639" height="888" alt="tab-lg-be" src="https://github.com/user-attachments/assets/7d4abaf9-ba55-46b5-83d0-dbc1d1b401e5" /> | <img width="640" height="881" alt="tab-lg-af" src="https://github.com/user-attachments/assets/0847e2a4-99b1-477b-8fcb-3b84daed47d3" /> |
| Tablet · Dark | <img width="619" height="875" alt="tab-dk-be" src="https://github.com/user-attachments/assets/a7c1240f-cc59-4728-be6e-b6ed40e61fb7" /> | <img width="621" height="881" alt="tab-dk-af" src="https://github.com/user-attachments/assets/a0ebd429-b971-42b9-bb8e-4a9cf0817555" /> |
| Mobile · Light | <img width="425" height="923" alt="mb-lg-be" src="https://github.com/user-attachments/assets/c60dcbaf-8f99-4f33-b524-113f3ee12776" /> | <img width="450" height="925" alt="mb-lg-af" src="https://github.com/user-attachments/assets/7f891225-da44-4a71-8bb5-a98756e0ca3b" /> |
| Mobile · Dark | <img width="418" height="915" alt="mb-dk-be" src="https://github.com/user-attachments/assets/7d1d401c-ef98-4762-9382-4e0d7886f48c" /> | <img width="428" height="912" alt="mb-dk-af" src="https://github.com/user-attachments/assets/f8926f82-8a2c-401c-9226-5a2c28383655" /> |
