### PR TITLE
feat(ui): add a network-operations leaderboard to the chain explorer

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -90,6 +90,10 @@ import type {
   ChainYield,
   ChainYieldDistribution,
   ChainSigners,
+  ChainServing,
+  ChainServingRow,
+  ChainPrometheus,
+  ChainPrometheusRow,
   ChainSignerEntry,
   Extrinsic,
   ExtrinsicCallArg,
@@ -3327,6 +3331,96 @@ export function normalizeChainTransferPairs(raw: unknown): ChainTransferPairs {
     pairs: normalizeChainRows(rec.pairs, MAX_CHAIN_TRANSFER_PAIRS, normalizeChainTransferPair),
   };
 }
+
+const MAX_CHAIN_SERVING = 30;
+
+function normalizeChainServingRow(raw: unknown): ChainServingRow | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  const announcements = coerceFiniteNumber(raw.announcements);
+  if (netuid == null || netuid < 0 || announcements == null) return null;
+  return {
+    netuid,
+    distinct_servers: coerceFiniteNumber(raw.distinct_servers) ?? 0,
+    announcements,
+    announcements_per_server: coerceFiniteNumber(raw.announcements_per_server) ?? null,
+  };
+}
+
+/** Network-wide per-subnet axon-serving leaderboard, ranked by announcement volume (#3463). */
+export const chainServingQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-serving", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/serving", {
+        params: { window, limit: MAX_CHAIN_SERVING },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const net = isRecord(d.network) ? d.network : {};
+      return {
+        data: {
+          schema_version: 1,
+          window,
+          observed_at: firstString(d.observed_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          network: {
+            distinct_servers: firstFiniteNumber(net.distinct_servers) ?? 0,
+            announcements: firstFiniteNumber(net.announcements) ?? 0,
+            announcements_per_server: coerceFiniteNumber(net.announcements_per_server) ?? null,
+          },
+          subnets: normalizeChainRows(d.subnets, MAX_CHAIN_SERVING, normalizeChainServingRow),
+        } as ChainServing,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainServing>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeChainPrometheusRow(raw: unknown): ChainPrometheusRow | null {
+  if (!isRecord(raw)) return null;
+  const netuid = coerceFiniteNumber(raw.netuid);
+  const announcements = coerceFiniteNumber(raw.announcements);
+  if (netuid == null || netuid < 0 || announcements == null) return null;
+  return {
+    netuid,
+    distinct_exporters: coerceFiniteNumber(raw.distinct_exporters) ?? 0,
+    announcements,
+    announcements_per_exporter: coerceFiniteNumber(raw.announcements_per_exporter) ?? null,
+  };
+}
+
+/** Network-wide per-subnet Prometheus-telemetry leaderboard, ranked by announcement volume (#3463). */
+export const chainPrometheusQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-prometheus", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/prometheus", {
+        params: { window, limit: MAX_CHAIN_SERVING },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const net = isRecord(d.network) ? d.network : {};
+      return {
+        data: {
+          schema_version: 1,
+          window,
+          observed_at: firstString(d.observed_at) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          network: {
+            distinct_exporters: firstFiniteNumber(net.distinct_exporters) ?? 0,
+            announcements: firstFiniteNumber(net.announcements) ?? 0,
+            announcements_per_exporter: coerceFiniteNumber(net.announcements_per_exporter) ?? null,
+          },
+          subnets: normalizeChainRows(d.subnets, MAX_CHAIN_SERVING, normalizeChainPrometheusRow),
+        } as ChainPrometheus,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainPrometheus>;
+    },
+    staleTime: STALE_SHORT,
+  });
 
 export const chainTransferPairsQuery = (
   window = "30d",

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2369,6 +2369,45 @@ export interface ChainFees {
   top_fee_payers: ChainFeePayer[];
 }
 
+/** One subnet's row on the network-wide axon-serving leaderboard (#3463). */
+export interface ChainServingRow {
+  netuid: number;
+  distinct_servers: number;
+  announcements: number;
+  announcements_per_server: number | null;
+}
+export interface ChainServing {
+  schema_version: number;
+  window: string;
+  observed_at: string | null;
+  subnet_count: number;
+  network: {
+    distinct_servers: number;
+    announcements: number;
+    announcements_per_server: number | null;
+  };
+  subnets: ChainServingRow[];
+}
+/** One subnet's row on the network-wide Prometheus-telemetry leaderboard (#3463). */
+export interface ChainPrometheusRow {
+  netuid: number;
+  distinct_exporters: number;
+  announcements: number;
+  announcements_per_exporter: number | null;
+}
+export interface ChainPrometheus {
+  schema_version: number;
+  window: string;
+  observed_at: string | null;
+  subnet_count: number;
+  network: {
+    distinct_exporters: number;
+    announcements: number;
+    announcements_per_exporter: number | null;
+  };
+  subnets: ChainPrometheusRow[];
+}
+
 /** One directed sender→receiver pair on the chain transfer-pairs leaderboard (#3476). */
 export interface ChainTransferPair {
   from: string;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -23,6 +23,8 @@ import {
   chainEventsStatsQuery,
   chainFeesQuery,
   chainSignersQuery,
+  chainServingQuery,
+  chainPrometheusQuery,
   chainStakeFlowQuery,
   chainStakeMovesQuery,
   chainTurnoverQuery,
@@ -739,6 +741,86 @@ function EconomicsTrendsSection({ trends }: { trends: EconomicsTrends }) {
   );
 }
 
+// #3463: one network operations leaderboard (axon-serving or prometheus-telemetry).
+// Both share the netuid-keyed shape — announcements, distinct endpoints, and the
+// per-endpoint intensity ratio — so this renders either via a normalized prop set,
+// mirroring the stake-transfer leaderboard table pattern used elsewhere on the page.
+function OpsLeaderboard({
+  title,
+  endpointNoun,
+  subnetCount,
+  network,
+  rows,
+  emptyLabel,
+}: {
+  title: string;
+  endpointNoun: string;
+  subnetCount: number;
+  network: { distinct: number; announcements: number; perEndpoint: number | null };
+  rows: Array<{
+    netuid: number;
+    distinct: number;
+    announcements: number;
+    perEndpoint: number | null;
+  }>;
+  emptyLabel: string;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            {title}
+          </h2>
+          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+            {formatNumber(network.announcements)} announcements across{" "}
+            {formatNumber(network.distinct)} {endpointNoun}s network-wide
+          </p>
+        </div>
+        <span className="font-mono text-[11px] text-ink-muted">{subnetCount} subnets</span>
+      </div>
+      {rows.length > 0 ? (
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={`${TH} text-right`}>Announcements</th>
+              <th className={`${TH} text-right`}>Distinct {endpointNoun}s</th>
+              <th className={`${TH} text-right`}>Per {endpointNoun}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => (
+              <tr key={r.netuid} className="hover:bg-surface/40">
+                <td className="px-4 py-2 font-mono text-[11px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: r.netuid }}
+                    className="text-ink-strong hover:text-accent hover:underline"
+                  >
+                    SN{r.netuid}
+                  </Link>
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {formatNumber(r.announcements)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {formatNumber(r.distinct)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {r.perEndpoint != null ? r.perEndpoint.toFixed(2) : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="font-mono text-[12px] text-ink-muted">{emptyLabel}</p>
+      )}
+    </section>
+  );
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -766,6 +848,8 @@ function ExplorerDashboard() {
     { data: axonChurnRes },
     { data: eventMixRes },
     { data: trendsRes },
+    { data: servingRes },
+    { data: prometheusRes },
   ] = useSuspenseQueries({
     queries: [
       chainActivityQuery(win),
@@ -779,6 +863,8 @@ function ExplorerDashboard() {
       chainAxonRemovalsQuery(win),
       chainEventsStatsQuery(),
       economicsTrendsQuery(win),
+      chainServingQuery(win),
+      chainPrometheusQuery(win),
     ],
   });
   const activity = activityRes.data;
@@ -792,6 +878,8 @@ function ExplorerDashboard() {
   const axonChurn = axonChurnRes.data;
   const eventMix = eventMixRes.data;
   const trends = trendsRes.data;
+  const serving = servingRes.data;
+  const prometheus = prometheusRes.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
   const chrono = [...activity.days].reverse();
@@ -1162,6 +1250,50 @@ function ExplorerDashboard() {
       </section>
 
       <AxonChurnSection churn={axonChurn} />
+
+      {/* #3463: network operations — per-subnet axon-serving + prometheus-telemetry
+          leaderboards side by side, each with its network-wide rollup. */}
+      <div>
+        <h2 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Network operations
+        </h2>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <OpsLeaderboard
+            title="Axon serving"
+            endpointNoun="server"
+            subnetCount={serving.subnet_count}
+            network={{
+              distinct: serving.network.distinct_servers,
+              announcements: serving.network.announcements,
+              perEndpoint: serving.network.announcements_per_server,
+            }}
+            rows={serving.subnets.map((s) => ({
+              netuid: s.netuid,
+              distinct: s.distinct_servers,
+              announcements: s.announcements,
+              perEndpoint: s.announcements_per_server,
+            }))}
+            emptyLabel="No serving activity in this window yet."
+          />
+          <OpsLeaderboard
+            title="Prometheus telemetry"
+            endpointNoun="exporter"
+            subnetCount={prometheus.subnet_count}
+            network={{
+              distinct: prometheus.network.distinct_exporters,
+              announcements: prometheus.network.announcements,
+              perEndpoint: prometheus.network.announcements_per_exporter,
+            }}
+            rows={prometheus.subnets.map((s) => ({
+              netuid: s.netuid,
+              distinct: s.distinct_exporters,
+              announcements: s.announcements,
+              perEndpoint: s.announcements_per_exporter,
+            }))}
+            emptyLabel="No prometheus telemetry in this window yet."
+          />
+        </div>
+      </div>
 
       <PalletEventMixSection stats={eventMix} />
     </div>


### PR DESCRIPTION
## What

Adds a **Network operations** section to `/explorer` — the network-wide axon-serving and Prometheus-telemetry leaderboards (`GET /api/v1/chain/serving`, `GET /api/v1/chain/prometheus`), which were live but had no UI touchpoint. Each is a per-subnet table ranked by announcement volume, with its network-wide rollup.

Closes #3463

## How

- `queries.ts`: add `chainServingQuery(window)` / `chainPrometheusQuery(window)` following the `chainSignersQuery` pattern (`queryOptions` + `k()` key + `apiFetch` + `isRecord`/`first*`/`normalizeChainRows`), plus their row normalizers.
- `types.ts`: add `ChainServing` / `ChainPrometheus` (+ row types).
- `explorer.tsx`: fetch both via the existing `useSuspenseQueries` block (driven by the page's 7d/30d window toggle) and render each as a per-subnet leaderboard (netuid → `/subnets/$netuid`, announcements, distinct endpoints, per-endpoint intensity ratio) with its rollup — modeled on the existing stake-transfer leaderboard. A shared `OpsLeaderboard` renders either side. It sits alongside the axon-churn leaderboard (#3464) as the issue intended.

## Checks

`eslint` + `tsc` clean. Rebased current on main.

## Screenshots

Same scroll region (anchored on the stake-transfer leaderboard) so the added section is visible; exact viewports, light + dark. **Note:** the serving/prometheus leaderboards render their empty states here — a live-API replica/cache situation currently returns 0 for these chain-aggregate endpoints in the browser (identical to the sibling fee/signer/stake-transfer leaderboards, which are empty too). The section populates the moment the browser receives data.

| viewport / theme | before | after |
|---|---|---|
| **desktop · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-desktop-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-tablet-dark-after.png)<br><sub>after</sub> |
| **mobile · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/netops-mobile-dark-after.png)<br><sub>after</sub> |
