### PR TITLE
feat(rpc): expose rate-limited state-query RPC methods (#4346)

### DIFF
--- a/docs/beta-roadmap.md
+++ b/docs/beta-roadmap.md
@@ -127,7 +127,11 @@ subnets and demonstrate the product to the broader ecosystem.
    → `rpc_method_blocked`; pools finney-rpc 4/5, finney-wss 4/4, finney-archive 8/8
    eligible. Cloudflare WAF on `/rpc/*` + the flag are in place (see the runbook in
    `docs/operations.md`). This is the hosted-infra feature that separates Metagraphed
-   from a pure-registry product.
+   from a pure-registry product. **State-query methods (#4344/9.2 — SHIPPED):**
+   `state_getStorage`/`state_getKeysPaged` proxy through a second, narrower
+   allowlist with param validation, a clamped page size, a dedicated
+   `STATE_QUERY_RATE_LIMITER` budget, and a response-size cap — see
+   `docs/operations.md`.
 
 ### P2 — Performance and scale
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -161,7 +161,15 @@ Enforced in the Worker:
 
 - **Method allowlist** — read-only `SAFE_RPC_METHODS` only; `DENIED_RPC_PREFIXES`
   (`author_`, `state_call`, `sudo_`, `payment_`, `contracts_`) and heavy reads
-  (`state_getMetadata`, `state_getStorage`) stay blocked.
+  (`state_getMetadata`) stay blocked.
+- **State-query methods (#4344/9.2)** — `state_getStorage` / `state_getKeysPaged` are
+  allowed through a second, narrower `SAFE_RPC_STATE_QUERY_METHODS` allowlist (still
+  denying `state_getPairs`, which has no caller-side pagination). Each call is
+  param-validated (hex key/prefix format + length cap), the `state_getKeysPaged`
+  page-size is clamped (not rejected) to `MAX_STATE_QUERY_KEYS_PAGE_SIZE`, and the
+  decoded upstream response is capped at `MAX_STATE_QUERY_RESPONSE_BYTES` (256 KB).
+  Metered by their own `STATE_QUERY_RATE_LIMITER` budget (20 req/60s per client IP,
+  `429 rpc_state_query_rate_limited`), on top of the general RPC rate limit below.
 - **Upstream SSRF guard** — only `TRUSTED_RPC_UPSTREAM_ORIGINS`, https/wss, no private IPs.
 - **Load balancing** — weighted-random across all eligible+safe pool endpoints.
 - **Body cap** 64 KB, **upstream timeout** 10 s, single JSON-RPC object only.

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
@@ -586,7 +586,12 @@ describe("state-query methods (#4344/9.2)", () => {
           method: "state_getStorage",
           params: [HEX_KEY],
         }),
-        rpcEnv(poolWith(ep("a", SAFE_A))),
+        // A present-and-passing limiter, distinct from the other tests here
+        // (which omit the binding entirely): exercises the `success` arm of
+        // the `!success` check below, not just its "binding absent" skip.
+        rpcEnv(poolWith(ep("a", SAFE_A)), {
+          STATE_QUERY_RATE_LIMITER: { limit: async () => ({ success: true }) },
+        }),
         url("/rpc/v1/finney"),
       );
       assert.equal(res.status, 200);
@@ -595,6 +600,21 @@ describe("state-query methods (#4344/9.2)", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("400 rpc_invalid_request when state_getStorage params is not an array", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getStorage",
+        params: { not: "an array" },
+      }),
+      rpcEnv(poolWith(ep("a", SAFE_A))),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_request");
   });
 
   test("502 rpc_response_too_large when the upstream response exceeds the state-query size cap", async () => {

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
@@ -12,6 +12,7 @@ import {
   proxyWithFailover,
   rpcCachePolicy,
 } from "../workers/request-handlers/rpc-proxy.mjs";
+import { MAX_STATE_QUERY_KEYS_PAGE_SIZE } from "../workers/config.mjs";
 
 const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
 
@@ -425,6 +426,214 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
       assert.equal(cache.store.size, 0);
     } finally {
       globalThis.caches = originalCaches;
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("state-query methods (#4344/9.2)", () => {
+  const rpcPost = (body) =>
+    req("/rpc/v1/finney", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "203.0.113.20",
+      },
+      body: JSON.stringify(body),
+    });
+  const HEX_KEY = `0x${"ab".repeat(16)}`;
+
+  test("state_getPairs stays blocked -- excluded from the narrower allowlist", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getPairs",
+        params: ["0x"],
+      }),
+      rpcEnv(poolWith(ep("a", SAFE_A))),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 403);
+    assert.equal(body.error.code, "rpc_method_blocked");
+    // The allowed_methods hint includes the state-query methods that ARE
+    // permitted, so a caller can tell "wrong method" from "misconfigured".
+    assert.ok(body.meta.allowed_methods.includes("state_getStorage"));
+    assert.ok(!body.meta.allowed_methods.includes("state_getPairs"));
+  });
+
+  test("400 rpc_invalid_request for a malformed state_getStorage key", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getStorage",
+        params: ["not-hex"],
+      }),
+      rpcEnv(poolWith(ep("a", SAFE_A))),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_request");
+    assert.match(body.error.message, /state_getStorage/);
+  });
+
+  test("400 rpc_invalid_request for a malformed state_getKeysPaged prefix", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getKeysPaged",
+        params: ["0xzz", 10],
+      }),
+      rpcEnv(poolWith(ep("a", SAFE_A))),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_request");
+    assert.match(body.error.message, /state_getKeysPaged/);
+  });
+
+  test("400 rpc_invalid_request for a malformed state_getKeysPaged startKey", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getKeysPaged",
+        params: [HEX_KEY, 10, "not-hex"],
+      }),
+      rpcEnv(poolWith(ep("a", SAFE_A))),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 400);
+    assert.equal(body.error.code, "rpc_invalid_request");
+    assert.match(body.error.message, /startKey/);
+  });
+
+  test("400 rpc_invalid_request for a non-integer/negative state_getKeysPaged count", async () => {
+    for (const count of [-1, "not-a-number", Number.NaN]) {
+      const res = await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getKeysPaged",
+          params: [HEX_KEY, count],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      const body = await errorJson(res, 400);
+      assert.equal(body.error.code, "rpc_invalid_request");
+    }
+  });
+
+  test("clamps an oversized state_getKeysPaged count before forwarding upstream", async () => {
+    // proxyWithFailover calls fetchFn(endpoint.url, {..., body}) -- a bare URL
+    // string plus an init object, not a Request -- so capture the init body
+    // directly rather than via scriptedFetch (which only records the URL arg).
+    const originalFetch = globalThis.fetch;
+    let forwardedBodyText = null;
+    globalThis.fetch = async (_endpointUrl, init) => {
+      forwardedBodyText = init?.body ?? null;
+      return jsonResponse(200, { jsonrpc: "2.0", id: 1, result: [] });
+    };
+    try {
+      await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getKeysPaged",
+          params: [HEX_KEY, MAX_STATE_QUERY_KEYS_PAGE_SIZE + 1000],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      assert.ok(forwardedBodyText, "expected the upstream fetch to be called");
+      const forwardedBody = JSON.parse(forwardedBodyText);
+      assert.equal(forwardedBody.params[1], MAX_STATE_QUERY_KEYS_PAGE_SIZE);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("429 rpc_state_query_rate_limited when the state-query limiter rejects the client", async () => {
+    const res = await handleRpcProxyRequest(
+      rpcPost({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getStorage",
+        params: [HEX_KEY],
+      }),
+      rpcEnv(poolWith(ep("a", SAFE_A)), {
+        STATE_QUERY_RATE_LIMITER: { limit: async () => ({ success: false }) },
+      }),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 429);
+    assert.equal(body.error.code, "rpc_state_query_rate_limited");
+  });
+
+  test("200 happy path for state_getStorage", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = scriptedFetch(
+      jsonResponse(200, { jsonrpc: "2.0", id: 1, result: "0xdeadbeef" }),
+    );
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getStorage",
+          params: [HEX_KEY],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.result, "0xdeadbeef");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("502 rpc_response_too_large when the upstream response exceeds the state-query size cap", async () => {
+    const originalFetch = globalThis.fetch;
+    // A clean tee-able stream emitting > 256 KiB of valid JSON in chunks
+    // (mirrors the >64 KiB oversized-body pattern above, sized for this
+    // method's own, tighter MAX_STATE_QUERY_RESPONSE_BYTES cap).
+    const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
+    let pulls = 0;
+    const bigBody = new globalThis.ReadableStream({
+      pull(controller) {
+        pulls += 1;
+        if (pulls <= 5) {
+          controller.enqueue(chunk);
+          return;
+        }
+        controller.close();
+      },
+    });
+    globalThis.fetch = scriptedFetch(
+      new Response(bigBody, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getKeysPaged",
+          params: [HEX_KEY, 10],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      const body = await errorJson(res, 502);
+      assert.equal(body.error.code, "rpc_response_too_large");
+    } finally {
       globalThis.fetch = originalFetch;
     }
   });

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -364,6 +364,36 @@ export const DENIED_RPC_PREFIXES = [
   "payment_",
   "contracts_",
 ];
+// A second, narrower allowlist for the public RPC proxy (#4344/9.2, design
+// spike in docs/block-explorer-data-model.md): storage-key reads take a
+// caller-supplied key/prefix with no natural bound, unlike every SAFE_RPC_METHODS
+// entry. Membership here is NOT sufficient on its own -- the handler additionally
+// requires param-shape validation and a separate, stricter rate-limit budget
+// (STATE_QUERY_RATE_LIMITER) before forwarding. state_getPairs is deliberately
+// excluded: it has no caller-side pagination at all and can return an entire
+// pallet's storage (keys AND values) under a shallow prefix in one response --
+// state_getKeysPaged already covers the legitimate "enumerate a prefix" use case
+// with a bounded page size.
+export const SAFE_RPC_STATE_QUERY_METHODS = new Set([
+  "state_getStorage",
+  "state_getKeysPaged",
+]);
+// A real storage key is at most two twox128 hashes (16 bytes each) plus one
+// hashed map key -- even a Blake2_128Concat key on a 32-byte AccountId stays
+// well under 128 bytes decoded. 256 bytes decoded (512 hex chars + "0x") is a
+// generous ceiling above any real key/prefix, not a bound anyone legitimate
+// would hit.
+export const MAX_STATE_QUERY_KEY_HEX_CHARS = 512;
+// state_getKeysPaged's caller-supplied page-size `count` is clamped (not
+// rejected) to this ceiling, mirroring how paginated REST routes in this repo
+// clamp rather than error on an over-large `?limit` (clampInt above).
+export const MAX_STATE_QUERY_KEYS_PAGE_SIZE = 250;
+// Post-fetch response-size cap for state-query methods specifically (separate
+// from any general proxy behavior): even with the page-size clamped, cap the
+// decoded upstream body so a pathological prefix can't relay an oversized
+// payload to the client. Same order of magnitude as the general proxy's 64 KB
+// *request* cap.
+export const MAX_STATE_QUERY_RESPONSE_BYTES = 262144; // 256 KB
 export const MAX_RPC_BODY_BYTES = 65536;
 export const METAGRAPH_LATEST_KEY = "metagraph:latest";
 export const MAX_WEBHOOK_BODY_BYTES = 8192;

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -56,8 +56,12 @@ import {
   DENIED_RPC_PREFIXES,
   JSON_CONTENT_TYPE,
   MAX_RPC_BODY_BYTES,
+  MAX_STATE_QUERY_KEY_HEX_CHARS,
+  MAX_STATE_QUERY_KEYS_PAGE_SIZE,
+  MAX_STATE_QUERY_RESPONSE_BYTES,
   resolveClientIp,
   SAFE_RPC_METHODS,
+  SAFE_RPC_STATE_QUERY_METHODS,
   TRUSTED_RPC_UPSTREAM_ORIGINS,
 } from "../config.mjs";
 
@@ -338,15 +342,66 @@ export async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     );
   }
 
-  if (!isSafeRpcMethod(rpcBody.method)) {
+  // State-query methods (#4344/9.2): a second, narrower allowlist for
+  // state_getStorage/state_getKeysPaged. Membership alone isn't sufficient --
+  // unlike every SAFE_RPC_METHODS entry, these take a caller-supplied key/
+  // prefix with no natural bound, so they additionally require the param
+  // validation + separate rate-limit budget below before forwarding. See
+  // docs/block-explorer-data-model.md's design spike.
+  const isStateQueryMethod = isSafeRpcStateQueryMethod(rpcBody.method);
+  if (!isSafeRpcMethod(rpcBody.method) && !isStateQueryMethod) {
     return errorResponse(
       "rpc_method_blocked",
       `RPC method is not allowed through this proxy: ${rpcBody.method}`,
       403,
       {
-        allowed_methods: [...SAFE_RPC_METHODS].sort(),
+        allowed_methods: [
+          ...SAFE_RPC_METHODS,
+          ...SAFE_RPC_STATE_QUERY_METHODS,
+        ].sort(),
       },
     );
+  }
+
+  if (isStateQueryMethod) {
+    // Own, stricter rate-limit budget (separate binding, not a lower shared
+    // bucket) -- consumed IN ADDITION TO the general RPC_RATE_LIMITER check
+    // above, so heavy state-query traffic from one client can't starve that
+    // same client's ordinary chain_getBlock/system_health calls through the
+    // same proxy, and vice versa.
+    if (env.STATE_QUERY_RATE_LIMITER?.limit) {
+      const clientKey = `rpc-state-query:${resolveClientIp(request)}`;
+      const { success } = await env.STATE_QUERY_RATE_LIMITER.limit({
+        key: clientKey,
+      });
+      if (!success) {
+        return errorResponse(
+          "rpc_state_query_rate_limited",
+          "Too many state-query RPC requests from this client; slow down.",
+          429,
+          {},
+          {
+            "retry-after": String(STATE_QUERY_RATE_LIMIT.windowSeconds),
+            "x-ratelimit-limit": String(STATE_QUERY_RATE_LIMIT.limit),
+            "x-ratelimit-policy": `${STATE_QUERY_RATE_LIMIT.limit};w=${STATE_QUERY_RATE_LIMIT.windowSeconds}`,
+            "x-ratelimit-remaining": "0",
+          },
+        );
+      }
+    }
+
+    const validated = validateStateQueryParams(rpcBody.method, rpcBody.params);
+    if (!validated.ok) {
+      return errorResponse("rpc_invalid_request", validated.message, 400);
+    }
+    // state_getKeysPaged's count is clamped (not rejected) server-side --
+    // rewrite both the parsed body and the raw text forwarded upstream so
+    // proxyWithFailover (which forwards `bodyText`, not `rpcBody`) sees the
+    // clamped value too.
+    if (validated.params !== rpcBody.params) {
+      rpcBody.params = validated.params;
+      bodyText = JSON.stringify(rpcBody);
+    }
   }
 
   const poolArtifact = await readRpcPoolArtifact(env);
@@ -488,6 +543,36 @@ export async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     latency_ms: Date.now() - startedAt,
     cache: cacheKey ? "miss" : "bypass",
   });
+  // Post-fetch response-size cap for state-query methods (#4344/9.2): even
+  // with state_getKeysPaged's count clamped above, a pathological prefix (or a
+  // future param-validation gap) could still return a large payload -- cap the
+  // decoded upstream body rather than relay it. Only inspected for these two
+  // methods; every other proxied response is unaffected.
+  if (isStateQueryMethod && response.status === 200) {
+    let sizeCheck;
+    try {
+      sizeCheck = await readResponseTextWithLimit(
+        response.clone(),
+        MAX_STATE_QUERY_RESPONSE_BYTES,
+      );
+    } catch {
+      // proxyWithFailover already tees the upstream body and fully drains its
+      // own inspection branch before ever returning a 200 here (see its
+      // "body-read-error" handling above) -- this sibling tee branch failing
+      // independently at this point isn't reachable in practice. Kept for the
+      // same reason the pre-existing cache-classification catch below is.
+      /* v8 ignore next */
+      sizeCheck = null;
+    }
+    if (sizeCheck?.truncated) {
+      return errorResponse(
+        "rpc_response_too_large",
+        "The upstream response for this state-query method exceeded the size limit for the public proxy.",
+        502,
+      );
+    }
+  }
+
   if (!cacheKey) {
     return response;
   }
@@ -713,6 +798,9 @@ function streamRpcResponse(upstream, endpoint, attempts, status) {
 // is unavailable — we surface the static policy (mirrors wrangler.jsonc:
 // 100 requests / 60s) plus Retry-After on a 429.
 const RPC_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
+// Mirrors wrangler.jsonc's STATE_QUERY_RATE_LIMITER binding (#4344/9.2) --
+// a fifth of the general proxy's budget, its own separate bucket.
+const STATE_QUERY_RATE_LIMIT = { limit: 20, windowSeconds: 60 };
 function setRpcRateLimitHeaders(headers) {
   headers.set("x-ratelimit-limit", String(RPC_RATE_LIMIT.limit));
   headers.set(
@@ -1089,4 +1177,78 @@ function isSafeRpcMethod(method) {
     return false;
   }
   return SAFE_RPC_METHODS.has(method);
+}
+
+// #4344/9.2: same DENIED_RPC_PREFIXES defense-in-depth as isSafeRpcMethod,
+// then membership in the narrower state-query set.
+function isSafeRpcStateQueryMethod(method) {
+  if (DENIED_RPC_PREFIXES.some((prefix) => method.startsWith(prefix))) {
+    return false;
+  }
+  return SAFE_RPC_STATE_QUERY_METHODS.has(method);
+}
+
+// A real storage key/prefix is always 0x-prefixed hex -- reject anything else
+// or anything past MAX_STATE_QUERY_KEY_HEX_CHARS outright (no real key/prefix
+// legitimately needs more).
+function isValidStateQueryHex(value) {
+  return (
+    typeof value === "string" &&
+    value.length <= MAX_STATE_QUERY_KEY_HEX_CHARS + 2 &&
+    /^0x[0-9a-fA-F]*$/.test(value)
+  );
+}
+
+// Validates + (for state_getKeysPaged) clamps the caller-supplied params for
+// a state-query method (#4344/9.2). Returns {ok:true, params} -- `params` is
+// the SAME array reference when nothing needed clamping, a new one otherwise,
+// so the caller can cheaply tell whether the request body needs re-serializing.
+// Returns {ok:false, message} on a malformed key/prefix -- the same
+// rpc_invalid_request shape the existing body-shape check above uses, no new
+// error taxonomy needed.
+function validateStateQueryParams(method, params) {
+  const args = Array.isArray(params) ? params : [];
+  if (method === "state_getStorage") {
+    if (!isValidStateQueryHex(args[0])) {
+      return {
+        ok: false,
+        message:
+          "state_getStorage requires params[0] to be a 0x-prefixed hex storage key.",
+      };
+    }
+    return { ok: true, params };
+  }
+  // state_getKeysPaged: [prefix, count, startKey?, at?]
+  if (!isValidStateQueryHex(args[0])) {
+    return {
+      ok: false,
+      message:
+        "state_getKeysPaged requires params[0] to be a 0x-prefixed hex key prefix.",
+    };
+  }
+  // startKey (params[2]), when present, is also a storage key.
+  if (args[2] !== undefined && !isValidStateQueryHex(args[2])) {
+    return {
+      ok: false,
+      message:
+        "state_getKeysPaged requires params[2] (startKey), when present, to be a 0x-prefixed hex key.",
+    };
+  }
+  const rawCount = args[1];
+  const count =
+    typeof rawCount === "number" && Number.isFinite(rawCount)
+      ? Math.trunc(rawCount)
+      : Number.NaN;
+  if (!Number.isFinite(count) || count < 0) {
+    return {
+      ok: false,
+      message:
+        "state_getKeysPaged requires params[1] (count) to be a non-negative integer.",
+    };
+  }
+  const clamped = Math.min(count, MAX_STATE_QUERY_KEYS_PAGE_SIZE);
+  if (clamped === rawCount) return { ok: true, params };
+  const nextParams = [...args];
+  nextParams[1] = clamped;
+  return { ok: true, params: nextParams };
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -190,5 +190,20 @@
         "period": 60,
       },
     },
+    // Per-client abuse control for the two state-query RPC methods
+    // (state_getStorage, state_getKeysPaged, #4344/9.2) — a fifth of the
+    // general RPC proxy's 100/60s, kept as its OWN binding rather than a lower
+    // shared bucket so heavy state-query traffic from one client can't starve
+    // that same client's ordinary chain_getBlock/system_health calls through
+    // the same proxy, and vice versa. Skipped when the binding is absent
+    // (local dev/CI). See docs/block-explorer-data-model.md's design spike.
+    {
+      "name": "STATE_QUERY_RATE_LIMITER",
+      "namespace_id": "1005",
+      "simple": {
+        "limit": 20,
+        "period": 60,
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Adds `state_getStorage` / `state_getKeysPaged` to the read-only RPC proxy through a **second, narrower allowlist** (`SAFE_RPC_STATE_QUERY_METHODS`) — `state_getPairs` stays blocked since it has no caller-side pagination and can dump an entire pallet's storage in one call.
- Param validation: hex key/prefix format + length cap (`MAX_STATE_QUERY_KEY_HEX_CHARS`); `state_getKeysPaged`'s page-size is **clamped** (not rejected) to `MAX_STATE_QUERY_KEYS_PAGE_SIZE`, matching the existing `clampInt` convention elsewhere in the proxy.
- A dedicated `STATE_QUERY_RATE_LIMITER` Cloudflare rate-limit binding (20 req/60s per client IP), separate from the general `RPC_RATE_LIMITER` budget, so heavy state-query traffic from one client can't starve that same client's ordinary RPC calls and vice versa.
- A post-fetch response-size cap (`MAX_STATE_QUERY_RESPONSE_BYTES`, 256 KB) via the existing `readResponseTextWithLimit` helper, applied only to these two methods (neither is in the cacheable set).
- Docs: `docs/operations.md`'s RPC Proxy runbook and `docs/beta-roadmap.md`'s Phase 2 RPC-proxy bullet both updated to describe the new methods and their guardrails.

Design followed the spike in `docs/block-explorer-data-model.md` (#4344/9.1).

## Test plan

- [x] `npm run test:coverage` (full, unsharded) — 249 files / 6887 tests passed; `rpc-proxy.mjs` and `config.mjs` have no new coverage gaps (one defensive catch branch is structurally untestable — mirrors an existing uncovered sibling catch a few lines below in the same file — annotated with `/* v8 ignore next */` and a justification comment)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean (repo-wide, excluding the pre-existing unrelated `docs/api-stability.md` drift)
- [x] `npm run validate` clean (129 subnets, 133 providers, 1529 surfaces, 2037 candidates)
- [x] New tests: allowlist enforcement (`state_getPairs` stays blocked), malformed key/prefix/startKey/count → 400, count-clamping (verified against the actual forwarded request body), rate-limit 429, happy-path 200, response-size-cap 502

Closes #4346