### PR TITLE
feat(ui): add FeesTrendCard component to display 7-day fee trends

### DIFF
--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -22,8 +22,9 @@ import { ShareButton } from "@/components/metagraphed/share-button";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
 import { CopyButton } from "@/components/metagraphed/copy-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
-import { extrinsicsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
+import { chainFeesQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
@@ -94,12 +95,56 @@ function ExtrinsicsPage() {
         }
       />
       <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="mb-6 h-24 w-full" />}>
+          <FeesTrendCard />
+        </Suspense>
+      </QueryErrorBoundary>
+      <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ExtrinsicsTable />
         </Suspense>
       </QueryErrorBoundary>
-      <ApiSourceFooter paths={["/api/v1/extrinsics"]} artifacts={["/metagraph/extrinsics.json"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/extrinsics", "/api/v1/chain/fees"]}
+        artifacts={["/metagraph/extrinsics.json"]}
+      />
     </AppShell>
+  );
+}
+
+/**
+ * Fees-over-time sparkline (#3385) — reuses chainFeesQuery + Sparkline the same
+ * way explorer.tsx charts "Total fees". Fixed 7d window; no ?window= toggle here.
+ */
+function FeesTrendCard() {
+  const fees = useSuspenseQuery(chainFeesQuery("7d")).data.data;
+  const feeChrono = [...fees.daily].reverse();
+  const values = feeChrono.map((d) => d.total_fee_tao);
+  const latest = values.length > 0 ? values[values.length - 1]! : null;
+
+  return (
+    <section className="mb-6 rounded-lg border border-border bg-card p-4 sm:p-5">
+      <div className="mb-2 flex items-baseline justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <h2 className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Fees, last 7d
+          </h2>
+          <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
+        </div>
+        <span className="font-mono text-[11px] tabular-nums text-ink-strong">
+          {latest == null ? "—" : formatTao(latest)}
+        </span>
+      </div>
+      <Sparkline
+        values={values}
+        points={feeChrono.map((d) => ({ t: d.day, v: d.total_fee_tao }))}
+        width={640}
+        height={48}
+        color="var(--accent)"
+        ariaLabel="Daily total fees"
+        formatValue={formatTao}
+      />
+    </section>
   );
 }
 


### PR DESCRIPTION
Closes #3385

`/extrinsics` was a filterable, paginated table with no trend context. `chainFeesQuery` (`GET /api/v1/chain/fees`) already powers the explorer's daily fee series via `Sparkline`, but nothing on the extrinsics index consumed it — a visitor browsing raw extrinsics had no at-a-glance sense of whether network fees were trending up or down.

## What changed

`apps/ui/src/routes/extrinsics.index.tsx` only:

- New `FeesTrendCard` between `PageHero` and the `ExtrinsicsTable` `QueryErrorBoundary`, wrapped in its own `QueryErrorBoundary` + `Suspense`/`Skeleton` so a slow/failed fees fetch does not block the table.
- Fetches `chainFeesQuery("7d")` (fixed window — no new `?window=` search param, per issue non-goals), reverses `fees.daily` to chronological order (same pattern as `explorer.tsx`), and charts `total_fee_tao` through the shared `Sparkline`.
- Card shows label ("Fees, last 7d"), day count, and latest daily total via existing `formatTao` — not a bare unlabeled chart.
- Empty/short series: latest renders "—" and `Sparkline` already draws a dashed baseline for empty input (no crash on `values[values.length - 1]`).
- `ApiSourceFooter` `paths` now includes `"/api/v1/chain/fees"` alongside `"/api/v1/extrinsics"`.

No changes to `explorer.tsx`, `queries.ts`, types, or backend — pure frontend consumption of an existing query + chart primitive. Did not extract `MiniSeries` / shared `fmtTao` (out of scope).

## Verification

- Confirmed against the live API on `/extrinsics`: card renders real 7d fee series with label + latest τ value above the table; empty-series path does not throw.
- No console errors.
- `npm run typecheck --workspace=apps/ui` — clean
- `npx eslint apps/ui/src/routes/extrinsics.index.tsx` — 0 errors
- `npx prettier --check apps/ui/src/routes/extrinsics.index.tsx` — clean
- `npm test --workspace=apps/ui` — 660 passed

## Screenshots — desktop / tablet / mobile × light + dark

Framed on `/extrinsics` so the new fees card (or its absence, in "before") is directly visible between the page hero and the extrinsics table.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/0e4aea10-d179-4449-bbb8-668eeeb01a29" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/b44b54c3-0da4-4f20-a608-cec4ec593286" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/91b32c5d-44cc-40bc-9f8b-f2cd6940327b" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/4c6e5ca1-1503-4039-828a-63c7f0ae57e7" /> |
| Tablet · Light   | <img width="1010" height="760" alt="image" src="https://github.com/user-attachments/assets/cac0b5fd-5828-4328-a2a2-0e4e1dc860c7" /> | <img width="1010" height="760" alt="image" src="https://github.com/user-attachments/assets/8a36a1ff-8f7c-4f70-88e4-7945f0e644d4" /> |
| Tablet · Dark    | <img width="1010" height="760" alt="image" src="https://github.com/user-attachments/assets/b5def454-e0bb-475c-802c-3f1dbcad9c47" /> | <img width="1010" height="760" alt="image" src="https://github.com/user-attachments/assets/532116f1-9405-4ffb-9c53-6949171d524e" /> |
| Mobile · Light   | <img width="507" height="760" alt="image" src="https://github.com/user-attachments/assets/bd9f5a7a-1f97-49e7-be8d-9fc4aad54142" /> | <img width="507" height="760" alt="image" src="https://github.com/user-attachments/assets/8e6bea41-7074-4920-9c58-d0960883e111" /> |
| Mobile · Dark    | <img width="428" height="760" alt="image" src="https://github.com/user-attachments/assets/ab9553ca-72a7-4506-98ac-5fdb0a7f753f" /> | <img width="428" height="760" alt="image" src="https://github.com/user-attachments/assets/6e2771d1-465c-4fb2-b607-97a25ead6b18" /> |