### PR TITLE
feat(registry): add SN30 Endure Network TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -80,6 +80,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Endure documentation linked from the project website."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-30-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Endure Network TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/30 on api.taomarketcap.com returning machine-readable JSON for SN30 Endure Network on-chain subnet state, hyperparameters, economics, and dTAO market fields. Endure publishes a website and documentation but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/30"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4029

Adds a community `subnet-api` surface for SN30 Endure Network: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/30` — public, no-auth, machine-readable JSON covering SN30's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** Endure publishes a website and documentation, but no first-party public API endpoint — the manifest's curation notes record that the common /api, /openapi.json, and Swagger paths on endure.network all 404. The TaoMarketCap indexed feed is the same provider/URL pattern already accepted in this registry for SN40, SN52, SN86, SN89, SN101, SN109, SN111, and SN116.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the tensorplex-labs subnet-docs entry for netuid 30 cross-references the subnet identity (the same provenance pattern accepted for the EfficientFrontier surface).

One file touched (`registry/subnets/endure-network.json`), append-only; no `curation`/top-level metadata changes. `npm run validate` and `npm run validate:surface` pass locally.