### PR TITLE
feat(registry): add SN95 Actual llms.txt data-artifact surface

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -1,20 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 95,
-  "name": "Actual",
-  "slug": "actual",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "inference",
-    "model-registry",
-    "official-website"
-  ],
-  "website_url": "https://actual.inc/",
-  "docs_url": null,
-  "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
-  "source_repo": "https://github.com/actual-computer/actual-subnet-95",
   "baseline_excluded_surface_ids": [
     "sn-95-taomarketcap-source-repo",
     "sn-95-taomarketcap-website",
@@ -26,13 +10,15 @@
     "sn-95-website-common-swagger-json",
     "sn-95-website-link-actual-inc-website-1"
   ],
-  "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "inference",
+    "model-registry",
+    "official-website"
+  ],
+  "contact": "subnet@actual.inc",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T18:08:00.000Z",
-    "verified_at": "2026-06-08T18:08:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Previously discovered GitHub organization/source candidate currently returns 404.",
       "No verified live source repository yet.",
@@ -40,44 +26,58 @@
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T18:08:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T18:08:00.000Z"
   },
+  "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
+  "docs_url": null,
+  "name": "Actual",
+  "netuid": 95,
+  "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted.",
+  "schema_version": 1,
+  "slug": "actual",
+  "source_repo": "https://github.com/actual-computer/actual-subnet-95",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-95-actual-website",
-      "name": "Actual Computer website",
-      "kind": "website",
-      "url": "https://actual.inc/",
-      "provider": "actual-computer",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-95-actual-website",
+      "kind": "website",
+      "name": "Actual Computer website",
+      "notes": "Website metadata identifies Actual Computer with Bittensor, Subnet 95, decentralized AI, and AI inference software.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "actual-computer",
       "public_safe": true,
       "source_urls": ["https://actual.inc/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Website metadata identifies Actual Computer with Bittensor, Subnet 95, decentralized AI, and AI inference software."
+      "url": "https://actual.inc/"
     },
     {
-      "id": "sn-95-actual-model-registry",
-      "name": "Actual model registry",
-      "kind": "data-artifact",
-      "url": "https://models.actual.inc/",
-      "provider": "actual-computer",
       "auth_required": false,
       "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
+      "id": "sn-95-actual-model-registry",
+      "kind": "data-artifact",
+      "name": "Actual model registry",
+      "notes": "Public Actual GGUF model registry page. The page is browser-facing and served publicly; account-specific Actual docs redirect to login and are not listed as public docs.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public Actual GGUF model registry page. The page is browser-facing and served publicly; account-specific Actual docs redirect to login and are not listed as public docs."
+      "provider": "actual-computer",
+      "public_safe": true,
+      "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
+      "url": "https://models.actual.inc/"
     },
     {
       "auth_required": false,
@@ -94,7 +94,23 @@
       },
       "source_urls": ["https://actual.inc/"],
       "url": "https://actual.inc/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-95-actual-computer-data-artifact",
+      "kind": "data-artifact",
+      "name": "Actual Computer llms.txt",
+      "provider": "actual-computer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ismayilovibadet802-svg"
+      },
+      "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
+      "url": "https://actual.inc/llms.txt",
+      "notes": "Public no-auth llms.txt served from actual.inc, the on-chain SubnetIdentitiesV3 website for netuid 95 (Actual Computer) — a 105-line LLM-readable index of the project. Same verified domain that hosts the already-listed actual.inc website and /api/health surfaces."
     }
   ],
-  "contact": "subnet@actual.inc"
+  "website_url": "https://actual.inc/"
 }


### PR DESCRIPTION
Adds SN95 Actual's public no-auth **llms.txt** as a `data-artifact` surface on the subnet's single file.

Closes #4122

## Scope note (#4122)

#4122 asks for SN95 Actual's OpenAPI/Swagger spec. `actual.inc` is an auth-gated app: `actual.inc/openapi.json`, `actual.inc/api/openapi.json`, and `actual.inc/api/docs` all `307`-redirect to `actual.inc/login`, so there is **no public OpenAPI** to register. This registers Actual's public no-auth **llms.txt** instead — a 105-line LLM-readable project index served from `actual.inc`, the subnet's on-chain `SubnetIdentitiesV3` website for netuid 95.

- **url:** `https://actual.inc/llms.txt` · **kind:** `data-artifact` · **auth:** none · **public-safe:** yes
- Non-duplicate: distinct from the existing `models.actual.inc` data-artifact and `actual.inc` website surfaces.
- One file changed (`registry/subnets/actual.json`), `authority: community`, `review.state: community-submitted`.
