### PR TITLE
feat(api,ui): link a Multisig call to its approval chain via call_hash

### DIFF
--- a/apps/ui/src/lib/metagraphed/extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.test.ts
@@ -5,6 +5,7 @@ import {
   extrinsicHashPathSegment,
   isDecodedCall,
   isValidExtrinsicHash,
+  multisigCallHash,
   proxyRealAccount,
 } from "./extrinsics";
 
@@ -88,6 +89,60 @@ describe("proxyRealAccount", () => {
     expect(proxyRealAccount("Proxy", "proxy", [{ name: "real", value: 123 }])).toBeNull();
     expect(
       proxyRealAccount("Proxy", "proxy", [{ name: "force_proxy_type", value: "Any" }]),
+    ).toBeNull();
+  });
+});
+
+describe("multisigCallHash", () => {
+  const HASH = `0x${"a".repeat(64)}`;
+
+  it("extracts a top-level call_hash arg (approve_as_multi/cancel_as_multi shape)", () => {
+    expect(
+      multisigCallHash("Multisig", [
+        { name: "threshold", value: 2 },
+        { name: "call_hash", value: HASH },
+      ]),
+    ).toBe(HASH);
+  });
+
+  it("extracts the nested call's own call_hash (as_multi shape)", () => {
+    expect(
+      multisigCallHash("Multisig", [
+        { name: "threshold", value: 2 },
+        {
+          name: "call",
+          value: {
+            call_module: "Balances",
+            call_function: "transfer",
+            call_hash: HASH,
+          },
+        },
+      ]),
+    ).toBe(HASH);
+  });
+
+  it("prefers a direct call_hash arg over a nested one when both are present", () => {
+    const OTHER = `0x${"b".repeat(64)}`;
+    expect(
+      multisigCallHash("Multisig", [
+        { name: "call_hash", value: HASH },
+        {
+          name: "call",
+          value: { call_module: "Balances", call_function: "transfer", call_hash: OTHER },
+        },
+      ]),
+    ).toBe(HASH);
+  });
+
+  it("returns null for non-Multisig calls, missing hashes, or malformed shapes", () => {
+    expect(multisigCallHash("Balances", [{ name: "call_hash", value: HASH }])).toBeNull();
+    expect(multisigCallHash("Multisig", [{ name: "threshold", value: 2 }])).toBeNull();
+    expect(multisigCallHash("Multisig", { call_hash: HASH })).toBeNull();
+    expect(multisigCallHash("Multisig", [{ name: "call_hash", value: "not-a-hash" }])).toBeNull();
+    expect(
+      multisigCallHash("Multisig", [
+        { name: "call", value: { call_module: "Balances", call_function: "transfer" } },
+      ]),
     ).toBeNull();
   });
 });

--- a/apps/ui/src/lib/metagraphed/extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.ts
@@ -63,3 +63,26 @@ export function proxyRealAccount(
   );
   return typeof real?.value === "string" ? real.value : null;
 }
+
+const CALL_HASH = /^0x[0-9a-fA-F]{64}$/;
+
+/** The `call_hash` a `Multisig` call is keyed by, or null when this isn't a
+ * Multisig call or no hash can be found. `approve_as_multi`/`cancel_as_multi`
+ * carry `call_hash` directly as a top-level arg (they only approve/cancel a
+ * pending call, never resubmit it); `as_multi` carries the full `call`
+ * instead, decoded the same way as any other nested call -- its own
+ * `call_hash` is one level down. Either way, this is the join key linking an
+ * initiating `as_multi` to its later `approve_as_multi`s and final execution
+ * (#4322). */
+export function multisigCallHash(
+  callModule: string | null | undefined,
+  callArgs: unknown,
+): string | null {
+  if (callModule !== "Multisig" || !Array.isArray(callArgs)) return null;
+  const args = callArgs as Array<{ name?: string | null; value?: unknown }>;
+  const direct = args.find((a) => a?.name === "call_hash");
+  if (typeof direct?.value === "string" && CALL_HASH.test(direct.value)) return direct.value;
+  const wrapped = args.find((a) => a?.name === "call" && isDecodedCall(a.value));
+  const nestedHash = (wrapped?.value as DecodedCall | undefined)?.call_hash;
+  return typeof nestedHash === "string" && CALL_HASH.test(nestedHash) ? nestedHash : null;
+}

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
-import { Boxes, Clock, FileText, UserCog } from "lucide-react";
+import { Boxes, Clock, FileText, Link2, UserCog } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
@@ -13,7 +13,7 @@ import { SectionAnchor } from "@/components/metagraphed/section-anchor";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { extrinsicQuery } from "@/lib/metagraphed/queries";
+import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import {
@@ -21,6 +21,7 @@ import {
   extrinsicHashPathSegment,
   isDecodedCall,
   isValidExtrinsicHash,
+  multisigCallHash,
   proxyRealAccount,
   type DecodedCall,
 } from "@/lib/metagraphed/extrinsics";
@@ -111,6 +112,21 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
   const realAccount = extrinsic
     ? proxyRealAccount(extrinsic.call_module, extrinsic.call_function, callArgs)
     : null;
+  // #4322: link a Multisig call to the rest of its approval chain (the
+  // initiating `as_multi`, later `approve_as_multi`s, the final execution) --
+  // all of them carry the same call_hash. A plain useQuery (not suspense):
+  // this is a secondary, best-effort section, so a slow/failed lookup
+  // shouldn't block or error the whole page. Hook order must stay stable
+  // regardless of `extrinsic`, so this runs before the not-found early return
+  // below and is simply disabled when there's no hash to look up.
+  const callHash = extrinsic ? multisigCallHash(extrinsic.call_module, callArgs) : null;
+  const relatedQuery = useQuery({
+    ...extrinsicsQuery({ call_module: "Multisig", call_hash: callHash ?? "", limit: 25 }),
+    enabled: Boolean(callHash),
+  });
+  const relatedCalls = (relatedQuery.data?.data ?? []).filter(
+    (e) => e.extrinsic_hash?.toLowerCase() !== hash.toLowerCase(),
+  );
 
   if (!extrinsic) {
     return (
@@ -259,6 +275,45 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           </p>
         ) : null}
       </SectionAnchor>
+
+      {callHash ? (
+        <SectionAnchor
+          id="multisig-chain"
+          title="Related Multisig calls"
+          subtitle="Other extrinsics approving or executing this same call_hash."
+          tone="accent"
+        >
+          {relatedQuery.isLoading ? (
+            <Skeleton className="h-16 w-full" />
+          ) : relatedCalls.length > 0 ? (
+            <ul className="flex flex-col gap-2">
+              {relatedCalls.map((e) => (
+                <li key={e.extrinsic_hash ?? `${e.block_number}-${e.extrinsic_index}`}>
+                  <Link
+                    to="/extrinsics/$hash"
+                    params={{ hash: e.extrinsic_hash ?? "" }}
+                    className="flex items-center gap-2 rounded border border-border bg-card px-3 py-2 text-sm hover:border-ink/30"
+                  >
+                    <Link2 className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
+                    <span className="font-mono text-ink-strong">
+                      {extrinsicCall(e.call_module, e.call_function)}
+                    </span>
+                    <span className="text-ink-muted">·</span>
+                    <span className="font-mono text-[11px] text-ink-muted">
+                      #{formatNumber(e.block_number ?? 0)}
+                    </span>
+                    <TimeAgo at={e.observed_at} className="ml-auto text-[11px] text-ink-muted" />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-ink-muted">
+              No other extrinsics reference this call_hash yet.
+            </p>
+          )}
+        </SectionAnchor>
+      ) : null}
 
       <SectionAnchor id="events" title="Emitted events" tone="accent">
         {events.length > 0 ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
     },
     "apps/ui": {
       "name": "metagraphed-ui",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@jsonbored/metagraphed": "*",
@@ -11774,7 +11774,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.13.13",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -1184,7 +1184,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345). */
+        /** Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?call_hash= (0x-prefixed 64-hex-char decoded call hash — matches a Multisig approval chain's linked calls, #4322), ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345). */
         get: operations["extrinsicsFeed"];
         put?: never;
         post?: never;
@@ -16782,6 +16782,7 @@ export interface operations {
                 signer?: string;
                 call_module?: string;
                 call_function?: string;
+                call_hash?: string;
                 success?: "true" | "false";
                 block_start?: number;
                 block_end?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6818,7 +6818,7 @@
     {
       "artifact_path": "/metagraph/extrinsics.json",
       "cache": "short",
-      "description": "Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345).",
+      "description": "Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?call_hash= (0x-prefixed 64-hex-char decoded call hash — matches a Multisig approval chain's linked calls, #4322), ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345).",
       "id": "extrinsics-feed",
       "method": "GET",
       "path": "/api/v1/extrinsics",
@@ -6869,6 +6869,13 @@
         {
           "name": "call_function",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "call_hash",
+          "schema": {
+            "pattern": "^0x[0-9a-fA-F]{64}$",
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -34008,6 +34008,15 @@
           },
           {
             "in": "query",
+            "name": "call_hash",
+            "required": false,
+            "schema": {
+              "pattern": "^0x[0-9a-fA-F]{64}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "success",
             "required": false,
             "schema": {
@@ -34191,7 +34200,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345).",
+        "summary": "Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?call_hash= (0x-prefixed 64-hex-char decoded call hash — matches a Multisig approval chain's linked calls, #4322), ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345).",
         "tags": [
           "extrinsics",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1184,7 +1184,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345). */
+        /** Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?call_hash= (0x-prefixed 64-hex-char decoded call hash — matches a Multisig approval chain's linked calls, #4322), ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345). */
         get: operations["extrinsicsFeed"];
         put?: never;
         post?: never;
@@ -16782,6 +16782,7 @@ export interface operations {
                 signer?: string;
                 call_module?: string;
                 call_function?: string;
+                call_hash?: string;
                 success?: "true" | "false";
                 block_start?: number;
                 block_end?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -3091,7 +3091,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/extrinsics",
     "/metagraph/extrinsics.json",
-    "Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345).",
+    "Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=<n>, ?signer=, ?call_module=, ?call_function=, ?call_hash= (0x-prefixed 64-hex-char decoded call hash — matches a Multisig approval chain's linked calls, #4322), ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range). Pass ?format=csv to download the filtered extrinsic rows as CSV. Computed live from the first-party extrinsics D1 tier (#1345).",
     "short",
     ["extrinsics", "analytics"],
     csvRouteQuery([
@@ -3102,6 +3102,10 @@ export const API_ROUTES = [
       { name: "signer", schema: { type: "string" } },
       { name: "call_module", schema: { type: "string" } },
       { name: "call_function", schema: { type: "string" } },
+      {
+        name: "call_hash",
+        schema: { type: "string", pattern: "^0x[0-9a-fA-F]{64}$" },
+      },
       { name: "success", schema: { type: "string", enum: ["true", "false"] } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -289,9 +289,10 @@ export function buildBlockExtrinsics(
 
 // Filtered extrinsic feed (newest first) with keyset cursor support (#1851).
 // Supported filters mirror GET /api/v1/extrinsics (#1846): signer, callModule,
-// callFunction, block, blockStart/blockEnd, from/to (observed_at epoch-ms), and
-// success (true|false only; omit for no filter). A cursor takes precedence over
-// offset when present — uses a (block_number, extrinsic_index) row-value seek.
+// callFunction, block, blockStart/blockEnd, from/to (observed_at epoch-ms),
+// success (true|false only; omit for no filter), and callHash (#4322 — see
+// below). A cursor takes precedence over offset when present — uses a
+// (block_number, extrinsic_index) row-value seek.
 export async function loadExtrinsics(
   d1,
   {
@@ -304,6 +305,7 @@ export async function loadExtrinsics(
     from,
     to,
     success,
+    callHash,
     limit,
     offset,
     cursor,
@@ -348,6 +350,22 @@ export async function loadExtrinsics(
   if (hasCallFunctionFilter) {
     conds.push("call_function = ?");
     params.push(callFunction);
+  }
+  // #4322 (Multisig approval-chain linking): call_hash isn't its own column —
+  // it lives inside call_args' decoded JSON, either as a top-level arg
+  // (Multisig.approve_as_multi/cancel_as_multi only carry the hash, not the
+  // full call) or nested inside a wrapped call's own call_hash field
+  // (Multisig.as_multi carries the full call, decoded the same way batch's
+  // inner calls are — see docs/block-explorer-data-model.md's "Nested-call
+  // decode depth" note). A LIKE scan of the raw JSON text is the simplest
+  // correct match for either shape without a schema change; always pair this
+  // filter with callModule (the caller does) so it scans a narrow slice, not
+  // the whole table. The quoted match (`"<hash>"`) requires the hash to
+  // appear as an actual JSON string value, not an arbitrary substring.
+  const hasCallHashFilter = Boolean(callHash);
+  if (hasCallHashFilter) {
+    conds.push("call_args LIKE ?");
+    params.push(`%"${callHash}"%`);
   }
   const hasSuccessFilter = success === true || success === false;
   if (success === true) {
@@ -398,6 +416,7 @@ export async function loadExtrinsics(
     !hasBlockRangeFilter &&
     !hasSignerFilter &&
     !hasCallFunctionFilter &&
+    !hasCallHashFilter &&
     !hasSuccessFilter &&
     from == null &&
     to == null &&

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -1231,3 +1231,25 @@ test("loadExtrinsics ANDs keyset cursor with filters and drops OFFSET", async ()
   assert.ok(params.includes(4200000));
   assert.ok(params.includes(3));
 });
+
+// #4322 — Multisig approval-chain linking: call_hash filter.
+test("loadExtrinsics binds callHash as a quoted LIKE match and omits it when unset", async () => {
+  const capture = [];
+  const d1 = recordingExtrinsicsD1(capture);
+  const hash = `0x${"a".repeat(64)}`;
+  await loadExtrinsics(d1, { callModule: "Multisig", callHash: hash });
+  assert.ok(/call_args LIKE \?/.test(capture[0].sql));
+  assert.ok(capture[0].params.includes(`%"${hash}"%`));
+
+  capture.length = 0;
+  await loadExtrinsics(d1, {});
+  assert.ok(!/call_args LIKE \?/.test(capture[0].sql));
+});
+
+test("loadExtrinsics does not force the module index when callHash is also set", async () => {
+  const capture = [];
+  const d1 = recordingExtrinsicsD1(capture);
+  const hash = `0x${"b".repeat(64)}`;
+  await loadExtrinsics(d1, { callModule: "Multisig", callHash: hash });
+  assert.ok(!/INDEXED BY idx_extrinsics_module_block/.test(capture[0].sql));
+});

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -5515,6 +5515,35 @@ describe("handleExtrinsics", () => {
     assert.ok(!/success = \?/.test(sql));
   });
 
+  test("rejects a malformed call_hash with 400 (#4322)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    const res = await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url("/api/v1/extrinsics?call_hash=not-a-hash"),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "call_hash");
+    assert.equal(
+      captures.sql.filter((s) => /FROM extrinsics/.test(s)).length,
+      0,
+    );
+  });
+
+  test("call_hash binds a quoted LIKE match, scoped alongside call_module (#4322)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    const hash = `0x${"c".repeat(64)}`;
+    await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url(`/api/v1/extrinsics?call_module=Multisig&call_hash=${hash}`),
+    );
+    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+    assert.ok(/call_args LIKE \?/.test(sql));
+    assert.ok(captures.params.flat().includes(`%"${hash}"%`));
+  });
+
   test("forces module-index for a module-only feed path (#2082)", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     await handleExtrinsics(
@@ -5532,11 +5561,13 @@ describe("handleExtrinsics", () => {
 
   test("does not force module-index for compound module filters", async () => {
     const recentMs = Date.now() - 60_000;
+    const hash = `0x${"a".repeat(64)}`;
     for (const query of [
       "call_module=Balances&call_function=__never__",
       "call_module=Balances&success=true",
       `call_module=Balances&from=${recentMs}`,
       `call_module=Balances&to=${recentMs}`,
+      `call_module=Multisig&call_hash=${hash}`,
     ]) {
       const { env, captures } = dbWith({ extrinsics: [] });
       await handleExtrinsics(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -3634,6 +3634,11 @@ export async function handleBlockEvents(request, env, ref, url) {
 // range simply matches nothing (never throws). Cold/absent store → schema-stable
 // zero. Reuses the chain-events meta since the same first-party poller fills this
 // tier. The per-row shape is bound, never interpolated.
+// A 0x-prefixed 64-hex-char hash — the same shape as extrinsic_hash (#2063),
+// reused here for call_hash (#4322). No `%`/`_` can appear in a valid match,
+// so it's also safe to interpolate into a LIKE pattern below.
+const CALL_HASH_RE = /^0x[0-9a-fA-F]{64}$/;
+
 export async function handleExtrinsics(request, env, url) {
   const validationError = validateEntityQuery(url, [
     "limit",
@@ -3643,6 +3648,7 @@ export async function handleExtrinsics(request, env, url) {
     "signer",
     "call_module",
     "call_function",
+    "call_hash",
     "success",
     "block_start",
     "block_end",
@@ -3670,11 +3676,19 @@ export async function handleExtrinsics(request, env, url) {
       message: "success must be one of: true, false.",
     });
   }
+  const callHashRaw = sp.get("call_hash");
+  if (callHashRaw !== null && !CALL_HASH_RE.test(callHashRaw)) {
+    return analyticsQueryError({
+      parameter: "call_hash",
+      message: "call_hash must be a 0x-prefixed 64-character hex string.",
+    });
+  }
   const data = await loadExtrinsics(d1Runner(env), {
     block: numericFilters.block ?? undefined,
     signer: sp.get("signer") || undefined,
     callModule: sp.get("call_module") || undefined,
     callFunction: sp.get("call_function") || undefined,
+    callHash: callHashRaw || undefined,
     success:
       successRaw === "true" ? true : successRaw === "false" ? false : undefined,
     blockStart: numericFilters.block_start ?? undefined,


### PR DESCRIPTION
Closes #4322

## Summary

`Multisig.as_multi`/`approve_as_multi`/`cancel_as_multi` calls are otherwise isolated on the extrinsic detail page — a viewer sees one call but not the initiating `as_multi`, the other approvals, or the final execution, even though they all reference the same `call_hash`.

**Backend:** `call_hash` isn't its own column (it lives inside `call_args`' decoded JSON), so added it as a new filter on `GET /api/v1/extrinsics` (`src/extrinsics.mjs`'s `loadExtrinsics`, `workers/request-handlers/entities.mjs`'s `handleExtrinsics`) — a `LIKE` scan of the raw JSON text, validated as a strict `0x` + 64-hex-char shape and always paired with `call_module` to keep the scan narrow. Regenerated `openapi.json`/`types.d.ts`/`api-index.json` for the new query param.

**Frontend:** `multisigCallHash()` (`lib/metagraphed/extrinsics.ts`) extracts the hash from either shape — a top-level `call_hash` arg (`approve_as_multi`/`cancel_as_multi`) or the nested call's own `call_hash` (`as_multi`, same decoded shape #4321 already renders). A new "Related Multisig calls" section on the extrinsic detail page queries and links the rest of the chain.

## Verification

Since live `Multisig` extrinsics aren't currently present in the recent-window sample, verified via a live Preview session with a synthetic `as_multi`/`approve_as_multi` pair sharing a `call_hash`, driven through the real query/render path (not mocked at the component level):

- Confirmed via the accessibility tree that the "Related Multisig calls" section renders and links to the `approve_as_multi` extrinsic sharing the same `call_hash`.
- Confirmed the backend filter's SQL construction and query-plan behavior with new unit tests (`tests/extrinsics.test.mjs`, `tests/request-handlers-entities.test.mjs`) — including that `call_hash` is validated (400 on a malformed hash) and doesn't force the wrong index when combined with `call_module`.
- `npm run lint` / `npm run format:check` / `npx tsc --noEmit` (apps/ui) / full backend `npm test` — all clean.

Maintainer PR — no screenshot table (test/backend-heavy change; the one new UI section was verified live via Preview as described above, not via a hosted screenshot table per the maintainer-PR precedent established this session).
