### PR TITLE
feat(registry): add SN48 Quantum Compute Open Quantum docs portal surface (#4052)

### DIFF
--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -104,6 +104,25 @@
         "https://github.com/qbittensor-labs/quantum-compute"
       ],
       "url": "https://raw.githubusercontent.com/qbittensor-labs/quantum-compute/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-48-quantum-compute-openquantum-docs",
+      "kind": "docs",
+      "name": "Open Quantum documentation portal",
+      "notes": "Public no-auth official documentation portal for Open Quantum, the platform through which SN48 Quantum Compute is accessed. The official SN48 repository (qbittensor-labs/quantum-compute, GitHub description 'SN 48 Quantum Compute') names 'Subnet 48' and directs users to OpenQuantum.com in its README, and the repo homepage www.qbittensorlabs.com/quantum links the same. Covers Getting Started, the Python SDK, Qiskit/PennyLane plugins, and the API reference for submitting quantum circuits to the subnet's backends.",
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute/blob/main/README.md",
+        "https://www.qbittensorlabs.com/quantum"
+      ],
+      "url": "https://docs.openquantum.com/"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Registers **SN48 Quantum Compute**'s official **Open Quantum documentation portal** as a `docs` surface — a public, no-auth documentation site the registry did not yet capture (SN48 currently has no docs surface and a null `docs_url`).

## Surface

- **kind:** `docs`
- **url:** `https://docs.openquantum.com/`
- **provider:** `qbittensor-labs` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://github.com/qbittensor-labs/quantum-compute/blob/main/README.md` — the registry's registered SN48 `source_repo` (GitHub description: **"SN 48 Quantum Compute"**). Its README names **"Subnet 48"** and directs users to **OpenQuantum.com**.
- `source_url` 2: `https://www.qbittensorlabs.com/quantum` — the repo's homepage / SN48 page, which links the same Open Quantum docs.
- So `docs.openquantum.com` is the documentation for the platform the official SN48 repo tells users to use.

## Verified live + public + safe

- `GET https://docs.openquantum.com/` → **HTTP 200**, `text/html`, **no auth** (loads without login, no redirect).
- Content: Getting Started, the Open Quantum web portal, Python SDK, Qiskit/PennyLane plugins, and the **API reference** for submitting quantum circuits.
- Public-safe: scanned for SS58/base58 wallet or hotkey strings → **zero matches**; documentation HTML only, no secrets.

## Non-duplication

SN48's existing surfaces are `website` (qbittensorlabs.com), `source-repo`, a `subnet-api` health endpoint, and a `min_compute.yml` data-artifact — **no docs surface exists**, and `docs_url` is null. This is a new `docs` kind at a distinct host. No open PR targets SN48.

## Scope note (relative to #4052)

#4052 asks for SN48's OpenAPI/Swagger spec. Open Quantum does not publish a standalone machine-readable OpenAPI JSON; its API is documented in this docs portal (the "API reference" + Python SDK sections). This registers that official documentation surface — the concrete public documentation behind the issue's intent.

## Validation (local)

- `npm run validate:surface -- registry/subnets/quantum-compute.json` → passes (5 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check` → clean
- `git diff --stat` → single file, 19-line pure append (no top-level metadata or other surfaces touched)

## Template Used

- Subnet surface

Closes #4052
