### PR TITLE
feat(registry): add SN89 InfiniteHash validator runtime-version data artifact

### DIFF
--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -87,6 +87,31 @@
         "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/89"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-89-infinitehash-runtime-version",
+      "kind": "data-artifact",
+      "name": "InfiniteHash validator runtime version spec",
+      "notes": "Public no-auth JSON runtime-version specification (node-subtensor spec/impl names, spec version, transaction/apis versions) used by the InfiniteHash SN89 validator/consensus simulator, published in the official backend-developers-ltd/InfiniteHash repository. Documents the on-chain runtime version the subnet's consensus targets.",
+      "provider": "infinitehash",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/app/src/infinite_hashes/testutils/simulator/runtime_version_318.json",
+        "https://github.com/backend-developers-ltd/InfiniteHash"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/b0313ed2edc8c07c8312effb108e9cadd580e314/app/src/infinite_hashes/testutils/simulator/runtime_version_318.json"
     }
   ],
   "website_url": "https://infinitehash.xyz/",


### PR DESCRIPTION
## Summary

Enriches **SN89 InfiniteHash** with a public runtime-version spec as a `data-artifact` surface.

- **url:** commit-pinned `runtime_version_318.json` from the official `backend-developers-ltd/InfiniteHash` repo — public, no-auth, verified live JSON.
- **What it is:** the node-subtensor runtime spec/impl + version fields the SN89 validator/consensus simulator targets.

## Why it's safe

- One file, one `data-artifact` surface (provider `infinitehash` already registered); purely additive.
- Not a duplicate; file verified clean (no secrets/keys/ss58); commit-pinned URL.
- `validate:surface` + `scan:public-safety` pass locally.

Closes #4116