### PR TITLE
feat(ui): human-readable event-kind labels in subnet activity table (#3367)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -56,6 +56,12 @@ import {
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import {
+  eventKindCategory,
+  eventKindCategoryLabel,
+  eventKindLabel,
+  type EventKindCategory,
+} from "@/lib/metagraphed/event-kinds";
 import { TableState } from "@/components/metagraphed/table-state";
 import type {
   AccountEvent,
@@ -658,6 +664,42 @@ function ActivityPanel({ netuid }: { netuid: number }) {
   );
 }
 
+const EVENT_KIND_CATEGORY_DOT: Record<EventKindCategory, string> = {
+  registration: "var(--chart-1)",
+  stake: "var(--chart-2)",
+  serving: "var(--chart-3)",
+  consensus: "var(--chart-4)",
+  delegation: "var(--chart-5)",
+  identity: "var(--chart-6)",
+  governance: "var(--accent)",
+  transfer: "var(--health-warn)",
+  other: "var(--health-unknown)",
+};
+
+function EventKindCell({ kind }: { kind: string | null | undefined }) {
+  const category = eventKindCategory(kind);
+  const categoryLabel = eventKindCategoryLabel(category);
+  const label = eventKindLabel(kind);
+
+  return (
+    <span
+      className="inline-flex flex-wrap items-center gap-1.5"
+      title={`${label} · ${categoryLabel}`}
+    >
+      <span
+        role="img"
+        aria-label={`Category: ${categoryLabel}`}
+        className="inline-block size-2 shrink-0 rounded-full"
+        style={{ background: EVENT_KIND_CATEGORY_DOT[category] }}
+      />
+      <span className="text-[11px] text-ink-strong">{label}</span>
+      <span className="inline-flex items-center rounded border border-border bg-surface/40 px-1.5 py-0.5 text-[10px] font-medium text-ink-muted">
+        {categoryLabel}
+      </span>
+    </span>
+  );
+}
+
 function ActivityTableLoader({ netuid }: { netuid: number }) {
   const { data } = useSuspenseQuery(subnetEventsQuery(netuid));
   const events = (data.data.events ?? []) as AccountEvent[];
@@ -699,8 +741,8 @@ function ActivityTableLoader({ netuid }: { netuid: number }) {
                   "—"
                 )}
               </td>
-              <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                {ev.event_kind ?? "—"}
+              <td className="px-4 py-2.5">
+                <EventKindCell kind={ev.event_kind} />
               </td>
               <td className="px-4 py-2.5 font-mono text-[11px]">
                 {ev.hotkey ? (


### PR DESCRIPTION
## Summary

- Replace raw `event_kind` strings in the subnet **On-chain activity** table Kind column with `eventKindLabel()` from `@/lib/metagraphed/event-kinds`
- Add a category-colored dot and text chip driven by `eventKindCategory()` + `eventKindCategoryLabel()`, with `title` and `aria-label` so category is not conveyed by color alone
- Introduce a small `EVENT_KIND_CATEGORY_DOT` palette mapping the nine categories to existing CSS chart/health tokens

Closes #3367 · Part of #2542

## Screenshots

Captured on `/subnets/3?tab=activity` (On-chain activity panel). Fixed viewports only — no full-page capture. Theme forced via `localStorage.setItem("mg-theme", "dark"|"light"); `location.reload()`. **Before:** `origin/main` @ `55772d53` (`:5173`) — Kind column shows raw API strings (`NeuronRegistered`, `StakeRemoved`, …). **After:** feature branch (`:5174`) — Kind column shows human labels with category dot and chip (e.g. "Neuron registered" · Registration).

> **Before vs after:** before shows monospace raw `event_kind` values; after shows readable labels plus category indicator and chip.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3367-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `/subnets/3?tab=activity` Kind column shows human labels (not raw `NeuronRegistered`-style strings)
- [x] Each row shows category dot + chip with correct category text
- [x] Hover `title` and screen-reader `aria-label` include category name
- [x] Unknown/null kinds fall back to `eventKindLabel()` defaults
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
