### PR TITLE
feat(registry): add SN111 oneoneone TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -127,6 +127,25 @@
         "https://github.com/oneoneone-io/subnet-111/blob/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/README.md"
       ],
       "url": "https://raw.githubusercontent.com/oneoneone-io/subnet-111/2e9b759039fc40d7ee1a50ff7362bae29eba5a2f/oneoneone/protocol.py"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-111-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "oneoneone TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/111 on api.taomarketcap.com returning machine-readable JSON for SN111 oneoneone on-chain subnet state, hyperparameters, economics, and dTAO market fields. oneoneone's first-party API access is key-gated with no verified public no-auth endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/oneoneone-io/subnet-111"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/111"
     }
   ],
   "contact": "support@oneoneone.io"


### PR DESCRIPTION
Closes #4146

Adds a community `subnet-api` surface for SN111 oneoneone: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/111` — public, no-auth, machine-readable JSON covering SN111's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** SN111's first-party API access is key-gated, so there is no verified public no-auth first-party endpoint. The TaoMarketCap indexed feed is the same provider/URL pattern already accepted in this registry for SN52, SN86, SN89, SN101, and SN109.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the subnet's own repository (`oneoneone-io/subnet-111`) cross-references the subnet identity.

One file touched (`registry/subnets/oneoneone.json`), append-only; no `curation`/top-level metadata changes. `npm run validate`, `npm run validate:surface`, and the artifact test suites pass locally.