### PR TITLE
feat(ui): add a live-tip hero band to the chain explorer

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -17,6 +17,7 @@ import { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
 import { SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import {
+  blocksQuery,
   chainActivityQuery,
   chainCallsQuery,
   chainEventsInfiniteQuery,
@@ -81,6 +82,35 @@ function fmtTaoSigned(v: number): string {
   return v < 0 ? `-${formatTao(-v)}` : `+${formatTao(v)}`;
 }
 
+/**
+ * #3373: compact chain-head tip in the explorer hero — "head #NNNN · N ago"
+ * from /api/v1/blocks (limit 1). Twin of the home ChainHeadTip (#3372). Plain
+ * useQuery so a cold/failed fetch renders a placeholder and never blocks the
+ * rest of the page.
+ */
+function ChainHeadTip() {
+  const { data } = useQuery(blocksQuery({ limit: 1 }));
+  const head = data?.data?.[0];
+  if (!head || head.block_number == null) {
+    return (
+      <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+        <span className="mg-live-dot" />
+        head —
+      </span>
+    );
+  }
+  return (
+    <Link
+      to="/blocks/$ref"
+      params={{ ref: String(head.block_number) }}
+      className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted transition-colors hover:text-accent"
+    >
+      <span className="mg-live-dot" />
+      head #{formatNumber(head.block_number)} · <TimeAgo at={head.observed_at} />
+    </Link>
+  );
+}
+
 function ExplorerPage() {
   return (
     <AppShell>
@@ -89,7 +119,12 @@ function ExplorerPage() {
         live
         title="Chain explorer"
         description="The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers."
-        actions={<ShareButton />}
+        actions={
+          <div className="flex flex-col items-start gap-3">
+            <ShareButton />
+            <ChainHeadTip />
+          </div>
+        }
       />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-[40rem] w-full" />}>
@@ -99,6 +134,7 @@ function ExplorerPage() {
       <ChainEventsFeedSection />
       <ApiSourceFooter
         paths={[
+          "/api/v1/blocks",
           "/api/v1/chain/activity",
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",


### PR DESCRIPTION
Closes #3373

`ExplorerPage` showed a live eyebrow and a daily-aggregate KPI grid, but nothing chain-head: no current block number and no relative freshness. `blocksQuery` already fetches `/api/v1/blocks` newest-first, and the home hero already renders the same tip via `ChainHeadTip` (#3372 / merged PR) — explorer never consumed it.

## What changed

`apps/ui/src/routes/explorer.tsx` only:

- New local `ChainHeadTip` (twin of the home tip): `useQuery(blocksQuery({ limit: 1 }))`, not suspense, so a slow/failed/cold fetch never blocks the dashboard.
- Renders `head #NNNN · N ago` under the existing Share action — `formatNumber` + `TimeAgo`, linking to `/blocks/$ref`.
- Cold/empty response: honest `head —` placeholder (no crash, no fabricated block number).
- `/api/v1/blocks` added to `ApiSourceFooter` `paths`.
- Existing 7d/30d window toggle and KPI grid left untouched.

No backend/schema change. Did not build `FreshnessBadge` / shared poll hook (out of scope per issue). Did not touch `index.tsx` / home hero.

## Verification

- Confirmed against the live API on `/explorer`: tip shows real head block + relative time when `/api/v1/blocks?limit=1` has a row; empty/cold path shows `head —`.
- No console errors.
- `npx eslint apps/ui/src/routes/explorer.tsx` — 0 errors
- `npx prettier --check apps/ui/src/routes/explorer.tsx` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Framed on `/explorer` so the new live-tip band (or its absence, in "before") is directly visible under the page hero / Share action.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2f6f3be3-b07f-4961-b8c5-f396e0cf091d" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/659ee04f-ad34-48e8-8cc6-43b201260f64" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/ca36b501-6bf2-4edf-a109-7034ac8fc92d" />| <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/0b0baf14-32df-49b7-bcdc-42985918babe" /> |
| Tablet · Light   | <img width="1107" height="760" alt="image" src="https://github.com/user-attachments/assets/b4d13aa3-5cb4-46ff-bc98-a02b36e3b946" /> | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/0b7ef537-6a49-49a2-9735-2270da851da0" /> |
| Tablet · Dark    | <img width="1107" height="760" alt="image" src="https://github.com/user-attachments/assets/456a3faf-a741-4e8a-b7e1-d7516d642ec8" /> | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/dd8013cf-4693-41ee-aee7-7e05f7834df5" /> |
| Mobile · Light   | <img width="510" height="760" alt="image" src="https://github.com/user-attachments/assets/f2492167-115a-4777-a841-196e90acd2c4" /> | <img width="510" height="760" alt="image" src="https://github.com/user-attachments/assets/8f7dbde9-365e-457e-b393-a31bb325b55d" /> |
| Mobile · Dark    | <img width="510" height="760" alt="image" src="https://github.com/user-attachments/assets/0293b833-2bdb-44ac-8de6-28ea6bcfc21c" /> | <img width="510" height="760" alt="image" src="https://github.com/user-attachments/assets/3fbd5170-ad86-452b-ac57-cddc1a2be990" /> |