### PR TITLE
fix(queries): restore repo link + notes on provider detail pages

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.provider-detail.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.provider-detail.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { normalizeProvider } from "./queries";
+
+// normalizeProvider (the /providers/:slug detail normalizer) says it "mirrors
+// normalizeProviderListItem". The list normalizer derives repo from github_url
+// and notes from public_notes; the detail endpoint emits exactly those two
+// snake_case fields (never a bare `repo`/`notes`). Before this fix the detail
+// normalizer omitted repo entirely and dropped the public_notes fallback, so
+// providers.$slug.tsx rendered no GitHub link (repoUrl={p?.repo}) and no
+// description (description={p?.notes}) even though the list view showed both.
+
+describe("normalizeProvider (detail) mirrors the list normalizer", () => {
+  it("derives repo from github_url and notes from public_notes", () => {
+    const out = normalizeProvider(
+      {
+        provider: {
+          id: "404-gen",
+          name: "404-GEN",
+          github_url: "https://github.com/404-Repo/404-gen-subnet",
+          public_notes: "Subnet 17 (404-GEN) team profile.",
+        },
+      },
+      "404-gen",
+    );
+    expect(out.repo).toBe("https://github.com/404-Repo/404-gen-subnet");
+    expect(out.notes).toBe("Subnet 17 (404-GEN) team profile.");
+  });
+
+  it("prefers an explicit repo/notes over the fallbacks and leaves them undefined when absent", () => {
+    const withExplicit = normalizeProvider(
+      { provider: { id: "x", repo: "https://example.com/x", notes: "n" } },
+      "x",
+    );
+    expect(withExplicit.repo).toBe("https://example.com/x");
+    expect(withExplicit.notes).toBe("n");
+
+    const bare = normalizeProvider({ provider: { id: "y", name: "Y" } }, "y");
+    expect(bare.repo).toBeUndefined();
+    expect(bare.notes).toBeUndefined();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6360,6 +6360,7 @@ export function normalizeProvider(raw: unknown, slug: string): Provider {
   const summary = (root.endpoint_summary as Record<string, unknown> | undefined) ?? undefined;
   const website = pickStr(inner.website_url, inner.homepage, inner.website);
   const docs = pickStr(inner.docs_url, inner.docs);
+  const repo = pickStr(inner.github_url, inner.repo, inner.repository);
   return {
     // Spread raw fields FIRST so the normalized/computed fields below win on
     // collision (mirrors normalizeProviderListItem). Spreading `...inner` last
@@ -6372,7 +6373,8 @@ export function normalizeProvider(raw: unknown, slug: string): Provider {
     homepage: website,
     website,
     docs,
-    notes: pickStr(inner.notes),
+    repo,
+    notes: pickStr(inner.notes, inner.public_notes),
     endpoint_summary: summary as ProviderEndpointSummary | undefined,
     // Normalize singular API field names (endpoint_count / surface_count) to
     // plural _count fields so all consumers use the same key regardless of


### PR DESCRIPTION
## Problem

Provider **detail** pages (`/providers/:slug`) silently render **no GitHub repo link and no description**, even though the data is present and the providers **list** shows both.

Root cause is in `normalizeProvider` (`apps/ui/src/lib/metagraphed/queries.ts`), the `/api/v1/providers/:slug` normalizer. Its own comment says it "mirrors `normalizeProviderListItem`", but it doesn't:

- **`repo` is never derived.** The list normalizer does `repo = pickStr(r.github_url, r.repo, r.repository)`; the detail normalizer omits it, so `repo` only survives if the raw payload already has a literal `repo` key.
- **`notes` drops the `public_notes` fallback.** List: `pickStr(r.notes, r.public_notes)`; detail: `pickStr(inner.notes)`.

The detail endpoint emits the snake_case fields, never a bare `repo`/`notes`. Confirmed against the live API — `GET /api/v1/providers/404-gen` returns:

```jsonc
"provider": {
  "github_url": "https://github.com/404-Repo/404-gen-subnet",
  "public_notes": "Subnet 17 (404-GEN) team profile …",
  // no "repo", no "notes"
}
```

So `p.repo` and `p.notes` come out `undefined`, and `providers.$slug.tsx` renders nothing for `repoUrl={p?.repo}` (the GitHub link) and `description={p?.notes}` (the profile blurb) — while `normalizeProviderListItem` maps both correctly on the list/cards.

## Fix

Make the detail normalizer mirror the list normalizer, exactly as its comment claims:

```diff
   const docs = pickStr(inner.docs_url, inner.docs);
+  const repo = pickStr(inner.github_url, inner.repo, inner.repository);
   // ...
     docs,
+    repo,
-    notes: pickStr(inner.notes),
+    notes: pickStr(inner.notes, inner.public_notes),
```

No other fields change; `amount_tao`-style rendered values are untouched.

## Test

Adds `queries.provider-detail.test.ts` unit-testing the exported `normalizeProvider`: a detail payload with `github_url` + `public_notes` now yields `repo`/`notes`, an explicit `repo`/`notes` still wins, and a bare payload leaves both `undefined`. The first assertion fails on the pre-fix code (`repo`/`notes` come back `undefined`) and passes after.

Local: `vitest run` (2 passed), `tsc --noEmit` (clean), `eslint` (0), `prettier --check` (clean).
