### PR TITLE
feat(registry): add SN83 CliqueAI TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -45,6 +45,25 @@
         "https://github.com/toptensor/CliqueAI/blob/main/min_compute.yml"
       ],
       "url": "https://raw.githubusercontent.com/toptensor/CliqueAI/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-83-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "CliqueAI TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/83 on api.taomarketcap.com returning machine-readable JSON for SN83 CliqueAI on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/toptensor/CliqueAI"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/83"
     }
   ],
   "source_repo": "https://github.com/toptensor/CliqueAI",


### PR DESCRIPTION
## Summary

Enriches **SN83 CliqueAI** with a public no-auth subnet-state API as a `subnet-api` surface.

- **url:** `https://api.taomarketcap.com/public/v1/subnets/83` — public, no-auth JSON (on-chain state, SubnetIdentitiesV3 metadata, economics, dTAO market fields), documented in the TaoMarketCap developer API.

## Why it's safe

- One file, one `subnet-api` surface (provider `taomarketcap` already registered); purely additive.
- Not a duplicate (SN83 has no existing taomarketcap surface).
- Same accepted pattern as the merged SN52 Dojo (#4655) and SN101 eni TaoMarketCap subnet-api surfaces.
- `validate:surface` + `scan:public-safety` pass locally.

Closes #4104