### PR TITLE
Enrich SN101 eni — add public API endpoint

### DIFF
--- a/registry/subnets/eni.json
+++ b/registry/subnets/eni.json
@@ -26,5 +26,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-101-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "eni TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/101 on api.taomarketcap.com returning machine-readable JSON for SN101 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Tag101 (eni) documents validator task flows in its official source repository but exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tag101-ai/tag101"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/101"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/eni.json` (SN101, eni/Tag101). Append-only — existing top-level fields are unchanged; this is the subnet's first registered surface.

## Surface

- **Netuid:** 101
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/101
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/tag101-ai/tag101
- **Provider slug:** `taomarketcap`

Tag101 (eni) documents validator task flows in its official source repository but exposes no verified first-party public API endpoint. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 101.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/eni.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/101` returns HTTP 200 with valid JSON (`netuid: 101`)
- [x] Confirmed no existing registry surface uses this URL (avoids duplicate-surface rejection)

Closes #4129

Made with [Cursor](https://cursor.com)