### PR TITLE
fix(ui): keep the account address copy button on-screen at mobile width

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -177,8 +177,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
               Cross-subnet registrations, first-party chain events, and daily activity rollups for
               one Bittensor account.
             </p>
-            <div className="max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
-              <CopyableCode value={ss58} truncate={false} />
+            <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+              <CopyableCode value={ss58} truncate={false} className="w-full sm:w-auto" />
             </div>
           </div>
         }


### PR DESCRIPTION
## What

On `/accounts/$ss58` the address display box was `max-w-fit`, so at mobile widths it sized to the full 48-char ss58 and overflowed the viewport — the trailing copy-to-clipboard button was clipped past the right edge and only partially tappable. Confirmed at 375px.

Closes #3944

## Fix

`apps/ui/src/routes/accounts.$ss58.tsx` — bound the box to the viewport on mobile and let the copy button fill it:
- `max-w-fit` → `max-w-full sm:max-w-fit` on the address box
- `className="w-full sm:w-auto"` on `CopyableCode`

On mobile the box is now viewport-bounded, so the address truncates as the component already intends (the mono `truncate` was previously dead because the box had no width bound), and the copy button stays fully visible and tappable. **≥640px (`sm:`) is untouched** — the full address still renders exactly as before. The copy behavior itself is unchanged (still copies the full value).

## Verification

Checked at all three viewports, both themes:
- **mobile 375** — before: copy icon clipped at the edge · after: box bounded, address truncates with `…`, icon fully visible ✓
- **tablet 768 / desktop 1280** — before/after identical (full address, icon visible) — no regression ✓

`eslint` + `tsc` clean. One file, no schema/contract change.

## Screenshots

Exact viewports (mobile 375×812, tablet 768×1024, desktop 1280×800), light + dark, before/after.

| viewport / theme | before | after |
|---|---|---|
| **mobile · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-mobile-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-tablet-dark-after.png)<br><sub>after</sub> |
| **desktop · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/acct-copy-desktop-dark-after.png)<br><sub>after</sub> |
