### PR TITLE
fix(ssrf): block IPv6 discard-only and NAT64 local-use in the webhook and probe guards

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -99,7 +99,13 @@ function isUnsafeIpv6Literal(host) {
     host.startsWith("fe") ||
     host.startsWith("fc") ||
     host.startsWith("fd") ||
-    host.startsWith("ff")
+    host.startsWith("ff") ||
+    // 0100::/8 discard-only (RFC 6666) and NAT64 local-use 64:ff9b:1::/48
+    // (RFC 8215, which can tunnel a v4 like 169.254.169.254 past the well-known
+    // 64:ff9b::/96 check) were missing here while the prober guard already
+    // rejects both — close the parity gap (#1538/#2375).
+    host.startsWith("100:") ||
+    host.startsWith("64:ff9b:1:")
   );
 }
 

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -105,6 +105,8 @@ export function isPublicWebhookAddress(value) {
       host.startsWith("fc") || // unique-local fc00::/7
       host.startsWith("fd") ||
       host.startsWith("ff") || // ff00::/8 multicast — not global unicast (2000::/3), matching the prober guard (#1538)
+      host.startsWith("100:") || // 0100::/8 discard-only (RFC 6666) — not routable, matching the prober guard
+      host.startsWith("64:ff9b:1:") || // NAT64 local-use 64:ff9b:1::/48 (RFC 8215) tunnels a v4 the well-known-prefix check below can't see (e.g. 64:ff9b:1::a9fe:a9fe = 169.254.169.254)
       host.startsWith("::ffff:") // IPv4-mapped
     ) {
       return false;

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -191,6 +191,20 @@ describe("isUnsafePublicUrl", () => {
     }
   });
 
+  test("blocks IPv6 discard-only (0100::/8) and NAT64 local-use (64:ff9b:1::/48)", () => {
+    // Both are non-public ranges the prober guard already rejects. 64:ff9b:1::/48
+    // (RFC 8215) can tunnel a v4 the well-known-prefix (64:ff9b::/96) decoder can't
+    // see — [64:ff9b:1::a9fe:a9fe] is 169.254.169.254 (cloud metadata).
+    for (const url of [
+      "http://[100::1]/x",
+      "http://[64:ff9b:1::a9fe:a9fe]/x",
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+    // The well-known-prefix NAT64 of a public v4 stays allowed (no over-block).
+    assert.equal(isUnsafePublicUrl("https://[64:ff9b::808:808]/x"), false);
+  });
+
   test("blocks a reserved/multicast v4 tunnelled inside an IPv6 literal host", () => {
     for (const url of [
       "http://[2002:e000:1::]/x", // 6to4 of 224.0.0.1 multicast

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -75,6 +75,17 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("64:ff9b::808:808"), true);
   });
 
+  test("IPv6 discard-only (0100::/8) and NAT64 local-use (64:ff9b:1::/48) → false", () => {
+    // 0100::/8 is RFC 6666 discard-only — not routable. 64:ff9b:1::/48 is RFC 8215
+    // NAT64 local-use: unlike the well-known 64:ff9b::/96 (caught by the embedded-v4
+    // check), it tunnels a v4 the guard can't decode — e.g. 64:ff9b:1::a9fe:a9fe is
+    // 169.254.169.254 (cloud metadata). The prober guard rejects both; this must too.
+    assert.equal(isPublicWebhookAddress("100::1"), false);
+    assert.equal(isPublicWebhookAddress("64:ff9b:1::a9fe:a9fe"), false);
+    // The well-known-prefix NAT64 of a public v4 is unaffected (stays routable).
+    assert.equal(isPublicWebhookAddress("64:ff9b::808:808"), true);
+  });
+
   test("private IPv4 literals → false", () => {
     assert.equal(isPublicWebhookAddress("10.0.0.1"), false);
     assert.equal(isPublicWebhookAddress("127.0.0.1"), false);


### PR DESCRIPTION
## Summary

Three sibling SSRF guards protect the outbound-fetch paths in this repo, and they are meant to stay in parity (see the `#1538` / `#2375` cross-guard alignment already in the code + tests):

- `isUnsafeIpAddress` — the live cron **prober** (`src/health-prober.mjs`), strictest
- `isUnsafeIpv6Literal` — the shared **probe-core** literal guard (`src/health-probe-core.mjs`)
- `isPublicWebhookAddress` — the **webhook** delivery guard (`src/webhooks.mjs`)

The probe-core and webhook guards had drifted: both **miss two non-public IPv6 ranges the prober already blocks**.

## Root cause

```js
// prober (correct) already has:
host.startsWith("100:")        // 0100::/8 discard-only
host.startsWith("64:ff9b:1:")  // NAT64 local-use 64:ff9b:1::/48
// probe-core + webhook guards were missing both.
```

- **`0100::/8`** — RFC 6666 discard-only; not routable, never a valid target.
- **`64:ff9b:1::/48`** — RFC 8215 NAT64 local-use. The guards decode the *well-known* `64:ff9b::/96` prefix (via `ipv6EmbeddedIpv4`) and correctly block e.g. `64:ff9b::7f00:1`, but the **local-use** prefix isn't decoded, so `64:ff9b:1::a9fe:a9fe` (which is `169.254.169.254`, the cloud-metadata address) fell through as a *public* target.

Demonstrated before the fix: `isPublicWebhookAddress("64:ff9b:1::a9fe:a9fe") === true` and `isPublicWebhookAddress("100::1") === true`, while the prober's `isUnsafeIpAddress` rejects both.

## Fix

Add the same two `startsWith` checks the prober already uses to both weaker guards, so all three agree. No new decoding logic — just closes the parity gap.

## Impact / severity

Defense-in-depth hardening of the SSRF guards. The literal-guard layer is one of several (the Node webhook dispatcher additionally DNS-pins and re-validates at delivery, and Workers/GitHub-runner egress typically can't route these), so this is not a demonstrated live breach — it removes a guard-parity gap where one layer classified a non-public range (including the NAT64-tunnelled metadata IP) as public.

## Tests

- `tests/webhooks-core.test.mjs`: new case asserting `100::1` and `64:ff9b:1::a9fe:a9fe` → not public, and that well-known-prefix `64:ff9b::808:808` (public 8.8.8.8) stays public.
- `tests/health-probe-core.test.mjs`: matching case for `isUnsafePublicUrl`.
- All 346 webhook/probe tests pass; `eslint` + `prettier --check` clean on the changed files. New branches are fully covered.

## Risk / tradeoffs

- Backward compatible: only the two genuinely non-public ranges change classification. The well-known-prefix NAT64 of a public v4 is explicitly tested to remain allowed, so no over-blocking of legitimate targets.

_Unsolicited bug fix — external contributors cannot open issues on this repo, so no `Closes #` is linked._