### PR TITLE
feat(ui): render a router-level not-found page for invalid block/extrinsic refs (#3422)

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useEffect, type ReactNode } from "react";
 import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
@@ -24,14 +24,18 @@ import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraph
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/blocks/$ref")({
+  // #3422: validate the ref at the router level so an invalid one renders the
+  // real not-found boundary (notFoundComponent) instead of an in-page early
+  // return. parseParams runs before the loader, so downstream code only ever
+  // sees a well-formed ref.
+  parseParams: ({ ref }) => {
+    if (!isValidBlockRef(ref)) throw notFound();
+    return { ref };
+  },
   // Prime the shared cache so head() can title the page with the real block
   // number. Non-fatal: any failure falls back to the ref-only copy and the
   // page's own useSuspenseQuery still drives the not-found/empty path.
   loader: async ({ context, params }) => {
-    if (!isValidBlockRef(params.ref)) {
-      return null;
-    }
-
     try {
       const { data } = await context.queryClient.ensureQueryData(blockQuery(params.ref));
       return { blockNumber: data?.block_number ?? null };
@@ -52,6 +56,20 @@ export const Route = createFileRoute("/blocks/$ref")({
       ],
     };
   },
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Block not found"
+        description="Block references must be a decimal block number or a 0x-prefixed hex hash."
+      />
+      <EmptyState
+        title="Invalid block reference"
+        description="Use a decimal block number or a 0x-prefixed hexadecimal block hash."
+        action={{ label: "Back to blocks", href: "/blocks" }}
+      />
+    </AppShell>
+  ),
   component: BlockDetailPage,
 });
 
@@ -69,23 +87,8 @@ function BlockDetailPage() {
 }
 
 function BlockDetail({ refValue }: { refValue: string }) {
-  if (!isValidBlockRef(refValue)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid block reference"
-          description="Block references must be a decimal block number or a 0x-prefixed hex hash."
-        />
-        <EmptyState
-          title="Invalid block reference"
-          description="Use a decimal block number or a 0x-prefixed hexadecimal block hash."
-          action={{ label: "Back to blocks", href: "/blocks" }}
-        />
-      </>
-    );
-  }
-
+  // The router's parseParams rejects malformed refs before this renders, so the
+  // detail component only ever runs with a well-formed ref.
   return <ValidBlockDetail refValue={refValue} />;
 }
 

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
 import { Boxes, Clock, FileText, Link2, UserCog } from "lucide-react";
@@ -27,13 +27,18 @@ import {
 } from "@/lib/metagraphed/extrinsics";
 
 export const Route = createFileRoute("/extrinsics/$hash")({
+  // #3422: validate the hash at the router level so an invalid one renders the
+  // real not-found boundary (notFoundComponent) instead of an in-page early
+  // return. parseParams runs before the loader, so downstream code only ever
+  // sees a well-formed hash.
+  parseParams: ({ hash }) => {
+    if (!isValidExtrinsicHash(hash)) throw notFound();
+    return { hash };
+  },
   // Prime the shared cache so head() can title with the call name. Non-fatal:
   // any failure falls back to the hash-only copy and the page's own
   // useSuspenseQuery still drives the not-found/empty path.
   loader: async ({ context, params }) => {
-    if (!isValidExtrinsicHash(params.hash)) {
-      return null;
-    }
     try {
       const { data } = await context.queryClient.ensureQueryData(extrinsicQuery(params.hash));
       return {
@@ -57,6 +62,20 @@ export const Route = createFileRoute("/extrinsics/$hash")({
       ],
     };
   },
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Extrinsic not found"
+        description="Extrinsic references must be a 0x-prefixed hexadecimal hash or a block#index label (e.g. 123456-2)."
+      />
+      <EmptyState
+        title="Invalid extrinsic reference"
+        description="Use a 0x-prefixed hexadecimal extrinsic hash or a block#index label (e.g. 123456-2)."
+        action={{ label: "Back to extrinsics", href: "/extrinsics" }}
+      />
+    </AppShell>
+  ),
   component: ExtrinsicDetailPage,
 });
 
@@ -74,22 +93,8 @@ function ExtrinsicDetailPage() {
 }
 
 function ExtrinsicDetail({ hash }: { hash: string }) {
-  if (!isValidExtrinsicHash(hash)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid extrinsic reference"
-          description="Extrinsic references must be a 0x-prefixed hexadecimal hash or a block#index label (e.g. 123456-2)."
-        />
-        <EmptyState
-          title="Invalid extrinsic reference"
-          description="Use a 0x-prefixed hexadecimal extrinsic hash or a block#index label (e.g. 123456-2)."
-          action={{ label: "Back to extrinsics", href: "/extrinsics" }}
-        />
-      </>
-    );
-  }
+  // The router's parseParams rejects malformed hashes before this renders, so
+  // the detail component only ever runs with a well-formed hash.
   return <ValidExtrinsicDetail hash={hash} />;
 }
 


### PR DESCRIPTION
## Summary

Closes #3422

- Moves invalid-ref/hash handling for `/blocks/$ref` and `/extrinsics/$hash` up to the  router (#3422): each route now validates in `parseParams` (throwing TanStack Router's  `notFound()` on a malformed ref/hash) and defines a `notFoundComponent`, so a bad ref  renders a real not-found boundary instead of an in-component early return.
- Mirrors the existing pattern in `providers.$slug.tsx` and `subnets.$netuid.tsx`.
- Removes the now-dead in-component "invalid reference" branches in `BlockDetail` /  `ExtrinsicDetail`, which the router intercepts before they render.

## Files
- `apps/ui/src/routes/blocks.$ref.tsx`
- `apps/ui/src/routes/extrinsics.$hash.tsx`

## Behaviour
- `/blocks/<invalid>` and `/extrinsics/<invalid>` now render the route-level not-found page  (titled "Block not found" / "Extrinsic not found") via the router boundary, with a  "Back to blocks" / "Back to extrinsics" action — instead of the old inline "Invalid
  reference" message rendered inside the detail component.
- Valid refs/hashes are unaffected.

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1428" height="628" alt="dek-lg-be" src="https://github.com/user-attachments/assets/2b6b8cb2-ef85-41e0-bc6c-95a474151a71" /> | <img width="1387" height="598" alt="dek-lg-af" src="https://github.com/user-attachments/assets/8db6853c-4814-4bb7-96a5-fe9d12719abc" /> |
| Desktop · Dark   | <img width="1406" height="565" alt="dek-dk-be" src="https://github.com/user-attachments/assets/1dedd798-7a81-4c79-a4c8-7a880db684c1" /> | <img width="1387" height="577" alt="dek-dk-af" src="https://github.com/user-attachments/assets/ca772cc2-f065-495e-8c36-9b7c2819a915" /> |
| Tablet · Light   | <img width="663" height="889" alt="tab-lg-be" src="https://github.com/user-attachments/assets/7b4fa6ff-2776-4e4c-a0e3-82c7761e7b3d" /> | <img width="639" height="886" alt="tab-lg-af" src="https://github.com/user-attachments/assets/45ff4554-1605-4e19-a74b-b5365ea54e54" /> |
| Tablet · Dark    | <img width="638" height="876" alt="tab-dk-be" src="https://github.com/user-attachments/assets/db4761af-f1ea-409f-9907-eb8ea8637dd5" /> | <img width="640" height="872" alt="tab-dk-af" src="https://github.com/user-attachments/assets/abb16a79-7d71-4c46-94a0-ae5baf6369d0" /> |
| Mobile · Light   | <img width="442" height="911" alt="mb-lg-be" src="https://github.com/user-attachments/assets/443888cc-a304-4f7f-a23a-0f44a1abef38" /> | <img width="435" height="922" alt="mb-lg-af" src="https://github.com/user-attachments/assets/87db739f-0c63-4d6e-abd7-b2be70bdbd29" /> |
| Mobile · Dark    | <img width="421" height="923" alt="mb-dk-be" src="https://github.com/user-attachments/assets/30ab0347-fec6-49b9-b033-ced56a4331ef" /> | <img width="419" height="918" alt="mb-dk-af" src="https://github.com/user-attachments/assets/9d8f9e18-7388-4fe7-9a0a-1e359cbf6c74" /> |

> The visible change: an invalid block/extrinsic ref now renders a proper router
> not-found page (heading "Block not found" / "Extrinsic not found") instead of the old
> in-page "Invalid reference" message.

## Validation
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
