### PR TITLE
fix(csv): stop the formula-injection guard from corrupting negative numbers

### DIFF
--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -94,6 +94,25 @@ test("rowsToCsv neutralizes spreadsheet formula-leading cells", () => {
   assert.equal(csv, expected);
 });
 
+test("rowsToCsv preserves negative and exponent numbers without the formula apostrophe", () => {
+  const csv = rowsToCsv([
+    {
+      net_flow_tao: -1250.5,
+      whole: -5,
+      exponent: -1e-7,
+      as_string: "-42",
+      positive: 3.5,
+      // still-dangerous leading-minus text keeps the guard
+      formula: "-1+cmd",
+    },
+  ]);
+
+  assert.equal(
+    csv,
+    "net_flow_tao,whole,exponent,as_string,positive,formula\r\n-1250.5,-5,-1e-7,-42,3.5,'-1+cmd",
+  );
+});
+
 test("csvRequested honors format and Accept negotiation", () => {
   assert.equal(csvRequested(url("?format=csv"), req()), true);
   assert.equal(

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -1364,7 +1364,9 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     assert.deepEqual(lines, [
       MOVERS_CSV_HEADER,
       "1,100,250,150,150,5,9,4,80,3,4,1,10,12,2",
-      "2,50,30,'-20,'-40,4,4,0,0,2,2,0,8,8,0",
+      // Signed stake/emission deltas export as plain numbers, not the corrupted
+      // "'-20" the spreadsheet-formula guard used to emit for leading-minus cells.
+      "2,50,30,-20,-40,4,4,0,0,2,2,0,8,8,0",
     ]);
   });
 

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,6 +1,15 @@
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 
 const SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
+// A plain numeric literal (including a leading-minus negative or exponent) can
+// never be a spreadsheet formula, so it must be exempt from the injection guard
+// below. Without this, a signed value like a net_flow_tao of -1250.5 serializes as
+// the literal text "'-1250.5", and every strict numeric CSV consumer (pandas,
+// spreadsheet formulas) reads that column as NaN — silent corruption across the
+// many signed columns the shared exporter emits. Formula-shaped text (=…, -1+1,
+// @SUM(), a leading tab/CR/LF) still matches SPREADSHEET_FORMULA_PREFIX and is
+// neutralized as before.
+const NUMERIC_LITERAL = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 // Keep each stream pull bounded without fragmenting typical endpoint exports
 // into overly small chunks.
 const CSV_STREAM_ROWS_PER_CHUNK = 128;
@@ -45,7 +54,10 @@ function stringifyCell(value) {
 
 function escapeCell(value) {
   const text = stringifyCell(value);
-  const safeText = SPREADSHEET_FORMULA_PREFIX.test(text) ? `'${text}` : text;
+  const safeText =
+    SPREADSHEET_FORMULA_PREFIX.test(text) && !NUMERIC_LITERAL.test(text)
+      ? `'${text}`
+      : text;
   if (!/[",\r\n]/.test(safeText)) {
     return safeText;
   }


### PR DESCRIPTION
## Summary

The shared CSV serializer (`workers/csv.mjs`) silently corrupts **negative numbers** in every `?format=csv` export.

Its spreadsheet-formula-injection guard prepends a `'` to any cell whose text begins with `= + - @` or a tab/CR/LF. The `-` in that character class fires on legitimate signed numeric values, not just formula-shaped text — so a cell of `-1250.5` is written to the CSV as the literal bytes `'-1250.5`.

```js
const SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
const safeText = SPREADSHEET_FORMULA_PREFIX.test(text) ? `'${text}` : text;
```

## Root cause

The OWASP CSV-injection defense is only needed for cells that a spreadsheet could evaluate as a formula. A **plain numeric literal** (e.g. `-1250.5`, `-5`, `-1e-7`) can never be a formula, but the guard's `-` branch neutralizes it anyway, mangling the value.

## Impact

Every CSV export containing a negative numeric cell is affected. This is request-triggerable on the public API and hits a serializer shared by ~15 endpoints:

- `GET /api/v1/subnets/movers?format=csv` — `stake_delta_tao`, `emission_delta_tao` (signed; net-outflow subnets emit negatives)
- `GET /api/v1/chain/stake-flow?format=csv` — `net_flow_tao` (`staked − unstaked`)
- other signed columns across chain/weights, serving, turnover, transfer-pairs, yield, concentration, registrations, etc.

Programmatic consumers (`pandas.read_csv(...).astype(float)`, spreadsheet numeric formulas, any strict CSV numeric parser) read the corrupted columns as text/NaN — silent data corruption in downstream analysis. The committed test `tests/metagraph-neurons.test.mjs` had actually **pinned** the corrupted output (`2,50,30,'-20,'-40,...`), which this PR corrects.

## Fix

Exempt plain numeric literals (leading-minus negatives and exponents included) from the apostrophe guard, while still neutralizing genuinely formula-shaped text:

```js
const NUMERIC_LITERAL = /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
const safeText =
  SPREADSHEET_FORMULA_PREFIX.test(text) && !NUMERIC_LITERAL.test(text)
    ? `'${text}`
    : text;
```

`=WEBSERVICE(...)`, `-1+1`, `-2+3`, `@SUM(1,1)`, `\t=1+1`, and `=evil` are all still apostrophe-prefixed (covered by the existing guard test); only cells that are wholly a number pass through unescaped.

## Tests

- New `rowsToCsv` case asserting `-1250.5`, `-5`, `-1e-7`, `"-42"` and `3.5` export verbatim while `-1+cmd` stays guarded.
- Existing formula-guard test unchanged (all formula-shaped cells still neutralized).
- Updated the movers CSV test that had encoded the buggy `'-20`/`'-40`.
- `workers/csv.mjs` retains 100% branch coverage; both branches of the new condition are exercised.

Ran locally: `eslint` + `prettier --check` clean on the changed files; `vitest run tests/csv.test.mjs tests/metagraph-neurons.test.mjs` green (84 tests).

## Risk / tradeoffs

- Backward compatible: only negative/exponent numeric cells change (apostrophe dropped) — that is the corruption being fixed. All formula-shaped strings are still escaped exactly as before, so the injection defense is unchanged.
- The build-time registry exporter `scripts/datasets.mjs` has an identical guard, but its columns are registry metadata (no negative numbers), so it is intentionally left out of scope and can be addressed separately.

_Unsolicited bug fix — external contributors cannot open issues on this repo, so no `Closes #` is linked._