### PR TITLE
feat(extrinsics): move nested RuntimeCall reconstruction server-side

### DIFF
--- a/src/bytes.mjs
+++ b/src/bytes.mjs
@@ -1,0 +1,79 @@
+// Server-side mirror of apps/ui/src/lib/metagraphed/bytes.ts (#4689) -- the
+// same raw byte-blob (Vec<u8> / BoundedVec<u8> / Bytes) shape reconciliation
+// between D1 (fetch-events.py) and Postgres (indexer-rs) call_args, needed
+// here too for #4691's nested-call decode: a nested call's own byte-blob
+// fields (a Proxy.proxy-wrapped commit/ciphertext, a nested call_hash, ...)
+// need the identical unwrap+hex treatment the client already applies to
+// top-level fields, but server-side so every consumer of the Postgres tier
+// (REST, MCP once wired, third-party SDKs) sees it, not just the one React
+// route that imports bytes.ts. Kept as a duplicate file (not a shared import)
+// because apps/ui is a separate TypeScript toolchain the Workers runtime
+// can't import from directly -- same split already established for
+// ss58.ts/ss58.mjs and chain-event-args.ts/chain-event-args.mjs.
+
+function isIntArray(value) {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (n) => typeof n === "number" && Number.isInteger(n) && n >= 0 && n <= 255,
+    )
+  );
+}
+
+/** Recursively peels indexer-rs's newtype-wrap array layers -- while the
+ * value is a single-element array wrapping another array, unwrap one level
+ * -- until it bottoms out at a flat array of byte values, or returns null if
+ * it never resolves to one. Depth-agnostic: handles both a flat `[u8; N]`
+ * field with zero wraps (e.g. Multisig's raw `call_hash`) and a
+ * newtype-wrapped `Hash`/`H256`/`BoundedVec<u8>` field with one or more
+ * wraps (e.g. a `commit_hash`, or `commit`/`ciphertext`'s variable-length
+ * payload) with the same function. */
+export function unwrapByteArray(value) {
+  let current = value;
+  while (
+    Array.isArray(current) &&
+    current.length === 1 &&
+    Array.isArray(current[0])
+  ) {
+    current = current[0];
+  }
+  return isIntArray(current) ? current : null;
+}
+
+/** Canonical lowercase `0x`-prefixed hex, matching D1's existing convention
+ * for opaque byte blobs. */
+export function bytesToHex(bytes) {
+  return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** `(callModule, callFunction, fieldName)` triples D1 renders as UTF-8 text
+ * rather than hex -- kept in sync with apps/ui/src/lib/metagraphed/bytes.ts's
+ * TEXTUAL_FIELDS (#4689); see that module for the verified-against-real-data
+ * provenance of this exact allowlist, and why SubtensorModule.set_identity/
+ * set_subnet_identity's textual fields are deliberately NOT yet included. */
+const TEXTUAL_FIELDS = new Set([
+  "System.remark.remark",
+  "System.remark_with_event.remark",
+]);
+
+/** Decodes a byte-blob call-arg field to its canonical representation: UTF-8
+ * text for the small, verified allowlist of genuinely textual fields above,
+ * hex for everything else (the safe default for opaque payloads, and the
+ * same fix for D1's own Ethereum.transact.input mojibake bug that field is
+ * deliberately NOT in the allowlist). */
+export function decodeBytesField(callModule, callFunction, fieldName, bytes) {
+  const key = `${callModule ?? ""}.${callFunction ?? ""}.${fieldName}`;
+  if (TEXTUAL_FIELDS.has(key)) {
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(
+        Uint8Array.from(bytes),
+      );
+    } catch {
+      // Malformed UTF-8 for a field expected to be textual -- fall back to
+      // hex rather than producing mojibake (the exact class of bug this
+      // module exists to avoid reproducing).
+      return bytesToHex(bytes);
+    }
+  }
+  return bytesToHex(bytes);
+}

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -12,6 +12,7 @@ import {
 } from "../workers/request-params.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { normalizePostgresValue } from "./scale-normalize.mjs";
+import { decodePostgresCallArgs } from "./postgres-call-args.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
 // Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
@@ -157,10 +158,16 @@ export function formatExtrinsic(row) {
   let call_args = null;
   if (row.call_args != null) {
     try {
-      // normalizePostgresValue (#4690) is a no-op on D1's own call_args shape
-      // (an array of {name,type,value} descriptors) -- safe to apply
-      // unconditionally regardless of which serving tier produced this row.
-      call_args = normalizePostgresValue(JSON.parse(row.call_args));
+      // decodePostgresCallArgs (#4691) MUST run before normalizePostgresValue
+      // (#4690) -- it needs the pristine raw nested-call shape to reconstruct
+      // correctly (see its own file header for why running it second would
+      // silently lose a genuinely zero-argument nested call). Both are
+      // no-ops on D1's own call_args shape (an array of {name,type,value}
+      // descriptors) -- safe to apply unconditionally regardless of which
+      // serving tier produced this row.
+      call_args = normalizePostgresValue(
+        decodePostgresCallArgs(JSON.parse(row.call_args)),
+      );
     } catch {
       call_args = null;
     }

--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -1,0 +1,164 @@
+// Server-side reconstruction of indexer-rs's (Postgres) nested-RuntimeCall
+// encoding within an extrinsic's call_args -- a generalized port of
+// apps/ui/src/lib/metagraphed/extrinsics.ts:58-94's normalizeIndexerRsCall/
+// asDecodedCall (#4676, client-only, one React route). This runs server-side
+// so every consumer of the Postgres tier (REST, MCP once wired, third-party
+// SDKs) sees the same reconstructed `{call_module, call_function, call_args}`
+// shape D1/substrate-interface already produces natively, instead of
+// indexer-rs's raw `{name: "PalletName", values: [{name: "function_name",
+// values: <args>}]}` enum-tree dump (#4691).
+//
+// Must run BEFORE scale-normalize.mjs's normalizePostgresValue (#4690), not
+// after or independently. Reconstruction needs the PRISTINE raw shape: a
+// genuinely zero-argument nested call's inner function-node is
+// `{name: "fn", values: []}` -- structurally identical to a C-like
+// unit-variant enum (ProxyType::Any, etc.). If normalizePostgresValue's
+// C-enum rule ran first, it would collapse that function-node to a bare
+// string "fn" before this module ever saw the `{name,values}` wrapper to
+// reconstruct, silently losing a valid zero-arg nested call. Reconstructing
+// first sidesteps the ambiguity entirely: the reconstructed
+// `{call_module, call_function, call_args}` shape has neither a "name" nor a
+// "values" key (isEnumTreeNode requires both), so normalizePostgresValue's
+// later pass over the combined tree recurses into it generically and never
+// misidentifies it -- see src/extrinsics.mjs's formatExtrinsic for the call
+// order this depends on.
+import { isEnumTreeNode } from "./scale-normalize.mjs";
+import { normalizeAccountId32Field } from "./ss58.mjs";
+import { unwrapByteArray, decodeBytesField } from "./bytes.mjs";
+
+// Field names decoded to SS58 within a reconstructed nested call's own args
+// (#4691's scope -- top-level call_args fields of the same type are a
+// separate, not-yet-covered gap, tracked on #4669). Mirrors
+// src/chain-event-args.mjs's ACCOUNT_KEYS (the analogous chain_events.args
+// decode, #4685) plus two additions specific to call_args' richer field
+// vocabulary: "real" (Proxy.proxy's acting-account arg, extrinsics.ts:117-129)
+// and the hotkey/coldkey SUFFIX rule below -- chain_events field names are
+// short single words ("who", "from"), but SubtensorModule call_args commonly
+// use compound names ("destination_coldkey", "origin_coldkey") that an
+// exact-match set alone would miss (confirmed against real
+// SubtensorModule.transfer_stake data, block 8587171/extrinsic_index 21).
+const ACCOUNT_KEYS = new Set([
+  "who",
+  "account",
+  "account_id",
+  "accountid",
+  "coldkey",
+  "hotkey",
+  "from",
+  "to",
+  "dest",
+  "destination",
+  "source",
+  "delegate",
+  "nominator",
+  "owner",
+  "target",
+  "validator",
+  "address",
+  "real",
+]);
+
+function isAccountField(keyHint) {
+  if (!keyHint) return false;
+  const lower = keyHint.toLowerCase();
+  return (
+    ACCOUNT_KEYS.has(lower) ||
+    lower.endsWith("_hotkey") ||
+    lower.endsWith("_coldkey")
+  );
+}
+
+// True when `value` is indexer-rs's generic dynamic-SCALE-value encoding of a
+// RuntimeCall-typed field: a single-variant enum wrapping another
+// single-variant enum, one level per nesting -- e.g.
+// {name:"SubtensorModule", values:[{name:"commit_timelocked_mechanism_weights",
+// values:{...}}]}. Reconstructing call_module/call_function from the two
+// `name` tags is safe and deterministic (pallet/function names are always
+// plain strings here, mirrors extrinsics.ts:60-71's identical rationale).
+// Reuses isEnumTreeNode for the OUTER shape only -- the inner function-node's
+// own `values` is the call's args and is NOT required to be an array (a
+// named-struct-args call has an object there), so it can't reuse
+// isEnumTreeNode (which requires Array.isArray(value.values)) for that half
+// of the check.
+function tryReconstructNestedCall(value) {
+  if (!isEnumTreeNode(value) || value.values.length !== 1) return null;
+  const inner = value.values[0];
+  if (!inner || typeof inner !== "object" || Array.isArray(inner)) return null;
+  if (typeof inner.name !== "string") return null;
+  return {
+    call_module: value.name,
+    call_function: inner.name,
+    // UNCHANGED, matching extrinsics.ts:83-84's identical choice -- decoded
+    // recursively by walk() below, not re-derived here.
+    call_args: inner.values,
+  };
+}
+
+// Recursive walk: reconstructs nested calls at any depth, and -- only within
+// an already-reconstructed call's own call_args (per #4691's scope) --
+// decodes AccountId32/MultiAddress fields to SS58 and byte-blob fields to
+// hex/text. `enclosingCall` is null at the top level (so call_args' own
+// top-level fields are deliberately left untouched) and becomes
+// `{callModule, callFunction}` for the NEAREST enclosing reconstructed call
+// once we've descended into one, so decodeBytesField's callModule/
+// callFunction-keyed textual-field lookup always uses the innermost call,
+// not the outer extrinsic's own call_module/call_function.
+function walk(value, keyHint, enclosingCall) {
+  const nested = tryReconstructNestedCall(value);
+  if (nested) {
+    const call = {
+      call_module: nested.call_module,
+      call_function: nested.call_function,
+    };
+    return {
+      ...call,
+      call_args: walk(nested.call_args, undefined, call),
+    };
+  }
+  if (enclosingCall && isAccountField(keyHint)) {
+    const ss58 = normalizeAccountId32Field(value);
+    if (ss58) return ss58;
+  }
+  if (enclosingCall) {
+    const bytes = unwrapByteArray(value);
+    if (bytes && bytes.length > 0) {
+      return decodeBytesField(
+        enclosingCall.call_module,
+        enclosingCall.call_function,
+        keyHint ?? "",
+        bytes,
+      );
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => walk(item, keyHint, enclosingCall));
+  }
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = walk(val, key, enclosingCall);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Reconstructs indexer-rs's nested-RuntimeCall enum-tree shape into D1's
+ * `{call_module, call_function, call_args}` shape at any nesting depth
+ * (Proxy.proxy wrapping one call, Utility.batch wrapping an array of calls,
+ * Multisig.as_multi/Sudo.sudo/Utility.batch_all composing three deep --
+ * all confirmed against real production data), and decodes AccountId32/
+ * MultiAddress/byte-blob fields within each reconstructed call's own args.
+ * Deliberately does NOT attempt to synthesize a nested call's own
+ * `call_hash` (Multisig.as_multi's permanent, accepted gap -- indexer-rs's
+ * dynamic-value dump has no equivalent of fetch-events.py's Python-side
+ * re-encode-and-hash step; the reconstructed object simply has no
+ * `call_hash` key, same as extrinsics.ts's normalizeIndexerRsCall). A no-op
+ * on D1's own call_args shape (an array of {name,type,value} descriptors --
+ * "value" singular is never mistaken for "values" plural) and on a
+ * call_args tree with no nested calls at all -- safe to apply
+ * unconditionally regardless of which tier produced the row, same contract
+ * as normalizePostgresValue (#4690). */
+export function decodePostgresCallArgs(value) {
+  return walk(value, undefined, null);
+}

--- a/tests/bytes.test.mjs
+++ b/tests/bytes.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  unwrapByteArray,
+  bytesToHex,
+  decodeBytesField,
+} from "../src/bytes.mjs";
+
+describe("unwrapByteArray", () => {
+  test("returns a flat byte array unchanged (zero wraps, e.g. Multisig's raw call_hash)", () => {
+    const bytes = [55, 179, 165, 105];
+    assert.deepEqual(unwrapByteArray(bytes), bytes);
+  });
+
+  test("unwraps one newtype layer (real SubtensorModule.commit_weights commit_hash, block 8587046/19)", () => {
+    const bytes = [59, 140, 220, 127, 37, 107, 167, 77];
+    assert.deepEqual(unwrapByteArray([bytes]), bytes);
+  });
+
+  test("unwraps two newtype layers", () => {
+    const bytes = [1, 2, 3];
+    assert.deepEqual(unwrapByteArray([[bytes]]), bytes);
+  });
+
+  test("does not loop on a single-element array whose element is a plain scalar, not another array", () => {
+    // Distinguishes a length-1 flat byte array ([5], a single-byte value)
+    // from a length-1 array WRAPPING another array ([[5]], a newtype wrap) --
+    // the while-loop's array-of-array check must stop here, not recurse into
+    // the scalar.
+    assert.deepEqual(unwrapByteArray([5]), [5]);
+  });
+
+  test("returns null for a non-byte-array value", () => {
+    assert.equal(unwrapByteArray("not an array"), null);
+    assert.equal(unwrapByteArray(null), null);
+    assert.equal(unwrapByteArray(undefined), null);
+    assert.equal(unwrapByteArray(42), null);
+    assert.equal(unwrapByteArray({ a: 1 }), null);
+  });
+
+  test("returns null for an array containing a non-integer or out-of-range value", () => {
+    assert.equal(unwrapByteArray([1, 2, "3"]), null);
+    assert.equal(unwrapByteArray([1, 2, 256]), null);
+    assert.equal(unwrapByteArray([1, 2, -1]), null);
+    assert.equal(unwrapByteArray([1, 2.5, 3]), null);
+  });
+
+  test("returns null for a multi-element array wrapping arrays (not a single-element newtype wrap)", () => {
+    assert.equal(
+      unwrapByteArray([
+        [1, 2],
+        [3, 4],
+      ]),
+      null,
+    );
+  });
+
+  test("returns an empty array for an empty flat array (vacuously a valid byte array)", () => {
+    assert.deepEqual(unwrapByteArray([]), []);
+  });
+});
+
+describe("bytesToHex", () => {
+  test("hex-encodes bytes matching D1's convention (real SubtensorModule.register work, block 8556317/20)", () => {
+    const bytes = [0x10, 0x40, 0x70, 0x6a, 0x68, 0x9d, 0x63, 0x7b];
+    assert.equal(bytesToHex(bytes), "0x1040706a689d637b");
+  });
+
+  test("pads single-digit hex values", () => {
+    assert.equal(bytesToHex([0, 1, 15, 16]), "0x00010f10");
+  });
+
+  test("returns 0x for an empty array", () => {
+    assert.equal(bytesToHex([]), "0x");
+  });
+});
+
+describe("decodeBytesField", () => {
+  test("UTF-8-decodes System.remark_with_event's remark field (real data, block 8512299/12: D1 = 'module-test-5f758613')", () => {
+    const text = "module-test-5f758613";
+    const bytes = Array.from(new TextEncoder().encode(text));
+    assert.equal(
+      decodeBytesField("System", "remark_with_event", "remark", bytes),
+      text,
+    );
+  });
+
+  test("UTF-8-decodes System.remark's remark field the same way", () => {
+    const bytes = Array.from(new TextEncoder().encode("hello"));
+    assert.equal(
+      decodeBytesField("System", "remark", "remark", bytes),
+      "hello",
+    );
+  });
+
+  test("hex-encodes Ethereum.transact's input field -- deliberately NOT reproducing D1's UTF-8/Latin1 mojibake bug (real bytes, block 8587453/9)", () => {
+    const bytes = [97, 70, 25, 84];
+    const decoded = decodeBytesField("Ethereum", "transact", "input", bytes);
+    assert.equal(decoded, "0x61461954");
+    const hasControlChar = Array.from(decoded).some(
+      (ch) => ch.charCodeAt(0) < 0x20,
+    );
+    assert.equal(hasControlChar, false);
+  });
+
+  test("hex-encodes opaque payload fields not on the textual allowlist (work, ciphertext, commit)", () => {
+    const bytes = [16, 64, 112, 106];
+    assert.equal(
+      decodeBytesField("SubtensorModule", "register", "work", bytes),
+      bytesToHex(bytes),
+    );
+    assert.equal(
+      decodeBytesField("MevShield", "submit_encrypted", "ciphertext", bytes),
+      bytesToHex(bytes),
+    );
+    assert.equal(
+      decodeBytesField(
+        "SubtensorModule",
+        "commit_timelocked_weights",
+        "commit",
+        bytes,
+      ),
+      bytesToHex(bytes),
+    );
+  });
+
+  test("falls back to hex when a field on the textual allowlist happens to contain invalid UTF-8", () => {
+    const invalidUtf8 = [0xff, 0xfe, 0xfd];
+    assert.equal(
+      decodeBytesField("System", "remark", "remark", invalidUtf8),
+      bytesToHex(invalidUtf8),
+    );
+  });
+
+  test("hex-encodes a remark-named field on an unrelated call_module/call_function (allowlist is keyed on the full triple)", () => {
+    const bytes = Array.from(new TextEncoder().encode("hello"));
+    assert.equal(
+      decodeBytesField("SomeOtherModule", "some_function", "remark", bytes),
+      bytesToHex(bytes),
+    );
+  });
+
+  test("handles null/undefined callModule or callFunction without throwing", () => {
+    const bytes = [1, 2, 3];
+    assert.equal(
+      decodeBytesField(null, null, "remark", bytes),
+      bytesToHex(bytes),
+    );
+    assert.equal(
+      decodeBytesField(undefined, undefined, "input", bytes),
+      bytesToHex(bytes),
+    );
+  });
+});

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -1,0 +1,492 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { decodePostgresCallArgs } from "../src/postgres-call-args.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+
+// decodePostgresCallArgs must run BEFORE normalizePostgresValue (see
+// src/postgres-call-args.mjs's own header for why) -- every test below
+// chains them in that order, matching src/extrinsics.mjs's formatExtrinsic.
+function decode(value) {
+  return normalizePostgresValue(decodePostgresCallArgs(value));
+}
+
+describe("decodePostgresCallArgs", () => {
+  describe("real production fixtures", () => {
+    test("Proxy.proxy wrapping SubtensorModule.commit_timelocked_mechanism_weights (block 8587453/22)", () => {
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [
+            {
+              name: "commit_timelocked_mechanism_weights",
+              values: {
+                mecid: 0,
+                commit: [[147, 47, 10, 12, 1, 83]],
+                netuid: 4,
+                reveal_round: 30280658,
+                commit_reveal_version: 4,
+              },
+            },
+          ],
+        },
+        real: {
+          name: "Id",
+          values: [
+            [
+              [
+                88, 174, 247, 177, 239, 180, 72, 6, 254, 20, 198, 197, 141, 12,
+                30, 182, 52, 165, 159, 210, 81, 63, 12, 237, 111, 45, 16, 224,
+                86, 154, 244, 13,
+              ],
+            ],
+          ],
+        },
+        force_proxy_type: { name: "None", values: [] },
+      };
+      const out = decode(raw);
+      assert.deepEqual(out.call, {
+        call_module: "SubtensorModule",
+        call_function: "commit_timelocked_mechanism_weights",
+        call_args: {
+          mecid: 0,
+          commit: "0x932f0a0c0153",
+          netuid: 4,
+          reveal_round: 30280658,
+          commit_reveal_version: 4,
+        },
+      });
+    });
+
+    test("byte-blob field within a reconstructed nested call decodes to hex, not raw array", () => {
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [
+            {
+              name: "commit_timelocked_mechanism_weights",
+              values: { commit: [[1, 2, 255, 0]] },
+            },
+          ],
+        },
+      };
+      assert.equal(decode(raw).call.call_args.commit, "0x0102ff00");
+    });
+
+    test("Proxy.proxy's own top-level fields (real, force_proxy_type) are NOT decoded -- out of #4691's scope, only fields WITHIN a reconstructed call are", () => {
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [{ name: "commit_timelocked_mechanism_weights", values: {} }],
+        },
+        real: {
+          name: "Id",
+          values: [
+            [
+              [
+                88, 174, 247, 177, 239, 180, 72, 6, 254, 20, 198, 197, 141, 12,
+                30, 182, 52, 165, 159, 210, 81, 63, 12, 237, 111, 45, 16, 224,
+                86, 154, 244, 13,
+              ],
+            ],
+          ],
+        },
+        force_proxy_type: { name: "None", values: [] },
+      };
+      const out = decode(raw);
+      // force_proxy_type IS unwrapped -- that's normalizePostgresValue's
+      // Option<T> rule (#4690), unaffected by #4691's narrower scope.
+      assert.equal(out.force_proxy_type, null);
+      // real stays the raw MultiAddress::Id shape -- neither pass touches a
+      // top-level field of this type today (documented gap, tracked on
+      // #4669 as the next piece after this issue).
+      assert.deepEqual(out.real, {
+        name: "Id",
+        values: [
+          [
+            [
+              88, 174, 247, 177, 239, 180, 72, 6, 254, 20, 198, 197, 141, 12,
+              30, 182, 52, 165, 159, 210, 81, 63, 12, 237, 111, 45, 16, 224, 86,
+              154, 244, 13,
+            ],
+          ],
+        ],
+      });
+    });
+
+    test("Utility.batch wrapping 8 SubtensorModule.transfer_stake calls, each independently reconstructed and decoded (block 8587171/21)", () => {
+      const hotkey = [
+        120, 150, 23, 189, 146, 106, 33, 202, 103, 15, 93, 72, 101, 244, 73,
+        248, 0, 42, 216, 188, 57, 209, 166, 43, 96, 120, 62, 61, 222, 107, 182,
+        36,
+      ];
+      const coldkeyA = [
+        102, 178, 9, 24, 55, 169, 128, 172, 45, 21, 139, 163, 206, 123, 174,
+        196, 240, 241, 190, 212, 101, 206, 12, 128, 30, 12, 121, 70, 229, 225,
+        181, 91,
+      ];
+      const coldkeyB = [
+        104, 9, 157, 251, 75, 66, 250, 0, 149, 146, 134, 20, 68, 117, 27, 138,
+        241, 231, 201, 190, 9, 253, 56, 248, 136, 133, 225, 84, 155, 76, 255,
+        21,
+      ];
+      const rawCall = (alphaAmount, destinationColdkey) => ({
+        name: "SubtensorModule",
+        values: [
+          {
+            name: "transfer_stake",
+            values: {
+              hotkey: [hotkey],
+              alpha_amount: alphaAmount,
+              origin_netuid: 9,
+              destination_netuid: 9,
+              destination_coldkey: [destinationColdkey],
+            },
+          },
+        ],
+      });
+      const raw = {
+        calls: [rawCall(3358540310, coldkeyA), rawCall(15059873560, coldkeyB)],
+      };
+      const out = decode(raw);
+      assert.equal(out.calls.length, 2);
+      for (const call of out.calls) {
+        assert.equal(call.call_module, "SubtensorModule");
+        assert.equal(call.call_function, "transfer_stake");
+        // Same hotkey across every batched call -- confirms the decode is
+        // per-instance (not accidentally memoized/shared) and correct on a
+        // repeated value.
+        assert.equal(
+          call.call_args.hotkey,
+          "5EnpBz2DoMTzMztFSVPSpi8jP2yfGadU6kgZgsjqnfvonMgu",
+        );
+      }
+      // destination_coldkey is a COMPOUND field name (not a bare "coldkey")
+      // -- exercises the hotkey/coldkey suffix rule, not just the exact-match
+      // ACCOUNT_KEYS set (confirmed missing this field name during
+      // implementation -- chain_events.args field names are short/single-word,
+      // call_args' are often compound).
+      assert.equal(
+        out.calls[0].call_args.destination_coldkey,
+        "5EPMdSCoV3NWhLb7DVZKvC6tXbW3GivbAHrVnp348PZeRoo9",
+      );
+      assert.equal(
+        out.calls[1].call_args.destination_coldkey,
+        "5ER7hD36RAFgXRKjfRjTBcP7TVnmfs284hgpzngH2pUmo4MR",
+      );
+      assert.equal(out.calls[0].call_args.alpha_amount, 3358540310);
+      assert.equal(out.calls[1].call_args.alpha_amount, 15059873560);
+    });
+
+    test("Multisig.as_multi -> Sudo.sudo -> Utility.batch_all -> AdminUtils, three reconstruction levels deep (block 8584692/19)", () => {
+      const raw = {
+        call: {
+          name: "Sudo",
+          values: [
+            {
+              name: "sudo",
+              values: {
+                call: {
+                  name: "Utility",
+                  values: [
+                    {
+                      name: "batch_all",
+                      values: {
+                        calls: [
+                          {
+                            name: "AdminUtils",
+                            values: [
+                              {
+                                name: "sudo_set_subnet_emission_enabled",
+                                values: { netuid: 78, enabled: true },
+                              },
+                            ],
+                          },
+                          {
+                            name: "AdminUtils",
+                            values: [
+                              {
+                                name: "sudo_set_subnet_emission_enabled",
+                                values: { netuid: 121, enabled: true },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        threshold: 2,
+        max_weight: { ref_time: 1089922230, proof_size: 47024 },
+        maybe_timepoint: {
+          name: "Some",
+          values: [{ index: 24, height: 8579473 }],
+        },
+        other_signatories: [
+          [
+            [
+              90, 138, 31, 119, 52, 147, 154, 124, 111, 20, 208, 31, 158, 15,
+              55, 225, 19, 181, 156, 209, 18, 191, 149, 15, 163, 102, 71, 123,
+              235, 91, 83, 11,
+            ],
+          ],
+        ],
+      };
+      const out = decode(raw);
+      assert.deepEqual(out.call, {
+        call_module: "Sudo",
+        call_function: "sudo",
+        call_args: {
+          call: {
+            call_module: "Utility",
+            call_function: "batch_all",
+            call_args: {
+              calls: [
+                {
+                  call_module: "AdminUtils",
+                  call_function: "sudo_set_subnet_emission_enabled",
+                  call_args: { netuid: 78, enabled: true },
+                },
+                {
+                  call_module: "AdminUtils",
+                  call_function: "sudo_set_subnet_emission_enabled",
+                  call_args: { netuid: 121, enabled: true },
+                },
+              ],
+            },
+          },
+        },
+      });
+      // Top-level Multisig fields untouched by #4691, normalized by #4690 as before.
+      assert.equal(out.threshold, 2);
+      assert.deepEqual(out.maybe_timepoint, { index: 24, height: 8579473 });
+    });
+
+    test("Multisig.as_multi's nested call_hash stays absent, not fabricated (block 8587390/13 -- the permanent accepted gap)", () => {
+      const raw = {
+        call: {
+          name: "Balances",
+          values: [
+            {
+              name: "transfer_keep_alive",
+              values: {
+                dest: {
+                  name: "Id",
+                  values: [
+                    [
+                      [
+                        202, 181, 160, 24, 153, 159, 12, 80, 104, 152, 143, 220,
+                        228, 103, 60, 102, 201, 95, 2, 218, 67, 10, 147, 67,
+                        239, 62, 216, 148, 99, 63, 194, 63,
+                      ],
+                    ],
+                  ],
+                },
+                value: 400000000000,
+              },
+            },
+          ],
+        },
+        threshold: 2,
+      };
+      const out = decode(raw);
+      assert.equal(out.call.call_module, "Balances");
+      assert.equal(out.call.call_function, "transfer_keep_alive");
+      assert.equal(
+        out.call.call_args.dest,
+        "5GeVV21s1W8aDuCg8zoNFQ5TnhPr643dXgEnigbUtGiZPeJY",
+      );
+      assert.equal(out.call.call_args.value, 400000000000);
+      // No call_hash key anywhere on the reconstructed call -- indexer-rs's
+      // dynamic-value dump has no equivalent of fetch-events.py's Python-side
+      // re-encode-and-hash step. Absent, not null and not fabricated.
+      assert.equal("call_hash" in out.call, false);
+    });
+  });
+
+  describe("Sudo.sudo_unchecked_weight (synthetic -- 0 confirmed occurrences in the retention window; code path still exercised)", () => {
+    test("reconstructs like any other single-nested call", () => {
+      const raw = {
+        call: {
+          name: "Sudo",
+          values: [
+            {
+              name: "sudo_unchecked_weight",
+              values: {
+                call: {
+                  name: "SubtensorModule",
+                  values: [
+                    {
+                      name: "set_root_claim_type",
+                      values: {
+                        new_root_claim_type: { name: "Swap", values: [] },
+                      },
+                    },
+                  ],
+                },
+                weight: { ref_time: 100, proof_size: 10 },
+              },
+            },
+          ],
+        },
+      };
+      const out = decode(raw);
+      assert.equal(out.call.call_module, "Sudo");
+      assert.equal(out.call.call_function, "sudo_unchecked_weight");
+      assert.deepEqual(out.call.call_args.call, {
+        call_module: "SubtensorModule",
+        call_function: "set_root_claim_type",
+        call_args: { new_root_claim_type: "Swap" },
+      });
+      assert.deepEqual(out.call.call_args.weight, {
+        ref_time: 100,
+        proof_size: 10,
+      });
+    });
+  });
+
+  describe("account-key-named field whose value isn't a decodable AccountId32 shape", () => {
+    test("falls through to the generic byte-blob/passthrough path instead of returning a decoded SS58", () => {
+      // "hotkey" matches isAccountField, but a 3-byte array is neither a flat
+      // 32-byte AccountId32 nor a newtype/MultiAddress wrap around one --
+      // normalizeAccountId32Field returns null, so this must NOT short-circuit
+      // on the account branch. It still happens to look like a tiny byte
+      // blob, so it hex-encodes rather than passing through as a bare array
+      // -- a defensible, non-crashing fallback for malformed input.
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [{ name: "transfer_stake", values: { hotkey: [1, 2, 3] } }],
+        },
+      };
+      assert.equal(decode(raw).call.call_args.hotkey, "0x010203");
+    });
+  });
+
+  describe("a reconstructed call whose own args are a bare byte blob with no field name", () => {
+    test("decodeBytesField receives an empty field-name hint, not undefined -- still hex-encodes", () => {
+      // nested.call_args here is the newtype-wrapped byte blob itself (not a
+      // struct/array of named fields), so walk() recurses with keyHint left
+      // undefined -- exercises decodeBytesField's `keyHint ?? ""` fallback.
+      const raw = {
+        call: {
+          name: "SomeModule",
+          values: [{ name: "raw_bytes_fn", values: [[1, 2, 3]] }],
+        },
+      };
+      assert.equal(decode(raw).call.call_args, "0x010203");
+    });
+  });
+
+  describe("ordering hazard: a genuinely zero-argument nested call", () => {
+    test("is reconstructed with call_args:[], not collapsed to a bare function-name string", () => {
+      // If normalizePostgresValue's C-like-unit-enum rule ran BEFORE this
+      // module (the wrong order), {name:"fn",values:[]} would collapse to
+      // the bare string "fn" -- structurally identical to a real C-like unit
+      // enum (ProxyType::Any etc.) -- silently losing the nested-call
+      // wrapper before reconstruction ever saw it. This proves the required
+      // call order (decodePostgresCallArgs first) actually holds.
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [{ name: "some_zero_arg_fn", values: [] }],
+        },
+      };
+      const out = decode(raw);
+      assert.deepEqual(out.call, {
+        call_module: "SubtensorModule",
+        call_function: "some_zero_arg_fn",
+        call_args: [],
+      });
+    });
+  });
+
+  describe("does not misidentify non-nested-call shapes (same disambiguation as extrinsics.ts's normalizeIndexerRsCall)", () => {
+    test("an Option<T> Some wrapper (values[0] is an array, not an object) is left for normalizePostgresValue", () => {
+      const raw = { name: "Some", values: [[0, 65535]] };
+      assert.deepEqual(decode(raw), [0, 65535]);
+    });
+
+    test("a C-like unit enum (values is empty) is left for normalizePostgresValue", () => {
+      assert.equal(decode({ name: "Any", values: [] }), "Any");
+    });
+
+    test("an enum-with-scalar-data node (values[0] is a bare scalar) is not reconstructed", () => {
+      const raw = { name: "Something", values: [42] };
+      assert.deepEqual(decodePostgresCallArgs(raw), {
+        name: "Something",
+        values: [42],
+      });
+    });
+
+    test("an enum-with-struct-data node whose payload has no string .name (Ethereum's EIP1559 shape) is not reconstructed", () => {
+      const raw = { name: "EIP1559", values: [{ nonce: 1, gas_price: 2 }] };
+      assert.deepEqual(decodePostgresCallArgs(raw), raw);
+    });
+
+    test("a MultiAddress::Id wrapper is not reconstructed as a nested call (its payload is an array, not an object)", () => {
+      const raw = {
+        name: "Id",
+        values: [
+          [
+            [
+              1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+              20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+          ],
+        ],
+      };
+      assert.equal(decodePostgresCallArgs(raw).name, "Id");
+    });
+  });
+
+  describe("D1-shaped idempotence (must be a no-op on D1's own call_args shapes)", () => {
+    test("leaves D1's {name,type,value} descriptor array untouched", () => {
+      const d1CallArgs = [
+        { name: "netuid", type: "NetUid", value: 9 },
+        { name: "dests", type: "Vec<u16>", value: [21, 209] },
+      ];
+      assert.deepEqual(decodePostgresCallArgs(d1CallArgs), d1CallArgs);
+    });
+
+    test("leaves D1's own already-decoded nested-call shape untouched, including a real call_hash", () => {
+      const d1NestedCall = {
+        call_index: "0x1c00",
+        call_module: "Balances",
+        call_function: "transfer_keep_alive",
+        call_args: [{ name: "dest", type: "MultiAddress", value: "5H..." }],
+        call_hash:
+          "0x4bf860882d143c4dc22bb5897dff810268789a297af20e5151cece736372d95",
+      };
+      assert.deepEqual(decodePostgresCallArgs(d1NestedCall), d1NestedCall);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("passes through null/undefined/scalars without throwing", () => {
+      assert.equal(decodePostgresCallArgs(null), null);
+      assert.equal(decodePostgresCallArgs(undefined), undefined);
+      assert.equal(decodePostgresCallArgs(42), 42);
+      assert.equal(decodePostgresCallArgs("x"), "x");
+      assert.equal(decodePostgresCallArgs(true), true);
+    });
+
+    test("passes through an empty array and empty object unchanged", () => {
+      assert.deepEqual(decodePostgresCallArgs([]), []);
+      assert.deepEqual(decodePostgresCallArgs({}), {});
+    });
+
+    test("a bare 32-byte AccountId32 array outside any reconstructed call is left untouched (top-level scope boundary)", () => {
+      const bytes = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+      ];
+      assert.deepEqual(decodePostgresCallArgs({ who: [bytes] }), {
+        who: [bytes],
+      });
+    });
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -90,6 +90,25 @@
     // as a roadmap of sub-issues (see the parent issue linked from #4669) --
     // do not flip this flag until that roadmap's normalizer work lands and a
     // real parity harness (not a single-extrinsic spot check) passes clean.
+    //
+    // Progress on that roadmap (src/scale-normalize.mjs, src/ss58.mjs,
+    // src/bytes.mjs, src/postgres-call-args.mjs -- all chained inside
+    // formatExtrinsic, #4690/#4691): Option<T>/C-enum/newtype-scalar shapes,
+    // and indexer-rs's nested-RuntimeCall enum-tree encoding (Proxy.proxy,
+    // Utility.batch/batch_all, Multisig.as_multi wrapping Sudo/AdminUtils --
+    // confirmed to arbitrary depth against real production extrinsics), are
+    // now reconstructed server-side into D1's {call_module, call_function,
+    // call_args} shape, with AccountId32/MultiAddress/byte-blob fields WITHIN
+    // each reconstructed nested call decoded to SS58/hex. Multisig.as_multi's
+    // nested call_hash stays permanently absent (indexer-rs has no equivalent
+    // of fetch-events.py's Python-side re-encode-and-hash step) -- accepted,
+    // not a bug. Still open: a TOP-LEVEL (non-nested) call's own AccountId32/
+    // byte-blob fields -- e.g. a bare Balances.transfer's dest, or Multisig's
+    // own other_signatories/max_weight siblings -- are not yet decoded at
+    // that outer layer, only within a reconstructed nested call; Ethereum/EVM
+    // U256+H160 shapes (#4692); BTreeSet/u64/u128-precision edge cases
+    // (#4693); and MCP's extrinsics tools are still D1-only (#4694). Do not
+    // flip until those land and the parity harness (#4695) passes clean.
     "METAGRAPH_BLOCKS_SOURCE": "d1",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },


### PR DESCRIPTION
## Summary
- Ports `normalizeIndexerRsCall`/`asDecodedCall` (`apps/ui/src/lib/metagraphed/extrinsics.ts:58-94`, client-only) into a new server-side module (`src/postgres-call-args.mjs`), reconstructing indexer-rs's raw `{name: "PalletName", values: [{name: "function_name", values: <args>}]}` nested-call encoding into D1's `{call_module, call_function, call_args}` shape inside `formatExtrinsic`, so REST, MCP (once wired), and third-party SDKs all see the same reconstructed shape instead of only the one React route.
- New `src/bytes.mjs` (server-side mirror of `apps/ui/src/lib/metagraphed/bytes.ts`, #4689) and reuse of `src/ss58.mjs` (#4688) decode AccountId32/MultiAddress and byte-blob fields **within each reconstructed nested call's own args**, at any depth — confirmed against real production data three levels deep (`Multisig.as_multi` → `Sudo.sudo` → `Utility.batch_all` → `AdminUtils`).
- Runs **before** `scale-normalize.mjs`'s Option/enum normalizer (#4690), not after: a genuinely zero-argument nested call's inner node (`{name:"fn", values:[]}`) is structurally identical to a C-like unit enum, so normalizing first would silently collapse a valid zero-arg nested call before reconstruction ever saw the wrapper. Verified with a synthetic regression test.
- `Multisig.as_multi`'s nested `call_hash` stays permanently absent (indexer-rs has no equivalent of `fetch-events.py`'s Python-side re-encode-and-hash step) — accepted gap, asserted in tests, not fabricated.
- Updated the `METAGRAPH_EXTRINSICS_SOURCE` comment in `wrangler.jsonc` to reflect what this closes vs. what's still open (top-level, non-nested call_args AccountId32/byte fields; Ethereum/EVM shapes; MCP wiring; the parity harness).

## Test plan
- [x] `tests/postgres-call-args.test.mjs` (20 tests, 100% branch coverage in isolation): real production fixtures for `Proxy.proxy` (block 8587453/22), `Utility.batch` (block 8587171/21, 8-call array), `Multisig.as_multi` → `Sudo.sudo` → `Utility.batch_all` → `AdminUtils` (block 8584692/19, triple-nested), `Multisig.as_multi`'s call_hash gap (block 8587390/13); a `Sudo.sudo_unchecked_weight` synthetic (0 confirmed occurrences, code path still exercised); the zero-arg ordering-hazard regression; D1-shape idempotence.
- [x] `tests/bytes.test.mjs` (18 tests, 100% coverage) — ported from the client's `bytes.test.ts`.
- [x] Existing `tests/extrinsics.test.mjs`/`tests/data-api.test.mjs`/`tests/scale-normalize.test.mjs`/`tests/ss58.test.mjs`/`tests/chain-event-args.test.mjs` all pass unchanged (no regression to D1-serving path).
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run test:coverage` clean (100% on both new files after closing two branch gaps found on the first pass)
- [x] `npm run validate:contract-drift` clean — `call_args` is already typed `["object","array","null"]` with no nested shape constraint, no OpenAPI change needed
- [x] Zero behavior change on `METAGRAPH_EXTRINSICS_SOURCE=d1` (both new passes are no-ops on D1's own shapes, confirmed via dedicated idempotence tests)

Refs #4669

<!-- No linked-issue close: #4691 is closed via the commit trailer; #4669 (parent roadmap) stays open. -->
Closes #4691