### PR TITLE
feat(ui): network weight-setters leaderboard on chain explorer (#3470)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-weight-setters.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-weight-setters.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainWeightSettersQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/weights/setters",
+  });
+}
+
+async function runQuery(window?: string) {
+  const opts = chainWeightSettersQuery(window as "7d" | "30d" | undefined);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("chainWeightSettersQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("passes window/limit params and normalizes setters", async () => {
+    resolveWith({
+      window: "7d",
+      distinct_setters: 2,
+      weight_sets: 10,
+      setters: [
+        { hotkey: "5Grw", uid: 1, weight_sets: 6, share: 0.6, last_set_at: "2026-07-01T00:00:00Z" },
+        { uid: 9, weight_sets: 4, share: 0.4 },
+        { weight_sets: 1 },
+      ],
+    });
+    const res = await runQuery("7d");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/weights/setters",
+      expect.objectContaining({ params: { window: "7d", limit: 20 } }),
+    );
+    expect(res.data.distinct_setters).toBe(2);
+    expect(res.data.setters).toHaveLength(2);
+    expect(res.data.setters[0]?.hotkey).toBe("5Grw");
+    expect(res.data.setters[1]?.hotkey).toBeNull();
+    expect(res.data.setters[1]?.uid).toBe(9);
+  });
+
+  it("returns an empty card for junk payloads", async () => {
+    resolveWith(null);
+    const res = await runQuery();
+    expect(res.data.setters).toEqual([]);
+    expect(res.data.distinct_setters).toBe(0);
+    expect(res.data.window).toBe("7d");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -94,6 +94,7 @@ import type {
   ChainYield,
   ChainYieldDistribution,
   ChainSigners,
+  ChainWeightSetters,
   ChainSignerEntry,
   Extrinsic,
   ExtrinsicCallArg,
@@ -255,6 +256,7 @@ const MAX_TURNOVER_SUBNETS = 24;
 const MAX_CHAIN_EVENT_GROUPS = 100;
 const DEFAULT_CHAIN_EVENT_BLOCKS = 1000;
 const MAX_CHAIN_SIGNERS = 20;
+const MAX_CHAIN_WEIGHT_SETTERS = 20;
 const MAX_CHAIN_IDENTITY_CHANGES = 200;
 const MAX_CHAIN_FEE_DAYS = 31;
 const MAX_CHAIN_FEE_PAYERS = 12;
@@ -3383,6 +3385,43 @@ export const chainSignersQuery = (window: ChainWindow = "7d") =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<ChainSigners>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeChainWeightSetters(raw: unknown, window: ChainWindow): ChainWeightSetters {
+  const rec = isRecord(raw) ? raw : {};
+  const setters = (Array.isArray(rec.setters) ? rec.setters : [])
+    .map(normalizeSubnetWeightSetter)
+    .filter(
+      (setter): setter is NonNullable<ReturnType<typeof normalizeSubnetWeightSetter>> =>
+        setter != null,
+    )
+    .slice(0, MAX_CHAIN_WEIGHT_SETTERS);
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? window,
+    observed_at: firstString(rec.observed_at) ?? null,
+    distinct_setters: firstFiniteNumber(rec.distinct_setters) ?? 0,
+    weight_sets: firstFiniteNumber(rec.weight_sets) ?? 0,
+    setter_count: firstFiniteNumber(rec.setter_count) ?? setters.length,
+    setters,
+  };
+}
+
+export const chainWeightSettersQuery = (window: ChainWindow = "7d") =>
+  queryOptions({
+    queryKey: k("chain-weight-setters", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/chain/weights/setters", {
+        params: { window, limit: 20 },
+        signal,
+      });
+      return {
+        data: normalizeChainWeightSetters(res.data, window),
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<ChainWeightSetters>;
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1583,6 +1583,9 @@ export interface SubnetWeightSetter {
   last_set_at: string | null;
 }
 
+/** One validator's network-wide weight-setting activity over the window (#3470). */
+export type ChainWeightSetter = SubnetWeightSetter;
+
 /**
  * Per-subnet weight-setters leaderboard over a 7d/30d window (#1657), from
  * /api/v1/subnets/{netuid}/weights/setters — the individual validators behind the
@@ -1597,6 +1600,21 @@ export interface SubnetWeightSetters {
   weight_sets: number;
   setter_count: number;
   setters: SubnetWeightSetter[];
+}
+
+/**
+ * Network-wide weight-setters leaderboard over a 7d/30d window (#3470), from
+ * GET /api/v1/chain/weights/setters — validators ranked by WeightsSet count
+ * across every subnet. Zeroed when cold.
+ */
+export interface ChainWeightSetters {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  distinct_setters: number;
+  weight_sets: number;
+  setter_count: number;
+  setters: ChainWeightSetter[];
 }
 
 /**

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -23,6 +23,7 @@ import {
   chainEventsStatsQuery,
   chainFeesQuery,
   chainSignersQuery,
+  chainWeightSettersQuery,
   chainStakeFlowQuery,
   chainStakeMovesQuery,
   chainTurnoverQuery,
@@ -103,6 +104,7 @@ function ExplorerPage() {
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
+          "/api/v1/chain/weights/setters",
           "/api/v1/chain/stake-flow",
           "/api/v1/chain/stake-moves",
           "/api/v1/chain/turnover",
@@ -739,6 +741,14 @@ function EconomicsTrendsSection({ trends }: { trends: EconomicsTrends }) {
   );
 }
 
+function fmtShare(share: number | null): string {
+  return share == null ? "—" : `${(share * 100).toFixed(1)}%`;
+}
+
+function weightSetterKey(setter: { hotkey: string | null; uid: number | null }): string {
+  return setter.hotkey ?? `uid:${setter.uid ?? "unknown"}`;
+}
+
 function ExplorerDashboard() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -759,6 +769,7 @@ function ExplorerDashboard() {
     { data: feesRes },
     { data: callsRes },
     { data: signersRes },
+    { data: weightSettersRes },
     { data: stakeFlowRes },
     { data: stakeMovesRes },
     { data: turnoverRes },
@@ -772,6 +783,7 @@ function ExplorerDashboard() {
       chainFeesQuery(win),
       chainCallsQuery(win),
       chainSignersQuery(win),
+      chainWeightSettersQuery(win),
       chainStakeFlowQuery(win),
       chainStakeMovesQuery(win),
       chainTurnoverQuery(win),
@@ -785,6 +797,7 @@ function ExplorerDashboard() {
   const fees = feesRes.data;
   const calls = callsRes.data;
   const signers = signersRes.data;
+  const weightSetters = weightSettersRes.data;
   const stakeFlow = stakeFlowRes.data;
   const stakeMoves = stakeMovesRes.data;
   const turnover = turnoverRes.data;
@@ -1021,6 +1034,67 @@ function ExplorerDashboard() {
           ) : (
             <p className="font-mono text-[12px] text-ink-muted">
               No fee payers in this window yet.
+            </p>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-border bg-card p-5 lg:col-span-2">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Network weight-setters
+            </h2>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {formatNumber(weightSetters.distinct_setters)} validators
+            </span>
+          </div>
+          {weightSetters.setters.length > 0 ? (
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Validator</th>
+                  <th className={`${TH} text-right`}>WeightsSet</th>
+                  <th className={`${TH} text-right`}>Share</th>
+                  <th className={`${TH} text-right`}>Last set</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {weightSetters.setters.map((setter) => (
+                  <tr key={weightSetterKey(setter)} className="hover:bg-surface/40">
+                    <td className="px-4 py-2 font-mono text-[11px]">
+                      {setter.hotkey ? (
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: setter.hotkey }}
+                          className="text-ink-strong hover:text-accent hover:underline"
+                          title={setter.hotkey}
+                        >
+                          {shortHash(setter.hotkey) ?? setter.hotkey}
+                        </Link>
+                      ) : (
+                        <span
+                          className="text-ink-muted"
+                          title="Uid-only setter (no network-wide hotkey)"
+                        >
+                          uid {setter.uid ?? "—"}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(setter.weight_sets)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {fmtShare(setter.share)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {setter.last_set_at ? <TimeAgo at={setter.last_set_at} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="font-mono text-[12px] text-ink-muted">
+              No weight-setters in this window yet.
             </p>
           )}
         </section>


### PR DESCRIPTION
## Summary

- Add `ChainWeightSetters` / `ChainWeightSetter` types and `chainWeightSettersQuery(window)` fetching `GET /api/v1/chain/weights/setters`
- Render a **Network weight-setters** ranked table on `/explorer` (in the fees grid, sibling to Top fee payers), showing validator identity, `weight_sets`, share %, and last set time
- Respect the page's existing `7d`/`30d` window toggle; add `/api/v1/chain/weights/setters` to `ApiSourceFooter`

Closes #3470 · Part of #2542

> **Scope note:** The issue title references `/leaderboards`, but main has no such route — this lands on `/explorer` per the issue deliverable.

## Screenshots

Captured on `/explorer?window=7d` (fees / leaderboard area). Theme forced via `localStorage.setItem("mg-theme", "dark"|"light")` before navigation. **Before:** `origin/main` @ `55772d53` (`:5173`) — Daily fees + Top fee payers, then economics trend. **After:** feature branch (`:5177`) — new **Network weight-setters** section appears between fee payers and economics trend.

> **Where to look:** after adds a new card titled **"Network weight-setters"** between **Top fee payers** and **Network economics trend**. Both show empty-state text while API data is cold — the difference is the **new section existing**, not populated rows.

### Transition detail (desktop · light) — clearest contrast

| Before (Top fee payers → economics trend) | After (Top fee payers → **Network weight-setters** → economics trend) |
| ----------------------------------------- | --------------------------------------------------------------------- |
| [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-before-transition-detail.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-before-transition-detail.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-after-transition-detail.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-after-transition-detail.png) |

**Before:** only Daily fees, Top fee payers, then Network economics trend  
**After:** **Network weight-setters** card appears (0 validators · "No weight-setters in this window yet.")

### Section detail (desktop · light)

| Before (no Network weight-setters) | After (new Network weight-setters section) |
| ---------------------------------- | ------------------------------------------ |
| [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-before-section-detail.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-before-section-detail.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-after-section-detail.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-after-section-detail.png) |

### Full page (all viewports)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3470-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `/explorer` shows **Network weight-setters** section below Top fee payers
- [x] Table columns: Validator (linked hotkey or uid fallback), WeightsSet, Share, Last set
- [x] Header shows `{distinct_setters} validators`
- [x] `7d`/`30d` toggle re-fetches via `chainWeightSettersQuery(win)`
- [x] Empty state: "No weight-setters in this window yet."
- [x] `ApiSourceFooter` includes `/api/v1/chain/weights/setters`
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
