### PR TITLE
Enrich SN20 GroundLayer — add public API endpoint

### DIFF
--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -121,6 +121,25 @@
         "https://www.groundlayer.xyz/"
       ],
       "url": "https://www.groundlayer.xyz/og-groundlayer.png"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-20-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "GroundLayer TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/20 on api.taomarketcap.com returning machine-readable JSON for SN20 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. GroundLayer's official website paths under www.groundlayer.xyz do not expose a verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://www.groundlayer.xyz/"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/20"
     }
   ],
   "social": { "x": "https://x.com/groundlayerhq" },


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/groundlayer.json` (SN20, GroundLayer). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 20
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/20
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://www.groundlayer.xyz/
- **Provider slug:** `taomarketcap`

GroundLayer's official website paths under www.groundlayer.xyz do not expose a verified first-party public API. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 20.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/groundlayer.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/20` returns HTTP 200 with valid JSON (`netuid: 20`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4016

Made with [Cursor](https://cursor.com)