### PR TITLE
feat(ui): surface a per-account stake-flow section on the account page (#3341)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-stake-flow.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-stake-flow.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountStakeFlowQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${ALICE}/stake-flow`,
+  });
+}
+
+async function runQuery(ss58: string, params?: { window?: "7d" | "30d" | "90d" }) {
+  const opts = accountStakeFlowQuery(ss58, params);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountStakeFlowQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the stake-flow route with the window param and shapes the scorecard", async () => {
+    resolveWith({
+      ss58: ALICE,
+      window: "7d",
+      total_staked_tao: 100,
+      total_unstaked_tao: 40,
+      net_flow_tao: 60,
+      gross_flow_tao: 140,
+      direction: "accumulating",
+      concentration: 0.5,
+      dominant_netuid: 8,
+      subnet_count: 1,
+      subnets: [
+        {
+          netuid: 8,
+          staked_tao: 100,
+          unstaked_tao: 40,
+          net_flow_tao: 60,
+          gross_flow_tao: 140,
+          flow_ratio: 0.42,
+          direction: "accumulating",
+          stake_events: 5,
+          unstake_events: 2,
+        },
+      ],
+    });
+    const res = await runQuery(ALICE, { window: "7d" });
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/stake-flow`,
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+    expect(res.data).toMatchObject({
+      ss58: ALICE,
+      window: "7d",
+      net_flow_tao: 60,
+      gross_flow_tao: 140,
+      direction: "accumulating",
+      dominant_netuid: 8,
+      subnet_count: 1,
+    });
+    expect(res.data.subnets[0]).toMatchObject({
+      netuid: 8,
+      direction: "accumulating",
+      stake_events: 5,
+    });
+  });
+
+  it("drops subnet rows with no netuid and coerces junk cells to null", async () => {
+    resolveWith({
+      ss58: ALICE,
+      subnets: [
+        { netuid: 3, net_flow_tao: "nope", gross_flow_tao: {} },
+        { staked_tao: 1 }, // no netuid → dropped
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 3,
+        staked_tao: null,
+        unstaked_tao: null,
+        net_flow_tao: null,
+        gross_flow_tao: null,
+        flow_ratio: null,
+        direction: null,
+        stake_events: null,
+        unstake_events: null,
+      },
+    ]);
+    // subnet_count falls back to the surviving-row count when absent.
+    expect(res.data.subnet_count).toBe(1);
+  });
+
+  it("degrades a cold / idle account to an empty breakdown, defaulting the window", async () => {
+    for (const raw of [{}, null, { subnets: "not-an-array" }]) {
+      resolveWith(raw);
+      const res = await runQuery(ALICE);
+      expect(res.data.ss58).toBe(ALICE);
+      expect(res.data.window).toBe("30d");
+      expect(res.data.subnets).toEqual([]);
+      expect(res.data.subnet_count).toBe(0);
+      expect(res.data.net_flow_tao).toBeNull();
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -46,6 +46,8 @@ import type {
   AccountEventsPage,
   AccountCounterparties,
   AccountCounterparty,
+  AccountStakeFlow,
+  AccountStakeFlowSubnet,
   AccountHistory,
   AccountPortfolio,
   AccountStakeMoves,
@@ -2579,6 +2581,67 @@ export const accountCounterpartiesQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountCounterparties>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #3341: per-account staking-behavior scorecard — net/gross flow, a direction
+// label, concentration, and a per-subnet stake/unstake breakdown over a window,
+// from the already-live /api/v1/accounts/{ss58}/stake-flow. Structured-object
+// response, so it mirrors accountSubnetsQuery's apiFetch + isRecord + per-row
+// normalize shape.
+function normalizeStakeFlowSubnet(raw: unknown): AccountStakeFlowSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    staked_tao: firstFiniteNumber(raw.staked_tao) ?? null,
+    unstaked_tao: firstFiniteNumber(raw.unstaked_tao) ?? null,
+    net_flow_tao: firstFiniteNumber(raw.net_flow_tao) ?? null,
+    gross_flow_tao: firstFiniteNumber(raw.gross_flow_tao) ?? null,
+    flow_ratio: firstFiniteNumber(raw.flow_ratio) ?? null,
+    direction: firstString(raw.direction) ?? null,
+    stake_events: firstFiniteNumber(raw.stake_events) ?? null,
+    unstake_events: firstFiniteNumber(raw.unstake_events) ?? null,
+  };
+}
+
+export const accountStakeFlowQuery = (
+  ss58: string,
+  params?: { window?: "7d" | "30d" | "90d"; direction?: "in" | "out" },
+) =>
+  queryOptions({
+    queryKey: k("account-stake-flow", ss58, params ?? {}),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/stake-flow`, {
+        params,
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const subnets = Array.isArray(d.subnets)
+        ? d.subnets.flatMap((row) => {
+            const s = normalizeStakeFlowSubnet(row);
+            return s ? [s] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          window: firstString(d.window) ?? params?.window ?? "30d",
+          total_staked_tao: firstFiniteNumber(d.total_staked_tao) ?? null,
+          total_unstaked_tao: firstFiniteNumber(d.total_unstaked_tao) ?? null,
+          net_flow_tao: firstFiniteNumber(d.net_flow_tao) ?? null,
+          gross_flow_tao: firstFiniteNumber(d.gross_flow_tao) ?? null,
+          direction: firstString(d.direction) ?? null,
+          concentration: firstFiniteNumber(d.concentration) ?? null,
+          dominant_netuid: firstFiniteNumber(d.dominant_netuid) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? subnets.length,
+          subnets,
+        } as AccountStakeFlow,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountStakeFlow>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1286,6 +1286,37 @@ export interface AccountCounterparties {
   counterparties: AccountCounterparty[];
   [key: string]: unknown;
 }
+/** One per-subnet stake/unstake flow row in /accounts/{ss58}/stake-flow. */
+export interface AccountStakeFlowSubnet {
+  netuid: number;
+  staked_tao: number | null;
+  unstaked_tao: number | null;
+  net_flow_tao: number | null;
+  gross_flow_tao: number | null;
+  flow_ratio: number | null;
+  direction: string | null;
+  stake_events: number | null;
+  unstake_events: number | null;
+}
+/**
+ * #3341: /api/v1/accounts/{ss58}/stake-flow — per-account staking-behavior
+ * scorecard (net/gross flow, direction, concentration) + a per-subnet breakdown
+ * over a 7d|30d|90d window.
+ */
+export interface AccountStakeFlow {
+  ss58: string;
+  window: string;
+  total_staked_tao: number | null;
+  total_unstaked_tao: number | null;
+  net_flow_tao: number | null;
+  gross_flow_tao: number | null;
+  direction: string | null;
+  concentration: number | null;
+  dominant_netuid: number | null;
+  subnet_count: number;
+  subnets: AccountStakeFlowSubnet[];
+  [key: string]: unknown;
+}
 export interface AccountPortfolio {
   ss58: string;
   captured_at?: string | null;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -40,6 +40,7 @@ import { AccountPositionHistoryChart } from "@/components/metagraphed/account-po
 import {
   accountAxonRemovalsQuery,
   accountCounterpartiesQuery,
+  accountStakeFlowQuery,
   accountPortfolioQuery,
   accountStakeMovesQuery,
   accountDeregistrationsQuery,
@@ -61,6 +62,7 @@ import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
 import type {
   AccountCounterparty,
+  AccountStakeFlowSubnet,
   AccountRegistration,
   AccountSummary,
   Extrinsic,
@@ -264,6 +266,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       ) : null}
 
       <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
+      {/* #3341: staking-flow scorecard over the same subnet footprint. */}
+      <AccountStakeFlowSection ss58={ss58} />
 
       <AccountPortfolioSection ss58={ss58} />
       <AccountStakeMovesSection ss58={ss58} />
@@ -350,6 +354,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
             { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
+            { label: "stake-flow", path: `/api/v1/accounts/${sourceRef}/stake-flow` },
             { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
             { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
           ]}
@@ -363,6 +368,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
           `/api/v1/accounts/${sourceRef}/counterparties`,
+          `/api/v1/accounts/${sourceRef}/stake-flow`,
           `/api/v1/accounts/${sourceRef}/serving`,
           `/api/v1/accounts/${sourceRef}/prometheus`,
         ]}
@@ -969,6 +975,207 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
           Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
       ) : null}
+    </SectionAnchor>
+  );
+}
+
+const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
+
+// Direction label → tone, reusing the emerald/amber/muted convention the
+// transfers section uses for sent/received direction.
+function stakeFlowDirClass(dir: string | null | undefined): string {
+  if (dir === "accumulating") return "text-emerald-500";
+  if (dir === "exiting") return "text-amber-500";
+  if (dir === "churning") return "text-amber-400";
+  return "text-ink-muted"; // idle / unknown
+}
+
+// #3341: per-account staking-behavior scorecard — net vs gross flow, a direction
+// label, and the per-subnet stake/unstake breakdown over a selectable window,
+// from accountStakeFlowQuery. Self-contained + non-blocking (same shape as the
+// sibling subnet-breakdown sections); the window control is section-local state.
+function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
+  const [window, setWindow] = useState<(typeof STAKE_FLOW_WINDOWS)[number]>("30d");
+  const result = useQuery(accountStakeFlowQuery(ss58, { window }));
+  const f = result.data?.data;
+  const SUBTITLE =
+    "Net staking direction and per-subnet stake / unstake flow for this account over the selected window.";
+  const windowControl = (
+    <SelectFilter
+      label="Window"
+      value={window}
+      onChange={(v) =>
+        setWindow((STAKE_FLOW_WINDOWS as readonly string[]).includes(v) ? (v as never) : "30d")
+      }
+      options={STAKE_FLOW_WINDOWS.map((w) => ({ value: w, label: w }))}
+    />
+  );
+
+  if (result.isPending && !f) {
+    return <AccountFeedSectionSkeleton id="stake-flow" title="Stake flow" subtitle={SUBTITLE} />;
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor
+        id="stake-flow"
+        title="Stake flow"
+        subtitle={SUBTITLE}
+        tone="accent"
+        right={windowControl}
+      >
+        <TableState
+          variant="error"
+          title="Couldn't load stake flow"
+          description="The stake-flow tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const subnets: AccountStakeFlowSubnet[] = f?.subnets ?? [];
+  const netFlow = f?.net_flow_tao ?? null;
+  const netStr =
+    netFlow == null ? "—" : `${netFlow >= 0 ? "+" : "−"}${fmtTaoCompact(Math.abs(netFlow))}`;
+  // BarMini widths are unsigned (value / cap), so bar the always-≥0 gross flow
+  // and surface each row's direction as a label in the table alongside.
+  const bars = [...subnets]
+    .filter((s) => (s.gross_flow_tao ?? 0) > 0)
+    .sort((a, b) => (b.gross_flow_tao ?? 0) - (a.gross_flow_tao ?? 0))
+    .slice(0, 12)
+    .map((s) => ({ label: `SN${s.netuid}`, value: s.gross_flow_tao ?? 0 }));
+
+  return (
+    <SectionAnchor
+      id="stake-flow"
+      title="Stake flow"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="Per-account staking behavior from /api/v1/accounts/{ss58}/stake-flow — net vs gross TAO flow, a direction label (accumulating / exiting / churning / idle), concentration, and the per-subnet stake / unstake breakdown over the window."
+      right={windowControl}
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile
+          icon={TrendingUp}
+          eyebrow="Net flow"
+          tone="accent"
+          value={
+            <span
+              className={netFlow != null && netFlow < 0 ? "text-amber-500" : "text-emerald-500"}
+            >
+              {netStr}
+            </span>
+          }
+          hint={`over ${f?.window ?? window}`}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Activity}
+          eyebrow="Gross flow"
+          value={fmtTaoCompact(f?.gross_flow_tao)}
+          hint="staked + unstaked"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Gauge}
+          eyebrow="Direction"
+          value={<span className={stakeFlowDirClass(f?.direction)}>{f?.direction ?? "—"}</span>}
+          hint={
+            f?.concentration != null
+              ? `${(f.concentration * 100).toFixed(0)}% concentrated`
+              : undefined
+          }
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Dominant subnet"
+          value={
+            f?.dominant_netuid != null ? (
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid: f.dominant_netuid }}
+                className="text-ink-strong hover:text-accent hover:underline"
+              >
+                SN{f.dominant_netuid}
+              </Link>
+            ) : (
+              "—"
+            )
+          }
+          hint={`${formatNumber(f?.subnet_count ?? 0)} subnets`}
+          className={KPI_TILE}
+        />
+      </div>
+
+      {bars.length > 0 ? (
+        <div className="mb-5 rounded-2xl border border-border/80 bg-card/95 px-5 py-4 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            gross flow by subnet (τ)
+          </div>
+          <BarMini data={bars} showValue={false} />
+        </div>
+      ) : null}
+
+      {subnets.length > 0 ? (
+        <DataPanel>
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/50">
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={TH}>Direction</th>
+                <th className={`${TH} text-right`}>Net flow</th>
+                <th className={`${TH} text-right`}>Gross flow</th>
+                <th className={`${TH} text-right`}>Events</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {[...subnets]
+                .sort((a, b) => (b.gross_flow_tao ?? 0) - (a.gross_flow_tao ?? 0))
+                .slice(0, 20)
+                .map((s) => (
+                  <tr key={s.netuid} className="hover:bg-surface/30">
+                    <td className="px-5 py-4 font-mono text-[12px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: s.netuid }}
+                        className="text-ink hover:text-accent hover:underline"
+                      >
+                        SN{s.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-4 font-mono text-[11px]">
+                      <span className={stakeFlowDirClass(s.direction)}>{s.direction ?? "—"}</span>
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums">
+                      {s.net_flow_tao == null ? (
+                        <span className="text-ink-muted">—</span>
+                      ) : (
+                        <span
+                          className={s.net_flow_tao >= 0 ? "text-emerald-500" : "text-amber-500"}
+                        >
+                          {s.net_flow_tao >= 0 ? "+" : "−"}
+                          {fmtStake(Math.abs(s.net_flow_tao))}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {fmtStake(s.gross_flow_tao)}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber((s.stake_events ?? 0) + (s.unstake_events ?? 0))}
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </DataPanel>
+      ) : (
+        <p className="rounded-2xl border border-border/80 bg-card/95 px-5 py-4 font-mono text-[11px] text-ink-muted">
+          No stake or unstake flow recorded for this account over the {f?.window ?? window} window.
+        </p>
+      )}
     </SectionAnchor>
   );
 }


### PR DESCRIPTION
Closes #3341

## Summary

Adds a **Stake flow** section to the account detail page — this account's net staking direction and per-subnet stake/unstake flow over a selectable window, from the already-live `GET /api/v1/accounts/{ss58}/stake-flow`. Data-layer + UI in one PR; **no backend change**.

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `accountStakeFlowQuery(ss58, { window })` + a `normalizeStakeFlowSubnet` helper, mirroring `accountSubnetsQuery`'s `apiFetch` + `isRecord` + per-row normalize shape. Numeric cells coerce to `null` (never `NaN`), netuid-less rows drop, `subnet_count`/`window` fall back sensibly.
- **`apps/ui/src/lib/metagraphed/types.ts`** — new `AccountStakeFlow` + `AccountStakeFlowSubnet` response types.
- **`apps/ui/src/routes/accounts.$ss58.tsx`** — new self-contained `AccountStakeFlowSection({ ss58 })` (non-blocking `useQuery`), placed right after the subnet-footprint section:
  - a summary `StatTile` row — **Net flow** (signed + green/amber toned), **Gross flow**, **Direction** (`accumulating`/`exiting`/`churning`/`idle`, color-coded), and the **Dominant subnet** (linked to `/subnets/$netuid`);
  - a `BarMini` of **gross flow by subnet** (unsigned — bars the always-≥0 gross flow, with each row's direction shown as a label in the table);
  - a per-subnet table (subnet → subnet page, direction, signed net flow, gross flow, events);
  - a **`7d`/`30d`/`90d` window `SelectFilter`** wired to section-local state that re-fetches on change.
  - Loading → shared skeleton; error → `TableState` without blocking the page; cold/idle account → an empty note (the section + its window control stay visible). The new route is added to the `EndpointSnippet` rows and `ApiSourceFooter`.

## Scope (matches the issue's acceptance criteria)

- [x] Diff touches `apps/ui/src/routes/accounts.$ss58.tsx` (not just `queries.ts`)
- [x] New `accountStakeFlowQuery` calling `/api/v1/accounts/{ss58}/stake-flow`
- [x] `AccountStakeFlowSection` imports + calls it via `useQuery`
- [x] Renders net/gross flow, a direction label, the dominant subnet (linked), and a per-subnet breakdown bar list keyed by netuid
- [x] `7d`/`30d`/`90d` window control re-fetches on change
- [x] Loading / empty (zero-subnet / cold) / error states handled; never blocks the page via `Suspense`

## Non-goals respected

- No `/subnets/{netuid}/stake-flow` wiring / `subnets.$netuid.tsx` change (#3342); no `/accounts/{ss58}/stake-moves` wiring; existing account queries untouched beyond adding the new one.

## Local verification

- `npm run typecheck --workspace=apps/ui` ✓
- `npm test --workspace=apps/ui` ✓ — **650 tests** (adds `accountStakeFlowQuery` param/normalize/cold-account tests)
- `eslint` clean on the changed files (0 errors)

## Before / after screenshots — account detail page

> **Note on the data:** live per-account `Balances` stake-flow is sparse for most accounts right now, so production accounts render this section's graceful empty state (covered by tests). To make the rendered component reviewable, the **`after`** captures use Playwright route-interception to serve a **representative** `/stake-flow` payload (realistic τ volumes + mixed directions across subnets). `before` = current production (same account) — the page has no stake-flow section.

| Viewport · Theme | Before (production — no section) | After (new Stake flow section, representative payload) |
| ---------------- | --- | --- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-light-before.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-light-after.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-light-after.png) |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-dark-before.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-dark-after.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-desktop-dark-after.png) |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-light-before.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-light-before.png) | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-light-after.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-light-after.png) |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-dark-before.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-dark-before.png) | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-dark-after.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-tablet-dark-after.png) |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-light-before.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-light-after.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-light-after.png) |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-dark-before.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-dark-after.png" width="360">](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/stakeflow-mobile-dark-after.png) |

On mobile the summary `StatTile`s stack to one column and the bar list / table read cleanly — compact values, no cell-wrap crowding.
