### PR TITLE
fix(ui): make multisigCallHash/proxyRealAccount shape-agnostic (#4669)

### DIFF
--- a/apps/ui/src/lib/metagraphed/extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.test.ts
@@ -92,7 +92,7 @@ describe("isDecodedCall", () => {
 describe("proxyRealAccount", () => {
   const REAL = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  it("extracts the real arg from a Proxy.proxy call", () => {
+  it("extracts the real arg from a Proxy.proxy call (D1 array shape)", () => {
     expect(
       proxyRealAccount("Proxy", "proxy", [
         { name: "real", value: REAL },
@@ -101,17 +101,29 @@ describe("proxyRealAccount", () => {
     ).toBe(REAL);
   });
 
+  it("extracts the real arg from the Postgres flat-object shape (#4669)", () => {
+    expect(
+      proxyRealAccount("Proxy", "proxy", {
+        real: REAL,
+        call: { call_module: "Balances", call_function: "transfer" },
+      }),
+    ).toBe(REAL);
+  });
+
   it("returns null for non-proxy calls", () => {
     expect(proxyRealAccount("Balances", "transfer", [{ name: "dest", value: REAL }])).toBeNull();
     expect(proxyRealAccount("Proxy", "add_proxy", [{ name: "real", value: REAL }])).toBeNull();
   });
 
-  it("returns null when call_args isn't an array or the real arg is malformed", () => {
-    expect(proxyRealAccount("Proxy", "proxy", { real: REAL })).toBeNull();
+  it("returns null when the real arg is missing or malformed, in either shape", () => {
     expect(proxyRealAccount("Proxy", "proxy", [{ name: "real", value: 123 }])).toBeNull();
     expect(
       proxyRealAccount("Proxy", "proxy", [{ name: "force_proxy_type", value: "Any" }]),
     ).toBeNull();
+    expect(proxyRealAccount("Proxy", "proxy", { real: 123 })).toBeNull();
+    expect(proxyRealAccount("Proxy", "proxy", { force_proxy_type: "Any" })).toBeNull();
+    expect(proxyRealAccount("Proxy", "proxy", "not-an-args-shape")).toBeNull();
+    expect(proxyRealAccount("Proxy", "proxy", null)).toBeNull();
   });
 });
 
@@ -156,15 +168,75 @@ describe("multisigCallHash", () => {
     ).toBe(HASH);
   });
 
+  it("extracts a top-level call_hash from the Postgres flat-object shape (#4669)", () => {
+    expect(multisigCallHash("Multisig", { threshold: 2, call_hash: HASH })).toBe(HASH);
+  });
+
+  it("extracts the nested call's own call_hash from the flat-object shape (#4669)", () => {
+    expect(
+      multisigCallHash("Multisig", {
+        threshold: 2,
+        call: { call_module: "Balances", call_function: "transfer", call_hash: HASH },
+      }),
+    ).toBe(HASH);
+  });
+
+  it("prefers a direct call_hash over a nested one in the flat-object shape too", () => {
+    const OTHER = `0x${"b".repeat(64)}`;
+    expect(
+      multisigCallHash("Multisig", {
+        call_hash: HASH,
+        call: { call_module: "Balances", call_function: "transfer", call_hash: OTHER },
+      }),
+    ).toBe(HASH);
+  });
+
+  it("hex-encodes a raw 32-byte call_hash array (indexer-rs's approve_as_multi shape, #4669)", () => {
+    // Real production data (block #8583926, extrinsic #20): indexer-rs's
+    // dynamic-SCALE-value dump for a [u8; 32] field, verified byte-for-byte
+    // against the same extrinsic's D1-decoded call_hash.
+    const rawBytes = [
+      55, 179, 165, 105, 21, 65, 52, 28, 2, 97, 174, 39, 138, 188, 216, 92, 59, 81, 41, 113, 95,
+      144, 196, 30, 171, 229, 58, 253, 236, 43, 238, 118,
+    ];
+    expect(multisigCallHash("Multisig", { threshold: 2, call_hash: rawBytes })).toBe(
+      "0x37b3a5691541341c0261ae278abcd85c3b5129715f90c41eabe53afdec2bee76",
+    );
+  });
+
+  it("does not mistake an arbitrary byte array for a call_hash (wrong length)", () => {
+    expect(multisigCallHash("Multisig", { call_hash: [1, 2, 3] })).toBeNull();
+    expect(
+      multisigCallHash("Multisig", { call_hash: Array(32).fill(256) }), // out of byte range
+    ).toBeNull();
+  });
+
+  it("degrades cleanly (null, not a wrong hash) for indexer-rs's nested as_multi shape, which encodes the wrapped call as a generic {name,values} enum tree rather than {call_module,call_function,call_hash} -- the remaining part of #4669, not fixable without the Rust indexer's decode source", () => {
+    expect(
+      multisigCallHash("Multisig", {
+        threshold: 2,
+        call: { name: "Balances", values: [{ name: "transfer_keep_alive", values: {} }] },
+      }),
+    ).toBeNull();
+  });
+
   it("returns null for non-Multisig calls, missing hashes, or malformed shapes", () => {
     expect(multisigCallHash("Balances", [{ name: "call_hash", value: HASH }])).toBeNull();
     expect(multisigCallHash("Multisig", [{ name: "threshold", value: 2 }])).toBeNull();
-    expect(multisigCallHash("Multisig", { call_hash: HASH })).toBeNull();
     expect(multisigCallHash("Multisig", [{ name: "call_hash", value: "not-a-hash" }])).toBeNull();
     expect(
       multisigCallHash("Multisig", [
         { name: "call", value: { call_module: "Balances", call_function: "transfer" } },
       ]),
     ).toBeNull();
+    expect(multisigCallHash("Multisig", { threshold: 2 })).toBeNull();
+    expect(multisigCallHash("Multisig", { call_hash: "not-a-hash" })).toBeNull();
+    expect(
+      multisigCallHash("Multisig", {
+        call: { call_module: "Balances", call_function: "transfer" },
+      }),
+    ).toBeNull();
+    expect(multisigCallHash("Multisig", "not-an-args-shape")).toBeNull();
+    expect(multisigCallHash("Multisig", null)).toBeNull();
   });
 });

--- a/apps/ui/src/lib/metagraphed/extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.ts
@@ -55,6 +55,25 @@ export function isDecodedCall(value: unknown): value is DecodedCall {
   );
 }
 
+/** Look up one named call-arg's value, regardless of which of the two valid
+ * call_args shapes this extrinsic decoded to: the D1/fetch-events.py array of
+ * `{name, type, value}` descriptors, or the Postgres/indexer-rs flat
+ * `{name: value}` object (#4669 -- the two ingestion pipelines encode this
+ * differently; `type` is decorative and never rendered by either shape's
+ * branch in renderCallArgs, so only `name`/`value` need reconciling here).
+ * Returns undefined when callArgs is neither shape or the name isn't found. */
+function callArgValue(callArgs: unknown, name: string): unknown {
+  if (Array.isArray(callArgs)) {
+    return (callArgs as Array<{ name?: string | null; value?: unknown }>).find(
+      (a) => a?.name === name,
+    )?.value;
+  }
+  if (callArgs && typeof callArgs === "object") {
+    return (callArgs as Record<string, unknown>)[name];
+  }
+  return undefined;
+}
+
 /** The real acting account for a `Proxy.proxy` call, or null when this isn't
  * a proxied call or its `real` arg is missing/malformed. The signer only
  * relayed the call on-chain -- `real` is the account it actually executes
@@ -65,14 +84,29 @@ export function proxyRealAccount(
   callArgs: unknown,
 ): string | null {
   if (callModule !== "Proxy" || callFunction !== "proxy") return null;
-  if (!Array.isArray(callArgs)) return null;
-  const real = (callArgs as Array<{ name?: string | null; value?: unknown }>).find(
-    (a) => a?.name === "real",
-  );
-  return typeof real?.value === "string" ? real.value : null;
+  const real = callArgValue(callArgs, "real");
+  return typeof real === "string" ? real : null;
 }
 
 const CALL_HASH = /^0x[0-9a-fA-F]{64}$/;
+
+/** A raw 32-byte array (indexer-rs's generic SCALE-value encoding for a
+ * `[u8; 32]` field, #4669) hex-encoded to the same "0x..." string
+ * fetch-events.py's Python decoder already produces. Only safe to apply at a
+ * field position that's semantically KNOWN to be a hash (like `call_hash`) --
+ * a bare 32-byte array is otherwise ambiguous with an AccountId32, which this
+ * repo encodes SS58 instead, and indexer-rs's dump carries no type metadata
+ * to tell the two apart generically. */
+function hashBytesToHex(value: unknown): string | null {
+  if (
+    Array.isArray(value) &&
+    value.length === 32 &&
+    value.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)
+  ) {
+    return `0x${(value as number[]).map((n) => n.toString(16).padStart(2, "0")).join("")}`;
+  }
+  return null;
+}
 
 /** The `call_hash` a `Multisig` call is keyed by, or null when this isn't a
  * Multisig call or no hash can be found. `approve_as_multi`/`cancel_as_multi`
@@ -81,16 +115,28 @@ const CALL_HASH = /^0x[0-9a-fA-F]{64}$/;
  * instead, decoded the same way as any other nested call -- its own
  * `call_hash` is one level down. Either way, this is the join key linking an
  * initiating `as_multi` to its later `approve_as_multi`s and final execution
- * (#4322). */
+ * (#4322).
+ *
+ * Postgres/indexer-rs parity (#4669): a direct `call_hash` arg reconciles --
+ * fetch-events.py emits it as a hex string, indexer-rs as a raw 32-byte array
+ * (hex-encoded here, unambiguous at this specific field). The NESTED case
+ * (`as_multi`'s wrapped `call` computing its OWN call_hash) does NOT reconcile
+ * -- indexer-rs's generic dynamic-value dump has no equivalent of
+ * fetch-events.py's Python-side re-encode-and-hash step, and the wrapped
+ * call's shape (a recursive `{name, values}` enum tree, not
+ * `{call_module, call_function, ...}`) isn't `isDecodedCall`-shaped at all, so
+ * this degrades to a clean `null` (no Related Multisig calls section) rather
+ * than a wrong hash -- tracked as the remaining part of #4669. */
 export function multisigCallHash(
   callModule: string | null | undefined,
   callArgs: unknown,
 ): string | null {
-  if (callModule !== "Multisig" || !Array.isArray(callArgs)) return null;
-  const args = callArgs as Array<{ name?: string | null; value?: unknown }>;
-  const direct = args.find((a) => a?.name === "call_hash");
-  if (typeof direct?.value === "string" && CALL_HASH.test(direct.value)) return direct.value;
-  const wrapped = args.find((a) => a?.name === "call" && isDecodedCall(a.value));
-  const nestedHash = (wrapped?.value as DecodedCall | undefined)?.call_hash;
+  if (callModule !== "Multisig") return null;
+  const direct = callArgValue(callArgs, "call_hash");
+  if (typeof direct === "string" && CALL_HASH.test(direct)) return direct;
+  const directHex = hashBytesToHex(direct);
+  if (directHex) return directHex;
+  const wrapped = callArgValue(callArgs, "call");
+  const nestedHash = isDecodedCall(wrapped) ? wrapped.call_hash : undefined;
   return typeof nestedHash === "string" && CALL_HASH.test(nestedHash) ? nestedHash : null;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -59,20 +59,29 @@
     // every column, including block_hash/parent_hash/author/observed_at, matched
     // exactly) -- safe to flip once ready.
     //
-    // extrinsics: DO NOT FLIP YET. Live-verified 2026-07-09 that indexer-rs's
-    // `call_args` (Postgres JSONB) is a flat {argName: value} map with NO type
-    // metadata (e.g. {"netuid":110,"dests":[155],"weights":[65535]}), while
-    // fetch-events.py's `call_args` (D1) is an array of {name,type,value}
-    // descriptors the UI and backend depend on (Multisig call_hash detection,
-    // nested-call/batch decode, renderCallArgs' array-vs-object branch). This
-    // is systemic, not an edge case -- checked commit_timelocked_mechanism_weights
-    // and set_weights, both extrinsics disagree in shape. Reconciling requires
-    // either the Rust indexer emitting the same {name,type,value} shape (its
-    // source has no git remote yet -- ADR 0013's own tracked risk) or a
-    // shape-translation layer here that would need SCALE type metadata the flat
-    // Postgres rows don't carry. Tracked as a follow-up; blocks/{ref} and
-    // extrinsics/{ref}'s embedded account_events are NOT affected by this (their
-    // own columns have no such shape divergence).
+    // extrinsics: PARTIALLY reconciled 2026-07-09 (#4669), still not flipped.
+    // indexer-rs's `call_args` (Postgres JSONB) is a flat {argName: value} map
+    // with no type metadata (e.g. {"netuid":110,"dests":[155]}), vs
+    // fetch-events.py's (D1) array of {name,type,value} descriptors -- `type`
+    // is decorative (never rendered by either shape) so this alone isn't a
+    // blocker; apps/ui/src/lib/metagraphed/extrinsics.ts's multisigCallHash/
+    // proxyRealAccount now read either shape via a shared callArgValue lookup,
+    // live-verified against real production data including a raw 32-byte
+    // call_hash array (indexer-rs's [u8;32] encoding, hex-encoded and checked
+    // byte-for-byte against the same extrinsic's D1 value). What remains
+    // unreconciled: a NESTED call (Multisig.as_multi's wrapped `call`,
+    // Utility.batch's inner calls, Proxy.proxy's wrapped call) is encoded as a
+    // recursive generic enum tree ({"name":"ModuleName","values":[...]}), not
+    // {call_module,call_function,...} -- isDecodedCall correctly doesn't
+    // recognize it, so nested-call rendering (NestedCallCard) and as_multi's
+    // own computed call_hash (a Python-side re-encode-and-hash step indexer-rs
+    // has no equivalent of) both degrade gracefully to a plain JSON dump /
+    // null rather than a crash or wrong data -- but that's still a real UX
+    // regression, not full parity. Fixing it needs either the Rust indexer's
+    // source (confirmed MISSING -- not on the indexer box, no git remote; see
+    // #4669) or a materially riskier generic-enum-tree reverse-engineering
+    // effort. Flip only once that's resolved or the UX regression is
+    // explicitly accepted.
     "METAGRAPH_BLOCKS_SOURCE": "d1",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },


### PR DESCRIPTION
## Summary

Partially resolves #4669 (found while live-verifying the blocks/extrinsics D1→Postgres serving cutover, #4668): `call_args` is decoded into two different shapes by the two ingestion pipelines --

- **D1** (`fetch-events.py`): array of `{name, type, value}` descriptors
- **Postgres** (`indexer-rs`): flat `{name: value}` map, no type metadata

Investigating further: `type` turns out to be **decorative** -- neither shape's `renderCallArgs` branch (`apps/ui/src/routes/extrinsics.$hash.tsx`) ever displays it, and `renderCallArgs` already has a working branch for the flat-object shape. The actual blocker was narrower: two small lookup functions, `multisigCallHash` and `proxyRealAccount`, both hard-required `Array.isArray(callArgs)` and returned `null` immediately otherwise -- silently disabling the "Related Multisig calls" link (#4322) and Proxy real-account detection for any extrinsic served from Postgres.

## Description

- Both functions now go through a shared `callArgValue(callArgs, name)` helper that reads a named arg from either shape.
- Also handles indexer-rs's raw 32-byte `call_hash` array (its native `[u8; 32]` SCALE encoding) by hex-encoding it -- **verified byte-for-byte against real production data**: block #8583926/extrinsic #20's `approve_as_multi` call_hash byte array hex-encodes to exactly the same value D1 already serves for that extrinsic.
- Live-verified in the preview: a synthetic extrinsic using the real Postgres flat-object shape (including the raw byte-array `call_hash`) now correctly activates the "Related Multisig calls" section, which would have silently stayed hidden before this fix.

## What's NOT fixed here (documented in `wrangler.jsonc` next to `METAGRAPH_EXTRINSICS_SOURCE`)

A **nested call** -- `Multisig.as_multi`'s wrapped `call`, `Utility.batch`'s inner calls, `Proxy.proxy`'s wrapped call -- is encoded by indexer-rs as a recursive generic enum tree (`{"name": "ModuleName", "values": [...]}`), not `{call_module, call_function, ...}`. `isDecodedCall` correctly doesn't recognize this shape, so nested-call rendering (`NestedCallCard`) and `as_multi`'s own computed `call_hash` (a Python-side re-encode-and-hash step indexer-rs has no equivalent of) both degrade gracefully -- a plain JSON dump / `null` -- rather than crashing or showing wrong data. That's still a real UX regression versus D1, though, not full parity.

Investigated whether to fix this too: it would need either (a) the Rust indexer's source, so it can emit the same shape fetch-events.py does, or (b) a generic-enum-tree-to-UI-shape translator in JS. Went looking for (a) -- **the indexer-rs source does not exist anywhere I could find**: not on the indexer box (only the compiled `backfill-rs` binary baked into the Docker image survives), not in this repo, not in the local infra-planning directory. This matches and confirms ADR 0013's own tracked risk ("production-adjacent code should not live in exactly one place with no backup") -- it's not a someday risk, it's already happened. Flagging this prominently as a separate, urgent finding rather than attempting (b) blind, which risks silently misinterpreting the enum tree (e.g. conflating a hash with an AccountId, both 32-byte arrays with no type tag to distinguish them).

`METAGRAPH_EXTRINSICS_SOURCE` stays `"d1"` -- not flipping until either the nested-call gap is resolved or explicitly accepted as a known limitation.

## Test plan

- [x] New/updated tests in `apps/ui/src/lib/metagraphed/extrinsics.test.ts` (26 tests, up from 19): flat-object shape for both functions, the real production byte-array `call_hash` case (asserting the exact expected hex), a malformed-byte-array rejection case, and a case confirming the nested-enum-tree shape degrades to `null` rather than crashing
- [x] Full apps/ui suite: 94 files, 654 tests, all passing
- [x] `eslint .` clean, `prettier --check` clean
- [x] `tsc --noEmit` clean
- [x] Live-verified in the preview against the real production byte shape (see above) -- confined to `apps/ui/src/lib/**` + tests, no route/component changes, so no screenshot table per the repo's own carve-out

Refs #4669 -- intentionally NOT using a closing keyword. #4669 stays open to track the remaining nested-call gap described above (retitling it in a follow-up comment).