### PR TITLE
fix(ui): give SubnetLineageSection a visible error state

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -466,8 +466,28 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
 // subnet pages); renders nothing unless this netuid is paired with a counterpart.
 // Reads lineageRes.data.links (NOT a top-level array).
 function SubnetLineageSection({ netuid }: { netuid: number }) {
-  const { data: lineageRes } = useQuery(lineageQuery());
+  const { data: lineageRes, isError, error, refetch } = useQuery(lineageQuery());
   const lineage = lineageRes?.data;
+
+  if (isError) {
+    return (
+      <SectionAnchor
+        id="lineage"
+        title="Lineage"
+        subtitle="Cross-network subnet pairing."
+        info="Cross-network lineage links the testnet and mainnet deployments of the same subnet, matched by chain name or source repo."
+      >
+        <TableState
+          variant="error"
+          title="Could not load lineage"
+          description="Cross-network lineage is optional enrichment — the rest of the subnet page is unaffected."
+          error={error}
+          onRetry={() => void refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
   const link = (lineage?.links ?? []).find(
     (l) => l.mainnet_netuid === netuid || l.testnet_netuid === netuid,
   );


### PR DESCRIPTION
## What

`SubnetLineageSection` (`apps/ui/src/routes/subnets.$netuid.tsx`) destructured only `data` from `useQuery(lineageQuery())`. On a failed fetch, `lineageRes` is `undefined` → `lineage` is `undefined` → the section hit the same `return null` as a subnet that genuinely has no lineage link. The error was silently swallowed, indistinguishable from a legitimate "no lineage" empty state.

## Change

- Destructure `isError`, `error`, `refetch` from the query.
- Add an `isError` branch (short-circuiting **before** the no-link check) rendering a `TableState variant="error"` notice with a retry — the same error treatment used elsewhere in the app.
- The legitimate no-lineage case (`return null`) and the lineage data source are unchanged (non-goals respected).

Single file, +21/−1.

## Screenshots

Subnet `#4` detail page, with `/api/v1/lineage` forced to `500` via request interception.

**Before:** on a fetch failure the section returned `null` — no error, no feedback, identical to a subnet that has no lineage.

**After:**

| Light | Dark |
|---|---|
| ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/lineage-shots/after-error-light.png) | ![](https://raw.githubusercontent.com/ismayilovibadet802-svg/metagraphed/assets/lineage-shots/after-error-dark.png) |

Closes #3967
