### PR TITLE
Enrich SN80 dogelayer — add public API endpoint

### DIFF
--- a/registry/subnets/dogelayer.json
+++ b/registry/subnets/dogelayer.json
@@ -47,6 +47,25 @@
         "https://github.com/dogelayer-ai/dogelayer/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/dogelayer-ai/dogelayer/main/dogelayer/core/chain_data/types.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-80-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "DogeLayer TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/80 on api.taomarketcap.com returning machine-readable JSON for SN80 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. DogeLayer's documented proxy API requires Bearer auth and has no verified no-auth first-party public endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/dogelayer-ai/dogelayer"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/80"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/dogelayer.json` (SN80, dogelayer). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 80
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/80
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/dogelayer-ai/dogelayer
- **Provider slug:** `taomarketcap`

DogeLayer's documented proxy API requires Bearer auth and has no verified no-auth first-party public endpoint. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 80.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/dogelayer.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/80` returns HTTP 200 with valid JSON (`netuid: 80`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4097

Made with [Cursor](https://cursor.com)