### PR TITLE
feat(ui): Alpha Holdings history chart + price-annotated stake-move table

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -1,0 +1,134 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
+import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { healthColorVar } from "@/lib/health-tokens";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import type { AccountPositionHistoryPoint } from "@/lib/metagraphed/types";
+
+// Lowercase windows, matching the /history API's window enum.
+type Win = "7d" | "30d" | "90d" | "1y" | "all";
+const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+
+function taoStr(v?: number) {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  return `${v.toFixed(v < 10 ? 3 : 2)} τ`;
+}
+
+function yieldStr(v?: number) {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return v.toExponential(2);
+}
+
+/** Staked/emission-over-time + yield daily history for one account's position
+ * on one subnet -- the "Alpha Holdings chart" (#4329/6.4), reusing the
+ * account_position_daily rollup. Mirrors validator-history-chart.tsx's window
+ * selector + stacked HistoryRow pattern. Renders null-safe empty state when
+ * this position has no history yet (e.g. a freshly-registered neuron). */
+export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; netuid: number }) {
+  const [win, setWin] = useState<Win>("90d");
+  const { data: res, isLoading } = useQuery(accountPositionHistoryQuery(ss58, netuid, win));
+  const points = useMemo<AccountPositionHistoryPoint[]>(
+    () => res?.data?.points ?? [],
+    [res?.data?.points],
+  );
+
+  const series = useMemo(() => {
+    const pick = (key: keyof AccountPositionHistoryPoint) =>
+      points
+        .map((p) => p[key])
+        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    return {
+      stake: pick("stake_tao"),
+      emission: pick("emission_tao"),
+      yield: pick("yield"),
+    };
+  }, [points]);
+
+  const hasData = series.stake.length + series.emission.length + series.yield.length > 0;
+
+  const windowSelector = (
+    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          onClick={() => setWin(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">{windowSelector}</div>
+      {isLoading ? (
+        <Skeleton className="h-32 w-full" />
+      ) : !hasData ? (
+        <EmptyState
+          title="No history yet"
+          description="Daily snapshots will appear here once enough chain history has accumulated for this position."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          {series.stake.length > 0 ? (
+            <HistoryRow
+              label="Staked"
+              series={series.stake}
+              color={healthColorVar("warn")}
+              format={taoStr}
+            />
+          ) : null}
+          {series.emission.length > 0 ? (
+            <HistoryRow
+              label="Emission"
+              series={series.emission}
+              color="var(--accent, #00c899)"
+              format={taoStr}
+            />
+          ) : null}
+          {series.yield.length > 0 ? (
+            <HistoryRow label="Yield" series={series.yield} color="#38bdf8" format={yieldStr} />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HistoryRow({
+  label,
+  series,
+  color,
+  format,
+}: {
+  label: string;
+  series: number[];
+  color: string;
+  format?: (v: number) => string;
+}) {
+  const last = series[series.length - 1]!;
+  const display = format ? format(last) : Number.isFinite(last) ? formatNumber(last) : "—";
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
+        {label}
+      </span>
+      <div className="flex-1 min-w-0">
+        <Sparkline values={series} color={color} width={220} height={28} formatValue={format} />
+      </div>
+      <span className="w-20 shrink-0 text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
+        {display}
+      </span>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -186,6 +186,8 @@ import type {
   ValidatorNominatorEntry,
   ValidatorHistory,
   ValidatorHistoryPoint,
+  AccountPositionHistory,
+  AccountPositionHistoryPoint,
   SubnetNeuronSnapshot,
   ConcentrationMetrics,
   ScoreDistribution,
@@ -2593,6 +2595,7 @@ function normalizeAccountStakeMovesSubnet(raw: unknown): AccountStakeMovesSubnet
     movements: coerceFiniteNumber(raw.movements) ?? 0,
     first_moved_at: firstString(raw.first_moved_at) ?? null,
     last_moved_at: firstString(raw.last_moved_at) ?? null,
+    price_tao_at_last_move: firstFiniteNumber(raw.price_tao_at_last_move) ?? null,
   };
 }
 
@@ -2624,6 +2627,60 @@ export const accountStakeMovesQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountStakeMoves>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeAccountPositionHistoryPoint(raw: unknown): AccountPositionHistoryPoint | null {
+  if (!isRecord(raw)) return null;
+  const snapshotDate = firstString(raw.snapshot_date);
+  if (!snapshotDate) return null;
+  return {
+    snapshot_date: snapshotDate,
+    captured_at: firstString(raw.captured_at) ?? null,
+    uid: coerceFiniteNumber(raw.uid) ?? null,
+    coldkey: firstString(raw.coldkey) ?? null,
+    role: raw.role === "validator" ? "validator" : "miner",
+    active: raw.active === true,
+    stake_tao: firstFiniteNumber(raw.stake_tao) ?? null,
+    emission_tao: firstFiniteNumber(raw.emission_tao) ?? null,
+    rank: firstFiniteNumber(raw.rank) ?? null,
+    trust: firstFiniteNumber(raw.trust) ?? null,
+    incentive: firstFiniteNumber(raw.incentive) ?? null,
+    dividends: firstFiniteNumber(raw.dividends) ?? null,
+    yield: firstFiniteNumber(raw.yield) ?? null,
+  };
+}
+
+/** Daily position history for one account on one subnet -- the "Alpha
+ * Holdings chart" (#4329/6.2/6.4): stake/emission/yield over time, reusing
+ * the account_position_daily rollup. */
+export const accountPositionHistoryQuery = (ss58: string, netuid: number, window: string) =>
+  queryOptions({
+    queryKey: k("account-position-history", ss58, netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/subnets/${netuid}/history`,
+        { params: { window }, signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const points = Array.isArray(d.points)
+        ? d.points.flatMap((row) => {
+            const p = normalizeAccountPositionHistoryPoint(row);
+            return p ? [p] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          netuid: coerceFiniteNumber(d.netuid) ?? netuid,
+          window: firstString(d.window) ?? null,
+          point_count: firstFiniteNumber(d.point_count) ?? points.length,
+          points,
+        } as AccountPositionHistory,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountPositionHistory>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1247,6 +1247,11 @@ export interface AccountStakeMovesSubnet {
   movements: number;
   first_moved_at?: string | null;
   last_moved_at?: string | null;
+  /** Alpha price (TAO) on the UTC day of last_moved_at, from the daily
+   * subnet_snapshots rollup (#4332/6.3). Null when that day has no snapshot
+   * yet or there was no move. Daily granularity, not the exact intra-day
+   * price of any one movement -- a known precision limit, not a bug. */
+  price_tao_at_last_move?: number | null;
 }
 export interface AccountStakeMoves {
   ss58: string;
@@ -1958,6 +1963,37 @@ export interface ValidatorHistory {
   window?: string | null;
   point_count: number;
   points: ValidatorHistoryPoint[];
+}
+
+/** One daily snapshot of an account's position on one subnet, from
+ * /api/v1/accounts/{ss58}/subnets/{netuid}/history (#4329/6.2 -- the "Alpha
+ * Holdings chart"). Same per-position field shape as AccountPortfolio's
+ * positions[] entries, plus the date/capture stamp. */
+export interface AccountPositionHistoryPoint {
+  snapshot_date: string;
+  captured_at?: string | null;
+  uid: number | null;
+  coldkey: string | null;
+  role: "validator" | "miner";
+  active: boolean;
+  stake_tao: number | null;
+  emission_tao: number | null;
+  rank: number | null;
+  trust: number | null;
+  incentive: number | null;
+  dividends: number | null;
+  /** Null when stake is 0/absent for the day (division by zero avoided server-side). */
+  yield: number | null;
+}
+
+/** Daily per-position history from GET /api/v1/accounts/{ss58}/subnets/{netuid}/history (#4329/6.2). */
+export interface AccountPositionHistory {
+  schema_version?: number;
+  ss58: string;
+  netuid: number;
+  window?: string | null;
+  point_count: number;
+  points: AccountPositionHistoryPoint[];
 }
 
 /** A single neuron snapshot from /api/v1/subnets/{netuid}/neurons/{uid}. */

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, type ReactNode } from "react";
+import { Fragment, Suspense, useState, type ReactNode } from "react";
 import {
   Activity,
   Boxes,
   TrendingUp,
   Sparkles,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Clock,
@@ -35,6 +36,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
+import { AccountPositionHistoryChart } from "@/components/metagraphed/account-position-history-chart";
 import {
   accountAxonRemovalsQuery,
   accountCounterpartiesQuery,
@@ -674,6 +676,15 @@ function fmtStake(v: number | null | undefined): string {
   return `${formatNumber(v)} τ`;
 }
 
+// Alpha price-at-tx (#4332/6.3, #4333/6.4) -- same precision rule as
+// subnet-price-ticker.tsx's priceStr, since this is the same alpha_price_tao
+// unit shown there.
+function fmtAlphaPrice(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v < 0.001) return `${v.toExponential(2)} τ`;
+  return `${v < 1 ? v.toFixed(4) : v.toFixed(3)} τ`;
+}
+
 const KPI_TILE =
   "rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]";
 
@@ -775,6 +786,7 @@ function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
               <th className={TH}>Subnet</th>
               <th className={`${TH} text-right`}>Movements</th>
               <th className={`${TH} text-right`}>Last moved</th>
+              <th className={`${TH} text-right`}>Price at last move</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -794,6 +806,9 @@ function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
                 </td>
                 <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
                   {s.last_moved_at ? <TimeAgo at={s.last_moved_at} /> : "—"}
+                </td>
+                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {fmtAlphaPrice(s.price_tao_at_last_move)}
                 </td>
               </tr>
             ))}
@@ -961,6 +976,10 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
 function AccountPortfolioSection({ ss58 }: { ss58: string }) {
   const result = useQuery(accountPortfolioQuery(ss58));
   const p = result.data?.data;
+  // Per-position drill-down (#4329/6.4 -- the "Alpha Holdings chart"): each
+  // row expands in place rather than navigating away, so a viewer can compare
+  // several positions' history without losing the portfolio table.
+  const [expandedNetuid, setExpandedNetuid] = useState<number | null>(null);
 
   if (result.isPending && !p) {
     return (
@@ -1036,6 +1055,7 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/50">
             <tr>
+              <th className={TH} aria-hidden="true" />
               <th className={TH}>Subnet</th>
               <th className={TH}>Role</th>
               <th className={`${TH} text-right`}>Stake</th>
@@ -1044,37 +1064,65 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {positions.map((pos) => (
-              <tr key={`${pos.netuid}-${pos.uid ?? "x"}`} className="hover:bg-surface/30">
-                <td className="px-5 py-4 font-mono text-[12px]">
-                  <Link
-                    to="/subnets/$netuid"
-                    params={{ netuid: pos.netuid }}
-                    className="text-ink hover:text-accent hover:underline"
-                  >
-                    SN{pos.netuid}
-                  </Link>
-                </td>
-                <td className="px-5 py-4 font-mono text-[11px]">
-                  {pos.role === "validator" ? (
-                    <span className="text-emerald-500">validator</span>
-                  ) : pos.role === "miner" ? (
-                    <span className="text-sky-500">miner</span>
-                  ) : (
-                    <span className="text-ink-muted">{"—"}</span>
-                  )}
-                </td>
-                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
-                  {fmtStake(pos.stake_tao)}
-                </td>
-                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
-                  {fmtStake(pos.emission_tao)}
-                </td>
-                <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                  {pos.incentive != null ? pos.incentive.toFixed(4) : "—"}
-                </td>
-              </tr>
-            ))}
+            {positions.map((pos) => {
+              const expanded = expandedNetuid === pos.netuid;
+              return (
+                <Fragment key={`${pos.netuid}-${pos.uid ?? "x"}`}>
+                  <tr className="hover:bg-surface/30">
+                    <td className="px-3 py-4">
+                      <button
+                        type="button"
+                        onClick={() => setExpandedNetuid(expanded ? null : pos.netuid)}
+                        aria-expanded={expanded}
+                        aria-label={`${expanded ? "Hide" : "Show"} SN${pos.netuid} position history`}
+                        className="flex size-5 items-center justify-center rounded text-ink-muted hover:text-ink-strong"
+                      >
+                        <ChevronDown
+                          className={classNames(
+                            "size-3.5 transition-transform",
+                            expanded ? "rotate-180" : "",
+                          )}
+                        />
+                      </button>
+                    </td>
+                    <td className="px-5 py-4 font-mono text-[12px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: pos.netuid }}
+                        className="text-ink hover:text-accent hover:underline"
+                      >
+                        SN{pos.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-4 font-mono text-[11px]">
+                      {pos.role === "validator" ? (
+                        <span className="text-emerald-500">validator</span>
+                      ) : pos.role === "miner" ? (
+                        <span className="text-sky-500">miner</span>
+                      ) : (
+                        <span className="text-ink-muted">{"—"}</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {fmtStake(pos.stake_tao)}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {fmtStake(pos.emission_tao)}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {pos.incentive != null ? pos.incentive.toFixed(4) : "—"}
+                    </td>
+                  </tr>
+                  {expanded ? (
+                    <tr className="bg-surface/20">
+                      <td colSpan={6} className="px-5 py-4">
+                        <AccountPositionHistoryChart ss58={ss58} netuid={pos.netuid} />
+                      </td>
+                    </tr>
+                  ) : null}
+                </Fragment>
+              );
+            })}
           </tbody>
         </table>
       </DataPanel>


### PR DESCRIPTION
Closes #4333

## Summary

Last piece of the Alpha Holdings epic (#4329) — 6.1-6.3 (the position-history route, per-position history route, and price-at-tx enrichment) were already shipped; this is the UI.

**Alpha Holdings history chart:** each row in the account detail page's Portfolio table now expands in place (accordion-style — click the chevron, no navigation away) into a stake/emission/yield history chart for that specific subnet position, with a 7d/30d/90d/1y/all window selector. New component `AccountPositionHistoryChart` mirrors `validator-history-chart.tsx`'s window-selector + stacked-Sparkline pattern exactly, driven by the already-shipped `/api/v1/accounts/{ss58}/subnets/{netuid}/history` route.

**Price-annotated transaction table:** the Stake moves table gains a "Price at last move" column surfacing `price_tao_at_last_move` (the already-shipped 6.3 backend enrichment), formatted with the same precision rule as `subnet-price-ticker.tsx`'s `priceStr` (4dp under 1 τ, exponential under 0.001 τ, since alpha prices are commonly sub-cent).

## Verification

Since the live metagraph-snapshot artifact tier is currently sparse (separate, already-flagged staleness issue, unrelated to this PR), verified via a live Preview session with a synthetic portfolio (2 positions) + stake-moves + position-history payload matching the exact API/normalizer shapes, driven through the real query/render path:

- Clicked the expand toggle on a portfolio row; confirmed via DOM inspection it correctly toggles `aria-expanded`, flips the button label ("Show" → "Hide"), and renders the chart with the exact expected values (Staked/Emission/Yield matching the synthetic data's last data point).
- Confirmed the Stake moves table's new column renders both a normal 4dp price (`0.0182 τ`) and a sub-0.001 price in exponential notation (`4.20e-4 τ`).
- `npm run lint` / `npm run format:check` / `npx tsc --noEmit` / full `npx vitest run` (apps/ui) — all clean.

Maintainer PR — no screenshot table (test/backend-heavy session convention established this session); the visual change was verified live via Preview as described above, including a full-page screenshot confirming both features render correctly and consistently with the design system.
