### PR TITLE
fix(api): guard the realtime ingest batch writes with a timeout + error response

### DIFF
--- a/tests/block-ingest.test.mjs
+++ b/tests/block-ingest.test.mjs
@@ -164,6 +164,45 @@ test("block ingest rejects a non-object body (400)", async () => {
   assert.equal(res.status, 400);
 });
 
+test("block ingest returns 500 ingest_write_failed when db.batch throws (#4651 incident hardening)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch() {
+        throw new Error("D1_ERROR: database is locked");
+      },
+    },
+  };
+  const res = await handleBlockIngest(
+    post({ blocks: [BLOCK], extrinsics: [EXTRINSIC] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 500);
+  const body = await res.json();
+  assert.equal(body.error.code, "ingest_write_failed");
+});
+
+test("block ingest batch-failure logging falls back to the thrown value when it has no .message", async () => {
+  // A rejection can throw a non-Error (a bare string, here) -- exercises the
+  // `error?.message ?? error` fallback arm alongside the Error-with-message
+  // case above.
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch() {
+        throw "db unavailable";
+      },
+    },
+  };
+  const res = await handleBlockIngest(
+    post({ blocks: [BLOCK], extrinsics: [EXTRINSIC] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 500);
+});
+
 test("block ingest rejects too many rows (413)", async () => {
   const env = {
     METAGRAPH_EVENTS_INGEST_SECRET: SECRET,

--- a/tests/event-ingest.test.mjs
+++ b/tests/event-ingest.test.mjs
@@ -241,6 +241,55 @@ test("ingest rejects a non-array body (400)", async () => {
   assert.equal(res.status, 400);
 });
 
+test("ingest returns 500 ingest_write_failed when db.batch throws (#4651 incident hardening)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch() {
+        throw new Error("D1_ERROR: database is locked");
+      },
+    },
+  };
+  const rows = [
+    {
+      block_number: 20,
+      event_index: 0,
+      event_kind: "WeightsSet",
+      observed_at: 1,
+    },
+  ];
+  const res = await handleEventIngest(post(rows, { secret: SECRET }), env);
+  assert.equal(res.status, 500);
+  const body = await res.json();
+  assert.equal(body.error.code, "ingest_write_failed");
+});
+
+test("ingest batch-failure logging falls back to the thrown value when it has no .message", async () => {
+  // A rejection can throw a non-Error (a bare string, here) -- exercises the
+  // `error?.message ?? error` fallback arm alongside the Error-with-message
+  // case above.
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch() {
+        throw "db unavailable";
+      },
+    },
+  };
+  const rows = [
+    {
+      block_number: 21,
+      event_index: 0,
+      event_kind: "WeightsSet",
+      observed_at: 1,
+    },
+  ];
+  const res = await handleEventIngest(post(rows, { secret: SECRET }), env);
+  assert.equal(res.status, 500);
+});
+
 test("ingest rejects too many rows (413)", async () => {
   const env = {
     METAGRAPH_EVENTS_INGEST_SECRET: SECRET,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -21,10 +21,12 @@ import {
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
 } from "./http.mjs";
 import {
+  d1TimeoutMs,
   latestPointer,
   logEvent,
   readArtifact,
   readHealthKv,
+  withTimeout,
 } from "./storage.mjs";
 import {
   contractStaleness,
@@ -580,7 +582,30 @@ export async function handleEventIngest(request, env) {
   // D1 `meta.changes` instead.
   let inserted = 0;
   if (rows.length) {
-    const results = await db.batch(eventInsertStatements(db, rows));
+    // Bounded + logged, matching d1All's read-side guard (workers/request-handlers/
+    // analytics.mjs): this D1 database now takes concurrent writes from several
+    // ingest/backfill paths, so an occasional contention timeout here is
+    // expected, not exceptional -- it must surface as a clean 500 the streamer's
+    // own retry loop already handles, never an uncaught exception (2026-07-09
+    // incident: an unguarded batch() failure here silently starved the realtime
+    // block/event feed for ~40 minutes with no server-side trace of why).
+    let results;
+    try {
+      results = await withTimeout(
+        db.batch(eventInsertStatements(db, rows)),
+        d1TimeoutMs(env),
+      );
+    } catch (error) {
+      logEvent(env, "error", "events_ingest_batch_failed", {
+        message: String(error?.message ?? error),
+        row_count: rows.length,
+      });
+      return errorResponse(
+        "ingest_write_failed",
+        "Event batch write failed; retry this payload.",
+        500,
+      );
+    }
     for (const result of results) inserted += result?.meta?.changes ?? 0;
   }
   return new Response(JSON.stringify({ ok: true, inserted }), {
@@ -670,7 +695,25 @@ export async function handleBlockIngest(request, env) {
   let blocksInserted = 0;
   let extrinsicsInserted = 0;
   if (blockStmts.length || extrinsicStmts.length) {
-    const results = await db.batch([...blockStmts, ...extrinsicStmts]);
+    // Bounded + logged, same reasoning as handleEventIngest's batch guard above.
+    let results;
+    try {
+      results = await withTimeout(
+        db.batch([...blockStmts, ...extrinsicStmts]),
+        d1TimeoutMs(env),
+      );
+    } catch (error) {
+      logEvent(env, "error", "blocks_ingest_batch_failed", {
+        message: String(error?.message ?? error),
+        block_count: blockStmts.length,
+        extrinsic_count: extrinsicStmts.length,
+      });
+      return errorResponse(
+        "ingest_write_failed",
+        "Block/extrinsic batch write failed; retry this payload.",
+        500,
+      );
+    }
     results.forEach((result, i) => {
       const changes = result?.meta?.changes ?? 0;
       if (i < blockStmts.length) blocksInserted += changes;


### PR DESCRIPTION
## Summary

Investigated why production's chain-events pipeline (\`/health\`'s \`chain_events\`, \`/api/v1/blocks\`, \`/api/v1/extrinsics\`) showed null/zero data for ~30-45 minutes on 2026-07-09.

**Architecture note:** these routes are D1-backed (\`metagraphed-health\`), fed by a realtime Python streamer (\`metagraphed-streamer\` on \`meta-indexer-01-us-lax1\`) POSTing to \`/api/v1/internal/events\`/\`/api/v1/internal/blocks\` — a separate, decoupled pipeline from the indexer-rs/Postgres/Hyperdrive tier on the same box (which serves deep history via the dedicated data-api Worker).

**What I found:** SSH'd into the indexer box, confirmed the streamer was healthy and correctly decoding chain data, but its ingest pushes were being rejected with HTTP 500 (Cloudflare error 1101 — uncaught Worker exception). \`handleEventIngest\`/\`handleBlockIngest\` call \`db.batch(...)\` directly with no timeout and no error handling, unlike the read-side \`d1All\` helper. The pipeline self-recovered before I could catch the live exception (confirmed via \`wrangler tail\` + a direct D1 query that both endpoints now succeed and D1 is fresh), but this closes the gap regardless — an uncaught D1 exception on the write path should never be silent, especially now that several other features (hyperparameter history, account identity history, position-daily) share this same D1 database's write capacity.

## Description

- \`handleEventIngest\` and \`handleBlockIngest\` (workers/api.mjs) now wrap their \`db.batch()\` call in \`withTimeout(..., d1TimeoutMs(env))\`, matching the existing read-side \`d1All\` guard.
- A caught failure is logged via \`logEvent(env, "error", ...)\` (row/block/extrinsic counts, error message) and returns a clean \`500 ingest_write_failed\` — the streamer's own retry-with-backoff logic already treats 5xx as retryable (only 401/403 are treated as permanent).
- Full incident writeup in Closes #4654.

## Test plan

- [x] New tests: both handlers return \`500 ingest_write_failed\` when \`db.batch\` throws (an \`Error\` with \`.message\`, and a bare thrown string exercising the \`error?.message ?? error\` fallback)
- [x] \`npm run lint\` clean
- [x] \`npx prettier --check\` clean on all 3 touched files
- [x] \`npm run test:coverage\` (full, unsharded) — 249/249 files, 6892/6892 tests passed; no new coverage gaps in \`workers/api.mjs\` (verified via lcov branch-detail that both new partial branches are now covered)

Closes #4654