### PR TITLE
feat(ui): add a block-throughput sparkline to the blocks index header

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -117,6 +117,10 @@ function BlocksPage() {
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
         kpis={throughputKpi}
+        // Tighten the hero's bottom spacing when the throughput KPI is present so
+        // the sparkline reads as part of the block-production header below it,
+        // instead of floating above a large gap (#3390 review).
+        className={throughputKpi ? "!mb-0 !pb-4 md:!pb-5" : undefined}
         actions={
           <>
             <DownloadCsvButton url={blocksCsvUrl} />

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -82,33 +82,6 @@ function BlocksPage() {
   const search = Route.useSearch();
   const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
 
-  // Block-throughput sparkline (#3390): daily block_count from /api/v1/chain/activity,
-  // the same source explorer.tsx uses. Non-blocking useQuery so the hero paints
-  // immediately; the KPI appears once the daily series loads.
-  const activity = useQuery(chainActivityQuery());
-  const chrono = [...(activity.data?.data.days ?? [])].reverse();
-  const blockCounts = chrono.map((d) => d.block_count);
-  const totalBlocks = blockCounts.reduce((acc, n) => acc + n, 0);
-  const throughputKpi =
-    blockCounts.length > 0
-      ? [
-          {
-            label: "Blocks / day",
-            value: `${formatNumber(totalBlocks)} total`,
-            chart: (
-              <Sparkline
-                values={blockCounts}
-                points={chrono.map((d) => ({ t: d.day, v: d.block_count }))}
-                width={168}
-                height={34}
-                ariaLabel="Daily block throughput, oldest to newest"
-                formatValue={formatNumber}
-              />
-            ),
-          },
-        ]
-      : undefined;
-
   return (
     <AppShell>
       <PageHero
@@ -116,11 +89,6 @@ function BlocksPage() {
         live
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
-        kpis={throughputKpi}
-        // Tighten the hero's bottom spacing when the throughput KPI is present so
-        // the sparkline reads as part of the block-production header below it,
-        // instead of floating above a large gap (#3390 review).
-        className={throughputKpi ? "!mb-0 !pb-4 md:!pb-5" : undefined}
         actions={
           <>
             <DownloadCsvButton url={blocksCsvUrl} />
@@ -128,6 +96,11 @@ function BlocksPage() {
           </>
         }
       />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-24 w-full mb-3" />}>
+          <BlockThroughputCard />
+        </Suspense>
+      </QueryErrorBoundary>
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-28 w-full mb-8" />}>
           <BlockProductionHeader />
@@ -143,6 +116,38 @@ function BlocksPage() {
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
       />
     </AppShell>
+  );
+}
+
+// #3390: block-throughput sparkline — daily block_count over the default window
+// from /api/v1/chain/activity (the source explorer.tsx already uses), rendered as
+// a compact card directly above the production-stats header so the throughput
+// trend sits with the other block-production metrics (no separate hero KPI).
+function BlockThroughputCard() {
+  const chrono = [...useSuspenseQuery(chainActivityQuery()).data.data.days].reverse();
+  const blockCounts = chrono.map((d) => d.block_count);
+  if (blockCounts.length === 0) return null;
+  const totalBlocks = blockCounts.reduce((acc, n) => acc + n, 0);
+  return (
+    <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border bg-card p-4">
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Blocks / day
+        </div>
+        <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
+          {formatNumber(totalBlocks)}
+          <span className="ml-1.5 text-sm font-normal text-ink-muted">total</span>
+        </div>
+      </div>
+      <Sparkline
+        values={blockCounts}
+        points={chrono.map((d) => ({ t: d.day, v: d.block_count }))}
+        width={220}
+        height={44}
+        ariaLabel="Daily block throughput, oldest to newest"
+        formatValue={formatNumber}
+      />
+    </div>
   );
 }
 

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -12,6 +12,7 @@ import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ListShell } from "@/components/metagraphed/list-shell";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import {
   PageSizeSelect,
   ResetFiltersButton,
@@ -20,7 +21,7 @@ import {
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
-import { blocksQuery, blocksSummaryQuery } from "@/lib/metagraphed/queries";
+import { blocksQuery, blocksSummaryQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
@@ -81,6 +82,33 @@ function BlocksPage() {
   const search = Route.useSearch();
   const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
 
+  // Block-throughput sparkline (#3390): daily block_count from /api/v1/chain/activity,
+  // the same source explorer.tsx uses. Non-blocking useQuery so the hero paints
+  // immediately; the KPI appears once the daily series loads.
+  const activity = useQuery(chainActivityQuery());
+  const chrono = [...(activity.data?.data.days ?? [])].reverse();
+  const blockCounts = chrono.map((d) => d.block_count);
+  const totalBlocks = blockCounts.reduce((acc, n) => acc + n, 0);
+  const throughputKpi =
+    blockCounts.length > 0
+      ? [
+          {
+            label: "Blocks / day",
+            value: `${formatNumber(totalBlocks)} total`,
+            chart: (
+              <Sparkline
+                values={blockCounts}
+                points={chrono.map((d) => ({ t: d.day, v: d.block_count }))}
+                width={168}
+                height={34}
+                ariaLabel="Daily block throughput, oldest to newest"
+                formatValue={formatNumber}
+              />
+            ),
+          },
+        ]
+      : undefined;
+
   return (
     <AppShell>
       <PageHero
@@ -88,6 +116,7 @@ function BlocksPage() {
         live
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
+        kpis={throughputKpi}
         actions={
           <>
             <DownloadCsvButton url={blocksCsvUrl} />
@@ -106,7 +135,7 @@ function BlocksPage() {
         </Suspense>
       </QueryErrorBoundary>
       <ApiSourceFooter
-        paths={["/api/v1/blocks", "/api/v1/blocks/summary"]}
+        paths={["/api/v1/blocks", "/api/v1/blocks/summary", "/api/v1/chain/activity"]}
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
       />
     </AppShell>


### PR DESCRIPTION
## Summary

Adds a block-throughput sparkline to the Blocks index page header, driven by daily `block_count` from `chainActivityQuery` (`/api/v1/chain/activity`) — the same source `explorer.tsx` already renders.

**Addressing the prior review** (the earlier attempts placed the sparkline in `PageHero`'s `kpis` slot, which left an awkward gap between it and the block-production stat cards): this version renders the sparkline as a compact **card directly above the `BlockProductionHeader` stat cards**, so the throughput trend sits *with* the other block-production metrics as one cohesive block — no floating hero KPI, no gap. This also follows #3390's own coordination note (don't reintroduce a "competing `PageHero.kpis` shape" now that #3488's stats header has landed).

Closes #3390

## What changed

`apps/ui/src/routes/blocks.index.tsx` only:

- New `BlockThroughputCard` — a `Suspense`/`QueryErrorBoundary`-wrapped card rendered immediately above `BlockProductionHeader` (tight `mb-3`, matching the stat-card rhythm). Shows "Blocks / day · <total>" with the shared `Sparkline` (reused, chronological oldest→newest via `[...days].reverse()`), and returns `null` when the series is empty.
- `/api/v1/chain/activity` added to this route's `ApiSourceFooter` `paths`.
- `PageHero`, `BlocksTable`, `blocksQuery`, pagination, and the `/api/v1/blocks/summary` stats header (#3488) are untouched.

## Screenshots

Route `/blocks`, header, fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes. The throughput card and the stat cards now sit together with consistent spacing (before: no card).

> ⚠️ **Data note:** `/api/v1/chain/activity` returns 0 days in prod right now, so both before and after inject the *same* representative activity fixture via request interception (same approach as merged #4578); the only difference is this PR's code.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3390-after-mobile-dark.png)<br><sub>after</sub> |

## Validation (full local run)

- [x] `npm run typecheck` — clean · `npm run lint` — 0 errors on the changed file
- [x] `npm test` — 611 passed · `npm run build` — green
- [x] Reuses `Sparkline`; no new query/endpoint/dependency; table + `#3488` stats header unchanged
