### PR TITLE
feat(api): serving-cutover for blocks + extrinsics from D1 to Postgres

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -18,6 +18,13 @@ const mockRows = vi.hoisted(() => ({
     },
   ],
 }));
+// A per-test queue of results for handlers that issue more than one query per
+// request (the new blocks/extrinsics detail routes: main row + a prev/next
+// neighbor lookup, or main row + embedded account_events) -- each top-level
+// sql`` call shifts the next queued result; once empty, falls back to the
+// single shared `mockRows.current` (preserving every existing chain-events
+// test's simpler one-shape-fits-all behavior unchanged).
+const mockQueue = vi.hoisted(() => ({ current: [] }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -25,6 +32,9 @@ vi.mock("postgres", () => ({
     // the handler awaits the outer query and ignores interpolated fragment values.
     const sql = (strings, ...values) => {
       sqlCalls.push({ text: Array.from(strings).join("?"), values });
+      if (mockQueue.current.length) {
+        return Promise.resolve(mockQueue.current.shift());
+      }
       return Promise.resolve(mockRows.current);
     };
     sql.end = () => Promise.resolve();
@@ -41,6 +51,7 @@ const queryText = () => sqlCalls.map((call) => call.text).join("\n");
 
 beforeEach(() => {
   sqlCalls.length = 0;
+  mockQueue.current = [];
   mockRows.current = [
     {
       block_number: "123",
@@ -254,6 +265,230 @@ test("chain-events rejects overlong or non-enumerable pallet/method filters", as
   expect(res.status).toBe(400);
   const punct = await req("/api/v1/chain-events?pallet=System;DROP");
   expect(punct.status).toBe(400);
+});
+
+// ---- D1 serving-cutover routes (#4656 followup): blocks + extrinsics -------
+
+const BLOCK_ROW = {
+  block_number: "8586300",
+  block_hash: "0xabc",
+  parent_hash: "0xdef",
+  author: "5Author",
+  extrinsic_count: 5,
+  event_count: 10,
+  spec_version: 424,
+  observed_at: "1783600000000",
+};
+
+const EXTRINSIC_HASH = `0x${"a".repeat(64)}`;
+
+const EXTRINSIC_ROW = {
+  block_number: "8586300",
+  extrinsic_index: 2,
+  extrinsic_hash: EXTRINSIC_HASH,
+  signer: "5Signer",
+  call_module: "SubtensorModule",
+  call_function: "set_weights",
+  call_args: '{"a":1}', // simulates the ::text cast of a JSONB column
+  success: true,
+  fee_tao: "0.01",
+  tip_tao: "0",
+  observed_at: "1783600000000",
+};
+
+test("GET /api/v1/blocks returns a block feed shaped like the D1 route", async () => {
+  mockRows.current = [BLOCK_ROW];
+  const res = await req("/api/v1/blocks?limit=1");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.schema_version).toBe(1);
+  expect(body.block_count).toBe(1);
+  expect(body.blocks[0].block_number).toBe(8586300);
+  expect(typeof body.blocks[0].block_number).toBe("number");
+  expect(body.blocks[0].author).toBe("5Author");
+  expect(body.next_cursor).toBe("8586300"); // rows.length === limit
+});
+
+test("GET /api/v1/blocks applies the same filter set as loadBlocks", async () => {
+  mockRows.current = [BLOCK_ROW];
+  await req(
+    "/api/v1/blocks?author=5A&spec_version=424&block_start=1&block_end=2&from=1&to=2&min_extrinsics=1&min_events=1",
+  );
+  const text = queryText();
+  expect(text).toContain("AND author =");
+  expect(text).toContain("AND spec_version =");
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+  expect(text).toContain("AND observed_at >=");
+  expect(text).toContain("AND observed_at <=");
+  expect(text).toContain("AND extrinsic_count >=");
+  expect(text).toContain("AND event_count >=");
+});
+
+test("GET /api/v1/blocks uses a cursor seek instead of OFFSET when cursor is present", async () => {
+  mockRows.current = [BLOCK_ROW];
+  await req("/api/v1/blocks?cursor=8586300");
+  const text = queryText();
+  expect(text).toContain("AND block_number <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/blocks/:ref resolves a numeric ref + neighbors", async () => {
+  // Queue slot 0 is the unconditional `SET statement_timeout` call every
+  // request issues before any route matching runs.
+  mockQueue.current = [[], [BLOCK_ROW], [{ prev: 8586299, next: 8586301 }]];
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block.block_number).toBe(8586300);
+  expect(body.prev_block_number).toBe(8586299);
+  expect(body.next_block_number).toBe(8586301);
+});
+
+test("GET /api/v1/blocks/:ref resolves a lowercased hash ref", async () => {
+  mockQueue.current = [[], [BLOCK_ROW], [{ prev: null, next: null }]];
+  const upperHash = `0x${"ABC".repeat(21)}D`; // 64 hex chars, mixed-case
+  const res = await req(`/api/v1/blocks/${upperHash}`);
+  expect(res.status).toBe(200);
+  expect(sqlCalls.some((c) => c.values.includes(upperHash.toLowerCase()))).toBe(
+    true,
+  );
+});
+
+test("GET /api/v1/blocks/:ref on a malformed ref skips the query entirely (block:null)", async () => {
+  const res = await req("/api/v1/blocks/not-a-real-ref");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block).toBeNull();
+  expect(sqlCalls.length).toBe(1); // only the unconditional SET call
+});
+
+test("GET /api/v1/blocks/:ref on an unknown block skips the neighbor query", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/blocks/999999999");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block).toBeNull();
+  expect(body.prev_block_number).toBeNull();
+  expect(body.next_block_number).toBeNull();
+  expect(sqlCalls.length).toBe(2); // SET + the main lookup, no neighbor query
+});
+
+test("GET /api/v1/extrinsics returns a feed with call_args parsed from the ::text cast", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  const res = await req("/api/v1/extrinsics?limit=1");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsic_count).toBe(1);
+  const ex = body.extrinsics[0];
+  expect(ex.block_number).toBe(8586300);
+  expect(ex.success).toBe(true);
+  expect(ex.call_args).toEqual({ a: 1 }); // parsed, not the raw string
+  expect(queryText()).toContain("call_args::text AS call_args");
+});
+
+test("GET /api/v1/extrinsics applies the same filter set as loadExtrinsics", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  await req(
+    "/api/v1/extrinsics?signer=5S&call_module=SubtensorModule&call_function=set_weights&success=true&block=1&block_start=1&block_end=2&from=1&to=2",
+  );
+  const text = queryText();
+  expect(text).toContain("AND block_number =");
+  expect(text).toContain("AND signer =");
+  expect(text).toContain("AND call_module =");
+  expect(text).toContain("AND call_function =");
+  expect(text).toContain("AND success =");
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+  expect(text).toContain("AND observed_at >=");
+  expect(text).toContain("AND observed_at <=");
+});
+
+test("GET /api/v1/extrinsics with success=false filters correctly, distinct from absent", async () => {
+  mockRows.current = [{ ...EXTRINSIC_ROW, success: false }];
+  const res = await req("/api/v1/extrinsics?success=false");
+  const body = await res.json();
+  expect(body.extrinsics[0].success).toBe(false);
+  expect(queryText()).toContain("AND success =");
+  sqlCalls.length = 0;
+  await req("/api/v1/extrinsics");
+  expect(queryText()).not.toContain("AND success =");
+});
+
+test("GET /api/v1/extrinsics matches call_hash against the cast call_args text", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  const hash = `0x${"a".repeat(64)}`;
+  await req(`/api/v1/extrinsics?call_hash=${hash}`);
+  expect(queryText()).toContain("AND call_args::text LIKE");
+  const call = sqlCalls.find((c) => c.text.includes("call_args::text LIKE"));
+  expect(call.values).toContain(`%"${hash}"%`);
+});
+
+test("GET /api/v1/extrinsics ignores a malformed call_hash instead of erroring", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  const res = await req("/api/v1/extrinsics?call_hash=not-a-hash");
+  expect(res.status).toBe(200);
+  expect(queryText()).not.toContain("call_args::text LIKE");
+});
+
+test("GET /api/v1/extrinsics uses a composite cursor seek instead of OFFSET", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  await req("/api/v1/extrinsics?cursor=8586300.2");
+  const text = queryText();
+  expect(text).toContain("AND (block_number, extrinsic_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/extrinsics/:ref resolves a hash ref with embedded account_events", async () => {
+  const eventRow = {
+    block_number: "8586300",
+    event_index: 0,
+    extrinsic_index: 2,
+    event_kind: "WeightsSet",
+    hotkey: "5Hot",
+    coldkey: "5Cold",
+    netuid: 4,
+    uid: 1,
+    amount_tao: "1.5",
+    alpha_amount: "0",
+    observed_at: "1783600000000",
+  };
+  // Queue slot 0 is the unconditional `SET statement_timeout` call.
+  mockQueue.current = [[], [EXTRINSIC_ROW], [eventRow]];
+  const res = await req(`/api/v1/extrinsics/${EXTRINSIC_HASH}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsic.extrinsic_hash).toBe(EXTRINSIC_HASH);
+  expect(body.events).toHaveLength(1);
+  expect(body.events[0].event_kind).toBe("WeightsSet");
+});
+
+test("GET /api/v1/extrinsics/:ref resolves a composite block-index ref", async () => {
+  mockQueue.current = [[], [EXTRINSIC_ROW], []];
+  const res = await req("/api/v1/extrinsics/8586300-2");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsic.extrinsic_index).toBe(2);
+  expect(body.events).toEqual([]);
+});
+
+test("GET /api/v1/extrinsics/:ref on a malformed ref skips the query (extrinsic:null)", async () => {
+  const res = await req("/api/v1/extrinsics/not-a-real-ref");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsic).toBeNull();
+  expect(body.events).toEqual([]);
+  expect(sqlCalls.length).toBe(1); // only the unconditional SET call
+});
+
+test("GET /api/v1/extrinsics/:ref skips the embedded-events query on an unresolved ref", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/extrinsics/0x${"a".repeat(64)}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsic).toBeNull();
+  expect(body.events).toEqual([]);
+  expect(sqlCalls.length).toBe(2); // SET + the main lookup, no events query
 });
 
 test("POST is rejected with 405", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -5976,6 +5976,196 @@ describe("handleExtrinsic", () => {
   });
 });
 
+describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
+  // Shared across handleBlocks/handleBlock/handleExtrinsics/handleExtrinsic: a
+  // per-tier env flag tries the DATA_API service binding first and falls back
+  // to D1 on ANY failure (absent binding, network error, non-2xx, unparseable
+  // body) -- never a client-facing error. dbWith(...) gives each test a D1
+  // fixture distinguishable from the Postgres fixture, so passing tests prove
+  // WHICH source actually served the response, not just that a 200 came back.
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("flag absent: uses D1 even when DATA_API is bound", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    env.DATA_API = dataApi(
+      Response.json({ schema_version: 1, block_count: 99, blocks: [] }),
+    );
+    const body = await json(
+      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
+    );
+    assert.equal(body.data.block_count, 1); // the D1 fixture's count, not 99
+    assert.ok(captures.sql.length > 0); // D1 was actually queried
+  });
+
+  test("flag=postgres + DATA_API succeeds: Postgres data wins, D1 never queried", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({ schema_version: 1, block_count: 99, blocks: [] }),
+    );
+    const body = await json(
+      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
+    );
+    assert.equal(body.data.block_count, 99); // the Postgres fixture, not D1's
+    assert.deepEqual(captures.sql, []); // D1 was never touched
+  });
+
+  test("flag=postgres + DATA_API throws: falls back to D1 seamlessly", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("network error");
+      },
+    };
+    const body = await json(
+      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
+    );
+    assert.equal(body.data.block_count, 1); // the D1 fixture, not an error
+  });
+
+  test("flag=postgres + DATA_API returns non-2xx: falls back to D1", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = dataApi(new Response("upstream error", { status: 502 }));
+    const body = await json(
+      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
+    );
+    assert.equal(body.data.block_count, 1);
+  });
+
+  test("flag=postgres + DATA_API returns unparseable JSON: falls back to D1", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = dataApi(new Response("not json", { status: 200 }));
+    const body = await json(
+      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
+    );
+    assert.equal(body.data.block_count, 1);
+  });
+
+  test("flag=postgres + DATA_API returns valid JSON that isn't an object: falls back to D1", async () => {
+    // A 200 with a bare JSON scalar (not `null`, which JSON.parse also accepts)
+    // parses without throwing but isn't a usable payload shape.
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = dataApi(Response.json(42));
+    const body = await json(
+      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
+    );
+    assert.equal(body.data.block_count, 1);
+  });
+
+  test("handleBlock: flag=postgres uses Postgres data over the D1 fixture", async () => {
+    const { env, captures } = dbWith({ blockDetail: blockRow() });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        ref: String(BLOCK_NUM),
+        block: { ...blockRow(), author: "postgres-author" },
+        prev_block_number: null,
+        next_block_number: null,
+      }),
+    );
+    const body = await json(
+      await handleBlock(
+        req(`/api/v1/blocks/${BLOCK_NUM}`),
+        env,
+        String(BLOCK_NUM),
+      ),
+    );
+    assert.equal(body.data.block.author, "postgres-author");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleBlock: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({ blockDetail: blockRow() });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
+    const body = await json(
+      await handleBlock(
+        req(`/api/v1/blocks/${BLOCK_NUM}`),
+        env,
+        String(BLOCK_NUM),
+      ),
+    );
+    assert.equal(body.data.block.block_number, BLOCK_NUM);
+  });
+
+  test("handleExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        extrinsic_count: 99,
+        limit: 50,
+        offset: 0,
+        next_cursor: null,
+        extrinsics: [],
+      }),
+    );
+    const body = await json(
+      await handleExtrinsics(
+        req("/api/v1/extrinsics"),
+        env,
+        url("/api/v1/extrinsics"),
+      ),
+    );
+    assert.equal(body.data.extrinsic_count, 99);
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleExtrinsics: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleExtrinsics(
+        req("/api/v1/extrinsics"),
+        env,
+        url("/api/v1/extrinsics"),
+      ),
+    );
+    assert.equal(body.data.extrinsic_count, 1);
+  });
+
+  test("handleExtrinsic: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ extrinsicDetail: extrinsicRow() });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        ref: HASH,
+        extrinsic: { ...extrinsicRow(), signer: "postgres-signer" },
+        events: [],
+      }),
+    );
+    const body = await json(
+      await handleExtrinsic(req(`/api/v1/extrinsics/${HASH}`), env, HASH),
+    );
+    assert.equal(body.data.extrinsic.signer, "postgres-signer");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleExtrinsic: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({ extrinsicDetail: extrinsicRow() });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
+    const body = await json(
+      await handleExtrinsic(req(`/api/v1/extrinsics/${HASH}`), env, HASH),
+    );
+    assert.equal(body.data.extrinsic.extrinsic_hash, HASH);
+  });
+});
+
 // ---- Cross-handler contract smoke tests -------------------------------------
 
 describe("entities handler exports (#1900)", () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -11,6 +11,9 @@
 // closed via ctx.waitUntil so it never blocks the response.
 import postgres from "postgres";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
+import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
+import { buildExtrinsic, buildExtrinsicFeed } from "../src/extrinsics.mjs";
+import { formatAccountEvent } from "../src/account-events.mjs";
 
 const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
@@ -66,6 +69,26 @@ function nonNegativeIntegerParam(params, key) {
   return Number.isSafeInteger(n) ? n : null;
 }
 
+function clampOffset(raw) {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+}
+
+const HASH_RE = /^0x[0-9a-fA-F]{64}$/;
+const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
+const MAX_EMBEDDED_EVENTS = 50;
+
+// The blocks/extrinsics SELECT column lists below must match src/blocks.mjs's
+// BLOCK_READ_COLUMNS / src/extrinsics.mjs's EXTRINSIC_READ_COLUMNS so
+// formatBlock/formatExtrinsic (reused unchanged, imported above) see the exact
+// same row shape from either sink. Written literally per query (not factored
+// into a shared string) because postgres.js tagged templates bind a `${...}`
+// interpolation as a query PARAMETER, not raw SQL -- a column list can't be
+// injected that way. extrinsics' call_args is cast to text: Postgres' JSONB
+// auto-parses to a JS object via the driver, but formatExtrinsic expects a
+// JSON-encoded STRING to JSON.parse, matching D1's TEXT column -- casting here
+// keeps that shared formatter untouched rather than teaching it two shapes.
+
 function coerceEvent(row) {
   return {
     ...row,
@@ -97,6 +120,196 @@ export default {
 
     try {
       await sql`SET statement_timeout = '3000ms'`;
+
+      // GET /api/v1/blocks (D1 serving-cutover, #4656 followup): the recent-block
+      // feed, mirroring src/blocks.mjs's loadBlocks filter set exactly (author,
+      // spec_version, block_start/block_end, from/to, min_extrinsics/min_events,
+      // cursor). The main Worker only calls this when its per-tier serving flag
+      // is on and forwards the SAME request it already validated -- this route
+      // trusts well-formed params rather than re-deriving 400s.
+      if (url.pathname === "/api/v1/blocks") {
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const offset = clampOffset(url.searchParams.get("offset"));
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 1);
+        const author = url.searchParams.get("author") || null;
+        const specVersion = nonNegativeIntegerParam(
+          url.searchParams,
+          "spec_version",
+        );
+        const blockStart = nonNegativeIntegerParam(
+          url.searchParams,
+          "block_start",
+        );
+        const blockEnd = nonNegativeIntegerParam(url.searchParams, "block_end");
+        const from = nonNegativeIntegerParam(url.searchParams, "from");
+        const to = nonNegativeIntegerParam(url.searchParams, "to");
+        const minExtrinsics = nonNegativeIntegerParam(
+          url.searchParams,
+          "min_extrinsics",
+        );
+        const minEvents = nonNegativeIntegerParam(
+          url.searchParams,
+          "min_events",
+        );
+        const rows = await sql`
+          SELECT block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at
+          FROM blocks
+          WHERE TRUE
+            ${author ? sql`AND author = ${author}` : sql``}
+            ${specVersion != null ? sql`AND spec_version = ${specVersion}` : sql``}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${from != null ? sql`AND observed_at >= ${from}` : sql``}
+            ${to != null ? sql`AND observed_at <= ${to}` : sql``}
+            ${minExtrinsics != null ? sql`AND extrinsic_count >= ${minExtrinsics}` : sql``}
+            ${minEvents != null ? sql`AND event_count >= ${minEvents}` : sql``}
+            ${cursor ? sql`AND block_number < ${cursor[0]}` : sql``}
+          ORDER BY block_number DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+        const last = rows.length === limit ? rows[rows.length - 1] : null;
+        const nextCursor = last
+          ? encodeCursor([numberOrNull(last.block_number)])
+          : null;
+        return json(buildBlockFeed(rows, { limit, offset, nextCursor }));
+      }
+
+      // GET /api/v1/blocks/:ref — per-block detail + nearest stored neighbors,
+      // mirroring src/blocks.mjs's loadBlock. ref is a numeric block_number or a
+      // 0x block_hash (lowercased before binding, matching the D1 path's
+      // case-insensitivity workaround).
+      const blockRef = url.pathname.match(/^\/api\/v1\/blocks\/([^/]+)$/);
+      if (blockRef) {
+        const ref = decodeURIComponent(blockRef[1]);
+        const isHash = HASH_RE.test(ref);
+        const blockNumber =
+          !isHash && /^\d+$/.test(ref) && Number.isSafeInteger(Number(ref))
+            ? Number(ref)
+            : null;
+        if (!isHash && blockNumber === null) {
+          return json(buildBlock(undefined, ref));
+        }
+        const rows = isHash
+          ? await sql`
+              SELECT block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at
+              FROM blocks WHERE block_hash = ${ref.toLowerCase()} LIMIT 1`
+          : await sql`
+              SELECT block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at
+              FROM blocks WHERE block_number = ${blockNumber} LIMIT 1`;
+        let prev = null;
+        let next = null;
+        const resolvedNumber = numberOrNull(rows[0]?.block_number);
+        if (resolvedNumber != null) {
+          const nbr = await sql`
+            SELECT
+              (SELECT MAX(block_number) FROM blocks WHERE block_number < ${resolvedNumber}) AS prev,
+              (SELECT MIN(block_number) FROM blocks WHERE block_number > ${resolvedNumber}) AS next`;
+          prev = nbr[0]?.prev ?? null;
+          next = nbr[0]?.next ?? null;
+        }
+        return json(buildBlock(rows[0], ref, { prev, next }));
+      }
+
+      // GET /api/v1/extrinsics — the recent-extrinsic feed, mirroring
+      // src/extrinsics.mjs's loadExtrinsics filter set exactly (signer,
+      // call_module, call_function, call_hash, success, block, block_start/
+      // block_end, from/to, cursor). Index selection is left to Postgres'
+      // planner (schema.sql's idx_extrinsics_signer_block / idx_extrinsics_call
+      // cover the same access patterns D1's INDEXED BY hints targeted) --
+      // Postgres has no INDEXED BY equivalent.
+      if (url.pathname === "/api/v1/extrinsics") {
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const offset = clampOffset(url.searchParams.get("offset"));
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+        const block = nonNegativeIntegerParam(url.searchParams, "block");
+        const signer = url.searchParams.get("signer") || null;
+        const callModule = url.searchParams.get("call_module") || null;
+        const callFunction = url.searchParams.get("call_function") || null;
+        const callHashRaw = url.searchParams.get("call_hash");
+        const callHash =
+          callHashRaw && HASH_RE.test(callHashRaw) ? callHashRaw : null;
+        const successRaw = url.searchParams.get("success");
+        const success =
+          successRaw === "true" ? true : successRaw === "false" ? false : null;
+        const blockStart = nonNegativeIntegerParam(
+          url.searchParams,
+          "block_start",
+        );
+        const blockEnd = nonNegativeIntegerParam(url.searchParams, "block_end");
+        const from = nonNegativeIntegerParam(url.searchParams, "from");
+        const to = nonNegativeIntegerParam(url.searchParams, "to");
+        const rows = await sql`
+          SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
+          FROM extrinsics
+          WHERE TRUE
+            ${block != null ? sql`AND block_number = ${block}` : sql``}
+            ${signer ? sql`AND signer = ${signer}` : sql``}
+            ${callModule ? sql`AND call_module = ${callModule}` : sql``}
+            ${callFunction ? sql`AND call_function = ${callFunction}` : sql``}
+            ${callHash ? sql`AND call_args::text LIKE ${'%"' + callHash + '"%'}` : sql``}
+            ${success != null ? sql`AND success = ${success}` : sql``}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${from != null ? sql`AND observed_at >= ${from}` : sql``}
+            ${to != null ? sql`AND observed_at <= ${to}` : sql``}
+            ${cursor ? sql`AND (block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY block_number DESC, extrinsic_index DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+        const last = rows.length === limit ? rows[rows.length - 1] : null;
+        const nextCursor = last
+          ? encodeCursor([
+              numberOrNull(last.block_number),
+              numberOrNull(last.extrinsic_index),
+            ])
+          : null;
+        return json(buildExtrinsicFeed(rows, { limit, offset, nextCursor }));
+      }
+
+      // GET /api/v1/extrinsics/:ref — per-extrinsic detail + embedded
+      // account_events (up to MAX_EMBEDDED_EVENTS), mirroring
+      // src/extrinsic-detail.mjs's loadExtrinsicDetail. ref is a 0x hash or a
+      // composite "block_number-extrinsic_index".
+      const extrinsicRef = url.pathname.match(
+        /^\/api\/v1\/extrinsics\/([^/]+)$/,
+      );
+      if (extrinsicRef) {
+        const ref = decodeURIComponent(extrinsicRef[1]);
+        const isHash = HASH_RE.test(ref);
+        let rows;
+        if (isHash) {
+          rows = await sql`
+            SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
+            FROM extrinsics WHERE extrinsic_hash = ${ref.toLowerCase()}
+            ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`;
+        } else {
+          const composite = COMPOSITE_REF_RE.exec(ref);
+          const blockNumber = composite ? Number(composite[1]) : NaN;
+          const extrinsicIndex = composite ? Number(composite[2]) : NaN;
+          rows =
+            composite &&
+            Number.isSafeInteger(blockNumber) &&
+            Number.isSafeInteger(extrinsicIndex)
+              ? await sql`
+                  SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
+                  FROM extrinsics WHERE block_number = ${blockNumber} AND extrinsic_index = ${extrinsicIndex} LIMIT 1`
+              : [];
+        }
+        const resolved = rows[0];
+        let events = [];
+        const resolvedBlock = numberOrNull(resolved?.block_number);
+        const resolvedIndex = numberOrNull(resolved?.extrinsic_index);
+        if (resolvedBlock != null && resolvedIndex != null) {
+          const eventRows = await sql`
+            SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+            FROM account_events
+            WHERE block_number = ${resolvedBlock} AND extrinsic_index = ${resolvedIndex}
+            ORDER BY event_index ASC LIMIT ${MAX_EMBEDDED_EVENTS}`;
+          events = eventRows.map(formatAccountEvent).filter(Boolean);
+        }
+        return json(buildExtrinsic(resolved, ref, events));
+      }
+
       // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events
       // tier). Distinct from the existing /blocks/:ref/events (curated, D1, #1852).
       const block = url.pathname.match(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -3401,6 +3401,34 @@ export async function handleSubnetRecycled(request, env, netuid) {
   );
 }
 
+// Gated D1 -> Postgres serving cutover (ADR 0013 Sequencing step 3, the
+// deploy/README.md "Serving cutover" runbook: "if FLAG[tier] == postgres: try
+// Postgres; on error -> D1"). Each tier has its own env flag so a rollback is a
+// single-flag flip, never a code change or redeploy of the fallback path.
+// `request` is forwarded UNCHANGED to the DATA_API service binding -- the caller
+// has already run the SAME validation the D1 path runs (analytics.mjs's
+// validateEntityQuery + friends), so this trusts well-formed params and treats
+// ANY failure (binding absent, network error, non-2xx, unparseable/malformed
+// body) as "fall back to D1", never as a client-facing error. Postgres never
+// gets to independently fail a request the D1 path would have served.
+async function tryPostgresTier(env, request, flagName) {
+  if (env[flagName] !== "postgres" || !env.DATA_API) return null;
+  let upstream;
+  try {
+    upstream = await env.DATA_API.fetch(request);
+  } catch {
+    return null;
+  }
+  if (!upstream.ok) return null;
+  let body;
+  try {
+    body = await upstream.json();
+  } catch {
+    return null;
+  }
+  return body && typeof body === "object" ? body : null;
+}
+
 // GET /api/v1/blocks: the recent-block feed (newest first), served live from the
 // `blocks` D1 tier (#1345 block explorer). ?limit clamp <=100, ?offset. Cold/
 // absent store → schema-stable zero (never throws). Reuses the chain-events meta
@@ -3447,19 +3475,21 @@ export async function handleBlocks(request, env, url) {
   const minExtrinsics = numericFilters.min_extrinsics ?? null;
   const minEvents = numericFilters.min_events ?? null;
 
-  const data = await loadBlocks(d1Runner(env), {
-    limit,
-    offset,
-    cursor,
-    author: sp.get("author") || undefined,
-    specVersion: numericFilters.spec_version ?? undefined,
-    blockStart,
-    blockEnd,
-    from,
-    to,
-    minExtrinsics,
-    minEvents,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
+    (await loadBlocks(d1Runner(env), {
+      limit,
+      offset,
+      cursor,
+      author: sp.get("author") || undefined,
+      specVersion: numericFilters.spec_version ?? undefined,
+      blockStart,
+      blockEnd,
+      from,
+      to,
+      minExtrinsics,
+      minEvents,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       data.blocks,
@@ -3512,50 +3542,56 @@ export async function handleBlocksSummary(request, env, url) {
 // unknown ref / cold store → 200 with block:null (schema-stable, mirrors the
 // neuron detail route — NEVER 404/throw).
 export async function handleBlock(request, env, ref) {
-  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  // A non-hash ref must be a strict decimal block_number; anything else (0x-short,
-  // 1e3, signs, empty) is a guaranteed miss, never a Number()-coerced wrong row.
-  const blockNumber = isHash ? null : strictBlockNumber(ref);
-  const sql = isHash
-    ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
-    : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
-  // The poller stores hashes lowercase (substrateinterface emits `0x` lowercase)
-  // and D1 text columns are BINARY-collated, so a mixed/upper-case 0x ref would
-  // miss. Normalize the hash ref to lowercase before binding (same for the block-
-  // extrinsics, block-events, and extrinsic handlers below).
-  const rows =
-    isHash || blockNumber !== null
-      ? await d1All(env, sql, [isHash ? ref.toLowerCase() : blockNumber])
-      : [];
-  // prev/next chain-walk neighbors (#1853): indexed scalar lookups for the
-  // nearest STORED block numbers around the resolved height (skips pruned gaps;
-  // null at the window edges). Derived from the resolved row's number (works for
-  // the hash path too). Only when the block resolved — a cold/unknown ref has no
-  // anchor. Keep these as WHERE-bounded subqueries so public detail requests use
-  // the block_number primary key instead of scanning the retained blocks table.
-  let prev = null;
-  let next = null;
-  // D1 can return the INTEGER block_number as a numeric string, and a bare
-  // Number.isInteger(rows[0]?.block_number) guard is false for "1234" — which
-  // would skip the neighbor query and make a resolved block wrongly report
-  // prev/next_block_number: null. Coerce the anchor first (mirrors formatBlock's
-  // toBlockNumber, and the string-cell fix applied to account-events #2489).
-  const resolvedRaw = Number(rows[0]?.block_number);
-  const resolvedNumber =
-    Number.isInteger(resolvedRaw) && resolvedRaw >= 0 ? resolvedRaw : null;
-  if (resolvedNumber !== null) {
-    const nbr = await d1All(
-      env,
-      `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next`,
-      [resolvedNumber, resolvedNumber],
-    );
-    prev = nbr[0]?.prev ?? null;
-    next = nbr[0]?.next ?? null;
+  const pg = await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE");
+  let data = pg;
+  if (!data) {
+    const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
+    // A non-hash ref must be a strict decimal block_number; anything else (0x-short,
+    // 1e3, signs, empty) is a guaranteed miss, never a Number()-coerced wrong row.
+    const blockNumber = isHash ? null : strictBlockNumber(ref);
+    const sql = isHash
+      ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
+      : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
+    // The poller stores hashes lowercase (substrateinterface emits `0x` lowercase)
+    // and D1 text columns are BINARY-collated, so a mixed/upper-case 0x ref would
+    // miss. Normalize the hash ref to lowercase before binding (same for the block-
+    // extrinsics, block-events, and extrinsic handlers below).
+    const rows =
+      isHash || blockNumber !== null
+        ? await d1All(env, sql, [isHash ? ref.toLowerCase() : blockNumber])
+        : [];
+    // prev/next chain-walk neighbors (#1853): indexed scalar lookups for the
+    // nearest STORED block numbers around the resolved height (skips pruned gaps;
+    // null at the window edges). Derived from the resolved row's number (works for
+    // the hash path too). Only when the block resolved — a cold/unknown ref has no
+    // anchor. Keep these as WHERE-bounded subqueries so public detail requests use
+    // the block_number primary key instead of scanning the retained blocks table.
+    let prev = null;
+    let next = null;
+    // D1 can return the INTEGER block_number as a numeric string, and a bare
+    // Number.isInteger(rows[0]?.block_number) guard is false for "1234" — which
+    // would skip the neighbor query and make a resolved block wrongly report
+    // prev/next_block_number: null. Coerce the anchor first (mirrors formatBlock's
+    // toBlockNumber, and the string-cell fix applied to account-events #2489).
+    const resolvedRaw = Number(rows[0]?.block_number);
+    const resolvedNumber =
+      Number.isInteger(resolvedRaw) && resolvedRaw >= 0 ? resolvedRaw : null;
+    if (resolvedNumber !== null) {
+      const nbr = await d1All(
+        env,
+        `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next`,
+        [resolvedNumber, resolvedNumber],
+      );
+      prev = nbr[0]?.prev ?? null;
+      next = nbr[0]?.next ?? null;
+    }
+    data = buildBlock(rows[0], ref, { prev, next });
   }
-  const data = buildBlock(rows[0], ref, { prev, next });
   // Finalized block detail is immutable once resolved; a cold/unknown ref stays
-  // on the short profile so clients re-check when the block lands.
-  const cacheProfile = rows[0] ? "static" : "short";
+  // on the short profile so clients re-check when the block lands. Checked on
+  // `data.block` (not the D1-only `rows[0]` var, now scoped to the D1 branch)
+  // so this works whether the row resolved via Postgres or D1.
+  const cacheProfile = data.block ? "static" : "short";
   return envelopeResponse(
     request,
     {
@@ -3683,22 +3719,28 @@ export async function handleExtrinsics(request, env, url) {
       message: "call_hash must be a 0x-prefixed 64-character hex string.",
     });
   }
-  const data = await loadExtrinsics(d1Runner(env), {
-    block: numericFilters.block ?? undefined,
-    signer: sp.get("signer") || undefined,
-    callModule: sp.get("call_module") || undefined,
-    callFunction: sp.get("call_function") || undefined,
-    callHash: callHashRaw || undefined,
-    success:
-      successRaw === "true" ? true : successRaw === "false" ? false : undefined,
-    blockStart: numericFilters.block_start ?? undefined,
-    blockEnd: numericFilters.block_end ?? undefined,
-    from: fromMs ?? undefined,
-    to: toMs ?? undefined,
-    limit,
-    offset,
-    cursor,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
+    (await loadExtrinsics(d1Runner(env), {
+      block: numericFilters.block ?? undefined,
+      signer: sp.get("signer") || undefined,
+      callModule: sp.get("call_module") || undefined,
+      callFunction: sp.get("call_function") || undefined,
+      callHash: callHashRaw || undefined,
+      success:
+        successRaw === "true"
+          ? true
+          : successRaw === "false"
+            ? false
+            : undefined,
+      blockStart: numericFilters.block_start ?? undefined,
+      blockEnd: numericFilters.block_end ?? undefined,
+      from: fromMs ?? undefined,
+      to: toMs ?? undefined,
+      limit,
+      offset,
+      cursor,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(data.extrinsics),
@@ -3927,7 +3969,9 @@ export async function handleSudoKey(request, env) {
 // embedded via a second lookup on (block_number, extrinsic_index) — bounded to 50.
 // Empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store.
 export async function handleExtrinsic(request, env, ref) {
-  const data = await loadExtrinsicDetail(d1Runner(env), ref);
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
+    (await loadExtrinsicDetail(d1Runner(env), ref));
   return envelopeResponse(
     request,
     {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -47,6 +47,34 @@
     // AI/VECTORIZE bindings are present, the routes serve live; otherwise they
     // return 503 ai_unavailable. Flip to "false" to instantly disable.
     "METAGRAPH_ENABLE_AI": "true",
+    // D1 -> Postgres serving-cutover flags (ADR 0013 Sequencing step 3, the
+    // deploy/README.md "Serving cutover" runbook). Set to "postgres" to route
+    // /api/v1/blocks(/{ref}) or /api/v1/extrinsics(/{ref}) through the DATA_API
+    // Hyperdrive Worker instead of D1 -- ANY failure there (binding absent,
+    // network error, bad response) transparently falls back to D1, so flipping
+    // this is a zero-downtime experiment and flipping it back is an instant
+    // rollback.
+    //
+    // blocks: live-verified byte-identical to D1 (2026-07-09, block #8586622 --
+    // every column, including block_hash/parent_hash/author/observed_at, matched
+    // exactly) -- safe to flip once ready.
+    //
+    // extrinsics: DO NOT FLIP YET. Live-verified 2026-07-09 that indexer-rs's
+    // `call_args` (Postgres JSONB) is a flat {argName: value} map with NO type
+    // metadata (e.g. {"netuid":110,"dests":[155],"weights":[65535]}), while
+    // fetch-events.py's `call_args` (D1) is an array of {name,type,value}
+    // descriptors the UI and backend depend on (Multisig call_hash detection,
+    // nested-call/batch decode, renderCallArgs' array-vs-object branch). This
+    // is systemic, not an edge case -- checked commit_timelocked_mechanism_weights
+    // and set_weights, both extrinsics disagree in shape. Reconciling requires
+    // either the Rust indexer emitting the same {name,type,value} shape (its
+    // source has no git remote yet -- ADR 0013's own tracked risk) or a
+    // shape-translation layer here that would need SCALE type metadata the flat
+    // Postgres rows don't carry. Tracked as a follow-up; blocks/{ref} and
+    // extrinsics/{ref}'s embedded account_events are NOT affected by this (their
+    // own columns have no such shape divergence).
+    "METAGRAPH_BLOCKS_SOURCE": "d1",
+    "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
   // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the


### PR DESCRIPTION
## Summary

Implements ADR 0013's Sequencing step 3 ("Serving cutover") for two tiers: `/api/v1/blocks(/{ref})` and `/api/v1/extrinsics(/{ref})` can now be served from Postgres (via the existing `DATA_API` Hyperdrive Worker) instead of D1, gated tier-by-tier per an env flag, with automatic fallback to D1 on **any** failure (binding absent, network error, non-2xx, unparseable/malformed body). Flipping a flag is a zero-downtime experiment; flipping it back is an instant rollback — no code change or redeploy either way.

**Motivation:** investigating the 2026-07-09 chain-events incident (see #4654) surfaced that Postgres already has complete, current, first-party data for `blocks`/`extrinsics`/`account_events` — more complete than D1 in every tier I checked — while D1 remains the sole write/read path for the live feed and is now taking concurrent write pressure from several other features shipped this cycle. This is the next concrete step toward retiring that write pressure entirely per the ADR's own plan.

## Description

- `workers/data-api.mjs`: four new routes (`GET /api/v1/blocks`, `/api/v1/blocks/:ref`, `/api/v1/extrinsics`, `/api/v1/extrinsics/:ref`), each mirroring `src/blocks.mjs`'s/`src/extrinsics.mjs`'s exact filter set, cursor semantics, and index-access patterns (Postgres has no `INDEXED BY`; `schema.sql`'s indexes cover the same patterns). Reuses `buildBlockFeed`/`formatBlock`/`buildExtrinsicFeed`/`formatExtrinsic`/`buildExtrinsic` **unchanged** so the response shape is identical regardless of which sink served it. `call_args` is cast to `::text` in the query so the JSONB auto-parse doesn't change shape ahead of the shared formatter's own `JSON.parse`.
- `workers/request-handlers/entities.mjs`: a shared `tryPostgresTier(env, request, flagName)` helper wired into `handleBlocks`, `handleBlock`, `handleExtrinsics`, `handleExtrinsic` — tries Postgres first when the flag is on, falls back to the existing D1 code path unchanged on any failure.
- `wrangler.jsonc`: two new flags, `METAGRAPH_BLOCKS_SOURCE` and `METAGRAPH_EXTRINSICS_SOURCE`, **both defaulted to `"d1"`** — this PR changes zero production behavior on merge.

## Live verification (2026-07-09, against production)

Per the runbook's own gate ("compare Postgres vs D1 row counts... only cut a tier once Postgres ≥ D1"):

- **blocks: verified safe.** Queried block #8586622 both ways — every column byte-identical (`block_hash`, `parent_hash`, `author`, `extrinsic_count`, `event_count`, `spec_version`, `observed_at`).
- **extrinsics: DO NOT FLIP YET.** `call_args` is a **systemically different shape** between the two pipelines — Postgres/indexer-rs stores a flat `{argName: value}` map with no type metadata; D1/`fetch-events.py` stores an array of `{name, type, value}` descriptors that the UI (and this session's own Multisig `call_hash` detection, `renderCallArgs`, and nested-call decode) depend on. Confirmed across multiple extrinsic types (`commit_timelocked_mechanism_weights`, `set_weights`) — not an edge case. Reconciling this needs either the Rust indexer to emit the matching shape (its source has no git remote yet — a real, already-tracked ADR 0013 risk) or a type-metadata-aware translation layer this PR doesn't attempt. Full writeup in the `wrangler.jsonc` comment next to the flag.

## Test plan

- [x] New tests: `tests/data-api.test.mjs` (36 tests — the 4 new routes' filter sets, cursor seeks, ref resolution, malformed-ref short-circuits, embedded-events, `call_args` JSONB→text→parse round-trip) and `tests/request-handlers-entities.test.mjs` (11 tests — the flag+fallback wiring for all 4 handlers: flag absent, flag on + success, flag on + network error/non-2xx/unparseable-JSON/non-object-JSON, each falling back to D1 correctly)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean on all touched files
- [x] `npm run validate` clean
- [x] `npm run test:coverage` (full, unsharded) — 249/249 files, 6921/6921 tests passed; no new coverage gaps (verified via lcov branch-detail)
- [x] Live parity check against production Postgres + the live D1-backed API (see above)

Not flipping either flag in this PR — that's a separate, supervised step per the runbook once ready.