### PR TITLE
feat(registry): add SN31 Recall min_compute data-artifact

### DIFF
--- a/registry/providers/candlestao.json
+++ b/registry/providers/candlestao.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/CandlesTAO/candles",
+  "id": "candlestao",
+  "kind": "subnet-team",
+  "name": "CandlesTAO",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://github.com/CandlesTAO/candles"
+}

--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-candlestao-data-artifact",
+      "kind": "data-artifact",
+      "name": "Recall minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official CandlesTAO/candles repository as min_compute.yml. Documents SN31 operator CPU, memory, storage, and network floors; the README Network Information table lists mainnet netuid 31.",
+      "provider": "candlestao",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsdevninja"
+      },
+      "source_urls": [
+        "https://github.com/CandlesTAO/candles/blob/main/min_compute.yml",
+        "https://github.com/CandlesTAO/candles"
+      ],
+      "url": "https://raw.githubusercontent.com/CandlesTAO/candles/main/min_compute.yml"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Append one community data-artifact surface to egistry/subnets/recall.json for SN31 Recall: CandlesTAO/candles min_compute.yml (public YAML hardware spec).
- Debut candlestao provider stub (egistry/providers/candlestao.json) required for validation — the operator GitHub org publishes the artifact and its README lists mainnet netuid 31.

Closes #4034

## Surface
- Netuid: 31
- Kind: data-artifact
- Public URL: https://raw.githubusercontent.com/CandlesTAO/candles/main/min_compute.yml
- Source URLs: https://github.com/CandlesTAO/candles/blob/main/min_compute.yml, https://github.com/CandlesTAO/candles
- Provider slug: candlestao

## Test plan
- [x] `npm run validate:surface -- registry/subnets/recall.json`
- [x] `npm run scan:public-safety`
- [x] Verified min_compute.yml resolves (no auth)
- [x] Append-only change to existing recall manifest (no curation/top-level edits)

Made with [Cursor](https://cursor.com)