### PR TITLE
feat(registry): add SN16 BitAds min_compute data-artifact surface (#4013)

### DIFF
--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -98,6 +98,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official BitAds source repository."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-16-bitads-min-compute",
+      "kind": "data-artifact",
+      "name": "BitAds minimum compute requirements",
+      "notes": "Public no-auth machine-readable min_compute.yml specifying the minimum and recommended hardware (CPU/RAM/storage/OS and network bandwidth) to run an SN16 BitAds miner or validator, published in the official BitAds source repository study-service/BitAds.ai — whose README states 'netuid 16' and whose GitHub homepage is the registered bitads.ai website. A standalone machine-readable reference artifact the registry did not yet capture (the manifest's source_repo field points at the operator's older FirstTensorLabs/BitAds repo; the live code now lives at study-service/BitAds.ai).",
+      "provider": "bitads",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/study-service/BitAds.ai/blob/main/README.md",
+        "https://github.com/study-service/BitAds.ai/blob/main/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/study-service/BitAds.ai/main/min_compute.yml"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Registers **SN16 BitAds**'s public **`min_compute.yml`** as a `data-artifact` surface — a standalone, no-auth, machine-readable hardware-requirements file the registry did not yet capture (the manifest's gap notes explicitly flag "No verified standalone static data artifact yet").

## Surface

- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/study-service/BitAds.ai/main/min_compute.yml`
- **provider:** `bitads` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://github.com/study-service/BitAds.ai/blob/main/README.md` — states **"netuid 16"** and its GitHub homepage is **bitads.ai** (the registered `website_url`), identifying this as the official SN16 BitAds repository.
- `source_url` 2: the file blob itself.
- Note: the manifest's `source_repo` field points at the operator's older `FirstTensorLabs/BitAds` repo; the live code now lives at `study-service/BitAds.ai` (same operator, same bitads.ai site). Both source_urls resolve HTTP 200.

## Verified live + public + safe

- `GET https://raw.githubusercontent.com/study-service/BitAds.ai/main/min_compute.yml` → **HTTP 200**, `text/plain; charset=utf-8`, **no auth**. Valid YAML: `version`, `compute_spec` (miner/validator CPU/RAM/storage/OS), `network_spec` (bandwidth).
- Public-safe: scanned for SS58/base58 wallet or hotkey strings → **zero matches**; hardware-spec YAML only, no secrets.

## Non-duplication

BitAds's existing surfaces are `website`, `docs`, and `source-repo` — **no data-artifact surface exists**. This is a new URL/kind. No open PR targets SN16.

## Scope note (relative to #4013)

#4013 asks for SN16's public **data artifact**. This `min_compute.yml` is a standalone, machine-readable, publicly-served reference file in the subnet's official repository — a concrete public data artifact matching the issue's exact ask.

## Validation (local)

- `npm run validate:surface -- registry/subnets/bitads.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check` → clean
- `git diff --stat` → single file, 19-line pure append

## Template Used

- Subnet surface

Closes #4013
