### PR TITLE
feat(registry): add SN61 RedTeam OpenAPI spec surface (#4067)

### DIFF
--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -145,6 +145,27 @@
         "https://github.com/RedTeamSubnet/RedTeam/blob/main/src/redteam_core/challenge_pool/active_challenges.yaml"
       ],
       "url": "https://raw.githubusercontent.com/RedTeamSubnet/RedTeam/main/src/redteam_core/challenge_pool/active_challenges.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-61-redteam-openapi",
+      "kind": "openapi",
+      "name": "RedTeam Device Fingerprinter Gate OpenAPI spec",
+      "notes": "Machine-readable OpenAPI 3.1 spec (title: Device Fingerprinter Gate) served from the official RedTeamSubnet/rest-dfp-proxy repository (homepage www.theredteam.io); documents the REST proxy that gates the dev_fingerprinter challenge defined in the subnet's RedTeamSubnet/RedTeam source repository.",
+      "provider": "redteam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "cleanjunc"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://raw.githubusercontent.com/RedTeamSubnet/rest-dfp-proxy/main/docs/pages/api-docs/openapi.json",
+      "source_urls": [
+        "https://github.com/RedTeamSubnet/rest-dfp-proxy",
+        "https://github.com/RedTeamSubnet/RedTeam/blob/main/docs/challenges/dev_fingerprinter/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/RedTeamSubnet/rest-dfp-proxy/main/docs/pages/api-docs/openapi.json"
     }
   ],
   "contact": "oscar@theredteam.io"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one `openapi` surface to `registry/subnets/redteam.json` (SN61 RedTeam). Append-only — no other file is touched.

## Summary

Adds the machine-readable **OpenAPI 3.1.0** specification for SN61 RedTeam's **Device Fingerprinter Gate** REST proxy, closing the "No verified OpenAPI/Swagger schema yet" gap recorded in the subnet's curation profile.

- **Ownership is first-party.** The spec (`info.title: "Device Fingerprinter Gate"`, `openapi: "3.1.0"`) is published in the subnet operator's own GitHub org at `RedTeamSubnet/rest-dfp-proxy`, whose repository homepage is the subnet's official site `https://www.theredteam.io` — the manifest's registered `website_url`. The same `RedTeamSubnet` org owns the subnet's registered `source_repo`, `RedTeamSubnet/RedTeam`.
- **Grounded to netuid 61.** The proxy serves the `dev_fingerprinter` challenge documented in the subnet's canonical repo at `RedTeamSubnet/RedTeam/docs/challenges/dev_fingerprinter/`, included as a second `source_url`.
- **`schema_status` / `schema_url`.** The document is a valid OpenAPI 3.1 spec (verified: parses as JSON; carries `openapi`, `info`, and `paths`). It is served from `raw.githubusercontent.com` with a `text/plain` content-type, so `surface:add`'s auto-enrich did not populate those two fields — they are set explicitly and truthfully.

## Surface

- Netuid: 61
- Kind: openapi
- Public URL: https://raw.githubusercontent.com/RedTeamSubnet/rest-dfp-proxy/main/docs/pages/api-docs/openapi.json
- Source URL (proves the claim): https://github.com/RedTeamSubnet/rest-dfp-proxy (with https://github.com/RedTeamSubnet/RedTeam/blob/main/docs/challenges/dev_fingerprinter/README.md)
- Provider slug: redteam

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #<n>`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/redteam.json` → passed (7 surfaces across 1 subnet file)
- [x] `npm run scan:public-safety` → passed

Closes #4067
