### PR TITLE
Enrich SN115 HashiChain — add public API endpoint

### DIFF
--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -49,6 +49,25 @@
         "timeout_ms": 10000
       },
       "notes": "Public HashiChain source repository for SN115."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-115-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "HashiChain TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/115 on api.taomarketcap.com returning machine-readable JSON for SN115 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. HashiChain currently has no separately verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/hashi115/hashichain"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/115"
     }
   ],
   "contact": "hashichain@outlook.com"


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/hashichain.json` (SN115, HashiChain). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 115
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/115
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/hashi115/hashichain
- **Provider slug:** `taomarketcap`

HashiChain currently has no separately verified first-party public API. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 115.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/hashichain.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/115` returns HTTP 200 with valid JSON (`netuid: 115`)

Closes #4154

Made with [Cursor](https://cursor.com)