### PR TITLE
feat(registry): add SN41 Almanac docs llms.txt data-artifact (#4046)

### DIFF
--- a/registry/subnets/almanac.json
+++ b/registry/subnets/almanac.json
@@ -47,6 +47,25 @@
         "https://api.almanac.market/api/markets/search?q=nfl"
       ],
       "url": "https://api.almanac.market/api/markets/events/202857"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-41-almanac-docs-llms-txt",
+      "kind": "data-artifact",
+      "name": "Almanac docs llms.txt index",
+      "notes": "Public no-auth machine-readable llms.txt index of the official SN41 Almanac documentation, served at docs.almanac.market — the same almanac.market domain as the registered website_url and the api.almanac.market surfaces. The official SN41 repository (sportstensor/sn41) README pins --netuid 41, and the docs describe its official api_trading.py client. Provides an agent-consumable Markdown map of the Almanac docs (content begins '# Almanac') for LLM/agent ingestion; distinct from the existing api.almanac.market market-snapshot data-artifact.",
+      "provider": "almanac",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/sportstensor/sn41/blob/main/README.md",
+        "https://almanac.market/"
+      ],
+      "url": "https://docs.almanac.market/llms.txt"
     }
   ],
   "website_url": "https://almanac.market/"


### PR DESCRIPTION
## Summary

Registers **SN41 Almanac**'s public **`llms.txt` documentation index** — an agent-consumable, no-auth, machine-readable Markdown map of the official Almanac docs. Almanac is under-enriched (2 surfaces, no docs), so this fills a real gap.

## Surface

- **kind:** `data-artifact`
- **url:** `https://docs.almanac.market/llms.txt`
- **provider:** `almanac` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://github.com/sportstensor/sn41/blob/main/README.md` — the registered SN41 `source_repo`; its README pins **`--netuid 41`** and points to the Almanac API/site.
- `source_url` 2: `https://almanac.market/` — the registered `website_url`. The docs host `docs.almanac.market` shares that exact domain (as do the registered `api.almanac.market` surfaces).

## Verified live + public + safe

- `GET https://docs.almanac.market/llms.txt` → **HTTP 200**, `Content-Type: text/markdown; charset=utf-8`, **no auth**. Content begins `# Almanac` and indexes the docs; the docs reference the official `api_trading.py` client in the SN41 repo.
- Public-safe: scanned for SS58/base58 wallet or hotkey strings → **zero matches**; markdown docs only, no secrets.

## Non-duplication

Almanac's only existing surfaces are `subnet-api` (`api.almanac.market/health`) and a `data-artifact` market-snapshot (`api.almanac.market/api/markets/events/202857`). It has **no docs/llms.txt surface**; this is a new URL/host. No open PR targets SN41.

## Scope note (relative to #4046)

#4046 asks for SN41's OpenAPI/Swagger spec. Almanac publishes no standalone machine-readable OpenAPI JSON; its docs (indexed by this llms.txt, and describing the `api_trading.py` client) are the agent-consumable machine-readable documentation surface it does publish — the concrete artifact behind the issue's intent, matching the accepted `llms.txt` data-artifact pattern.

## Validation (local)

- `npm run validate:surface -- registry/subnets/almanac.json` → passes (3 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check` → clean
- `git diff --stat` → single file, 19-line pure append

## Template Used

- Subnet surface

Closes #4046
