### PR TITLE
feat(registry): add Minos chr20 reference FAI data-artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,31 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-chr20-reference-fai",
+      "kind": "data-artifact",
+      "name": "Minos chr20 reference FAI index",
+      "notes": "Public no-auth GET for the chr20 FASTA index (.fai) served via the Minos platform reference redirect at api.theminos.ai/reference/.... The official minos_subnet status checks use this exact URL as REF_HEALTH_URL.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/neurons/status.py#L95",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/reference/chr20/chr20.fa.fai"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

- Append one `data-artifact` surface to `registry/subnets/minos.json` for the public chr20 FASTA index (`.fai`) at `https://api.theminos.ai/reference/chr20/chr20.fa.fai`.
- Proof: official `minos_subnet` `neurons/status.py` (`REF_HEALTH_URL`) and README.

Closes #4141

## Why

SN107 Minos already has a verified `subnet-api` health surface. The chr20 reference FAI index is a separate public static dataset probed by the subnet's own status checks but was not yet registered as a standalone data-artifact.

## Validation

```sh
npm run validate:surface -- registry/subnets/minos.json
npm run scan:public-safety
```

- Live probe: GET follows redirect and returns the `.fai` index payload.
- Append-only change to exactly one registry file; no key reordering.

## Test plan

- [x] `validate:surface` passes
- [x] `scan:public-safety` passes
- [x] No duplicate URL/kind in `minos.json`
- [x] No screenshots required (registry-only change)

Made with [Cursor](https://cursor.com)