### PR TITLE
fix(ui): render indexer-rs's nested-call shape in the extrinsic detail page

### DIFF
--- a/apps/ui/src/lib/metagraphed/extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  asDecodedCall,
   extrinsicCall,
   extrinsicHashPathSegment,
   isCompositeExtrinsicRef,
   isDecodedCall,
   isValidExtrinsicHash,
   multisigCallHash,
+  normalizeIndexerRsCall,
   proxyRealAccount,
 } from "./extrinsics";
 
@@ -86,6 +88,77 @@ describe("isDecodedCall", () => {
     expect(isDecodedCall(null)).toBe(false);
     expect(isDecodedCall({ call_module: "Utility" })).toBe(false);
     expect(isDecodedCall({ call_function: "batch" })).toBe(false);
+  });
+});
+
+describe("normalizeIndexerRsCall", () => {
+  it("reconstructs call_module/call_function from indexer-rs's {name,values} enum wrapper (#4669)", () => {
+    expect(
+      normalizeIndexerRsCall({
+        name: "Balances",
+        values: [{ name: "transfer_keep_alive", values: { dest: "5X", value: 100 } }],
+      }),
+    ).toEqual({
+      call_module: "Balances",
+      call_function: "transfer_keep_alive",
+      call_args: { dest: "5X", value: 100 },
+    });
+  });
+
+  it("real production shape: Utility.batch_all's inner AdminUtils call (block #8584692)", () => {
+    expect(
+      normalizeIndexerRsCall({
+        name: "AdminUtils",
+        values: [
+          {
+            name: "sudo_set_subnet_emission_enabled",
+            values: { netuid: 78, enabled: true },
+          },
+        ],
+      }),
+    ).toEqual({
+      call_module: "AdminUtils",
+      call_function: "sudo_set_subnet_emission_enabled",
+      call_args: { netuid: 78, enabled: true },
+    });
+  });
+
+  it("rejects shapes that aren't a single-variant enum wrapper", () => {
+    expect(
+      normalizeIndexerRsCall({ call_module: "Balances", call_function: "transfer" }),
+    ).toBeNull();
+    expect(normalizeIndexerRsCall({ name: "Balances", values: [] })).toBeNull();
+    expect(
+      normalizeIndexerRsCall({ name: "Balances", values: [{ name: "a" }, { name: "b" }] }),
+    ).toBeNull();
+    expect(normalizeIndexerRsCall({ name: "Balances", values: ["not-an-object"] })).toBeNull();
+    expect(normalizeIndexerRsCall({ name: "Balances", values: [{ values: {} }] })).toBeNull();
+    expect(normalizeIndexerRsCall([{ name: "Balances", values: [] }])).toBeNull();
+    expect(normalizeIndexerRsCall("Balances")).toBeNull();
+    expect(normalizeIndexerRsCall(null)).toBeNull();
+  });
+});
+
+describe("asDecodedCall", () => {
+  it("recognizes the D1 shape directly", () => {
+    expect(asDecodedCall({ call_module: "Utility", call_function: "batch" })).toEqual({
+      call_module: "Utility",
+      call_function: "batch",
+    });
+  });
+
+  it("recognizes and normalizes the indexer-rs enum-wrapper shape", () => {
+    expect(asDecodedCall({ name: "Utility", values: [{ name: "batch", values: {} }] })).toEqual({
+      call_module: "Utility",
+      call_function: "batch",
+      call_args: {},
+    });
+  });
+
+  it("returns null for neither shape", () => {
+    expect(asDecodedCall("Utility.batch")).toBeNull();
+    expect(asDecodedCall([{ call_module: "Utility", call_function: "batch" }])).toBeNull();
+    expect(asDecodedCall(null)).toBeNull();
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.ts
@@ -55,6 +55,44 @@ export function isDecodedCall(value: unknown): value is DecodedCall {
   );
 }
 
+/** indexer-rs's generic dynamic-SCALE-value encoding of a RuntimeCall-typed
+ * value (a nested call): `{name: "PalletName", values: [{name:
+ * "function_name", values: <args>}]}` -- a single-variant enum wrapping
+ * another single-variant enum, one level per nesting (#4669). Reconstructing
+ * `call_module`/`call_function` from the two `name` fields is safe and
+ * deterministic (pallet/function names are always plain strings here); this
+ * is NOT the same risk as guessing whether a bare 32-byte array is a Hash or
+ * an AccountId32 -- there's no ambiguity in an enum variant's own tag. The
+ * reconstructed `call_args` is `values` UNCHANGED (still indexer-rs's native
+ * shape recursively -- callArgValue/normalizeIndexerRsCall both already
+ * handle it), so any byte-array fields inside stay raw arrays rather than a
+ * guessed hex/SS58 encoding. */
+export function normalizeIndexerRsCall(value: unknown): DecodedCall | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const outer = value as Record<string, unknown>;
+  if (typeof outer.name !== "string") return null;
+  if (!Array.isArray(outer.values) || outer.values.length !== 1) return null;
+  const inner = outer.values[0];
+  if (!inner || typeof inner !== "object" || Array.isArray(inner)) return null;
+  const innerName = (inner as Record<string, unknown>).name;
+  if (typeof innerName !== "string") return null;
+  return {
+    call_module: outer.name,
+    call_function: innerName,
+    call_args: (inner as Record<string, unknown>).values,
+  };
+}
+
+/** A value that decodes to a nested call under EITHER shape -- D1's
+ * `{call_module, call_function, ...}` (isDecodedCall) or indexer-rs's
+ * `{name, values}` enum-tree wrapper (normalizeIndexerRsCall) -- normalized
+ * to the D1 shape either way so callers (NestedCallCard, multisigCallHash's
+ * nested branch) don't need to know which pipeline produced it. */
+export function asDecodedCall(value: unknown): DecodedCall | null {
+  if (isDecodedCall(value)) return value;
+  return normalizeIndexerRsCall(value);
+}
+
 /** Look up one named call-arg's value, regardless of which of the two valid
  * call_args shapes this extrinsic decoded to: the D1/fetch-events.py array of
  * `{name, type, value}` descriptors, or the Postgres/indexer-rs flat
@@ -121,10 +159,10 @@ function hashBytesToHex(value: unknown): string | null {
  * fetch-events.py emits it as a hex string, indexer-rs as a raw 32-byte array
  * (hex-encoded here, unambiguous at this specific field). The NESTED case
  * (`as_multi`'s wrapped `call` computing its OWN call_hash) does NOT reconcile
- * -- indexer-rs's generic dynamic-value dump has no equivalent of
- * fetch-events.py's Python-side re-encode-and-hash step, and the wrapped
- * call's shape (a recursive `{name, values}` enum tree, not
- * `{call_module, call_function, ...}`) isn't `isDecodedCall`-shaped at all, so
+ * -- asDecodedCall correctly recognizes indexer-rs's wrapped-call shape (the
+ * module/function reconstruction is safe), but indexer-rs's dynamic-value
+ * dump has no equivalent of fetch-events.py's Python-side re-encode-and-hash
+ * step, so the reconstructed call simply has no `call_hash` field to read --
  * this degrades to a clean `null` (no Related Multisig calls section) rather
  * than a wrong hash -- tracked as the remaining part of #4669. */
 export function multisigCallHash(
@@ -137,6 +175,6 @@ export function multisigCallHash(
   const directHex = hashBytesToHex(direct);
   if (directHex) return directHex;
   const wrapped = callArgValue(callArgs, "call");
-  const nestedHash = isDecodedCall(wrapped) ? wrapped.call_hash : undefined;
+  const nestedHash = asDecodedCall(wrapped)?.call_hash;
   return typeof nestedHash === "string" && CALL_HASH.test(nestedHash) ? nestedHash : null;
 }

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -17,9 +17,9 @@ import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import {
+  asDecodedCall,
   extrinsicCall,
   extrinsicHashPathSegment,
-  isDecodedCall,
   isValidExtrinsicHash,
   multisigCallHash,
   proxyRealAccount,
@@ -505,24 +505,32 @@ function renderCallArgs(callArgs: unknown, depth = 0) {
 }
 
 // One arg's value: a nested call (or a list of them, e.g. a batch's `calls`)
-// expands as its own call card; anything else prints as before.
+// expands as its own call card; anything else prints as before. asDecodedCall
+// (not the bare isDecodedCall predicate) so this recognizes a nested call
+// under EITHER ingestion pipeline's shape (#4669) -- D1's
+// {call_module,call_function,...} directly, or indexer-rs's {name,values}
+// enum-tree wrapper, normalized to the same shape before rendering.
 function renderCallArgValue(value: unknown, depth: number): ReactNode {
   if (depth < MAX_NESTED_CALL_DEPTH) {
-    if (isDecodedCall(value)) {
-      return <NestedCallCard call={value} depth={depth} />;
+    const decoded = asDecodedCall(value);
+    if (decoded) {
+      return <NestedCallCard call={decoded} depth={depth} />;
     }
-    if (Array.isArray(value) && value.length > 0 && value.every(isDecodedCall)) {
-      return (
-        <div className="flex flex-col gap-2">
-          {(value as DecodedCall[]).map((call, i) => (
-            <NestedCallCard
-              key={typeof call.call_hash === "string" ? call.call_hash : i}
-              call={call}
-              depth={depth}
-            />
-          ))}
-        </div>
-      );
+    if (Array.isArray(value) && value.length > 0) {
+      const decodedCalls = value.map(asDecodedCall);
+      if (decodedCalls.every((c): c is DecodedCall => c !== null)) {
+        return (
+          <div className="flex flex-col gap-2">
+            {decodedCalls.map((call, i) => (
+              <NestedCallCard
+                key={typeof call.call_hash === "string" ? call.call_hash : i}
+                call={call}
+                depth={depth}
+              />
+            ))}
+          </div>
+        );
+      }
     }
   }
   return formatCallArgValue(value);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -59,29 +59,30 @@
     // every column, including block_hash/parent_hash/author/observed_at, matched
     // exactly) -- safe to flip once ready.
     //
-    // extrinsics: PARTIALLY reconciled 2026-07-09 (#4669), still not flipped.
-    // indexer-rs's `call_args` (Postgres JSONB) is a flat {argName: value} map
-    // with no type metadata (e.g. {"netuid":110,"dests":[155]}), vs
-    // fetch-events.py's (D1) array of {name,type,value} descriptors -- `type`
-    // is decorative (never rendered by either shape) so this alone isn't a
-    // blocker; apps/ui/src/lib/metagraphed/extrinsics.ts's multisigCallHash/
-    // proxyRealAccount now read either shape via a shared callArgValue lookup,
-    // live-verified against real production data including a raw 32-byte
-    // call_hash array (indexer-rs's [u8;32] encoding, hex-encoded and checked
-    // byte-for-byte against the same extrinsic's D1 value). What remains
-    // unreconciled: a NESTED call (Multisig.as_multi's wrapped `call`,
-    // Utility.batch's inner calls, Proxy.proxy's wrapped call) is encoded as a
-    // recursive generic enum tree ({"name":"ModuleName","values":[...]}), not
-    // {call_module,call_function,...} -- isDecodedCall correctly doesn't
-    // recognize it, so nested-call rendering (NestedCallCard) and as_multi's
-    // own computed call_hash (a Python-side re-encode-and-hash step indexer-rs
-    // has no equivalent of) both degrade gracefully to a plain JSON dump /
-    // null rather than a crash or wrong data -- but that's still a real UX
-    // regression, not full parity. Fixing it needs either the Rust indexer's
-    // source (confirmed MISSING -- not on the indexer box, no git remote; see
-    // #4669) or a materially riskier generic-enum-tree reverse-engineering
-    // effort. Flip only once that's resolved or the UX regression is
-    // explicitly accepted.
+    // extrinsics: reconciled 2026-07-09 (#4669), still not flipped pending a
+    // live cutover decision. indexer-rs's `call_args` (Postgres JSONB) is a
+    // flat {argName: value} map with no type metadata (e.g.
+    // {"netuid":110,"dests":[155]}), vs fetch-events.py's (D1) array of
+    // {name,type,value} descriptors -- `type` is decorative (never rendered by
+    // either shape) so this alone isn't a blocker; apps/ui/src/lib/metagraphed/
+    // extrinsics.ts's multisigCallHash/proxyRealAccount read either shape via
+    // a shared callArgValue lookup, live-verified against real production data
+    // including a raw 32-byte call_hash array (indexer-rs's [u8;32] encoding,
+    // hex-encoded and checked byte-for-byte against the same extrinsic's D1
+    // value). A NESTED call (Multisig.as_multi's wrapped `call`, Utility.batch's
+    // inner calls, Proxy.proxy's wrapped call) is encoded as a recursive
+    // generic enum tree ({"name":"ModuleName","values":[...]}), not
+    // {call_module,call_function,...} -- normalizeIndexerRsCall/asDecodedCall
+    // reconstruct call_module/call_function from the enum wrapper's own tag
+    // names (safe and deterministic -- an enum variant's own name carries no
+    // Hash-vs-AccountId32 ambiguity), so NestedCallCard now renders this shape
+    // too. Two narrow, accepted gaps remain, neither a data-correctness risk:
+    // (a) as_multi's own computed call_hash (a Python-side re-encode-and-hash
+    // step indexer-rs's dump has no equivalent of, so multisigCallHash
+    // degrades to a clean null rather than a wrong hash for this one sub-case);
+    // (b) raw byte-array VALUES nested inside call args stay unconverted
+    // (correctly -- a bare 32-byte array is ambiguous between Hash and
+    // AccountId32 with no type metadata to disambiguate generically).
     "METAGRAPH_BLOCKS_SOURCE": "d1",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },


### PR DESCRIPTION
Refs #4669

### Motivation
- indexer-rs (Postgres, the D1->Postgres serving-cutover target) encodes a nested `RuntimeCall` (`Multisig.as_multi`'s wrapped call, `Utility.batch*`'s inner calls, `Proxy.proxy`'s wrapped call) as a recursive generic enum tree (`{"name":"PalletName","values":[...]}`), not D1's `{call_module, call_function, call_args}` shape.
- `isDecodedCall` correctly didn't recognize the indexer-rs shape, so the extrinsic detail page fell back to a raw JSON dump instead of a `NestedCallCard` for any nested call under that shape -- a real UX regression versus today's D1-only baseline, blocking the extrinsics tier of the D1->Postgres cutover (#4668/#4669).

### Description
- Add `normalizeIndexerRsCall(value)` / `asDecodedCall(value)` in `apps/ui/src/lib/metagraphed/extrinsics.ts`: reconstructs `call_module`/`call_function` from the enum wrapper's own tag names. This is safe and deterministic -- an enum variant's own name carries no type ambiguity, unlike a bare scalar byte-array value (which correctly stays unconverted elsewhere in the tree).
- Wire `asDecodedCall` into `multisigCallHash` (nested-call branch) and into the route's `renderCallArgValue`, replacing the D1-only `isDecodedCall` check.
- Update `wrangler.jsonc`'s `METAGRAPH_EXTRINSICS_SOURCE` comment and issue #4669 to reflect the reconciled state and the two narrow, accepted remaining gaps (neither a data-correctness risk): `as_multi`'s own computed `call_hash` (needs a re-encode-and-hash step indexer-rs's dump has no equivalent of), and raw byte-array values nested inside call args (ambiguous Hash-vs-AccountId32 without type metadata).

### Testing
- `npx vitest run` in `apps/ui`: 94 files / 660 tests passing (6 new tests covering `normalizeIndexerRsCall`/`asDecodedCall`, including a real production-shape case from block #8584692).
- `npx tsc --noEmit` clean, `npx eslint` 0 errors (pre-existing fast-refresh warnings only, unrelated to this change), `npx prettier --check` clean.

## Screenshots

Captured via a synthetic API response driven through the real query/render path on `/extrinsics/<hash>` (a `Multisig.as_multi` wrapping `Sudo`->`Utility.batch_all`->2x `AdminUtils.sudo_set_subnet_emission_enabled` calls, indexer-rs's real production shape from block #8584692), comparing the merge-base (pre-fix) against this branch. Desktop, light theme.

| Section | Before | After |
| ------- | ------ | ----- |
| Nested call arg | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4669-nested-before.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4669-nested-before.png)<br><sub>raw JSON dump for the `call` arg, including a stray "[Max depth exceeded]" placeholder</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4669-nested-after.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4669-nested-after.png)<br><sub>`Utility.batch_all` renders as a proper `NestedCallCard` tree with 2 nested `AdminUtils.sudo_set_subnet_emission_enabled` cards</sub> |
