### PR TITLE
fix(ui): show error state in account Balance tile on fetch failure (#3960)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -3,6 +3,7 @@ import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Fragment, Suspense, useState, type ReactNode } from "react";
 import {
   Activity,
+  AlertCircle,
   Boxes,
   TrendingUp,
   Sparkles,
@@ -14,6 +15,7 @@ import {
   Fingerprint,
   Gauge,
   Radar,
+  RefreshCw,
   Rows3,
   Scale,
   Unplug,
@@ -157,7 +159,19 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const signedExtrinsics = extrinsicsResult.data?.data ?? [];
   const transfers = transfersResult.data?.data ?? [];
 
-  const balanceValue = balanceResult.isPending ? (
+  const balanceValue = balanceResult.isError ? (
+    <span className="inline-flex items-center gap-2">
+      <AlertCircle aria-hidden className="size-4 text-health-down" />
+      <span className="text-base font-medium text-health-down">Unavailable</span>
+      <button
+        type="button"
+        onClick={() => void balanceResult.refetch()}
+        className="inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 text-[11px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
+      >
+        <RefreshCw className="size-3" /> Retry
+      </button>
+    </span>
+  ) : balanceResult.isPending ? (
     <span className="text-ink-muted">…</span>
   ) : balance?.balance_tao != null ? (
     formatTao(balance.balance_tao)
@@ -214,12 +228,18 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 
       <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <StatTile
-          icon={Coins}
+          icon={balanceResult.isError ? AlertCircle : Coins}
           eyebrow="Balance"
           value={balanceValue}
-          hint={balance?.balance_tao != null ? "free + reserved · live RPC" : "live RPC"}
-          tone="accent"
-          className="rounded-2xl border-accent/25 bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
+          hint={
+            balanceResult.isError
+              ? "live RPC failed"
+              : balance?.balance_tao != null
+                ? "free + reserved · live RPC"
+                : "live RPC"
+          }
+          tone={balanceResult.isError ? "down" : "accent"}
+          className="rounded-2xl bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
         />
         <StatTile
           icon={Activity}


### PR DESCRIPTION
## Summary

The account **Balance** tile on `apps/ui/src/routes/accounts.$ss58.tsx` only handled `isPending` and success — on a failed `/api/v1/accounts/{ss58}/balance` fetch it gave **no error feedback**, leaving the tile in an indistinct loading/empty state with no way to tell "failed" from "still loading" or "no data".

This adds an `isError` branch (the query already reports it) that renders a distinct in-tile error state — a red alert icon, **"Unavailable"**, and a **Retry** action (`balanceResult.refetch()`) — and switches the tile `tone` to `down` (red hairline) and its hint to `live RPC failed`. Loading (`…`), error, and unknown (`—`) are now visually distinct from each other.

Per the issue, a compact KPI tile gets an inline error affordance rather than a full `ErrorState` card.

## Change

- One file: `apps/ui/src/routes/accounts.$ss58.tsx` (Balance `StatTile` only).
- No change to the balance query, network layer, or retry policy (issue non-goal) — purely a render branch on the `isError` the query already surfaces.
- Successful fetch and the genuine "no balance" case render exactly as before.

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors (file clean)
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 647 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Error state reproduced by aborting the `/**/balance**` request in the browser; React Query surfaces `isError` after its retry backoff, at which point the tile shows the error + Retry instead of a silent placeholder.

## Screenshots

Balance fetch blocked on `/accounts/{ss58}`. **Before:** the Balance tile shows a silent placeholder (`— live RPC`) indistinguishable from empty — no indication the fetch failed. **After:** a distinct red "Unavailable" state with a Retry action.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3960/mobile-dark-after.png)<br><sub>after</sub> |

Closes #3960
