### PR TITLE
feat(registry): add SN107 Minos GATK quality-parameter data-artifact (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,26 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-gatk-config",
+      "kind": "data-artifact",
+      "name": "Minos GATK HaplotypeCaller quality parameters",
+      "notes": "Public no-auth INI-style GATK HaplotypeCaller quality-parameter specification (min_base_quality_score, min_mapping_quality_score, standard_min_confidence_threshold_for_calling, PCR indel model, assembly graph settings) published in the official minos-protocol/minos_subnet repository at configs/gatk.conf. Miners tune these miner-submittable hyperparameters for SN107 genomic variant-calling rounds; the README project layout documents configs/ as miner-tunable quality parameters and utils/config_loader.py parses the tool config files.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/configs/gatk.conf",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/utils/config_loader.py"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/configs/gatk.conf"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Registers SN107 Minos's public GATK HaplotypeCaller quality-parameter configuration — the miner-tunable hyperparameter spec the registry did not yet capture.

## Surface

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/configs/gatk.conf | Public INI-style GATK quality parameters (base quality, mapping quality, confidence thresholds, PCR indel model) miners submit for SN107 variant-calling rounds |

## Proof of ownership

- `source_url` 1: https://github.com/minos-protocol/minos_subnet/blob/main/README.md — project layout documents `configs/` as miner-tunable quality parameters
- `source_url` 2: https://github.com/minos-protocol/minos_subnet/blob/main/configs/gatk.conf — the published artifact file
- `source_url` 3: https://github.com/minos-protocol/minos_subnet/blob/main/utils/config_loader.py — tool config parser that loads configs/

## Verified live + public + safe

- `GET` the raw GitHub URL → HTTP 200, public text config, no auth
- Content is variant-caller tuning parameters only — no wallet addresses, hotkeys, or credentials

## Non-duplication

- Distinct from the existing `sn-107-minos-subnet-api` health endpoint
- Distinct URL from prior closed `min_compute.yml` attempts on #4141
- No open PR targets SN107

## Validation

- [x] `npm run validate:surface -- registry/subnets/minos.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/minos.json`
- [ ] `npm run validate`
- [ ] CI green

Closes #4141