### PR TITLE
feat(registry): add SN76 Byzantium validator-weights subnet-api surface (#4090)

### DIFF
--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -85,6 +85,24 @@
         "https://github.com/byzantiumaitao-arch/byzantium/blob/main/ai-agent-kit/byzantium.config.json"
       ],
       "url": "https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/ai-agent-kit/byzantium.config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-76-byzantium-validator-weights",
+      "kind": "subnet-api",
+      "name": "Byzantium validator weights API",
+      "notes": "Public no-auth JSON feed of per-miner weight values; the subnet's sole public validator endpoint per its route.ts doc-comment.",
+      "provider": "byzantium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "cleanjunc"
+      },
+      "source_urls": [
+        "https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/link-service/app/api/validator/weights/route.ts"
+      ],
+      "url": "https://link.byzantiumai.net/api/validator/weights"
     }
   ],
   "website_url": "https://www.byzantiumai.net/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `subnet-api` surface to `registry/subnets/byzantium.json` (SN76 Byzantium) — the subnet's public validator-weights endpoint. Append-only; no other file is touched.

## Surface

- Netuid: 76
- Kind: subnet-api
- Public URL: https://link.byzantiumai.net/api/validator/weights
- Source URL (proves the claim): https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/link-service/app/api/validator/weights/route.ts
- Provider slug: byzantium

The `url` returns live, no-auth JSON (`generated_at`, `formula`, `count`, and a `weights[]` array of per-miner objects). The `source_url` is the `route.ts` that implements `/api/validator/weights` inside `byzantiumaitao-arch/byzantium` — SN76's registered `source_repo` — whose doc-comment calls it the only public validator endpoint in v1. Ownership is confirmed two ways: the source repo is the subnet's registered `source_repo`, and `link.byzantiumai.net` is a subdomain of the registered website `byzantiumai.net`.

## Checklist

- [x] Changes exactly one `registry/subnets/byzantium.json` file (append-only).
- [x] Lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (no existing subnet-api surface on SN76).
- [x] Links a tracked issue that is still OPEN (`Closes #4090`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/byzantium.json`
- [x] `npm run scan:public-safety`

Closes #4090
