### PR TITLE
feat(shared): extract AccountId32/MultiAddress SS58 encoder module

### DIFF
--- a/src/ss58.mjs
+++ b/src/ss58.mjs
@@ -1,0 +1,122 @@
+// Shared server-side SS58 codec for AccountId32-typed chain data (Workers
+// runtime). @noble/hashes' blake2b is required here, not node:crypto's
+// createHash("blake2b512") -- that throws "Digest method not supported" in
+// workerd (confirmed live: account-balance.mjs's GET
+// /api/v1/accounts/{ss58}/balance 500'd on every request for exactly this
+// reason before the switch to @noble/hashes). Extracted from src/sudo-key.mjs
+// (#4310) so #4669/#4685/#4688's Postgres AccountId32 decoding reuses the one
+// implementation already verified working in production, instead of a second
+// hand-rolled copy.
+import { blake2b } from "@noble/hashes/blake2.js";
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const SS58_PREIMAGE = new TextEncoder().encode("SS58PRE");
+
+/** The Bittensor / generic-Substrate SS58 address format prefix. */
+export const DEFAULT_SS58_PREFIX = 42;
+
+// The general base58 "leading zero byte -> leading '1' character" convention
+// doesn't apply to any caller here: the payload always starts with a
+// non-zero network prefix byte, so the byte array this ever sees can't start
+// with a zero byte.
+function encodeBase58(bytes) {
+  let num = 0n;
+  for (const b of bytes) num = (num << 8n) | BigInt(b);
+  let out = "";
+  while (num > 0n) {
+    const rem = num % 58n;
+    out = BASE58_ALPHABET[Number(rem)] + out;
+    num /= 58n;
+  }
+  return out;
+}
+
+/**
+ * AccountId32 -> SS58: payload = prefix_byte + 32 account bytes, checksum =
+ * blake2b512("SS58PRE" + payload)[0:2], address = base58(payload + checksum).
+ * Returns null when `accountIdBytes` isn't exactly 32 bytes. Golden-value
+ * tested in tests/ss58.test.mjs against real production data.
+ */
+export function encodeAccountId32(
+  accountIdBytes,
+  prefix = DEFAULT_SS58_PREFIX,
+) {
+  const bytes =
+    accountIdBytes instanceof Uint8Array
+      ? accountIdBytes
+      : Uint8Array.from(accountIdBytes);
+  if (bytes.length !== 32) return null;
+  const payload = new Uint8Array(1 + bytes.length);
+  payload[0] = prefix;
+  payload.set(bytes, 1);
+  const preimage = new Uint8Array(SS58_PREIMAGE.length + payload.length);
+  preimage.set(SS58_PREIMAGE, 0);
+  preimage.set(payload, SS58_PREIMAGE.length);
+  const hash = blake2b(preimage, { dkLen: 64 });
+  const full = new Uint8Array(payload.length + 2);
+  full.set(payload, 0);
+  full[payload.length] = hash[0];
+  full[payload.length + 1] = hash[1];
+  return encodeBase58(full);
+}
+
+function isByteArray(value, len) {
+  return (
+    Array.isArray(value) &&
+    value.length === len &&
+    value.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)
+  );
+}
+
+/**
+ * indexer-rs's generic dynamic-SCALE-value dump wraps a Rust tuple-struct
+ * with one field (like `AccountId32([u8; 32])`) in an extra array layer -- a
+ * bare AccountId32 field arrives as `[[b0..b31]]`, not a flat 32-byte array.
+ * Unwraps that one layer; returns null if `value` isn't that shape.
+ */
+function unwrapAccountId32Newtype(value) {
+  if (Array.isArray(value) && value.length === 1 && isByteArray(value[0], 32)) {
+    return value[0];
+  }
+  return null;
+}
+
+/**
+ * indexer-rs's `MultiAddress::Id(AccountId32)` variant arrives as
+ * `{"name":"Id","values":[<AccountId32 newtype shape>]}`. Unwraps to the raw
+ * 32 bytes for the `Id` variant only; returns null for `Index`/`Raw`/
+ * `Address32`/`Address20` -- none of those carry a 32-byte AccountId32
+ * payload in this shape (`Address20` is a 20-byte H160, `Index` is a compact
+ * integer, `Raw` is arbitrary-length bytes), and none have been observed on
+ * this chain, so declining is safer than guessing (#4669/#4688).
+ */
+export function unwrapMultiAddressId(value) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    value.name !== "Id" ||
+    !Array.isArray(value.values) ||
+    value.values.length !== 1
+  ) {
+    return null;
+  }
+  return unwrapAccountId32Newtype(value.values[0]);
+}
+
+/**
+ * One-stop helper for a field the caller already knows is `AccountId32`-typed:
+ * accepts the bare newtype-wrapped shape (`[[b0..b31]]`), a flat 32-element
+ * byte array, or a `MultiAddress::Id` wrapper, and returns the SS58 string
+ * (or null if the shape doesn't resolve to 32 bytes). This function does NOT
+ * infer "is this an account" from shape alone -- a bare flat 32-byte array is
+ * structurally indistinguishable from a `Hash`/`H256` (#4669's accepted
+ * ambiguity note), so callers must gate on field-name/context first.
+ */
+export function normalizeAccountId32Field(value, prefix = DEFAULT_SS58_PREFIX) {
+  if (isByteArray(value, 32)) return encodeAccountId32(value, prefix);
+  const unwrapped =
+    unwrapAccountId32Newtype(value) ?? unwrapMultiAddressId(value);
+  return unwrapped ? encodeAccountId32(unwrapped, prefix) : null;
+}

--- a/src/sudo-key.mjs
+++ b/src/sudo-key.mjs
@@ -7,14 +7,10 @@
 // computed at runtime. Mirrors src/account-balance.mjs's live-RPC + KV-cache
 // shape for GET /api/v1/accounts/{ss58}/balance.
 
-// node:crypto's createHash("blake2b512") is NOT implemented in the Cloudflare
-// Workers runtime (confirmed live in production: this same call throws
-// "Error: Digest method not supported" in workerd -- account-balance.mjs's
-// GET /api/v1/accounts/{ss58}/balance, which had the identical pattern, was
-// 500ing on every request for exactly this reason). @noble/hashes is
-// audited, zero-dependency, pure JS, and verified working in workerd
-// (wrangler dev) with output identical to node:crypto's blake2b512.
-import { blake2b } from "@noble/hashes/blake2.js";
+// Server-side SS58 encoding lives in src/ss58.mjs (extracted #4688) -- see
+// that module's header for why @noble/hashes' blake2b is required over
+// node:crypto's createHash("blake2b512") (unsupported in workerd).
+import { encodeAccountId32 } from "./ss58.mjs";
 
 const SUDO_KEY_STORAGE_KEY =
   "0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b";
@@ -22,48 +18,7 @@ export const SUDO_KEY_KV_TTL = 3600; // seconds — the sudo key changes extreme
 export const SUDO_KEY_NEGATIVE_KV_TTL = 10; // seconds
 export const SUDO_KEY_RPC_TIMEOUT_MS = 5000;
 const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
-
-const SS58_BASE58_ALPHABET =
-  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const FINNEY_SS58_PREFIX = 42;
-const SS58_PREIMAGE = new TextEncoder().encode("SS58PRE");
-
-// The general base58 "leading zero byte -> leading '1' character" convention
-// (account-balance.mjs's decodeBase58 handles the inverse) doesn't apply to
-// this call site: the one caller always passes [prefix, ...accountId,
-// checksumHi, checksumLo], and FINNEY_SS58_PREFIX (42) is never zero, so the
-// byte array this function ever sees can't start with a zero byte.
-function encodeBase58(bytes) {
-  let num = 0n;
-  for (const b of bytes) num = (num << 8n) | BigInt(b);
-  let out = "";
-  while (num > 0n) {
-    const rem = num % 58n;
-    out = SS58_BASE58_ALPHABET[Number(rem)] + out;
-    num /= 58n;
-  }
-  return out;
-}
-
-// AccountId32 -> SS58 (finney prefix 42): payload = prefix_byte + 32 account
-// bytes, checksum = blake2b512("SS58PRE" + payload)[0:2], address =
-// base58(payload + checksum). The exact inverse of account-balance.mjs's
-// verifyFinneySs58Checksum (decode direction) — golden-value-tested against
-// the live-confirmed 2026-07-08 Sudo key in tests/sudo-key.test.mjs.
-function ss58Encode(accountIdBytes, prefix = FINNEY_SS58_PREFIX) {
-  const payload = new Uint8Array(1 + accountIdBytes.length);
-  payload[0] = prefix;
-  payload.set(accountIdBytes, 1);
-  const preimage = new Uint8Array(SS58_PREIMAGE.length + payload.length);
-  preimage.set(SS58_PREIMAGE, 0);
-  preimage.set(payload, SS58_PREIMAGE.length);
-  const hash = blake2b(preimage, { dkLen: 64 });
-  const full = new Uint8Array(payload.length + 2);
-  full.set(payload, 0);
-  full[payload.length] = hash[0];
-  full[payload.length + 1] = hash[1];
-  return encodeBase58(full);
-}
 
 // The one call site already validated a "0x"-prefixed 64-hex-char string via
 // regex, so this only ever strips that guaranteed prefix — not a general
@@ -113,7 +68,7 @@ export async function loadSudoKey(env) {
       const rpcBody = await rpcResp.json();
       const raw = rpcBody?.result;
       if (typeof raw === "string" && /^0x[0-9a-fA-F]{64}$/.test(raw)) {
-        hotkey = ss58Encode(hexToBytes(raw));
+        hotkey = encodeAccountId32(hexToBytes(raw), FINNEY_SS58_PREFIX);
         rpcOk = true;
       } else if (raw === null) {
         // Storage genuinely unset (sudo renounced) — a valid, not-failed result.

--- a/tests/ss58.test.mjs
+++ b/tests/ss58.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  DEFAULT_SS58_PREFIX,
+  encodeAccountId32,
+  normalizeAccountId32Field,
+  unwrapMultiAddressId,
+} from "../src/ss58.mjs";
+
+// Carried over from tests/sudo-key.test.mjs -- live-confirmed 2026-07-08
+// against finney (bittensor 10.5.0, substrate.create_storage_key("Sudo",
+// "Key") + a raw state_getStorage RPC call).
+const GOLDEN_RAW_STORAGE =
+  "0x4471816662ea3cfadc9868e5f083e26a3be6706b8d8dad7fbef565983afb3556";
+const GOLDEN_SS58 = "5DcSqBNqCmfdJZRGFSwwcRb2dZdJHZuKK8Tb1Gx8gbmF5E8s";
+
+function hexToBytes(hex) {
+  const clean = hex.slice(2);
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i += 1)
+    out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  return out;
+}
+
+// Real production data (2026-07-09/10 D1-vs-Postgres shape-parity audit,
+// #4669/#4688): SubtensorModule.add_stake, block 8587451, extrinsic_index 20.
+// Independently re-confirmed live against Postgres (D1 has since rolled this
+// block out of its retention window) and cross-checked byte-for-byte against
+// the SS58 string D1 served for the same extrinsic before this fix landed.
+const ADD_STAKE_HOTKEY_BYTES = [
+  218, 242, 207, 184, 146, 103, 37, 85, 165, 200, 187, 85, 14, 162, 252, 59, 70,
+  104, 173, 244, 214, 178, 164, 112, 5, 200, 46, 53, 22, 206, 26, 85,
+];
+const ADD_STAKE_HOTKEY_SS58 =
+  "5H1nRfbCbDGh3t17er9Y8hwFEsXCrjBbaN6jLrnez8KpUKju";
+
+// Balances.transfer_all, block 8587450, extrinsic_index 20 -- the
+// MultiAddress::Id(AccountId32) shape (Balances/Proxy/Contracts dest fields).
+const TRANSFER_ALL_DEST_BYTES = [
+  148, 23, 68, 122, 121, 209, 249, 231, 72, 77, 75, 123, 3, 244, 110, 63, 98,
+  234, 211, 56, 18, 215, 171, 86, 162, 59, 211, 147, 124, 3, 247, 30,
+];
+const TRANSFER_ALL_DEST_SS58 =
+  "5FQsrbnp2dEvemXG41JmjnrsSaSQyfGAoe5hK3EHBhu8Z1sT";
+
+describe("encodeAccountId32", () => {
+  test("encodes the golden Sudo::Key raw storage bytes to its known SS58 address", () => {
+    assert.equal(
+      encodeAccountId32(hexToBytes(GOLDEN_RAW_STORAGE)),
+      GOLDEN_SS58,
+    );
+  });
+
+  test("encodes the real add_stake hotkey bytes to its known SS58 address", () => {
+    assert.equal(
+      encodeAccountId32(ADD_STAKE_HOTKEY_BYTES),
+      ADD_STAKE_HOTKEY_SS58,
+    );
+  });
+
+  test("accepts a plain array or a Uint8Array identically", () => {
+    assert.equal(
+      encodeAccountId32(ADD_STAKE_HOTKEY_BYTES),
+      encodeAccountId32(Uint8Array.from(ADD_STAKE_HOTKEY_BYTES)),
+    );
+  });
+
+  test("defaults to the generic-Substrate/Bittensor prefix (42)", () => {
+    assert.equal(DEFAULT_SS58_PREFIX, 42);
+  });
+
+  test("returns null for a non-32-byte input", () => {
+    assert.equal(encodeAccountId32([1, 2, 3]), null);
+    assert.equal(encodeAccountId32(new Array(31).fill(0)), null);
+    assert.equal(encodeAccountId32(new Array(33).fill(0)), null);
+  });
+});
+
+describe("unwrapMultiAddressId", () => {
+  test("unwraps the Id variant to its raw 32 bytes", () => {
+    assert.deepEqual(
+      unwrapMultiAddressId({ name: "Id", values: [[TRANSFER_ALL_DEST_BYTES]] }),
+      TRANSFER_ALL_DEST_BYTES,
+    );
+  });
+
+  test("returns null for the Index/Raw/Address32/Address20 variants (not observed on this chain, decline rather than guess)", () => {
+    assert.equal(unwrapMultiAddressId({ name: "Index", values: [5] }), null);
+    assert.equal(
+      unwrapMultiAddressId({ name: "Raw", values: [[1, 2, 3]] }),
+      null,
+    );
+    assert.equal(
+      unwrapMultiAddressId({
+        name: "Address32",
+        values: [[new Array(32).fill(1)]],
+      }),
+      null,
+    );
+    assert.equal(
+      unwrapMultiAddressId({
+        name: "Address20",
+        values: [[new Array(20).fill(1)]],
+      }),
+      null,
+    );
+  });
+
+  test("returns null for non-enum-shaped input", () => {
+    assert.equal(unwrapMultiAddressId(null), null);
+    assert.equal(unwrapMultiAddressId(undefined), null);
+    assert.equal(unwrapMultiAddressId(TRANSFER_ALL_DEST_BYTES), null);
+    assert.equal(unwrapMultiAddressId({ name: "Id" }), null);
+    assert.equal(unwrapMultiAddressId({ name: "Id", values: [] }), null);
+    assert.equal(unwrapMultiAddressId({ name: "Id", values: [1, 2] }), null);
+  });
+});
+
+describe("normalizeAccountId32Field", () => {
+  test("resolves the newtype-wrapped bare AccountId32 shape (hotkey/coldkey/etc.)", () => {
+    assert.equal(
+      normalizeAccountId32Field([ADD_STAKE_HOTKEY_BYTES]),
+      ADD_STAKE_HOTKEY_SS58,
+    );
+  });
+
+  test("resolves a flat 32-byte array the same way", () => {
+    assert.equal(
+      normalizeAccountId32Field(ADD_STAKE_HOTKEY_BYTES),
+      ADD_STAKE_HOTKEY_SS58,
+    );
+  });
+
+  test("resolves the MultiAddress::Id wrapper", () => {
+    assert.equal(
+      normalizeAccountId32Field({
+        name: "Id",
+        values: [[TRANSFER_ALL_DEST_BYTES]],
+      }),
+      TRANSFER_ALL_DEST_SS58,
+    );
+  });
+
+  test("returns null for a shape that doesn't resolve to 32 bytes", () => {
+    assert.equal(
+      normalizeAccountId32Field({ name: "Index", values: [5] }),
+      null,
+    );
+    assert.equal(normalizeAccountId32Field([1, 2, 3]), null);
+    assert.equal(normalizeAccountId32Field(null), null);
+    assert.equal(normalizeAccountId32Field(42), null);
+  });
+});


### PR DESCRIPTION
Refs #4669, #4688

### Motivation
- `src/sudo-key.mjs` had a private, workerd-verified SS58 encoder (blake2b via `@noble/hashes`, since `node:crypto`'s `blake2b512` isn't supported in the Workers runtime) with no shared, importable form.
- The Postgres `call_args`/`chain_events` shape-parity roadmap (#4669 and its sub-issues) needs this exact capability server-side in several places -- extracting it now avoids a second hand-rolled implementation.

### Description
- New `src/ss58.mjs`: `encodeAccountId32` (the extracted codec), `unwrapMultiAddressId` (unwraps indexer-rs's `MultiAddress::Id(AccountId32)` enum wrapper, declining -- not guessing -- on `Index`/`Raw`/`Address32`/`Address20`), and `normalizeAccountId32Field` (one-stop helper handling the bare newtype-wrapped shape, a flat 32-byte array, or a `MultiAddress::Id` wrapper).
- `src/sudo-key.mjs` now imports `encodeAccountId32` instead of keeping its own private copy.

### Testing
- `tests/sudo-key.test.mjs` passes unchanged (12/12) -- confirms the extraction is behavior-preserving.
- New `tests/ss58.test.mjs` (12 tests, 100% statement/branch/function coverage on both touched files) with golden vectors drawn from **real production extrinsics** (`SubtensorModule.add_stake` block 8587451/idx 20, `Balances.transfer_all` block 8587450/idx 20) -- independently re-verified against Postgres directly during this session (D1 has since rolled these blocks out of its retention window), not just taken from the prior audit's citation.
- `npx eslint`/`npx prettier --check` clean.

No screenshot table -- no `apps/ui` files touched.