### PR TITLE
feat(registry): add SN52 Dojo TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -190,6 +190,25 @@
         "https://raw.githubusercontent.com/tensorplex-labs/dojo-worker-api/main/docs/swagger.json"
       ],
       "url": "https://cdn.jsdelivr.net/gh/tensorplex-labs/dojo-worker-api@main/docs/swagger.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-52-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Dojo TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/52 on api.taomarketcap.com returning machine-readable JSON for SN52 Dojo on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/dojo"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/52"
     }
   ],
   "contact": "jarvis@tensorplex.ai"


### PR DESCRIPTION
## Summary

Enriches **SN52 Dojo** with a public no-auth subnet-state API as a `subnet-api` surface.

- **url:** `https://api.taomarketcap.com/public/v1/subnets/52` — public, no-auth JSON (on-chain state, SubnetIdentitiesV3 metadata, economics, dTAO market fields), documented in the TaoMarketCap developer API.

## Why it's safe

- One file, one `subnet-api` surface (provider `taomarketcap` already registered); purely additive.
- Not a duplicate (SN52 has no existing taomarketcap surface).
- Same accepted pattern as the merged SN101 eni TaoMarketCap subnet-api (community authority, honest 'indexed feed' framing).
- `validate:surface` + `scan:public-safety` pass locally.

Closes #4056