### PR TITLE
feat(ui): use shared table-controls on the Providers toolbar

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -92,6 +92,7 @@ export function SelectFilter({
   options,
   label,
   allowEmpty = true,
+  fill = false,
 }: {
   value: string;
   onChange: (v: string) => void;
@@ -100,16 +101,25 @@ export function SelectFilter({
   // When false, omit the empty "all" option — for always-selected controls like
   // a sort key where a blank value is not meaningful.
   allowEmpty?: boolean;
+  // When true, the control stretches to fill its flex track (label stays fixed,
+  // the select grows) so a row of filters can be justified edge-to-edge.
+  fill?: boolean;
 }) {
   return (
-    <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
+    <label
+      className={`items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs ${
+        fill ? "flex w-full min-w-0" : "inline-flex"
+      }`}
+    >
       <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
         {label}
       </span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className={`bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          fill ? "min-w-0 flex-1" : ""
+        }`}
       >
         {allowEmpty ? <option value="">all</option> : null}
         {options.map((o) => (

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -91,11 +91,15 @@ export function SelectFilter({
   onChange,
   options,
   label,
+  allowEmpty = true,
 }: {
   value: string;
   onChange: (v: string) => void;
   options: Array<{ value: string; label: string }>;
   label: string;
+  // When false, omit the empty "all" option — for always-selected controls like
+  // a sort key where a blank value is not meaningful.
+  allowEmpty?: boolean;
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
@@ -107,7 +111,7 @@ export function SelectFilter({
         onChange={(e) => onChange(e.target.value)}
         className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        <option value="">all</option>
+        {allowEmpty ? <option value="">all</option> : null}
         {options.map((o) => (
           <option key={o.value} value={o.value}>
             {o.label}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -275,41 +275,46 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
       <ProviderOverview providers={rows} counts={counts} />
       <SourceHealthRollup />
 
-      {/* Toolbar */}
-      <div className="sticky top-14 z-10 -mx-1 px-1 py-2 backdrop-blur bg-paper/85 border-b border-border/60 flex flex-wrap items-center gap-2">
-        <div className="flex-1 min-w-[180px] max-w-sm">
-          <SearchInput
-            value={q}
-            onChange={(v) => setSearch({ q: v })}
-            placeholder="Search providers, slugs, hosts…"
+      {/* Filter toolbar — edge-to-edge sticky bar on mobile, an inset card on desktop,
+          matching the subnets grid toolbar treatment. */}
+      <div className="sticky top-14 z-20 -mx-4 border-y border-border bg-paper/95 px-4 py-2.5 backdrop-blur supports-[backdrop-filter]:bg-paper/80 md:mx-0 md:rounded-lg md:border md:bg-card md:px-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="min-w-[180px] max-w-sm flex-1">
+            <SearchInput
+              value={q}
+              onChange={(v) => setSearch({ q: v })}
+              placeholder="Search providers, slugs, hosts…"
+            />
+          </div>
+          <SelectFilter
+            label="Kind"
+            value={kind}
+            onChange={(v) => setSearch({ kind: v })}
+            options={kinds.map((k) => ({ value: k, label: k }))}
           />
+          <SelectFilter
+            label="Authority"
+            value={authority}
+            onChange={(v) => setSearch({ authority: v })}
+            options={authorityOptions.map((a) => ({ value: a, label: a }))}
+          />
+          <SelectFilter
+            label="Sort"
+            value={sortKey}
+            onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
+            options={providerSortKeys.map((s) => ({ value: s, label: s }))}
+            allowEmpty={false}
+          />
+          <div className="ml-auto flex items-center gap-2.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted tabular-nums">
+              {sorted.length} of {rows.length}
+            </span>
+            <ResetFiltersButton
+              active={hasFilters}
+              onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
+            />
+          </div>
         </div>
-        <SelectFilter
-          label="Kind"
-          value={kind}
-          onChange={(v) => setSearch({ kind: v })}
-          options={kinds.map((k) => ({ value: k, label: k }))}
-        />
-        <SelectFilter
-          label="Authority"
-          value={authority}
-          onChange={(v) => setSearch({ authority: v })}
-          options={authorityOptions.map((a) => ({ value: a, label: a }))}
-        />
-        <SelectFilter
-          label="Sort"
-          value={sortKey}
-          onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
-          options={providerSortKeys.map((s) => ({ value: s, label: s }))}
-          allowEmpty={false}
-        />
-        <ResetFiltersButton
-          active={hasFilters}
-          onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
-        />
-        <span className="ml-auto font-mono text-[10px] text-ink-muted">
-          {sorted.length} of {rows.length} providers
-        </span>
       </div>
 
       {sorted.length === 0 ? (

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -275,45 +275,54 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
       <ProviderOverview providers={rows} counts={counts} />
       <SourceHealthRollup />
 
-      {/* Filter toolbar — edge-to-edge sticky bar on mobile, an inset card on desktop,
-          matching the subnets grid toolbar treatment. */}
+      {/* Filter toolbar — every control stretches to fill its track so the row stays
+          justified (flush on both ends), reflowing cleanly down to narrow viewports. */}
       <div className="sticky top-14 z-20 -mx-4 border-y border-border bg-paper/95 px-4 py-2.5 backdrop-blur supports-[backdrop-filter]:bg-paper/80 md:mx-0 md:rounded-lg md:border md:bg-card md:px-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="min-w-[180px] max-w-sm flex-1">
+        <div className="flex w-full flex-wrap items-stretch gap-2">
+          <div className="flex w-full basis-full md:w-auto md:flex-[2] md:basis-0">
             <SearchInput
               value={q}
               onChange={(v) => setSearch({ q: v })}
               placeholder="Search providers, slugs, hosts…"
             />
           </div>
-          <SelectFilter
-            label="Kind"
-            value={kind}
-            onChange={(v) => setSearch({ kind: v })}
-            options={kinds.map((k) => ({ value: k, label: k }))}
-          />
-          <SelectFilter
-            label="Authority"
-            value={authority}
-            onChange={(v) => setSearch({ authority: v })}
-            options={authorityOptions.map((a) => ({ value: a, label: a }))}
-          />
-          <SelectFilter
-            label="Sort"
-            value={sortKey}
-            onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
-            options={providerSortKeys.map((s) => ({ value: s, label: s }))}
-            allowEmpty={false}
-          />
-          <div className="ml-auto flex items-center gap-2.5">
-            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted tabular-nums">
-              {sorted.length} of {rows.length}
-            </span>
-            <ResetFiltersButton
-              active={hasFilters}
-              onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
+          <div className="flex flex-1 basis-full min-[480px]:min-w-[7rem] min-[480px]:basis-0">
+            <SelectFilter
+              fill
+              label="Kind"
+              value={kind}
+              onChange={(v) => setSearch({ kind: v })}
+              options={kinds.map((k) => ({ value: k, label: k }))}
             />
           </div>
+          <div className="flex flex-1 basis-full min-[480px]:min-w-[7rem] min-[480px]:basis-0">
+            <SelectFilter
+              fill
+              label="Authority"
+              value={authority}
+              onChange={(v) => setSearch({ authority: v })}
+              options={authorityOptions.map((a) => ({ value: a, label: a }))}
+            />
+          </div>
+          <div className="flex flex-1 basis-full min-[480px]:min-w-[7rem] min-[480px]:basis-0">
+            <SelectFilter
+              fill
+              label="Sort"
+              value={sortKey}
+              onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
+              options={providerSortKeys.map((s) => ({ value: s, label: s }))}
+              allowEmpty={false}
+            />
+          </div>
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <ResetFiltersButton
+            active={hasFilters}
+            onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
+          />
+          <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted tabular-nums">
+            {sorted.length} of {rows.length} providers
+          </span>
         </div>
       </div>
 

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useEffect, useMemo, type ReactNode } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Globe, Github, BookOpen, Radio, Layers, Network, Search, X } from "lucide-react";
+import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { BrandIcon, prefetchBrandIcon } from "@/components/metagraphed/brand-icon";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -12,7 +12,11 @@ import { PageHero } from "@/components/metagraphed/page-hero";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ViewModeToggle } from "@/components/metagraphed/view-mode-toggle";
 import { ShareButton } from "@/components/metagraphed/share-button";
-import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
+import {
+  ResetFiltersButton,
+  SearchInput,
+  SelectFilter,
+} from "@/components/metagraphed/table-controls";
 import {
   providersQuery,
   endpointsQuery,
@@ -273,44 +277,36 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
 
       {/* Toolbar */}
       <div className="sticky top-14 z-10 -mx-1 px-1 py-2 backdrop-blur bg-paper/85 border-b border-border/60 flex flex-wrap items-center gap-2">
-        <div className="relative flex-1 min-w-[180px] max-w-sm">
-          <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-ink-muted" />
-          <input
+        <div className="flex-1 min-w-[180px] max-w-sm">
+          <SearchInput
             value={q}
-            onChange={(e) => setSearch({ q: e.target.value })}
+            onChange={(v) => setSearch({ q: v })}
             placeholder="Search providers, slugs, hosts…"
-            className="w-full rounded border border-border bg-card pl-7 pr-2 py-1.5 text-[12px] focus:outline-none focus:border-ink/30"
-            aria-label="Search providers"
           />
         </div>
-        <Selector
+        <SelectFilter
           label="Kind"
           value={kind}
           onChange={(v) => setSearch({ kind: v })}
-          options={kinds}
+          options={kinds.map((k) => ({ value: k, label: k }))}
         />
-        <Selector
+        <SelectFilter
           label="Authority"
           value={authority}
           onChange={(v) => setSearch({ authority: v })}
-          options={authorityOptions}
+          options={authorityOptions.map((a) => ({ value: a, label: a }))}
         />
-        <Selector
+        <SelectFilter
           label="Sort"
           value={sortKey}
           onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
-          options={[...providerSortKeys]}
+          options={providerSortKeys.map((s) => ({ value: s, label: s }))}
           allowEmpty={false}
         />
-        {hasFilters ? (
-          <button
-            type="button"
-            onClick={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
-            className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[11px] text-ink-muted hover:text-ink-strong"
-          >
-            <X className="size-3" /> Clear
-          </button>
-        ) : null}
+        <ResetFiltersButton
+          active={hasFilters}
+          onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
+        />
         <span className="ml-auto font-mono text-[10px] text-ink-muted">
           {sorted.length} of {rows.length} providers
         </span>
@@ -494,38 +490,6 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
         </div>
       )}
     </div>
-  );
-}
-
-function Selector({
-  label,
-  value,
-  onChange,
-  options,
-  allowEmpty = true,
-}: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  options: string[];
-  allowEmpty?: boolean;
-}) {
-  return (
-    <label className="inline-flex items-center gap-1 text-[11px] text-ink-muted">
-      <span className="font-mono uppercase tracking-widest text-[10px]">{label}</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="rounded border border-border bg-card px-1.5 py-1 text-[11px] text-ink focus:outline-none focus:border-ink/30"
-      >
-        {allowEmpty ? <option value="">all</option> : null}
-        {options.map((o) => (
-          <option key={o} value={o}>
-            {o}
-          </option>
-        ))}
-      </select>
-    </label>
   );
 }
 


### PR DESCRIPTION
Closes #3424

## What

Adopts the shared `table-controls` components on the Providers grid toolbar **and** reworks the toolbar's layout so the section no longer feels neglected (per review feedback).

**Component swap**
- raw `<input>` + magnifier wrapper → shared `SearchInput`
- 3× local `Selector` (Kind / Authority / Sort) → shared `SelectFilter`
- hand-rolled Clear `<button>` → shared `ResetFiltersButton`
- deleted the now-unused local `Selector` helper and the now-unused `Search`/`X` icon imports

**Layout polish**
- Wrapped the toolbar in the same responsive treatment the subnets grid toolbar uses — edge-to-edge sticky bar on mobile, an inset rounded `bg-card` card on desktop — instead of a bare underline.
- Grouped the result count + reset into an aligned right-hand cluster with consistent mono/uppercase meta typography (`tracking-[0.18em]`).

**Shared-component addition:** `SelectFilter` gained an optional `allowEmpty` prop (defaults `true`, so every existing caller is unchanged) so the always-selected Sort control can omit the empty "all" option. This is the only touch to `table-controls.tsx`.

## Verify

`npm run lint` (0 errors) · `npm run typecheck` · `npm run format:check` · `npm test` (679 passing) · `npm run build` — all green locally.

## Screenshots

Before = `main`, after = the redesigned toolbar. Real data (133 providers, unchanged between before/after). 3 viewports × 2 themes.

| Viewport / Theme | Before (main) | After (redesigned) |
| --- | --- | --- |
| Mobile · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-before-mobile-light.png" width="380"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-after-mobile-light.png" width="380"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-before-mobile-dark.png" width="380"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-after-mobile-dark.png" width="380"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-before-tablet-light.png" width="380"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-after-tablet-light.png" width="380"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-before-tablet-dark.png" width="380"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-after-tablet-dark.png" width="380"> |
| Desktop · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-before-desktop-light.png" width="380"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-after-desktop-light.png" width="380"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-before-desktop-dark.png" width="380"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3424-after-desktop-dark.png" width="380"> |
