### PR TITLE
fix(states): make the loading Skeleton visible against same-surface containers in dark mode

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -224,7 +224,11 @@ export function StaleBanner({
 }
 
 export function Skeleton({ className = "h-4 w-full" }: { className?: string }) {
-  return <div className={`animate-pulse rounded bg-surface ${className}`} />;
+  // bg-surface-2 (a step lighter than bg-surface in both themes) plus a hairline
+  // border so the pulse placeholder stays readable against a same-surface
+  // container — bg-surface alone vanished into the background in dark mode, where
+  // the surface tokens sit only a hair apart (#3993).
+  return <div className={`animate-pulse rounded border border-border bg-surface-2 ${className}`} />;
 }
 
 /**


### PR DESCRIPTION
## Problem

The shared `Skeleton` placeholder (`states.tsx`) uses `bg-surface`. When a skeleton sits inside a same-`surface` container in **dark mode**, it's nearly invisible — the dark surface tokens sit only a hair apart, so the loading state reads as an unexplained blank void rather than a placeholder (#3993, seen on the account page's feed sections).

## Fix

Give the placeholder `bg-surface-2` (a step lighter than `bg-surface` in both themes) **plus a hairline `border-border`** for definition, keeping the existing `animate-pulse` shimmer. `bg-surface-2` alone was still too subtle against a same-surface dark background; the border makes the box read as a distinct loading element in both themes. One shared component, so every skeleton benefits.

## Before / after

Account page with its feed queries held pending (`DetailSkeleton`), captured at desktop.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![before dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3993-screenshots/screenshots/3993/before_desktop_dark.png) | ![after dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3993-screenshots/screenshots/3993/after_desktop_dark.png) |
| Light | ![before light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3993-screenshots/screenshots/3993/before_desktop_light.png) | ![after light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3993-screenshots/screenshots/3993/after_desktop_light.png) |

Before, the PORTFOLIO / feed skeletons are invisible dark voids; after, they read as clearly-bounded pulsing placeholders.

Local: `tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check` (clean).

Closes #3993
