### PR TITLE
feat(ui): recognize block#index extrinsic refs in the omnibox

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -21,6 +21,7 @@ import { safeExternalUrl } from "./external-link";
 import { loadRecent, pushRecent } from "@/lib/metagraphed/search-history";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { isCompositeExtrinsicRef } from "@/lib/metagraphed/extrinsics";
 import { pickPromotedSubnetHit, hitKind } from "@/lib/metagraphed/search-hit-score";
 
 interface Props {
@@ -200,6 +201,18 @@ export function NavOmnibox({ onOpenPalette }: Props) {
         params: { ref: q },
         icon: Hash,
         badge: "block",
+      });
+    }
+
+    if (isCompositeExtrinsicRef(q)) {
+      targets.push({
+        kind: "nav",
+        label: `Extrinsic ${q}`,
+        hint: "Jump to extrinsic by block#index",
+        to: "/extrinsics/$hash",
+        params: { hash: q },
+        icon: ArrowRightLeft,
+        badge: "block#index",
       });
     }
 

--- a/apps/ui/src/lib/metagraphed/extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extrinsicCall,
   extrinsicHashPathSegment,
+  isCompositeExtrinsicRef,
   isDecodedCall,
   isValidExtrinsicHash,
   proxyRealAccount,
@@ -10,11 +11,31 @@ import {
 
 const VALID_HASH = "0xabc123def456";
 
+describe("isCompositeExtrinsicRef", () => {
+  it("accepts block_number-extrinsic_index composite labels", () => {
+    expect(isCompositeExtrinsicRef("123456-2")).toBe(true);
+    expect(isCompositeExtrinsicRef("1-0")).toBe(true);
+  });
+
+  it("rejects malformed near-misses and leading-zero block numbers", () => {
+    expect(isCompositeExtrinsicRef("123-")).toBe(false);
+    expect(isCompositeExtrinsicRef("-2")).toBe(false);
+    expect(isCompositeExtrinsicRef("123456-2-3")).toBe(false);
+    expect(isCompositeExtrinsicRef("0-2")).toBe(false);
+    expect(isCompositeExtrinsicRef("0123-2")).toBe(false);
+    expect(isCompositeExtrinsicRef(VALID_HASH)).toBe(false);
+  });
+});
+
 describe("isValidExtrinsicHash", () => {
   it("accepts 0x-prefixed hex extrinsic hashes", () => {
     expect(isValidExtrinsicHash(VALID_HASH)).toBe(true);
     expect(isValidExtrinsicHash("0xDEADBEEF")).toBe(true);
     expect(isValidExtrinsicHash(`0x${"a".repeat(128)}`)).toBe(true);
+  });
+
+  it("accepts block#index composite refs", () => {
+    expect(isValidExtrinsicHash("123456-2")).toBe(true);
   });
 
   it("rejects malformed hash refs", () => {
@@ -27,8 +48,9 @@ describe("isValidExtrinsicHash", () => {
 });
 
 describe("extrinsicHashPathSegment", () => {
-  it("returns an encoded path segment for valid hashes", () => {
+  it("returns an encoded path segment for valid hashes and composite refs", () => {
     expect(extrinsicHashPathSegment(VALID_HASH)).toBe(encodeURIComponent(VALID_HASH));
+    expect(extrinsicHashPathSegment("123456-2")).toBe("123456-2");
   });
 
   it("throws before encoding invalid hash refs", () => {

--- a/apps/ui/src/lib/metagraphed/extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.ts
@@ -1,10 +1,18 @@
 // Helpers for the extrinsic (transaction) explorer — the sibling of blocks.ts.
 
 const EXTRINSIC_HASH = /^0x[0-9a-fA-F]{1,128}$/;
+/** block_number-extrinsic_index (e.g. 123456-2). Mirrors src/extrinsic-detail.mjs COMPOSITE_REF_RE,
+ *  but disallows a leading-zero block number so omnibox decimal-block detection stays disjoint. */
+const COMPOSITE_EXTRINSIC_REF = /^[1-9][0-9]*-[0-9]+$/;
 
-/** True when a route/API ref is a 0x-prefixed extrinsic hash. */
+/** True when a ref is a block_number-extrinsic_index composite label. */
+export function isCompositeExtrinsicRef(ref: string): boolean {
+  return COMPOSITE_EXTRINSIC_REF.test(ref);
+}
+
+/** True when a route/API ref is a 0x-prefixed extrinsic hash or a block#index composite. */
 export function isValidExtrinsicHash(ref: string): boolean {
-  return EXTRINSIC_HASH.test(ref);
+  return EXTRINSIC_HASH.test(ref) || COMPOSITE_EXTRINSIC_REF.test(ref);
 }
 
 /** Encode a validated extrinsic hash as a single URL path segment. */

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -79,11 +79,11 @@ function ExtrinsicDetail({ hash }: { hash: string }) {
         <PageHeading
           eyebrow="Explorer"
           title="Invalid extrinsic reference"
-          description="Extrinsic references must be a 0x-prefixed hexadecimal hash."
+          description="Extrinsic references must be a 0x-prefixed hexadecimal hash or a block#index label (e.g. 123456-2)."
         />
         <EmptyState
           title="Invalid extrinsic reference"
-          description="Use a 0x-prefixed hexadecimal extrinsic hash."
+          description="Use a 0x-prefixed hexadecimal extrinsic hash or a block#index label (e.g. 123456-2)."
           action={{ label: "Back to extrinsics", href: "/extrinsics" }}
         />
       </>


### PR DESCRIPTION
## Summary

- Adds a `block#index` branch to `navTargets` in `nav-omnibox.tsx` so inputs like `123456-2` surface a **Go to Extrinsic** target navigating to `/extrinsics/123456-2`.
- Extends `isValidExtrinsicHash` / adds `isCompositeExtrinsicRef` in `extrinsics.ts` so the extrinsic detail route accepts composite refs (matching backend `COMPOSITE_REF_RE` in `src/extrinsic-detail.mjs`).
- Composite regex disallows leading-zero block numbers (`/^[1-9][0-9]*-[0-9]+$/`) so it stays disjoint from the existing decimal-block branch.
- Updates invalid-ref copy on `/extrinsics/$hash` to mention block#index labels.

Closes #3393

## Test plan

- [x] `npm run test --workspace=apps/ui -- extrinsics.test.ts` (15 tests)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npx eslint` + `npx prettier --check` on the four changed files
- [x] Malformed near-misses (`123-`, `-2`, `123456-2-3`, `0-2`) do not match composite detection
- [x] Existing ss58 / decimal-block / hash branches unchanged

Made with [Cursor](https://cursor.com)