### PR TITLE
feat(ui): trap focus in the nav mega-menu dialog + add aria-modal (#3432)

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
@@ -55,6 +55,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
   const triggerRefs = useRef<Record<string, HTMLAnchorElement | null>>({});
   const filterInputRef = useRef<HTMLInputElement>(null);
   const itemsRef = useRef<Array<HTMLAnchorElement | null>>([]);
+  const panelRef = useRef<HTMLDivElement>(null);
   const typeBufRef = useRef<string>("");
   const typeBufTimer = useRef<number | null>(null);
 
@@ -151,6 +152,30 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
   }
 
   function onPanelKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    // #3432: focus containment — while the modal panel is open, Tab / Shift+Tab
+    // cycle only through the panel's own focusable elements (the filter input,
+    // registered item links, and any inline links/buttons the content renders),
+    // wrapping at the ends, instead of escaping into the underlying page.
+    if (e.key === "Tab") {
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = Array.from(
+        panel.querySelectorAll<HTMLElement>(
+          'a[href],button:not([disabled]),input:not([disabled]),[tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+      return;
+    }
     const items = itemsRef.current.filter(Boolean) as HTMLAnchorElement[];
     if (items.length === 0) return;
     const currentIdx = items.findIndex((el) => el === document.activeElement);
@@ -255,8 +280,10 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
         <>
           <div aria-hidden className="mg-mega-scrim" onClick={() => setOpenKey(null)} />
           <div
+            ref={panelRef}
             className="absolute left-1/2 -translate-x-1/2 top-full mt-3 z-40"
             role="dialog"
+            aria-modal="true"
             aria-label={`${activePanel.label} menu`}
             onKeyDown={onPanelKeyDown}
             onMouseEnter={() => {


### PR DESCRIPTION
## Summary

Closes #3432

- Adds `aria-modal="true"` and keyboard focus containment to the nav mega-menu's  `role="dialog"` panel (#3432): while open, Tab / Shift+Tab cycle only through the  panel's own focusable elements (filter input + item links), wrapping at the ends,
  instead of escaping into the underlying page. Esc-to-close and focus-return already existed.
- Single-file change to `apps/ui/src/components/metagraphed/nav-mega-menu.tsx`.

## Note on screenshots
This is a **keyboard-accessibility / focus-containment** change — it has **no visual difference** in the mega-menu's rendered output. The before/after captures below show the panel open (identical by design); the change is verifiable by keyboard (Tab/Shift+Tab stay within the open panel and wrap). Mobile is N/A — the mega-menu is a desktop/tablet nav surface.

## Screenshots
| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1410" height="622" alt="dsk-lg-af" src="https://github.com/user-attachments/assets/442666dd-0cc7-4d9b-988e-56920e08595e" /> | <img width="1410" height="622" alt="dsk-lg-af" src="https://github.com/user-attachments/assets/19b92344-1a96-4772-9750-af54b7f3ffed" /> |
| Desktop · Dark   | <img width="1393" height="579" alt="dsk-dk-af" src="https://github.com/user-attachments/assets/c24e7ade-d222-4f43-842f-e3fc02fcdf27" /> | <img width="1393" height="579" alt="dsk-dk-af" src="https://github.com/user-attachments/assets/3c4e2539-0aa9-4bef-ae01-b0b4dd4e78fa" /> |
| Tablet · Light   | <img width="630" height="887" alt="tab-lg-af" src="https://github.com/user-attachments/assets/744b23fe-21f4-4986-8c2a-99798745968d" /> | <img width="630" height="887" alt="tab-lg-af" src="https://github.com/user-attachments/assets/d6e72c93-e28a-4ae3-9e08-5d75494feef3" /> |
| Tablet · Dark    | <img width="639" height="880" alt="tab-dk-af" src="https://github.com/user-attachments/assets/8c4c1d42-f7f5-40c3-82ca-5d76bf861437" /> | <img width="639" height="880" alt="tab-dk-af" src="https://github.com/user-attachments/assets/b707b915-0318-405d-8c30-fc5352b758a1" /> |

## Validation
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (nav-mega-menu — 5 passing)
- [x] `npm run build --workspace=apps/ui`
