### PR TITLE
Enrich SN104 for sale (burn to uid1) — add public API endpoint

### DIFF
--- a/registry/subnets/for-sale-burn-to-uid1.json
+++ b/registry/subnets/for-sale-burn-to-uid1.json
@@ -50,6 +50,25 @@
         "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/104"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-104-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "SN104 TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/104 on api.taomarketcap.com returning machine-readable JSON for SN104 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. SN104 exposes no first-party API, repository, or static dataset; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/104"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/for-sale-burn-to-uid1.json` (SN104). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 104
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/104
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1
- **Provider slug:** `taomarketcap`

SN104 exposes no first-party API, repository, or static dataset. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 104.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/for-sale-burn-to-uid1.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/104` returns HTTP 200 with valid JSON (`netuid: 104`)

Closes #4135

Made with [Cursor](https://cursor.com)