### PR TITLE
test(ui): re-verify AI reviewer no longer false-flags bot-captured screenshots

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -334,8 +334,13 @@ function SiteFooter() {
       </div>
       <div className="border-t border-border/70">
         <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
-          <span>
-            © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+          <span className="flex items-center gap-2">
+            <span>
+              © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+            </span>
+            <span className="rounded border border-border/70 px-1.5 py-0.5 text-[10px] tracking-wide text-ink-muted">
+              AGPL-3.0
+            </span>
           </span>
           <EndpointHealthPill />
         </div>


### PR DESCRIPTION
Re-uses the exact commit from JSONbored/metagraphed#4713 (same head SHA, so bot-capture's R2 cache is reused — no new browser renders) to verify the review-skill fix for JSONbored/gittensory#4565: the AI reviewer should no longer independently flag missing screenshot evidence as a blocker now that it's been told the deterministic gate (not its own pre-capture judgment) is authoritative for that dimension.