### PR TITLE
feat(registry): add Minos chr20 reference FAI data-artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,31 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-chr20-reference-fai",
+      "kind": "data-artifact",
+      "name": "Minos chr20 reference FAI index",
+      "notes": "Public no-auth GET for the chr20 FASTA index (.fai) served via the Minos platform reference redirect at api.theminos.ai/reference/.... The official minos_subnet status checks use this exact URL as REF_HEALTH_URL.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/neurons/status.py#L95",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/reference/chr20/chr20.fa.fai"
     }
   ],
   "contact": "contact@theminos.ai"

--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,31 +34,5 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": [
-    {
-      "auth_required": false,
-      "authority": "community",
-      "id": "sn-31-taomarketcap-subnet-snapshot",
-      "kind": "data-artifact",
-      "name": "SN31 on-chain subnet snapshot",
-      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN31 on-chain subnet state (active flag, mechanism emission split, latest snapshot block, economics, registration/burn parameters, and dTAO market fields). SN31 Recall exposes no verified first-party API, repository, or static dataset; this indexed feed is documented in the TaoMarketCap developer API.",
-      "probe": {
-        "enabled": true,
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "jimcody1995"
-      },
-      "source_urls": [
-        "https://api.taomarketcap.com/developer/documentation/",
-        "https://backprop.finance/dtao/subnets/31-recall"
-      ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
-    }
-  ]
+  "surfaces": []
 }

--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,31 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-snapshot",
+      "kind": "data-artifact",
+      "name": "SN31 on-chain subnet snapshot",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN31 on-chain subnet state (active flag, mechanism emission split, latest snapshot block, economics, registration/burn parameters, and dTAO market fields). SN31 Recall exposes no verified first-party API, repository, or static dataset; this indexed feed is documented in the TaoMarketCap developer API.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/31-recall"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Append one `data-artifact` surface to `registry/subnets/minos.json` for the public chr20 FASTA index (`.fai`) served at `https://api.theminos.ai/reference/chr20/chr20.fa.fai`.
- Proof: official `minos_subnet` `neurons/status.py` (`REF_HEALTH_URL`) and README.

Closes #4141

## Why

SN107 Minos already has a verified `subnet-api` health surface. The chr20 reference FAI index is a separate public static dataset probed by the subnet's own status checks but was not yet registered as a standalone data-artifact.

**CI note:** The prior SN31 Recall TaoMarketCap surface was reverted because SN31 must remain in `agentCatalog.blocked_subnets` (`artifacts.test.mjs` requires `missing-callable-service` blocker). This retargets the same PR to the Minos gap instead.

## Validation

```sh
npm run validate:surface -- registry/subnets/minos.json
npm run scan:public-safety
```

- Live probe: GET returns HTTP 200 for the `.fai` index file.
- Append-only change; no key reordering in `minos.json`.

## Test plan

- [x] `validate:surface` passes
- [x] `scan:public-safety` passes
- [x] No duplicate URL/kind in `minos.json`
- [x] SN31 blocked-subnet assertion preserved (recall.json unchanged)
- [x] No screenshots required (registry-only change)

Made with [Cursor](https://cursor.com)