### PR TITLE
feat(registry): add SN116 TaoLend TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -92,6 +92,25 @@
         "https://github.com/oxylok/116-taolend/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/oxylok/116-taolend/main/const.ts"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-116-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "TaoLend TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/116 on api.taomarketcap.com returning machine-readable JSON for SN116 TaoLend on-chain subnet state, hyperparameters, economics, and dTAO market fields. TaoLend exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/oxylok/116-taolend"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/116"
     }
   ],
   "website_url": "https://taolend.io/"


### PR DESCRIPTION
Closes #4157

Adds a community `subnet-api` surface for SN116 TaoLend: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/116` — public, no-auth, machine-readable JSON covering SN116's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** SN116 TaoLend has no verified first-party public API endpoint (its website currently degrades to server errors, per the manifest's own curation notes). The TaoMarketCap indexed feed is the same provider/URL pattern already accepted in this registry for SN52, SN86, SN89, SN101, and SN109.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the subnet's official repository (`oxylok/116-taolend`, already referenced by this manifest's existing surfaces) cross-references the subnet identity.

One file touched (`registry/subnets/taolend.json`), append-only; no `curation`/top-level metadata changes. `npm run validate` and `npm run validate:surface` pass locally.