### PR TITLE
fix(data-api): flip blocks serving to Postgres, correct stale ADR notes

### DIFF
--- a/docs/adr/0010-chain-direct-block-explorer.md
+++ b/docs/adr/0010-chain-direct-block-explorer.md
@@ -2,8 +2,12 @@
 
 - **Status:** Accepted (partial) — first-party ingestion + serving shipped
   (#1345 vertical slices: blocks, extrinsics, account events; Aura block-author
-  decode). Deep history (#1519 R2 SQL, #1349 archive RPC) is pending the
-  self-hosted infrastructure.
+  decode). Deep history landed via ADR 0013's Postgres/archive-node build
+  instead of #1519's originally-proposed R2 SQL columnar sibling (#1519 stays
+  open only as a declined-for-now enhancement, JSO-2054/#2518 option (a));
+  #1349's archive RPC is live (closed). `/api/v1/blocks` serves Postgres deep
+  history as of 2026-07-09 (`METAGRAPH_BLOCKS_SOURCE=postgres`); extrinsics
+  cutover is reconciled (#4669) and pending its own flip.
 - **Date:** 2026-06-23
 - **Relates to:** ADR 0006 (provenance-tiered storage — D1 for dynamic data) and
   ADR 0002 (the existing probe / RPC-pool plane this reuses).

--- a/docs/adr/0013-hybrid-deployment-topology.md
+++ b/docs/adr/0013-hybrid-deployment-topology.md
@@ -26,9 +26,11 @@
 > and `scripts/backfill-chain.py` (referenced below and in `deploy/README.md`)
 > are retired — a Rust implementation (live-follow + sharded historical backfill
 > in one binary) replaces both, verified faster and handling more event
-> coverage. Its source has no git remote yet (tracked as a real, still-open
-> risk — production-adjacent code should not live in exactly one place with no
-> backup). Separately: `deploy/postgres/schema.sql`'s TimescaleDB hypertable
+> coverage. Its source lives in the private `JSONbored/metagraphed-indexer-rs`
+> repo (a remote was added 2026-07-03, closing the "exactly one place with no
+> backup" risk this amendment originally flagged) — confirmed 2026-07-09 that
+> the repo's last commit timestamp matches the deployed image's build time to
+> within 3 minutes. Separately: `deploy/postgres/schema.sql`'s TimescaleDB hypertable
 > section, as originally committed, could never actually apply —
 > `create_hypertable()` requires the partition column (`observed_at`) in every
 > unique constraint, and none of the original primary keys included it. Fixed

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,9 +55,10 @@
     // this is a zero-downtime experiment and flipping it back is an instant
     // rollback.
     //
-    // blocks: live-verified byte-identical to D1 (2026-07-09, block #8586622 --
-    // every column, including block_hash/parent_hash/author/observed_at, matched
-    // exactly) -- safe to flip once ready.
+    // blocks: FLIPPED 2026-07-09 -- live-verified byte-identical to D1
+    // (block #8586622, every column including block_hash/parent_hash/author/
+    // observed_at matched exactly). Now serving deep history from Postgres,
+    // with automatic D1 fallback on any DATA_API failure.
     //
     // extrinsics: reconciled 2026-07-09 (#4669), still not flipped pending a
     // live cutover decision. indexer-rs's `call_args` (Postgres JSONB) is a
@@ -83,7 +84,7 @@
     // (b) raw byte-array VALUES nested inside call args stay unconverted
     // (correctly -- a bare 32-byte array is ambiguous between Hash and
     // AccountId32 with no type metadata to disambiguate generically).
-    "METAGRAPH_BLOCKS_SOURCE": "d1",
+    "METAGRAPH_BLOCKS_SOURCE": "postgres",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent


### PR DESCRIPTION
### Motivation
- `METAGRAPH_BLOCKS_SOURCE` (#4668) was left at `"d1"` after the Postgres tier was live-verified byte-identical (block #8586622, every column matched exactly) -- ready to flip, just not flipped yet.
- Found two stale ADR notes during an infra sweep, both about to mislead future work.

### Description
- Flip `METAGRAPH_BLOCKS_SOURCE` to `"postgres"` in `wrangler.jsonc`. `tryPostgresTier` falls back to D1 transparently on any DATA_API failure (binding absent, network error, bad response) -- zero-downtime, instantly reversible by flipping back.
- Correct `docs/adr/0013-hybrid-deployment-topology.md`'s "indexer-rs has no git remote yet" amendment -- confirmed the private `JSONbored/metagraphed-indexer-rs` repo has had a remote since 2026-07-03 (its last commit timestamp matches the deployed image's build time within 3 minutes). The originally-flagged risk is resolved, not open.
- Correct `docs/adr/0010-chain-direct-block-explorer.md`'s "deep history pending self-hosted infrastructure" -- the infra landed (archive node + Postgres); #1349 (archive RPC) is closed; #1519 (R2 SQL) remains open only as a declined-for-now columnar-sibling enhancement (JSO-2054/#2518 option (a)), not a live gap.

### Testing
- `npx wrangler deploy --dry-run` confirms `METAGRAPH_BLOCKS_SOURCE` resolves to `"postgres"` and all bindings (including `DATA_API`) are present.
- `npx vitest run tests/request-handlers-entities.test.mjs tests/data-api.test.mjs` -- 405 tests passing (these already cover the flag-on/flag-off/fallback paths from #4668).
- `npx prettier --check` clean, `npm run lint` clean.

No screenshot table -- no `apps/ui` files touched (config + docs only).