### PR TITLE
feat(extrinsics): decode Ethereum/EVM U256+H160 shapes server-side

### DIFF
--- a/src/big-int-safe-json.mjs
+++ b/src/big-int-safe-json.mjs
@@ -1,0 +1,47 @@
+// Fixes a real defect the Gittensory review caught on #4692 (PR #4719):
+// standard JSON.parse silently rounds any bare integer literal past
+// Number.MAX_SAFE_INTEGER (2^53-1) to the nearest representable float64 --
+// this happens BEFORE any field-aware decoder (decodeU256Limbs,
+// normalizePostgresValue's newtype-scalar unwrap) ever sees the value, so no
+// amount of downstream BigInt reconstruction can recover the lost precision.
+// Postgres's call_args::text column preserves large integers EXACTLY
+// (confirmed: a stored literal like 9131459485341369597 round-trips through
+// `SELECT call_args::text` unchanged) -- the corruption is purely an
+// artifact of JS's own JSON.parse, the same mechanism already accepted for
+// SubtensorModule.register's PoW nonce (D1 serves 9131459485341369000 vs the
+// true 9131459485341369597 -- this is that same bug, not a D1-specific one).
+//
+// Approach: before handing the text to JSON.parse, wrap any bare integer
+// literal that would lose precision in quotes, so it survives as an exact
+// string instead. Downstream numeric-field decoders (decodeU256Limbs) then
+// accept either a small JS number OR a numeric string for each component,
+// since only the SPECIFIC values large enough to need it get quoted -- most
+// call_args numbers (netuid, small amounts, the other 3 zero limbs in a
+// typical U256) stay plain JS numbers, untouched.
+//
+// The regex alternates between a full JSON string literal (consumed whole,
+// so digits inside a string -- an SS58 address, a hex blob -- are never
+// mistaken for a bare number) and a bare JSON number literal. Regex
+// alternation always tries the string branch first at each match position,
+// so a string token is fully consumed before the number branch ever gets a
+// chance to look inside it.
+const JSON_STRING_OR_NUMBER =
+  /"(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g;
+
+function quoteUnsafeIntegers(text) {
+  return text.replace(JSON_STRING_OR_NUMBER, (token) => {
+    if (token[0] === '"') return token; // already a string -- leave untouched
+    if (!/^-?\d+$/.test(token)) return token; // has a decimal point/exponent -- not a bare integer, Number() already the only sane representation
+    return Number.isSafeInteger(Number(token)) ? token : `"${token}"`;
+  });
+}
+
+/** JSON.parse with large bare integer literals preserved as exact strings
+ * instead of silently rounded to the nearest float64. A no-op transform
+ * (identical result to plain JSON.parse) on any JSON text with no integer
+ * literal past Number.MAX_SAFE_INTEGER -- which is every call_args payload
+ * except the specific numeric fields (U256 limbs, u64 PoW nonces, ...) large
+ * enough to need it. */
+export function parseJsonPreservingBigInts(text) {
+  return JSON.parse(quoteUnsafeIntegers(text));
+}

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -13,7 +13,11 @@ import {
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { normalizePostgresValue } from "./scale-normalize.mjs";
 import { decodePostgresCallArgs } from "./postgres-call-args.mjs";
-import { decodeEthereumEvmCallArgs } from "./indexer-rs-ethereum-decode.mjs";
+import {
+  decodeEthereumEvmCallArgs,
+  hasEthereumEvmDecoder,
+} from "./indexer-rs-ethereum-decode.mjs";
+import { parseJsonPreservingBigInts } from "./big-int-safe-json.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
 // Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
@@ -170,11 +174,28 @@ export function formatExtrinsic(row) {
       // All three are no-ops on D1's own call_args shape (an array of
       // {name,type,value} descriptors) -- safe to apply unconditionally
       // regardless of which serving tier produced this row.
+      //
+      // parseJsonPreservingBigInts (#4692 review fix) is gated to ONLY the
+      // call types indexer-rs-ethereum-decode.mjs actually decodes: plain
+      // JSON.parse would ALREADY silently round a U256 limb past
+      // Number.MAX_SAFE_INTEGER before decodeU256Limbs ever saw it (caught by
+      // Gittensory review on the original #4692 PR -- see that module's
+      // header). Scoping to hasEthereumEvmDecoder's 4 call types, rather than
+      // applying it to every extrinsic, avoids ALSO silently changing other
+      // call types' already-known-imprecise large-integer fields (e.g.
+      // SubtensorModule.register's PoW nonce) from a number to a string --
+      // that's #4693's scope, not a side effect to smuggle in here.
+      const parseCallArgs = hasEthereumEvmDecoder(
+        row.call_module,
+        row.call_function,
+      )
+        ? parseJsonPreservingBigInts
+        : JSON.parse;
       call_args = decodeEthereumEvmCallArgs(
         row.call_module,
         row.call_function,
         normalizePostgresValue(
-          decodePostgresCallArgs(JSON.parse(row.call_args)),
+          decodePostgresCallArgs(parseCallArgs(row.call_args)),
         ),
       );
     } catch {

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -13,6 +13,7 @@ import {
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { normalizePostgresValue } from "./scale-normalize.mjs";
 import { decodePostgresCallArgs } from "./postgres-call-args.mjs";
+import { decodeEthereumEvmCallArgs } from "./indexer-rs-ethereum-decode.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
 // Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
@@ -161,12 +162,20 @@ export function formatExtrinsic(row) {
       // decodePostgresCallArgs (#4691) MUST run before normalizePostgresValue
       // (#4690) -- it needs the pristine raw nested-call shape to reconstruct
       // correctly (see its own file header for why running it second would
-      // silently lose a genuinely zero-argument nested call). Both are
-      // no-ops on D1's own call_args shape (an array of {name,type,value}
-      // descriptors) -- safe to apply unconditionally regardless of which
-      // serving tier produced this row.
-      call_args = normalizePostgresValue(
-        decodePostgresCallArgs(JSON.parse(row.call_args)),
+      // silently lose a genuinely zero-argument nested call). Ethereum/EVM
+      // decode (#4692) can safely run last -- U256/H160/tuple-variant-enum
+      // shapes are untouched by either earlier pass (verified: neither the
+      // newtype-scalar rule nor the nested-call detector matches an
+      // array-wrapping-an-array or a payload lacking its own string `.name`).
+      // All three are no-ops on D1's own call_args shape (an array of
+      // {name,type,value} descriptors) -- safe to apply unconditionally
+      // regardless of which serving tier produced this row.
+      call_args = decodeEthereumEvmCallArgs(
+        row.call_module,
+        row.call_function,
+        normalizePostgresValue(
+          decodePostgresCallArgs(JSON.parse(row.call_args)),
+        ),
       );
     } catch {
       call_args = null;

--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -1,0 +1,238 @@
+// Server-side decoders for indexer-rs's (Postgres) Ethereum/EVM pallet
+// shapes and the third-party pallets sharing its tuple-variant enum
+// convention -- Ethereum.transact's U256/H160/EIP1559 fields, EVM.withdraw's
+// H160 address, and the Signature::Sr25519 payload shared by
+// LimitOrders.execute_batched_orders and Drand.write_pulse (#4692).
+//
+// Scoped to these SPECIFIC (call_module, call_function) pairs and named
+// fields -- never a generic "any 4-limb array is a U256" or "any bytes
+// field is an address" heuristic, since neither shape has been confirmed
+// unique across the schema (a Vec<u64> or an AccountId32 could coincidentally
+// look similar). MevShield was named as a *probable* third Signature::Sr25519
+// user in the original research, but verifying against real production data
+// (block 8543969/7 submit_encrypted, block 8543971/1 announce_next_key)
+// shows neither function has a signature field at all --
+// submit_encrypted's sole arg is a raw ciphertext byte blob, announce_next_key's
+// is an Option-wrapped encryption public key -- so MevShield is deliberately
+// NOT in the dispatch table below.
+//
+// ## The U256 precision decision (#4692 Requirement 2)
+//
+// D1's `nonce`/`value`/`gas_limit`/`max_fee_per_gas`/`max_priority_fee_per_gas`
+// are already known to lose precision for large values -- but tracing
+// scripts/fetch-events.py shows this is NOT a D1-specific behavior to
+// reconcile: fetch-events.py writes the exact Python int via json.dumps
+// (lossless at the storage layer; no str()/precision handling anywhere in
+// that file), and the actual corruption happens in the SHARED
+// src/extrinsics.mjs formatExtrinsic's `JSON.parse(row.call_args)` call --
+// the same JSON.parse used for BOTH D1 and Postgres rows. So "reproduce D1's
+// behavior" and "the bug this repo already accepts for
+// SubtensorModule.register's PoW nonce" are the same underlying JS
+// large-integer/JSON.parse issue, not something unique to the EVM fields.
+//
+// Given Postgres hands us the 4 raw little-endian u64 limbs with NO
+// precision lost yet, and real production data already has `value` (wei)
+// fields exceeding Number.MAX_SAFE_INTEGER for perfectly ordinary transfers
+// (confirmed: 0.02-1.5 ETH = 2e16-1.5e18 wei, all past 9007199254740991) --
+// this is the normal case for any non-trivial transfer, not a remote edge
+// case at 2^256 -- this decoder DIVERGES from reproducing that precision
+// loss: U256 fields decode to an EXACT decimal STRING via BigInt, matching
+// how ethers.js/web3.js/viem represent U256 (never a plain JS number, for
+// exactly this reason). This is a real type divergence from D1's current
+// (already-lossy) plain-number shape even for small values that fit safely
+// -- a deliberate, documented choice per Requirement 2, not an oversight.
+import { isEnumTreeNode } from "./scale-normalize.mjs";
+import { unwrapByteArray, bytesToHex } from "./bytes.mjs";
+
+// Peels indexer-rs's one newtype-wrap layer around a U256's 4-limb
+// little-endian u64 array ([[limb0,limb1,limb2,limb3]]). Limbs are u64
+// values (up to 2^64-1), so this can't reuse bytes.mjs's unwrapByteArray --
+// that caps individual elements at 0-255 for a genuine byte blob.
+function unwrapU256Limbs(value) {
+  if (!Array.isArray(value) || value.length !== 1 || !Array.isArray(value[0])) {
+    return null;
+  }
+  const limbs = value[0];
+  if (limbs.length !== 4) return null;
+  return limbs.every(
+    (n) => typeof n === "number" && Number.isInteger(n) && n >= 0,
+  )
+    ? limbs
+    : null;
+}
+
+/** 4-limb little-endian u64 array -> exact decimal string (see module header
+ * for why this is a string, not a JS number). Returns `value` unchanged
+ * (no-op) when the shape doesn't match -- safe on D1's own already-decoded
+ * plain-number fields, since a JS number is never a 1-element array. */
+export function decodeU256Limbs(value) {
+  const limbs = unwrapU256Limbs(value);
+  if (!limbs) return value;
+  const [l0, l1, l2, l3] = limbs.map(BigInt);
+  return (l0 + (l1 << 64n) + (l2 << 128n) + (l3 << 192n)).toString();
+}
+
+/** 20-byte array (H160), newtype-wrapped or flat -- lowercase 0x-prefixed
+ * hex, matching D1's address string form. Reuses bytes.mjs's depth-agnostic
+ * unwrapByteArray (already length-agnostic; H160 is just a 20-byte case of
+ * the same generic byte-blob shape #4689 already handles). Returns `value`
+ * unchanged when the shape doesn't match. */
+export function decodeH160Bytes(value) {
+  const bytes = unwrapByteArray(value);
+  return bytes && bytes.length === 20 ? bytesToHex(bytes) : value;
+}
+
+// A 32-byte hash-like value (Ethereum's ECDSA signature r/s components) --
+// same generic byte-blob-to-hex treatment, just gated on length 32 instead
+// of 20. Not exported: only meaningful composed inside decodeEip1559Payload
+// below, unlike decodeH160Bytes which Requirement 3 names as its own
+// reusable unit.
+function decodeHash32Bytes(value) {
+  const bytes = unwrapByteArray(value);
+  return bytes && bytes.length === 32 ? bytesToHex(bytes) : value;
+}
+
+/** Rust single-field tuple-variant enum ({name, values:[x]}) -> D1's
+ * single-key shorthand ({[name]: decodePayload(x)}). A no-op passthrough
+ * (returns `value` unchanged) when the shape doesn't match -- safe on D1's
+ * own {Name: value} shape or a plain scalar. */
+function decodeTupleVariantEnum(value, decodePayload) {
+  if (!isEnumTreeNode(value) || value.values.length !== 1) return value;
+  return { [value.name]: decodePayload(value.values[0]) };
+}
+
+const U256_FIELDS = [
+  "nonce",
+  "value",
+  "gas_limit",
+  "max_fee_per_gas",
+  "max_priority_fee_per_gas",
+];
+
+// Ethereum.transact's `transaction` field's inner EIP1559 struct: the 5 U256
+// fields above, `action` (a nested TransactionAction::Call tuple-variant
+// wrapping an H160), and `signature.r`/`signature.s` (32-byte hash-like
+// values, NOT wrapped in an enum -- EIP1559's own ECDSA signature is a plain
+// struct, unrelated to the Signature::Sr25519 enum family below).
+// `chain_id`/`odd_y_parity`/`access_list` need no decode (already plain
+// scalars/empty arrays either tier). `input` is deliberately left untouched
+// -- its own mojibake bug is D1's, out of scope here (bytes.mjs's own header).
+function decodeEip1559Payload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const out = { ...payload };
+  for (const field of U256_FIELDS) {
+    if (field in out) out[field] = decodeU256Limbs(out[field]);
+  }
+  if ("action" in out) {
+    out.action = decodeTupleVariantEnum(out.action, decodeH160Bytes);
+  }
+  if (out.signature && typeof out.signature === "object") {
+    out.signature = {
+      ...out.signature,
+      r: decodeHash32Bytes(out.signature.r),
+      s: decodeHash32Bytes(out.signature.s),
+    };
+  }
+  return out;
+}
+
+/** Ethereum.transact's call_args: decodes the `transaction` field's nested
+ * EIP1559 payload (U256s, action's H160, signature's hash bytes) into D1's
+ * `{transaction: {EIP1559: {...}}}` shape. No-op (returns callArgs
+ * unchanged) when `transaction` isn't Postgres's enum-tree shape -- D1's own
+ * `[{name,type,value}]` descriptor array has no `.transaction` property at
+ * all (arrays don't have named keys), so this never fires on a D1 row. */
+export function decodeEthereumTransactArgs(callArgs) {
+  if (!callArgs || typeof callArgs !== "object" || Array.isArray(callArgs)) {
+    return callArgs;
+  }
+  const tx = callArgs.transaction;
+  if (!isEnumTreeNode(tx) || tx.values.length !== 1) return callArgs;
+  return {
+    ...callArgs,
+    transaction: decodeTupleVariantEnum(tx, decodeEip1559Payload),
+  };
+}
+
+/** EVM.withdraw's call_args: decodes `address` (H160) to hex. Same D1
+ * no-op guarantee as above (a D1 descriptor array has no `.address` key). */
+export function decodeEvmWithdrawArgs(callArgs) {
+  if (!callArgs || typeof callArgs !== "object" || Array.isArray(callArgs)) {
+    return callArgs;
+  }
+  if (!("address" in callArgs)) return callArgs;
+  return { ...callArgs, address: decodeH160Bytes(callArgs.address) };
+}
+
+// {name:"Sr25519", values:[bytes]} -> {Sr25519: "0x..."}. Gated on the
+// variant name specifically (not "any tuple-variant enum found under a key
+// named signature") since MultiSignature has other variants (Ed25519,
+// Ecdsa) not evidenced in this repo's data yet -- declines rather than
+// guessing their payload shape. #4690's Option<T> pass already strips any
+// Some(...) wrapper before this runs (confirmed against real
+// Drand.write_pulse data: signature arrives as {name:"Some",
+// values:[{name:"Sr25519",...}]} pre-normalize, bare {name:"Sr25519",...}
+// after), so this only needs to handle the bare variant.
+function decodeSr25519SignatureValue(value) {
+  if (
+    !isEnumTreeNode(value) ||
+    value.name !== "Sr25519" ||
+    value.values.length !== 1
+  ) {
+    return value;
+  }
+  const bytes = unwrapByteArray(value.values[0]);
+  return bytes ? { Sr25519: bytesToHex(bytes) } : value;
+}
+
+// Recursively finds every key literally named "signature" and decodes it if
+// (and only if) its value matches the Sr25519 shape above -- scoped to
+// LimitOrders.execute_batched_orders/Drand.write_pulse specifically (via the
+// dispatch table below), not applied to every call's args. A plain
+// recursive walk rather than a fixed-depth lookup because the two calls
+// place `signature` at different depths: Drand.write_pulse has it as a
+// direct top-level field, LimitOrders.execute_batched_orders has it nested
+// inside each entry of its (Vec-wrapped) `orders` array -- both confirmed
+// against real production data.
+function walkForSignatureFields(value) {
+  if (Array.isArray(value)) return value.map(walkForSignatureFields);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] =
+        key === "signature"
+          ? decodeSr25519SignatureValue(val)
+          : walkForSignatureFields(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** LimitOrders.execute_batched_orders / Drand.write_pulse call_args: decodes
+ * any `signature` field matching the Sr25519 shape, at whatever depth it
+ * occurs. A no-op on D1's own already-decoded {"Sr25519": "0x..."} shape
+ * (isEnumTreeNode requires a "values" array key, which a single-key shorthand
+ * object doesn't have). */
+export function decodeSignatureFieldArgs(callArgs) {
+  return walkForSignatureFields(callArgs);
+}
+
+const DECODERS = {
+  "Ethereum.transact": decodeEthereumTransactArgs,
+  "EVM.withdraw": decodeEvmWithdrawArgs,
+  "LimitOrders.execute_batched_orders": decodeSignatureFieldArgs,
+  "Drand.write_pulse": decodeSignatureFieldArgs,
+};
+
+/** Dispatches to the right decoder for (callModule, callFunction), or
+ * returns callArgs unchanged for every other call type -- safe to apply
+ * unconditionally in formatExtrinsic regardless of which tier produced the
+ * row or what call it decoded, same contract as normalizePostgresValue
+ * (#4690) and decodePostgresCallArgs (#4691). */
+export function decodeEthereumEvmCallArgs(callModule, callFunction, callArgs) {
+  const decoder = DECODERS[`${callModule}.${callFunction}`];
+  return decoder ? decoder(callArgs) : callArgs;
+}

--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -30,19 +30,48 @@
 // SubtensorModule.register's PoW nonce" are the same underlying JS
 // large-integer/JSON.parse issue, not something unique to the EVM fields.
 //
-// Given Postgres hands us the 4 raw little-endian u64 limbs with NO
-// precision lost yet, and real production data already has `value` (wei)
-// fields exceeding Number.MAX_SAFE_INTEGER for perfectly ordinary transfers
-// (confirmed: 0.02-1.5 ETH = 2e16-1.5e18 wei, all past 9007199254740991) --
-// this is the normal case for any non-trivial transfer, not a remote edge
-// case at 2^256 -- this decoder DIVERGES from reproducing that precision
-// loss: U256 fields decode to an EXACT decimal STRING via BigInt, matching
-// how ethers.js/web3.js/viem represent U256 (never a plain JS number, for
-// exactly this reason). This is a real type divergence from D1's current
-// (already-lossy) plain-number shape even for small values that fit safely
-// -- a deliberate, documented choice per Requirement 2, not an oversight.
+// Given real production data already has `value` (wei) fields exceeding
+// Number.MAX_SAFE_INTEGER for perfectly ordinary transfers (confirmed:
+// 0.02-1.5 ETH = 2e16-1.5e18 wei, all past 9007199254740991) -- the normal
+// case for any non-trivial transfer, not a remote edge case at 2^256 -- this
+// decoder DIVERGES from reproducing that precision loss: U256 fields decode
+// to an EXACT decimal STRING via BigInt, matching how ethers.js/web3.js/viem
+// represent U256 (never a plain JS number, for exactly this reason).
+//
+// IMPORTANT: this decision is only real if the limbs Postgres hands over
+// actually survive intact to this point. A first version of this module
+// (caught by Gittensory review on the original #4692 PR) reconstructed the
+// BigInt correctly but from an ALREADY-corrupted input: src/extrinsics.mjs's
+// formatExtrinsic ran plain `JSON.parse(row.call_args)` before this decoder
+// ever ran, and standard JSON.parse silently rounds any bare integer literal
+// past 2^53 the exact same way -- so a limb like 9131459485341369597 arrived
+// here already rounded to 9131459485341369344, and the resulting decimal
+// string LOOKED exact while being built from imprecise input. Fixed by
+// routing row.call_args through src/big-int-safe-json.mjs's
+// parseJsonPreservingBigInts instead of bare JSON.parse -- see that module's
+// header for the mechanism. toLimbBigInt below accepts either a plain number
+// (the common case: 3 of a U256's 4 limbs are usually 0, safe either way) or
+// the numeric STRING that parser produces for a limb large enough to need it.
 import { isEnumTreeNode } from "./scale-normalize.mjs";
 import { unwrapByteArray, bytesToHex } from "./bytes.mjs";
+
+// A single limb (u64, up to 2^64-1) as delivered by src/extrinsics.mjs's
+// parseJsonPreservingBigInts (#4692 review fix): most limbs are small enough
+// to survive plain JSON.parse as a JS number (the common case -- 3 of a
+// U256's 4 limbs are usually 0), but a limb large enough to lose precision
+// under standard JSON.parse arrives pre-quoted as an exact numeric STRING
+// instead. Accepts either; returns null for anything else (so a genuinely
+// malformed/negative/fractional limb correctly fails unwrapU256Limbs rather
+// than silently coercing).
+function toLimbBigInt(limb) {
+  if (typeof limb === "number") {
+    return Number.isInteger(limb) && limb >= 0 ? BigInt(limb) : null;
+  }
+  if (typeof limb === "string") {
+    return /^\d+$/.test(limb) ? BigInt(limb) : null;
+  }
+  return null;
+}
 
 // Peels indexer-rs's one newtype-wrap layer around a U256's 4-limb
 // little-endian u64 array ([[limb0,limb1,limb2,limb3]]). Limbs are u64
@@ -54,11 +83,8 @@ function unwrapU256Limbs(value) {
   }
   const limbs = value[0];
   if (limbs.length !== 4) return null;
-  return limbs.every(
-    (n) => typeof n === "number" && Number.isInteger(n) && n >= 0,
-  )
-    ? limbs
-    : null;
+  const bigLimbs = limbs.map(toLimbBigInt);
+  return bigLimbs.every((b) => b !== null) ? bigLimbs : null;
 }
 
 /** 4-limb little-endian u64 array -> exact decimal string (see module header
@@ -68,7 +94,7 @@ function unwrapU256Limbs(value) {
 export function decodeU256Limbs(value) {
   const limbs = unwrapU256Limbs(value);
   if (!limbs) return value;
-  const [l0, l1, l2, l3] = limbs.map(BigInt);
+  const [l0, l1, l2, l3] = limbs;
   return (l0 + (l1 << 64n) + (l2 << 128n) + (l3 << 192n)).toString();
 }
 
@@ -235,4 +261,16 @@ const DECODERS = {
 export function decodeEthereumEvmCallArgs(callModule, callFunction, callArgs) {
   const decoder = DECODERS[`${callModule}.${callFunction}`];
   return decoder ? decoder(callArgs) : callArgs;
+}
+
+/** True for exactly the 4 call types this module decodes. Lets
+ * formatExtrinsic route ONLY these through the big-int-safe JSON parse
+ * (src/big-int-safe-json.mjs) instead of every extrinsic -- deliberately
+ * narrow: applying that parse globally would ALSO silently change other
+ * call types' already-known-imprecise large-integer fields (e.g.
+ * SubtensorModule.register's PoW nonce) from a number to a string, which is
+ * #4693's scope to fix, not a side effect to smuggle in here. Reuses this
+ * module's own dispatch table so the two lists can't drift apart. */
+export function hasEthereumEvmDecoder(callModule, callFunction) {
+  return `${callModule}.${callFunction}` in DECODERS;
 }

--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -80,8 +80,22 @@ function isAccountField(keyHint) {
 // named-struct-args call has an object there), so it can't reuse
 // isEnumTreeNode (which requires Array.isArray(value.values)) for that half
 // of the check.
+//
+// Excludes "Some"/"None" as the OUTER name: an Option<T> wrapping an
+// enum-shaped T (e.g. Option<MultiSignature>, confirmed real shape --
+// Drand.write_pulse's `signature`: {name:"Some", values:[{name:"Sr25519",
+// values:[bytes]}]}) is structurally IDENTICAL to a nested-call encoding --
+// both are "an outer {name,values} node wrapping exactly one inner
+// {name,values}-shaped node." Without this guard, that Option wrapper gets
+// misreconstructed as call_module:"Some", call_function:"Sr25519" (caught
+// during #4692's Ethereum/EVM decoder work, which was the first real fixture
+// exercising an Option wrapping an enum -- every #4691 fixture's wrapped
+// value lacked its own string `.name`, so this never fired there). Safe:
+// "Some"/"None" are Rust/Option-reserved names, never a real pallet
+// identifier, so this can't produce a false negative for a genuine call.
 function tryReconstructNestedCall(value) {
   if (!isEnumTreeNode(value) || value.values.length !== 1) return null;
+  if (value.name === "Some" || value.name === "None") return null;
   const inner = value.values[0];
   if (!inner || typeof inner !== "object" || Array.isArray(inner)) return null;
   if (typeof inner.name !== "string") return null;

--- a/tests/big-int-safe-json.test.mjs
+++ b/tests/big-int-safe-json.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { parseJsonPreservingBigInts } from "../src/big-int-safe-json.mjs";
+
+describe("parseJsonPreservingBigInts", () => {
+  test("preserves a large integer literal as an exact string instead of rounding it (the real corruption case caught by Gittensory review on #4692's original PR)", () => {
+    // The exact value cited throughout this session's SubtensorModule.register
+    // PoW nonce example -- D1 was found serving 9131459485341369000 for the
+    // true 9131459485341369597. Plain JSON.parse reproduces that exact
+    // corruption; this must not.
+    const text = '{"nonce":[9131459485341369597]}';
+    const parsed = parseJsonPreservingBigInts(text);
+    assert.equal(typeof parsed.nonce[0], "string");
+    assert.equal(parsed.nonce[0], "9131459485341369597");
+  });
+
+  test("preserves a large limb inside a nested U256 array shape", () => {
+    const text = '{"value":[[9131459485341369597,0,0,0]]}';
+    const parsed = parseJsonPreservingBigInts(text);
+    assert.equal(parsed.value[0][0], "9131459485341369597");
+    assert.equal(parsed.value[0][1], 0);
+  });
+
+  test("leaves small integers as plain numbers, unaffected", () => {
+    const text = '{"netuid":9,"nonce":69392,"list":[1,2,3]}';
+    assert.deepEqual(parseJsonPreservingBigInts(text), {
+      netuid: 9,
+      nonce: 69392,
+      list: [1, 2, 3],
+    });
+  });
+
+  test("leaves Number.MAX_SAFE_INTEGER itself as a plain number (boundary, not past it)", () => {
+    const text = `{"n":${Number.MAX_SAFE_INTEGER}}`;
+    const parsed = parseJsonPreservingBigInts(text);
+    assert.equal(typeof parsed.n, "number");
+    assert.equal(parsed.n, Number.MAX_SAFE_INTEGER);
+  });
+
+  test("wraps Number.MAX_SAFE_INTEGER + 1 as a string (just past the boundary)", () => {
+    const justPast = (BigInt(Number.MAX_SAFE_INTEGER) + 1n).toString();
+    const parsed = parseJsonPreservingBigInts(`{"n":${justPast}}`);
+    assert.equal(typeof parsed.n, "string");
+    assert.equal(parsed.n, justPast);
+  });
+
+  test("does not mistake digits inside a string value for a bare number literal", () => {
+    // An SS58 address, a base58 string, or any string that happens to contain
+    // a long digit run must not get quoted a second time or otherwise mangled
+    // -- the string-token alternative in the regex must consume it whole.
+    const text =
+      '{"note":"contains 99999999999999999999999999999 digits inside a string"}';
+    assert.deepEqual(parseJsonPreservingBigInts(text), {
+      note: "contains 99999999999999999999999999999 digits inside a string",
+    });
+  });
+
+  test("does not mistake digits inside a string containing an escaped quote", () => {
+    const text = '{"note":"a \\"quoted\\" 99999999999999999999 value"}';
+    assert.deepEqual(parseJsonPreservingBigInts(text), {
+      note: 'a "quoted" 99999999999999999999 value',
+    });
+  });
+
+  test("preserves a negative large integer as a string", () => {
+    const text = '{"n":-9131459485341369597}';
+    const parsed = parseJsonPreservingBigInts(text);
+    assert.equal(parsed.n, "-9131459485341369597");
+  });
+
+  test("leaves a decimal (non-integer) large literal as a plain number -- Number() is already the only sane representation for a fractional value", () => {
+    const text = '{"n":123456789012345678901.5}';
+    const parsed = parseJsonPreservingBigInts(text);
+    assert.equal(typeof parsed.n, "number");
+  });
+
+  test("is a no-op on a payload with no large integers anywhere (matches plain JSON.parse exactly)", () => {
+    const text =
+      '{"call_module":"SubtensorModule","call_function":"transfer_stake","call_args":{"netuid":9,"alpha_amount":3358540310}}';
+    assert.deepEqual(parseJsonPreservingBigInts(text), JSON.parse(text));
+  });
+
+  test("handles booleans and null without disturbing them", () => {
+    const text = '{"success":true,"absent":null,"other":false}';
+    assert.deepEqual(parseJsonPreservingBigInts(text), {
+      success: true,
+      absent: null,
+      other: false,
+    });
+  });
+});

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -291,6 +291,44 @@ test("formatExtrinsic parses call_args (array, object, parse-failure->null)", ()
   assert.equal(sparse.fee_tao, null);
 });
 
+test("formatExtrinsic preserves a U256 value past Number.MAX_SAFE_INTEGER through the REAL JSON.parse path, not just pre-parsed objects (#4692 review fix)", () => {
+  // Gittensory review caught that the original #4692 PR's precision claim
+  // was false: decodeEthereumEvmCallArgs ran on the output of a plain
+  // JSON.parse(row.call_args), which had already silently rounded any U256
+  // limb past 2^53 before decodeU256Limbs ever saw it. This constructs the
+  // call_args as a raw JSON TEXT string (as it would exist in Postgres'
+  // call_args::text column) containing the true, exact large-limb literal --
+  // NOT a JS object built from a number literal in source code, which would
+  // already be rounded by the JS parser before ever reaching JSON.stringify.
+  const callArgsText =
+    '{"transaction":{"name":"EIP1559","values":[{"value":[[9131459485341369597,0,0,0]],"nonce":[[69392,0,0,0]]}]}}';
+  const out = formatExtrinsic({
+    block_number: 8587453,
+    extrinsic_index: 9,
+    call_module: "Ethereum",
+    call_function: "transact",
+    call_args: callArgsText,
+  });
+  assert.equal(out.call_args.transaction.EIP1559.value, "9131459485341369597");
+  assert.equal(out.call_args.transaction.EIP1559.nonce, "69392");
+});
+
+test("formatExtrinsic does NOT extend the big-int-safe parse to call types outside indexer-rs-ethereum-decode.mjs's dispatch table -- preserves existing (already-imprecise) D1-serving behavior for out-of-scope call types", () => {
+  // Scoping the fix to hasEthereumEvmDecoder's 4 call types is deliberate:
+  // SubtensorModule.register's PoW nonce precision loss is an existing,
+  // already-accepted issue (#4693's scope) -- this must not silently change
+  // that field's type from number to string as a side effect of #4692.
+  const out = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    call_module: "SubtensorModule",
+    call_function: "register",
+    call_args: '{"nonce":[9131459485341369597]}',
+  });
+  assert.equal(typeof out.call_args.nonce, "number");
+  assert.equal(out.call_args.nonce, 9131459485341369000);
+});
+
 test("formatExtrinsic normalizes success (0->false, null->null)", () => {
   assert.equal(
     formatExtrinsic({ block_number: 1, extrinsic_index: 0, success: 0 })

--- a/tests/indexer-rs-ethereum-decode.test.mjs
+++ b/tests/indexer-rs-ethereum-decode.test.mjs
@@ -72,10 +72,38 @@ describe("decodeU256Limbs", () => {
     assert.deepEqual(decodeU256Limbs([[1, 2, 3]]), [[1, 2, 3]]);
   });
 
-  test("is a no-op when one of the 4 limbs isn't a non-negative integer", () => {
+  test("is a no-op when one of the 4 limbs isn't a non-negative integer or a numeric string", () => {
     assert.deepEqual(decodeU256Limbs([[1, -1, 0, 0]]), [[1, -1, 0, 0]]);
     assert.deepEqual(decodeU256Limbs([[1, 2.5, 0, 0]]), [[1, 2.5, 0, 0]]);
-    assert.deepEqual(decodeU256Limbs([[1, "2", 0, 0]]), [[1, "2", 0, 0]]);
+    assert.deepEqual(decodeU256Limbs([[1, "abc", 0, 0]]), [[1, "abc", 0, 0]]);
+    assert.deepEqual(decodeU256Limbs([[1, "-2", 0, 0]]), [[1, "-2", 0, 0]]);
+    assert.deepEqual(decodeU256Limbs([[1, null, 0, 0]]), [[1, null, 0, 0]]);
+  });
+
+  describe("string-limb support (src/big-int-safe-json.mjs quotes a limb large enough to lose precision under plain JSON.parse)", () => {
+    test("accepts a numeric-string limb the same as a number limb", () => {
+      assert.equal(decodeU256Limbs([["69392", 0, 0, 0]]), "69392");
+    });
+
+    test("preserves exact precision when one limb arrives as a string (the real corruption case caught by Gittensory review)", () => {
+      // 9131459485341369597 exceeds Number.MAX_SAFE_INTEGER -- this is exactly
+      // the shape src/big-int-safe-json.mjs's parseJsonPreservingBigInts
+      // produces: the large limb pre-quoted as a string, the other 3 (small,
+      // usually 0) limbs left as plain numbers.
+      assert.equal(
+        decodeU256Limbs([["9131459485341369597", 0, 0, 0]]),
+        "9131459485341369597",
+      );
+    });
+
+    test("combines a string limb with number limbs across multiple positions", () => {
+      const expected =
+        9131459485341369597n + (5n << 64n) + (3n << 128n) + (1n << 192n);
+      assert.equal(
+        decodeU256Limbs([["9131459485341369597", 5, 3, 1]]),
+        expected.toString(),
+      );
+    });
   });
 });
 

--- a/tests/indexer-rs-ethereum-decode.test.mjs
+++ b/tests/indexer-rs-ethereum-decode.test.mjs
@@ -1,0 +1,412 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  decodeU256Limbs,
+  decodeH160Bytes,
+  decodeEthereumTransactArgs,
+  decodeEvmWithdrawArgs,
+  decodeSignatureFieldArgs,
+  decodeEthereumEvmCallArgs,
+} from "../src/indexer-rs-ethereum-decode.mjs";
+import { decodePostgresCallArgs } from "../src/postgres-call-args.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+
+// Full formatExtrinsic-equivalent pipeline, matching src/extrinsics.mjs's
+// actual call order (decodePostgresCallArgs -> normalizePostgresValue ->
+// decodeEthereumEvmCallArgs).
+function decode(callModule, callFunction, raw) {
+  return decodeEthereumEvmCallArgs(
+    callModule,
+    callFunction,
+    normalizePostgresValue(decodePostgresCallArgs(raw)),
+  );
+}
+
+describe("decodeU256Limbs", () => {
+  test("decodes a small value (real Ethereum.transact nonce, block 8587453/9)", () => {
+    assert.equal(decodeU256Limbs([[69392, 0, 0, 0]]), "69392");
+  });
+
+  test("decodes zero", () => {
+    assert.equal(decodeU256Limbs([[0, 0, 0, 0]]), "0");
+  });
+
+  test("decodes a value already past Number.MAX_SAFE_INTEGER losslessly (real 1.5 ETH transfer, block 8543743/20)", () => {
+    // 1500000000000000000 wei = 1.5 ETH, confirmed via direct Postgres query
+    // to already exceed Number.MAX_SAFE_INTEGER (9007199254740991) -- this is
+    // the normal case for any transfer above ~0.009 ETH, not a remote edge
+    // case at 2^256. limb0 alone carries the full value here since it's
+    // still under 2^64.
+    assert.equal(
+      decodeU256Limbs([[1500000000000000000, 0, 0, 0]]),
+      "1500000000000000000",
+    );
+  });
+
+  test("decodes a value spanning multiple limbs (2^64 + 5)", () => {
+    assert.equal(decodeU256Limbs([[5, 1, 0, 0]]), (2n ** 64n + 5n).toString());
+  });
+
+  test("decodes a value near 2^256 (synthetic -- no real data approaches this magnitude)", () => {
+    // A true max limb (2^64-1) can't be written as an exact JS number literal
+    // (it's past Number.MAX_SAFE_INTEGER) without the fixture itself already
+    // being imprecise, so this uses the largest SAFE limb value in all 4
+    // positions -- still exercises every limb contributing to the total via
+    // its own bit-shift, just short of the true 2^256 ceiling.
+    const limbs = [
+      9007199254740991, 9007199254740991, 9007199254740991, 9007199254740991,
+    ];
+    const expected =
+      BigInt(limbs[0]) +
+      (BigInt(limbs[1]) << 64n) +
+      (BigInt(limbs[2]) << 128n) +
+      (BigInt(limbs[3]) << 192n);
+    assert.equal(decodeU256Limbs([limbs]), expected.toString());
+  });
+
+  test("is a no-op on a value that isn't the wrapped-4-limb shape", () => {
+    assert.equal(decodeU256Limbs(69392), 69392);
+    assert.equal(decodeU256Limbs("69392"), "69392");
+    assert.equal(decodeU256Limbs(null), null);
+    assert.deepEqual(decodeU256Limbs([1, 2, 3]), [1, 2, 3]);
+    assert.deepEqual(decodeU256Limbs([[1, 2, 3]]), [[1, 2, 3]]);
+  });
+
+  test("is a no-op when one of the 4 limbs isn't a non-negative integer", () => {
+    assert.deepEqual(decodeU256Limbs([[1, -1, 0, 0]]), [[1, -1, 0, 0]]);
+    assert.deepEqual(decodeU256Limbs([[1, 2.5, 0, 0]]), [[1, 2.5, 0, 0]]);
+    assert.deepEqual(decodeU256Limbs([[1, "2", 0, 0]]), [[1, "2", 0, 0]]);
+  });
+});
+
+describe("decodeH160Bytes", () => {
+  test("decodes a real address (EVM.withdraw, block 8573895/15)", () => {
+    const wrapped = [
+      [
+        211, 47, 118, 124, 7, 153, 44, 49, 231, 209, 195, 129, 20, 9, 75, 146,
+        116, 40, 240, 71,
+      ],
+    ];
+    assert.equal(
+      decodeH160Bytes(wrapped),
+      "0xd32f767c07992c31e7d1c38114094b927428f047",
+    );
+  });
+
+  test("decodes a flat (non-wrapped) 20-byte array", () => {
+    const flat = [
+      126, 76, 156, 196, 185, 110, 235, 3, 90, 161, 111, 26, 115, 223, 85, 37,
+      45, 199, 5, 92,
+    ];
+    assert.equal(
+      decodeH160Bytes(flat),
+      "0x7e4c9cc4b96eeb035aa16f1a73df55252dc7055c",
+    );
+  });
+
+  test("is a no-op on a non-20-byte value (e.g. a 32-byte hash, or an already-decoded D1 hex string)", () => {
+    const hash32 = Array(32).fill(1);
+    assert.deepEqual(decodeH160Bytes([hash32]), [hash32]);
+    assert.equal(decodeH160Bytes("0xalready-hex"), "0xalready-hex");
+  });
+});
+
+describe("decodeEthereumTransactArgs (real production fixture, block 8587453/9)", () => {
+  const raw = {
+    transaction: {
+      name: "EIP1559",
+      values: [
+        {
+          input: [97, 70, 25, 84],
+          nonce: [[69392, 0, 0, 0]],
+          value: [[0, 0, 0, 0]],
+          action: {
+            name: "Call",
+            values: [
+              [
+                [
+                  126, 76, 156, 196, 185, 110, 235, 3, 90, 161, 111, 26, 115,
+                  223, 85, 37, 45, 199, 5, 92,
+                ],
+              ],
+            ],
+          },
+          chain_id: 964,
+          gas_limit: [[300000, 0, 0, 0]],
+          signature: {
+            r: [
+              [
+                8, 71, 174, 80, 131, 185, 205, 97, 210, 130, 20, 61, 150, 119,
+                7, 123, 74, 227, 128, 243, 112, 107, 216, 158, 201, 141, 159,
+                228, 40, 114, 48, 219,
+              ],
+            ],
+            s: [
+              [
+                55, 72, 213, 45, 171, 108, 6, 125, 2, 51, 41, 15, 126, 129, 135,
+                44, 190, 140, 220, 234, 168, 85, 223, 188, 22, 29, 64, 69, 198,
+                186, 126, 108,
+              ],
+            ],
+            odd_y_parity: true,
+          },
+          access_list: [],
+          max_fee_per_gas: [[10000000000, 0, 0, 0]],
+          max_priority_fee_per_gas: [[0, 0, 0, 0]],
+        },
+      ],
+    },
+  };
+
+  test("decodes to D1's {transaction:{EIP1559:{...}}} shorthand with all fields correctly typed", () => {
+    const out = decode("Ethereum", "transact", raw);
+    assert.deepEqual(out.transaction.EIP1559, {
+      input: [97, 70, 25, 84], // untouched -- D1's own mojibake bug is out of scope here
+      nonce: "69392",
+      value: "0",
+      action: { Call: "0x7e4c9cc4b96eeb035aa16f1a73df55252dc7055c" },
+      chain_id: 964,
+      gas_limit: "300000",
+      signature: {
+        r: "0x0847ae5083b9cd61d282143d9677077b4ae380f3706bd89ec98d9fe4287230db",
+        s: "0x3748d52dab6c067d0233290f7e81872cbe8cdceaa855dfbc161d4045c6ba7e6c",
+        odd_y_parity: true,
+      },
+      access_list: [],
+      max_fee_per_gas: "10000000000",
+      max_priority_fee_per_gas: "0",
+    });
+  });
+
+  test("is a no-op on D1's own call_args shape (an array of {name,type,value} descriptors has no .transaction property)", () => {
+    const d1Shape = [
+      { name: "transaction", type: "Transaction", value: { EIP1559: {} } },
+    ];
+    assert.deepEqual(decodeEthereumTransactArgs(d1Shape), d1Shape);
+  });
+
+  test("is a no-op when transaction is missing or already D1-shaped", () => {
+    assert.deepEqual(decodeEthereumTransactArgs({}), {});
+    assert.deepEqual(
+      decodeEthereumTransactArgs({ transaction: { EIP1559: {} } }),
+      {
+        transaction: { EIP1559: {} },
+      },
+    );
+    assert.equal(decodeEthereumTransactArgs(null), null);
+  });
+
+  test("passes a non-object EIP1559 payload through unchanged (malformed/defensive case)", () => {
+    const malformed = {
+      transaction: { name: "EIP1559", values: [42] },
+    };
+    assert.deepEqual(decodeEthereumTransactArgs(malformed), {
+      transaction: { EIP1559: 42 },
+    });
+  });
+
+  test("tolerates a transaction variant with an unexpected number of associated values (not reconstructed as EIP1559)", () => {
+    const raw = { transaction: { name: "EIP1559", values: [] } };
+    assert.deepEqual(decodeEthereumTransactArgs(raw), raw);
+  });
+
+  test("only decodes the U256/action/signature fields actually present, leaving a partial payload otherwise untouched", () => {
+    const partial = {
+      transaction: {
+        name: "EIP1559",
+        values: [{ chain_id: 964, nonce: [[1, 0, 0, 0]] }],
+      },
+    };
+    assert.deepEqual(decodeEthereumTransactArgs(partial), {
+      transaction: { EIP1559: { chain_id: 964, nonce: "1" } },
+    });
+  });
+
+  test("leaves a non-32-byte signature.r/s untouched (malformed/defensive case)", () => {
+    const raw = {
+      transaction: {
+        name: "EIP1559",
+        values: [
+          {
+            signature: { r: [1, 2, 3], s: "already-hex", odd_y_parity: false },
+          },
+        ],
+      },
+    };
+    assert.deepEqual(decodeEthereumTransactArgs(raw), {
+      transaction: {
+        EIP1559: {
+          signature: { r: [1, 2, 3], s: "already-hex", odd_y_parity: false },
+        },
+      },
+    });
+  });
+
+  test("leaves a non-enum-tree-shaped action field untouched (malformed/defensive case)", () => {
+    // Unlike the outer transaction field (pre-filtered by
+    // decodeEthereumTransactArgs's own isEnumTreeNode guard before
+    // decodeTupleVariantEnum is ever called), action has no such pre-filter
+    // -- decodeTupleVariantEnum's own guard is the only gate here.
+    const raw = {
+      transaction: {
+        name: "EIP1559",
+        values: [{ action: "already-a-string" }],
+      },
+    };
+    assert.deepEqual(decodeEthereumTransactArgs(raw), {
+      transaction: { EIP1559: { action: "already-a-string" } },
+    });
+  });
+});
+
+describe("decodeEvmWithdrawArgs (real production fixture, block 8573895/15)", () => {
+  test("decodes address to hex, leaves value untouched (a native-currency amount, not U256)", () => {
+    const raw = {
+      value: 67756440,
+      address: [
+        [
+          211, 47, 118, 124, 7, 153, 44, 49, 231, 209, 195, 129, 20, 9, 75, 146,
+          116, 40, 240, 71,
+        ],
+      ],
+    };
+    assert.deepEqual(decode("EVM", "withdraw", raw), {
+      value: 67756440,
+      address: "0xd32f767c07992c31e7d1c38114094b927428f047",
+    });
+  });
+
+  test("is a no-op when address is absent or already D1-shaped", () => {
+    assert.deepEqual(decodeEvmWithdrawArgs({ value: 1 }), { value: 1 });
+    const d1Shape = [{ name: "address", type: "H160", value: "0x..." }];
+    assert.deepEqual(decodeEvmWithdrawArgs(d1Shape), d1Shape);
+  });
+});
+
+describe("decodeSignatureFieldArgs", () => {
+  test("decodes LimitOrders.execute_batched_orders' nested signature (real production fixture, block 8587347/16)", () => {
+    const raw = {
+      netuid: 71,
+      orders: [
+        [
+          {
+            order: { name: "V1", values: [{ limit_price: 5888441 }] },
+            signature: {
+              name: "Sr25519",
+              values: [
+                [
+                  150, 11, 211, 2, 35, 114, 0, 219, 83, 224, 23, 73, 4, 11, 105,
+                  77, 181, 36, 146, 170, 87, 211, 46, 110, 18, 183, 246, 16, 37,
+                  147, 87, 121, 140, 28, 231, 228, 214, 168, 22, 120, 201, 143,
+                  193, 100, 165, 76, 63, 174, 94, 13, 50, 45, 252, 173, 211, 94,
+                  23, 249, 44, 150, 98, 104, 48, 139,
+                ],
+              ],
+            },
+            partial_fill: { name: "None", values: [] },
+          },
+        ],
+      ],
+    };
+    const out = decode("LimitOrders", "execute_batched_orders", raw);
+    assert.deepEqual(out.orders[0][0].signature, {
+      Sr25519:
+        "0x960bd302237200db53e01749040b694db52492aa57d32e6e12b7f610259357798c1ce7e4d6a81678c98fc164a54c3fae5e0d322dfcadd35e17f92c966268308b",
+    });
+    // Sibling fields untouched by this decoder (out of #4692's scope).
+    assert.equal(out.netuid, 71);
+    assert.equal(out.orders[0][0].partial_fill, null);
+  });
+
+  test("decodes Drand.write_pulse's top-level Option-wrapped signature (real production fixture, block 8543971/2)", () => {
+    const raw = {
+      signature: {
+        name: "Some",
+        values: [
+          {
+            name: "Sr25519",
+            values: [
+              [
+                132, 185, 151, 13, 196, 53, 78, 98, 152, 163, 237, 123, 202, 6,
+                153, 146, 216, 96, 29, 147, 184, 14, 12, 119, 148, 197, 197, 85,
+                251, 45, 114, 126, 160, 35, 1, 194, 136, 27, 171, 210, 21, 6,
+                156, 198, 204, 127, 170, 185, 118, 81, 53, 215, 218, 54, 128,
+                216, 69, 6, 142, 249, 24, 165, 93, 141,
+              ],
+            ],
+          },
+        ],
+      },
+      pulses_payload: {
+        // A DIFFERENT field that happens to also be Sr25519-shaped (a
+        // MultiSigner public key, not a MultiSignature) -- deliberately left
+        // untouched, confirming decodeSignatureFieldArgs only targets keys
+        // literally named "signature", not any Sr25519-shaped value anywhere.
+        public: { name: "Sr25519", values: [[1, 2, 3, 4]] },
+      },
+    };
+    const out = decode("Drand", "write_pulse", raw);
+    assert.deepEqual(out.signature, {
+      Sr25519:
+        "0x84b9970dc4354e6298a3ed7bca069992d8601d93b80e0c7794c5c555fb2d727ea02301c2881babd215069cc6cc7faab9765135d7da3680d845068ef918a55d8d",
+    });
+    assert.deepEqual(out.pulses_payload.public, {
+      name: "Sr25519",
+      values: [[1, 2, 3, 4]],
+    });
+  });
+
+  test("is a no-op on D1's own already-decoded {Sr25519: hex} shorthand", () => {
+    const alreadyDecoded = { signature: { Sr25519: "0x1234" } };
+    assert.deepEqual(decodeSignatureFieldArgs(alreadyDecoded), alreadyDecoded);
+  });
+
+  test("declines a signature field with a different (unevidenced) variant name rather than guessing its payload shape", () => {
+    const raw = { signature: { name: "Ed25519", values: [[1, 2, 3]] } };
+    assert.deepEqual(decodeSignatureFieldArgs(raw), raw);
+  });
+
+  test("leaves an Sr25519-tagged signature untouched when its payload isn't a byte array (malformed/defensive case)", () => {
+    const raw = { signature: { name: "Sr25519", values: [{ not: "bytes" }] } };
+    assert.deepEqual(decodeSignatureFieldArgs(raw), raw);
+  });
+});
+
+describe("decodeEthereumEvmCallArgs dispatch", () => {
+  test("MevShield is NOT in the dispatch table -- verified against real production data, not assumed", () => {
+    // Requirement 4 flagged MevShield as a "probable" third Signature::Sr25519
+    // user. Direct verification against real data (block 8543969/7
+    // submit_encrypted, block 8543971/1 announce_next_key) shows neither
+    // function has a signature field at all: submit_encrypted's sole arg is
+    // a raw ciphertext byte blob, announce_next_key's is an Option-wrapped
+    // encryption public key. The probable-user note doesn't hold up.
+    const submitEncrypted = { ciphertext: [[1, 2, 3]] };
+    assert.deepEqual(
+      decodeEthereumEvmCallArgs(
+        "MevShield",
+        "submit_encrypted",
+        submitEncrypted,
+      ),
+      submitEncrypted,
+    );
+    const announceNextKey = {
+      enc_key: { name: "Some", values: [[[1, 2, 3]]] },
+    };
+    assert.deepEqual(
+      decodeEthereumEvmCallArgs(
+        "MevShield",
+        "announce_next_key",
+        announceNextKey,
+      ),
+      announceNextKey,
+    );
+  });
+
+  test("is a no-op for any call type with no registered decoder", () => {
+    const raw = { some_field: 42 };
+    assert.deepEqual(
+      decodeEthereumEvmCallArgs("SubtensorModule", "transfer_stake", raw),
+      raw,
+    );
+  });
+});

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -441,6 +441,27 @@ describe("decodePostgresCallArgs", () => {
       };
       assert.equal(decodePostgresCallArgs(raw).name, "Id");
     });
+
+    test("an Option<T> wrapping an enum-shaped T is NOT reconstructed as a nested call (real Drand.write_pulse signature, block 8543971/2) -- regression, caught during #4692", () => {
+      // {name:"Some", values:[{name:"Sr25519", values:[bytes]}]} is
+      // structurally IDENTICAL to a nested-call encoding (an outer
+      // {name,values} node wrapping exactly one inner {name,values}-shaped
+      // node) -- every #4691 fixture's Option-wrapped value lacked its own
+      // string `.name`, so this ambiguity went untested until a real
+      // Option<MultiSignature> fixture surfaced it. Without the "Some"/"None"
+      // exclusion in tryReconstructNestedCall, this misreconstructs to
+      // {call_module:"Some", call_function:"Sr25519", call_args:[bytes]}.
+      const raw = {
+        name: "Some",
+        values: [{ name: "Sr25519", values: [[1, 2, 3]] }],
+      };
+      const out = decodePostgresCallArgs(raw);
+      assert.equal("call_module" in out, false);
+      assert.deepEqual(out, raw);
+      // normalizePostgresValue then correctly Some-unwraps it, leaving the
+      // bare Sr25519 enum-tree node for #4692's decoder to recognize.
+      assert.deepEqual(decode(raw), { name: "Sr25519", values: [[1, 2, 3]] });
+    });
   });
 
   describe("D1-shaped idempotence (must be a no-op on D1's own call_args shapes)", () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -105,10 +105,36 @@
     // not a bug. Still open: a TOP-LEVEL (non-nested) call's own AccountId32/
     // byte-blob fields -- e.g. a bare Balances.transfer's dest, or Multisig's
     // own other_signatories/max_weight siblings -- are not yet decoded at
-    // that outer layer, only within a reconstructed nested call; Ethereum/EVM
-    // U256+H160 shapes (#4692); BTreeSet/u64/u128-precision edge cases
-    // (#4693); and MCP's extrinsics tools are still D1-only (#4694). Do not
-    // flip until those land and the parity harness (#4695) passes clean.
+    // that outer layer, only within a reconstructed nested call.
+    //
+    // #4692 (src/indexer-rs-ethereum-decode.mjs, chained last in
+    // formatExtrinsic): Ethereum.transact's U256 fields (nonce/value/
+    // gas_limit/max_fee_per_gas/max_priority_fee_per_gas), its `action`/
+    // `transaction` tuple-variant-enum shorthand, EVM.withdraw's H160
+    // `address`, and the Signature::Sr25519 payload shared by
+    // LimitOrders.execute_batched_orders/Drand.write_pulse are now decoded.
+    // MevShield was suspected as a third Sr25519 user but does NOT use that
+    // type (verified against real data, not assumed). U256 fields are a
+    // DELIBERATE type divergence from D1: tracing scripts/fetch-events.py
+    // shows D1's storage is actually lossless (json.dumps on Python's
+    // arbitrary-precision int); the precision loss for large values happens
+    // in the SHARED formatExtrinsic's JSON.parse(row.call_args) call itself
+    // (same mechanism already accepted for SubtensorModule.register's PoW
+    // nonce), not anything D1-specific. Since Postgres hands us the 4 raw
+    // limbs before that JSON.parse ever runs, U256 fields decode to an exact
+    // decimal STRING via BigInt instead of reproducing that precision loss --
+    // real data already has `value` (wei) past Number.MAX_SAFE_INTEGER for
+    // any transfer above ~0.009 ETH, the normal case, not a 2^256 edge case.
+    //
+    // Still open: a TOP-LEVEL (non-nested) call's own AccountId32/byte-blob
+    // fields -- e.g. a bare Balances.transfer's dest, or Multisig's own
+    // other_signatories/max_weight siblings -- are not yet decoded at that
+    // outer layer, only within a reconstructed nested call; BTreeSet/u64/
+    // u128-precision edge cases elsewhere (#4693, likely also the right home
+    // to reconsider the register-nonce JSON.parse precision issue generally,
+    // now that #4692 traced its root cause); MCP's extrinsics tools are
+    // still D1-only (#4694). Do not flip until those land and the parity
+    // harness (#4695) passes clean.
     "METAGRAPH_BLOCKS_SOURCE": "d1",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },


### PR DESCRIPTION
## Summary
- Adds `src/indexer-rs-ethereum-decode.mjs`, chained last in `formatExtrinsic`: `Ethereum.transact`'s U256 fields (`nonce`/`value`/`gas_limit`/`max_fee_per_gas`/`max_priority_fee_per_gas`), its `action`/`transaction` tuple-variant-enum shorthand (matching D1's `{VariantName: value}` convention), `EVM.withdraw`'s H160 `address`, and the `Signature::Sr25519` payload shared by `LimitOrders.execute_batched_orders`/`Drand.write_pulse`.
- **U256 precision decision (issue Requirement 2 — explicitly left open, resolved here with evidence):** decodes to an exact decimal **string** via BigInt, not a JS number. Traced `scripts/fetch-events.py` directly — D1's own storage is lossless (Python's arbitrary-precision `int` via `json.dumps`); the known precision loss (already accepted for `SubtensorModule.register`'s PoW nonce) happens in the **shared** `formatExtrinsic`'s `JSON.parse(row.call_args)` call itself, used by both D1 and Postgres rows — not anything D1-specific to "match." Since Postgres hands us the 4 raw limbs before that `JSON.parse` ever runs, there's no reason to reproduce the loss: real production data already has `value` (wei) past `Number.MAX_SAFE_INTEGER` for any transfer above ~0.009 ETH (confirmed: 0.02–1.5 ETH transfers in current data) — the normal case, not a remote 2^256 edge case.
- `MevShield` was flagged as a *probable* third `Signature::Sr25519` user in the original research. Verified against real production data (`submit_encrypted`/`announce_next_key`) that neither function uses that type at all — deliberately not in the dispatch table.
- **Also fixes a real bug in the already-merged #4691** (`src/postgres-call-args.mjs`): `Option<T>` wrapping an enum-shaped payload (e.g. `Drand.write_pulse`'s `Option<MultiSignature>`, `{name:"Some", values:[{name:"Sr25519",...}]}`) is structurally identical to a nested-call encoding, and was being misreconstructed as `call_module:"Some"`. None of #4691's own fixtures had an Option wrapping an enum-shaped value, so this went untested until a real Drand fixture surfaced it here. Fixed by excluding `"Some"`/`"None"` as the outer name in `tryReconstructNestedCall` (both are Rust/Option-reserved, never a real pallet identifier).
- Updated the `METAGRAPH_EXTRINSICS_SOURCE` comment in `wrangler.jsonc`.

## Test plan
- [x] `tests/indexer-rs-ethereum-decode.test.mjs` (27 tests, 100% coverage): real production fixtures for `Ethereum.transact` (block 8587453/9), `EVM.withdraw` (block 8573895/15), `LimitOrders.execute_batched_orders` (block 8587347/16), `Drand.write_pulse` (block 8543971/2, including the Option-wrapped signature), the confirmed-negative `MevShield` case, and the near-2^256 synthetic precision test.
- [x] `tests/postgres-call-args.test.mjs`: added a regression test for the Option-wrapping-an-enum bug (21 tests total, 100% coverage).
- [x] All existing `tests/extrinsics.test.mjs`/`tests/data-api.test.mjs`/`tests/scale-normalize.test.mjs`/`tests/ss58.test.mjs`/`tests/bytes.test.mjs`/`tests/chain-event-args.test.mjs` pass unchanged.
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run test:coverage` clean — 100% on all three touched/new files
- [x] `npm run validate:contract-drift` clean
- [x] Zero behavior change on `METAGRAPH_EXTRINSICS_SOURCE=d1` (no-op on D1's own shapes, confirmed via dedicated idempotence tests)

Refs #4669
Closes #4692