### PR TITLE
feat(ui): add an enrichment-evidence board to the gaps review surface

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6902,6 +6902,41 @@ export const reviewEnrichmentTargetsQuery = () =>
     staleTime: STALE_LONG,
   });
 
+// #3354: the detailed candidate-evidence view behind the enrichment queue —
+// distinct from the enrichment-queue summary. GET /api/v1/review/enrichment-evidence,
+// collection key `entries`, one row per subnet.
+export const reviewEnrichmentEvidenceQuery = () =>
+  queryOptions({
+    queryKey: k("review-enrichment-evidence"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/enrichment-evidence",
+        "entries",
+        undefined,
+        signal,
+      );
+      // API rows: { netuid, name, slug, lane, evidence_action, missing_kinds,
+      // direct_submission_kinds, priority_score, ... }.
+      const rows = res.data.map((r) => ({
+        id: (r.slug as string) ?? (r.name as string) ?? String(r.netuid ?? ""),
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        lane: r.lane as string | undefined,
+        evidenceAction: r.evidence_action as string | undefined,
+        priority:
+          typeof r.priority_score === "number"
+            ? String(Math.round(r.priority_score as number))
+            : undefined,
+        missing: Array.isArray(r.missing_kinds) ? (r.missing_kinds as string[]).join(", ") : "",
+        directSubmission: Array.isArray(r.direct_submission_kinds)
+          ? (r.direct_submission_kinds as string[]).join(", ")
+          : "",
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
 function normalizeSchema(raw: unknown): SchemaInfo {
   if (!raw || typeof raw !== "object") return raw as SchemaInfo;
   const s = raw as Record<string, unknown>;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -30,6 +30,7 @@ import {
   reviewAdapterCandidatesQuery,
   reviewEnrichmentQueueQuery,
   reviewEnrichmentTargetsQuery,
+  reviewEnrichmentEvidenceQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
@@ -215,6 +216,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="enrichment-evidence"
+          eyebrow="Evidence"
+          title="Enrichment evidence"
+          description="The detailed candidate evidence behind the enrichment queue — per subnet, one level down from the summary."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <EnrichmentEvidence />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -224,6 +238,7 @@ function GapsPage() {
           "/api/v1/review/adapter-candidates",
           "/api/v1/review/enrichment-queue",
           "/api/v1/review/enrichment-targets",
+          "/api/v1/review/enrichment-evidence",
         ]}
       />
     </AppShell>
@@ -1076,6 +1091,74 @@ function EnrichmentTargets() {
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// #3354: detailed candidate evidence behind the enrichment queue — one row per
+// subnet from /api/v1/review/enrichment-evidence, mirroring the table idiom above.
+function EnrichmentEvidence() {
+  const { data } = useSuspenseQuery(reviewEnrichmentEvidenceQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No enrichment evidence"
+        description="No candidate evidence is currently awaiting review."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-4 py-2.5 text-left">Netuid</th>
+              <th className="px-4 py-2.5 text-left">Subnet</th>
+              <th className="px-4 py-2.5 text-left">Lane</th>
+              <th className="px-4 py-2.5 text-left">Evidence action</th>
+              <th className="px-4 py-2.5 text-left">Missing</th>
+              <th className="px-4 py-2.5 text-left">Direct submission</th>
+              <th className="px-4 py-2.5 text-left">Priority</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => (
+              <tr key={r.id} className="mg-row-hover">
+                <td className="px-4 py-2.5 font-mono text-[11px]">
+                  {r.netuid != null ? (
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="hover:text-accent"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-strong">{r.name ?? "—"}</td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.lane ?? "—"}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.evidenceAction ?? "—"}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.missing || "—"}</td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                  {r.directSubmission || "—"}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary

Adds an **Enrichment evidence** section to the gaps review surface (`/gaps`), wiring the live `GET /api/v1/review/enrichment-evidence` endpoint — the detailed candidate-evidence view, one level down from the "Enrichment queue" summary — which nothing in `apps/ui/src` consumed yet.

Closes #3354

> Prior attempts (#4491, #4556) closed without an automated blocker; this re-do includes the full before/after screenshot table below (real live data). Code follows the same sibling pattern as the just-merged #3355 (enrichment-targets).

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `reviewEnrichmentEvidenceQuery`, following the `reviewEnrichmentQueueQuery`/`reviewEnrichmentTargetsQuery` pattern: `fetchList` on the `entries` collection key; normalizes `netuid`, `name`, `lane`, `evidence_action`, `missing_kinds`, `direct_submission_kinds`, `priority_score`.
- **`apps/ui/src/routes/gaps.tsx`** — a self-contained `EnrichmentEvidence` component + `<PageSection id="enrichment-evidence">` after the `enrichment-targets` section, mirroring the sibling table idiom (columns: Netuid · Subnet · Lane · Evidence action · Missing · Direct submission · Priority), the shared `TableState` empty state, the page's standard `Suspense`/`QueryErrorBoundary`, and `/api/v1/review/enrichment-evidence` appended to `ApiSourceFooter`.
- Scoped to the flat `entries` list (one row per subnet); no backend/schema change — the endpoint is already live.

## Screenshots

Route `/gaps`, the new section scrolled into view, fixed viewports (Desktop 1280×800, Tablet 768×1024, Mobile 375×812), both themes. **Real live data** — before: page ends at "Enrichment targets"; after: the "Enrichment evidence" board is added below it.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3354-after-mobile-dark.png)<br><sub>after</sub> |

## Validation (full local run)

- [x] `npm run typecheck` — clean · `npm run lint` — 0 errors on the changed files
- [x] `npm test` — 647 passed · `npm run build` — green
- [x] Data layer + UI wiring in one PR; reuses the sibling table/empty-state idiom; no new dependency
