### PR TITLE
fix(ui): add loading + error states to AccountFootprintSection (#3965)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1578,6 +1578,42 @@ function AccountFootprintSection({
 }) {
   const subnetsResult = useQuery(accountSubnetsQuery(ss58));
   const rows = subnetsResult.data?.data.subnets ?? fallback;
+
+  // Match the loading/error handling of the sibling account feed sections
+  // (teardown, deregistration, weight-setting, endpoint-announcement): skeleton
+  // while pending with nothing to show, a distinct error state on failure.
+  const phase = accountFeedSectionPhase({
+    isPending: subnetsResult.isPending,
+    isError: subnetsResult.isError,
+    rowCount: rows.length,
+  });
+  if (phase === "skeleton") {
+    return (
+      <AccountFeedSectionSkeleton
+        id="footprint"
+        title="Subnet footprint"
+        subtitle="Current registrations across the indexed network, netuid-ordered, with stake distribution."
+      />
+    );
+  }
+  if (phase === "error") {
+    return (
+      <SectionAnchor
+        id="footprint"
+        title="Subnet footprint"
+        subtitle="Current registrations across the indexed network, netuid-ordered, with stake distribution."
+        tone="accent"
+      >
+        <TableState
+          variant="error"
+          title="Could not load subnet footprint"
+          description="The account's cross-subnet registrations could not be loaded."
+          error={subnetsResult.error}
+          onRetry={() => void subnetsResult.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
   if (rows.length === 0) return null;
 
   const staked = rows


### PR DESCRIPTION
## Summary

`AccountFootprintSection` (`apps/ui/src/routes/accounts.$ss58.tsx`) was the one account feed section with **no loading or error handling** — it used `useQuery(accountSubnetsQuery(ss58))`, fell straight back to the summary's registrations, and returned `null` on empty, so a failed fetch silently removed the whole section with no feedback. Its four siblings — teardown, deregistration, weight-setting, endpoint-announcement — all branch on pending/error via the shared `accountFeedSectionPhase` helper.

This makes `AccountFootprintSection` structurally consistent with those siblings: it now uses `accountFeedSectionPhase({ isPending, isError, rowCount })` to render `AccountFeedSectionSkeleton` while pending (with nothing to show) and a distinct `TableState variant="error"` (with Retry) on failure.

## Change

- One file: `apps/ui/src/routes/accounts.$ss58.tsx` (`AccountFootprintSection` only).
- Reuses the existing shared `accountFeedSectionPhase` helper + `AccountFeedSectionSkeleton` + `TableState` — no new components, no new styling.
- The `fallback` behavior is preserved: `rowCount` counts fallback rows, so the skeleton only appears when there is genuinely nothing to show (matching the helper's `isPending && rowCount === 0` rule). Successful load and the genuine empty case are unchanged.
- No change to `accountSubnetsQuery` or the section's data/content (issue non-goal).

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors (file clean)
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 647 passed
npm run test:e2e --workspace=apps/ui    # 24 passed
```

Error state reproduced by aborting the account `/subnets` request in the browser; React Query surfaces `isError` after its retry backoff, at which point the section renders the error card instead of vanishing.

## Screenshots

`/subnets` fetch blocked on `/accounts/{ss58}`. **Before:** the Subnet-footprint section silently disappears (nothing between *Daily activity* and *Weight-setting activity*). **After:** a distinct error card ("Could not load subnet footprint", with Retry), consistent with the sibling sections.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3965/mobile-dark-after.png)<br><sub>after</sub> |

Closes #3965
