### PR TITLE
feat(ui): add an enrichment-targets board to the gaps review surface

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6852,6 +6852,45 @@ export const reviewEnrichmentQueueQuery = () =>
     staleTime: STALE_LONG,
   });
 
+// #3355: the per-target enrichment board — distinct from the per-subnet
+// enrichment-queue rollup above. GET /api/v1/review/enrichment-targets, flat
+// `targets` list (the `groups`/`summary` wrapper is out of scope).
+export const reviewEnrichmentTargetsQuery = () =>
+  queryOptions({
+    queryKey: k("review-enrichment-targets"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/enrichment-targets",
+        "targets",
+        undefined,
+        signal,
+      );
+      // API rows: { netuid, name, target_type, target_action, priority_score,
+      // missing_kinds, recommended_action, contribution_prompt, ... }.
+      const rows = res.data.map((r) => ({
+        id:
+          (r.target_id as string) ??
+          `${(r.slug as string) ?? String(r.netuid ?? "")}-${(r.target_type as string) ?? ""}`,
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        targetType: (r.target_type as string) ?? (r.kind as string),
+        targetAction: r.target_action as string | undefined,
+        priority:
+          typeof r.priority_score === "number"
+            ? String(Math.round(r.priority_score as number))
+            : undefined,
+        note:
+          (Array.isArray(r.missing_kinds) && r.missing_kinds.length > 0
+            ? (r.missing_kinds as string[]).join(", ")
+            : undefined) ??
+          (r.recommended_action as string) ??
+          (r.contribution_prompt as string),
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
 function normalizeSchema(raw: unknown): SchemaInfo {
   if (!raw || typeof raw !== "object") return raw as SchemaInfo;
   const s = raw as Record<string, unknown>;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -29,6 +29,7 @@ import {
   reviewProfileCompletenessQuery,
   reviewAdapterCandidatesQuery,
   reviewEnrichmentQueueQuery,
+  reviewEnrichmentTargetsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
@@ -201,6 +202,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="enrichment-targets"
+          eyebrow="Targets"
+          title="Enrichment targets"
+          description="Per-target contributor task board — the specific surfaces to add per subnet, ranked by priority."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <EnrichmentTargets />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -209,6 +223,7 @@ function GapsPage() {
           "/api/v1/review/profile-completeness",
           "/api/v1/review/adapter-candidates",
           "/api/v1/review/enrichment-queue",
+          "/api/v1/review/enrichment-targets",
         ]}
       />
     </AppShell>
@@ -994,6 +1009,70 @@ function EnrichmentQueue() {
                   ) : (
                     "—"
                   )}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// #3355: per-target enrichment board — mirrors EnrichmentQueue's table idiom but
+// sourced from /api/v1/review/enrichment-targets (several targets per subnet).
+function EnrichmentTargets() {
+  const { data } = useSuspenseQuery(reviewEnrichmentTargetsQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No enrichment targets"
+        description="Every subnet's target surfaces are covered — nothing outstanding."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-4 py-2.5 text-left">Netuid</th>
+              <th className="px-4 py-2.5 text-left">Subnet</th>
+              <th className="px-4 py-2.5 text-left">Target</th>
+              <th className="px-4 py-2.5 text-left">Action</th>
+              <th className="px-4 py-2.5 text-left">Priority</th>
+              <th className="px-4 py-2.5 text-left">Missing / recommended</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => (
+              <tr key={r.id} className="mg-row-hover">
+                <td className="px-4 py-2.5 font-mono text-[11px]">
+                  {r.netuid != null ? (
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="hover:text-accent"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-strong">{r.name ?? "—"}</td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.targetType ?? "—"}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.targetAction ?? "—"}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>


### PR DESCRIPTION
## Summary

Adds an **Enrichment targets** section to the gaps review surface (`/gaps`), wiring the live `GET /api/v1/review/enrichment-targets` endpoint — the per-target contributor task board — which nothing in `apps/ui/src` consumed yet. Distinct from, and additive to, the existing per-subnet "Enrichment queue" rollup on the same page.

Closes #3355

> Re-do of #4223 (closed only because it lacked before/after screenshot evidence — its code scored readiness 100/100). Same wiring, now with the full screenshot table below.

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `reviewEnrichmentTargetsQuery` following the sibling `reviewEnrichmentQueueQuery` pattern (`fetchList` on the `targets` key; normalizes `netuid`, `name`, `target_type`, `target_action`, `priority_score`, and a `missing_kinds`→`recommended_action`→`contribution_prompt` note fallback).
- **`apps/ui/src/routes/gaps.tsx`** — a new self-contained `EnrichmentTargets` component + `<PageSection id="enrichment-targets">` rendered right after the `enrichment-queue` section, mirroring `EnrichmentQueue`'s table idiom (columns: Netuid · Subnet · Target · Action · Priority · Missing/recommended), the shared `TableState` empty state, the page's standard `Suspense`/`QueryErrorBoundary`, and `/api/v1/review/enrichment-targets` appended to `ApiSourceFooter`.
- Scoped to the flat `targets` list (the `groups`/`summary` wrapper is out of scope, matching the sibling sections). No backend/schema change — the endpoint is already live.

## Screenshots

Route `/gaps`, the new section scrolled into view, fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes. **Real live data** (the endpoint returns 151 targets) — before: the page ends at "Enrichment queue"; after: the "Enrichment targets" board is added below it.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3355-after-mobile-dark.png)<br><sub>after</sub> |

## Validation (full local run)

- [x] `npm run typecheck` — clean · `npm run lint` — 0 errors on the changed files
- [x] `npm test` — 647 passed · `npm run build` — green
- [x] Data layer + UI wiring in one PR; reuses the sibling table/empty-state idiom; no new dependency
