### PR TITLE
feat(registry): add SN72 StreetVision TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/streetvision-by-natix.json
+++ b/registry/subnets/streetvision-by-natix.json
@@ -207,6 +207,25 @@
         "https://github.com/natixnetwork/streetvision-subnet/blob/main/README.md"
       ],
       "url": "https://docs.natix.network/whitepaper/llms.txt"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-72-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "StreetVision TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/72 on api.taomarketcap.com returning machine-readable JSON for SN72 StreetVision on-chain subnet state, hyperparameters, economics, and dTAO market fields. NATIX publishes websites, docs, and dataset artifacts but no verified first-party public subnet API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/natixnetwork/streetvision-subnet"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/72"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4085

Adds a community `subnet-api` surface for SN72 StreetVision by NATIX: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/72` — public, no-auth, machine-readable JSON covering SN72's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** NATIX publishes websites, docs, and HuggingFace dataset artifacts for StreetVision, but no first-party public *subnet* API endpoint — the manifest's curation notes record that gap, and the file's only callable-JSON surface today is the HF datasets-server rows feed (a dataset artifact, not a subnet-state API). The TaoMarketCap indexed feed is the same provider/URL pattern already accepted in this registry for SN30, SN40, SN52, SN86, SN89, SN101, SN109, SN111, and SN116.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the subnet's official repository (`natixnetwork/streetvision-subnet`, already referenced throughout this manifest) cross-references the subnet identity.

One file touched (`registry/subnets/streetvision-by-natix.json`), append-only; no `curation`/top-level metadata changes. `npm run validate` and `npm run validate:surface` pass locally.