### PR TITLE
test(ui): add AGPL-3.0 badge to footer to validate visual-capture pipeline

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -334,8 +334,13 @@ function SiteFooter() {
       </div>
       <div className="border-t border-border/70">
         <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
-          <span>
-            © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+          <span className="flex items-center gap-2">
+            <span>
+              © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+            </span>
+            <span className="rounded border border-border/70 px-1.5 py-0.5 text-[10px] tracking-wide text-ink-muted">
+              AGPL-3.0
+            </span>
           </span>
           <EndpointHealthPill />
         </div>


### PR DESCRIPTION
Small, real footer addition (license disclosure, matching the sibling gittensory repo's own AGPL-3.0 badge) used to validate the visual-capture bot-screenshot pipeline end-to-end after JSONbored/gittensory#4564 (per-repo `review.visual.production_url` override + generalized route inference for `apps/ui/**`).