### PR TITLE
fix(ui): show a distinct error state for the account Balance panel on fetch failure

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -24,7 +24,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, ErrorState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { TableState } from "@/components/metagraphed/table-state";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ShareButton } from "@/components/metagraphed/share-button";
@@ -211,14 +211,24 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       />
 
       <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <StatTile
-          icon={Coins}
-          eyebrow="Balance"
-          value={balanceValue}
-          hint={balance?.balance_tao != null ? "free + reserved · live RPC" : "live RPC"}
-          tone="accent"
-          className="rounded-2xl border-accent/25 bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
-        />
+        {balanceResult.isError ? (
+          // #3960: the balance live-RPC call can fail outright — surface a distinct
+          // error state with a retry instead of an indefinite loading indicator.
+          <ErrorState
+            error={balanceResult.error}
+            onRetry={() => balanceResult.refetch()}
+            context="account balance"
+          />
+        ) : (
+          <StatTile
+            icon={Coins}
+            eyebrow="Balance"
+            value={balanceValue}
+            hint={balance?.balance_tao != null ? "free + reserved · live RPC" : "live RPC"}
+            tone="accent"
+            className="rounded-2xl border-accent/25 bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
+          />
+        )}
         <StatTile
           icon={Activity}
           eyebrow="Events"


### PR DESCRIPTION
## What

The account **Balance** tile on `/accounts/$ss58` is a separate live-RPC call. When it fails outright (`net::ERR_FAILED`), the tile stayed on its loading indicator (`— live RPC`) **indefinitely** — no timeout, no error, no retry. The UI gave no sign anything went wrong.

Closes #3960

## Fix

`apps/ui/src/routes/accounts.$ss58.tsx` — branch on the balance query's `isError` and render the shared `ErrorState` (with a **retry** that refetches) in the tile's place, mirroring how `AccountHistoryChart` already handles its error. A successful fetch renders the balance exactly as before; a still-pending (slow) fetch keeps the loading indicator. Render-branch only — the query itself is untouched.

## Checks

`eslint` + `tsc` clean. One component file, no data-layer/contract changes.

## Screenshots

Same region (anchored on the account title), balance fetch forced to fail (blocked endpoint), both themes. **before:** the tile silently shows `— live RPC` forever · **after:** a distinct error card ("Couldn't load account balance") with **Retry** + **Open API URL**.

| viewport / theme | before | after |
|---|---|---|
| **desktop · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-light-after.png)<br><sub>after</sub> |
| **desktop · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-desktop-dark-after.png)<br><sub>after</sub> |
| **tablet · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-light-after.png)<br><sub>after</sub> |
| **tablet · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-tablet-dark-after.png)<br><sub>after</sub> |
| **mobile · light** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-light-after.png)<br><sub>after</sub> |
| **mobile · dark** | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/bal-mobile-dark-after.png)<br><sub>after</sub> |
