### PR TITLE
feat(registry): add SN30 Endure OpenGraph card image data-artifact (#4031)

### DIFF
--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -80,6 +80,22 @@
         "timeout_ms": 10000
       },
       "notes": "Official Endure documentation linked from the project website."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-30-endure-og-card-image",
+      "kind": "data-artifact",
+      "name": "Endure OpenGraph card image",
+      "notes": "Public no-auth JPEG brand image served at endure.network/metadata-endure.jpg and registered as the official Endure Network OpenGraph and Twitter card image for SN30 social previews.",
+      "provider": "endure",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "thomasalvaedison7777-lgtm"
+      },
+      "source_urls": ["https://endure.network/metadata-endure.jpg"],
+      "url": "https://endure.network/metadata-endure.jpg"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

- Appends a community `data-artifact` surface for **SN30 Endure Network**: the official `metadata-endure.jpg` OpenGraph/Twitter card image on endure.network.
- Closes #4031.

## Surface

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://endure.network/metadata-endure.jpg | Public JPEG brand image used as the official Endure OpenGraph and Twitter card image |

## Proof of ownership

- `source_url`: https://endure.network/metadata-endure.jpg — image served from the verified first-party endure.network host

## Non-duplication

- Distinct from the existing official `website` and `docs` surfaces (binary JPEG vs HTML pages)

## Validation

- [x] `npm run validate:surface -- registry/subnets/endure-network.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/endure-network.json`
- [ ] CI green

Closes #4031