### PR TITLE
feat(ui): add a kind filter dropdown to the subnet on-chain activity table

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -3927,14 +3927,14 @@ export const subnetStakeFlowQuery = (netuid: number, window = "30d") =>
     staleTime: STALE_MED,
   });
 
-export const subnetEventsQuery = (netuid: number) =>
+export const subnetEventsQuery = (netuid: number, kind?: string) =>
   queryOptions({
-    queryKey: k("subnet-events", netuid),
+    queryKey: k("subnet-events", netuid, kind ?? null),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Record<string, unknown>>(
-        `/api/v1/subnets/${netuid}/events?limit=100`,
-        { signal },
-      );
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/subnets/${netuid}/events`, {
+        params: { limit: 100, ...(kind ? { kind } : {}) },
+        signal,
+      });
       const d = (res.data ?? {}) as Record<string, unknown>;
       const events = normalizeAccountEvents(d.events);
       return {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -18,6 +18,7 @@ import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { SchemaDriftSummary } from "@/components/metagraphed/schema-drift";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
+import { SelectFilter } from "@/components/metagraphed/table-controls";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
@@ -55,6 +56,7 @@ import {
   subnetHyperparametersQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
+import { EVENT_KIND_LABELS } from "@/lib/metagraphed/event-kinds";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { TableState } from "@/components/metagraphed/table-state";
 import type {
@@ -85,6 +87,7 @@ type SearchParams = {
   tab?: string;
   sev?: string;
   uid?: number;
+  ev_kind?: string;
 };
 
 export const Route = createFileRoute("/subnets/$netuid")({
@@ -94,6 +97,7 @@ export const Route = createFileRoute("/subnets/$netuid")({
       tab: typeof s.tab === "string" ? s.tab : undefined,
       sev: typeof s.sev === "string" ? s.sev : undefined,
       uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined,
+      ev_kind: typeof s.ev_kind === "string" && s.ev_kind ? s.ev_kind : undefined,
     };
   },
   parseParams: ({ netuid }) => {
@@ -641,32 +645,55 @@ function StakeFlowScorecard({ netuid }: { netuid: number }) {
 }
 
 function ActivityPanel({ netuid }: { netuid: number }) {
+  const { ev_kind } = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const kindOptions = Object.entries(EVENT_KIND_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  }));
   return (
     <SectionAnchor
       id="activity"
       title="On-chain activity"
       subtitle="First-party chain events for this subnet, newest first."
       info="Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
+      right={
+        <SelectFilter
+          label="Kind"
+          value={ev_kind ?? ""}
+          onChange={(v) =>
+            navigate({
+              search: (prev: SearchParams) => ({ ...prev, ev_kind: v || undefined }),
+              resetScroll: false,
+            })
+          }
+          options={kindOptions}
+        />
+      }
     >
       <StakeFlowScorecard netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <ActivityTableLoader netuid={netuid} />
+          <ActivityTableLoader netuid={netuid} kind={ev_kind} />
         </Suspense>
       </QueryErrorBoundary>
     </SectionAnchor>
   );
 }
 
-function ActivityTableLoader({ netuid }: { netuid: number }) {
-  const { data } = useSuspenseQuery(subnetEventsQuery(netuid));
+function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }) {
+  const { data } = useSuspenseQuery(subnetEventsQuery(netuid, kind));
   const events = (data.data.events ?? []) as AccountEvent[];
   if (events.length === 0) {
     return (
       <TableState
         variant="empty"
-        title="No recent on-chain activity"
-        description="No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+        title={kind ? `No ${kind} events` : "No recent on-chain activity"}
+        description={
+          kind
+            ? "Try clearing the kind filter to see the unfiltered feed."
+            : "No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+        }
         generatedAt={data.meta?.generated_at}
       />
     );


### PR DESCRIPTION
Closes #3369

## What
The "On-chain activity" section on `/subnets/$netuid` (the Activity tab) rendered its event table with no filter UI, even though `workers/request-handlers/entities.mjs`'s `handleSubnetEvents` already validates and applies `?kind=` server-side. This mirrors the account page's existing kind-filter UX (`AccountEventsSection` in `accounts.$ss58.tsx`) onto the subnet activity table.

## Changes
- **`apps/ui/src/lib/metagraphed/queries.ts`** — `subnetEventsQuery(netuid, kind?)` now accepts an optional `kind` param and forwards it as a query-string param on the `/api/v1/subnets/{netuid}/events` fetch, alongside the existing `limit=100`, matching how `accountEventsQuery` already forwards `params.kind`.
- **`apps/ui/src/routes/subnets.$netuid.tsx`** — extended the route's `SearchParams`/`validateSearch` with `ev_kind` (same naming as the accounts page). `ActivityPanel` reads `ev_kind`, renders a `SelectFilter` (from `table-controls.tsx`) in the section header via `SectionAnchor`'s `right` slot, sourced from the shared `EVENT_KIND_LABELS` map in `event-kinds.ts` (subnets have no per-subnet `event_kinds` summary field to derive options from, unlike the account page). Selecting a kind updates `?ev_kind=` and re-fetches the filtered feed; clearing it (`SelectFilter`'s built-in "all" option) returns to the unfiltered feed. `ActivityTableLoader`'s empty state also now distinguishes "No `<kind>` events" from the generic empty message, matching `AccountEventsSection`'s convention.
- No backend files touched — `handleSubnetEvents`'s `?kind=` support is already merged and live; this is a frontend-only PR.

## Screenshots

The live `/api/v1/subnets/{netuid}/events` endpoint currently returns zero events across sampled subnets in this environment (a temporary data-pipeline gap, not a bug in this component or its query). The screenshots below mock a realistic mixed-kind event feed — the same response shape the real endpoint returns, filtered server-side by `?kind=` exactly like the mocked route implements — via Playwright route interception, to demonstrate the feature against the actual component code rather than against empty live data.

| State | Screenshot |
| --- | --- |
| Before (no filter UI) | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-event-kind-filter-3369/before-subnet-activity-light.png" width="480">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-event-kind-filter-3369/before-subnet-activity-light.png) |
| After — unfiltered ("Kind: all") | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-event-kind-filter-3369/after-subnet-activity-light.png" width="480">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-event-kind-filter-3369/after-subnet-activity-light.png) |
| After — filtered to "Stake added" | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-event-kind-filter-3369/after-subnet-activity-filtered-light.png" width="480">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-event-kind-filter-3369/after-subnet-activity-filtered-light.png) |

Verified interactively (Playwright): selecting "Stake added" in the dropdown updates the URL to `?tab=activity&ev_kind=StakeAdded` (shareable/reloadable link, matching `ev_kind`'s round-trip behavior on `/accounts/$ss58`) and the table re-renders filtered to only that kind.

## Acceptance criteria
- [x] `apps/ui/src/routes/subnets.$netuid.tsx` and `apps/ui/src/lib/metagraphed/queries.ts` both appear in the diff
- [x] `subnetEventsQuery` accepts and forwards an optional `kind` parameter to `/api/v1/subnets/{netuid}/events`
- [x] The "On-chain activity" section on `/subnets/$netuid` renders a `SelectFilter` kind dropdown (using `EVENT_KIND_LABELS` from `event-kinds.ts` as the option source)
- [x] Selecting a kind updates the route's search params (`?ev_kind=StakeAdded`) and the fetched/rendered events are filtered to that kind
- [x] Clearing the filter (selecting "all") returns to the unfiltered feed with the search param removed from the URL
- [x] No backend files touched — `handleSubnetEvents` needed no changes
- [x] Before/after screenshots included

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on both changed files: clean aside from pre-existing CRLF/fast-refresh noise unrelated to this change.
- Diff is 38 insertions / 11 deletions across exactly the two files the issue names.
