### PR TITLE
Enrich SN69 ain — add public API endpoint

### DIFF
--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -46,6 +46,25 @@
         "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/README.md"
       ],
       "url": "https://raw.githubusercontent.com/HeraldMedia/herald/4de1577e82b74807d4081c3f61edffaee9ed718a/herald/validator/news/outlets.seed.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "ain TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/69 on api.taomarketcap.com returning machine-readable JSON for SN69 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Herald (ain) exposes outlet registry seed data and heraldmedia.ai but no verified no-auth first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/README.md"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/69"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/ain.json` (SN69, ain/Herald). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 69
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/69
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/README.md
- **Provider slug:** `taomarketcap`

Herald (ain) exposes outlet registry seed data and heraldmedia.ai but no verified no-auth first-party public API endpoint. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 69.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/ain.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/69` returns HTTP 200 with valid JSON (`netuid: 69`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4077

Made with [Cursor](https://cursor.com)