### PR TITLE
feat(ui): add network operations leaderboard to the chain explorer (#3463)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-operations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-operations.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  chainServingQuery,
+  chainPrometheusQuery,
+  normalizeChainServing,
+  normalizeChainPrometheus,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown, url: string): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url,
+  });
+}
+
+describe("normalizeChainServing", () => {
+  it("passes a well-formed serving leaderboard through", () => {
+    expect(
+      normalizeChainServing({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: { distinct_servers: 5, announcements: 70, announcements_per_server: 14 },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          { netuid: 1, distinct_servers: 4, announcements: 40, announcements_per_server: 10 },
+          { netuid: 2, distinct_servers: 2, announcements: 30, announcements_per_server: 15 },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: { distinct_servers: 5, announcements: 70, announcements_per_server: 14 },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        { netuid: 1, distinct_servers: 4, announcements: 40, announcements_per_server: 10 },
+        { netuid: 2, distinct_servers: 2, announcements: 30, announcements_per_server: 15 },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainServing(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.subnets).toEqual([]);
+      expect(card.network).toEqual({
+        distinct_servers: 0,
+        announcements: 0,
+        announcements_per_server: null,
+      });
+      expect(card.intensity_distribution).toBeNull();
+    }
+  });
+
+  it("drops malformed subnet rows and coerces a junk per-server ratio to null", () => {
+    const card = normalizeChainServing({
+      network: { announcements_per_server: { pct: 1 } },
+      subnets: [{ distinct_servers: 4 }, { netuid: 2, announcements: 30 }],
+    });
+    expect(card.subnets).toHaveLength(1);
+    expect(card.subnets[0]?.netuid).toBe(2);
+    expect(card.subnets[0]?.announcements_per_server).toBeNull();
+    expect(card.network.announcements_per_server).toBeNull();
+  });
+});
+
+describe("normalizeChainPrometheus", () => {
+  it("passes a well-formed telemetry leaderboard through", () => {
+    const card = normalizeChainPrometheus({
+      window: "30d",
+      subnet_count: 1,
+      network: { distinct_exporters: 3, announcements: 9, announcements_per_exporter: 3 },
+      subnets: [
+        { netuid: 7, distinct_exporters: 3, announcements: 9, announcements_per_exporter: 3 },
+      ],
+    });
+    expect(card.subnet_count).toBe(1);
+    expect(card.subnets).toEqual([
+      { netuid: 7, distinct_exporters: 3, announcements: 9, announcements_per_exporter: 3 },
+    ]);
+  });
+
+  it("degrades a cold / empty store to a schema-stable zeroed leaderboard", () => {
+    const card = normalizeChainPrometheus({});
+    expect(card.subnet_count).toBe(0);
+    expect(card.subnets).toEqual([]);
+    expect(card.network).toEqual({
+      distinct_exporters: 0,
+      announcements: 0,
+      announcements_per_exporter: null,
+    });
+    expect(card.intensity_distribution).toBeNull();
+  });
+});
+
+describe("chain operations queries", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("chainServingQuery passes window/limit params and normalizes", async () => {
+    resolveWith(
+      {
+        window: "30d",
+        subnet_count: 1,
+        network: { distinct_servers: 4, announcements: 40, announcements_per_server: 10 },
+        subnets: [
+          { netuid: 1, distinct_servers: 4, announcements: 40, announcements_per_server: 10 },
+        ],
+      },
+      "/api/v1/chain/serving",
+    );
+    const opts = chainServingQuery("30d", 5);
+    const res = await opts.queryFn!({
+      signal: new AbortController().signal,
+      queryKey: opts.queryKey,
+      meta: undefined,
+    } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/serving",
+      expect.objectContaining({ params: { window: "30d", limit: 5 } }),
+    );
+    expect(res.data.subnets).toHaveLength(1);
+  });
+
+  it("chainPrometheusQuery defaults to the 7d window and limit 20", async () => {
+    resolveWith({}, "/api/v1/chain/prometheus");
+    const opts = chainPrometheusQuery();
+    await opts.queryFn!({
+      signal: new AbortController().signal,
+      queryKey: opts.queryKey,
+      meta: undefined,
+    } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/prometheus",
+      expect.objectContaining({ params: { window: "7d", limit: 20 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -80,6 +80,10 @@ import type {
   ChainTransferPairs,
   ChainStakeTransfers,
   ChainStakeTransferSubnet,
+  ChainServing,
+  ChainServingSubnet,
+  ChainPrometheus,
+  ChainPrometheusSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -245,6 +249,8 @@ const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
+const MAX_CHAIN_SERVING = 100;
+const MAX_CHAIN_PROMETHEUS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3314,6 +3320,106 @@ export const chainStakeTransfersQuery = (window = "7d", limit = 20) =>
       });
       return {
         data: normalizeChainStakeTransfers(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3463: network-wide axon-serving leaderboard over a 7d/30d window — which
+// subnets are actively announcing serving axons, ranked by announcement volume.
+// Every numeric cell coerces defensively: counts fall through to 0, the
+// per-server ratio to null (never NaN), and malformed subnet rows are dropped.
+function normalizeChainServingSubnet(raw: unknown): ChainServingSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_servers: firstFiniteNumber(raw.distinct_servers) ?? 0,
+    announcements: firstFiniteNumber(raw.announcements) ?? 0,
+    announcements_per_server: firstFiniteNumber(raw.announcements_per_server) ?? null,
+  };
+}
+
+export function normalizeChainServing(raw: unknown): ChainServing {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_servers: firstFiniteNumber(networkRec.distinct_servers) ?? 0,
+      announcements: firstFiniteNumber(networkRec.announcements) ?? 0,
+      announcements_per_server: firstFiniteNumber(networkRec.announcements_per_server) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(rec.subnets, MAX_CHAIN_SERVING, normalizeChainServingSubnet),
+  };
+}
+
+export const chainServingQuery = (window = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-serving", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainServing>>("/api/v1/chain/serving", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainServing(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3463: network-wide Prometheus-telemetry leaderboard, the exporter-side
+// sibling of the serving leaderboard. Same defensive coercion.
+function normalizeChainPrometheusSubnet(raw: unknown): ChainPrometheusSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_exporters: firstFiniteNumber(raw.distinct_exporters) ?? 0,
+    announcements: firstFiniteNumber(raw.announcements) ?? 0,
+    announcements_per_exporter: firstFiniteNumber(raw.announcements_per_exporter) ?? null,
+  };
+}
+
+export function normalizeChainPrometheus(raw: unknown): ChainPrometheus {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_exporters: firstFiniteNumber(networkRec.distinct_exporters) ?? 0,
+      announcements: firstFiniteNumber(networkRec.announcements) ?? 0,
+      announcements_per_exporter: firstFiniteNumber(networkRec.announcements_per_exporter) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(rec.subnets, MAX_CHAIN_PROMETHEUS, normalizeChainPrometheusSubnet),
+  };
+}
+
+export const chainPrometheusQuery = (window = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-prometheus", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainPrometheus>>("/api/v1/chain/prometheus", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainPrometheus(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2403,6 +2403,56 @@ export interface ChainStakeTransfers {
   subnets: ChainStakeTransferSubnet[];
 }
 
+/** One subnet row in the axon-serving leaderboard from GET /api/v1/chain/serving. */
+export interface ChainServingSubnet {
+  netuid: number;
+  distinct_servers: number;
+  announcements: number;
+  announcements_per_server: number | null;
+}
+
+export interface ChainServingNetwork {
+  distinct_servers: number;
+  announcements: number;
+  announcements_per_server: number | null;
+}
+
+/** Network-wide axon-serving announcement leaderboard from GET /api/v1/chain/serving. */
+export interface ChainServing {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainServingNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainServingSubnet[];
+}
+
+/** One subnet row in the Prometheus-telemetry leaderboard from GET /api/v1/chain/prometheus. */
+export interface ChainPrometheusSubnet {
+  netuid: number;
+  distinct_exporters: number;
+  announcements: number;
+  announcements_per_exporter: number | null;
+}
+
+export interface ChainPrometheusNetwork {
+  distinct_exporters: number;
+  announcements: number;
+  announcements_per_exporter: number | null;
+}
+
+/** Network-wide Prometheus-telemetry announcement leaderboard from GET /api/v1/chain/prometheus. */
+export interface ChainPrometheus {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainPrometheusNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainPrometheusSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -29,6 +29,8 @@ import {
   chainStakeTransfersQuery,
   chainTransferPairsQuery,
   economicsTrendsQuery,
+  chainServingQuery,
+  chainPrometheusQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -689,7 +691,8 @@ function ExplorerDashboard() {
   // all fast, and the full page eventually completing at ~33s with a longer
   // timeout). useSuspenseQueries fires all fetches concurrently and suspends
   // once, so the page waits on the slowest single query, not the sum. #3365
-  // adds a 10th (economics/trends, a different data source entirely).
+  // adds a 10th (economics/trends, a different data source entirely); #3463
+  // adds the serving + prometheus operations leaderboards.
   const [
     { data: activityRes },
     { data: feesRes },
@@ -699,6 +702,8 @@ function ExplorerDashboard() {
     { data: stakeMovesRes },
     { data: turnoverRes },
     { data: stakeTransfersRes },
+    { data: servingRes },
+    { data: prometheusRes },
     { data: eventMixRes },
     { data: trendsRes },
   ] = useSuspenseQueries({
@@ -711,6 +716,8 @@ function ExplorerDashboard() {
       chainStakeMovesQuery(win),
       chainTurnoverQuery(win),
       chainStakeTransfersQuery(win),
+      chainServingQuery(win),
+      chainPrometheusQuery(win),
       chainEventsStatsQuery(),
       economicsTrendsQuery(win),
     ],
@@ -723,6 +730,8 @@ function ExplorerDashboard() {
   const stakeMoves = stakeMovesRes.data;
   const turnover = turnoverRes.data;
   const stakeTransfers = stakeTransfersRes.data;
+  const serving = servingRes.data;
+  const prometheus = prometheusRes.data;
   const eventMix = eventMixRes.data;
   const trends = trendsRes.data;
 
@@ -1079,6 +1088,128 @@ function ExplorerDashboard() {
           </p>
         )}
       </section>
+
+      {/* #3463: network operations — axon-serving + prometheus-telemetry leaderboards */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-lg border border-border bg-card p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+                Axon serving
+              </h2>
+              <p className="mt-1 font-mono text-[11px] text-ink-muted">
+                {formatNumber(serving.network.announcements)} announcements across{" "}
+                {formatNumber(serving.network.distinct_servers)} servers network-wide
+              </p>
+            </div>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {serving.subnets.length} subnets
+            </span>
+          </div>
+          {serving.subnets.length > 0 ? (
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Announcements</th>
+                  <th className={`${TH} text-right`}>Distinct servers</th>
+                  <th className={`${TH} text-right`}>Per server</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {serving.subnets.map((s) => (
+                  <tr key={s.netuid} className="hover:bg-surface/40">
+                    <td className="px-4 py-2 font-mono text-[11px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: s.netuid }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                      >
+                        SN{s.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(s.announcements)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber(s.distinct_servers)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {s.announcements_per_server != null
+                        ? s.announcements_per_server.toFixed(2)
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="font-mono text-[12px] text-ink-muted">
+              No serving announcements in this window yet.
+            </p>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-border bg-card p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+                Prometheus telemetry
+              </h2>
+              <p className="mt-1 font-mono text-[11px] text-ink-muted">
+                {formatNumber(prometheus.network.announcements)} announcements across{" "}
+                {formatNumber(prometheus.network.distinct_exporters)} exporters network-wide
+              </p>
+            </div>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {prometheus.subnets.length} subnets
+            </span>
+          </div>
+          {prometheus.subnets.length > 0 ? (
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Announcements</th>
+                  <th className={`${TH} text-right`}>Distinct exporters</th>
+                  <th className={`${TH} text-right`}>Per exporter</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {prometheus.subnets.map((s) => (
+                  <tr key={s.netuid} className="hover:bg-surface/40">
+                    <td className="px-4 py-2 font-mono text-[11px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: s.netuid }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                      >
+                        SN{s.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(s.announcements)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber(s.distinct_exporters)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {s.announcements_per_exporter != null
+                        ? s.announcements_per_exporter.toFixed(2)
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="font-mono text-[12px] text-ink-muted">
+              No telemetry announcements in this window yet.
+            </p>
+          )}
+        </section>
+      </div>
+
       <PalletEventMixSection stats={eventMix} />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #3463

- Adds a "Network operations" leaderboard section to `/explorer` (#3463), rendering the  network-wide axon-serving and Prometheus-telemetry leaderboards side by side, each with  its network-wide rollup — backed by the live, previously-unconsumed `GET /api/v1/chain/serving`  and `GET /api/v1/chain/prometheus` endpoints.
- New `chainServingQuery`/`chainPrometheusQuery` + normalizers (mirroring the stake-transfers  pattern), `ChainServing`/`ChainPrometheus` types, and a normalizer/query test (7 tests).


## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1371" height="856" alt="dsk-lg-be" src="https://github.com/user-attachments/assets/599eb4d9-956c-4254-b403-28e00a20e7ec" /> | <img width="1393" height="824" alt="dsk-lg-af" src="https://github.com/user-attachments/assets/1b36b1a5-68bb-4a33-957b-93d721daf39d" /> |
| Desktop · Dark   | <img width="1403" height="839" alt="dsk-dk-be" src="https://github.com/user-attachments/assets/4bd4cf8c-af30-4dff-bff2-9765b6ec3c22" /> | <img width="1367" height="842" alt="dsk-dk-af" src="https://github.com/user-attachments/assets/8724b47b-02dc-407b-a04e-5e3f8161611c" /> |
| Tablet · Light   | <img width="642" height="893" alt="tab-lg-be" src="https://github.com/user-attachments/assets/bf5f4d78-48e6-4d95-9b0f-78458781b080" /> | <img width="636" height="886" alt="tab-lg-af" src="https://github.com/user-attachments/assets/be3c5991-09bd-4ea5-aa12-c8803060b376" /> |
| Tablet · Dark    | <img width="629" height="886" alt="tab-dk-be" src="https://github.com/user-attachments/assets/14905dd5-8537-4526-8d08-ead79bbfe617" /> | <img width="630" height="877" alt="tab-dk-af" src="https://github.com/user-attachments/assets/ff0d0360-0cf4-4e7f-af71-6e4b4262d139" /> |
| Mobile · Light   | <img width="425" height="917" alt="mb-lg-be" src="https://github.com/user-attachments/assets/15b27209-2392-492c-bcd9-fa791d8f909d" /> | <img width="437" height="926" alt="mb-lg-af" src="https://github.com/user-attachments/assets/6a4c7ef3-b13d-4383-a361-e114dd519a53" /> |
| Mobile · Dark    | <img width="420" height="917" alt="mb-dk-be" src="https://github.com/user-attachments/assets/a9117ae5-cd41-4584-9aa5-49670a06def3" /> | <img width="429" height="921" alt="mb-dk-af" src="https://github.com/user-attachments/assets/c43616bb-e42c-4aae-92b8-dce52531f7b3" /> |

## Validation
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (queries.chain-operations — 7 passing)
- [x] `npm run build --workspace=apps/ui`
