### PR TITLE
Enrich SN109 Academia — add public API endpoint

### DIFF
--- a/registry/subnets/academia.json
+++ b/registry/subnets/academia.json
@@ -70,6 +70,25 @@
         "timeout_ms": 10000
       },
       "notes": "Public Academia archives dataset repository for Bittensor historical subnet/archive data."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-109-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Academia TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/109 on api.taomarketcap.com returning machine-readable JSON for SN109 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Academia exposes source repositories and archives but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/fx-integral/academia"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/109"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/academia.json` (SN109, Academia). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 109
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/109
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/fx-integral/academia
- **Provider slug:** `taomarketcap`

Academia exposes official source repositories and archives but no verified first-party public API endpoint. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 109.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/academia.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/109` returns HTTP 200 with valid JSON (`netuid: 109`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4144

Made with [Cursor](https://cursor.com)