### PR TITLE
feat(registry): add SN122 Bitrecs llms.txt docs-index data-artifact (#733)

### DIFF
--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -106,6 +106,25 @@
         "https://github.com/bitrecs/bitrecs-subnet/blob/main/tests/test_json.py"
       ],
       "url": "https://raw.githubusercontent.com/bitrecs/bitrecs-subnet/main/tests/data/amazon/fashion/amazon_fashion_sample_1000.json"
+    },
+    {
+      "id": "sn-122-bitrecs-llms-txt",
+      "name": "Bitrecs llms.txt docs index",
+      "kind": "data-artifact",
+      "url": "https://www.bitrecs.ai/llms.txt",
+      "provider": "bitrecs",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://www.bitrecs.ai/llms.txt",
+        "https://www.bitrecs.ai/"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "notes": "Machine-readable llms.txt docs index published on the official Bitrecs website; self-identifies as Bittensor subnet 122 and links the homepage, Shopify app, and Taostats subnet page."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Registers the machine-readable **`llms.txt` docs index** that Bitrecs (Bittensor subnet 122) publishes on its official website, as a `data-artifact` community surface. One file changed: `registry/subnets/bitrecs.json` (single appended surface).

## Scope note (relative to #733)

#733 asks for SN122's **public API endpoint / OpenAPI/Swagger spec**. Bitrecs publishes **no** machine-readable OpenAPI JSON and **no** unauthenticated public API: its REST API and MCP server are explicitly labeled **"(coming soon)"** in the `llms.txt` itself, and `api.bitrecs.ai` does not resolve. This registers the concrete machine-readable surface Bitrecs **does** publish — the `llms.txt` docs index — the agent-consumable artifact behind the issue's intent, matching the accepted `llms.txt` data-artifact pattern (cf. #4622, #4596).

## Surface

| Field | Value |
| --- | --- |
| `kind` | `data-artifact` |
| `url` | https://www.bitrecs.ai/llms.txt |
| `source_urls` | https://www.bitrecs.ai/llms.txt , https://www.bitrecs.ai/ |
| `authority` | `community` |
| `review.state` | `community-submitted` |

## Proof

- `url` returns **HTTP 200**, `content-type: text/plain; charset=utf-8`, 5021 bytes of real markdown (not an SPA shell).
- The body self-identifies: *"...operating as **Bittensor subnet 122**"* and links the Bitrecs homepage, Shopify app, and the Taostats subnet-122 page — tying the artifact to the same owner/domain as the already-registered official website surface.
- Use the `www.` host: the apex `bitrecs.ai/llms.txt` 308-redirects and does not serve the artifact.

## Validation

```
npm run validate:surface -- registry/subnets/bitrecs.json   # passed
npm run scan:public-safety                                  # passed
```

Not a duplicate: the existing SN122 data-artifact is the Amazon-fashion sample catalog JSON; this is the distinct `llms.txt` docs index.

Closes #733
