### PR TITLE
fix(ui): serve the recorded fixture for date-in-path endpoints in HAR replay

### DIFF
--- a/apps/ui/tests/e2e/har-path.js
+++ b/apps/ui/tests/e2e/har-path.js
@@ -1,5 +1,6 @@
 // Shared between responsive-overflow.spec.ts and record-har.mjs so the two
 // can't silently drift apart -- one HAR fixture file per ROUTES entry.
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,4 +9,35 @@ export const HAR_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "
 export function harPathForRoute(route) {
   const slug = route === "/" ? "home" : route.replace(/^\//, "").replace(/\//g, "-");
   return path.join(HAR_DIR, `${slug}.har`);
+}
+
+// Some endpoints bake volatile data into the URL path itself rather than a
+// query param -- e.g. /api/v1/health/history/{date} defaults client-side to
+// "today" (status-diagnostics.tsx's defaultDate), so a HAR recorded on one day
+// never matches the same request replayed on a later day and silently falls
+// back to live data, reintroducing the exact nondeterminism this fixture
+// layer exists to remove. List each such endpoint's STABLE path prefix here
+// (ignoring the volatile segment) so callers can register a priority route
+// that serves whatever the HAR recorded regardless of what the live app
+// requests today.
+export const DATED_ENDPOINT_PATTERNS = [/\/api\/v1\/health\/history\/\d{4}-\d{2}-\d{2}(?:[/?]|$)/];
+
+// Finds the first recorded entry in `harPath` matching `pattern` and returns
+// its response as Playwright `route.fulfill()` options, or null if the HAR
+// has no matching entry (nothing to serve, caller should skip registering a
+// route for it).
+export function findHarFixture(harPath, pattern) {
+  const har = JSON.parse(readFileSync(harPath, "utf8"));
+  const entry = har.log.entries.find((e) => pattern.test(e.request.url));
+  if (!entry) return null;
+  const content = entry.response.content ?? {};
+  const body =
+    content.encoding === "base64"
+      ? Buffer.from(content.text ?? "", "base64")
+      : (content.text ?? "");
+  return {
+    status: entry.response.status,
+    contentType: content.mimeType || "application/json",
+    body,
+  };
 }

--- a/apps/ui/tests/e2e/responsive-overflow.spec.ts
+++ b/apps/ui/tests/e2e/responsive-overflow.spec.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { test, expect } from "@playwright/test";
 import { findOverflowViolations } from "./find-overflow-violations.js";
 import { ROUTES, VIEWPORTS } from "./overflow-check.config.js";
-import { harPathForRoute } from "./har-path.js";
+import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.js";
 
 // Baseline-diff, not zero-tolerance: this app has pre-existing, already-tracked
 // overflow bugs (#3930, #3931, #3985, etc.) that are separately-scored
@@ -67,6 +67,17 @@ for (const route of ROUTES) {
           notFound: "fallback",
           update: false,
         });
+        // Registered AFTER routeFromHAR (Playwright matches the most-recently
+        // registered handler first), so a dated endpoint's fixture is served
+        // regardless of which date the live app requests today -- otherwise
+        // it would miss the HAR's exact-URL match and fall back to live data
+        // (see DATED_ENDPOINT_PATTERNS in har-path.js for why).
+        for (const pattern of DATED_ENDPOINT_PATTERNS) {
+          const fixture = findHarFixture(harPath, pattern);
+          if (fixture) {
+            await page.route(pattern, (route) => route.fulfill(fixture));
+          }
+        }
         await page.setViewportSize({ width: viewport.width, height: viewport.height });
         await page.goto(route);
         // HAR-replayed responses resolve near-instantly (no real network


### PR DESCRIPTION
Closes #4584

## Summary

Follow-up to #4542 (merged) — the Gittensory Orb review on that PR caught a real gap I'd missed: `notFound: "fallback"` in the HAR replay means any request the recording doesn't exactly match falls through to live production data, which can silently reintroduce the exact nondeterminism #4542 was fixing.

I audited all 6 recorded HAR fixtures for volatile URL segments and confirmed one real, guaranteed-to-fire instance: `/api/v1/health/history/{date}` (used by `/status`'s probe-history drill-down, `status-diagnostics.tsx`) defaults client-side to "today's" UTC date. A HAR recorded on one day bakes in that day's literal date in the URL path — so on any later day, the live app requests a different date, misses the HAR's exact-URL match, and falls back to live data. This is the same `/status` route/endpoint class that was the *original* source of the flakiness #4542 set out to fix, so leaving it unfixed would have quietly undone the point of that PR.

(Audited the other 5 HAR files too — window params like `7d`/`30d`/`90d` are stable relative strings, not absolute dates; no other date-in-path or otherwise-volatile URL segments found.)

## Fix

`apps/ui/tests/e2e/har-path.js`: added `DATED_ENDPOINT_PATTERNS` (currently just the one regex for `health/history/{date}`) and `findHarFixture(harPath, pattern)`, which reads the HAR's recorded response for whatever entry matches the pattern.

`apps/ui/tests/e2e/responsive-overflow.spec.ts`: after `page.routeFromHAR(...)`, registers a `page.route()` per pattern that serves the recorded fixture directly via `route.fulfill()`. Playwright matches the most-recently-registered handler first, so this intercepts the dated endpoint before it ever reaches the HAR's exact-URL lookup — regardless of what date the live app requests today.

## Validation

- Full 24/24 local run of `responsive-overflow.spec.ts` (all 6 routes × 4 viewports), green.
- Wrote a standalone script that registers only the new interceptor and requests `/api/v1/health/history/2099-12-31` (a date guaranteed absent from any recording) directly — confirmed it still returns status 200 with the *recorded* fixture's `date` field, proving the match is genuinely date-independent rather than a coincidental exact match against today's data.
- `npm run lint` / `npm run format:check` — clean except pre-existing unrelated drift (confirmed via `git diff --stat` against those files: empty, not touched by this branch).

Maintainer PR — no screenshot table (test-infrastructure fix, no visual/product change).
