### PR TITLE
feat(ui): add a block-throughput sparkline to the blocks index header

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -12,6 +12,7 @@ import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ListShell } from "@/components/metagraphed/list-shell";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import {
   PageSizeSelect,
   ResetFiltersButton,
@@ -20,7 +21,7 @@ import {
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
-import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
+import { blocksQuery, blocksSummaryQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
@@ -81,6 +82,33 @@ function BlocksPage() {
   const search = Route.useSearch();
   const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
 
+  // Block-throughput sparkline (#3390): daily block_count from /api/v1/chain/activity,
+  // the same source explorer.tsx uses. Non-blocking useQuery so the hero paints
+  // immediately; the KPI appears once the daily series loads.
+  const activity = useQuery(chainActivityQuery());
+  const chrono = [...(activity.data?.data.days ?? [])].reverse();
+  const blockCounts = chrono.map((d) => d.block_count);
+  const totalBlocks = blockCounts.reduce((acc, n) => acc + n, 0);
+  const throughputKpi =
+    blockCounts.length > 0
+      ? [
+          {
+            label: "Blocks / day",
+            value: `${formatNumber(totalBlocks)} total`,
+            chart: (
+              <Sparkline
+                values={blockCounts}
+                points={chrono.map((d) => ({ t: d.day, v: d.block_count }))}
+                width={168}
+                height={34}
+                ariaLabel="Daily block throughput, oldest to newest"
+                formatValue={formatNumber}
+              />
+            ),
+          },
+        ]
+      : undefined;
+
   return (
     <AppShell>
       <PageHero
@@ -88,6 +116,7 @@ function BlocksPage() {
         live
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
+        kpis={throughputKpi}
         actions={
           <>
             <DownloadCsvButton url={blocksCsvUrl} />
@@ -106,7 +135,7 @@ function BlocksPage() {
         </Suspense>
       </QueryErrorBoundary>
       <ApiSourceFooter
-        paths={["/api/v1/blocks", "/api/v1/blocks/summary"]}
+        paths={["/api/v1/blocks", "/api/v1/blocks/summary", "/api/v1/chain/activity"]}
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
       />
     </AppShell>


### PR DESCRIPTION
## Summary

Adds a compact block-throughput sparkline to the Blocks index page header, driven by the daily `block_count` series from `chainActivityQuery` (`/api/v1/chain/activity`) — the same data path `explorer.tsx` already renders — so a visitor sees the recent blocks-per-day trend before scanning the raw table.

Closes #3390

## What changed

`apps/ui/src/routes/blocks.index.tsx` only:

- `BlocksPage` now fetches `chainActivityQuery()` via a non-blocking `useQuery` (so the hero paints immediately; the KPI appears once the daily series loads — no unguarded `useSuspenseQuery`).
- Populates `PageHero`'s existing `kpis` slot with a `"Blocks / day"` KPI whose `chart` is the shared `Sparkline` (reused, not reimplemented), rendered chronologically oldest→newest via `[...days].reverse()` — mirroring `explorer.tsx`'s `MiniSeries`. Rendered only when `block_count` days exist.
- Adds `/api/v1/chain/activity` to this route's `ApiSourceFooter` `paths`.
- `BlocksTable`, `blocksQuery`, pagination, and the `/api/v1/blocks/summary` production-stats header (#3488) are untouched.

## Screenshots

Route `/blocks`, header (KPI is above the fold), fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes.

> ⚠️ **Data note:** the live `/api/v1/chain/activity` tier returns **0 days** in every window right now (the chain-activity indexer is unpopulated in prod), so a live capture shows no sparkline. To demonstrate the chart, **both before and after inject the *same* representative activity fixture** via request interception — the only difference between columns is this PR's code (the added header KPI + sparkline). Same approach as the merged #4578.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-dark.png)<br><sub>after</sub> |

## Validation (full local run)

- [x] `npm run typecheck` (apps/ui) — clean
- [x] `npm test` (apps/ui) — 611 passed
- [x] `npm run build` (apps/ui) — green
- [x] `npm run lint` — 0 errors on the changed file
- [x] Reuses `Sparkline`; no new query/endpoint/dependency; table + summary header unchanged
