### PR TITLE
feat(command-palette): actionable "No matches" empty state with recovery suggestions

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -478,6 +478,16 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
   };
 
   const showSuggestions = !debounced;
+  // #3401: a debounced query that matches nothing is a dead-end with just
+  // "No matches." — surface the same Recent/Try recovery block (plus a heading)
+  // so the user always has a concrete next step.
+  const noResults =
+    !!debounced &&
+    !isFetching &&
+    !isSemanticFetching &&
+    hits.length === 0 &&
+    filteredRoutes.length === 0 &&
+    navigateTargets.length === 0;
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
@@ -517,8 +527,13 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
           {isFetching ? "Searching…" : debounced ? "No matches." : "Start typing to search."}
         </CommandEmpty>
 
-        {showSuggestions ? (
+        {showSuggestions || noResults ? (
           <div className="px-3 py-3 space-y-3 border-b border-border">
+            {noResults ? (
+              <div className="mg-label text-ink-muted">
+                No matches for "{debounced}" — try instead:
+              </div>
+            ) : null}
             {recent.length > 0 ? (
               <div>
                 <div className="flex items-center justify-between mb-1.5">


### PR DESCRIPTION
## Problem

When a command-palette query matches nothing, `CommandPaletteBody` (`command-palette-body.tsx`) shows a dead-end: the `<CommandEmpty>` text "No matches.", with the palette jumping straight to the two generic "Filter /subnets by …" / "Filter /endpoints by …" actions — no cue that the search found nothing and no suggested queries to recover with. Meanwhile the *empty-query* state already renders a rich "Recent" + "Try" block (from `SUGGESTED_QUERIES`), so the zero-result case is strictly thinner than the no-query case (#3401).

## Feature

Surface that same recovery block on a zero-result query. When a debounced query returns zero combined results across `hits`, `filteredRoutes`, and `navigateTargets` (and search has settled), render the existing Recent/Try block prefixed with a **"No matches for '<query>' — try instead:"** heading, so the user always has a concrete next step (a suggested query chip that repopulates the search, or the Filter actions below). Successful-result rendering and the empty-query suggestions are unchanged.

The change reuses the existing block and chip handlers (`setQ`) — it just widens the gate from `showSuggestions` (empty query) to `showSuggestions || noResults`, with `noResults` computed from the same result sets the palette already tracks.

## Before / after

Command palette with a query that matches nothing (`zzqxwvnomatch`), captured at desktop.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![before dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3401-screenshots/screenshots/3401/before_dark.png) | ![after dark](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3401-screenshots/screenshots/3401/after_dark.png) |
| Light | ![before light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3401-screenshots/screenshots/3401/before_light.png) | ![after light](https://raw.githubusercontent.com/jeffrey701/metagraphed/assets-3401-screenshots/screenshots/3401/after_light.png) |

Before, a no-match query drops straight into the generic Filter actions. After, it leads with "No matches for … — try instead:" and the clickable Try chips (`bittensor`, `taostats`, `rpc`, `openapi`, `sn7`).

Local: `tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check` (clean). Only `command-palette-body.tsx` changes.

Closes #3401
