### PR TITLE
fix(ui): give the network-decentralization panel a Suspense skeleton + distinct error state

### DIFF
--- a/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
@@ -1,9 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import { Scale, Users, BarChart3, Activity, Percent, Coins, ShieldCheck } from "lucide-react";
 import { chainConcentrationQuery, chainPerformanceQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
-import { EmptyState } from "@/components/metagraphed/states";
+import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
   networkDecentralizationModel,
   type DecentralizationTile,
@@ -27,10 +27,26 @@ const TILE_ICONS: Record<string, LucideIcon> = {
   "validator-trust-median": ShieldCheck,
 };
 
-function Notice({ children }: { children: string }) {
+// Suspense fallback that mirrors the panel's own grid (6 concentration tiles +
+// a 3-tile score row) so the skeleton occupies the same responsive height as
+// the loaded content — no layout shift when the data arrives, unlike a single
+// flat box.
+export function NetworkDecentralizationSkeleton() {
   return (
-    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
-      {children}
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-[76px]" />
+        ))}
+      </div>
+      <div>
+        <Skeleton className="mb-3 h-3 w-48" />
+        <div className="grid gap-3 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-[76px]" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -55,14 +71,14 @@ function Tile({ tile }: { tile: DecentralizationTile }) {
  * once (shared cache) and renders through the pure view-model helper.
  */
 export function NetworkDecentralizationPanel() {
-  const { data: cRes, isPending: cPending } = useQuery(chainConcentrationQuery());
-  const { data: pRes, isPending: pPending } = useQuery(chainPerformanceQuery());
+  // Suspense-driven loading (the Suspense fallback in status.tsx renders the
+  // Skeleton) and QueryErrorBoundary-driven errors, matching every sibling
+  // section on the status page — so a fetch error surfaces as a distinct error
+  // state rather than being conflated with a legitimately-empty result below.
+  const { data: cRes } = useSuspenseQuery(chainConcentrationQuery());
+  const { data: pRes } = useSuspenseQuery(chainPerformanceQuery());
 
   const model = networkDecentralizationModel(cRes?.data, pRes?.data);
-
-  if ((cPending || pPending) && !model.hasData) {
-    return <Notice>Loading network decentralization…</Notice>;
-  }
 
   if (!model.hasData) {
     return (

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -23,7 +23,10 @@ import {
   HealthHistoryDrilldown,
   SourceHealthTable,
 } from "@/components/metagraphed/status-diagnostics";
-import { NetworkDecentralizationPanel } from "@/components/metagraphed/network-decentralization-panel";
+import {
+  NetworkDecentralizationPanel,
+  NetworkDecentralizationSkeleton,
+} from "@/components/metagraphed/network-decentralization-panel";
 import { EmissionYieldPanel } from "@/components/metagraphed/emission-yield-panel";
 
 const SURFACES_INITIAL = 10;
@@ -112,7 +115,9 @@ function StatusPage() {
             intro="Chain-wide stake & emission concentration (Gini, HHI, Nakamoto coefficient, entropy, top-1% share) and the trust/consensus score spread, computed across every subnet from the metagraph snapshot."
           />
           <QueryErrorBoundary>
-            <NetworkDecentralizationPanel />
+            <Suspense fallback={<NetworkDecentralizationSkeleton />}>
+              <NetworkDecentralizationPanel />
+            </Suspense>
           </QueryErrorBoundary>
         </section>
 


### PR DESCRIPTION
## What

On `/status`, the Network Decentralization panel was the only section wrapped in `QueryErrorBoundary` **without** a `Suspense`/`Skeleton` fallback. While pending it rendered an ad-hoc plain-text *"Loading network decentralization…"* card (via a local `Notice`) — unlike every sibling section, which use the standard Skeleton — and it conflated a genuine fetch error with a legitimately-empty result (both fell through to the empty state).

Closes #3966

## Fix

- `network-decentralization-panel.tsx`: convert the two `useQuery` calls to `useSuspenseQuery` so loading is Suspense-driven and a fetch error surfaces through `QueryErrorBoundary` as a **distinct** state (no longer conflated with empty); drop the local `Notice`.
- `status.tsx`: wrap the panel in `<Suspense fallback={<NetworkDecentralizationSkeleton />}>`, matching the sibling sections.
- The fallback is a **grid-shaped skeleton** that mirrors the panel's own 6-tile concentration grid + 3-tile score row, so it occupies the same responsive height as the loaded content (~150px desktop / 375px tablet / 820px mobile) — **no layout shift** when data arrives.

## Verification

`eslint` + `tsc` clean. Screenshots force the loading state (endpoints blocked) to show the treatment change: **before** = plain-text card · **after** = the standard grid Skeleton. Skeletons are `animate-pulse bg-surface` (they shimmer live).

## Screenshots

Exact viewports, light + dark, before/after — the panel's loading state.

| viewport / theme | before | after |
|---|---|---|
| **desktop · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-desktop-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-tablet-dark-after.png)<br><sub>after</sub> |
| **mobile · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netdecel-mobile-dark-after.png)<br><sub>after</sub> |
