### PR TITLE
feat(registry): add SN107 Minos chr20 reference FAI data-artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -1,5 +1,6 @@
 {
   "categories": [],
+  "contact": "contact@theminos.ai",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
@@ -13,7 +14,6 @@
   },
   "source_repo": "https://github.com/minos-protocol/minos_subnet",
   "status": "active",
-  "website_url": "https://theminos.ai/",
   "surfaces": [
     {
       "auth_required": false,
@@ -38,7 +38,32 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-data-artifact",
+      "kind": "data-artifact",
+      "name": "Minos chr20 reference FAI index",
+      "notes": "Public no-auth GET for the chr20 FASTA index (.fai) served via the Minos platform reference redirect path at api.theminos.ai/reference/.... This exact URL is used as REF_HEALTH_URL in the official minos_subnet status checks.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/neurons/status.py#L95",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md#reference-data-storage"
+      ],
+      "url": "https://api.theminos.ai/reference/chr20/chr20.fa.fai"
     }
   ],
-  "contact": "contact@theminos.ai"
+  "website_url": "https://theminos.ai/"
 }


### PR DESCRIPTION
## Summary

- Append one `data-artifact` surface to `registry/subnets/minos.json` for the public chr20 FASTA index file (`.fai`) at `https://api.theminos.ai/reference/chr20/chr20.fa.fai`.
- Add explicit probe metadata (`GET`, `expect: any`) and source proofs pinned to exact upstream lines (`status.py#L95`, README reference-data section).

Closes #4141

## Why

SN107 already has a public subnet-api health surface. This adds a standalone, no-auth, machine-consumable reference artifact used directly by Minos runtime health checks.

## Validation

```sh
npm run validate:surface -- registry/subnets/minos.json
npm run scan:public-safety
```

- URL resolves and returns the expected one-line chr20 `.fai` index.
- Only one file changed: `registry/subnets/minos.json`.

## Test plan

- [x] `validate:surface` passes
- [x] `scan:public-safety` passes
- [x] Surface is append-only and uses `authority: community` + `review.state: community-submitted`
- [x] No screenshots required (registry-only change)


Made with [Cursor](https://cursor.com)