### PR TITLE
feat(ui): render nested batch calls and Proxy real-account on extrinsic detail

### DIFF
--- a/apps/ui/src/lib/metagraphed/extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { extrinsicCall, extrinsicHashPathSegment, isValidExtrinsicHash } from "./extrinsics";
+import {
+  extrinsicCall,
+  extrinsicHashPathSegment,
+  isDecodedCall,
+  isValidExtrinsicHash,
+  proxyRealAccount,
+} from "./extrinsics";
 
 const VALID_HASH = "0xabc123def456";
 
@@ -43,5 +49,43 @@ describe("extrinsicCall", () => {
   it("returns an em dash when both sides are absent", () => {
     expect(extrinsicCall()).toBe("—");
     expect(extrinsicCall(null, null)).toBe("—");
+  });
+});
+
+describe("isDecodedCall", () => {
+  it("accepts an object carrying string call_module and call_function", () => {
+    expect(isDecodedCall({ call_module: "Utility", call_function: "batch" })).toBe(true);
+  });
+
+  it("rejects arrays, scalars, and objects missing either field", () => {
+    expect(isDecodedCall([{ call_module: "Utility", call_function: "batch" }])).toBe(false);
+    expect(isDecodedCall("Utility.batch")).toBe(false);
+    expect(isDecodedCall(null)).toBe(false);
+    expect(isDecodedCall({ call_module: "Utility" })).toBe(false);
+    expect(isDecodedCall({ call_function: "batch" })).toBe(false);
+  });
+});
+
+describe("proxyRealAccount", () => {
+  const REAL = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  it("extracts the real arg from a Proxy.proxy call", () => {
+    expect(
+      proxyRealAccount("Proxy", "proxy", [
+        { name: "real", value: REAL },
+        { name: "call", value: { call_module: "Balances", call_function: "transfer" } },
+      ]),
+    ).toBe(REAL);
+  });
+
+  it("returns null for non-proxy calls", () => {
+    expect(proxyRealAccount("Balances", "transfer", [{ name: "dest", value: REAL }])).toBeNull();
+    expect(proxyRealAccount("Proxy", "add_proxy", [{ name: "real", value: REAL }])).toBeNull();
+  });
+
+  it("returns null when call_args isn't an array or the real arg is malformed", () => {
+    expect(proxyRealAccount("Proxy", "proxy", { real: REAL })).toBeNull();
+    expect(proxyRealAccount("Proxy", "proxy", [{ name: "real", value: 123 }])).toBeNull();
+    expect(proxyRealAccount("Proxy", "proxy", [{ name: "force_proxy_type", value: "Any" }])).toBeNull();
   });
 });

--- a/apps/ui/src/lib/metagraphed/extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.test.ts
@@ -86,6 +86,8 @@ describe("proxyRealAccount", () => {
   it("returns null when call_args isn't an array or the real arg is malformed", () => {
     expect(proxyRealAccount("Proxy", "proxy", { real: REAL })).toBeNull();
     expect(proxyRealAccount("Proxy", "proxy", [{ name: "real", value: 123 }])).toBeNull();
-    expect(proxyRealAccount("Proxy", "proxy", [{ name: "force_proxy_type", value: "Any" }])).toBeNull();
+    expect(
+      proxyRealAccount("Proxy", "proxy", [{ name: "force_proxy_type", value: "Any" }]),
+    ).toBeNull();
   });
 });

--- a/apps/ui/src/lib/metagraphed/extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.ts
@@ -20,3 +20,46 @@ export function extrinsicCall(module?: string | null, fn?: string | null): strin
   if (module && fn) return `${module}.${fn}`;
   return module || fn || "—";
 }
+
+/** A fully-decoded nested call, as substrate-interface emits it inside a
+ * parent's `call_args` -- a `Utility.batch*` inner call, a `Multisig`
+ * `call` arg, or a `Proxy.proxy` `call` arg all share this identical shape
+ * at any nesting depth (docs/block-explorer-data-model.md's "Nested-call
+ * decode depth" note, #4319/4.1). */
+export interface DecodedCall {
+  call_module?: string | null;
+  call_function?: string | null;
+  call_args?: unknown;
+  call_hash?: string | null;
+  [key: string]: unknown;
+}
+
+/** True when a call_args value is itself a fully-decoded nested call, not a
+ * plain scalar/struct -- lets a renderer tell "expand this as a call" from
+ * "print this as JSON". */
+export function isDecodedCall(value: unknown): value is DecodedCall {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).call_module === "string" &&
+    typeof (value as Record<string, unknown>).call_function === "string"
+  );
+}
+
+/** The real acting account for a `Proxy.proxy` call, or null when this isn't
+ * a proxied call or its `real` arg is missing/malformed. The signer only
+ * relayed the call on-chain -- `real` is the account it actually executes
+ * as, easy to miss buried in a raw args table. */
+export function proxyRealAccount(
+  callModule: string | null | undefined,
+  callFunction: string | null | undefined,
+  callArgs: unknown,
+): string | null {
+  if (callModule !== "Proxy" || callFunction !== "proxy") return null;
+  if (!Array.isArray(callArgs)) return null;
+  const real = (callArgs as Array<{ name?: string | null; value?: unknown }>).find(
+    (a) => a?.name === "real",
+  );
+  return typeof real?.value === "string" ? real.value : null;
+}

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
-import { Boxes, Clock, FileText } from "lucide-react";
+import { Boxes, Clock, FileText, UserCog } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
@@ -19,7 +19,10 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import {
   extrinsicCall,
   extrinsicHashPathSegment,
+  isDecodedCall,
   isValidExtrinsicHash,
+  proxyRealAccount,
+  type DecodedCall,
 } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/extrinsics/$hash")({
@@ -105,6 +108,9 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
       ? Object.keys(callArgs).length
       : 0;
   const callArgsOmitted = Math.max(0, callArgsTotal - 64);
+  const realAccount = extrinsic
+    ? proxyRealAccount(extrinsic.call_module, extrinsic.call_function, callArgs)
+    : null;
 
   if (!extrinsic) {
     return (
@@ -143,6 +149,24 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         actions={<ShareButton />}
         caption="explorer / v1"
       />
+
+      {realAccount ? (
+        <div className="mb-8 flex flex-wrap items-center gap-3 rounded border border-accent/30 bg-accent-surface px-4 py-3">
+          <UserCog className="size-4 shrink-0 text-accent" aria-hidden="true" />
+          <span className="text-sm text-ink">
+            Executed on behalf of{" "}
+            <Link
+              to="/accounts/$ss58"
+              params={{ ss58: realAccount }}
+              className="font-mono text-ink-strong hover:underline"
+            >
+              {shortHash(realAccount) ?? realAccount}
+            </Link>{" "}
+            — the account below only relayed this <code className="font-mono">Proxy.proxy</code>{" "}
+            call, it isn't the account the inner call actually acts as.
+          </span>
+        </div>
+      ) : null}
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
         <StatTile
@@ -339,7 +363,16 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
   );
 }
 
-function renderCallArgs(callArgs: unknown) {
+// Utility.batch/batch_all/force_batch, Multisig's `call`, and Proxy's `call`
+// all carry the SAME fully-decoded-call shape (#4319/4.1 — verified live, see
+// docs/block-explorer-data-model.md's "Nested-call decode depth" note), and
+// that decoded call's own args can nest again (a batch inside a multisig
+// inside a batch). Cap the recursion rather than flattening to raw JSON, so a
+// viewer can read a batch's inner transfers/multisig's wrapped call directly
+// instead of parsing an escaped JSON blob by eye.
+const MAX_NESTED_CALL_DEPTH = 4;
+
+function renderCallArgs(callArgs: unknown, depth = 0) {
   if (Array.isArray(callArgs)) {
     const args = (callArgs as Array<{ name?: string | null; value?: unknown }>).slice(0, 64);
     if (args.length === 0) {
@@ -357,11 +390,11 @@ function renderCallArgs(callArgs: unknown) {
           <tbody className="divide-y divide-border">
             {args.map((arg, i) => (
               <tr key={`${arg.name ?? i}`} className="hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong align-top">
                   {arg.name ?? `arg_${i + 1}`}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {formatCallArgValue(arg.value)}
+                  {renderCallArgValue(arg.value, depth)}
                 </td>
               </tr>
             ))}
@@ -388,9 +421,11 @@ function renderCallArgs(callArgs: unknown) {
           <tbody className="divide-y divide-border">
             {entries.map(([key, value]) => (
               <tr key={key} className="hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">{key}</td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong align-top">
+                  {key}
+                </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {formatCallArgValue(value)}
+                  {renderCallArgValue(value, depth)}
                 </td>
               </tr>
             ))}
@@ -401,6 +436,46 @@ function renderCallArgs(callArgs: unknown) {
   }
 
   return <p className="text-sm text-ink-muted">No call args were indexed.</p>;
+}
+
+// One arg's value: a nested call (or a list of them, e.g. a batch's `calls`)
+// expands as its own call card; anything else prints as before.
+function renderCallArgValue(value: unknown, depth: number): ReactNode {
+  if (depth < MAX_NESTED_CALL_DEPTH) {
+    if (isDecodedCall(value)) {
+      return <NestedCallCard call={value} depth={depth} />;
+    }
+    if (Array.isArray(value) && value.length > 0 && value.every(isDecodedCall)) {
+      return (
+        <div className="flex flex-col gap-2">
+          {(value as DecodedCall[]).map((call, i) => (
+            <NestedCallCard
+              key={typeof call.call_hash === "string" ? call.call_hash : i}
+              call={call}
+              depth={depth}
+            />
+          ))}
+        </div>
+      );
+    }
+  }
+  return formatCallArgValue(value);
+}
+
+function NestedCallCard({ call, depth }: { call: DecodedCall; depth: number }) {
+  return (
+    <div className="rounded border border-border/70 bg-surface/30 p-3">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <span className="font-mono text-[11px] font-semibold text-ink-strong">
+          {extrinsicCall(call.call_module, call.call_function)}
+        </span>
+        {typeof call.call_hash === "string" && call.call_hash ? (
+          <CopyableCode value={call.call_hash} label="call_hash" />
+        ) : null}
+      </div>
+      {renderCallArgs(call.call_args, depth + 1)}
+    </div>
+  );
 }
 
 function formatCallArgValue(value: unknown): string {


### PR DESCRIPTION
Closes #4321
Closes #4323

## Summary

`Utility.batch`/`batch_all`/`force_batch`'s inner calls, and `Multisig`/`Proxy`'s wrapped `call` arg, all carry substrate-interface's fully-decoded call shape already — `call_module`/`call_function`/`call_args`/`call_hash` at any nesting depth (confirmed live against finney in #4319/4.1, see `docs/block-explorer-data-model.md`'s "Nested-call decode depth" note). No backend decode addition needed — this is pure rendering.

**#4321 — nested batch calls:** the extrinsic detail page's call-args renderer previously flattened any nested-call value to a raw stringified JSON blob. Generalized `renderCallArgs`/`NestedCallCard` (`apps/ui/src/routes/extrinsics.$hash.tsx`) to detect a decoded-call-shaped value (`isDecodedCall`, new in `lib/metagraphed/extrinsics.ts`) — a single nested call or an array of them (a batch's `calls`) — and expand it as its own card with a module.function header, a copyable `call_hash`, and its own args table, recursively (capped at 4 levels, since a call can itself be wrapped again — e.g. a Multisig around a batch).

**#4323 — Proxy real-account substitution:** `Proxy.proxy` executes as a different account (`real`) than the transaction's signer. Added `proxyRealAccount()` (extracts `real` from a `Proxy.proxy` call's args) and a callout banner near the top of the page: "Executed on behalf of `{real}` — the account below only relayed this `Proxy.proxy` call, it isn't the account the inner call actually acts as." Previously this was only visible by reading the raw `real` arg in the args table.

The nested-call renderer also transparently covers `Proxy.proxy`'s wrapped `call` arg (and would cover Multisig's `as_multi`/`approve_as_multi`'s `call` arg the same way) — #4322 (Multisig `call_hash` cross-linking) is being tracked as a separate, slightly larger change since it needs a small new backend filter to actually join extrinsics by `call_hash`, not just display.

## Verification

`docs/block-explorer-data-model.md`'s #4319/4.1 note documents real live samples for `Utility.batch_all` — but the `/api/v1/extrinsics` and `/api/v1/blocks` endpoints are currently returning zero rows across the board (a separate, already-flagged data-pipeline issue, unrelated to this change — the API is otherwise healthy, e.g. `/api/v1/health` is fully populated). Verified this PR's rendering by installing a `window.fetch` mock in a live Preview session serving the exact recorded `batch_all` JSON from the research note (plus a synthetic `Proxy.proxy` example matching the documented pallet call shape), then driving `TanStack Router`'s client-side `navigate()` to the extrinsic detail route:

- Confirmed via the accessibility tree that both inner calls of a batch (`SubtensorModule.remove_stake_limit`, `Balances.transfer_keep_alive`) render as separate cards with their own args tables and `call_hash` copy buttons, replacing the old raw-JSON cell.
- Confirmed via `preview_inspect` that `NestedCallCard` renders with the correct classes/props/computed styles.
- Confirmed the Proxy banner renders "Executed on behalf of 5Grwva…GKutQY — ..." and that the wrapped `call` arg *also* gets the nested-call treatment (recursion working across the two call classes with one shared code path).
- `npm run lint` / `npx tsc --noEmit` / `npx vitest run` (apps/ui) — all clean; added unit tests for the new `isDecodedCall`/`proxyRealAccount` helpers.

Maintainer PR — no screenshot table (established this session for maintainer/owner PRs); visual correctness was verified directly via Preview as described above, including full before/after screenshots comparing the old raw-JSON-blob rendering against the new nested-call cards.
