### PR TITLE
feat(registry): add Compute Horde map contract ABI data-artifact

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -132,6 +132,31 @@
         "submitted_by": "galuis116"
       },
       "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-12-compute-horde-map-abi",
+      "kind": "data-artifact",
+      "name": "Compute Horde map contract ABI",
+      "notes": "Public no-auth JSON ABI for the Compute Horde map smart contract, published in the official ComputeHorde repository at compute_horde/smart_contracts/abi/map_abi.json. Loaded at runtime by get_contract_abi() in smart_contracts/utils.py and used by map_contract.py to instantiate the on-chain map contract for dynamic config reads.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde/compute_horde/smart_contracts/map_contract.py",
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/compute_horde/compute_horde/smart_contracts/utils.py"
+      ],
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/86ebc5b8df46/compute_horde/compute_horde/smart_contracts/abi/map_abi.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Append one `data-artifact` surface to `registry/subnets/compute-horde.json` for the official map smart-contract ABI at `compute_horde/smart_contracts/abi/map_abi.json`.
- URL pinned to commit `86ebc5b8df46` on the registered ComputeHorde source repository.
- Proof: `map_contract.py` loads `map_abi.json` via `get_contract_abi()` in `smart_contracts/utils.py`.

Closes #4010

## Why

SN12 Compute Horde already has website, source repo, Grafana dashboard, SDK, and Facilitator subnet-api surfaces. The map contract ABI is a separate public static JSON artifact loaded at runtime by subnet code but was not yet registered as a standalone data-artifact.

## Validation

```sh
npm run validate:surface -- registry/subnets/compute-horde.json
npm run scan:public-safety
```

- Live probe: GET returns HTTP 200 JSON (Solidity ABI).
- Append-only change to exactly one registry file; no key reordering.
- Follows the same contract-ABI `data-artifact` pattern as SN113 TensorUSD (`tusdt_vault.json`).

## Test plan

- [x] `validate:surface` passes
- [x] `scan:public-safety` passes
- [x] No duplicate URL/kind in `compute-horde.json`
- [x] No screenshots required (registry-only change)

Made with [Cursor](https://cursor.com)