### PR TITLE
feat(registry): add SN116 TaoLend contract constants data artifact

### DIFF
--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -73,6 +73,25 @@
         "https://github.com/oxylok/116-taolend/blob/main/README.md"
       ],
       "url": "https://github.com/oxylok/116-taolend"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-116-taolend-contract-constants",
+      "kind": "data-artifact",
+      "name": "TaoLend contract and precompile constants",
+      "notes": "Public no-auth TypeScript constants file from the official oxylok/116-taolend repository publishing SN116 TaoLend deployed LendingPoolV1 address (0xE41852a75e51812adA39C8D0aae18c7c59935C0d) and Bittensor EVM precompile addresses (metagraph, neuron, staking, alpha, subnet, balance transfer) used by the lending protocol CLI and validator.",
+      "provider": "taolend",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://github.com/oxylok/116-taolend/blob/main/const.ts",
+        "https://github.com/oxylok/116-taolend/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/oxylok/116-taolend/main/const.ts"
     }
   ],
   "website_url": "https://taolend.io/"


### PR DESCRIPTION
## Summary

- Adds a `data-artifact` surface for SN116 TaoLend: the official `const.ts` from `oxylok/116-taolend`.
- The file publishes deployed LendingPoolV1 and Bittensor EVM precompile addresses used by the TaoLend lending protocol CLI and validator.
- `taolend.io` currently returns 500; the GitHub-hosted constants file is the verified first-party artifact from the registered source repository.

Closes #4159

## Test plan

- [x] `npm run validate:surface -- registry/subnets/taolend.json`
- [x] `npm run scan:public-safety`
- [x] Confirmed `url` resolves (raw GitHub, HTTP 200)
- [x] Confirmed `source_urls` prove official SN116 TaoLend publication (const.ts + README in oxylok/116-taolend)
- [x] Single-file diff: `registry/subnets/taolend.json` only

Made with [Cursor](https://cursor.com)