### PR TITLE
feat(ui): add network-wide deregistrations leaderboard (#3466)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-deregistrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-deregistrations.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainDeregistrationsQuery, normalizeChainDeregistrations } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/deregistrations",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainDeregistrationsQuery(window as "7d" | "30d" | undefined, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainDeregistrations", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainDeregistrations({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          distinct_deregistered_hotkeys: 5,
+          deregistrations: 70,
+          deregistrations_per_hotkey: 14,
+        },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          {
+            netuid: 1,
+            distinct_deregistered_hotkeys: 4,
+            deregistrations: 40,
+            deregistrations_per_hotkey: 10,
+          },
+          {
+            netuid: 2,
+            distinct_deregistered_hotkeys: 2,
+            deregistrations: 30,
+            deregistrations_per_hotkey: 15,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: {
+        distinct_deregistered_hotkeys: 5,
+        deregistrations: 70,
+        deregistrations_per_hotkey: 14,
+      },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        {
+          netuid: 1,
+          distinct_deregistered_hotkeys: 4,
+          deregistrations: 40,
+          deregistrations_per_hotkey: 10,
+        },
+        {
+          netuid: 2,
+          distinct_deregistered_hotkeys: 2,
+          deregistrations: 30,
+          deregistrations_per_hotkey: 15,
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainDeregistrations(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.network.deregistrations).toBe(0);
+      expect(card.network.distinct_deregistered_hotkeys).toBe(0);
+      expect(card.network.deregistrations_per_hotkey).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+
+  it("drops malformed subnet rows", () => {
+    const card = normalizeChainDeregistrations({
+      subnet_count: 2,
+      network: {},
+      subnets: [{ netuid: "bad" }, { netuid: 3, deregistrations: 5 }],
+    });
+    expect(card.subnets).toEqual([
+      {
+        netuid: 3,
+        distinct_deregistered_hotkeys: 0,
+        deregistrations: 5,
+        deregistrations_per_hotkey: null,
+      },
+    ]);
+  });
+});
+
+describe("chainDeregistrationsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches with window and limit params", async () => {
+    resolveWith({ subnet_count: 0, network: {}, subnets: [] });
+    await runQuery("30d", 50);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/deregistrations", {
+      params: { window: "30d", limit: 50 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("defaults to 7d and limit 100", async () => {
+    resolveWith({ subnet_count: 0, network: {}, subnets: [] });
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/deregistrations", {
+      params: { window: "7d", limit: 100 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -82,6 +82,8 @@ import type {
   ChainStakeTransferSubnet,
   ChainAxonRemovals,
   ChainAxonRemovalSubnet,
+  ChainDeregistrations,
+  ChainDeregistrationsSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -250,6 +252,7 @@ const MAX_CHAIN_FEE_PAYERS = 12;
 const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
 const MAX_CHAIN_AXON_REMOVALS = 100;
+const MAX_CHAIN_DEREGISTRATIONS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3415,6 +3418,62 @@ export const chainAxonRemovalsQuery = (window = "7d", limit = 20) =>
       });
       return {
         data: normalizeChainAxonRemovals(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainDeregistrationsSubnet(raw: unknown): ChainDeregistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_deregistered_hotkeys: firstFiniteNumber(raw.distinct_deregistered_hotkeys) ?? 0,
+    deregistrations: firstFiniteNumber(raw.deregistrations) ?? 0,
+    deregistrations_per_hotkey: firstFiniteNumber(raw.deregistrations_per_hotkey) ?? null,
+  };
+}
+
+// #3466: network-wide neuron-deregistration leaderboard over a 7d/30d window — the
+// exit-side twin of /api/v1/chain/registrations. Every numeric cell coerces defensively:
+// counts fall through to 0, averages to null (never NaN), and malformed subnet rows are
+// dropped on a cold store or junk.
+export function normalizeChainDeregistrations(raw: unknown): ChainDeregistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_deregistered_hotkeys:
+        firstFiniteNumber(networkRec.distinct_deregistered_hotkeys) ?? 0,
+      deregistrations: firstFiniteNumber(networkRec.deregistrations) ?? 0,
+      deregistrations_per_hotkey: firstFiniteNumber(networkRec.deregistrations_per_hotkey) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_DEREGISTRATIONS,
+      normalizeChainDeregistrationsSubnet,
+    ),
+  };
+}
+
+export const chainDeregistrationsQuery = (window: ChainWindow = "7d", limit = 100) =>
+  queryOptions({
+    queryKey: k("chain-deregistrations", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainDeregistrations>>("/api/v1/chain/deregistrations", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainDeregistrations(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2454,6 +2454,37 @@ export interface ChainAxonRemovals {
   subnets: ChainAxonRemovalSubnet[];
 }
 
+/** One subnet's row on the network-wide neuron-deregistration leaderboard (#3466). */
+export interface ChainDeregistrationsSubnet {
+  netuid: number;
+  distinct_deregistered_hotkeys: number;
+  deregistrations: number;
+  deregistrations_per_hotkey: number | null;
+}
+
+/** Network-wide deregistration rollup — true distinct-hotkey count (not a per-subnet sum) + total deregistrations. */
+export interface ChainDeregistrationsNetwork {
+  distinct_deregistered_hotkeys: number;
+  deregistrations: number;
+  deregistrations_per_hotkey: number | null;
+}
+
+/**
+ * Network-wide neuron-deregistration activity over a 7d/30d window (#3466), from
+ * GET /api/v1/chain/deregistrations — subnets ranked by NeuronDeregistered event count,
+ * plus the true network-wide distinct-hotkey rollup and a distribution summary of
+ * per-subnet re-deregistration intensity. Zeroed with an empty subnets list when cold.
+ */
+export interface ChainDeregistrations {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainDeregistrationsNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainDeregistrationsSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
+import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as ExplorerRouteImport } from './routes/explorer'
@@ -54,6 +55,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SchemasRoute = SchemasRouteImport.update({
   id: '/schemas',
   path: '/schemas',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LeaderboardsRoute = LeaderboardsRouteImport.update({
+  id: '/leaderboards',
+  path: '/leaderboards',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HealthRoute = HealthRouteImport.update({
@@ -175,6 +181,7 @@ export interface FileRoutesByFullPath {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -203,6 +210,7 @@ export interface FileRoutesByTo {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -232,6 +240,7 @@ export interface FileRoutesById {
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
+  '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -262,6 +271,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -290,6 +300,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -318,6 +329,7 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/gaps'
     | '/health'
+    | '/leaderboards'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -347,6 +359,7 @@ export interface RootRouteChildren {
   ExplorerRoute: typeof ExplorerRoute
   GapsRoute: typeof GapsRoute
   HealthRoute: typeof HealthRoute
+  LeaderboardsRoute: typeof LeaderboardsRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
@@ -396,6 +409,13 @@ declare module '@tanstack/react-router' {
       path: '/schemas'
       fullPath: '/schemas'
       preLoaderRoute: typeof SchemasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/leaderboards': {
+      id: '/leaderboards'
+      path: '/leaderboards'
+      fullPath: '/leaderboards'
+      preLoaderRoute: typeof LeaderboardsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/health': {
@@ -563,6 +583,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExplorerRoute: ExplorerRoute,
   GapsRoute: GapsRoute,
   HealthRoute: HealthRoute,
+  LeaderboardsRoute: LeaderboardsRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -1,0 +1,217 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useMemo } from "react";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { UserMinus } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageHero } from "@/components/metagraphed/page-hero";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { BrandIcon } from "@/components/metagraphed/brand-icon";
+import { TimeAgo } from "@/components/metagraphed/time-ago";
+import { chainDeregistrationsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { Subnet } from "@/lib/metagraphed/types";
+
+const leaderboardsSearchSchema = z.object({
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+});
+
+export const Route = createFileRoute("/leaderboards")({
+  validateSearch: zodValidator(leaderboardsSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Leaderboards — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Network-wide Bittensor leaderboards — neuron deregistrations ranked by subnet over 7d and 30d windows.",
+      },
+      { property: "og:title", content: "Leaderboards — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Network-wide Bittensor leaderboards — neuron deregistrations ranked by subnet over 7d and 30d windows.",
+      },
+    ],
+  }),
+  component: LeaderboardsPage,
+});
+
+const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+
+function LeaderboardsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Explorer"
+        live
+        title="Leaderboards"
+        description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+          <DeregistrationsLeaderboard />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/chain/deregistrations"]} />
+    </AppShell>
+  );
+}
+
+function DeregistrationsLeaderboard() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const win = search.window;
+
+  const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
+  const { data: snRes } = useSuspenseQuery(subnetsQuery());
+  const board = boardRes.data;
+
+  const subnetById = useMemo(() => {
+    const m = new Map<number, Subnet>();
+    for (const s of (snRes.data ?? []) as Subnet[]) m.set(s.netuid, s);
+    return m;
+  }, [snRes]);
+
+  const network = board.network;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Deregistrations
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
+            window.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {(["7d", "30d"] as const).map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() => navigate({ search: { window: w } })}
+              className={
+                w === win
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
+                  : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
+              }
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={UserMinus}
+          eyebrow="Deregistrations"
+          value={formatNumber(network.deregistrations)}
+          hint={`${win} network total`}
+          tone="accent"
+        />
+        <StatTile
+          icon={UserMinus}
+          eyebrow="Distinct hotkeys"
+          value={formatNumber(network.distinct_deregistered_hotkeys)}
+          hint="network-wide unique"
+        />
+        <StatTile
+          icon={UserMinus}
+          eyebrow="Per hotkey"
+          value={
+            network.deregistrations_per_hotkey != null
+              ? network.deregistrations_per_hotkey.toFixed(2)
+              : "—"
+          }
+          hint="network intensity"
+        />
+      </div>
+
+      {board.subnet_count === 0 || board.subnets.length === 0 ? (
+        <EmptyState
+          title="No deregistrations in this window"
+          description="The chain poller has not indexed any NeuronDeregistered events for this window yet, or eviction activity was zero."
+          lastChecked={board.observed_at ?? undefined}
+        />
+      ) : (
+        <section className="rounded-lg border border-border bg-card">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Per-subnet rankings
+            </span>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {formatNumber(board.subnet_count)} subnets
+              {board.observed_at ? (
+                <>
+                  {" "}
+                  · observed <TimeAgo at={board.observed_at} />
+                </>
+              ) : null}
+            </span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Rank</th>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Deregistrations</th>
+                  <th className={`${TH} text-right`}>Distinct hotkeys</th>
+                  <th className={`${TH} text-right`}>Per hotkey</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {board.subnets.map((row, i) => {
+                  const subnet = subnetById.get(row.netuid);
+                  const name = subnet?.name ?? `Subnet ${row.netuid}`;
+                  return (
+                    <tr key={row.netuid} className="hover:bg-surface/40">
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: row.netuid }}
+                          className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                        >
+                          <BrandIcon
+                            size={18}
+                            name={name}
+                            fallback={row.netuid}
+                            netuid={row.netuid}
+                            subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                          />
+                          <span className="truncate text-sm text-ink-strong">{name}</span>
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                        {formatNumber(row.deregistrations)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatNumber(row.distinct_deregistered_hotkeys)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {row.deregistrations_per_hotkey != null
+                          ? row.deregistrations_per_hotkey.toFixed(2)
+                          : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `/leaderboards` route with a network-wide neuron-deregistration leaderboard sourced from `GET /api/v1/chain/deregistrations`
- Add `ChainDeregistrations` types and `chainDeregistrationsQuery` / `normalizeChainDeregistrations` in the UI data layer
- Render network rollup `StatTile`s (deregistrations, distinct hotkeys, per-hotkey intensity), a ranked per-subnet table with `BrandIcon` + links to `/subnets/$netuid`, and a 7d/30d window toggle
- Handle loading (`Suspense`/`Skeleton`), errors (`QueryErrorBoundary`), and cold empty state when `subnet_count === 0`

Closes #3466 · Part of #2542

## Screenshots

Captured on `/leaderboards`. Fixed viewports only — no full-page capture. Theme forced via `localStorage.setItem("mg-theme", "dark"|"light"); `location.reload()`. **Before:** `origin/main` @ `55772d53` (`:5173`) — route missing, app 404 ("No registry resource at this URL"). **After:** feature branch (`:5174`) — new deregistrations leaderboard page.

> **Before vs after:** before shows the root not-found page; after shows the new `/leaderboards` route with network rollup tiles and the deregistrations section (empty-state while API data is cold).

| Viewport · Theme | Before                                                                                                                                                                                                                                                        | After                                                                                                                                                                                                                                                      |
| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-dark-before.png)<br><sub>before</sub>   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-desktop-dark-after.png)<br><sub>after</sub>   |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-light-before.png)<br><sub>before</sub>   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-light-after.png)<br><sub>after</sub>   |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-dark-before.png)<br><sub>before</sub>     | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-tablet-dark-after.png)<br><sub>after</sub>     |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-light-before.png)<br><sub>before</sub>   | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-light-after.png)<br><sub>after</sub>   |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-dark-before.png)<br><sub>before</sub>     | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3466-mobile-dark-after.png)<br><sub>after</sub>     |

## Test plan

- [x] `/leaderboards` loads with network rollup tiles and per-subnet table when data is present
- [x] 7d/30d toggle re-fetches via `window` query param
- [x] Empty state shown when `subnet_count === 0` (cold data)
- [x] Table rows link to `/subnets/$netuid`
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
