### PR TITLE
fix(ui): normalize byte-blob call args to hex, fix Ethereum.transact.input

### DIFF
--- a/apps/ui/src/lib/metagraphed/bytes.test.ts
+++ b/apps/ui/src/lib/metagraphed/bytes.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { unwrapByteArray, bytesToHex, decodeBytesField } from "./bytes";
+
+describe("unwrapByteArray", () => {
+  it("returns a flat byte array unchanged (zero wraps, e.g. Multisig's raw call_hash)", () => {
+    const bytes = [55, 179, 165, 105];
+    expect(unwrapByteArray(bytes)).toEqual(bytes);
+  });
+
+  it("unwraps one newtype layer (real SubtensorModule.commit_weights commit_hash, block 8587046/19)", () => {
+    const bytes = [59, 140, 220, 127, 37, 107, 167, 77];
+    expect(unwrapByteArray([bytes])).toEqual(bytes);
+  });
+
+  it("unwraps a variable-length newtype-wrapped blob (real commit_timelocked_weights commit field shape)", () => {
+    const bytes = [134, 255, 107, 242, 50, 150];
+    expect(unwrapByteArray([bytes])).toEqual(bytes);
+  });
+
+  it("unwraps two newtype layers", () => {
+    const bytes = [1, 2, 3];
+    expect(unwrapByteArray([[bytes]])).toEqual(bytes);
+  });
+
+  it("does not loop on a single-element array whose element is a plain scalar, not another array", () => {
+    // Distinguishes a length-1 flat byte array ([5], a single-byte value)
+    // from a length-1 array WRAPPING another array ([[5]], a newtype wrap) --
+    // the while-loop's array-of-array check must stop here, not recurse
+    // into the scalar.
+    expect(unwrapByteArray([5])).toEqual([5]);
+  });
+
+  it("returns null for a non-byte-array value", () => {
+    expect(unwrapByteArray("not an array")).toBeNull();
+    expect(unwrapByteArray(null)).toBeNull();
+    expect(unwrapByteArray(undefined)).toBeNull();
+    expect(unwrapByteArray(42)).toBeNull();
+    expect(unwrapByteArray({ a: 1 })).toBeNull();
+  });
+
+  it("returns null for an array containing a non-integer or out-of-range value", () => {
+    expect(unwrapByteArray([1, 2, "3"])).toBeNull();
+    expect(unwrapByteArray([1, 2, 256])).toBeNull();
+    expect(unwrapByteArray([1, 2, -1])).toBeNull();
+    expect(unwrapByteArray([1, 2.5, 3])).toBeNull();
+  });
+
+  it("returns null for a multi-element array wrapping arrays (not a single-element newtype wrap)", () => {
+    expect(
+      unwrapByteArray([
+        [1, 2],
+        [3, 4],
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns an empty array for an empty flat array (vacuously a valid byte array)", () => {
+    expect(unwrapByteArray([])).toEqual([]);
+  });
+});
+
+describe("bytesToHex", () => {
+  it("hex-encodes bytes matching D1's convention (real SubtensorModule.register work, block 8556317/20)", () => {
+    const bytes = [0x10, 0x40, 0x70, 0x6a, 0x68, 0x9d, 0x63, 0x7b];
+    expect(bytesToHex(bytes)).toBe("0x1040706a689d637b");
+  });
+
+  it("pads single-digit hex values", () => {
+    expect(bytesToHex([0, 1, 15, 16])).toBe("0x00010f10");
+  });
+
+  it("returns 0x for an empty array", () => {
+    expect(bytesToHex([])).toBe("0x");
+  });
+});
+
+describe("decodeBytesField", () => {
+  it("UTF-8-decodes System.remark_with_event's remark field (real data, block 8512299/12: D1 = 'module-test-5f758613')", () => {
+    const text = "module-test-5f758613";
+    const bytes = Array.from(new TextEncoder().encode(text));
+    expect(decodeBytesField("System", "remark_with_event", "remark", bytes)).toBe(text);
+  });
+
+  it("UTF-8-decodes System.remark's remark field the same way", () => {
+    const bytes = Array.from(new TextEncoder().encode("hello"));
+    expect(decodeBytesField("System", "remark", "remark", bytes)).toBe("hello");
+  });
+
+  it("hex-encodes Ethereum.transact's input field -- deliberately NOT reproducing D1's UTF-8/Latin1 mojibake bug (real bytes, block 8587453/9)", () => {
+    const bytes = [97, 70, 25, 84];
+    const decoded = decodeBytesField("Ethereum", "transact", "input", bytes);
+    expect(decoded).toBe("0x61461954");
+    // D1's current (buggy) behavior force-decodes these same bytes as
+    // UTF-8/Latin1, embedding an unprintable control character in the
+    // rendered string. Confirm this decoder's output has no such character.
+    const hasControlChar = Array.from(decoded).some((ch) => ch.charCodeAt(0) < 0x20);
+    expect(hasControlChar).toBe(false);
+  });
+
+  it("hex-encodes opaque payload fields not on the textual allowlist (work, ciphertext, commit)", () => {
+    const bytes = [16, 64, 112, 106];
+    expect(decodeBytesField("SubtensorModule", "register", "work", bytes)).toBe(bytesToHex(bytes));
+    expect(decodeBytesField("MevShield", "submit_encrypted", "ciphertext", bytes)).toBe(
+      bytesToHex(bytes),
+    );
+    expect(decodeBytesField("SubtensorModule", "commit_timelocked_weights", "commit", bytes)).toBe(
+      bytesToHex(bytes),
+    );
+  });
+
+  it("falls back to hex when a field on the textual allowlist happens to contain invalid UTF-8", () => {
+    const invalidUtf8 = [0xff, 0xfe, 0xfd];
+    expect(decodeBytesField("System", "remark", "remark", invalidUtf8)).toBe(
+      bytesToHex(invalidUtf8),
+    );
+  });
+
+  it("hex-encodes a remark-named field on an unrelated call_module/call_function (allowlist is keyed on the full triple)", () => {
+    const bytes = Array.from(new TextEncoder().encode("hello"));
+    expect(decodeBytesField("SomeOtherModule", "some_function", "remark", bytes)).toBe(
+      bytesToHex(bytes),
+    );
+  });
+
+  it("handles null/undefined callModule or callFunction without throwing", () => {
+    const bytes = [1, 2, 3];
+    expect(decodeBytesField(null, null, "remark", bytes)).toBe(bytesToHex(bytes));
+    expect(decodeBytesField(undefined, undefined, "input", bytes)).toBe(bytesToHex(bytes));
+  });
+});

--- a/apps/ui/src/lib/metagraphed/bytes.ts
+++ b/apps/ui/src/lib/metagraphed/bytes.ts
@@ -1,0 +1,81 @@
+// Raw byte-blob (Vec<u8> / BoundedVec<u8> / Bytes) shape reconciliation
+// between D1 (fetch-events.py) and Postgres (indexer-rs) call_args (#4669,
+// #4689). D1 is itself inconsistent for this Rust type family -- hex string
+// for opaque payloads (PoW work, weight commits), UTF-8-decoded text for a
+// few known textual fields (System.remark) -- while Postgres always emits a
+// flat or newtype-wrapped integer array with no type metadata to tell them
+// apart generically. This picks ONE canonical target per named field (a
+// curated allowlist, defaulting to hex for everything not explicitly
+// listed) rather than sniffing byte content, which risks exactly the kind
+// of silent corruption already found in D1's own Ethereum.transact.input
+// field (force-decoded as UTF-8/Latin1 today, producing mojibake with
+// embedded control characters on every occurrence -- fixed here by NOT
+// adding `input` to the textual allowlist, so it renders as clean hex
+// instead of reproducing that bug).
+
+function isIntArray(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.every((n) => typeof n === "number" && Number.isInteger(n) && n >= 0 && n <= 255)
+  );
+}
+
+/** Recursively peels indexer-rs's newtype-wrap array layers -- while the
+ * value is a single-element array wrapping another array, unwrap one level
+ * -- until it bottoms out at a flat array of byte values, or returns null
+ * if it never resolves to one. Depth-agnostic: handles both a flat `[u8; N]`
+ * field with zero wraps (e.g. Multisig's raw `call_hash`) and a
+ * newtype-wrapped `Hash`/`H256`/`BoundedVec<u8>` field with one or more
+ * wraps (e.g. a `commit_hash`, or `commit`/`ciphertext`'s variable-length
+ * payload) with the same function, rather than a hardcoded wrap-depth
+ * assumption tuned to only one of the two. */
+export function unwrapByteArray(value: unknown): number[] | null {
+  let current = value;
+  while (Array.isArray(current) && current.length === 1 && Array.isArray(current[0])) {
+    current = current[0];
+  }
+  return isIntArray(current) ? current : null;
+}
+
+/** Canonical lowercase `0x`-prefixed hex, matching D1's existing convention
+ * for opaque byte blobs. */
+export function bytesToHex(bytes: number[]): string {
+  return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** `(callModule, callFunction, fieldName)` triples D1 renders as UTF-8 text
+ * rather than hex -- verified against real production data (System.
+ * remark_with_event, block 8512299/extrinsic_index 12: D1 `remark:
+ * "module-test-5f758613"`, Postgres the same bytes undecoded). NOT YET
+ * covered: SubtensorModule.set_identity/set_subnet_identity's textual
+ * fields (name/url/discord/description-style) -- D1's exact behavior and
+ * field names for these are unverified (no occurrence in either store's
+ * current retention window as of this writing), so they default to hex
+ * below rather than guessing; add them here once confirmed against a real
+ * example. */
+const TEXTUAL_FIELDS = new Set(["System.remark.remark", "System.remark_with_event.remark"]);
+
+/** Decodes a byte-blob call-arg field to its canonical representation: UTF-8
+ * text for the small, verified allowlist of genuinely textual fields above,
+ * hex for everything else (the safe default for opaque payloads, and the
+ * fix for D1's own Ethereum.transact.input mojibake bug -- that field is
+ * deliberately NOT in the allowlist). */
+export function decodeBytesField(
+  callModule: string | null | undefined,
+  callFunction: string | null | undefined,
+  fieldName: string,
+  bytes: number[],
+): string {
+  const key = `${callModule ?? ""}.${callFunction ?? ""}.${fieldName}`;
+  if (TEXTUAL_FIELDS.has(key)) {
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(Uint8Array.from(bytes));
+    } catch {
+      // Malformed UTF-8 for a field expected to be textual -- fall back to
+      // hex rather than producing mojibake (the exact class of bug this
+      // module exists to avoid reproducing).
+      return bytesToHex(bytes);
+    }
+  }
+  return bytesToHex(bytes);
+}

--- a/apps/ui/src/lib/metagraphed/extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/extrinsics.ts
@@ -1,5 +1,7 @@
 // Helpers for the extrinsic (transaction) explorer — the sibling of blocks.ts.
 
+import { unwrapByteArray, bytesToHex } from "./bytes";
+
 const EXTRINSIC_HASH = /^0x[0-9a-fA-F]{1,128}$/;
 /** block_number-extrinsic_index (e.g. 123456-2). Mirrors src/extrinsic-detail.mjs COMPOSITE_REF_RE,
  *  but disallows a leading-zero block number so omnibox decimal-block detection stays disjoint. */
@@ -134,16 +136,13 @@ const CALL_HASH = /^0x[0-9a-fA-F]{64}$/;
  * field position that's semantically KNOWN to be a hash (like `call_hash`) --
  * a bare 32-byte array is otherwise ambiguous with an AccountId32, which this
  * repo encodes SS58 instead, and indexer-rs's dump carries no type metadata
- * to tell the two apart generically. */
+ * to tell the two apart generically. Reuses bytes.ts's depth-agnostic
+ * unwrapByteArray/bytesToHex (#4689) rather than a second hardcoded-depth
+ * hex-encoder, so a hash value works whether indexer-rs emits it flat
+ * (confirmed for Multisig's call_hash) or newtype-wrapped. */
 function hashBytesToHex(value: unknown): string | null {
-  if (
-    Array.isArray(value) &&
-    value.length === 32 &&
-    value.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)
-  ) {
-    return `0x${(value as number[]).map((n) => n.toString(16).padStart(2, "0")).join("")}`;
-  }
-  return null;
+  const bytes = unwrapByteArray(value);
+  return bytes && bytes.length === 32 ? bytesToHex(bytes) : null;
 }
 
 /** The `call_hash` a `Multisig` call is keyed by, or null when this isn't a

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -16,6 +16,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { unwrapByteArray, decodeBytesField } from "@/lib/metagraphed/bytes";
 import {
   asDecodedCall,
   extrinsicCall,
@@ -278,7 +279,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         title="Call arguments"
         subtitle="The decoded parameters passed to this extrinsic."
       >
-        {renderCallArgs(callArgs)}
+        {renderCallArgs(callArgs, extrinsic.call_module, extrinsic.call_function)}
         {callArgsOmitted > 0 ? (
           <p className="mt-2 font-mono text-[11px] text-ink-muted">
             Showing 64 of {formatNumber(callArgsTotal)} call args — {formatNumber(callArgsOmitted)}{" "}
@@ -438,7 +439,12 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
 // instead of parsing an escaped JSON blob by eye.
 const MAX_NESTED_CALL_DEPTH = 4;
 
-function renderCallArgs(callArgs: unknown, depth = 0) {
+function renderCallArgs(
+  callArgs: unknown,
+  callModule: string | null | undefined,
+  callFunction: string | null | undefined,
+  depth = 0,
+) {
   if (Array.isArray(callArgs)) {
     const args = (callArgs as Array<{ name?: string | null; value?: unknown }>).slice(0, 64);
     if (args.length === 0) {
@@ -460,7 +466,7 @@ function renderCallArgs(callArgs: unknown, depth = 0) {
                   {arg.name ?? `arg_${i + 1}`}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {renderCallArgValue(arg.value, depth)}
+                  {renderCallArgValue(arg.value, arg.name, callModule, callFunction, depth)}
                 </td>
               </tr>
             ))}
@@ -491,7 +497,7 @@ function renderCallArgs(callArgs: unknown, depth = 0) {
                   {key}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {renderCallArgValue(value, depth)}
+                  {renderCallArgValue(value, key, callModule, callFunction, depth)}
                 </td>
               </tr>
             ))}
@@ -510,7 +516,22 @@ function renderCallArgs(callArgs: unknown, depth = 0) {
 // under EITHER ingestion pipeline's shape (#4669) -- D1's
 // {call_module,call_function,...} directly, or indexer-rs's {name,values}
 // enum-tree wrapper, normalized to the same shape before rendering.
-function renderCallArgValue(value: unknown, depth: number): ReactNode {
+//
+// A raw byte-blob value (Postgres/indexer-rs's Vec<u8>/BoundedVec<u8>/Bytes
+// shape, #4689) decodes via decodeBytesField before falling to the generic
+// JSON dump -- this runs AFTER the nested-call checks (mutually exclusive
+// shapes: a decoded call requires string call_module/call_function fields,
+// never a bare integer array) and is deliberately generic on VALUE shape
+// alone, not fieldName -- unlike an eventual AccountId32 check (#4691, not
+// yet wired here), which must run before this to avoid this ever
+// hex-encoding what should be an SS58 address.
+function renderCallArgValue(
+  value: unknown,
+  fieldName: string | null | undefined,
+  callModule: string | null | undefined,
+  callFunction: string | null | undefined,
+  depth: number,
+): ReactNode {
   if (depth < MAX_NESTED_CALL_DEPTH) {
     const decoded = asDecodedCall(value);
     if (decoded) {
@@ -533,6 +554,15 @@ function renderCallArgValue(value: unknown, depth: number): ReactNode {
       }
     }
   }
+  // length > 0: an empty array is vacuously a valid (empty) byte blob per
+  // unwrapByteArray's own contract, but it's indistinguishable from a
+  // genuinely empty Vec<T> of some other element type (e.g. a Multisig with
+  // no other_signatories) -- default to the generic "[]" JSON rendering for
+  // that ambiguous case rather than a misleading "0x".
+  const bytes = unwrapByteArray(value);
+  if (bytes && bytes.length > 0) {
+    return decodeBytesField(callModule, callFunction, fieldName ?? "", bytes);
+  }
   return formatCallArgValue(value);
 }
 
@@ -547,7 +577,7 @@ function NestedCallCard({ call, depth }: { call: DecodedCall; depth: number }) {
           <CopyableCode value={call.call_hash} label="call_hash" />
         ) : null}
       </div>
-      {renderCallArgs(call.call_args, depth + 1)}
+      {renderCallArgs(call.call_args, call.call_module, call.call_function, depth + 1)}
     </div>
   );
 }


### PR DESCRIPTION
Refs #4669, #4689

### Motivation
- Postgres/indexer-rs's generic dynamic-SCALE dump renders every `Vec<u8>`/`BoundedVec<u8>`/`Bytes` call-arg field (commit-reveal weight commits -- the single highest-volume call family right now, PoW `work`, MevShield `ciphertext`, `Commitments`' raw data, `Ethereum.transact`'s calldata) as a flat or newtype-wrapped integer array. D1 is itself inconsistent for this Rust type family -- hex string for opaque payloads, UTF-8-decoded text for a few known textual fields (`System.remark`) -- so there's no single existing shape to converge on.
- Along the way, found a live D1 correctness bug independent of this cutover: `Ethereum.transact`'s `input` field is force-decoded as UTF-8/Latin1 in D1 today, producing mojibake with embedded control characters on every occurrence (confirmed via real production data, block 8587453/extrinsic_index 9).

### Description
- New `apps/ui/src/lib/metagraphed/bytes.ts`: `unwrapByteArray` (a depth-agnostic recursive peel -- handles both a flat field like Multisig's `call_hash` and a newtype-wrapped one like `commit`/`ciphertext` with the same function, rather than a hardcoded wrap-depth assumption), `bytesToHex`, and `decodeBytesField` (a curated allowlist of genuinely textual fields -- currently just `System.remark`/`remark_with_event`'s `remark`, verified against real data -- defaulting to hex for everything else, which fixes the `Ethereum.transact.input` bug for free rather than needing a special case).
- **Deliberately did not guess `SubtensorModule.set_identity`/`set_subnet_identity`'s textual field names** -- no occurrence in either store's current retention window, so I couldn't verify D1's exact behavior/field names for them. They default to hex for now; a follow-up can add them once confirmed against a real example (noted in a code comment).
- Wired into `apps/ui/src/routes/extrinsics.$hash.tsx`'s call-arg rendering (threading `callModule`/`callFunction`/`fieldName` through `renderCallArgs`/`renderCallArgValue` so `decodeBytesField`'s allowlist can key on the full triple).
- `extrinsics.ts`'s `hashBytesToHex` now reuses the same shared `unwrapByteArray`/`bytesToHex` rather than a second hex-encoding implementation (also gains depth-agnostic unwrapping for free, not just the previously-flat-only case).

### Testing
- New `apps/ui/src/lib/metagraphed/bytes.test.ts` (20 tests) with real production fixtures (`SubtensorModule.register`'s `work`, `SubtensorModule.commit_weights`'s `commit_hash`, `Ethereum.transact`'s `input` bytes) plus full branch coverage of `unwrapByteArray`'s wrap-depth cases.
- Full `apps/ui` suite: 95 files / 679 tests passing. `npx tsc --noEmit` clean, `npx eslint` 0 errors (pre-existing fast-refresh warnings only), `npx prettier --check` clean.
- Live-verified via the running dev server (Preview tools: patched `window.fetch` + TanStack Router's `navigate()`, then a file-based Playwright capture for the table below) using the real `commit_timelocked_weights` production shape.

## Screenshots

Driven through the real query/render path on `/extrinsics/<hash>` (`SubtensorModule.commit_timelocked_weights`, real production shape from block 8556317/idx 20's `commit` field), comparing the merge-base (pre-fix) against this branch. Desktop, dark theme.

| Section | Before | After |
| ------- | ------ | ----- |
| `commit` call arg | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4689-bytes-before.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4689-bytes-before.png)<br><sub>raw integer array `[[134,255,107,242,...]]`</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4689-bytes-after.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4689-bytes-after.png)<br><sub>clean hex `0x86ff6bf232962025de7e1dafc02358b91d2eb905ac7bf2a6a6f548c07a345e9d`</sub> |
