### PR TITLE
feat(ui): add CSV export to the account events, extrinsics, and transfers feeds

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -31,6 +31,8 @@ import { PageHero } from "@/components/metagraphed/page-hero";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
 import { SelectFilter } from "@/components/metagraphed/table-controls";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
+import { buildUrl, type QueryParams } from "@/lib/metagraphed/client";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
@@ -311,6 +313,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
 
       <AccountExtrinsicsSection
+        ss58={ss58}
         rows={signedExtrinsics}
         isPending={extrinsicsResult.isPending}
         isError={extrinsicsResult.isError}
@@ -425,13 +428,27 @@ function AccountFeedSectionSkeleton({
   );
 }
 
+// #3407: absolute CSV-export URL for an account sub-resource feed. The server
+// emits text/csv (with a Content-Disposition filename) for the same list routes
+// the tables read, so DownloadCsvButton just appends format=csv to this URL and
+// the export mirrors exactly the rows/filters currently in view.
+function accountCsvUrl(
+  ss58: string,
+  sub: "events" | "extrinsics" | "transfers",
+  params?: QueryParams,
+): string {
+  return buildUrl(`/api/v1/accounts/${ss58PathSegment(ss58)}/${sub}`, params);
+}
+
 function AccountExtrinsicsSection({
+  ss58,
   rows,
   isPending,
   isError,
   error,
   onRetry,
 }: {
+  ss58: string;
   rows: Extrinsic[];
   isPending?: boolean;
   isError?: boolean;
@@ -477,7 +494,12 @@ function AccountExtrinsicsSection({
       title="Signed extrinsics"
       subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
       tone="accent"
-      right={<SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>}
+      right={
+        <div className="flex items-center gap-2">
+          <DownloadCsvButton url={accountCsvUrl(ss58, "extrinsics", { limit: 25 })} />
+          <SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>
+        </div>
+      }
     >
       <DataPanel>
         <table className="w-full text-left text-sm">
@@ -599,7 +621,12 @@ function AccountTransfersSection({
       title="Transfers"
       subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
       tone="accent"
-      right={<SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>}
+      right={
+        <div className="flex items-center gap-2">
+          <DownloadCsvButton url={accountCsvUrl(ss58, "transfers", { limit: 25 })} />
+          <SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>
+        </div>
+      }
     >
       <DataPanel>
         <table className="w-full text-left text-sm">
@@ -1739,14 +1766,17 @@ function AccountEventsSection({
       subtitle="Full first-party event feed for this account, newest first — filter by kind, page through history."
       tone="accent"
       right={
-        kindOptions.length > 0 ? (
-          <SelectFilter
-            label="Kind"
-            value={search.ev_kind ?? ""}
-            onChange={(v) => setSearch({ ev_kind: v || undefined, ev_offset: undefined })}
-            options={kindOptions.map((k) => ({ value: k.kind, label: k.kind }))}
-          />
-        ) : undefined
+        <div className="flex items-center gap-2">
+          <DownloadCsvButton url={accountCsvUrl(ss58, "events", params)} />
+          {kindOptions.length > 0 ? (
+            <SelectFilter
+              label="Kind"
+              value={search.ev_kind ?? ""}
+              onChange={(v) => setSearch({ ev_kind: v || undefined, ev_offset: undefined })}
+              options={kindOptions.map((k) => ({ value: k.kind, label: k.kind }))}
+            />
+          ) : null}
+        </div>
       }
     >
       {events.length > 0 ? (


### PR DESCRIPTION
## Summary

Closes #3407

Adds one-click **CSV export** to the three chain-direct feeds on the account detail page (`/accounts/$ss58`) — **Chain events**, **Signed extrinsics**, and **Transfers**. Each section header gets a `Download CSV` button next to its row
count / kind filter. The list routes already emit `text/csv` (with a `Content-Disposition` filename) for the same endpoints the tables read, so the button appends `format=csv` to the current list URL — the export mirrors exactly the rows and active filters in view (the events button carries the selected kind filter and page window).

## Changes

- `routes/accounts.$ss58.tsx` — `accountCsvUrl()` helper + a `DownloadCsvButton`  in each of the three feed section headers; threads `ss58` into the extrinsics  section so its export URL can be built.

## Screenshots

Account detail page (`/accounts/5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u`) — the new **Download CSV** button in the Chain events, Signed extrinsics, and Transfers section headers.

| Viewport / Theme | Before | After |
|---|---|---|
| Desktop 1280×800 · light | <img width="1373" height="909" alt="dek-lg-be" src="https://github.com/user-attachments/assets/d8546da8-a383-445f-93f7-cade26ffa26a" /> | <img width="1377" height="815" alt="dek-lg-af" src="https://github.com/user-attachments/assets/c3bfde7d-6199-485f-a823-024b3b010ba0" /> |
| Desktop 1280×800 · dark | <img width="1360" height="899" alt="dek-dk-be" src="https://github.com/user-attachments/assets/ec40ae11-d4d5-4e45-97ca-8c356aa075aa" /> | <img width="1368" height="820" alt="dek-dk-af" src="https://github.com/user-attachments/assets/f97f4564-9344-4278-ba76-2c2465c8bae1" /> |
| Tablet 768×1024 · light | <img width="653" height="875" alt="tab-lg-be" src="https://github.com/user-attachments/assets/5d935b0d-2f44-4481-8f0f-6606b1cce7f0" /> | <img width="636" height="875" alt="tab-lg-af" src="https://github.com/user-attachments/assets/b825e94c-6da9-46f6-922d-6308eabaf174" /> |
| Tablet 768×1024 · dark | <img width="628" height="871" alt="tab-dk-be" src="https://github.com/user-attachments/assets/15aa4b25-4adf-4cc5-a89f-fe3b4d2596a3" /> | <img width="619" height="874" alt="tab-dk-ag" src="https://github.com/user-attachments/assets/a24701a7-f968-477b-8dd2-8c12ab4de808" /> |
| Mobile 375×812 · light | <img width="431" height="922" alt="mb-lg-be" src="https://github.com/user-attachments/assets/d7d80ab2-c341-433c-94b7-b2f8ea101f3c" /> | <img width="431" height="910" alt="mb-lg-af" src="https://github.com/user-attachments/assets/b67c25bd-fa60-4416-87c3-5b43b1d38f47" /> |
| Mobile 375×812 · dark | <img width="419" height="905" alt="mb-dk-be" src="https://github.com/user-attachments/assets/b86c8811-8180-4f4d-979d-e0e26963ef06" /> | <img width="432" height="920" alt="mb-dk-af" src="https://github.com/user-attachments/assets/3490d93b-2465-4317-9c51-a43c5776827e" /> |

## Validation

- `tsc --noEmit` ✓ · `prettier --check` (3.9.4) ✓ · `eslint` (0 errors) ✓
- `vitest run` — 647/647 pass ✓ · `build` ✓
