### PR TITLE
feat(registry): add SN86 TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/subnet-86.json
+++ b/registry/subnets/subnet-86.json
@@ -50,6 +50,25 @@
         "https://backprop.finance/dtao/subnets/86-subnet-86"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/86"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-86-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Subnet 86 TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/86 on api.taomarketcap.com returning machine-readable JSON for SN86 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. SN86 exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/86-subnet-86"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/86"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/subnet-86.json` (SN86). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 86
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/86
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://backprop.finance/dtao/subnets/86-subnet-86
- **Provider slug:** `taomarketcap`

SN86 exposes no verified first-party public API endpoint. The TaoMarketCap developer API documents this indexed no-auth JSON feed for on-chain subnet state (same pattern as merged #4615 / #4716).

Closes #4108

## Validation

```sh
npm run validate:surface -- registry/subnets/subnet-86.json
npm run scan:public-safety
```

- Live probe: GET returns JSON with `netuid: 86`.
- No duplicate surface kind+URL conflict (existing `data-artifact` uses the same URL under a different kind, matching DogeLayer SN80).

## Test plan

- [x] `validate:surface` passes
- [x] `scan:public-safety` passes
- [x] No screenshots required (registry-only change)

Made with [Cursor](https://cursor.com)