### PR TITLE
fix(validators): clamp stake_dominance so a sub-total share never rounds up to a flat 1

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -111,6 +111,18 @@ function round(value, dp = 6) {
   return Math.round(value * factor) / factor;
 }
 
+// Share/ratio variant of `round` for a part-of-total value: a sub-total share
+// (value < 1) must never round UP to a flat 1.0, which would overstate one
+// entity as owning the whole set. Mirrors the anti-overstatement clamp used by
+// the sibling share rounders (roundRatio/roundShare/roundConcentration). The
+// caller here always passes a finite value (network total is guarded > 0 and
+// numberOrZero coerces the numerator), so no null handling is needed.
+function roundShare(value, dp = 6) {
+  const factor = 10 ** dp;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
+}
+
 // Coerce a D1 0/1 INTEGER flag cell to a boolean. Numeric strings like "0"
 // must not pass through Boolean(), which treats any non-empty string as true.
 // Mirrors the local toD1Flag added to formatRegistration by #2487.
@@ -267,7 +279,7 @@ function applyStakeDominance(validators) {
   }
   return validators.map((entry) => ({
     ...entry,
-    stake_dominance: round(
+    stake_dominance: roundShare(
       numberOrZero(entry.total_stake_tao) / networkStakeTotal,
     ),
   }));

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -820,6 +820,36 @@ describe("metagraph-neurons builders", () => {
     );
   });
 
+  test("buildGlobalValidators clamps a sub-total stake dominance away from a flat 1", () => {
+    // hk-monopoly holds 999999.6 of a 1,000,000 TAO network total (a 0.9999996
+    // share), while the other validators hold a real 0.4 TAO between them — so
+    // the monopoly does NOT own the whole network. Its share rounds to 1.000000
+    // at 6dp and must be clamped down to 0.999999 rather than overstate it as
+    // owning 100% of network validator stake.
+    const data = buildGlobalValidators(
+      [
+        {
+          ...ROW,
+          netuid: 1,
+          uid: 0,
+          hotkey: "hk-monopoly",
+          stake_tao: 999999.6,
+        },
+        { ...ROW, netuid: 2, uid: 1, hotkey: "hk-a", stake_tao: 0.1 },
+        { ...ROW, netuid: 3, uid: 2, hotkey: "hk-b", stake_tao: 0.1 },
+        { ...ROW, netuid: 4, uid: 3, hotkey: "hk-c", stake_tao: 0.1 },
+        { ...ROW, netuid: 5, uid: 4, hotkey: "hk-d", stake_tao: 0.1 },
+      ],
+      { sort: "total_stake", limit: 10 },
+    );
+
+    const monopoly = data.validators.find((v) => v.hotkey === "hk-monopoly");
+    assert.equal(monopoly.total_stake_tao, 999999.6);
+    // Pre-fix this was 1 (overstated as owning the whole network); the
+    // anti-overstatement clamp keeps a sub-total share strictly below 1.
+    assert.equal(monopoly.stake_dominance, 0.999999);
+  });
+
   test("buildGlobalValidators nulls stake dominance when network stake is zero", () => {
     const data = buildGlobalValidators(
       [


### PR DESCRIPTION
## Summary

Fixes a correctness bug on the **network-wide validator leaderboard** (`buildGlobalValidators` in `src/metagraph-neurons.mjs`): a validator's `stake_dominance` — its share of total network validator stake — could round **up to a flat `1`** even when the validator does **not** hold the whole network, overstating it as owning 100% of validator stake. `stake_dominance` is also a sortable leaderboard field, so a near-monopoly validator was falsely pinned at exactly `1`.

`Refs #2565` — this is the `stake_dominance` value the network validator-dominance view surfaces; the fix keeps that value honest. Standalone, self-contained correctness fix.

## The bug

`stake_dominance` used the plain `round` helper, which has **no anti-overstatement clamp**, so a sub-total share in `[0.9999995, 1)` rounds to exactly `1.000000` at 6dp. Every sibling share/ratio rounder already guards this invariant — `roundRatio` (`concentration.mjs`), `roundShare` (`chain-transfer-pairs.mjs`), `roundConcentration` (`account-stake-flow.mjs`), the share rounders in `chain-turnover.mjs`/`movers.mjs`, `displayUptimeRatio` (`reliability.mjs`) — matching the maintainer's #2971 / #2985 anti-overstatement work. This one call site was missed.

### Concrete example (from the added test)
- `hk-monopoly` holds 999999.6 TAO; four others hold 0.1 TAO each → network total 1,000,000 TAO.
- True share = **0.9999996 (< 1)** — the others really do hold 0.4 TAO.
- **Before:** `stake_dominance: 1` (overstated as owning the whole network).
- **After:** `stake_dominance: 0.999999` (largest 6dp value below 1).

## The fix

A dedicated `roundShare(value, dp)` used **only** for `stake_dominance`: a sub-total value (`value < 1`) that rounds to `1` is clamped to `(10**dp − 1) / 10**dp`. The shared `round` is left unchanged — it's also used for trust/rank/consensus/incentive/dividends (0..1 scores where a legitimate `0.9999996` *should* round to `1`). The genuine sole-holder case (share exactly `1.0`, all others `0`) still reports `1`.

## Tests

- Added `buildGlobalValidators clamps a sub-total stake dominance away from a flat 1` — **proven to fail pre-fix** (returns `1`) and **pass post-fix** (returns `0.999999`).
- The existing sole-holder test (`stake_dominance === 1` for a validator holding 100/100) still passes — the clamp only rewrites values `< 1`, so it never over-fires.
- Full `tests/metagraph-neurons.test.mjs` suite green (62 tests). `roundShare`'s added lines + all ternary branches are covered (100% patch coverage), lint + prettier clean. No schema/contract change (`stake_dominance` remains `number | null`), so no generated-artifact update.
