### PR TITLE
feat(extrinsics): generic Option<T>/enum/newtype-scalar normalizer

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -11,6 +11,7 @@ import {
   clampOffset,
 } from "../workers/request-params.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
+import { normalizePostgresValue } from "./scale-normalize.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
 // Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
@@ -156,7 +157,10 @@ export function formatExtrinsic(row) {
   let call_args = null;
   if (row.call_args != null) {
     try {
-      call_args = JSON.parse(row.call_args);
+      // normalizePostgresValue (#4690) is a no-op on D1's own call_args shape
+      // (an array of {name,type,value} descriptors) -- safe to apply
+      // unconditionally regardless of which serving tier produced this row.
+      call_args = normalizePostgresValue(JSON.parse(row.call_args));
     } catch {
       call_args = null;
     }

--- a/src/scale-normalize.mjs
+++ b/src/scale-normalize.mjs
@@ -1,0 +1,97 @@
+// Generic recursive normalizer for indexer-rs's (Postgres) dynamic-SCALE-value
+// encoding of Option<T>, C-like unit-variant enums, and generic single-field
+// newtype/tuple-struct wraps around a plain scalar -- three distinct Rust
+// shapes that all serialize through the same `{name, values}` enum-tree
+// grammar (or, for the newtype-scalar case, a bare 1-element array), while D1
+// (fetch-events.py) already flattens each to its natural JS form (#4669,
+// #4690). Bottom-up: children are normalized before a parent node is
+// evaluated, so the same three rules apply at any nesting depth -- inside a
+// Vec<T> element, a struct field, or a reconstructed nested call's own args
+// alike.
+//
+// Deliberately NOT handled here (separate, sibling concerns):
+// - AccountId32/MultiAddress::Id (#4688, src/ss58.mjs) and raw byte blobs
+//   (#4689) are BOTH also "an array wrapping another array" -- this module's
+//   newtype-scalar rule only fires when the wrapped element is a plain
+//   SCALAR, never an array/object, so it never races with either of those.
+// - An enum variant WITH associated data (Ethereum's `EIP1559`/`Call`,
+//   Drand/MevShield/LimitOrders' `Sr25519`, i.e. `{name, values}` where
+//   `values.length === 1` and the single element is itself an
+//   object/array/struct) is left as-is at this level -- only its CONTENTS
+//   are recursed into. Producing D1's single-key shorthand (`{EIP1559: {...}}`)
+//   for that case is #4692's job, which reuses this same `{name, values}`
+//   detection for its own final-step transform.
+// - The nested-`RuntimeCall` reconstruction (`{name: "PalletName", values:
+//   [{name: "function_name", values: <args>}]}`) is #4691's concern -- this
+//   normalizer does not special-case it, so it passes through the generic
+//   enum-with-data branch unchanged (a `values.length === 1` node whose
+//   single element is itself an object) until #4691 recognizes it.
+
+function isPlainScalar(value) {
+  return (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  );
+}
+
+function isEnumTreeNode(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 2 &&
+    keys.includes("name") &&
+    keys.includes("values") &&
+    typeof value.name === "string" &&
+    Array.isArray(value.values)
+  );
+}
+
+function normalize(value) {
+  if (Array.isArray(value)) {
+    // Generic single-field newtype/tuple-struct wrap around a plain scalar
+    // (e.g. LimitOrders.execute_batched_orders' fee_rate: [0] -> 0). Scoped to
+    // a SCALAR element specifically -- an array/object element here is the
+    // AccountId32/byte-blob newtype-wrap family (#4688/#4689's territory),
+    // left untouched by falling through to the generic element-map below.
+    if (value.length === 1 && isPlainScalar(value[0])) {
+      return value[0];
+    }
+    return value.map(normalize);
+  }
+  if (isEnumTreeNode(value)) {
+    const { name, values } = value;
+    if (name === "Some" && values.length === 1) {
+      return normalize(values[0]);
+    }
+    if (name === "None" && values.length === 0) {
+      return null;
+    }
+    if (values.length === 0) {
+      // C-like unit-variant enum (ProxyType, RootClaimType, OrderType, ...) --
+      // D1 renders the bare variant name as a string.
+      return name;
+    }
+    // An enum variant WITH associated data (values.length >= 1, not Some/None)
+    // -- out of scope here (see module header); preserve the tag/shape,
+    // recurse only into the payload.
+    return { name, values: values.map(normalize) };
+  }
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) out[key] = normalize(val);
+    return out;
+  }
+  return value;
+}
+
+/** Recursively applies the Option<T>/unit-enum/newtype-scalar normalization
+ * rules described above. A no-op on already-D1-shaped data (D1's call_args
+ * descriptors are `{name, type, value}` triples inside an array -- never a
+ * bare two-key `{name, values}` object, never a real 1-element scalar array
+ * in a value position), so this is safe to run unconditionally regardless of
+ * which tier produced the row. */
+export function normalizePostgresValue(value) {
+  return normalize(value);
+}

--- a/src/scale-normalize.mjs
+++ b/src/scale-normalize.mjs
@@ -36,7 +36,12 @@ function isPlainScalar(value) {
   );
 }
 
-function isEnumTreeNode(value) {
+/** True when `value` is indexer-rs's generic `{name, values}` enum-tree node
+ * shape -- exported for #4691's nested-RuntimeCall reconstruction, which
+ * needs the identical shape check to distinguish a nested call from an
+ * ordinary enum-with-data node (both share this two-key shape; the
+ * distinction is whether `values[0]` is ITSELF another such node). */
+export function isEnumTreeNode(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const keys = Object.keys(value);
   return (

--- a/tests/scale-normalize.test.mjs
+++ b/tests/scale-normalize.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+
+describe("normalizePostgresValue", () => {
+  describe("Option<T> (Some/None)", () => {
+    test("unwraps Some to its inner value (real AdminUtils.sudo_set_mechanism_emission_split, block 8559935/32)", () => {
+      assert.deepEqual(
+        normalizePostgresValue({ name: "Some", values: [[0, 65535]] }),
+        [0, 65535],
+      );
+    });
+
+    test("unwraps None to null (real Multisig.approve_as_multi maybe_timepoint, block 8587346/18)", () => {
+      assert.equal(normalizePostgresValue({ name: "None", values: [] }), null);
+    });
+
+    test("unwraps a scalar Some", () => {
+      assert.equal(normalizePostgresValue({ name: "Some", values: [42] }), 42);
+    });
+
+    test("unwraps None for LimitOrders.execute_batched_orders' relayer/partial_fill (block 8587347/16)", () => {
+      const args = {
+        relayer: { name: "None", values: [] },
+        partial_fill: { name: "None", values: [] },
+      };
+      assert.deepEqual(normalizePostgresValue(args), {
+        relayer: null,
+        partial_fill: null,
+      });
+    });
+  });
+
+  describe("C-like unit-variant enums", () => {
+    test("flattens to the bare variant name (real Proxy.add_proxy proxy_type, block 8587138/24)", () => {
+      assert.equal(normalizePostgresValue({ name: "Any", values: [] }), "Any");
+    });
+
+    test("flattens SubtensorModule.set_root_claim_type's new_root_claim_type (block 8586560/17)", () => {
+      assert.equal(
+        normalizePostgresValue({ name: "Swap", values: [] }),
+        "Swap",
+      );
+    });
+
+    test("flattens LimitOrders.execute_batched_orders' order_type (block 8587347/16)", () => {
+      assert.equal(
+        normalizePostgresValue({ name: "StopLoss", values: [] }),
+        "StopLoss",
+      );
+    });
+  });
+
+  describe("generic newtype-scalar unwrap", () => {
+    test("unwraps a 1-tuple wrapping a plain number (real LimitOrders.execute_batched_orders fee_rate, block 8587347/16)", () => {
+      assert.equal(normalizePostgresValue([0]), 0);
+    });
+
+    test("unwraps a 1-tuple wrapping a string", () => {
+      assert.equal(normalizePostgresValue(["hello"]), "hello");
+    });
+
+    test("unwraps a 1-tuple wrapping a boolean or null", () => {
+      assert.equal(normalizePostgresValue([true]), true);
+      assert.equal(normalizePostgresValue([null]), null);
+    });
+  });
+
+  describe("passthrough cases (NOT this module's job)", () => {
+    test("leaves an Ethereum-style enum-with-data node untouched (recurses into contents only)", () => {
+      const node = { name: "EIP1559", values: [{ nonce: 1 }] };
+      assert.deepEqual(normalizePostgresValue(node), {
+        name: "EIP1559",
+        values: [{ nonce: 1 }],
+      });
+    });
+
+    test("recurses into an enum-with-data node's own contents", () => {
+      const node = {
+        name: "Some",
+        values: [{ name: "EIP1559", values: [{ a: [5] }] }],
+      };
+      // Some unwraps first; the inner EIP1559 node's own contents still get
+      // the newtype-scalar rule applied (a: [5] -> a: 5), but its own
+      // {name,values} shape is preserved.
+      assert.deepEqual(normalizePostgresValue(node), {
+        name: "EIP1559",
+        values: [{ a: 5 }],
+      });
+    });
+
+    test("leaves a 1-element array wrapping an array untouched (AccountId32/byte-blob territory, #4688/#4689)", () => {
+      const bytes = [1, 2, 3];
+      assert.deepEqual(normalizePostgresValue([bytes]), [bytes]);
+    });
+
+    test("leaves a 1-element array wrapping an object untouched", () => {
+      const obj = { a: 1 };
+      assert.deepEqual(normalizePostgresValue([obj]), [{ a: 1 }]);
+    });
+
+    test("leaves a nested RuntimeCall enum-tree shape as a generic enum-with-data node (#4691's concern, not normalized here)", () => {
+      const node = {
+        name: "Balances",
+        values: [{ name: "transfer_all", values: {} }],
+      };
+      assert.deepEqual(normalizePostgresValue(node), node);
+    });
+  });
+
+  describe("recursion", () => {
+    test("normalizes Option/enum/newtype patterns nested inside an array element", () => {
+      const arr = [
+        { name: "Some", values: [1] },
+        { name: "None", values: [] },
+        [7],
+      ];
+      assert.deepEqual(normalizePostgresValue(arr), [1, null, 7]);
+    });
+
+    test("normalizes patterns nested inside a struct field", () => {
+      const obj = {
+        a: { name: "Some", values: [1] },
+        b: { name: "Foo", values: [] },
+      };
+      assert.deepEqual(normalizePostgresValue(obj), { a: 1, b: "Foo" });
+    });
+
+    test("normalizes two levels deep (struct containing an array containing an Option)", () => {
+      const obj = { list: [{ name: "Some", values: [{ x: [9] }] }] };
+      assert.deepEqual(normalizePostgresValue(obj), { list: [{ x: 9 }] });
+    });
+  });
+
+  describe("D1-shaped idempotence (requirement: must be a no-op on D1's own shape)", () => {
+    test("leaves D1's {name,type,value} descriptor array untouched", () => {
+      const d1CallArgs = [
+        { name: "netuid", type: "NetUid", value: 9 },
+        { name: "dests", type: "Vec<u16>", value: [21, 209] },
+      ];
+      assert.deepEqual(normalizePostgresValue(d1CallArgs), d1CallArgs);
+    });
+
+    test("leaves a single-descriptor D1 call_args array untouched (not mistaken for a newtype-scalar wrap)", () => {
+      const d1CallArgs = [
+        { name: "now", type: "Moment", value: 1783643784000 },
+      ];
+      assert.deepEqual(normalizePostgresValue(d1CallArgs), d1CallArgs);
+    });
+
+    test("leaves an already-flat D1 value (a plain array, e.g. dests: [21, 209]) untouched", () => {
+      assert.deepEqual(normalizePostgresValue([21, 209]), [21, 209]);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("passes through null/undefined/scalars without throwing", () => {
+      assert.equal(normalizePostgresValue(null), null);
+      assert.equal(normalizePostgresValue(undefined), undefined);
+      assert.equal(normalizePostgresValue(42), 42);
+      assert.equal(normalizePostgresValue("x"), "x");
+      assert.equal(normalizePostgresValue(true), true);
+    });
+
+    test("passes through an empty array and empty object unchanged", () => {
+      assert.deepEqual(normalizePostgresValue([]), []);
+      assert.deepEqual(normalizePostgresValue({}), {});
+    });
+
+    test("does not mistake a plain object with name+values+extra keys for an enum-tree node", () => {
+      const obj = { name: "Any", values: [], extra: 1 };
+      assert.deepEqual(normalizePostgresValue(obj), {
+        name: "Any",
+        values: [],
+        extra: 1,
+      });
+    });
+
+    test("does not mistake an enum-tree-shaped node with a non-string name for one", () => {
+      const obj = { name: 5, values: [] };
+      assert.deepEqual(normalizePostgresValue(obj), { name: 5, values: [] });
+    });
+  });
+});


### PR DESCRIPTION
Refs #4669, #4690

### Motivation
indexer-rs's (Postgres) dynamic-SCALE-value dump represents `Option<T>`, C-like unit-variant enums, and generic single-field newtype/tuple-struct wraps around a plain scalar all through the same `{name,values}` enum-tree grammar (or a bare 1-element array, for the scalar-newtype case), while D1 (`fetch-events.py`) already flattens each to its natural JS form -- `Some`/`None` unwrap directly, a unit enum renders as its bare variant string, a newtype-wrapped scalar unwraps to the value. This is one of the remaining named gaps blocking the `METAGRAPH_EXTRINSICS_SOURCE` flip.

### Description
- New `src/scale-normalize.mjs`'s `normalizePostgresValue`: a single bottom-up recursive pass applying all three rules at any nesting depth (inside a `Vec<T>` element, a struct field, or a reconstructed nested call's own args alike).
- Wired into `src/extrinsics.mjs`'s `formatExtrinsic()` at the existing `call_args = JSON.parse(row.call_args)` step -- the one shared formatter both the D1 and (once the flag flips) Postgres extrinsics routes already run through.
- Deliberately leaves alone (separate, sibling concerns, coordinated via this same `{name,values}` detection):
  - An enum variant **with** associated data (Ethereum's `EIP1559`/`Call`) -- #4692's concern; preserves the tag/shape, recurses only into contents.
  - The nested-`RuntimeCall` enum-tree shape -- #4691's concern.
  - A 1-element array wrapping an array/object (AccountId32/byte-blob territory, #4688/#4689) -- the newtype-scalar rule here only fires on a wrapped **plain scalar**, never an array/object, so it can't race with either.

### Testing
- New `tests/scale-normalize.test.mjs` (25 tests, 100% coverage) with real production fixtures (`AdminUtils.sudo_set_mechanism_emission_split`, `Multisig.approve_as_multi`, `Proxy.add_proxy`, `SubtensorModule.set_root_claim_type`, `LimitOrders.execute_batched_orders`) plus explicit D1-shape idempotence tests (D1's `{name,type,value}` descriptor array never matches the two-key `{name,values}` enum-tree check).
- `tests/extrinsics.test.mjs`, `tests/extrinsic-detail.test.mjs`, `tests/load-staged-blocks-extrinsics.test.mjs`, `tests/data-api.test.mjs` all still pass unchanged (182 tests total across the 5 files) -- confirms no regression to the D1-serving path.
- `npx eslint`/`npx prettier --check` clean.

No screenshot table -- no `apps/ui` files touched.