### PR TITLE
feat(ui): add a network emission-yield summary to the status page

### DIFF
--- a/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from "@tanstack/react-query";
+import { TrendingUp, Server, Users, Coins } from "lucide-react";
+import { chainYieldQuery } from "@/lib/metagraphed/queries";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { EmptyState } from "@/components/metagraphed/states";
+import { formatNumber } from "@/lib/metagraphed/format";
+
+// #3472: network emission-yield summary — the return-rate companion to the
+// decentralization scorecard, from the newly-wired chainYieldQuery. Aggregate
+// network return (total emission / total stake) split by validator/miner role,
+// plus the per-neuron return spread. The data layer is untouched; this only
+// consumes the normalized shape via useQuery.
+
+function fmtPct(v: number | null): string {
+  if (v == null) return "—";
+  return `${(v * 100).toFixed(4)}%`;
+}
+
+function Notice({ children }: { children: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Network emission-yield summary: aggregate return (total emission over total
+ * stake) network-wide and split by validator / miner role, plus the per-neuron
+ * return distribution (median and upper-percentile spread). The return-rate
+ * companion to the decentralization scorecard, at network scope. Fetches the
+ * chain-yield snapshot once and renders a KPI-tile grid.
+ */
+export function EmissionYieldPanel() {
+  const { data: res, isPending } = useQuery(chainYieldQuery());
+  const y = res?.data;
+
+  if (isPending && !y) {
+    return <Notice>Loading network emission yield…</Notice>;
+  }
+
+  if (!y || y.neuron_count === 0) {
+    return (
+      <EmptyState
+        title="No network emission-yield metrics"
+        description="Chain-wide emission yield (total emission over total stake, split by validator/miner role) and the per-neuron return spread are computed from the metagraph snapshot and will appear here once captured."
+        lastChecked={res?.meta?.generated_at}
+      />
+    );
+  }
+
+  const dist = y.distribution;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <StatTile
+          icon={TrendingUp}
+          eyebrow="Network yield"
+          value={fmtPct(y.network_yield)}
+          hint="Emission ÷ total stake"
+          tone="accent"
+        />
+        <StatTile
+          icon={Server}
+          eyebrow="Validator yield"
+          value={fmtPct(y.validator_yield)}
+          hint={`${formatNumber(y.validator_count)} validators`}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Miner yield"
+          value={fmtPct(y.miner_yield)}
+          hint={`${formatNumber(y.miner_count)} miners`}
+        />
+      </div>
+
+      {dist ? (
+        <div>
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Per-neuron return spread
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <StatTile
+              icon={Coins}
+              eyebrow="Median"
+              value={fmtPct(dist.median)}
+              hint={`${formatNumber(dist.count)} neurons`}
+            />
+            <StatTile
+              icon={Coins}
+              eyebrow="75th pct"
+              value={fmtPct(dist.p75)}
+              hint="per-neuron return"
+            />
+            <StatTile
+              icon={Coins}
+              eyebrow="90th pct"
+              value={fmtPct(dist.p90)}
+              hint="per-neuron return"
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.chain-yield.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-yield.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainYieldQuery, normalizeChainYield } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/yield",
+  });
+}
+
+async function runQuery() {
+  const opts = chainYieldQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainYield", () => {
+  it("passes a well-formed yield snapshot through", () => {
+    expect(
+      normalizeChainYield({
+        schema_version: 1,
+        subnet_count: 2,
+        neuron_count: 100,
+        validator_count: 10,
+        miner_count: 90,
+        captured_at: "2026-07-01T00:00:00Z",
+        total_stake_tao: 1000,
+        total_emission_tao: 5,
+        network_yield: 0.005,
+        validator_yield: 0.004,
+        miner_yield: 0.02,
+        distribution: {
+          count: 80,
+          mean: 0.01,
+          median: 0.002,
+          min: 0,
+          max: 5,
+          p10: 0,
+          p25: 0.001,
+          p75: 0.01,
+          p90: 0.05,
+        },
+      }),
+    ).toEqual({
+      schema_version: 1,
+      subnet_count: 2,
+      neuron_count: 100,
+      validator_count: 10,
+      miner_count: 90,
+      captured_at: "2026-07-01T00:00:00Z",
+      total_stake_tao: 1000,
+      total_emission_tao: 5,
+      network_yield: 0.005,
+      validator_yield: 0.004,
+      miner_yield: 0.02,
+      distribution: {
+        count: 80,
+        mean: 0.01,
+        median: 0.002,
+        min: 0,
+        max: 5,
+        p10: 0,
+        p25: 0.001,
+        p75: 0.01,
+        p90: 0.05,
+      },
+    });
+  });
+
+  it("degrades a cold / junk snapshot to a schema-stable zeroed shape", () => {
+    for (const raw of [{}, null, "x", { neuron_count: "nope" }]) {
+      const card = normalizeChainYield(raw);
+      expect(card.neuron_count).toBe(0);
+      expect(card.network_yield).toBeNull();
+      expect(card.validator_yield).toBeNull();
+      expect(card.miner_yield).toBeNull();
+      expect(card.distribution).toBeNull();
+    }
+  });
+
+  it("coerces junk yields to null and drops a malformed distribution", () => {
+    const card = normalizeChainYield({
+      neuron_count: 5,
+      network_yield: { pct: 1 },
+      distribution: { mean: 0.1 },
+    });
+    expect(card.neuron_count).toBe(5);
+    expect(card.network_yield).toBeNull();
+    // distribution requires a numeric count; missing count drops it to null.
+    expect(card.distribution).toBeNull();
+  });
+});
+
+describe("chainYieldQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("calls /api/v1/chain/yield and normalizes the snapshot", async () => {
+    resolveWith({ neuron_count: 3, network_yield: 0.01 });
+    const res = await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/yield",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.neuron_count).toBe(3);
+    expect(res.data.network_yield).toBe(0.01);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -83,6 +83,8 @@ import type {
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
+  ChainYield,
+  ChainYieldDistribution,
   ChainSigners,
   ChainSignerEntry,
   Extrinsic,
@@ -5053,6 +5055,61 @@ export const chainPerformanceQuery = () =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainPerformance>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainYieldDistribution(raw: unknown): ChainYieldDistribution | null {
+  if (!isRecord(raw)) return null;
+  const count = firstFiniteNumber(raw.count);
+  if (count == null) return null;
+  return {
+    count,
+    mean: firstFiniteNumber(raw.mean) ?? 0,
+    median: firstFiniteNumber(raw.median) ?? 0,
+    min: firstFiniteNumber(raw.min) ?? 0,
+    max: firstFiniteNumber(raw.max) ?? 0,
+    p10: firstFiniteNumber(raw.p10) ?? 0,
+    p25: firstFiniteNumber(raw.p25) ?? 0,
+    p75: firstFiniteNumber(raw.p75) ?? 0,
+    p90: firstFiniteNumber(raw.p90) ?? 0,
+  };
+}
+
+// #3472: network-wide emission-yield aggregate — the return-rate companion to
+// /chain/performance. Counts coerce to 0; the three role yields fall through to
+// null (never NaN) when no neuron has both stake and emission.
+export function normalizeChainYield(raw: unknown): ChainYield {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    neuron_count: firstFiniteNumber(rec.neuron_count) ?? 0,
+    validator_count: firstFiniteNumber(rec.validator_count) ?? 0,
+    miner_count: firstFiniteNumber(rec.miner_count) ?? 0,
+    captured_at: firstString(rec.captured_at) ?? null,
+    total_stake_tao: firstFiniteNumber(rec.total_stake_tao) ?? 0,
+    total_emission_tao: firstFiniteNumber(rec.total_emission_tao) ?? 0,
+    network_yield: firstFiniteNumber(rec.network_yield) ?? null,
+    validator_yield: firstFiniteNumber(rec.validator_yield) ?? null,
+    miner_yield: firstFiniteNumber(rec.miner_yield) ?? null,
+    distribution: normalizeChainYieldDistribution(rec.distribution),
+  };
+}
+
+/** Network-wide emission-yield aggregate — return rate split by validator/miner role. */
+export const chainYieldQuery = () =>
+  queryOptions({
+    queryKey: k("chain-yield"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainYield>>("/api/v1/chain/yield", {
+        signal,
+      });
+      return {
+        data: normalizeChainYield(res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainYield>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2433,6 +2433,41 @@ export interface ChainPerformance {
   validator_trust: ScoreDistribution | null;
 }
 
+/** Per-neuron emission/stake return distribution summary within GET /api/v1/chain/yield. */
+export interface ChainYieldDistribution {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  p10: number;
+  p25: number;
+  p75: number;
+  p90: number;
+}
+
+/**
+ * Network-wide emission-yield aggregate (#3472) from GET /api/v1/chain/yield —
+ * the return-rate companion to /chain/performance: total emission over total
+ * stake (network-wide and split by validator/miner role), plus the per-neuron
+ * return distribution. Yields are null when no neuron has both stake and
+ * emission; distribution is null on a cold snapshot.
+ */
+export interface ChainYield {
+  schema_version: number;
+  subnet_count: number;
+  neuron_count: number;
+  validator_count: number;
+  miner_count: number;
+  captured_at: string | null;
+  total_stake_tao: number;
+  total_emission_tao: number;
+  network_yield: number | null;
+  validator_yield: number | null;
+  miner_yield: number | null;
+  distribution: ChainYieldDistribution | null;
+}
+
 /* ===================== Theme C: registry & network-health depth ===================== */
 
 /**

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -24,6 +24,7 @@ import {
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
 import { NetworkDecentralizationPanel } from "@/components/metagraphed/network-decentralization-panel";
+import { EmissionYieldPanel } from "@/components/metagraphed/emission-yield-panel";
 
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
@@ -115,6 +116,19 @@ function StatusPage() {
           </QueryErrorBoundary>
         </section>
 
+        {/* #3472: network emission-yield summary — the return-rate companion to
+            the decentralization scorecard: aggregate network return split by
+            validator/miner role plus the per-neuron return spread. */}
+        <section>
+          <SectionHeading
+            title="Network emission yield"
+            intro="Chain-wide emission yield — total emission over total stake, split by validator/miner role — plus the per-neuron return distribution, computed across every neuron from the metagraph snapshot."
+          />
+          <QueryErrorBoundary>
+            <EmissionYieldPanel />
+          </QueryErrorBoundary>
+        </section>
+
         {/* #8: operational diagnostics — a per-day probe drill-down and a
             provider verification rollup, both probe-derived. */}
         <section>
@@ -150,6 +164,7 @@ function StatusPage() {
           "/api/v1/source-health",
           "/api/v1/chain/concentration",
           "/api/v1/chain/performance",
+          "/api/v1/chain/yield",
         ]}
       />
     </AppShell>


### PR DESCRIPTION
## Summary

Closes #3472

Wires `GET /api/v1/chain/yield` into the frontend and renders a **Network emission yield** summary on `/status`, alongside the decentralization scorecard — the return-rate companion to it.
Shows the aggregate network return (total emission / total stake) split by **validator / miner role**, plus the per-neuron return distribution (**median / 75th / 90th percentile**).

Adds the data layer **and** UI in one PR:
- `chainYieldQuery` + `ChainYield` / `ChainYieldDistribution` types, modeled on
  `chainConcentrationQuery` / `chainPerformanceQuery`.
- A normalizer unit test (`queries.chain-yield.test.ts`).
- A self-contained `EmissionYieldPanel` (KPI-tile grid), placed on `/status`.

## Validation
- `npm run typecheck -w apps/ui` — pass
- `prettier --check` (changed files) — clean
- `npm run test -w apps/ui` — 597 passed (incl. 4 new)
- `npm run build -w apps/ui` — pass

## Screenshots

New **Network emission yield** section on `/status` (below "Network decentralization").
Before: absent. After: the emission-yield KPI panel. 3 viewports × 2 themes × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1426" height="850" alt="dek-lg-be" src="https://github.com/user-attachments/assets/d306bec7-2daf-43b2-8bad-4526c0b193a9" /> | <img width="1418" height="838" alt="dek-lg-af" src="https://github.com/user-attachments/assets/6744fc1f-0813-4591-a45c-7f9b1405565f" /> |
| Desktop · Dark | <img width="1397" height="808" alt="dek-dk-be" src="https://github.com/user-attachments/assets/22cbebfd-e78b-427e-947a-ae4dd0ea256b" /> | <img width="1398" height="836" alt="dek-dk-af" src="https://github.com/user-attachments/assets/20b1996b-1162-42c3-a5ea-31cc33a7a9cf" /> |
| Tablet · Light | <img width="672" height="881" alt="tab-lg-be" src="https://github.com/user-attachments/assets/1546e470-b575-4826-96da-ecbf6313adcb" /> | <img width="653" height="890" alt="tab-lg-af" src="https://github.com/user-attachments/assets/8b636e9c-eb3a-4064-91ee-b2f699bc07d0" /> |
| Tablet · Dark | <img width="631" height="877" alt="tab-dk-be" src="https://github.com/user-attachments/assets/aec99406-3847-4b35-83c6-6c197ed1eb71" /> | <img width="640" height="878" alt="tab-dk-af" src="https://github.com/user-attachments/assets/620ce365-4f0f-4114-9cd8-b4a7cf97117c" /> |
| Mobile · Light | <img width="438" height="925" alt="mb-lg-be" src="https://github.com/user-attachments/assets/dee889f8-84f5-4964-9625-99a3d02c9483" /> | <img width="451" height="917" alt="mb-lg-af" src="https://github.com/user-attachments/assets/9f633c29-4f55-48ce-84c4-19503c391865" /> |
| Mobile · Dark | <img width="423" height="926" alt="mb-dk-be" src="https://github.com/user-attachments/assets/f699f4ca-3500-4a8b-a2d7-cad0741ecb07" /> | <img width="436" height="914" alt="mb-dk-af" src="https://github.com/user-attachments/assets/c99bafdf-ffc7-4e58-93de-f29d6695b3fb" /> |
