### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Recall TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning machine-readable JSON for SN31 Recall on-chain subnet state, hyperparameters, economics, and dTAO market fields. Recall (renamed from Halftime) has no verified first-party website, repository, or API surface; this indexed on-chain feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #4032

Adds a community `subnet-api` surface for SN31 Recall: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/31` — public, no-auth, machine-readable JSON covering SN31's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** SN31 Recall (renamed from Halftime) currently has no verified first-party website, repository, or API surface at all — the manifest's `surfaces` array is empty and its curation notes record the gap. The indexed on-chain feed is subnet-identity-agnostic (it reports chain state for netuid 31 regardless of branding) and is the same provider/URL pattern already accepted in this registry for SN30, SN40, SN52, SN72, SN86, SN89, SN101, SN109, SN111, and SN116.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the tensorplex-labs subnet-docs entry for netuid 31 cross-references the subnet identity (the provenance pattern accepted for the EfficientFrontier and SN30 surfaces).

One file touched (`registry/subnets/recall.json`), append-only; no `curation`/top-level metadata changes. `npm run validate` and `npm run validate:surface` pass locally.