### PR TITLE
feat(ui): add ss58 format guidance to the invalid-address empty state

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -119,13 +119,19 @@ function AccountDetail({ ss58 }: { ss58: string }) {
         <PageHeading
           eyebrow="Explorer"
           title="Invalid account address"
-          description="Account addresses must be a valid ss58 (base58) string."
+          description="Account addresses are ss58 (base58) strings, 46–49 characters long."
         />
         <EmptyState
           title="Invalid account address"
-          description="Use a valid hotkey or coldkey ss58 address."
+          description="Bittensor addresses use the base58 alphabet (no 0, O, I, or l), are 46–49 characters long, and typically start with 5. Check for a truncated or wrong-chain address, then try again."
           action={{ label: "Back to accounts", href: "/accounts" }}
         />
+        <p className="mt-3 text-center text-[11px] text-ink-muted">
+          Example:{" "}
+          <span className="font-mono break-all text-ink-strong">
+            5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          </span>
+        </p>
       </>
     );
   }


### PR DESCRIPTION
## Summary

The account detail page's invalid-address branch (`accounts.$ss58.tsx`) told visitors an address was invalid but never what a **valid** one looks like — a mistyped or truncated URL got a dead-end with no actionable hint.

This enriches the existing `PageHeading` + `EmptyState` with the concrete format facts already encoded in `apps/ui/src/lib/metagraphed/accounts.ts`'s `SS58` regex (`/^[1-9A-HJ-NP-Za-km-z]{46,49}$/`):

- **Alphabet** — base58 (no `0`, `O`, `I`, or `l`)
- **Length** — 46–49 characters
- **Prefix** — typically starts with `5`
- **Example** — a full ss58 address rendered in a wrapping monospace line (`break-all`, so it never overflows on mobile)

No validation logic changes; reuses the existing `EmptyState` component and design tokens (`text-ink-muted` / `text-ink-strong` / `font-mono`). One file, +8/−2.

## Screenshots

Deterministic, data-independent state (`/accounts/<invalid>`), captured before/after from the same local dev server against the same live API. The only intended diff is the empty-state content; header pulse stats match (only the snapshot-age label ticks between captures).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-mobile-dark.png)<br><sub>after</sub> |

Closes #3400