### PR TITLE
feat(registry): add SN27 NI Compute OpenCompute W&B dashboard surface

### DIFF
--- a/registry/subnets/ni-compute.json
+++ b/registry/subnets/ni-compute.json
@@ -51,6 +51,25 @@
         "https://github.com/neuralinternet/SN27-opencompute/blob/main/config.yaml"
       ],
       "url": "https://raw.githubusercontent.com/neuralinternet/SN27-opencompute/main/config.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-27-ni-compute-opencompute-wandb",
+      "kind": "dashboard",
+      "name": "NI Compute OpenCompute W&B dashboard",
+      "notes": "Public Weights & Biases project for SN27 NI Compute's OpenCompute GPU-hardware metrics (entity neuralinternet, project opencompute; 6000+ logged runs). Declared as the subnet's PUBLIC W&B source in the official neuralinternet/SN27-opencompute repository — server.py sets PUBLIC_WANDB_ENTITY = 'neuralinternet' and PUBLIC_WANDB_NAME = 'opencompute', and that repo's .env.example pins NETUID=27. It is the data source for the public opencompute.streamlit.app GPU dashboard the repo deploys. Publicly readable, no auth.",
+      "provider": "nodexo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py",
+        "https://github.com/neuralinternet/SN27-opencompute/blob/main/.env.example"
+      ],
+      "url": "https://wandb.ai/neuralinternet/opencompute"
     }
   ]
 }


### PR DESCRIPTION
Closes #4024

## Summary
Registers **SN27 NI Compute**'s official public **OpenCompute Weights & Biases dashboard** — the subnet's public GPU-hardware metrics data source, which the registry didn't yet have.

## Surface
- kind: `dashboard`
- url: `https://wandb.ai/neuralinternet/opencompute`
- provider: `nodexo` (existing)

## Proof of ownership (airtight, code-backed)
- The official SN27 monitoring repo `neuralinternet/SN27-opencompute` **declares this exact W&B project in code**: `server.py` sets `PUBLIC_WANDB_ENTITY = "neuralinternet"` and `PUBLIC_WANDB_NAME = "opencompute"` (→ `wandb.ai/neuralinternet/opencompute`).
- That same repo's `.env.example` pins **`NETUID=27`**, and the repo is already registered as SN27's `source-repo`.
- It is the data source behind the public `opencompute.streamlit.app` GPU dashboard the repo deploys.

## Verified live + public
- `GET https://wandb.ai/neuralinternet/opencompute` → **HTTP 200**; W&B GraphQL shows the project is publicly accessible with **6053 logged runs** (real GPU-spec data).

## Scope note (#4024)
#4024 asks for SN27's public API endpoint. NI Compute exposes no public no-auth HTTP API (the main `neuralinternet/SN27` code repo is now private; `facilitator`-style hosts are auth-gated). Its genuine public machine-usable metrics surface is this W&B project (mirrored to the public streamlit dashboard) — registered here as a `dashboard`.

## Non-duplication
ni-compute.json currently has only a `source-repo` and one `data-artifact` (the `config.yaml` GPU reference file). This W&B project is a different URL, host, and kind (the live metrics dashboard). No open PR targets SN27.

## Validation (local)
- `npx prettier --check registry/subnets/ni-compute.json` → clean
- `npm run validate:surface -- registry/subnets/ni-compute.json` → passes (3 surfaces)
- single file, 19-line pure append, no reordering, no generated artifacts.
