### PR TITLE
feat(ui): render human-readable event-kind labels in event tables

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -59,6 +59,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
+import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import type {
   AccountCounterparty,
   AccountRegistration,
@@ -1780,8 +1781,11 @@ function AccountEventsSection({
                       "—"
                     )}
                   </td>
-                  <td className="px-5 py-4 font-mono text-[11px] text-ink-strong">
-                    {ev.event_kind ?? "—"}
+                  <td
+                    className="px-5 py-4 font-mono text-[11px] text-ink-strong"
+                    title={ev.event_kind ?? undefined}
+                  >
+                    {eventKindLabel(ev.event_kind)}
                   </td>
                   <td className="px-5 py-4 font-mono text-[11px] text-ink-muted">
                     {ev.netuid != null ? (

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -24,6 +24,7 @@ import { formatNumber } from "@/lib/metagraphed/format";
 import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
+import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 
 export const Route = createFileRoute("/blocks/$ref")({
   // Prime the shared cache so head() can title the page with the real block
@@ -385,8 +386,11 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                       key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
                       className="hover:bg-surface/40"
                     >
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                        {event.event_kind ?? "—"}
+                      <td
+                        className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
+                        title={event.event_kind ?? undefined}
+                      >
+                        {eventKindLabel(event.event_kind)}
                       </td>
                       <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
                         {event.hotkey ? (

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -16,6 +16,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import {
   extrinsicCall,
   extrinsicHashPathSegment,
@@ -347,8 +348,11 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                         "—"
                       )}
                     </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                      {ev.event_kind ?? "—"}
+                    <td
+                      className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
+                      title={ev.event_kind ?? undefined}
+                    >
+                      {eventKindLabel(ev.event_kind)}
                     </td>
                     <td className="px-4 py-2.5 font-mono text-[11px]">
                       {ev.hotkey ? (


### PR DESCRIPTION
## Summary

- Wires the existing `eventKindLabel` helper (`apps/ui/src/lib/metagraphed/event-kinds.ts`, merged in #3563) into the three raw `event_kind` render sites: `apps/ui/src/routes/blocks.$ref.tsx`, `apps/ui/src/routes/extrinsics.$hash.tsx`, and `apps/ui/src/routes/accounts.$ss58.tsx` (`AccountEventsSection`).
- Each "Kind" cell now renders `eventKindLabel(event.event_kind)` (e.g. `StakeAdded` -> "Stake added", `null` -> "Unknown event", an unmapped kind -> humanized fallback) instead of the raw identifier / `?? "—"`.
- Each replaced `<td>` keeps its existing Tailwind classes and gains a `title` attribute exposing the raw `event_kind` for hover-inspection/debugging.
- No changes to `event-kinds.ts`, no category color/chip styling, no filter UI, no backend changes — text-only consumption of the already-merged map, per the issue's stated non-goals.

Closes #3368

## Screenshots

Live chain-indexed block/extrinsic/account data was unavailable from the shared API at capture time (`/api/v1/blocks`, `/api/v1/extrinsics` currently return empty result sets in this environment even though aggregate stats exist). To still exercise the real page code with real rendered pixels, each capture mocks the network responses for `GET /api/v1/blocks/{ref}`, `.../events`, `GET /api/v1/extrinsics/{hash}`, and `GET /api/v1/accounts/{ss58}(/events)` with a fixture payload matching the exact contract shapes in `apps/ui/src/lib/metagraphed/types.ts` (`BlockEvent`/`AccountEvent`) — the app itself, real components, and real `eventKindLabel` logic are unmodified; only the API layer is stubbed. The fixture set intentionally covers every `eventKindLabel` branch: a mapped label (`StakeAdded`), a second mapped label (`HotkeySwapped`), a governance-category mapped label (`SubnetOwnerHotkeySet`), a `null` kind (-> "Unknown event"), and an unmapped kind (`SomeNewPalletEvent` -> fallback humanization).

Tablet (768px) is omitted: the events table lives in a fixed `overflow-x-auto` container with no responsive column changes between 768px and 1280px, so Tablet renders the identical "Kind" column markup already shown at Desktop — Mobile (375px) and Desktop (1280px) are the two breakpoints that actually differ (card-adjacent horizontal scroll vs. full-width table).

| Page · Viewport · Theme | Before | After |
| --- | --- | --- |
| Block detail · Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-light-after.png)<br><sub>after</sub> |
| Block detail · Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-desktop-dark-after.png)<br><sub>after</sub> |
| Block detail · Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-light-after.png)<br><sub>after</sub> |
| Block detail · Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-block-mobile-dark-after.png)<br><sub>after</sub> |
| Extrinsic detail · Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-light-after.png)<br><sub>after</sub> |
| Extrinsic detail · Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-desktop-dark-after.png)<br><sub>after</sub> |
| Extrinsic detail · Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-light-after.png)<br><sub>after</sub> |
| Extrinsic detail · Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-extrinsic-mobile-dark-after.png)<br><sub>after</sub> |
| Account detail · Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-light-after.png)<br><sub>after</sub> |
| Account detail · Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-desktop-dark-after.png)<br><sub>after</sub> |
| Account detail · Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-light-after.png)<br><sub>after</sub> |
| Account detail · Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/event-kind-labels-3368-account-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (647 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification: ran two dev servers (merge-base vs. this branch) with identical mocked API responses and captured real before/after screenshots per the table above
