### PR TITLE
feat(command-palette): actionable "No matches" empty state with recovery suggestions

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -478,6 +478,16 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
   };
 
   const showSuggestions = !debounced;
+  // #3401: a debounced query that matches nothing is a dead-end with just
+  // "No matches." — surface the same Recent/Try recovery block (plus a heading)
+  // so the user always has a concrete next step.
+  const noResults =
+    !!debounced &&
+    !isFetching &&
+    !isSemanticFetching &&
+    hits.length === 0 &&
+    filteredRoutes.length === 0 &&
+    navigateTargets.length === 0;
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
@@ -517,8 +527,13 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
           {isFetching ? "Searching…" : debounced ? "No matches." : "Start typing to search."}
         </CommandEmpty>
 
-        {showSuggestions ? (
+        {showSuggestions || noResults ? (
           <div className="px-3 py-3 space-y-3 border-b border-border">
+            {noResults ? (
+              <div className="mg-label text-ink-muted">
+                No matches for "{debounced}" — try instead:
+              </div>
+            ) : null}
             {recent.length > 0 ? (
               <div>
                 <div className="flex items-center justify-between mb-1.5">


### PR DESCRIPTION
## Problem

When a command-palette query matches nothing, `CommandPaletteBody` (`command-palette-body.tsx`) is a dead-end: the `<CommandEmpty>` text "No matches." with the palette jumping straight to the generic "Filter /subnets by …" / "Filter /endpoints by …" actions — no cue that the search found nothing, and no suggested queries to recover with. The *empty-query* state already renders a rich "Recent" + "Try" block (from `SUGGESTED_QUERIES`), so the zero-result case is strictly thinner than the no-query case (#3401).

## Feature

Surface that same recovery block on a zero-result query. When a debounced query returns zero combined results across `hits`, `filteredRoutes`, and `navigateTargets` (and search has settled), render the existing Recent/Try block prefixed with a **"No matches for '&lt;query&gt;' — try instead:"** heading, so the user always has a concrete next step (a suggested-query chip that repopulates the search, or the Filter actions below). Successful-result rendering and the empty-query suggestions are unchanged. The change reuses the existing block and chip handlers (`setQ`) — it just widens the gate from `showSuggestions` to `showSuggestions || noResults`.

## Screenshots

Command palette with a query that matches nothing (`zzqxwvnomatch`). Viewports per Phase C2 (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes, before/after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/cmdpal-after-mobile-dark.png)<br><sub>after</sub> |

Before, a no-match query drops straight into the generic Filter actions; after, it leads with "No matches for … — try instead:" and the clickable Try chips (`bittensor`, `taostats`, `rpc`, `openapi`, `sn7`).

## Local gates

`tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check` (clean). Only `command-palette-body.tsx` changes; screenshots live on a separate `screenshots` branch, not this diff.

Closes #3401
