### PR TITLE
fix(a11y): make activity-heatmap day cells keyboard-focusable so tooltips reveal on focus

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -125,8 +125,12 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
               {col.map((c) => (
                 <Tooltip key={c.key} delayDuration={120}>
                   <TooltipTrigger asChild>
-                    <div
-                      className="aspect-square rounded-[2px] border border-border/40"
+                    {/* A focusable <button> (not a bare div) so keyboard users can
+                        reach each day and reveal its Radix tooltip — the tooltip
+                        only shows on focus for genuinely focusable triggers (#3955). */}
+                    <button
+                      type="button"
+                      className="aspect-square w-full rounded-[2px] border border-border/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                       style={{ background: tone(c.score, maxScore) }}
                       aria-label={`${c.key}: ${c.probes} probes, ${c.incidents} incidents`}
                     />


### PR DESCRIPTION
## Problem

In the subnet Registry-activity `activity-heatmap.tsx`, each day cell is a bare `<div>` wrapped in a Radix `<TooltipTrigger asChild>`, with an `aria-label` but no `tabIndex`/`role`. Radix tooltips only reveal on focus for genuinely focusable triggers, so a bare `<div>` — never in the tab order — leaves keyboard users unable to reach the per-day tooltip (probes / incidents / uptime). The sibling `subnet-pulse-grid.tsx` wraps the same pattern around a naturally-focusable `<Link>` and works correctly (#3955).

## Fix

Swap the cell's bare `<div>` for a semantic, naturally-focusable `<button type="button">` (the cell has no navigational purpose), with a `focus-visible` ring. It's now in the tab order, so keyboard focus reveals the same Radix tooltip that hover does. Visual rendering on load is unchanged.

## Before / after

Subnet page Registry-activity heatmap; the same day cell is focused programmatically in both.

| Theme | Before (bare `<div>`) | After (`<button>`) |
| --- | --- | --- |
| Dark | ![before dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3955-screenshots/screenshots/3955/before_dark.png) | ![after dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3955-screenshots/screenshots/3955/after_dark.png) |
| Light | ![before light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3955-screenshots/screenshots/3955/before_light.png) | ![after light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3955-screenshots/screenshots/3955/after_light.png) |

Before, focusing a cell is a no-op (`div`, not in the tab order → no focus ring, no tooltip). After, the cell takes focus (`button`), shows a focus ring, and reveals its tooltip — exactly what a keyboard user gets.

Local: `tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check` (clean).

Closes #3955
