### PR TITLE
feat(registry): add SN20 GroundLayer OpenGraph card image data-artifact (#4018)

### DIFF
--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -102,6 +102,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official GroundLayer roadmap page."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-20-groundlayer-og-card-image",
+      "kind": "data-artifact",
+      "name": "GroundLayer OpenGraph card image",
+      "notes": "Public no-auth PNG brand image served at www.groundlayer.xyz/og-groundlayer.png and referenced by the official GroundLayer homepage OpenGraph and Twitter card metadata for SN20 social previews.",
+      "provider": "groundlayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "thomasalvaedison7777-lgtm"
+      },
+      "source_urls": [
+        "https://www.groundlayer.xyz/og-groundlayer.png",
+        "https://www.groundlayer.xyz/"
+      ],
+      "url": "https://www.groundlayer.xyz/og-groundlayer.png"
     }
   ],
   "social": { "x": "https://x.com/groundlayerhq" },


### PR DESCRIPTION
## Summary

- Appends a community `data-artifact` surface for SN20 GroundLayer: the official `og-groundlayer.png` OpenGraph/Twitter card image on www.groundlayer.xyz.
- Closes #4018.

## Surface

| Kind | URL | Notes |
|------|-----|-------|
| `data-artifact` | https://www.groundlayer.xyz/og-groundlayer.png | Public PNG brand image referenced by homepage OpenGraph/Twitter metadata |

## Proof of ownership

- `source_url` 1: https://www.groundlayer.xyz/og-groundlayer.png — first-party published image
- `source_url` 2: https://www.groundlayer.xyz/ — homepage OpenGraph metadata references this asset

## Non-duplication

- Distinct from existing official `website` surfaces (subnet page, roadmap, homepage HTML).

## Validation

- [x] `npm run validate:surface -- registry/subnets/groundlayer.json`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check registry/subnets/groundlayer.json`
- [ ] CI green

Closes #4018