### PR TITLE
feat(ui): render the explorer call-mix as a Donut + clickable legend

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -13,6 +13,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
+import { Donut, type DonutSegment } from "@/components/metagraphed/charts/donut";
 import { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
 import { SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
@@ -174,57 +175,71 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
     (c) => c.call_function != null && (selected == null || c.call_module === selected),
   );
 
+  const chartPalette = [
+    "var(--chart-1)",
+    "var(--chart-2)",
+    "var(--chart-3)",
+    "var(--chart-4)",
+    "var(--chart-5)",
+    "var(--chart-6)",
+  ];
+  const moduleSegs: DonutSegment[] = modules.map((c, i) => ({
+    label: c.call_module,
+    value: c.count,
+    color: chartPalette[i % chartPalette.length]!,
+  }));
+
   return (
     <section className="rounded-lg border border-border bg-card p-5">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
           Call mix
         </h2>
-        <span className="font-mono text-[11px] text-ink-muted">
-          {formatNumber(calls.total_extrinsics)} calls
-        </span>
       </div>
       {modules.length > 0 ? (
         <div className="space-y-4">
-          <ul className="space-y-1.5">
-            {modules.map((c) => {
-              const cap = Math.max(1, ...modules.map((m) => m.count));
-              const pct = Math.max(2, Math.round((c.count / cap) * 100));
-              const active = selected === c.call_module;
-              return (
-                <li key={c.call_module}>
-                  <button
-                    type="button"
-                    onClick={() => setSelected(active ? null : c.call_module)}
-                    className="grid w-full grid-cols-[7rem_1fr_auto] items-center gap-2 text-left"
-                    aria-pressed={active}
-                  >
-                    <span
-                      className={
-                        active
-                          ? "truncate font-mono text-[10px] uppercase tracking-widest text-accent"
-                          : "truncate font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-                      }
+          <div className="flex items-center gap-4">
+            <Donut
+              segments={moduleSegs}
+              size={88}
+              strokeWidth={11}
+              centerLabel={formatNumber(calls.total_extrinsics)}
+              centerSub="calls"
+            />
+            <ul className="min-w-0 flex-1 space-y-1">
+              {moduleSegs.map((s) => {
+                const active = selected === s.label;
+                return (
+                  <li key={s.label}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(active ? null : s.label)}
+                      className="flex w-full items-center gap-2 text-left"
+                      aria-pressed={active}
                     >
-                      {c.call_module}
-                    </span>
-                    <span className="relative h-1.5 overflow-hidden rounded-full bg-surface">
                       <span
-                        className="absolute inset-y-0 left-0 rounded-full"
-                        style={{
-                          width: `${pct}%`,
-                          background: active ? "var(--accent)" : "var(--chart-1)",
-                        }}
+                        aria-hidden
+                        className="inline-block size-2 shrink-0 rounded-sm"
+                        style={{ background: s.color }}
                       />
-                    </span>
-                    <span className="font-mono text-[10px] tabular-nums text-ink-strong">
-                      {formatNumber(c.count)}
-                    </span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+                      <span
+                        className={
+                          active
+                            ? "truncate font-mono text-[10px] uppercase tracking-widest text-accent"
+                            : "truncate font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+                        }
+                      >
+                        {s.label}
+                      </span>
+                      <span className="ml-auto font-mono text-[10px] tabular-nums text-ink-strong">
+                        {formatNumber(s.value)}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
 
           {functions.length > 0 ? (
             <div className="border-t border-border pt-3">


### PR DESCRIPTION
Closes #3384

## What
`explorer.tsx`'s `CallMixSection` rendered the top-10 call-module counts as a hand-rolled `<ul>` with an inline percentage bar, instead of the shared `Donut`/legend primitives every other "N labeled categories with counts" panel in the app already uses (`providers.index.tsx`'s kind/status breakdowns, `status.tsx`, `health.tsx`, `subnet-profile-panel.tsx`, `economics-mini.tsx`). This PR swaps it for `Donut` + an interactive legend, following the same donut-plus-legend layout and `--chart-N` palette convention as `providers.index.tsx`'s `ProviderOverview` (`kindPalette`/`kindSegs`).

## Changes
- **`apps/ui/src/routes/explorer.tsx`** — `CallMixSection`'s hand-rolled module `<ul>`/bar markup is replaced by `<Donut segments={moduleSegs} centerLabel={formatNumber(calls.total_extrinsics)} centerSub="calls" />` beside a legend, using the same `var(--chart-1)`..`var(--chart-6)` cycled palette as `providers.index.tsx`. The shared `DonutLegend` component isn't interactive (no click handler), and per the issue's non-goals `components/metagraphed/charts/donut.tsx` isn't touched, so the legend rows are built inline in `explorer.tsx` as buttons — preserving the existing `selected`/`setSelected` click-to-select drill-down and `aria-pressed` active state exactly as before. The function-level drill-down sub-chart (`BarMini` for `functions.slice(0, 10)`) is untouched, still rendering `BarMini` per the issue's non-goals. The header's separate `{formatNumber(calls.total_extrinsics)} calls` span is removed since the same total now surfaces via the donut's `centerLabel`/`centerSub`.
- No changes outside `explorer.tsx` — no edits to `donut.tsx`, `bar-mini.tsx`, or backend/schema files.

## Screenshots

The live `/api/v1/chain/calls` endpoint currently returns zero `calls` in this environment (a temporary data gap, not a bug in this component or its query). The screenshots below mock a realistic top-10 module distribution — the same response shape the real endpoint returns — via Playwright route interception, to demonstrate the feature against the actual component code rather than against empty live data.

| Theme | Before | After |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/before-explorer-light.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/before-explorer-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/after-explorer-light.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/after-explorer-light.png)<br><sub>after</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/before-explorer-dark.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/before-explorer-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/after-explorer-dark.png" width="320">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-explorer-call-mix-donut-3384/after-explorer-dark.png)<br><sub>after</sub> |

Click-to-select drill-down verified interactively (Playwright): clicking a legend row sets `aria-pressed="true"`, highlights the row in `var(--accent)`, and re-renders the function-breakdown copy below — matching pre-existing behavior exactly.

## Acceptance criteria
- [x] `CallMixSection`'s hand-rolled module `<ul>`/bar markup is replaced by `<Donut>` + a clickable-legend variant fed from `modules`
- [x] `Donut` is imported from `@/components/metagraphed/charts/donut` in `explorer.tsx`
- [x] Click-to-select drill-down preserved: clicking a module sets `selected`, filters `functions`, and highlights the active module via `aria-pressed`
- [x] The function-level breakdown (`functions.slice(0, 10)` via `BarMini`) is untouched
- [x] `formatNumber(calls.total_extrinsics)` still surfaces as a total, now via `Donut`'s `centerLabel`/`centerSub`
- [x] No changes outside `apps/ui/src/routes/explorer.tsx`

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean aside from pre-existing CRLF/fast-refresh noise unrelated to this change.
- Diff is 54 insertions / 39 deletions in a single file.
