### PR TITLE
feat(extrinsics): unwrap BTreeSet fields, pin u64/u128 precision as accepted

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -18,6 +18,7 @@ import {
   hasEthereumEvmDecoder,
 } from "./indexer-rs-ethereum-decode.mjs";
 import { parseJsonPreservingBigInts } from "./big-int-safe-json.mjs";
+import { decodeBTreeSetFields } from "./postgres-collection-normalize.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
 // Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
@@ -167,13 +168,23 @@ export function formatExtrinsic(row) {
       // (#4690) -- it needs the pristine raw nested-call shape to reconstruct
       // correctly (see its own file header for why running it second would
       // silently lose a genuinely zero-argument nested call). Ethereum/EVM
-      // decode (#4692) can safely run last -- U256/H160/tuple-variant-enum
-      // shapes are untouched by either earlier pass (verified: neither the
-      // newtype-scalar rule nor the nested-call detector matches an
-      // array-wrapping-an-array or a payload lacking its own string `.name`).
-      // All three are no-ops on D1's own call_args shape (an array of
-      // {name,type,value} descriptors) -- safe to apply unconditionally
-      // regardless of which serving tier produced this row.
+      // decode (#4692) and the BTreeSet unwrap (#4693) can safely run last --
+      // neither earlier pass touches the shapes they target (verified: the
+      // newtype-scalar rule only partially/coincidentally collapses a
+      // SINGLE-element BTreeSet as an unrelated side effect -- see
+      // postgres-collection-normalize.mjs's header for why that doesn't
+      // conflict with running this pass afterward). All four are no-ops on
+      // D1's own call_args shape (an array of {name,type,value} descriptors)
+      // -- safe to apply unconditionally regardless of which serving tier
+      // produced this row.
+      //
+      // u64/u128 precision (SubtensorModule.register's PoW nonce,
+      // set_children's near-u64::MAX sentinel) is DELIBERATELY left as-is
+      // here -- #4693 pins this as an accepted, tested invariant (Postgres's
+      // exact literal converges on the same IEEE-754 double D1 already
+      // serves for the two confirmed fixtures) rather than attempting a fix;
+      // see tests/extrinsics.test.mjs's precision-pinning tests and
+      // wrangler.jsonc's METAGRAPH_EXTRINSICS_SOURCE comment.
       //
       // parseJsonPreservingBigInts (#4692 review fix) is gated to ONLY the
       // call types indexer-rs-ethereum-decode.mjs actually decodes: plain
@@ -191,11 +202,15 @@ export function formatExtrinsic(row) {
       )
         ? parseJsonPreservingBigInts
         : JSON.parse;
-      call_args = decodeEthereumEvmCallArgs(
+      call_args = decodeBTreeSetFields(
         row.call_module,
         row.call_function,
-        normalizePostgresValue(
-          decodePostgresCallArgs(parseCallArgs(row.call_args)),
+        decodeEthereumEvmCallArgs(
+          row.call_module,
+          row.call_function,
+          normalizePostgresValue(
+            decodePostgresCallArgs(parseCallArgs(row.call_args)),
+          ),
         ),
       );
     } catch {

--- a/src/postgres-collection-normalize.mjs
+++ b/src/postgres-collection-normalize.mjs
@@ -1,0 +1,57 @@
+// Unwraps indexer-rs's (Postgres) BTreeSet<T> extra array-nesting layer for
+// specific, confirmed call-arg fields (#4693) -- e.g.
+// SubtensorModule.claim_root's `subnets`: D1 serves `[104]`, Postgres serves
+// `[[104]]` (confirmed real data, block 8587445/extrinsic_index 19, 162
+// in-window occurrences).
+//
+// Deliberately scoped to named (callModule, callFunction, fieldName)
+// triples, NOT a generic "strip any outer array wrapping another array"
+// rule. That shape is structurally IDENTICAL to an AccountId32/MultiAddress/
+// H160/Hash newtype wrap (src/ss58.mjs, src/bytes.mjs,
+// src/indexer-rs-ethereum-decode.mjs's territory) -- unwrapping it
+// unconditionally here would silently corrupt those fields wherever this
+// module's dispatch and theirs might overlap. A BTreeSet's element count is
+// unbounded (0, 1, many), unlike a fixed-width byte/account wrap, but
+// nothing in the JSON shape itself distinguishes "a 1-element BTreeSet" from
+// "a 1-element newtype wrap around something array-shaped" -- so this stays
+// an opt-in allowlist of fields independently confirmed to be BTreeSet-typed,
+// the same discipline #4692's Ethereum/EVM decoders already established.
+//
+// Chained AFTER scale-normalize.mjs's normalizePostgresValue (#4690) in
+// formatExtrinsic, not before -- ordering doesn't matter for correctness
+// here (verified: normalizePostgresValue's generic newtype-scalar rule
+// already happens to partially collapse a SINGLE-element BTreeSet as a side
+// effect, e.g. [[104]] -> [104], via its own unrelated scalar-unwrap logic;
+// this module's unwrap step is a no-op on that already-correct shape since
+// unwrapping requires the wrapped element to STILL be an array. For a
+// MULTI-element BTreeSet, normalizePostgresValue leaves the outer wrap
+// completely untouched -- e.g. [[104,71,9]] stays [[104,71,9]] -- which is
+// exactly what this module then unwraps to [104,71,9]), but running after
+// keeps the two passes' responsibilities cleanly separated: generic
+// Option/enum/scalar shapes first, named-field collection shapes second.
+const BTREESET_FIELDS = new Set(["SubtensorModule.claim_root.subnets"]);
+
+function unwrapBTreeSetLayer(value) {
+  return Array.isArray(value) && value.length === 1 && Array.isArray(value[0])
+    ? value[0]
+    : value;
+}
+
+/** Unwraps BTreeSet-typed fields in callArgs for the small set of
+ * (callModule, callFunction, fieldName) triples confirmed to need it. A
+ * no-op (returns callArgs unchanged, or with only the confirmed fields
+ * touched) for every other call -- safe to apply unconditionally in
+ * formatExtrinsic regardless of which tier produced the row, same contract
+ * as normalizePostgresValue (#4690) and decodePostgresCallArgs (#4691). */
+export function decodeBTreeSetFields(callModule, callFunction, callArgs) {
+  if (!callArgs || typeof callArgs !== "object" || Array.isArray(callArgs)) {
+    return callArgs;
+  }
+  const out = { ...callArgs };
+  for (const key of Object.keys(callArgs)) {
+    if (BTREESET_FIELDS.has(`${callModule}.${callFunction}.${key}`)) {
+      out[key] = unwrapBTreeSetLayer(callArgs[key]);
+    }
+  }
+  return out;
+}

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -329,6 +329,51 @@ test("formatExtrinsic does NOT extend the big-int-safe parse to call types outsi
   assert.equal(out.call_args.nonce, 9131459485341369000);
 });
 
+test("formatExtrinsic unwraps a single-element BTreeSet (real SubtensorModule.claim_root, block 8587445/19, #4693)", () => {
+  const out = formatExtrinsic({
+    block_number: 8587445,
+    extrinsic_index: 19,
+    call_module: "SubtensorModule",
+    call_function: "claim_root",
+    call_args: '{"subnets": [[104]]}',
+  });
+  assert.deepEqual(out.call_args.subnets, [104]);
+});
+
+test("formatExtrinsic pins SubtensorModule.register's PoW nonce precision as an accepted, tested invariant (real block 8556317/20, #4693) -- Postgres's exact literal converges on the same value D1 already serves, not a regression to fix here", () => {
+  // nonce is a BARE u64 scalar in the real Postgres row (confirmed via
+  // direct query -- not newtype-wrapped like most other fields), and
+  // formatExtrinsic deliberately does NOT route SubtensorModule.register
+  // through the big-int-safe parse (#4692's hasEthereumEvmDecoder gate) --
+  // per #4693's explicit requirement, this ticket pins the current
+  // convergent-but-lossy behavior rather than fixing it.
+  const out = formatExtrinsic({
+    block_number: 8556317,
+    extrinsic_index: 20,
+    call_module: "SubtensorModule",
+    call_function: "register",
+    call_args:
+      '{"work":[16,64,112,106],"nonce":9131459485341369597,"netuid":21}',
+  });
+  assert.equal(out.call_args.nonce, 9131459485341369000);
+});
+
+test("formatExtrinsic pins SubtensorModule.set_children's near-u64::MAX sentinel precision as an accepted, tested invariant (real block 8585337/19, #4693)", () => {
+  // children is Vec<(u64, AccountId32)> -- children[0][0] is the proportion
+  // (here the true u64::MAX "take-all" sentinel), children[0][1] the child's
+  // AccountId32 (untouched here -- top-level AccountId32 decode is a
+  // separate, not-yet-covered gap, out of #4693's scope).
+  const out = formatExtrinsic({
+    block_number: 8585337,
+    extrinsic_index: 19,
+    call_module: "SubtensorModule",
+    call_function: "set_children",
+    call_args:
+      '{"netuid":121,"children":[[18446744073709551615,[[100,65,10,124,236,80,140,19,181,73,132,35,107,50,57,120,44,20,174,42,203,246,252,17,211,55,209,239,75,249,82,33]]]]}',
+  });
+  assert.equal(out.call_args.children[0][0], 18446744073709552000);
+});
+
 test("formatExtrinsic normalizes success (0->false, null->null)", () => {
   assert.equal(
     formatExtrinsic({ block_number: 1, extrinsic_index: 0, success: 0 })

--- a/tests/postgres-collection-normalize.test.mjs
+++ b/tests/postgres-collection-normalize.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { decodeBTreeSetFields } from "../src/postgres-collection-normalize.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+
+// Chains after normalizePostgresValue, matching src/extrinsics.mjs's actual
+// formatExtrinsic call order.
+function decode(callModule, callFunction, raw) {
+  return decodeBTreeSetFields(
+    callModule,
+    callFunction,
+    normalizePostgresValue(raw),
+  );
+}
+
+describe("decodeBTreeSetFields", () => {
+  test("unwraps a single-element BTreeSet (real SubtensorModule.claim_root, block 8587445/19)", () => {
+    const out = decode("SubtensorModule", "claim_root", {
+      subnets: [[104]],
+    });
+    assert.deepEqual(out.subnets, [104]);
+  });
+
+  test("unwraps a multi-element BTreeSet (synthetic -- no confirmed real multi-subnet claim_root occurrence, but the shape structurally supports it)", () => {
+    const out = decode("SubtensorModule", "claim_root", {
+      subnets: [[104, 71, 9]],
+    });
+    assert.deepEqual(out.subnets, [104, 71, 9]);
+  });
+
+  test("unwraps an empty BTreeSet", () => {
+    const out = decode("SubtensorModule", "claim_root", { subnets: [[]] });
+    assert.deepEqual(out.subnets, []);
+  });
+
+  test("is a no-op for a different call type's same-named field -- scoped to (callModule, callFunction, fieldName), not fieldName alone", () => {
+    // A multi-element inner array here, deliberately -- normalizePostgresValue
+    // (#4690) coincidentally partially collapses a SINGLE-element
+    // [[x]] -> [x] on its own (an unrelated, pre-existing behavior of its
+    // generic newtype-scalar rule, flagged separately), which would confound
+    // this test's actual purpose: proving decodeBTreeSetFields's OWN
+    // call-type scoping, not re-litigating that other pass's behavior.
+    const out = decode("SomeOtherModule", "some_function", {
+      subnets: [[104, 71]],
+    });
+    assert.deepEqual(out.subnets, [[104, 71]]);
+  });
+
+  test("is a no-op for a different field on the same call type", () => {
+    const out = decode("SubtensorModule", "claim_root", {
+      other_field: [[104, 71]],
+    });
+    assert.deepEqual(out.other_field, [[104, 71]]);
+  });
+
+  test("is a no-op on D1's own call_args shape (an array of {name,type,value} descriptors, not an object)", () => {
+    const d1Shape = [
+      { name: "subnets", type: "BTreeSet<NetUid>", value: [104, 71] },
+    ];
+    assert.deepEqual(
+      decodeBTreeSetFields("SubtensorModule", "claim_root", d1Shape),
+      d1Shape,
+    );
+  });
+
+  test("is a no-op on null/undefined/scalar call_args", () => {
+    assert.equal(
+      decodeBTreeSetFields("SubtensorModule", "claim_root", null),
+      null,
+    );
+    assert.equal(
+      decodeBTreeSetFields("SubtensorModule", "claim_root", undefined),
+      undefined,
+    );
+    assert.equal(decodeBTreeSetFields("SubtensorModule", "claim_root", 42), 42);
+  });
+
+  test("leaves sibling fields on the same call untouched", () => {
+    const out = decode("SubtensorModule", "claim_root", {
+      subnets: [[104]],
+      netuid: 9,
+    });
+    assert.equal(out.netuid, 9);
+  });
+});

--- a/tests/scale-normalize.test.mjs
+++ b/tests/scale-normalize.test.mjs
@@ -52,7 +52,7 @@ describe("normalizePostgresValue", () => {
   });
 
   describe("generic newtype-scalar unwrap", () => {
-    test("unwraps a 1-tuple wrapping a plain number (real LimitOrders.execute_batched_orders fee_rate, block 8587347/16)", () => {
+    test("unwraps a 1-tuple wrapping a plain number (real LimitOrders.execute_batched_orders fee_rate, block 8587347/16) -- satisfies #4693's scalar-newtype-generalization requirement: this rule was never special-cased to byte-blob-shaped wrappers only", () => {
       assert.equal(normalizePostgresValue([0]), 0);
     });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -126,15 +126,36 @@
     // real data already has `value` (wei) past Number.MAX_SAFE_INTEGER for
     // any transfer above ~0.009 ETH, the normal case, not a 2^256 edge case.
     //
+    // #4693 (src/postgres-collection-normalize.mjs): BTreeSet<T> fields
+    // (confirmed: SubtensorModule.claim_root's `subnets`) now unwrap
+    // indexer-rs's extra array-nesting layer the same way D1 serves them.
+    // The generic scalar-newtype unwrap (#4690) already generalized beyond
+    // byte-blob-shaped wrappers with no changes needed (verified against
+    // LimitOrders.execute_batched_orders' fee_rate).
+    //
+    // u64/u128 precision (SubtensorModule.register's PoW nonce,
+    // set_children's near-u64::MAX sentinel): ACCEPTED, not fixed, per
+    // #4693's explicit requirement. Traced the mechanism during #4692:
+    // fetch-events.py's stored D1 text is itself lossless (Python's
+    // arbitrary-precision int via json.dumps); the rounding happens in the
+    // SHARED formatExtrinsic's plain JSON.parse(row.call_args), applied
+    // identically to both tiers. Verified the two confirmed fixtures
+    // (register nonce, set_children children[0][0]) converge on the exact
+    // same IEEE-754 double D1 already serves -- so flipping the flag would
+    // not change what's served for these two fields today; pinned as tested
+    // invariants in tests/extrinsics.test.mjs rather than "fixed," since a
+    // real fix would need the same big-int-safe parse #4692 built for
+    // Ethereum/EVM, applied more broadly -- deliberately out of scope here
+    // to avoid an uncontrolled type-change blast radius (number -> string)
+    // across every call type; a real investigation into that broader
+    // question is tracked separately.
+    //
     // Still open: a TOP-LEVEL (non-nested) call's own AccountId32/byte-blob
     // fields -- e.g. a bare Balances.transfer's dest, or Multisig's own
     // other_signatories/max_weight siblings -- are not yet decoded at that
-    // outer layer, only within a reconstructed nested call; BTreeSet/u64/
-    // u128-precision edge cases elsewhere (#4693, likely also the right home
-    // to reconsider the register-nonce JSON.parse precision issue generally,
-    // now that #4692 traced its root cause); MCP's extrinsics tools are
-    // still D1-only (#4694). Do not flip until those land and the parity
-    // harness (#4695) passes clean.
+    // outer layer, only within a reconstructed nested call; MCP's extrinsics
+    // tools are still D1-only (#4694). Do not flip until those land and the
+    // parity harness (#4695) passes clean.
     "METAGRAPH_BLOCKS_SOURCE": "d1",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
   },


### PR DESCRIPTION
## Summary
- Adds `src/postgres-collection-normalize.mjs`: strips indexer-rs's extra array-nesting layer around `BTreeSet<T>` fields (confirmed real fixture: `SubtensorModule.claim_root`'s `subnets`, block 8587445/19 — D1 serves `[104]`, Postgres serves `[[104]]`). **Deliberately scoped** to specific `(callModule, callFunction, fieldName)` triples via an allowlist, not a generic "unwrap any outer array wrapping an array" rule — that shape is structurally identical to an AccountId32/H160/Hash newtype wrap (`src/ss58.mjs`/`src/bytes.mjs`/`src/indexer-rs-ethereum-decode.mjs`'s territory) and must not be touched here.
- The generic scalar-newtype unwrap (#4690) already generalizes beyond byte-blob-shaped wrappers — verified against the issue's cited `LimitOrders.execute_batched_orders` `fee_rate` example, already covered by an existing test (annotated to note it satisfies this requirement too). No new code needed for this part.
- u64/u128 precision (`SubtensorModule.register`'s PoW nonce, `set_children`'s near-`u64::MAX` sentinel) is **pinned as an accepted, tested invariant**, per the issue's explicit instruction not to attempt a fix here: Postgres's exact literal, once round-tripped through `formatExtrinsic`'s plain `JSON.parse`, converges on the exact same IEEE-754 double D1 already serves for both confirmed fixtures — verified directly.
- Updated the `METAGRAPH_EXTRINSICS_SOURCE` comment in `wrangler.jsonc` recording all three outcomes.
- While testing, found and separately flagged (not fixed here, out of this issue's scope) a related but distinct latent issue: the generic scalar-newtype unwrap rule can't structurally distinguish "a genuine 1-tuple wrap" from "a genuine single-element collection," which could affect any D1-served field with exactly one array element. Filed as #4724 for independent investigation, not addressed in this PR.

## Test plan
- [x] `tests/postgres-collection-normalize.test.mjs` (8 tests, 100% coverage): real `claim_root` fixture, synthetic multi-element/empty BTreeSet cases, call-type/field-name scoping, D1-shape no-op.
- [x] `tests/extrinsics.test.mjs`: added `formatExtrinsic` integration tests for the real `claim_root` BTreeSet unwrap, and the real `register`/`set_children` precision-pinning fixtures.
- [x] `tests/scale-normalize.test.mjs`: annotated the existing `fee_rate` test to note it satisfies this issue's scalar-newtype-generalization requirement.
- [x] All existing tests pass unchanged (237 tests across the affected suite).
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run test:coverage` clean — 100% on the new file, no patch-coverage regression on `extrinsics.mjs`
- [x] `npm run validate:contract-drift` clean
- [x] Zero behavior change on `METAGRAPH_EXTRINSICS_SOURCE=d1` (no-op on D1's own shapes, confirmed via dedicated idempotence tests)

Refs #4669
Closes #4693
