### PR TITLE
feat(ui): add a top-fee-payers bar chart to the explorer fees section

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/bar-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/bar-mini.tsx
@@ -13,6 +13,8 @@ interface Props {
   className?: string;
   /** Show numeric value to the right of each bar. */
   showValue?: boolean;
+  /** Format the shown value (e.g. TAO amounts) instead of the raw number. */
+  formatValue?: (value: number) => string;
   /** Accessible name; synthesized from `data` when omitted. */
   ariaLabel?: string;
 }
@@ -22,7 +24,7 @@ interface Props {
  * proportional bar + optional value. Used for distribution rows
  * (gaps by severity, surfaces by kind, etc.).
  */
-export function BarMini({ data, max, className, showValue = true, ariaLabel }: Props) {
+export function BarMini({ data, max, className, showValue = true, formatValue, ariaLabel }: Props) {
   const cap = max ?? Math.max(1, ...data.map((d) => d.value));
   const label = ariaLabel ?? synthesizeBarMiniAriaLabel(data);
   return (
@@ -41,7 +43,9 @@ export function BarMini({ data, max, className, showValue = true, ariaLabel }: P
               />
             </span>
             {showValue ? (
-              <span className="font-mono text-[10px] tabular-nums text-ink-strong">{d.value}</span>
+              <span className="font-mono text-[10px] tabular-nums text-ink-strong">
+                {formatValue ? formatValue(d.value) : d.value}
+              </span>
             ) : null}
           </li>
         );

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -902,41 +902,55 @@ function ExplorerDashboard() {
             </span>
           </div>
           {fees.top_fee_payers.length > 0 ? (
-            <table className="w-full text-left text-sm">
-              <thead>
-                <tr>
-                  <th className={TH}>Account</th>
-                  <th className={`${TH} text-right`}>Fees</th>
-                  <th className={`${TH} text-right`}>Tips</th>
-                  <th className={`${TH} text-right`}>Txs</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {fees.top_fee_payers.map((p) => (
-                  <tr key={p.signer} className="hover:bg-surface/40">
-                    <td className="px-4 py-2 font-mono text-[11px]">
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: p.signer }}
-                        className="text-ink-strong hover:text-accent hover:underline"
-                        title={p.signer}
-                      >
-                        {shortHash(p.signer) ?? p.signer}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                      {fmtTao(p.total_fee_tao)}
-                    </td>
-                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {fmtTao(p.total_tip_tao)}
-                    </td>
-                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                      {formatNumber(p.extrinsic_count)}
-                    </td>
+            <>
+              <BarMini
+                className="mb-4"
+                data={[...fees.top_fee_payers]
+                  .sort((a, b) => b.total_fee_tao - a.total_fee_tao)
+                  .slice(0, 8)
+                  .map((p) => ({
+                    label: shortHash(p.signer) ?? p.signer,
+                    value: p.total_fee_tao,
+                  }))}
+                formatValue={fmtTao}
+                ariaLabel="Top fee payers ranked by total fees paid this window"
+              />
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr>
+                    <th className={TH}>Account</th>
+                    <th className={`${TH} text-right`}>Fees</th>
+                    <th className={`${TH} text-right`}>Tips</th>
+                    <th className={`${TH} text-right`}>Txs</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {fees.top_fee_payers.map((p) => (
+                    <tr key={p.signer} className="hover:bg-surface/40">
+                      <td className="px-4 py-2 font-mono text-[11px]">
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: p.signer }}
+                          className="text-ink-strong hover:text-accent hover:underline"
+                          title={p.signer}
+                        >
+                          {shortHash(p.signer) ?? p.signer}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                        {fmtTao(p.total_fee_tao)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {fmtTao(p.total_tip_tao)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatNumber(p.extrinsic_count)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
           ) : (
             <p className="font-mono text-[12px] text-ink-muted">
               No fee payers in this window yet.


### PR DESCRIPTION
## Summary

Adds a ranked bar-chart visualization of the top fee payers above the existing table in the explorer's "Top fee payers" section, so the magnitude gap between payers is readable at a glance (mirroring how the adjacent "Call mix" section pairs a list with a `BarMini`). Reuses the existing `BarMini` primitive — no new chart component, no new dependency.

Closes #3386

## What changed

- **`apps/ui/src/routes/explorer.tsx`** — in the "Top fee payers" `<section>`, renders a `BarMini` above the existing `<table>` when `fees.top_fee_payers.length > 0`: bars sorted by `total_fee_tao` (top 8), labelled with `shortHash(p.signer)`, values TAO-formatted via the local `fmtTao`. The table (Account / Fees / Tips / Txs) and the "No fee payers in this window yet." empty state are unchanged.
- **`apps/ui/src/components/metagraphed/charts/bar-mini.tsx`** — adds an optional, backward-compatible `formatValue?: (n) => string` prop so `showValue` can render TAO amounts instead of raw floats (default behaviour unchanged for all existing `BarMini` usages). This keeps the chart on the existing primitive rather than introducing a new one.

## Screenshots

Route `/explorer`, "Top fee payers" section scrolled into view, fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes.

> ⚠️ **Data note:** the live `/api/v1/chain/fees` tier currently returns **0 fee payers** in every window (the chain-fee aggregation is unpopulated in prod right now), so a live capture would only show the empty state. To demonstrate the actual chart, **both the before and after shots inject the *same* representative fee-payers fixture** via request interception — so the only difference between the columns is this PR's code (the added bar chart), not the data. Before = table only; after = chart + the same table.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3386-after-mobile-dark.png)<br><sub>after</sub> |

## Validation (full local run)

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm test` (apps/ui) — 593 passed
- [x] `npm run build` (apps/ui) — green
- [x] `npm run lint` — my two files add 0 errors (`npx eslint` on them is clean)
- [x] No new dependency; existing `BarMini` reused; table + empty state preserved
