### PR TITLE
fix(ui): surface shared ErrorState for GapsPanel fetch failures (#3961)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1292,39 +1292,9 @@ function CandidatesPanel({ netuid }: { netuid: number }) {
 }
 
 function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
-  const { data: gapsResult, isLoading, error } = useQuery(subnetGapsQuery(netuid));
-  const gaps = gapsResult?.data;
-  const missing = gaps?.missing_kinds ?? [];
-  const notes = gaps?.gap_notes ?? [];
-  if (isLoading) {
-    return (
-      <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
-        <Skeleton className="h-24 w-full" />
-      </SectionAnchor>
-    );
-  }
-  if (error) {
-    return (
-      <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
-        <EmptyState
-          title="Gaps unavailable"
-          description="The subnet gaps endpoint did not respond."
-          action={RECOVERY.gaps}
-        />
-      </SectionAnchor>
-    );
-  }
-  if (missing.length === 0 && notes.length === 0) {
-    return (
-      <SectionAnchor id="gaps" title="Gaps">
-        <EmptyState
-          title="No outstanding gaps"
-          description="Profile looks complete."
-          action={RECOVERY.gaps}
-        />
-      </SectionAnchor>
-    );
-  }
+  // Match the seven sibling tabs on this page: a genuine fetch error surfaces the
+  // shared red-bordered ErrorState (with retry) via QueryErrorBoundary, rather than
+  // reusing the success-case EmptyState look. Loading is the Suspense fallback.
   return (
     <SectionAnchor
       id="gaps"
@@ -1332,34 +1302,57 @@ function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
       subtitle="Missing resources, profile incompleteness, and curation notes."
       info="GET /api/v1/subnets/{netuid}/gaps"
     >
-      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-        {missing.length > 0 ? (
-          <div>
-            <div className="mg-label mb-1">Missing kinds</div>
-            <div className="flex flex-wrap gap-1">
-              {missing.map((k) => (
-                <span
-                  key={k}
-                  className="rounded border border-dashed border-ink-subtle bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
-                >
-                  {k}
-                </span>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {notes.length > 0 ? (
-          <ul className="space-y-1 text-[12px] text-ink leading-relaxed">
-            {notes.map((n, i) => (
-              <li key={i}>· {n}</li>
-            ))}
-          </ul>
-        ) : null}
-        <div className="border-t border-border pt-2 text-[11px] text-ink-muted">
-          Help close these gaps by opening a PR against the public registry repo.
-        </div>
-      </div>
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+          <GapsList netuid={netuid} />
+        </Suspense>
+      </QueryErrorBoundary>
     </SectionAnchor>
+  );
+}
+
+function GapsList({ netuid }: { netuid: number }) {
+  const { data: gapsResult } = useSuspenseQuery(subnetGapsQuery(netuid));
+  const gaps = gapsResult?.data;
+  const missing = gaps?.missing_kinds ?? [];
+  const notes = gaps?.gap_notes ?? [];
+  if (missing.length === 0 && notes.length === 0) {
+    return (
+      <EmptyState
+        title="No outstanding gaps"
+        description="Profile looks complete."
+        action={RECOVERY.gaps}
+      />
+    );
+  }
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      {missing.length > 0 ? (
+        <div>
+          <div className="mg-label mb-1">Missing kinds</div>
+          <div className="flex flex-wrap gap-1">
+            {missing.map((k) => (
+              <span
+                key={k}
+                className="rounded border border-dashed border-ink-subtle bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+              >
+                {k}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {notes.length > 0 ? (
+        <ul className="space-y-1 text-[12px] text-ink leading-relaxed">
+          {notes.map((n, i) => (
+            <li key={i}>· {n}</li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="border-t border-border pt-2 text-[11px] text-ink-muted">
+        Help close these gaps by opening a PR against the public registry repo.
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

`GapsPanel` (`apps/ui/src/routes/subnets.$netuid.tsx`) was the only tab-panel on the subnet detail page that handled loading/error manually via plain `useQuery`, and on a genuine fetch error it rendered the same flat `EmptyState` used for the legitimate "no outstanding gaps" success case — just different copy ("Gaps unavailable"), with no red border and no retry. Every sibling tab (Surfaces, Endpoints, Callable services, Schemas, Metagraph, Validators, Activity, Identity) wraps its fetch in `QueryErrorBoundary` + `Suspense` and gets the shared red-bordered `ErrorState` (with Retry) on failure.

This migrates `GapsPanel` to that same pattern: a wrapper `GapsPanel` renders the `SectionAnchor` + `QueryErrorBoundary` + `Suspense`, and an inner `GapsList` uses `useSuspenseQuery`. A genuine error now surfaces the shared `ErrorState` automatically; the "no outstanding gaps" success `EmptyState` is unchanged.

## Change

- One file: `apps/ui/src/routes/subnets.$netuid.tsx` (`GapsPanel` split into `GapsPanel` wrapper + `GapsList`).
- Removes the manual `isLoading` skeleton branch (now the `Suspense` fallback) and the manual `error` → `EmptyState` branch (now the boundary's shared `ErrorState`).
- No change to `subnetGapsQuery` or the "no outstanding gaps" definition (issue non-goals). The compact usage in the overview tab is preserved via the `compact` title prop.

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors (file clean)
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 647 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (incl. /subnets/1)
```

Error state reproduced by aborting `/api/v1/subnets/1/gaps` on `/subnets/1?tab=gaps`; the panel now renders the shared `ErrorState` ("Couldn't load this data" + Retry) instead of the flat `EmptyState`.

## Screenshots

Gaps fetch blocked on `/subnets/1?tab=gaps`. **Before:** a flat borderless "Gaps unavailable" empty-state — indistinguishable from a success/empty state, no retry. **After:** the shared red-bordered `ErrorState` with a Retry action, matching the sibling tabs.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3961/mobile-dark-after.png)<br><sub>after</sub> |

Closes #3961
