### PR TITLE
fix(queries): stop normalizeBlockEvent conflating alpha_amount with amount_tao

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.block-events.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.block-events.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { blockEventsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/blocks/5000000/events",
+  });
+}
+
+async function runQuery(ref: string) {
+  const opts = blockEventsQuery(ref);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("blockEventsQuery — amount_tao / alpha_amount normalization", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("keeps a block event's alpha_amount distinct from its TAO amount", async () => {
+    // A StakeAdded row carrying both a TAO figure and an alpha-token figure.
+    // These are separate quantities on the BlockEvent contract; normalizing
+    // must not overwrite alpha_amount with the TAO-first coalesced amount.
+    resolveWith({
+      block_number: 5000000,
+      event_count: 1,
+      events: [
+        {
+          block_number: 5000000,
+          event_index: 0,
+          event_kind: "StakeAdded",
+          hotkey: "5Ffff",
+          amount_tao: 5,
+          alpha_amount: 100,
+        },
+      ],
+    });
+    const res = await runQuery("5000000");
+    expect(res.data.events).toHaveLength(1);
+    expect(res.data.events[0]?.amount_tao).toBe(5);
+    expect(res.data.events[0]?.alpha_amount).toBe(100);
+  });
+
+  it("leaves alpha_amount null when the row has no alpha figure (no TAO bleed-through)", async () => {
+    resolveWith({
+      block_number: 5000000,
+      event_count: 1,
+      events: [{ event_index: 1, event_kind: "StakeAdded", amount_tao: 7 }],
+    });
+    const res = await runQuery("5000000");
+    expect(res.data.events[0]?.amount_tao).toBe(7);
+    expect(res.data.events[0]?.alpha_amount).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1650,7 +1650,7 @@ function normalizeBlockEvent(raw: unknown): BlockEvent | null {
     amount_tao: amount,
     observed_at: firstString(raw.observed_at),
     extrinsic_index: firstFiniteNumber(raw.extrinsic_index),
-    alpha_amount: amount,
+    alpha_amount: firstFiniteNumber(raw.alpha_amount) ?? null,
   };
 }
 


### PR DESCRIPTION
## Problem

`normalizeBlockEvent` (`apps/ui/src/lib/metagraphed/queries.ts`) builds one TAO-first coalesced scalar and assigns it to **two distinct fields** — `amount_tao` **and** `alpha_amount`:

```ts
const amount =
  firstFiniteNumber(raw.amount_tao) ??
  firstFiniteNumber(raw.amount) ??
  firstFiniteNumber(raw.alpha_amount);   // TAO-first
return {
  ...(raw as object),
  amount_tao: amount,      // correct — the TAO figure
  alpha_amount: amount,    // BUG — same value as amount_tao
};
```

Because `amount` prefers `amount_tao`, a normalized block event's `alpha_amount` can **never differ** from its `amount_tao`. A raw row carrying a genuinely distinct `alpha_amount` alongside `amount_tao` (e.g. a `StakeAdded` / `StakeMoved` event with both a TAO and an alpha-token figure) has its real alpha silently overwritten; a row with only `amount_tao` gets the TAO amount copied into `alpha_amount` instead of being left empty.

### Why this is wrong (source evidence)

- The sibling normalizer **`normalizeAccountEvent`** reads the same field pair independently:
  ```ts
  amount_tao: coerceFiniteNumber(raw.amount_tao) ?? null,
  alpha_amount: coerceFiniteNumber(raw.alpha_amount) ?? null,
  ```
- The **`BlockEvent`** type (`types.ts`) declares `amount_tao?: number | null` and `alpha_amount?: number | null` as two independent fields. `normalizeBlockEvent` is the only normalizer that conflates them.

`alpha_amount` isn't rendered by any current consumer, so there's no user-visible symptom today — this is a latent data-integrity fix (any future reader of `BlockEvent.alpha_amount` would get the TAO amount mislabelled as alpha). No issue reference because outside contributors can't open issues on this repo; the write-up lives here.

## Fix

One line — source `alpha_amount` from the raw row (mirroring `normalizeAccountEvent`), leaving `amount_tao` untouched (it is rendered; its coalescing is intentional):

```diff
-    alpha_amount: amount,
+    alpha_amount: firstFiniteNumber(raw.alpha_amount) ?? null,
```

## Test

Adds `queries.block-events.test.ts`, exercising the exported `blockEventsQuery` (previously without normalization coverage) via the repo's established mock-`apiFetch` pattern. It asserts a row with `amount_tao: 5, alpha_amount: 100` normalizes to two distinct values, and a row with only `amount_tao: 7` yields `alpha_amount: null`. Both assertions fail on the pre-fix code (`5`/`7` bleed into alpha) and pass after.

Local: `vitest run` (2 passed), `tsc --noEmit` (clean), `eslint` (0), `prettier --check` (clean).
