### PR TITLE
feat(ui): add reusable FreshnessBadge component

### DIFF
--- a/apps/ui/src/components/metagraphed/freshness-badge.test.ts
+++ b/apps/ui/src/components/metagraphed/freshness-badge.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  freshnessBadgeTimeCopy,
+  freshnessDotClass,
+  freshnessTierLabel,
+} from "./freshness-badge";
+
+describe("freshnessTierLabel", () => {
+  it("maps realtime to Live and daily to Daily rollup", () => {
+    expect(freshnessTierLabel("realtime")).toBe("Live");
+    expect(freshnessTierLabel("daily")).toBe("Daily rollup");
+  });
+});
+
+describe("freshnessDotClass", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T18:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns unknown when at is missing", () => {
+    expect(freshnessDotClass(null)).toBe("bg-health-unknown");
+    expect(freshnessDotClass(undefined)).toBe("bg-health-unknown");
+  });
+
+  it("returns ok for a fresh timestamp within the threshold", () => {
+    const at = new Date("2026-07-09T17:30:00.000Z").toISOString();
+    expect(freshnessDotClass(at, 60 * 60_000)).toBe("bg-health-ok");
+  });
+
+  it("returns warn for a stale timestamp beyond the threshold", () => {
+    const at = new Date("2026-07-09T10:00:00.000Z").toISOString();
+    expect(freshnessDotClass(at, 60 * 60_000)).toBe("bg-health-warn");
+  });
+});
+
+describe("freshnessBadgeTimeCopy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T18:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty strings before mount to avoid hydration mismatch", () => {
+    expect(freshnessBadgeTimeCopy("2026-07-09T17:00:00.000Z", false)).toEqual({
+      absolutePhrase: null,
+      relative: "",
+    });
+  });
+
+  it("renders both absolute and relative forms from the same timestamp", () => {
+    const at = "2026-07-09T17:00:00.000Z";
+    const copy = freshnessBadgeTimeCopy(at, true);
+    expect(copy.absolutePhrase).toBe(`as of ${new Date(at).toLocaleString()}`);
+    expect(copy.relative).toMatch(/1h ago/);
+  });
+
+  it("omits the absolute phrase but keeps the relative fallback when at is missing", () => {
+    expect(freshnessBadgeTimeCopy(null, true)).toEqual({
+      absolutePhrase: null,
+      relative: "—",
+    });
+  });
+});

--- a/apps/ui/src/components/metagraphed/freshness-badge.test.ts
+++ b/apps/ui/src/components/metagraphed/freshness-badge.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  freshnessBadgeTimeCopy,
-  freshnessDotClass,
-  freshnessTierLabel,
-} from "./freshness-badge";
+import { freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel } from "./freshness-badge";
 
 describe("freshnessTierLabel", () => {
   it("maps realtime to Live and daily to Daily rollup", () => {

--- a/apps/ui/src/components/metagraphed/freshness-badge.tsx
+++ b/apps/ui/src/components/metagraphed/freshness-badge.tsx
@@ -81,10 +81,7 @@ export function FreshnessBadge({ at, tier, thresholdMs, className }: Props) {
       </span>
       <span className="inline-flex items-center gap-1.5">
         <span className={classNames("size-1.5 shrink-0 rounded-full", dotCls)} />
-        <span
-          className="font-mono text-[10px] text-ink-muted"
-          suppressHydrationWarning
-        >
+        <span className="font-mono text-[10px] text-ink-muted" suppressHydrationWarning>
           {absolutePhrase ? (
             <>
               <span>{absolutePhrase}</span>

--- a/apps/ui/src/components/metagraphed/freshness-badge.tsx
+++ b/apps/ui/src/components/metagraphed/freshness-badge.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import { classNames, formatRelative, isStaleFreshness } from "@/lib/metagraphed/format";
+import { formatFreshnessAbsolute } from "@/lib/metagraphed/freshness";
+
+export type FreshnessTier = "realtime" | "daily";
+
+interface Props {
+  at?: string | null;
+  tier: FreshnessTier;
+  /** Stale threshold in ms (default 12h — see isStaleFreshness). */
+  thresholdMs?: number;
+  className?: string;
+}
+
+/** Visible tier label for realtime block data vs daily rollup snapshots. */
+export function freshnessTierLabel(tier: FreshnessTier): string {
+  return tier === "realtime" ? "Live" : "Daily rollup";
+}
+
+/** Dot colour class mirroring FreshnessIndicator staleness semantics. */
+export function freshnessDotClass(at?: string | null, thresholdMs?: number): string {
+  const missing = at == null;
+  const stale = !missing && isStaleFreshness(at, thresholdMs);
+  return missing ? "bg-health-unknown" : stale ? "bg-health-warn" : "bg-health-ok";
+}
+
+/** Absolute + relative copy derived from the shared freshness formatters. */
+export function freshnessBadgeTimeCopy(
+  at?: string | null,
+  mounted = true,
+): { absolutePhrase: string | null; relative: string } {
+  if (!mounted) return { absolutePhrase: null, relative: "" };
+  const absolute = formatFreshnessAbsolute(at);
+  return {
+    absolutePhrase: absolute ? `as of ${absolute}` : null,
+    relative: formatRelative(at),
+  };
+}
+
+function tierChipClass(tier: FreshnessTier): string {
+  return tier === "realtime"
+    ? "border-accent/35 bg-accent/10 text-accent"
+    : "border-border bg-surface/50 text-ink-muted";
+}
+
+/**
+ * Reusable freshness badge — tier label ("Live" vs "Daily rollup"), staleness
+ * dot, absolute "as of …" stamp, and relative "N ago" phrasing. Built on the
+ * same formatRelative/isStaleFreshness/formatFreshnessAbsolute primitives as
+ * FreshnessIndicator and the spark/methodology call sites.
+ */
+export function FreshnessBadge({ at, tier, thresholdMs, className }: Props) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const missing = at == null;
+  const stale = !missing && isStaleFreshness(at, thresholdMs);
+  const dotCls = freshnessDotClass(at, thresholdMs);
+  const { absolutePhrase, relative } = freshnessBadgeTimeCopy(at, mounted);
+  const title = missing
+    ? "No freshness data"
+    : !mounted
+      ? undefined
+      : stale
+        ? `Stale — ${absolutePhrase ?? "unknown time"} (${relative})`
+        : `Fresh — ${absolutePhrase ?? "unknown time"} (${relative})`;
+
+  return (
+    <span
+      className={classNames("inline-flex flex-wrap items-center gap-1.5", className)}
+      title={title}
+      suppressHydrationWarning
+    >
+      <span
+        className={classNames(
+          "inline-flex items-center rounded-full border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em]",
+          tierChipClass(tier),
+        )}
+      >
+        {freshnessTierLabel(tier)}
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <span className={classNames("size-1.5 shrink-0 rounded-full", dotCls)} />
+        <span
+          className="font-mono text-[10px] text-ink-muted"
+          suppressHydrationWarning
+        >
+          {absolutePhrase ? (
+            <>
+              <span>{absolutePhrase}</span>
+              <span className="text-ink-muted/70"> · </span>
+            </>
+          ) : null}
+          <span>{relative}</span>
+        </span>
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `FreshnessBadge` in `apps/ui/src/components/metagraphed/freshness-badge.tsx` — a shared badge for tier label (`Live` vs `Daily rollup`), staleness dot, absolute `as of …` stamp, and relative `N ago` text.
- Reuses `formatRelative` / `isStaleFreshness` from `lib/metagraphed/format.ts` and `formatFreshnessAbsolute` from `lib/metagraphed/freshness.ts` (no new time math).
- Adds `freshness-badge.test.ts` covering tier labels, stale vs fresh dot classes, hydration-safe pre-mount copy, and missing `at`.
- Additive only — no existing freshness consumers migrated (follow-ups #3376, #3378, #3379, #3380, #3381).

Closes #3370

## Screenshots

Component is not mounted in any route yet (by design). Isolated render states:

| State | Before | After |
| --- | --- | --- |
| Realtime · fresh | *(no shared component)* | `[Live]` green dot · `as of 7/9/2026, 1:30:00 PM · 2m ago` |
| Daily · fresh | *(no shared component)* | `[Daily rollup]` green dot · `as of 7/9/2026, 12:00:00 AM · 6h ago` |
| Daily · stale | *(no shared component)* | `[Daily rollup]` amber dot · `as of 7/8/2026, 6:00:00 PM · 18h ago` |
| Missing timestamp | *(no shared component)* | `[Live]` grey dot · `—` |

## Test plan

- [x] `npm run test --workspace=apps/ui -- freshness-badge.test.ts`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npx eslint apps/ui/src/components/metagraphed/freshness-badge.tsx apps/ui/src/components/metagraphed/freshness-badge.test.ts`
- [x] `npx prettier --check` on the two new files
- [x] No existing freshness consumers modified

Made with [Cursor](https://cursor.com)