### PR TITLE
fix(data-api): add observability into tryPostgresTier's fallback branches

### DIFF
--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -3411,22 +3411,49 @@ export async function handleSubnetRecycled(request, env, netuid) {
 // ANY failure (binding absent, network error, non-2xx, unparseable/malformed
 // body) as "fall back to D1", never as a client-facing error. Postgres never
 // gets to independently fail a request the D1 path would have served.
+// Every branch below logs before falling back (#4686) -- prior to this, a
+// canceled/failed DATA_API subrequest was indistinguishable from "the flag
+// isn't on," which let a silently-unreliable Postgres tier look shipped
+// while actually falling back to D1 on most requests (see the blocks-tier
+// incident this was added for: METAGRAPH_BLOCKS_SOURCE was flipped, live
+// re-testing found DATA_API subrequests reporting outcome "canceled" on a
+// real fraction of requests, and there was no signal anywhere to catch it
+// before a wider live-testing pass happened to notice).
 async function tryPostgresTier(env, request, flagName) {
   if (env[flagName] !== "postgres" || !env.DATA_API) return null;
   let upstream;
   try {
     upstream = await env.DATA_API.fetch(request);
-  } catch {
+  } catch (err) {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API fetch failed, falling back to D1:`,
+      err,
+    );
     return null;
   }
-  if (!upstream.ok) return null;
+  if (!upstream.ok) {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status}, falling back to D1`,
+    );
+    return null;
+  }
   let body;
   try {
     body = await upstream.json();
-  } catch {
+  } catch (err) {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API response body unparseable, falling back to D1:`,
+      err,
+    );
     return null;
   }
-  return body && typeof body === "object" ? body : null;
+  if (!body || typeof body !== "object") {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API response was not a JSON object, falling back to D1`,
+    );
+    return null;
+  }
+  return body;
 }
 
 // GET /api/v1/blocks: the recent-block feed (newest first), served live from the


### PR DESCRIPTION
Refs #4669, #4686 -- partial: ships the observability piece; root-cause of the "canceled" outcome itself remains open, see below.

### Motivation
`METAGRAPH_BLOCKS_SOURCE` was flipped to `postgres`, then reverted the same day: live re-testing found the `DATA_API` service-binding subrequest reporting outcome `"canceled"` on a real fraction of requests, with **zero signal anywhere** to distinguish that from "the flag isn't on." A silently-unreliable Postgres tier looked shipped because nothing logged which tier actually answered a request.

### Description
- `tryPostgresTier`'s four failure branches (fetch threw, non-2xx, unparseable body, non-object body) now each `console.error` before falling back to D1, so a canceled/failing subrequest is visible in Workers observability going forward instead of requiring an ad hoc `wrangler tail` session to catch it.
- **Root-cause investigation on the "canceled" outcome itself**: ruled out per-request Postgres client creation (`workers/data-api.mjs` creates a new `postgres()` client on every request) as the cause -- Cloudflare's own Hyperdrive documentation explicitly recommends this exact pattern ("Create a new connection on each request. Hyperdrive maintains the underlying database connection pool, so creating a new client is fast."), so it isn't an anti-pattern. The remaining question (what specifically triggers the cancellation) needs live correlation once this logging is deployed -- that's why `METAGRAPH_BLOCKS_SOURCE` stays `"d1"` for now, tracked in #4686.

### Testing
- All four branches already had existing test coverage (network error, non-2xx, unparseable JSON, valid-but-non-object JSON) in `tests/request-handlers-entities.test.mjs` -- confirmed each new log line fires exactly once per its corresponding existing test (369/369 passing), no new tests needed.
- `npx eslint`/`npx prettier --check` clean.

No screenshot table -- no `apps/ui` files touched.