### PR TITLE
fix(ui): show error state in SubnetLineageSection on fetch failure (#3967)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -466,8 +466,27 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
 // subnet pages); renders nothing unless this netuid is paired with a counterpart.
 // Reads lineageRes.data.links (NOT a top-level array).
 function SubnetLineageSection({ netuid }: { netuid: number }) {
-  const { data: lineageRes } = useQuery(lineageQuery());
+  const { data: lineageRes, isError, error, refetch } = useQuery(lineageQuery());
   const lineage = lineageRes?.data;
+
+  if (isError) {
+    return (
+      <SectionAnchor
+        id="lineage"
+        title="Lineage"
+        info="Cross-network lineage links the testnet and mainnet deployments of the same subnet, matched by chain name or source repo."
+      >
+        <TableState
+          variant="error"
+          title="Lineage unavailable"
+          description="The cross-network lineage data failed to load."
+          error={error}
+          onRetry={() => void refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
   const link = (lineage?.links ?? []).find(
     (l) => l.mainnet_netuid === netuid || l.testnet_netuid === netuid,
   );


### PR DESCRIPTION
## Summary

`SubnetLineageSection` (`apps/ui/src/routes/subnets.$netuid.tsx`) used `useQuery(lineageQuery())` and returned `null` whenever `!lineage || !link` — which collapsed **fetch-error**, **still-loading**, and **genuinely-no-lineage** into the same silent nothing. On a failed `/api/v1/lineage` fetch the section just disappeared, with no indication anything went wrong.

This adds an `isError` branch that renders the shared `TableState variant="error"` component (with a **Retry** action, consistent with sibling sections on the same page), before the no-link check. The genuine "no lineage" case is unchanged (still `null`, per the issue's non-goals).

## Change

- One file: `apps/ui/src/routes/subnets.$netuid.tsx`, `SubnetLineageSection` only.
- Destructures `isError`, `error`, `refetch` from the existing query; on error, renders a `SectionAnchor id="lineage"` containing `TableState variant="error"` with `onRetry={() => void refetch()}`.
- Error state is visually distinct from the empty/no-lineage state (red alert tone, error message, retry), satisfying the "distinct from a legitimate empty state" requirement.

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 647 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow, incl. /subnets/1)
```

The error state was reproduced by aborting the `/api/v1/lineage` request in the browser (React Query surfaces `isError` after its retry backoff); a successful fetch and the genuine no-lineage case render exactly as before.

## Screenshots

Error state reproduced by blocking `/api/v1/lineage` on `/subnets/1`. **Before:** the Lineage section silently vanishes (nothing renders between *Reliability* and *Sources & evidence*). **After:** a distinct error card with a Retry action.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/mobile-dark-after.png)<br><sub>after</sub> |

Closes #3967
