### PR TITLE
fix(registry): use JSON CDN for RedTeam OpenAPI

### DIFF
--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -160,12 +160,12 @@
         "submitted_by": "cleanjunc"
       },
       "schema_status": "machine-readable",
-      "schema_url": "https://raw.githubusercontent.com/RedTeamSubnet/rest-dfp-proxy/main/docs/pages/api-docs/openapi.json",
+      "schema_url": "https://cdn.jsdelivr.net/gh/RedTeamSubnet/rest-dfp-proxy@main/docs/pages/api-docs/openapi.json",
       "source_urls": [
         "https://github.com/RedTeamSubnet/rest-dfp-proxy",
         "https://github.com/RedTeamSubnet/RedTeam/blob/main/docs/challenges/dev_fingerprinter/README.md"
       ],
-      "url": "https://raw.githubusercontent.com/RedTeamSubnet/rest-dfp-proxy/main/docs/pages/api-docs/openapi.json"
+      "url": "https://cdn.jsdelivr.net/gh/RedTeamSubnet/rest-dfp-proxy@main/docs/pages/api-docs/openapi.json"
     }
   ],
   "contact": "oscar@theredteam.io"


### PR DESCRIPTION
### Motivation
- The SN61 RedTeam `openapi` surface was declared `schema_status: "machine-readable"` but pointed at `raw.githubusercontent.com`, which can be served as `text/plain` and is rejected by the OpenAPI snapshotter, causing the schema to be not captured.

### Description
- Update the `sn-61-redteam-openapi` surface in `registry/subnets/redteam.json` to use the jsDelivr CDN URL `https://cdn.jsdelivr.net/gh/RedTeamSubnet/rest-dfp-proxy@main/docs/pages/api-docs/openapi.json` for both `schema_url` and `url`, preserving the existing surface metadata and review fields.

### Testing
- Ran `npm run validate:surface -- registry/subnets/redteam.json`, `npm run scan:public-safety`, and `node -e "JSON.parse(require('fs').readFileSync('registry/subnets/redteam.json','utf8'))"`; the validators passed and the file parses, while a live `HEAD` request to `cdn.jsdelivr.net` could not complete here due to DNS resolution (`EAI_AGAIN`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff354fb6c832c95568300ce4c07f5)