### PR TITLE
feat(registry): add EfficientFrontier TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -119,6 +119,25 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
       ],
       "url": "https://raw.githubusercontent.com/oxylok/53-EfficientFrontier/be5d620ced30b34b41c0e33b6a8a76121747d005/docs/Introduction/RankingRulesEN.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-53-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "EfficientFrontier TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/53 on api.taomarketcap.com returning machine-readable JSON for SN53 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. SignalPlus EfficientFrontier documents validator scoring in its community source repository and mining app, but exposes no verified first-party no-auth public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "thomasalvaedison7777-lgtm"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/53"
     }
   ],
   "website_url": "https://www.signalplus.com/"


### PR DESCRIPTION
## Summary

- Append one `subnet-api` surface to `registry/subnets/efficientfrontier.json` for the public TaoMarketCap SN53 on-chain subnet snapshot feed.
- URL: `https://api.taomarketcap.com/public/v1/subnets/53` (verified live JSON, `netuid: 53`).
- Proof: TaoMarketCap developer API docs + Tensorplex subnet-docs SN53 directory entry.

Closes #4057

## Surface

| Field | Value |
|-------|-------|
| id | `sn-53-taomarketcap-subnet-api` |
| kind | `subnet-api` |
| url | `https://api.taomarketcap.com/public/v1/subnets/53` |
| provider | `taomarketcap` |

## Why

SN53 EfficientFrontier has verified website, mining dashboard, community source repository, and ranking-rules data-artifact surfaces, but no verified first-party no-auth public API endpoint. This follows the established TaoMarketCap subnet snapshot pattern used on SN89, SN101, and SN115.

## Proof

- `https://api.taomarketcap.com/developer/documentation/`
- `https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json`

No README or wallet/hotkey config files in `source_urls`.

## Non-duplication

Distinct `kind` from existing website, dashboard, source-repo, and data-artifact surfaces. New URL not already registered in `efficientfrontier.json`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/efficientfrontier.json`
- [x] `npm run scan:public-safety`
- [x] Live probe: GET returns HTTP 200 JSON with `netuid: 53`
- [x] Append-only change to exactly one registry file
- [x] Branch name matches PR content

## Test plan

- [x] Surface validation passes locally
- [x] Public-safety scan passes locally
- [x] No duplicate URL/kind in manifest