### PR TITLE
feat(ui): auto-refresh the extrinsics feed first page

### DIFF
--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -118,7 +119,11 @@ function ExtrinsicsTable() {
   // Only send filters the user actually set, so an empty bar is the plain feed.
   const queryParams = extrinsicsQueryParams(search);
 
-  const rows = (useSuspenseQuery(extrinsicsQuery(queryParams)).data.data ?? []) as Extrinsic[];
+  // Extrinsics turn over as fast as blocks — poll the first page only, so
+  // paging through older extrinsics (offset > 0) isn't yanked or reflowed mid-read.
+  const refetchInterval = useRefetchInterval(15_000, search.offset === 0);
+  const rows = (useSuspenseQuery({ ...extrinsicsQuery(queryParams), refetchInterval }).data.data ??
+    []) as Extrinsic[];
 
   // Offset pagination: the API returns newest-first pages with no total. A full
   // page (rows === limit) implies more may exist; a short page is the tail.


### PR DESCRIPTION
## Summary

- `apps/ui/src/routes/extrinsics.index.tsx`'s `ExtrinsicsTable` now polls `GET /api/v1/extrinsics` on a `refetchInterval` so newly-indexed extrinsics show up without a manual reload, matching the twin fix already merged for `blocks.index.tsx` (#3374).
- Reuses the existing `useRefetchInterval` hook (`apps/ui/src/hooks/use-refetch-interval.ts`, from #3371) — no new hook, no new component.
- Polling is gated to `search.offset === 0` (first page only), the identical gate `blocks.index.tsx` uses, so paging back through older extrinsics is never yanked or reflowed mid-read.
- No changes to filters, pagination shape, row/column layout, `queries.ts`, or `types.ts`.

Closes #3375

## Screenshots

Not applicable — this change has zero rendered-output diff. The JSX, DOM structure, and styling are byte-identical before and after; only the `useSuspenseQuery` options object gains a `refetchInterval` value. Verified via a scripted Playwright check against the local dev server: DOM/console output on `/extrinsics` is unaffected by the change, and the pre-existing dev-only hydration warning reproduces identically on the untouched `/blocks` page.

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (618 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests, incl. responsive-overflow on `/extrinsics`)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification: started the dev server and confirmed via a scripted Playwright check that `/api/v1/extrinsics` is refetched on the configured interval on `/extrinsics`, and that no new console errors appear versus the unchanged `/blocks` page