### PR TITLE
fix(data-api): decode chain_events.args AccountId32 fields server-side

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -1,0 +1,92 @@
+// Server-side port of apps/ui/src/lib/metagraphed/chain-event-args.ts (#3984,
+// PR #4621) -- that fix decoded chain-event args client-side, but only inside
+// apps/ui/src/routes/blocks.$ref.tsx. Every other consumer of the same
+// chain_events.args column (the REST /api/v1/chain-events routes and the
+// list_chain_events/get_block_chain_events/get_extrinsic_chain_events MCP
+// tools, all served unconditionally with no D1 fallback) still got the raw
+// shape. This decodes once, server-side, so every consumer sees the same
+// human-readable values (#4685).
+//
+// chain-event args arrive as decoded SCALE values, where account ids are raw
+// 32-byte number arrays (indexer-rs's generic dynamic-value dump wraps a
+// tuple-struct-with-one-field like AccountId32([u8;32]) in an extra array
+// layer -- [[b0..b31]], not a flat 32-byte array). Rendered verbatim they
+// read like `{"who":[[109,111,100,101,...]]}` -- unreadable and unbounded.
+// This walks the value and rewrites 32-byte arrays into a human-readable
+// form: an SS58 address when the field name marks it as an account,
+// otherwise a 0x-hex string (so a 32-byte hash isn't mislabelled as an
+// address, and an untagged positional arg with no key hint -- e.g. a
+// non-System/Balances pallet event's args tuple -- always falls to hex
+// rather than guessing). Everything else is untouched.
+import { encodeAccountId32 } from "./ss58.mjs";
+
+const ACCOUNT_KEYS = new Set([
+  "who",
+  "account",
+  "account_id",
+  "accountid",
+  "coldkey",
+  "hotkey",
+  "from",
+  "to",
+  "dest",
+  "destination",
+  "source",
+  "delegate",
+  "nominator",
+  "owner",
+  "target",
+  "validator",
+  "address",
+]);
+
+function isByteArray(v, len) {
+  return (
+    Array.isArray(v) &&
+    v.length === len &&
+    v.every(
+      (n) => typeof n === "number" && Number.isInteger(n) && n >= 0 && n <= 255,
+    )
+  );
+}
+
+function toHex(bytes) {
+  return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function decode(value, keyHint) {
+  if (isByteArray(value, 32)) {
+    // encodeAccountId32 can't return null here -- isByteArray already
+    // confirmed exactly 32 bytes, the only condition it checks internally.
+    if (keyHint && ACCOUNT_KEYS.has(keyHint.toLowerCase())) {
+      return encodeAccountId32(value);
+    }
+    return toHex(value);
+  }
+  // indexer-rs newtype-wraps a bare (non-Vec) AccountId32/[u8;32] field in an
+  // extra array layer -- `who: [[b0..b31]]`, depth 2 -- so it must collapse
+  // to a bare decoded value, not `[decoded]`. A genuine `Vec<AccountId32>`
+  // stays distinguishable by depth: each of ITS entries is independently
+  // newtype-wrapped too (`other_signatories: [[[b..]], [[b..]]]`, depth 3
+  // per entry), so the outer Vec's array-map below still produces one
+  // decoded value per entry -- this collapse only fires one layer at a time.
+  if (Array.isArray(value) && value.length === 1 && isByteArray(value[0], 32)) {
+    return decode(value[0], keyHint);
+  }
+  // Arrays inherit the parent key hint (e.g. `who: [<accountId bytes>]`) --
+  // this is also what makes an untagged positional args array (no object
+  // key at all) correctly fall through to hex: the hint stays undefined at
+  // every recursion depth, so the ACCOUNT_KEYS check never fires.
+  if (Array.isArray(value)) return value.map((item) => decode(item, keyHint));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [k, val] of Object.entries(value)) out[k] = decode(val, k);
+    return out;
+  }
+  return value;
+}
+
+/** Decode account ids inside a chain-event args value (leaves everything else as-is). */
+export function decodeChainEventArgs(args) {
+  return decode(args, undefined);
+}

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { decodeChainEventArgs } from "../src/chain-event-args.mjs";
+
+describe("decodeChainEventArgs", () => {
+  test("decodes an account-keyed 32-byte field to SS58 (real TransactionFeePaid.who, block 8587754/412)", () => {
+    const args = {
+      tip: 0,
+      who: [
+        [
+          230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117,
+          251, 19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175,
+          143, 88,
+        ],
+      ],
+      actual_fee: 2131419,
+    };
+    assert.deepEqual(decodeChainEventArgs(args), {
+      tip: 0,
+      who: "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i",
+      actual_fee: 2131419,
+    });
+  });
+
+  test("decodes both to/from account-keyed fields (real Balances.Transfer, block 8587754/119)", () => {
+    const args = {
+      to: [
+        [
+          109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
+      ],
+      from: [
+        [
+          109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 15, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
+      ],
+      amount: 30681,
+    };
+    assert.deepEqual(decodeChainEventArgs(args), {
+      to: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+      from: "5EYCAe5jLQhn6ofDSvuKE7htj4zVF4Tq1J7DTNzTePVJucfX",
+      amount: 30681,
+    });
+  });
+
+  test("hex-encodes an untagged positional 32-byte value with no field name (real SubtensorModule.TimelockedWeightsRevealed, block 8587756/2)", () => {
+    const args = [
+      78,
+      [
+        [
+          162, 193, 121, 87, 196, 67, 129, 183, 243, 158, 111, 10, 171, 37, 31,
+          122, 9, 152, 89, 131, 234, 97, 249, 41, 16, 168, 179, 154, 146, 252,
+          209, 69,
+        ],
+      ],
+    ];
+    assert.deepEqual(decodeChainEventArgs(args), [
+      78,
+      "0xa2c17957c44381b7f39e6f0aab251f7a09985983ea61f92910a8b39a92fcd145",
+    ]);
+  });
+
+  test("preserves array-ness for a hypothetical Vec<AccountId>-shaped field (each entry independently newtype-wrapped, not collapsed like a scalar field)", () => {
+    // No currently-observed chain_events field has this shape (a real
+    // Vec<AccountId> -- e.g. Multisig.other_signatories, verified this
+    // session as [[[b..]], [[b..]]], each entry its own [[bytes]] newtype
+    // wrap -- lives in extrinsics.call_args, not chain_events.args). This is
+    // a defensive structural test, keyed on an actual ACCOUNT_KEYS entry
+    // ("who"), proving the collapse only fires one array layer at a time so
+    // a genuine multi-entry array isn't flattened into a single value the
+    // way a bare scalar field correctly is.
+    const sig1 = new Array(32).fill(1);
+    const sig2 = new Array(32).fill(2);
+    const args = { who: [[sig1], [sig2]] };
+    const decoded = decodeChainEventArgs(args);
+    assert.ok(Array.isArray(decoded.who));
+    assert.equal(decoded.who.length, 2);
+    assert.ok(
+      decoded.who.every((s) => typeof s === "string" && s.startsWith("5")),
+    );
+    assert.notEqual(decoded.who[0], decoded.who[1]);
+  });
+
+  test("hex-encodes a 32-byte field whose name isn't in the account allowlist (e.g. a hash)", () => {
+    const bytes = new Array(32).fill(7);
+    assert.deepEqual(decodeChainEventArgs({ call_hash: [bytes] }), {
+      call_hash: "0x" + "07".repeat(32),
+    });
+  });
+
+  test("is idempotent on already-decoded data (safe no-op if run twice)", () => {
+    const decoded = decodeChainEventArgs({
+      who: [new Array(32).fill(1)],
+    });
+    assert.deepEqual(decodeChainEventArgs(decoded), decoded);
+  });
+
+  test("leaves non-byte-array values (scalars, short arrays, nested structs) untouched", () => {
+    const args = { netuid: 5, weights: [1, 2, 3], nested: { a: "b" } };
+    assert.deepEqual(decodeChainEventArgs(args), args);
+  });
+
+  test("passes through null/undefined/non-object args without throwing", () => {
+    assert.equal(decodeChainEventArgs(null), null);
+    assert.equal(decodeChainEventArgs(undefined), undefined);
+    assert.equal(decodeChainEventArgs(42), 42);
+    assert.equal(decodeChainEventArgs("x"), "x");
+  });
+});

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -121,6 +121,116 @@ test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () =
   expect(typeof body.events[0].observed_at).toBe("number");
 });
 
+// #4685: chain_events.args decodes AccountId32 byte arrays to SS58 (or hex
+// for non-account/untagged values) -- fixtures below are real production
+// rows, independently re-verified directly against Postgres during this
+// session, not synthetic examples.
+test("chain-events decodes an account-keyed field (TransactionFeePaid.who) to SS58", async () => {
+  mockRows.current = [
+    {
+      block_number: "8587754",
+      event_index: 412,
+      pallet: "TransactionPayment",
+      method: "TransactionFeePaid",
+      args: {
+        tip: 0,
+        who: [
+          [
+            230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117,
+            251, 19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175,
+            143, 88,
+          ],
+        ],
+        actual_fee: 2131419,
+      },
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 200,
+      observed_at: "100",
+    },
+  ];
+  const res = await req("/api/v1/chain-events?limit=1");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.events[0].args.who).toBe(
+    "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i",
+  );
+  expect(body.events[0].args.tip).toBe(0);
+  expect(body.events[0].args.actual_fee).toBe(2131419);
+});
+
+test("chain-events decodes both account-keyed fields of a Balances.Transfer (to and from)", async () => {
+  mockRows.current = [
+    {
+      block_number: "8587754",
+      event_index: 119,
+      pallet: "Balances",
+      method: "Transfer",
+      args: {
+        to: [
+          [
+            109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          ],
+        ],
+        from: [
+          [
+            109, 111, 100, 108, 115, 117, 98, 116, 101, 110, 115, 114, 15, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          ],
+        ],
+        amount: 30681,
+      },
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 100,
+      observed_at: "100",
+    },
+  ];
+  const res = await req("/api/v1/blocks/123/chain-events");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.events[0].args.to).toBe(
+    "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+  );
+  expect(body.events[0].args.from).toBe(
+    "5EYCAe5jLQhn6ofDSvuKE7htj4zVF4Tq1J7DTNzTePVJucfX",
+  );
+  expect(body.events[0].args.amount).toBe(30681);
+});
+
+test("chain-events hex-encodes an untagged positional 32-byte value (no field name to key SS58 off of)", async () => {
+  // Real SubtensorModule.TimelockedWeightsRevealed row (block 8587756, event
+  // 2): args has no field names at all for non-System/Balances pallets --
+  // must degrade to hex, never guess an SS58 address with no key hint.
+  mockRows.current = [
+    {
+      block_number: "8587756",
+      event_index: 2,
+      pallet: "SubtensorModule",
+      method: "TimelockedWeightsRevealed",
+      args: [
+        78,
+        [
+          [
+            162, 193, 121, 87, 196, 67, 129, 183, 243, 158, 111, 10, 171, 37,
+            31, 122, 9, 152, 89, 131, 234, 97, 249, 41, 16, 168, 179, 154, 146,
+            252, 209, 69,
+          ],
+        ],
+      ],
+      phase: "ApplyExtrinsic",
+      extrinsic_index: 50,
+      observed_at: "100",
+    },
+  ];
+  const res = await req("/api/v1/blocks/123/chain-events");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.events[0].args).toEqual([
+    78,
+    "0xa2c17957c44381b7f39e6f0aab251f7a09985983ea61f92910a8b39a92fcd145",
+  ]);
+});
+
 test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)", async () => {
   const res = await req(
     "/api/v1/chain-events?limit=1&pallet=System&method=ExtrinsicSuccess&before=500",

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -14,6 +14,7 @@ import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
 import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "../src/extrinsics.mjs";
 import { formatAccountEvent } from "../src/account-events.mjs";
+import { decodeChainEventArgs } from "../src/chain-event-args.mjs";
 
 const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
@@ -89,12 +90,20 @@ const MAX_EMBEDDED_EVENTS = 50;
 // JSON-encoded STRING to JSON.parse, matching D1's TEXT column -- casting here
 // keeps that shared formatter untouched rather than teaching it two shapes.
 
+// args (#4685): decode AccountId32 byte arrays to SS58 (or hex for
+// non-account/untagged values) before this ever reaches a consumer -- REST
+// and the three MCP tools that select `args` (list_chain_events,
+// get_block_chain_events, get_extrinsic_chain_events) all route through this
+// one function, so there's a single decode point rather than three. Guarded
+// on `!== undefined` since chain-events/stats' GROUP BY query never selects
+// `args` at all and shouldn't gain a spurious `args: null` key.
 function coerceEvent(row) {
   return {
     ...row,
     ...(row.block_number !== undefined
       ? { block_number: numberOrNull(row.block_number) }
       : {}),
+    ...(row.args !== undefined ? { args: decodeChainEventArgs(row.args) } : {}),
     observed_at: numberOrNull(row.observed_at),
   };
 }

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -94,16 +94,20 @@ const MAX_EMBEDDED_EVENTS = 50;
 // non-account/untagged values) before this ever reaches a consumer -- REST
 // and the three MCP tools that select `args` (list_chain_events,
 // get_block_chain_events, get_extrinsic_chain_events) all route through this
-// one function, so there's a single decode point rather than three. Guarded
-// on `!== undefined` since chain-events/stats' GROUP BY query never selects
-// `args` at all and shouldn't gain a spurious `args: null` key.
+// one function, so there's a single decode point rather than three.
+// Unconditional (unlike the block_number guard below): both call sites
+// always select `args` in their SQL (chain-events/stats, which doesn't,
+// never calls coerceEvent at all) -- and decodeChainEventArgs(undefined)
+// resolves to `args: undefined`, which JSON.stringify drops from the
+// response the same as an absent key, so there's no schema-shape risk in
+// leaving this unconditional.
 function coerceEvent(row) {
   return {
     ...row,
     ...(row.block_number !== undefined
       ? { block_number: numberOrNull(row.block_number) }
       : {}),
-    ...(row.args !== undefined ? { args: decodeChainEventArgs(row.args) } : {}),
+    args: decodeChainEventArgs(row.args),
     observed_at: numberOrNull(row.observed_at),
   };
 }


### PR DESCRIPTION
Closes #4685

### Motivation
`chain_events.args` serves straight from Postgres `jsonb` to REST and three MCP tools (`list_chain_events`, `get_block_chain_events`, `get_extrinsic_chain_events`) with **no serving-tier flag and no D1 fallback** -- unlike `blocks`/`extrinsics`, there was never a D1 implementation for this tier to fall back to. AccountId32 fields (indexer-rs's generic dynamic-SCALE dump) render as raw newtype-wrapped byte arrays instead of SS58 addresses, live in production today against a 34M+-row and growing table.

This exact bug was already hit and partially patched **client-side only** (commit `6eb2c1ae` / #4621, closes #3984): `apps/ui/src/lib/metagraphed/chain-event-args.ts` + `ss58.ts`, wired up only inside `apps/ui/src/routes/blocks.$ref.tsx`. Every other consumer still got the raw shape.

### Description
- New `src/chain-event-args.mjs`: a server-side port of the same decode algorithm, using the newly-extracted `src/ss58.mjs` encoder (#4688, merged).
- Wired into `workers/data-api.mjs`'s `coerceEvent()` -- the single function all three affected routes/MCP tools already route through (verified via direct code trace: none of the three tools run independent SQL, all proxy `DATA_API`).
- **Found and fixed a real bug while porting**: the client's recursive decode doesn't collapse indexer-rs's newtype-wrap array layer -- `who: [[bytes]]` decoded to `[SS58]` (an array) instead of a bare SS58 string. Fixed with an explicit one-layer collapse, which still correctly preserves array-ness for a genuine `Vec<AccountId>` (each entry independently newtype-wrapped one level deeper than a scalar field -- verified against real production data this session, e.g. `Multisig.other_signatories`'s actual shape).
- `apps/ui/src/routes/blocks.$ref.tsx` needs **no changes**: its existing decode call is idempotent on already-decoded data (a safe no-op once the server does it first) -- verified with an explicit test, not just assumed.

### Testing
- New `tests/chain-event-args.test.mjs` (8 tests, 100% coverage) using **real production fixtures**, independently re-verified directly against Postgres this session: `TransactionPayment.TransactionFeePaid` (block 8587754/412), `Balances.Transfer` (block 8587754/119), `SubtensorModule.TimelockedWeightsRevealed` (block 8587756/2, the untagged-positional-args case).
- New tests added to `tests/data-api.test.mjs` covering the same fixtures through the actual REST route.
- `apps/ui/src/lib/metagraphed/chain-event-args.test.ts` (client-side, untouched) still passes unchanged -- confirms no regression.
- `npx eslint`/`npx prettier --check` clean.

No screenshot table -- no `apps/ui` files touched.