### PR TITLE
fix(ui): report extrinsic truncation totals

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -77,7 +77,9 @@ describe("normalizeExtrinsic", () => {
     });
 
     expect(out?.call_args).toHaveLength(64);
+    expect(out?.call_args_total).toBe(80);
     expect(out?.events).toHaveLength(100);
+    expect(out?.events_total).toBe(120);
   });
 
   it("sanitizes deeply nested and circular call arg values before rendering", () => {

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1892,6 +1892,12 @@ export const blocksSummaryQuery = () =>
     staleTime: STALE_SHORT,
   });
 
+function countExtrinsicCallArgs(raw: unknown): number | null {
+  if (Array.isArray(raw)) return raw.length;
+  if (isRecord(raw)) return Object.keys(raw).length;
+  return null;
+}
+
 function normalizeExtrinsicCallArgs(raw: unknown): Extrinsic["call_args"] {
   if (Array.isArray(raw)) {
     return raw
@@ -1972,12 +1978,15 @@ export function normalizeExtrinsic(raw: unknown, rawEvents?: unknown): Extrinsic
   }
 
   const callArgs = normalizeExtrinsicCallArgs(raw.call_args);
+  const callArgsTotal = countExtrinsicCallArgs(raw.call_args);
 
   const eventsSource = Array.isArray(rawEvents)
     ? rawEvents
     : Array.isArray(raw.events)
       ? raw.events
       : [];
+
+  const eventsTotal = eventsSource.length;
 
   const events = Array.isArray(eventsSource)
     ? eventsSource
@@ -2009,7 +2018,9 @@ export function normalizeExtrinsic(raw: unknown, rawEvents?: unknown): Extrinsic
     fee_tao: firstFiniteNumber(raw.fee_tao),
     tip_tao: firstFiniteNumber(raw.tip_tao),
     call_args: callArgs,
+    call_args_total: callArgsTotal,
     events,
+    events_total: eventsTotal,
     success: typeof raw.success === "boolean" ? raw.success : null,
     observed_at: firstString(raw.observed_at),
   } as Extrinsic;

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -989,7 +989,9 @@ export interface Extrinsic {
   fee_tao?: number | null;
   tip_tao?: number | null;
   call_args?: ExtrinsicCallArg[] | Record<string, unknown> | null;
+  call_args_total?: number | null;
   events?: AccountEvent[];
+  events_total?: number;
   success?: boolean | null;
   observed_at?: string; // iso
   [key: string]: unknown;

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -101,13 +101,18 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
   // #3423: the events/call-args lists are sliced to bound render cost on an
   // already-fetched payload; surface how many rows were clipped so a viewer can
   // tell a complete record from a truncated one.
-  const eventsTotal = extrinsic?.events?.length ?? 0;
+  const eventsTotal =
+    typeof extrinsic?.events_total === "number"
+      ? extrinsic.events_total
+      : (extrinsic?.events?.length ?? 0);
   const eventsOmitted = Math.max(0, eventsTotal - events.length);
-  const callArgsTotal = Array.isArray(callArgs)
-    ? callArgs.length
-    : callArgs && typeof callArgs === "object"
-      ? Object.keys(callArgs).length
-      : 0;
+  const callArgsTotal = typeof extrinsic?.call_args_total === "number"
+    ? extrinsic.call_args_total
+    : Array.isArray(callArgs)
+      ? callArgs.length
+      : callArgs && typeof callArgs === "object"
+        ? Object.keys(callArgs).length
+        : 0;
   const callArgsOmitted = Math.max(0, callArgsTotal - 64);
   const realAccount = extrinsic
     ? proxyRealAccount(extrinsic.call_module, extrinsic.call_function, callArgs)

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -106,13 +106,14 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
       ? extrinsic.events_total
       : (extrinsic?.events?.length ?? 0);
   const eventsOmitted = Math.max(0, eventsTotal - events.length);
-  const callArgsTotal = typeof extrinsic?.call_args_total === "number"
-    ? extrinsic.call_args_total
-    : Array.isArray(callArgs)
-      ? callArgs.length
-      : callArgs && typeof callArgs === "object"
-        ? Object.keys(callArgs).length
-        : 0;
+  const callArgsTotal =
+    typeof extrinsic?.call_args_total === "number"
+      ? extrinsic.call_args_total
+      : Array.isArray(callArgs)
+        ? callArgs.length
+        : callArgs && typeof callArgs === "object"
+          ? Object.keys(callArgs).length
+          : 0;
   const callArgsOmitted = Math.max(0, callArgsTotal - 64);
   const realAccount = extrinsic
     ? proxyRealAccount(extrinsic.call_module, extrinsic.call_function, callArgs)


### PR DESCRIPTION
Closes #4647

### Motivation
- The extrinsic detail page computed omitted counts from already-normalized, capped arrays, so the "more omitted" notices never appeared for payloads truncated by the normalizer.
- Preserve the original totals so the UI can display truthful omitted counts while keeping the rendered collections bounded for cost control.

### Description
- Add `call_args_total` and `events_total` to the normalized `Extrinsic` object and its TypeScript type so raw totals are preserved even when render arrays are sliced.
- Introduce `countExtrinsicCallArgs` to compute the unhashed call-argument count from raw payloads and capture `events_total` from the raw events source in `normalizeExtrinsic`.
- Update the extrinsic detail route to use `events_total` and `call_args_total` (with fallbacks to the existing lengths) when calculating `eventsOmitted` and `callArgsOmitted`, enabling the truncation notices to appear for over-cap payloads.
- Extend the existing normalizer test to assert both capped render arrays and the preserved uncapped totals.

## Screenshots

Since production's chain-events indexer currently has no extrinsic with an over-cap events/call-args payload to browse live, captured via a synthetic API response (70 call-args, 105 events — both over their respective 64/100 caps) driven through the real query/render path on `/extrinsics/<hash>`, comparing the merge-base (`d5a4b932`, pre-fix) against this branch. Desktop, dark theme (app default).

| Section | Before | After |
| ------- | ------ | ----- |
| Call arguments | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-callargs-before.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-callargs-before.png)<br><sub>no notice — field_63 runs straight into EMITTED EVENTS</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-callargs-after.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-callargs-after.png)<br><sub>"Showing 64 of 70 call args — 6 more omitted."</sub> |
| Emitted events | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-events-before.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-events-before.png)<br><sub>no notice — table ends, straight to footer</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-events-after.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4614-events-after.png)<br><sub>"Showing 100 of 105 events — 5 more omitted."</sub> |

### Testing
- Ran the targeted unit tests with `npm run test --workspace=apps/ui -- src/lib/metagraphed/queries.test.ts` and the suite passed (`1 file, 51 tests, all passed`).
- Verified formatting with `npx prettier --check 'apps/ui/src/routes/extrinsics.$hash.tsx' apps/ui/src/lib/metagraphed/queries.ts apps/ui/src/lib/metagraphed/types.ts apps/ui/src/lib/metagraphed/queries.test.ts` and it reported no style issues (fixed a formatting issue introduced in the initial commit — CI's `ui` lint job caught it).
- Ran `eslint .` on apps/ui — 0 errors (pre-existing repo-wide warnings only).
- Ran type checking with `npm run typecheck --workspace=apps/ui` and it completed without errors.
- Ran the full apps/ui suite (`vitest run`) — 94 files, 647 tests, all passed.
