### PR TITLE
feat(registry): add SN69 Herald outlet registry seed data-artifact (#4079)

### DIFF
--- a/registry/providers/herald.json
+++ b/registry/providers/herald.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "herald",
+  "name": "Herald",
+  "kind": "subnet-team",
+  "website_url": "https://www.heraldmedia.ai/",
+  "github_url": "https://github.com/HeraldMedia/herald",
+  "authority": "community",
+  "public_notes": "SN69 ain (Herald) verified media placement subnet. Identity from the official Herald website and HeraldMedia/herald source repository (README declares Bittensor netuid 69). Review input only (authority: community).",
+  "social": {
+    "x": "https://x.com/heraldmedia_ai"
+  }
+}

--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -27,5 +27,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-herald-outlet-registry-seed",
+      "kind": "data-artifact",
+      "name": "Herald outlet registry seed data",
+      "notes": "Public no-auth JSON seed outlet registry (version_id, outlet_id, tier, domains) for SN69 Herald verified media placement. Default load path in herald/validator/news/registry.py via _SEED_PATH and load_registry(); validators map article URLs to approved outlet tiers during oracle scoring. Pinned to an immutable commit.",
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "petermilord"
+      },
+      "source_urls": [
+        "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/herald/validator/news/registry.py",
+        "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/HeraldMedia/herald/4de1577e82b74807d4081c3f61edffaee9ed718a/herald/validator/news/outlets.seed.json"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Debuts `herald` provider and adds a commit-pinned `data-artifact` for the official Herald outlet registry seed JSON used by validator oracle scoring.

Closes #4079

## Test plan
- [x] `npm run validate:surface -- registry/subnets/ain.json`
- [x] `npm run scan:public-safety`
- [x] Artifact URL pinned to immutable commit `4de1577e`