### PR TITLE
fix(extrinsics): preserve collection-typed call_args as arrays at any element count

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -176,7 +176,14 @@ export function formatExtrinsic(row) {
       // conflict with running this pass afterward). All four are no-ops on
       // D1's own call_args shape (an array of {name,type,value} descriptors)
       // -- safe to apply unconditionally regardless of which serving tier
-      // produced this row.
+      // produced this row. This is a genuine guarantee, not an assumption:
+      // normalizePostgresValue (#4724) reads each D1 descriptor's own `type`
+      // string before touching its `value`, so a collection-typed field
+      // (Vec<T>/BTreeSet<T>/etc) is preserved as an array at ANY element
+      // count -- decodeBTreeSetFields is then a true no-op on D1 rows
+      // regardless, since D1's call_args never becomes the flat
+      // {fieldName: value} object shape that function's own Array.isArray
+      // early-return requires it to skip.
       //
       // u64/u128 precision (SubtensorModule.register's PoW nonce,
       // set_children's near-u64::MAX sentinel) is DELIBERATELY left as-is

--- a/src/scale-normalize.mjs
+++ b/src/scale-normalize.mjs
@@ -26,6 +26,33 @@
 //   normalizer does not special-case it, so it passes through the generic
 //   enum-with-data branch unchanged (a `values.length === 1` node whose
 //   single element is itself an object) until #4691 recognizes it.
+//
+// #4724 CORRECTION: this module was originally documented (and tested) as an
+// unconditional no-op on D1's own `{name, type, value}` call_args descriptor
+// shape -- that claim was FALSE. D1's `value` field for a genuinely
+// collection-typed field (Vec<T>/BTreeSet<T>/BoundedVec<T>/BTreeMap<K,V>) is
+// a bare array of however many elements the call actually carried, and when
+// that array happens to hold exactly one element, it is INDISTINGUISHABLE
+// from the newtype-scalar wrap above by shape alone. Confirmed live in
+// production (direct D1 query, blocks 8560000-8589000):
+// SubtensorModule.set_mechanism_weights' dests/weights (10,129 occurrences
+// EACH in just that window), set_weights' dests/weights (2,337 each),
+// reveal_weights/reveal_mechanism_weights's uids/values (35-155 each),
+// claim_root's subnets (84), Multisig.approve_as_multi/as_multi's
+// other_signatories (8-9, string-typed -- confirming the fix must not assume
+// numeric elements). All were being served with the field collapsed from
+// e.g. `[0]` to a bare `0`, or `["5F..."]` to a bare `"5F..."`, silently
+// changing the field's JSON type from array to scalar for consumers.
+//
+// The fix: D1's descriptor shape carries a sibling `type` string the
+// Postgres/indexer-rs shapes never have -- isTypedFieldDescriptor +
+// COLLECTION_TYPE_RE below use it to skip the newtype-scalar collapse
+// specifically when `type` names a collection, regardless of element count.
+// This is scoped to the `{name, type, value}` shape ONLY -- it does not
+// change behavior for Postgres's untyped dump (which has no `type` field to
+// consult and remains exactly as ambiguous as before; see
+// postgres-collection-normalize.mjs's narrow per-field allowlist for how
+// that side is handled instead).
 
 function isPlainScalar(value) {
   return (
@@ -34,6 +61,57 @@ function isPlainScalar(value) {
     typeof value === "string" ||
     typeof value === "boolean"
   );
+}
+
+/** True when `value` is D1's per-field call_args descriptor shape: `{name,
+ * type, value}`, where `type` is the Substrate/SCALE type string (e.g.
+ * "Vec<u16>", "NetUid", "BTreeSet<NetUid>"). Distinguished from
+ * isEnumTreeNode's `{name, values}` shape by key count/name (3 keys incl.
+ * "type" + singular "value", vs. 2 keys incl. plural "values") -- the two
+ * never collide. Postgres/indexer-rs's raw dump never produces this shape
+ * (its call_args is either a flat `{fieldName: value}` object or a bare
+ * array), so this is D1-specific by construction, not just by convention. */
+export function isTypedFieldDescriptor(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 3 &&
+    keys.includes("name") &&
+    keys.includes("type") &&
+    keys.includes("value") &&
+    typeof value.name === "string" &&
+    typeof value.type === "string"
+  );
+}
+
+// Matches anywhere in the type string (not anchored) so a collection nested
+// inside another generic -- e.g. a hypothetical "Option<Vec<u16>>" -- is
+// still recognized; the cost of a false positive here (a genuine 1-tuple
+// newtype-scalar stays wrapped in its array) is a cosmetic no-op, while the
+// cost of a false negative (a genuine collection gets collapsed) is the data
+// corruption this fix exists to close, so this deliberately errs toward
+// over-preserving array-ness. Prefixes confirmed present in real D1
+// call_args `type` strings (see the query note above): Vec, BoundedVec,
+// BTreeSet, BTreeMap. WeakBoundedVec/BoundedBTreeSet/BoundedBTreeMap are
+// Substrate's other standard bounded-collection wrappers -- included
+// pre-emptively even though not yet observed in a real fixture, since they
+// share the exact same "generic collection type name" convention.
+const COLLECTION_TYPE_RE =
+  /(?:Vec|BoundedVec|WeakBoundedVec|BTreeSet|BoundedBTreeSet|BTreeMap|BoundedBTreeMap)</;
+
+function isCollectionType(type) {
+  return COLLECTION_TYPE_RE.test(type);
+}
+
+// A known-collection-typed descriptor's `value` must stay an array
+// regardless of element count -- skips the newtype-scalar collapse for the
+// OUTER array specifically, but still normalizes each element (an element
+// could itself be an Option, nested struct, etc). Falls through to the
+// generic normalize() if `value` isn't actually an array (defensive; not
+// expected for a real collection-typed field).
+function normalizeCollectionValue(value) {
+  if (!Array.isArray(value)) return normalize(value);
+  return value.map(normalize);
 }
 
 /** True when `value` is indexer-rs's generic `{name, values}` enum-tree node
@@ -83,6 +161,20 @@ function normalize(value) {
     // recurse only into the payload.
     return { name, values: values.map(normalize) };
   }
+  if (isTypedFieldDescriptor(value)) {
+    // #4724: consult the sibling `type` string before deciding what to do
+    // with `value` -- the generic array-recursion below has no way to know,
+    // from shape alone, whether a single-element array is a genuine
+    // newtype-scalar wrap or a genuine collection that happens to hold one
+    // entry. See COLLECTION_TYPE_RE above.
+    return {
+      name: value.name,
+      type: value.type,
+      value: isCollectionType(value.type)
+        ? normalizeCollectionValue(value.value)
+        : normalize(value.value),
+    };
+  }
   if (value && typeof value === "object") {
     const out = {};
     for (const [key, val] of Object.entries(value)) out[key] = normalize(val);
@@ -92,11 +184,16 @@ function normalize(value) {
 }
 
 /** Recursively applies the Option<T>/unit-enum/newtype-scalar normalization
- * rules described above. A no-op on already-D1-shaped data (D1's call_args
- * descriptors are `{name, type, value}` triples inside an array -- never a
- * bare two-key `{name, values}` object, never a real 1-element scalar array
- * in a value position), so this is safe to run unconditionally regardless of
- * which tier produced the row. */
+ * rules described above. Safe to run unconditionally regardless of which tier
+ * produced the row: on D1's own call_args shape (an array of `{name, type,
+ * value}` descriptors), the isTypedFieldDescriptor branch reads each
+ * descriptor's `type` string and only ever touches `value` in ways that
+ * respect it -- a collection-typed field's `value` always stays an array
+ * (any element count), and a non-collection field's `value` gets the same
+ * generic normalization applied to any other position (#4724 -- this was
+ * PREVIOUSLY (incorrectly) documented and tested as an unconditional no-op on
+ * D1 data; that was false whenever a collection-typed field held exactly one
+ * element, e.g. SubtensorModule.set_weights' dests/weights). */
 export function normalizePostgresValue(value) {
   return normalize(value);
 }

--- a/tests/scale-normalize.test.mjs
+++ b/tests/scale-normalize.test.mjs
@@ -153,6 +153,82 @@ describe("normalizePostgresValue", () => {
     });
   });
 
+  describe("#4724 regression: a collection-typed D1 descriptor must stay an array at ANY element count", () => {
+    test("preserves a single-destination SubtensorModule.set_weights dests (real, block 8588865/15 -- was served as bare 0, confirmed live before this fix)", () => {
+      const descriptor = { name: "dests", type: "Vec<u16>", value: [0] };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("preserves a single-weight SubtensorModule.set_weights weights (real, block 8588865/15 -- was served as bare 65535)", () => {
+      const descriptor = { name: "weights", type: "Vec<u16>", value: [65535] };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("preserves single-element dests/weights inside a full call_args array (both fields collapse independently -- must both survive)", () => {
+      const callArgs = [
+        { name: "netuid", type: "NetUid", value: 3 },
+        { name: "dests", type: "Vec<u16>", value: [11] },
+        { name: "weights", type: "Vec<u16>", value: [65535] },
+        { name: "version_key", type: "u64", value: 1 },
+      ];
+      assert.deepEqual(normalizePostgresValue(callArgs), callArgs);
+    });
+
+    test("preserves a single-subnet SubtensorModule.claim_root subnets (real, block 8588525/16 -- BTreeSet<NetUid>, was served as bare 104)", () => {
+      const descriptor = {
+        name: "subnets",
+        type: "BTreeSet<NetUid>",
+        value: [104],
+      };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("preserves a single-signatory Multisig.approve_as_multi other_signatories (string-typed element, not numeric -- confirms the fix isn't scalar-type-specific)", () => {
+      const descriptor = {
+        name: "other_signatories",
+        type: "Vec<AccountId>",
+        value: ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"],
+      };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("preserves a single-entry BoundedVec descriptor (generic collection prefix coverage beyond bare Vec/BTreeSet)", () => {
+      const descriptor = {
+        name: "orders",
+        type: "BoundedVec<SignedOrder<AccountId>, MaxOrdersPerBatch>",
+        value: [{ id: 1 }],
+      };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("still collapses a genuine non-collection single-value descriptor (NOT a regression -- Moment/NetUid/etc never wrapped an array to begin with)", () => {
+      const descriptor = { name: "netuid", type: "NetUid", value: 9 };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("falls through to generic normalize() for a collection-typed descriptor whose value isn't actually an array (defensive; not expected for a real row)", () => {
+      const descriptor = {
+        name: "subnets",
+        type: "BTreeSet<NetUid>",
+        value: null,
+      };
+      assert.deepEqual(normalizePostgresValue(descriptor), descriptor);
+    });
+
+    test("still recurses normally inside a preserved collection's elements (an element could itself be an Option/enum)", () => {
+      const descriptor = {
+        name: "maybe_list",
+        type: "Vec<Option<u16>>",
+        value: [{ name: "Some", values: [5] }],
+      };
+      assert.deepEqual(normalizePostgresValue(descriptor), {
+        name: "maybe_list",
+        type: "Vec<Option<u16>>",
+        value: [5],
+      });
+    });
+  });
+
   describe("edge cases", () => {
     test("passes through null/undefined/scalars without throwing", () => {
       assert.equal(normalizePostgresValue(null), null);


### PR DESCRIPTION
## Summary

- `normalizePostgresValue` (`src/scale-normalize.mjs`) applied its generic newtype-scalar collapse rule to D1's `{name, type, value}` call_args descriptors without ever consulting the sibling `type` field, so a genuinely collection-typed field with exactly one element was indistinguishable from a genuine 1-tuple newtype wrap and got flattened from an array to a bare scalar.
- Confirmed **live** via direct query against the production D1 database (block range 8560000-8589000, ~29k blocks):

  | call | field | occurrences in window |
  |---|---|---|
  | `SubtensorModule.set_mechanism_weights` | `dests` | 10,129 |
  | `SubtensorModule.set_mechanism_weights` | `weights` | 10,129 |
  | `SubtensorModule.set_weights` | `dests` | 2,337 |
  | `SubtensorModule.set_weights` | `weights` | 2,337 |
  | `SubtensorModule.reveal_mechanism_weights` | `uids`/`values` | 155 each |
  | `SubtensorModule.reveal_weights` | `uids`/`values` | 35 each |
  | `SubtensorModule.claim_root` | `subnets` | 84 |
  | `Multisig.approve_as_multi`/`as_multi` | `other_signatories` | 8-9 (string-typed) |

  e.g. block 8588865/extrinsic 15 was served with `"dests": 0` / `"weights": 65535` instead of `"dests": [0]` / `"weights": [65535]`.
- The existing "D1-shaped idempotence" test suite only exercised a 2-element array for `dests`, never the 1-element case where it actually broke — that coverage gap is why this shipped unnoticed in #4690.

## Fix

`normalize()` now checks for D1's descriptor shape (`isTypedFieldDescriptor`) and, when present, reads the `type` string before deciding what to do with `value`: a recognized collection-type prefix (`Vec<`, `BoundedVec<`, `WeakBoundedVec<`, `BTreeSet<`, `BoundedBTreeSet<`, `BTreeMap<`, `BoundedBTreeMap<`, matched anywhere in the string so a nested generic like `Option<Vec<u16>>` is also caught) always stays an array regardless of element count. Non-collection fields keep the existing behavior unchanged. Verified this has no effect on Postgres's own (already-correct) BTreeSet handling in `postgres-collection-normalize.mjs`, since that pass only ever touches a flat `{fieldName: value}` object shape, which D1's descriptor array never becomes.

## Test plan

- [x] `npx vitest run tests/scale-normalize.test.mjs tests/extrinsics.test.mjs tests/postgres-collection-normalize.test.mjs tests/postgres-call-args.test.mjs` — 128 passed
- [x] New regression tests built directly from the confirmed real fixtures above (single-element `dests`/`weights`, `subnets`, string-typed `other_signatories`, a `BoundedVec` prefix case, and the defensive non-array fallback branch)
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run validate` clean
- [x] `npm run test:coverage` — 7070 passed, `scale-normalize.mjs` at 100% statements/branches/functions/lines
- [x] `npm run build` — no unexpected artifact drift

Closes #4724