### PR TITLE
fix(treemap): collapse illegibly-small tail tiles into a "+N more" group

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/treemap-mini.tsx
@@ -1,4 +1,5 @@
 import { classNames } from "@/lib/metagraphed/format";
+import { collapseSmallTreemapTiles } from "@/lib/metagraphed/treemap-collapse";
 
 export interface TreemapMiniDatum {
   label: string;
@@ -117,7 +118,8 @@ interface Props {
  * (e.g. validator stake share within a subnet).
  */
 export function TreemapMini({ data, className, formatValue = String, ariaLabel }: Props) {
-  const tiles = squarify(data);
+  // Fold the illegibly-small tail into a single "+N more" tile before layout (#3937).
+  const tiles = squarify(collapseSmallTreemapTiles(data));
   if (tiles.length === 0) return null;
 
   const label =

--- a/apps/ui/src/lib/metagraphed/treemap-collapse.test.ts
+++ b/apps/ui/src/lib/metagraphed/treemap-collapse.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { collapseSmallTreemapTiles } from "./treemap-collapse";
+
+const labels = (data: { label: string }[]) => data.map((d) => d.label);
+
+describe("collapseSmallTreemapTiles", () => {
+  it("folds the tail of a skewed distribution into one '+N more' tile", () => {
+    // One dominant validator + 8 tiny tail tiles (the common Bittensor case).
+    const data = [
+      { label: "#1", value: 900 },
+      ...Array.from({ length: 8 }, (_, i) => ({ label: `#${i + 2}`, value: 12 })),
+    ];
+    const out = collapseSmallTreemapTiles(data);
+    expect(labels(out)).toEqual(["#1", "+8 more"]);
+    // value is preserved by the grouping
+    expect(out.reduce((a, d) => a + d.value, 0)).toBe(900 + 8 * 12);
+    expect(out[1].value).toBe(8 * 12);
+  });
+
+  it("leaves an already-legible small distribution untouched", () => {
+    const data = [
+      { label: "a", value: 50 },
+      { label: "b", value: 30 },
+      { label: "c", value: 20 },
+    ];
+    expect(collapseSmallTreemapTiles(data)).toEqual(data);
+  });
+
+  it("keeps a lone tail tile rather than making a '+1 more'", () => {
+    const data = [
+      { label: "a", value: 60 },
+      { label: "b", value: 39 },
+      { label: "tiny", value: 1 }, // 1% < 2.5% minShare, but it is the only tail
+    ];
+    expect(labels(collapseSmallTreemapTiles(data))).toEqual(["a", "b", "tiny"]);
+  });
+
+  it("caps a large uniform distribution at maxTiles with a grouped remainder", () => {
+    const data = Array.from({ length: 20 }, (_, i) => ({ label: `#${i}`, value: 5 }));
+    const out = collapseSmallTreemapTiles(data, { maxTiles: 10 });
+    expect(out.length).toBe(10);
+    expect(out[9].label).toBe("+11 more");
+    expect(out.reduce((a, d) => a + d.value, 0)).toBe(100);
+  });
+
+  it("drops non-positive / non-finite values and returns [] when empty", () => {
+    expect(collapseSmallTreemapTiles([{ label: "z", value: 0 }])).toEqual([]);
+    expect(collapseSmallTreemapTiles([{ label: "n", value: NaN }])).toEqual([]);
+    expect(
+      labels(
+        collapseSmallTreemapTiles([
+          { label: "a", value: 10 },
+          { label: "neg", value: -5 },
+        ]),
+      ),
+    ).toEqual(["a"]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/treemap-collapse.ts
+++ b/apps/ui/src/lib/metagraphed/treemap-collapse.ts
@@ -1,0 +1,63 @@
+// #3937: a squarified treemap squashes the tail of a skewed distribution (the
+// common Bittensor case — one validator dominates) into near-zero-height tiles
+// whose label + value overlap into illegible text. Collapse the tail into a
+// single "+N more" tile BEFORE layout so every rendered tile stays legible.
+
+export interface TreemapDatum {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+export interface CollapseOptions {
+  /** Tiles below this share of the total are candidates for grouping. */
+  minShare?: number;
+  /** Hard cap on rendered tiles (including the "+N more" tile). */
+  maxTiles?: number;
+  /** Color for the grouped "+N more" tile. */
+  restColor?: string;
+  /** Builds the grouped tile's label from the number of grouped items. */
+  restLabel?: (n: number) => string;
+}
+
+const DEFAULTS = {
+  minShare: 0.025,
+  maxTiles: 10,
+  restColor: "var(--surface-2)",
+  restLabel: (n: number) => `+${n} more`,
+};
+
+/**
+ * Reduce treemap data so no illegibly-small tiles are rendered: keep the largest
+ * tiles that clear `minShare` (up to `maxTiles - 1`) and fold the rest into one
+ * aggregated "+N more" tile. A lone tail tile is kept as-is rather than turned
+ * into a pointless "+1 more". Non-positive / non-finite values are dropped.
+ */
+export function collapseSmallTreemapTiles(
+  data: TreemapDatum[],
+  options: CollapseOptions = {},
+): TreemapDatum[] {
+  const { minShare, maxTiles, restColor, restLabel } = { ...DEFAULTS, ...options };
+  const positive = data.filter((d) => Number.isFinite(d.value) && d.value > 0);
+  const total = positive.reduce((acc, d) => acc + d.value, 0);
+  if (total <= 0) return [];
+
+  const sorted = [...positive].sort((a, b) => b.value - a.value);
+  const keep: TreemapDatum[] = [];
+  const tail: TreemapDatum[] = [];
+  for (const d of sorted) {
+    const belowShare = d.value / total < minShare;
+    const overCap = keep.length >= maxTiles - 1;
+    if (belowShare || overCap) tail.push(d);
+    else keep.push(d);
+  }
+
+  if (tail.length === 1) {
+    // One small tile is fine on its own — grouping it would just read "+1 more".
+    keep.push(tail[0]);
+  } else if (tail.length > 1) {
+    const restValue = tail.reduce((acc, d) => acc + d.value, 0);
+    keep.push({ label: restLabel(tail.length), value: restValue, color: restColor });
+  }
+  return keep;
+}


### PR DESCRIPTION
## Problem

`TreemapMini` squarifies tiles by area, so when one validator dominates a subnet's stake — the common Bittensor case — the tail validators collapse to near-zero-height slivers whose `#uid` label and value overlap into illegible text (or show a bare truncated label with no value). The smallest tiles aren't legibly rendered at any viewport (#3937, on the subnet Validators tab's "Stake dominance" map).

## Fix

Fold the illegibly-small tail into a single **"+N more"** tile *before* layout. New pure module `lib/metagraphed/treemap-collapse.ts` (`collapseSmallTreemapTiles`) keeps the largest tiles that clear a `minShare` (up to `maxTiles - 1`) and aggregates the rest into one grouped tile — value preserved, a lone tail tile kept as-is (no pointless "+1 more"), and non-positive/non-finite values dropped. `TreemapMini` calls it in one line before `squarify`. The grouping logic is framework-free and unit-tested; the component change is minimal.

## Before / after

Subnet Validators tab with a skewed stake distribution (one dominant validator + 9 small ones), captured at desktop.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![before dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3937-screenshots/screenshots/3937/before_dark.png) | ![after dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3937-screenshots/screenshots/3937/after_dark.png) |
| Light | ![before light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3937-screenshots/screenshots/3937/before_light.png) | ![after light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3937-screenshots/screenshots/3937/after_light.png) |

Before, tiles #2–#10 are squashed into unreadable slivers down the right edge; after, the map reads as the dominant tile plus one legible **"+9 more"** group.

## Test

`treemap-collapse.test.ts` (5): folds a skewed tail into "+N more" (value preserved), leaves an already-legible small set untouched, keeps a lone tail tile, caps a large uniform set at `maxTiles`, and drops non-positive/non-finite values.

Local: `vitest run` (5 passed), `tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check` (clean).

Closes #3937
