### PR TITLE
feat(ui): display endpoint-pools composition on endpoints page (#3349)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6214,6 +6214,16 @@ export const rpcPoolsQuery = () =>
     staleTime: STALE_MED,
   });
 
+export const endpointPoolsQuery = () =>
+  queryOptions({
+    queryKey: k("endpoint-pools"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<unknown>("/api/v1/endpoint-pools", "pools", undefined, signal);
+      return { ...res, data: res.data.map(normalizePool) } as ApiResult<RpcPool[]>;
+    },
+    staleTime: STALE_MED,
+  });
+
 function normalizeRpcEndpoint(raw: unknown): RpcEndpoint | undefined {
   if (!isRecord(raw)) return undefined;
   const id = asString(raw.id);

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -39,6 +39,7 @@ import { useScrolled } from "@/hooks/use-scrolled";
 import {
   endpointsQuery,
   endpointIncidentsQuery,
+  endpointPoolsQuery,
   rpcPoolsQuery,
   rpcEndpointsQuery,
   statusToHealth,
@@ -176,6 +177,14 @@ function EndpointsPage() {
             </QueryErrorBoundary>
           </section>
           <section>
+            <SectionHeading title="Endpoint pools" />
+            <QueryErrorBoundary>
+              <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+                <EndpointPoolsTable />
+              </Suspense>
+            </QueryErrorBoundary>
+          </section>
+          <section>
             <SectionHeading title="Root RPC/WSS endpoints" />
             <QueryErrorBoundary>
               <Suspense fallback={<Skeleton className="h-24 w-full" />}>
@@ -207,6 +216,7 @@ function EndpointsPage() {
           "/api/v1/rpc/usage",
           "/api/v1/endpoints",
           "/api/v1/rpc/pools",
+          "/api/v1/endpoint-pools",
           "/api/v1/rpc/endpoints",
           "/api/v1/endpoint-incidents",
         ]}
@@ -331,6 +341,84 @@ function PoolsTable() {
       <p className="px-1 font-mono text-[10px] text-ink-muted">
         Proxy-eligible members serve live traffic through the reverse proxy above; the proxy prefers
         in-sync, healthy nodes and fails over automatically.
+      </p>
+    </div>
+  );
+}
+
+function EndpointPoolsTable() {
+  const { data } = useSuspenseQuery(endpointPoolsQuery());
+  const rows = (data.data ?? []) as RpcPool[];
+  const stale = isStaleFreshness(data.meta?.generated_at);
+  if (rows.length === 0)
+    return (
+      <EmptyState
+        title="No endpoint pools tracked"
+        description="Generalized pool composition across subtensor-rpc, subtensor-wss, and archive kinds appears here once pools are scored."
+      />
+    );
+  return (
+    <div className="space-y-2">
+      {stale ? (
+        <StaleBanner
+          generatedAt={data.meta?.generated_at}
+          refreshQueryKeys={[
+            endpointPoolsQuery().queryKey,
+            endpointsQuery().queryKey,
+            endpointIncidentsQuery().queryKey,
+          ]}
+        />
+      ) : null}
+      <div className="rounded border border-border bg-card overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-3 py-2 text-left">Pool</th>
+              <th className="px-3 py-2 text-left">Kind</th>
+              <th className="px-3 py-2 text-right">Endpoints</th>
+              <th className="px-3 py-2 text-left">Best endpoint</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((p) => {
+              const eligible = typeof p.eligible_count === "number" ? p.eligible_count : null;
+              const total =
+                typeof p.endpoint_count === "number"
+                  ? p.endpoint_count
+                  : typeof p.members_count === "number"
+                    ? p.members_count
+                    : null;
+              const bestId =
+                typeof p.best_endpoint_id === "string" && p.best_endpoint_id.trim()
+                  ? p.best_endpoint_id
+                  : null;
+              return (
+                <tr
+                  key={p.id}
+                  id={`endpoint-pool-${p.id}`}
+                  className="mg-row-hover scroll-mt-24 target:bg-accent/10"
+                >
+                  <td className="px-3 py-2 font-medium text-ink-strong">{p.id}</td>
+                  <td className="px-3 py-2 font-mono text-[11px]">{String(p.kind ?? "—")}</td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px]">
+                    {eligible != null && total != null
+                      ? `${eligible}/${total} eligible`
+                      : total != null
+                        ? String(total)
+                        : "—"}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                    {bestId ?? "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p className="px-1 font-mono text-[10px] text-ink-muted">
+        Covers all pool kinds (subtensor-rpc, subtensor-wss, archive) from the generalized
+        endpoint-pools artifact — distinct from the Bittensor RPC proxy pools above.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add `endpointPoolsQuery()` in `queries.ts`, fetching `GET /api/v1/endpoint-pools` via the existing `fetchList` + `normalizePool` pattern (reuses `RpcPool` shape)
- Add a new **Endpoint pools** section on `/endpoints` with `EndpointPoolsTable`, sibling to the existing Bittensor-specific **RPC pools** section
- Render per-pool id, kind, eligible/total endpoint counts, and best endpoint id; add `/api/v1/endpoint-pools` to `ApiSourceFooter`

Closes #3349 · Part of #2542

## Screenshots

Captured on `/endpoints` (scrolled to the pools area). Fixed viewports only. Theme forced via `localStorage.setItem("mg-theme", "dark"|"light"); `location.reload()`. **Before:** `origin/main` @ `55772d53` (`:5173`) — RPC pools section flows directly into Root RPC/WSS endpoints. **After:** feature branch (`:5174`) — new **Endpoint pools** table appears between them.

> **Where to look:** the new **Endpoint pools** section sits between **RPC pools** and **Root RPC/WSS endpoints**. On a long page, full-page thumbnails are easy to misread — use the **transition detail crops** below (RPC pools footer → next section).


### Full page (all viewports)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3349-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [ ] `/endpoints` shows both "RPC pools" and "Endpoint pools" sections
- [ ] Endpoint pools table lists pool id, kind, `eligible/total` counts, and best endpoint id (or "—")
- [ ] Empty state when pools array is empty
- [ ] `ApiSourceFooter` includes `/api/v1/endpoint-pools`
- [ ] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui`
- [ ] `npm test --workspace=apps/ui`
- [ ] `npm run build --workspace=apps/ui`
