### PR TITLE
feat(ui): route-level notFound for invalid block/extrinsic refs

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
 import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
@@ -24,14 +24,17 @@ import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraph
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/blocks/$ref")({
+  // Validate the ref at the router level so an invalid block reference renders a
+  // real not-found boundary instead of a component-level early return — matching
+  // subnets.$netuid.tsx / providers.$slug.tsx.
+  parseParams: ({ ref }) => {
+    if (!isValidBlockRef(ref)) throw notFound();
+    return { ref };
+  },
   // Prime the shared cache so head() can title the page with the real block
   // number. Non-fatal: any failure falls back to the ref-only copy and the
   // page's own useSuspenseQuery still drives the not-found/empty path.
   loader: async ({ context, params }) => {
-    if (!isValidBlockRef(params.ref)) {
-      return null;
-    }
-
     try {
       const { data } = await context.queryClient.ensureQueryData(blockQuery(params.ref));
       return { blockNumber: data?.block_number ?? null };
@@ -53,6 +56,18 @@ export const Route = createFileRoute("/blocks/$ref")({
     };
   },
   component: BlockDetailPage,
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Invalid block reference"
+        description="Block references must be a decimal block number or a 0x-prefixed hexadecimal block hash."
+      />
+      <Link to="/blocks" className="text-sm underline">
+        Back to blocks
+      </Link>
+    </AppShell>
+  ),
 });
 
 function BlockDetailPage() {
@@ -61,32 +76,11 @@ function BlockDetailPage() {
     <AppShell>
       <QueryErrorBoundary>
         <Suspense fallback={<DetailSkeleton />}>
-          <BlockDetail refValue={ref} />
+          <ValidBlockDetail refValue={ref} />
         </Suspense>
       </QueryErrorBoundary>
     </AppShell>
   );
-}
-
-function BlockDetail({ refValue }: { refValue: string }) {
-  if (!isValidBlockRef(refValue)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid block reference"
-          description="Block references must be a decimal block number or a 0x-prefixed hex hash."
-        />
-        <EmptyState
-          title="Invalid block reference"
-          description="Use a decimal block number or a 0x-prefixed hexadecimal block hash."
-          action={{ label: "Back to blocks", href: "/blocks" }}
-        />
-      </>
-    );
-  }
-
-  return <ValidBlockDetail refValue={refValue} />;
 }
 
 function ValidBlockDetail({ refValue }: { refValue: string }) {

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
 import { Boxes, Clock, FileText } from "lucide-react";
@@ -23,13 +23,17 @@ import {
 } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/extrinsics/$hash")({
+  // Validate the hash at the router level so an invalid extrinsic reference
+  // renders a real not-found boundary instead of a component-level early return —
+  // matching subnets.$netuid.tsx / providers.$slug.tsx.
+  parseParams: ({ hash }) => {
+    if (!isValidExtrinsicHash(hash)) throw notFound();
+    return { hash };
+  },
   // Prime the shared cache so head() can title with the call name. Non-fatal:
   // any failure falls back to the hash-only copy and the page's own
   // useSuspenseQuery still drives the not-found/empty path.
   loader: async ({ context, params }) => {
-    if (!isValidExtrinsicHash(params.hash)) {
-      return null;
-    }
     try {
       const { data } = await context.queryClient.ensureQueryData(extrinsicQuery(params.hash));
       return {
@@ -54,6 +58,18 @@ export const Route = createFileRoute("/extrinsics/$hash")({
     };
   },
   component: ExtrinsicDetailPage,
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Invalid extrinsic reference"
+        description="Extrinsic references must be a 0x-prefixed hexadecimal hash."
+      />
+      <Link to="/extrinsics" className="text-sm underline">
+        Back to extrinsics
+      </Link>
+    </AppShell>
+  ),
 });
 
 function ExtrinsicDetailPage() {
@@ -62,31 +78,11 @@ function ExtrinsicDetailPage() {
     <AppShell>
       <QueryErrorBoundary>
         <Suspense fallback={<DetailSkeleton />}>
-          <ExtrinsicDetail hash={hash} />
+          <ValidExtrinsicDetail hash={hash} />
         </Suspense>
       </QueryErrorBoundary>
     </AppShell>
   );
-}
-
-function ExtrinsicDetail({ hash }: { hash: string }) {
-  if (!isValidExtrinsicHash(hash)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid extrinsic reference"
-          description="Extrinsic references must be a 0x-prefixed hexadecimal hash."
-        />
-        <EmptyState
-          title="Invalid extrinsic reference"
-          description="Use a 0x-prefixed hexadecimal extrinsic hash."
-          action={{ label: "Back to extrinsics", href: "/extrinsics" }}
-        />
-      </>
-    );
-  }
-  return <ValidExtrinsicDetail hash={hash} />;
 }
 
 function ValidExtrinsicDetail({ hash }: { hash: string }) {


### PR DESCRIPTION
## Summary

`blocks.$ref.tsx` and `extrinsics.$hash.tsx` validated their route param **in-component** (`isValidBlockRef` / `isValidExtrinsicHash`) and rendered an inline "Invalid ref" `EmptyState`. Neither defined `parseParams` or `notFoundComponent`.

This moves that validation up to the router — `parseParams` throws TanStack Router's `notFound()` on an invalid ref/hash, and each route gets a `notFoundComponent` — **matching the pattern already used by `providers.$slug.tsx` and `subnets.$netuid.tsx`**. The now-dead in-component invalid-ref branches are removed.

- No validation logic change (reuses `isValidBlockRef` / `isValidExtrinsicHash`).
- The bad-param case now renders as a real not-found boundary instead of a component-level early return.
- 2 files, −52/+42.

**Validation:** `npm run lint --workspace=apps/ui`, `npm run typecheck --workspace=apps/ui`, `npm test --workspace=apps/ui` (593 tests), and `npm run build --workspace=apps/ui` all pass; `prettier --check` clean. Runtime-verified: `/blocks/<invalid>` and `/extrinsics/<invalid>` render the notFoundComponent; valid refs still resolve.

## Screenshots

The invalid-ref state is deterministic and data-independent (`/blocks/not-a-block`, `/extrinsics/not-a-hash`), captured before/after from the same warm local dev server so header stats match. The visible change is the invalid-ref surface moving from a bordered `EmptyState` card to the router not-found boundary (`PageHeading` + "Back to …" link), matching the existing subnets/providers not-found look.

### /blocks/$ref (invalid ref)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-desktop-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-desktop-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-desktop-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-desktop-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-tablet-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-tablet-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-tablet-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-tablet-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-mobile-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-mobile-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-mobile-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-blocks-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-mobile-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-blocks-mobile-dark.png)<br><sub>after</sub> |

### /extrinsics/$hash (invalid ref)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-desktop-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-desktop-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-desktop-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-desktop-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-tablet-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-tablet-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-tablet-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-tablet-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-mobile-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-mobile-light.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-mobile-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/before-extrinsics-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-mobile-dark.png" width="260">](https://raw.githubusercontent.com/reyanthony062001-ops/metagraphed/screenshots/after-extrinsics-mobile-dark.png)<br><sub>after</sub> |

Closes #3422