### PR TITLE
feat(ui): add a recent subnet-identity-changes widget to the homepage (#3474)

### DIFF
--- a/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { chainIdentityHistoryQuery } from "@/lib/metagraphed/queries";
+import { EmptyState } from "@/components/metagraphed/states";
+import { TimeAgo } from "@/components/metagraphed/time-ago";
+
+// #3474: homepage widget — the live network-wide feed of recent subnet-identity
+// changes (name / symbol / description / URL / logo edits observed on-chain),
+// newest first, from the newly-wired chainIdentityHistoryQuery. Self-contained:
+// fetches via useQuery and renders a compact feed list.
+
+function Notice({ children }: { children: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Recent subnet-identity changes across the whole network, newest first — each
+ * row links to its subnet, shows the current name/symbol, and when the change
+ * was observed on-chain. Wraps the middle column in min-w-0 + truncate so long
+ * names/descriptions never escape the row at mobile width.
+ */
+export function RecentIdentityChanges() {
+  const { data: res, isPending } = useQuery(chainIdentityHistoryQuery(10));
+  const changes = res?.data?.changes ?? [];
+
+  if (isPending && !res) {
+    return <Notice>Loading recent identity changes…</Notice>;
+  }
+
+  if (changes.length === 0) {
+    return (
+      <EmptyState
+        title="No recent identity changes"
+        description="Subnet identity edits (name, symbol, description, URL, logo) observed on-chain across every subnet appear here, newest first, once captured."
+        lastChecked={res?.meta?.generated_at}
+      />
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+      {changes.map((c) => (
+        <li key={`${c.netuid}-${c.identity_hash}`} className="flex items-center gap-3 px-4 py-3">
+          <Link
+            to="/subnets/$netuid"
+            params={{ netuid: c.netuid }}
+            className="shrink-0 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-accent"
+          >
+            SN{c.netuid}
+          </Link>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm text-ink-strong">
+              {c.subnet_name ?? "—"}
+              {c.symbol ? <span className="ml-1.5 text-ink-muted">({c.symbol})</span> : null}
+            </div>
+            {c.description ? (
+              <div className="truncate font-mono text-[10px] text-ink-muted">{c.description}</div>
+            ) : null}
+          </div>
+          <span className="shrink-0 font-mono text-[10px] text-ink-muted">
+            <TimeAgo at={c.observed_at} />
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.chain-identity-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-identity-history.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainIdentityHistoryQuery, normalizeChainIdentityHistory } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/identity-history",
+  });
+}
+
+async function runQuery(limit?: number) {
+  const opts = chainIdentityHistoryQuery(limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainIdentityHistory", () => {
+  it("passes a well-formed feed through", () => {
+    const card = normalizeChainIdentityHistory({
+      schema_version: 1,
+      count: 2,
+      subnet_count: 2,
+      changes: [
+        {
+          netuid: 7,
+          identity_hash: "0xabc",
+          block_number: 100,
+          observed_at: "2026-07-01T00:00:00Z",
+          subnet_name: "Allways",
+          symbol: "ALL",
+          description: "desc",
+          github_repo: "https://github.com/x",
+          subnet_url: "https://all-ways.io",
+          logo_url: null,
+          discord: null,
+        },
+        { netuid: 74, identity_hash: "0xdef" },
+      ],
+    });
+    expect(card.count).toBe(2);
+    expect(card.changes).toHaveLength(2);
+    expect(card.changes[0]?.netuid).toBe(7);
+    expect(card.changes[0]?.subnet_name).toBe("Allways");
+    // missing string fields coerce to null, not undefined
+    expect(card.changes[1]?.subnet_name).toBeNull();
+    expect(card.changes[1]?.block_number).toBeNull();
+  });
+
+  it("degrades a cold / junk store to a schema-stable empty feed", () => {
+    for (const raw of [{}, null, "x", { count: "nope" }]) {
+      const card = normalizeChainIdentityHistory(raw);
+      expect(card.count).toBe(0);
+      expect(card.changes).toEqual([]);
+    }
+  });
+
+  it("drops change rows that have no netuid", () => {
+    const card = normalizeChainIdentityHistory({
+      changes: [{ identity_hash: "0x1" }, { netuid: 3, identity_hash: "0x2" }],
+    });
+    expect(card.changes).toHaveLength(1);
+    expect(card.changes[0]?.netuid).toBe(3);
+  });
+});
+
+describe("chainIdentityHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes the limit param and normalizes the feed", async () => {
+    resolveWith({ count: 1, changes: [{ netuid: 5, identity_hash: "0x5" }] });
+    const res = await runQuery(25);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/identity-history",
+      expect.objectContaining({ params: { limit: 25 } }),
+    );
+    expect(res.data.changes).toHaveLength(1);
+  });
+
+  it("defaults to limit 10", async () => {
+    resolveWith({});
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/identity-history",
+      expect.objectContaining({ params: { limit: 10 } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -61,6 +61,8 @@ import type {
   EconomicsTrends,
   EconomicsTrendsDay,
   ChainCalls,
+  ChainIdentityHistory,
+  ChainIdentityChange,
   ChainStakeFlow,
   ChainStakeFlowDistribution,
   ChainStakeFlowNetwork,
@@ -249,6 +251,7 @@ const MAX_TURNOVER_SUBNETS = 24;
 const MAX_CHAIN_EVENT_GROUPS = 100;
 const DEFAULT_CHAIN_EVENT_BLOCKS = 1000;
 const MAX_CHAIN_SIGNERS = 20;
+const MAX_CHAIN_IDENTITY_CHANGES = 200;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
@@ -3191,6 +3194,59 @@ export const chainCallsQuery = (window: ChainWindow = "7d") =>
       } as ApiResult<ChainCalls>;
     },
     staleTime: STALE_SHORT,
+  });
+
+function normalizeChainIdentityChange(raw: unknown): ChainIdentityChange | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    identity_hash: firstString(raw.identity_hash) ?? "",
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+    subnet_name: firstString(raw.subnet_name) ?? null,
+    symbol: firstString(raw.symbol) ?? null,
+    description: firstString(raw.description) ?? null,
+    github_repo: firstString(raw.github_repo) ?? null,
+    subnet_url: firstString(raw.subnet_url) ?? null,
+    logo_url: firstString(raw.logo_url) ?? null,
+    discord: firstString(raw.discord) ?? null,
+  };
+}
+
+// #3474: network-wide feed of recent subnet-identity changes, newest first.
+// Malformed rows (no netuid) drop out; a cold store yields an empty list.
+export function normalizeChainIdentityHistory(raw: unknown): ChainIdentityHistory {
+  const rec = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    count: firstFiniteNumber(rec.count) ?? 0,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    changes: normalizeChainRows(
+      rec.changes,
+      MAX_CHAIN_IDENTITY_CHANGES,
+      normalizeChainIdentityChange,
+    ),
+  };
+}
+
+/** Network-wide feed of recent subnet-identity changes (name/symbol/etc. edits). */
+export const chainIdentityHistoryQuery = (limit = 10) =>
+  queryOptions({
+    queryKey: k("chain-identity-history", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainIdentityHistory>>("/api/v1/chain/identity-history", {
+        params: { limit },
+        signal,
+      });
+      return {
+        data: normalizeChainIdentityHistory(res.data),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainIdentityHistory>;
+    },
+    staleTime: STALE_MED,
   });
 
 function normalizeChainEventsStatsEntry(raw: unknown): ChainEventsStatsEntry | null {

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1472,6 +1472,24 @@ export interface SubnetIdentityHistoryEntry {
   discord: string | null;
 }
 
+/** One network-wide subnet-identity change from GET /api/v1/chain/identity-history — a SubnetIdentityHistoryEntry plus its netuid. */
+export interface ChainIdentityChange extends SubnetIdentityHistoryEntry {
+  netuid: number;
+}
+
+/**
+ * Network-wide feed of recent subnet-identity changes (#3474) from
+ * GET /api/v1/chain/identity-history — the most recent SubnetIdentitiesV3 edits
+ * (name / symbol / description / URL / logo) across every subnet, newest first.
+ * Zeroed with an empty changes list when none have been observed.
+ */
+export interface ChainIdentityHistory {
+  schema_version: number;
+  count: number;
+  subnet_count: number;
+  changes: ChainIdentityChange[];
+}
+
 /** One subnet's consensus, economic, and governance hyperparameters (#4307/1.4).
  * *_ratio fields are 0..1 ratios; min_burn_tao/max_burn_tao are TAO floats;
  * bonds_moving_avg_raw is the raw on-chain integer (not yet ratio-converted). */

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -33,6 +33,7 @@ import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-sc
 import { SubnetPriceTicker } from "@/components/metagraphed/subnet-price-ticker";
 import { HeroSubnetChips } from "@/components/metagraphed/hero-subnet-chips";
 import { QuickActionsRow } from "@/components/metagraphed/quick-actions-row";
+import { RecentIdentityChanges } from "@/components/metagraphed/recent-identity-changes";
 import { ContinueExploring } from "@/components/metagraphed/continue-exploring";
 
 import {
@@ -225,6 +226,18 @@ function OverviewPage() {
           <Suspense fallback={<TableSkeleton />}>
             <SubnetPreviewTable />
           </Suspense>
+        </QueryErrorBoundary>
+      </section>
+
+      {/* #3474: live network-wide feed of recent subnet-identity changes. */}
+      <section className="mt-section-gap">
+        <SectionHeader
+          eyebrow="Network activity"
+          title="Recent identity changes."
+          description="Subnet name, symbol, and profile edits observed on-chain across the network, newest first."
+        />
+        <QueryErrorBoundary>
+          <RecentIdentityChanges />
         </QueryErrorBoundary>
       </section>
 


### PR DESCRIPTION
## Summary

Closes #3474

Wires `GET /api/v1/chain/identity-history` into the frontend and renders a **Recent identity changes** feed widget on the homepage — the live network-wide list of subnet name / symbol / profile edits observed on-chain, newest first, each row linking to its subnet.

Adds the data layer **and** UI in one PR:
- `chainIdentityHistoryQuery` + `ChainIdentityHistory` / `ChainIdentityChange` types, modeled on `chainCallsQuery`.
- A normalizer unit test (`queries.chain-identity-history.test.ts`).
- A self-contained `RecentIdentityChanges` feed widget, placed on the homepage.

## Validation
- `npm run typecheck -w apps/ui` — pass
- `prettier --check` (changed files) — clean
- `npm run test -w apps/ui` — 616 passed (incl. 4 new)
- `npm run build -w apps/ui` — pass

## Screenshots

New **Recent identity changes** section on the homepage. Before: absent. After: present.
3 viewports × 2 themes × before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1406" height="883" alt="dek-lg-be" src="https://github.com/user-attachments/assets/efd1be22-cfc3-4284-be6b-174184e13c8b" /> | <img width="1390" height="871" alt="dek-lg-af" src="https://github.com/user-attachments/assets/550eb97a-ef97-4e4d-9c87-9389ee46dfcb" /> |
| Desktop · Dark | <img width="1419" height="880" alt="dek-dk-be" src="https://github.com/user-attachments/assets/9d66e0d1-671e-48ce-af32-aeb0d44e7d5d" /> | <img width="1380" height="855" alt="dek-dk-af" src="https://github.com/user-attachments/assets/1ad3e04f-c401-4773-8aec-182eb3beef4b" /> |
| Tablet · Light | <img width="637" height="887" alt="tab-lg-be" src="https://github.com/user-attachments/assets/3cef1bd9-0826-4052-84c7-323f06441bdb" /> | <img width="644" height="890" alt="tab-lg-af" src="https://github.com/user-attachments/assets/d5e5dcde-d9a4-4863-86c8-fe2b1e902289" /> |
| Tablet · Dark | <img width="630" height="868" alt="tab-dk-be" src="https://github.com/user-attachments/assets/1294e79d-c01c-4b48-8626-6b311df5a640" /> | <img width="631" height="878" alt="tab-dk-af" src="https://github.com/user-attachments/assets/bcdd5287-4f95-4dac-a01c-49b714633fb7" /> |
| Mobile · Light | <img width="436" height="911" alt="mb-lg-be" src="https://github.com/user-attachments/assets/29249983-ad4b-4491-907a-b9304a41a6ab" /> | <img width="467" height="914" alt="mb-lg-af" src="https://github.com/user-attachments/assets/f03f3d90-ebc8-44ba-b993-b7d1d6b1bef5" /> |
| Mobile · Dark | <img width="436" height="927" alt="mb-dk-be" src="https://github.com/user-attachments/assets/9e7616e2-063b-4659-9c2d-7208d816e4ad" /> | <img width="425" height="913" alt="mb-dk-af" src="https://github.com/user-attachments/assets/b8f6b8ea-f220-4699-ba9e-fc592a623530" /> |
