### PR TITLE
feat(registry): add SN40 Chunking TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/chunking.json
+++ b/registry/subnets/chunking.json
@@ -95,6 +95,25 @@
         "https://github.com/salahawk/chunking_subnet/blob/main/min_compute.yml"
       ],
       "url": "https://raw.githubusercontent.com/salahawk/chunking_subnet/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-40-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Chunking TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/40 on api.taomarketcap.com returning machine-readable JSON for SN40 Chunking on-chain subnet state, hyperparameters, economics, and dTAO market fields. Chunking publishes a website, source repository, and compute spec but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/salahawk/chunking_subnet"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/40"
     }
   ],
   "website_url": "https://subnet.chunking.com/"


### PR DESCRIPTION
Closes #4043

Adds a community `subnet-api` surface for SN40 Chunking: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/40` — public, no-auth, machine-readable JSON covering SN40's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** Chunking publishes a website, source repository, and compute spec, but no verified first-party public API endpoint (the manifest's curation notes record that gap). The TaoMarketCap indexed feed is the same provider/URL pattern already accepted in this registry for SN52, SN86, SN89, SN101, SN109, SN111, and SN116.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the subnet's official repository (`salahawk/chunking_subnet`, already referenced by this manifest's existing surfaces) cross-references the subnet identity.

One file touched (`registry/subnets/chunking.json`), append-only; no `curation`/top-level metadata changes. `npm run validate` and `npm run validate:surface` pass locally.