### PR TITLE
feat(registry): add SN72 StreetVision by NATIX whitepaper llms.txt docs data-artifact (#4086)

### DIFF
--- a/registry/subnets/streetvision-by-natix.json
+++ b/registry/subnets/streetvision-by-natix.json
@@ -188,6 +188,25 @@
         "submitted_by": "galuis116"
       },
       "notes": "Public no-auth Hugging Face Datasets Server rows API for the official StreetVision roadwork dataset — returns machine-readable JSON (schema + row records with image/id/width/height/scene metadata), a distinct callable endpoint from the existing HF dataset webpage surface above. Fills the file's gap note for a verified safe public subnet API endpoint."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-72-natix-whitepaper-llms-txt",
+      "kind": "data-artifact",
+      "name": "NATIX whitepaper docs llms.txt index",
+      "notes": "Public no-auth machine-readable llms.txt index of the official StreetVision by NATIX (SN72) whitepaper documentation, served at docs.natix.network — the same official docs domain already registered as the sn-72-natix-whitepaper-docs surface and as the file's docs_url. Provides an agent-consumable Markdown map of the NATIX docs (Executive Summary, Introduction, Problem, Solution, xNodes, etc.) for LLM/agent ingestion; content begins '# NATIX Network Whitepaper'. Distinct from the HTML whitepaper docs page (a different URL and a machine-readable text/markdown artifact).",
+      "provider": "natix",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://docs.natix.network/whitepaper",
+        "https://github.com/natixnetwork/streetvision-subnet/blob/main/README.md"
+      ],
+      "url": "https://docs.natix.network/whitepaper/llms.txt"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Registers **SN72 StreetVision by NATIX**'s public **`llms.txt` documentation index** — an agent-consumable, no-auth, machine-readable Markdown map of the official NATIX whitepaper docs that the registry did not yet capture.

## Surface

- **kind:** `data-artifact`
- **url:** `https://docs.natix.network/whitepaper/llms.txt`
- **provider:** `natix` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://docs.natix.network/whitepaper` — the official NATIX docs domain **already registered in this file** as the `sn-72-natix-whitepaper-docs` surface and as the file's `docs_url`. The llms.txt sits under that exact accepted docs path.
- `source_url` 2: the official `natixnetwork/streetvision-subnet` README (registered `source_repo`), confirming SN72 identity.

## Verified live + public + safe

- `GET https://docs.natix.network/whitepaper/llms.txt` → **HTTP 200**, `Content-Type: text/markdown; charset=utf-8`, **no auth** (GitBook static route). Content begins `# NATIX Network Whitepaper` followed by a link index (Executive Summary, Introduction, Problem, Solution, xNodes, …).
- Public-safe: scanned the full body for SS58/base58 wallet or hotkey strings → **zero matches**; markdown docs only, no secrets.

## Non-duplication

Distinct from the existing `sn-72-natix-whitepaper-docs` surface (the HTML page `https://docs.natix.network/whitepaper`) — this is a **different URL** and a machine-readable `text/markdown` artifact, not the HTML docs page. No other surface uses this URL; no open PR targets SN72.

## Scope note (relative to #4086)

#4086 asks for SN72's OpenAPI/Swagger spec. NATIX publishes no OpenAPI (its subnet is a DePIN computer-vision data network; verified there is no machine-readable OpenAPI). This registers the concrete machine-readable documentation surface NATIX does publish — the `llms.txt` docs index — the agent-consumable artifact behind the issue's intent, matching the accepted `llms.txt` data-artifact pattern.

## Validation (local)

- `npm run validate:surface -- registry/subnets/streetvision-by-natix.json` → passes (9 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check` → clean
- `git diff --stat` → single file, 19-line pure append (no top-level metadata or other surfaces touched)

## Template Used

- Subnet surface

Closes #4086
