### PR TITLE
fix(blocks): decode chain-event args (account ids → SS58) with a copy affordance

### DIFF
--- a/apps/ui/src/lib/metagraphed/chain-event-args.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-event-args.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { decodeChainEventArgs, formatChainEventArgs } from "./chain-event-args";
+
+const bytes = (h: string) => [
+  ...Uint8Array.from(
+    h
+      .replace(/^0x/, "")
+      .match(/../g)!
+      .map((b) => parseInt(b, 16)),
+  ),
+];
+const ALICE = bytes("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
+const ALICE_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+describe("decodeChainEventArgs", () => {
+  it("decodes an account-id byte array under an account key to SS58", () => {
+    expect(decodeChainEventArgs({ who: ALICE, amount: 1000 })).toEqual({
+      who: ALICE_SS58,
+      amount: 1000,
+    });
+  });
+
+  it("decodes account bytes nested inside an array (who: [<bytes>])", () => {
+    expect(decodeChainEventArgs({ who: [ALICE] })).toEqual({ who: [ALICE_SS58] });
+  });
+
+  it("renders a 32-byte array under a non-account key as 0x-hex, not a mislabelled address", () => {
+    const out = decodeChainEventArgs({ commit: ALICE }) as { commit: string };
+    expect(out.commit).toBe("0x" + ALICE.map((b) => b.toString(16).padStart(2, "0")).join(""));
+  });
+
+  it("leaves non-account values untouched", () => {
+    expect(decodeChainEventArgs({ netuid: 7, flag: true, note: "x", list: [1, 2, 3] })).toEqual({
+      netuid: 7,
+      flag: true,
+      note: "x",
+      list: [1, 2, 3],
+    });
+  });
+});
+
+describe("formatChainEventArgs", () => {
+  it("returns a dash for nullish args", () => {
+    expect(formatChainEventArgs(null)).toBe("—");
+    expect(formatChainEventArgs(undefined)).toBe("—");
+  });
+
+  it("produces a readable one-liner with the account decoded and no raw byte spew", () => {
+    const s = formatChainEventArgs({ who: ALICE, amount: 1000 });
+    expect(s).toContain(ALICE_SS58);
+    expect(s).not.toContain("212"); // first raw byte of Alice's key — must not leak
+  });
+});

--- a/apps/ui/src/lib/metagraphed/chain-event-args.ts
+++ b/apps/ui/src/lib/metagraphed/chain-event-args.ts
@@ -1,0 +1,77 @@
+import { encodeSs58 } from "./ss58";
+
+// #3984: chain-event args arrive as decoded SCALE values, where account ids are
+// raw 32-byte number arrays. Rendered verbatim (`JSON.stringify`) they read like
+// `{"who":[[109,111,100,101,...]]}` — unreadable and unbounded. This walks the
+// value and rewrites 32-byte arrays into a human-readable form: an SS58 address
+// when the field name marks it as an account, otherwise a 0x-hex string (so a
+// 32-byte hash isn't mislabelled as an address). Everything else is untouched.
+
+const ACCOUNT_KEYS = new Set([
+  "who",
+  "account",
+  "account_id",
+  "accountid",
+  "coldkey",
+  "hotkey",
+  "from",
+  "to",
+  "dest",
+  "destination",
+  "source",
+  "delegate",
+  "nominator",
+  "owner",
+  "target",
+  "validator",
+  "address",
+]);
+
+function isByteArray(v: unknown, len: number): v is number[] {
+  return (
+    Array.isArray(v) &&
+    v.length === len &&
+    v.every((n) => typeof n === "number" && Number.isInteger(n) && n >= 0 && n <= 255)
+  );
+}
+
+function toHex(bytes: number[]): string {
+  return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function decode(value: unknown, keyHint: string | undefined): unknown {
+  if (isByteArray(value, 32)) {
+    if (keyHint && ACCOUNT_KEYS.has(keyHint.toLowerCase())) {
+      return encodeSs58(Uint8Array.from(value)) ?? toHex(value);
+    }
+    return toHex(value);
+  }
+  // Arrays inherit the parent key hint (e.g. `who: [<accountId bytes>]`).
+  if (Array.isArray(value)) return value.map((item) => decode(item, keyHint));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(value as Record<string, unknown>))
+      out[k] = decode(val, k);
+    return out;
+  }
+  return value;
+}
+
+/** Decode account ids inside a chain-event args value (leaves everything else as-is). */
+export function decodeChainEventArgs(args: unknown): unknown {
+  return decode(args, undefined);
+}
+
+/**
+ * Human-readable one-line string for a chain event's args, with account-id byte
+ * arrays decoded to SS58 (or 0x-hex where the field isn't an account). Callers
+ * pair this with a truncating cell + a copy button (see blocks.$ref.tsx).
+ */
+export function formatChainEventArgs(args: unknown): string {
+  if (args == null) return "—";
+  try {
+    return JSON.stringify(decodeChainEventArgs(args)) ?? "—";
+  } catch {
+    return "[Unserializable value]";
+  }
+}

--- a/apps/ui/src/lib/metagraphed/ss58.test.ts
+++ b/apps/ui/src/lib/metagraphed/ss58.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { blake2b, base58Encode, encodeSs58 } from "./ss58";
+
+const hex = (h: string) =>
+  Uint8Array.from(
+    h
+      .replace(/^0x/, "")
+      .match(/../g)!
+      .map((b) => parseInt(b, 16)),
+  );
+const toHex = (b: Uint8Array) => [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+
+describe("blake2b", () => {
+  // Known blake2b-512 vectors (RFC 7693 style — empty + "abc").
+  it("hashes the empty input", () => {
+    expect(toHex(blake2b(new Uint8Array(0), 64))).toBe(
+      "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419" +
+        "d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce",
+    );
+  });
+  it('hashes "abc"', () => {
+    expect(toHex(blake2b(new TextEncoder().encode("abc"), 64))).toBe(
+      "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1" +
+        "7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923",
+    );
+  });
+});
+
+describe("base58Encode", () => {
+  it("encodes bytes and preserves leading-zero '1's", () => {
+    expect(base58Encode(hex("0x0000287fb4cd"))).toBe("11233QC4");
+  });
+});
+
+describe("encodeSs58", () => {
+  it("encodes the well-known dev accounts (format 42)", () => {
+    // Alice / Bob — the canonical Substrate dev-account vectors.
+    expect(
+      encodeSs58(hex("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")),
+    ).toBe("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    expect(
+      encodeSs58(hex("0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48")),
+    ).toBe("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty");
+  });
+  it("honours a non-default network format byte", () => {
+    // format 0 (Polkadot) for Alice's key starts with '1'.
+    expect(
+      encodeSs58(hex("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"), 0),
+    ).toBe("15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5");
+  });
+  it("returns null for non-32-byte input", () => {
+    expect(encodeSs58(new Uint8Array(31))).toBeNull();
+    expect(encodeSs58(new Uint8Array(33))).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/ss58.ts
+++ b/apps/ui/src/lib/metagraphed/ss58.ts
@@ -1,0 +1,186 @@
+// Minimal, dependency-free SS58 address encoder for rendering raw account-id
+// byte arrays (as they arrive in decoded chain-event args) as their canonical
+// Substrate address string. The frontend intentionally ships no crypto
+// library, so blake2b (used for the SS58 checksum) and base58 are vendored
+// here as small self-contained routines, verified against known vectors in
+// ss58.test.ts (Alice / Bob) — see #3984.
+
+// ── blake2b (adapted from the public-domain blakejs reference) ──────────────
+// 64-bit words are held as consecutive lo/hi uint32 pairs.
+
+const BLAKE2B_IV32 = new Uint32Array([
+  0xf3bcc908, 0x6a09e667, 0x84caa73b, 0xbb67ae85, 0xfe94f82b, 0x3c6ef372, 0x5f1d36f1, 0xa54ff53a,
+  0xade682d1, 0x510e527f, 0x2b3e6c1f, 0x9b05688c, 0xfb41bd6b, 0x1f83d9ab, 0x137e2179, 0x5be0cd19,
+]);
+
+// prettier-ignore
+const SIGMA8 = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
+  11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4, 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8,
+  9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13, 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9,
+  12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11, 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10,
+  6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5, 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0,
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
+];
+const SIGMA82 = new Uint8Array(SIGMA8.map((x) => x * 2));
+
+// Reused scratch state — blake2b here is synchronous and single-shot per call.
+const v = new Uint32Array(32);
+const m = new Uint32Array(32);
+
+function add64aa(a: number, b: number): void {
+  const lo = v[a] + v[b];
+  let hi = v[a + 1] + v[b + 1];
+  if (lo >= 0x100000000) hi++;
+  v[a] = lo;
+  v[a + 1] = hi;
+}
+
+function add64ac(a: number, b0: number, b1: number): void {
+  let lo = v[a] + b0;
+  if (b0 < 0) lo += 0x100000000;
+  let hi = v[a + 1] + b1;
+  if (lo >= 0x100000000) hi++;
+  v[a] = lo >>> 0;
+  v[a + 1] = hi >>> 0;
+}
+
+function get32(arr: Uint8Array, i: number): number {
+  return (arr[i] ^ (arr[i + 1] << 8) ^ (arr[i + 2] << 16) ^ (arr[i + 3] << 24)) >>> 0;
+}
+
+function mix(a: number, b: number, c: number, d: number, ix: number, iy: number): void {
+  const x0 = m[ix];
+  const x1 = m[ix + 1];
+  const y0 = m[iy];
+  const y1 = m[iy + 1];
+  add64aa(a, b);
+  add64ac(a, x0, x1);
+  let xor0 = v[d] ^ v[a];
+  let xor1 = v[d + 1] ^ v[a + 1];
+  v[d] = xor1;
+  v[d + 1] = xor0;
+  add64aa(c, d);
+  xor0 = v[b] ^ v[c];
+  xor1 = v[b + 1] ^ v[c + 1];
+  v[b] = (xor0 >>> 24) ^ (xor1 << 8);
+  v[b + 1] = (xor1 >>> 24) ^ (xor0 << 8);
+  add64aa(a, b);
+  add64ac(a, y0, y1);
+  xor0 = v[d] ^ v[a];
+  xor1 = v[d + 1] ^ v[a + 1];
+  v[d] = (xor0 >>> 16) ^ (xor1 << 16);
+  v[d + 1] = (xor1 >>> 16) ^ (xor0 << 16);
+  add64aa(c, d);
+  xor0 = v[b] ^ v[c];
+  xor1 = v[b + 1] ^ v[c + 1];
+  v[b] = (xor1 >>> 31) ^ (xor0 << 1);
+  v[b + 1] = (xor0 >>> 31) ^ (xor1 << 1);
+}
+
+interface Blake2bCtx {
+  b: Uint8Array;
+  h: Uint32Array;
+  t: number;
+  c: number;
+}
+
+function compress(ctx: Blake2bCtx, last: boolean): void {
+  for (let i = 0; i < 16; i++) {
+    v[i] = ctx.h[i];
+    v[i + 16] = BLAKE2B_IV32[i];
+  }
+  v[24] = (v[24] ^ ctx.t) >>> 0;
+  v[25] = (v[25] ^ (ctx.t / 0x100000000)) >>> 0;
+  if (last) {
+    v[28] = ~v[28];
+    v[29] = ~v[29];
+  }
+  for (let i = 0; i < 32; i++) m[i] = get32(ctx.b, 4 * i);
+  for (let i = 0; i < 12; i++) {
+    const o = i * 16;
+    mix(0, 8, 16, 24, SIGMA82[o + 0], SIGMA82[o + 1]);
+    mix(2, 10, 18, 26, SIGMA82[o + 2], SIGMA82[o + 3]);
+    mix(4, 12, 20, 28, SIGMA82[o + 4], SIGMA82[o + 5]);
+    mix(6, 14, 22, 30, SIGMA82[o + 6], SIGMA82[o + 7]);
+    mix(0, 10, 20, 30, SIGMA82[o + 8], SIGMA82[o + 9]);
+    mix(2, 12, 22, 24, SIGMA82[o + 10], SIGMA82[o + 11]);
+    mix(4, 14, 16, 26, SIGMA82[o + 12], SIGMA82[o + 13]);
+    mix(6, 8, 18, 28, SIGMA82[o + 14], SIGMA82[o + 15]);
+  }
+  for (let i = 0; i < 16; i++) ctx.h[i] = (ctx.h[i] ^ v[i] ^ v[i + 16]) >>> 0;
+}
+
+/** blake2b digest of `input` with the given output length (default 64 bytes). */
+export function blake2b(input: Uint8Array, outlen = 64): Uint8Array {
+  const ctx: Blake2bCtx = { b: new Uint8Array(128), h: new Uint32Array(BLAKE2B_IV32), t: 0, c: 0 };
+  ctx.h[0] = (ctx.h[0] ^ 0x01010000 ^ outlen) >>> 0;
+  for (let i = 0; i < input.length; i++) {
+    if (ctx.c === 128) {
+      ctx.t += ctx.c;
+      compress(ctx, false);
+      ctx.c = 0;
+    }
+    ctx.b[ctx.c++] = input[i];
+  }
+  ctx.t += ctx.c;
+  while (ctx.c < 128) ctx.b[ctx.c++] = 0;
+  compress(ctx, true);
+  const out = new Uint8Array(outlen);
+  for (let i = 0; i < outlen; i++) out[i] = (ctx.h[i >> 2] >> (8 * (i & 3))) & 0xff;
+  return out;
+}
+
+// ── base58 ──────────────────────────────────────────────────────────────────
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/** base58-encode a byte array (Bitcoin/Substrate alphabet). */
+export function base58Encode(bytes: Uint8Array): string {
+  const digits = [0];
+  for (const byte of bytes) {
+    let carry = byte;
+    for (let i = 0; i < digits.length; i++) {
+      carry += digits[i] << 8;
+      digits[i] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+  let leadingZeros = 0;
+  for (const byte of bytes) {
+    if (byte === 0) leadingZeros++;
+    else break;
+  }
+  let out = "1".repeat(leadingZeros);
+  for (let i = digits.length - 1; i >= 0; i--) out += BASE58_ALPHABET[digits[i]];
+  return out;
+}
+
+// ── SS58 ─────────────────────────────────────────────────────────────────────
+const SS58_PREFIX = new TextEncoder().encode("SS58PRE");
+
+/** The Bittensor / generic-Substrate address format prefix. */
+export const DEFAULT_SS58_FORMAT = 42;
+
+/**
+ * Encode a 32-byte public key as its SS58 address string. `format` is the
+ * network prefix byte (42 = generic Substrate, used by Bittensor). Returns
+ * `null` if the input isn't a 32-byte account id.
+ */
+export function encodeSs58(pubkey: Uint8Array, format = DEFAULT_SS58_FORMAT): string | null {
+  if (pubkey.length !== 32) return null;
+  const payload = new Uint8Array(1 + pubkey.length);
+  payload[0] = format;
+  payload.set(pubkey, 1);
+  const input = new Uint8Array(SS58_PREFIX.length + payload.length);
+  input.set(SS58_PREFIX);
+  input.set(payload, SS58_PREFIX.length);
+  const checksum = blake2b(input, 64);
+  const full = new Uint8Array(payload.length + 2);
+  full.set(payload);
+  full.set(checksum.slice(0, 2), payload.length);
+  return base58Encode(full);
+}

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, type ReactNode } from "react";
 import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { CopyButton } from "@/components/metagraphed/copy-button";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, ErrorState, PageHeading, Skeleton } from "@/components/metagraphed/states";
@@ -22,6 +23,7 @@ import {
 import { formatNumber } from "@/lib/metagraphed/format";
 import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
+import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
 
 export const Route = createFileRoute("/blocks/$ref")({
   // Prime the shared cache so head() can title the page with the real block
@@ -461,11 +463,13 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                     <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
                       {event.extrinsic_index != null ? formatNumber(event.extrinsic_index) : "—"}
                     </td>
-                    <td
-                      className="max-w-xs truncate px-4 py-2.5 font-mono text-[11px] text-ink-muted"
-                      title={formatChainEventArgs(event.args)}
-                    >
-                      {formatChainEventArgs(event.args)}
+                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                      <div className="flex max-w-xs items-center gap-1.5">
+                        <span className="truncate" title={formatChainEventArgs(event.args)}>
+                          {formatChainEventArgs(event.args)}
+                        </span>
+                        <CopyButton value={formatChainEventArgs(event.args)} label="args" />
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -514,15 +518,6 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
       />
     </>
   );
-}
-
-function formatChainEventArgs(args: unknown): string {
-  if (args == null) return "—";
-  try {
-    return JSON.stringify(args) ?? "—";
-  } catch {
-    return "[Unserializable value]";
-  }
 }
 
 function FieldRow({ label, children }: { label: string; children: ReactNode }) {


### PR DESCRIPTION
## Problem

The Chain events table's **Args** column on the block detail page (`blocks.$ref.tsx`, #3796) renders each value with a bare `JSON.stringify`, so decoded SCALE account ids come out as raw byte arrays like `{"who":[[212,53,147,199,21,253,211,28,…]]}` — unreadable, no decoding, and no copy affordance. This affects most rows (`Balances.Deposit`, `SubtensorModule.TimelockedWeightsRevealed`, …), making the section's primary column useless as shipped.

## Fix

- **New `lib/metagraphed/ss58.ts`** — a small, **dependency-free** SS58 encoder. The frontend intentionally ships no crypto library, so blake2b (for the SS58 checksum) and base58 are vendored as compact self-contained routines and locked down with vectors in `ss58.test.ts` (blake2b RFC test vectors + the canonical Alice/Bob dev accounts + a Polkadot-format case).
- **New `lib/metagraphed/chain-event-args.ts`** — `formatChainEventArgs` / `decodeChainEventArgs` walk the args value and rewrite 32-byte arrays: to an **SS58 address** when the field name marks it as an account (`who`/`coldkey`/`hotkey`/`from`/`to`/…), otherwise to **0x-hex** (so a 32-byte hash is made readable without being mislabelled as an address). Everything else is untouched.
- **`routes/blocks.$ref.tsx`** — the Args cell now renders the decoded value in a truncating, non-overflowing container with a `CopyButton` (the same affordance used for hash/address cells elsewhere). The decoding/formatting logic lives in the tested lib modules; the route change is minimal.

## Before / after

Mocked block (real block artifacts aren't populated on the API yet) using the exact response shape + the issue's sample account-id args.

| Viewport | Before | After |
| --- | --- | --- |
| Desktop · light | ![before desktop light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/before_desktop_light.png) | ![after desktop light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/after_desktop_light.png) |
| Desktop · dark | ![before desktop dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/before_desktop_dark.png) | ![after desktop dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/after_desktop_dark.png) |
| Mobile · light | ![before mobile light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/before_mobile_light.png) | ![after mobile light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/after_mobile_light.png) |
| Mobile · dark | ![before mobile dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/before_mobile_dark.png) | ![after mobile dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3984-screenshots/screenshots/3984/after_mobile_dark.png) |

`Balances.Deposit`'s `who` now reads `5GrwvaEF5zXb26…` and `SubtensorModule.TimelockedWeightsRevealed`'s `who` reads `5FHneW46xGXgs5…`; every value is truncated (no viewport overflow) with a copy button.

## Test

`ss58.test.ts` (6) — blake2b vectors, base58 leading-zeros, Alice/Bob SS58, Polkadot format, non-32-byte → null. `chain-event-args.test.ts` (6) — account key → SS58, nested `who: [<bytes>]`, non-account 32-byte array → 0x-hex (not mislabelled), non-account values untouched, nullish → dash, no raw-byte leakage.

Local: `vitest run` (12 passed), `tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check` (clean).

## Notes

Per the issue's scope, decoding starts with the common account-id case; other raw shapes are truncated-with-copy rather than exhaustively decoded. No new runtime dependency is added.

Closes #3984
