### PR TITLE
feat(extrinsics): wire MCP extrinsics tools through the Postgres serving tier

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ export default [
         Request: "readonly",
         Response: "readonly",
         URL: "readonly",
+        URLSearchParams: "readonly",
         console: "readonly",
         crypto: "readonly",
         fetch: "readonly",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -18,6 +18,7 @@ import {
 import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
+import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
@@ -936,6 +937,46 @@ function mcpD1Runner(ctx) {
       return [];
     }
   };
+}
+
+// Synthetic GET /api/v1/extrinsics{...} requests forwarded UNCHANGED to
+// DATA_API via tryPostgresTier (#4694) -- MCP tool handlers receive
+// structured args, not an inbound Request the way REST's handleExtrinsics
+// does, so this reconstructs the identical query-string shape
+// workers/data-api.mjs's extrinsics routes parse. list_extrinsics'
+// inputSchema has no call_hash param (REST-only, #4322), so that filter is
+// never forwarded here -- nothing else to reconcile. The host in the URL is
+// never dispatched to (DATA_API.fetch resolves the binding directly, the
+// same convention src/data-api-mcp.mjs's dataApiFetchJson already uses).
+function mcpExtrinsicsListRequest(args) {
+  const params = new URLSearchParams();
+  const block = optionalNonNegativeInt(args, "block");
+  if (block != null) params.set("block", String(block));
+  const signer = optionalString(args, "signer");
+  if (signer) params.set("signer", signer);
+  const callModule = optionalString(args, "call_module");
+  if (callModule) params.set("call_module", callModule);
+  const callFunction = optionalString(args, "call_function");
+  if (callFunction) params.set("call_function", callFunction);
+  const success = optionalSuccessFilter(args);
+  if (success !== undefined) params.set("success", String(success));
+  const blockStart = optionalNonNegativeInt(args, "block_start");
+  if (blockStart != null) params.set("block_start", String(blockStart));
+  const blockEnd = optionalNonNegativeInt(args, "block_end");
+  if (blockEnd != null) params.set("block_end", String(blockEnd));
+  const from = optionalNonNegativeInt(args, "from");
+  if (from != null) params.set("from", String(from));
+  const to = optionalNonNegativeInt(args, "to");
+  if (to != null) params.set("to", String(to));
+  if (args?.limit != null) params.set("limit", String(args.limit));
+  if (args?.offset != null) params.set("offset", String(args.offset));
+  const cursor = optionalString(args, "cursor");
+  if (cursor) params.set("cursor", cursor);
+  return new Request(`https://d/api/v1/extrinsics?${params.toString()}`);
+}
+
+function mcpExtrinsicDetailRequest(ref) {
+  return new Request(`https://d/api/v1/extrinsics/${encodeURIComponent(ref)}`);
 }
 
 // One subnet's economics: live KV tier (KV-primary), else the committed R2
@@ -5404,20 +5445,31 @@ export const MCP_TOOLS = [
       const callModule = optionalString(args, "call_module");
       const callFunction = optionalString(args, "call_function");
       const cursor = optionalString(args, "cursor");
-      return loadExtrinsics(mcpD1Runner(ctx), {
-        block: optionalNonNegativeInt(args, "block") ?? undefined,
-        signer: signer ?? undefined,
-        callModule: callModule ?? undefined,
-        callFunction: callFunction ?? undefined,
-        success: optionalSuccessFilter(args),
-        blockStart: optionalNonNegativeInt(args, "block_start") ?? undefined,
-        blockEnd: optionalNonNegativeInt(args, "block_end") ?? undefined,
-        from: optionalNonNegativeInt(args, "from") ?? undefined,
-        to: optionalNonNegativeInt(args, "to") ?? undefined,
-        limit: args?.limit,
-        offset: args?.offset,
-        cursor: cursor ?? undefined,
-      });
+      // Mirrors REST's handleExtrinsics: try Postgres first (#4694), fall
+      // back to D1 on any failure -- same tryPostgresTier contract, same
+      // METAGRAPH_EXTRINSICS_SOURCE flag, so this tool and GET
+      // /api/v1/extrinsics never diverge on which tier answered.
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpExtrinsicsListRequest(args),
+          "METAGRAPH_EXTRINSICS_SOURCE",
+        )) ??
+        (await loadExtrinsics(mcpD1Runner(ctx), {
+          block: optionalNonNegativeInt(args, "block") ?? undefined,
+          signer: signer ?? undefined,
+          callModule: callModule ?? undefined,
+          callFunction: callFunction ?? undefined,
+          success: optionalSuccessFilter(args),
+          blockStart: optionalNonNegativeInt(args, "block_start") ?? undefined,
+          blockEnd: optionalNonNegativeInt(args, "block_end") ?? undefined,
+          from: optionalNonNegativeInt(args, "from") ?? undefined,
+          to: optionalNonNegativeInt(args, "to") ?? undefined,
+          limit: args?.limit,
+          offset: args?.offset,
+          cursor: cursor ?? undefined,
+        }))
+      );
     },
   },
   {
@@ -5446,7 +5498,15 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const ref = requireString(args, "ref");
-      return loadExtrinsicDetail(mcpD1Runner(ctx), ref);
+      // Mirrors REST's handleExtrinsic: try Postgres first (#4694), fall
+      // back to D1 on any failure.
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpExtrinsicDetailRequest(ref),
+          "METAGRAPH_EXTRINSICS_SOURCE",
+        )) ?? (await loadExtrinsicDetail(mcpD1Runner(ctx), ref))
+      );
     },
   },
   {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -12866,6 +12866,155 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     assert.match(res.body.result.content[0].text, /ref/);
   });
 
+  // #4694: list_extrinsics/get_extrinsic mirror REST's handleExtrinsics/
+  // handleExtrinsic tier-selection exactly (same METAGRAPH_EXTRINSICS_SOURCE
+  // flag, same tryPostgresTier fallback contract) -- see the equivalent
+  // "flag=postgres" tests for handleExtrinsics/handleExtrinsic in
+  // tests/request-handlers-entities.test.mjs, which this block mirrors.
+  describe("D1 -> Postgres serving cutover (#4694)", () => {
+    function dataApi(response) {
+      return { fetch: async (request) => response ?? { request } };
+    }
+
+    test("list_extrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+      const capture = [];
+      const env = chainD1({ extrinsics: [] }, capture);
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = dataApi(
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 99,
+          limit: 50,
+          offset: 0,
+          next_cursor: null,
+          extrinsics: [],
+        }),
+      );
+      const res = await callTool("list_extrinsics", {}, { env });
+      assert.equal(res.body.result.structuredContent.extrinsic_count, 99);
+      assert.deepEqual(capture, []);
+    });
+
+    test("list_extrinsics: flag=postgres falls back to D1 on failure", async () => {
+      const env = chainD1({ extrinsics: [EXTRINSIC_ROW] });
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      };
+      const res = await callTool("list_extrinsics", {}, { env });
+      assert.equal(res.body.result.structuredContent.extrinsic_count, 1);
+    });
+
+    test("list_extrinsics: flag absent uses D1 even when DATA_API is bound (zero regression, unflipped)", async () => {
+      const capture = [];
+      const env = chainD1({ extrinsics: [EXTRINSIC_ROW] }, capture);
+      env.DATA_API = dataApi(
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 99,
+          extrinsics: [],
+        }),
+      );
+      const res = await callTool("list_extrinsics", {}, { env });
+      assert.equal(res.body.result.structuredContent.extrinsic_count, 1);
+      assert.ok(capture.length > 0, "D1 must actually be queried");
+    });
+
+    test("list_extrinsics: flag=postgres forwards filters as REST-equivalent query params", async () => {
+      const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+      let seenUrl;
+      const env = chainD1({ extrinsics: [] });
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = {
+        fetch: async (request) => {
+          seenUrl = new URL(request.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            extrinsics: [],
+          });
+        },
+      };
+      await callTool(
+        "list_extrinsics",
+        {
+          block: 4200000,
+          signer: SS58,
+          call_module: "SubtensorModule",
+          call_function: "set_weights",
+          success: true,
+          limit: 10,
+          offset: 20,
+        },
+        { env },
+      );
+      assert.equal(seenUrl.pathname, "/api/v1/extrinsics");
+      assert.equal(seenUrl.searchParams.get("block"), "4200000");
+      assert.equal(seenUrl.searchParams.get("offset"), "20");
+      assert.equal(seenUrl.searchParams.get("signer"), SS58);
+      assert.equal(seenUrl.searchParams.get("call_module"), "SubtensorModule");
+      assert.equal(seenUrl.searchParams.get("call_function"), "set_weights");
+      assert.equal(seenUrl.searchParams.get("success"), "true");
+      assert.equal(seenUrl.searchParams.get("limit"), "10");
+    });
+
+    test("get_extrinsic: flag=postgres uses Postgres data, D1 never queried", async () => {
+      const hash = "0x" + "c".repeat(64);
+      const capture = [];
+      const env = chainD1({ extrinsic: EXTRINSIC_ROW }, capture);
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = dataApi(
+        Response.json({
+          schema_version: 1,
+          ref: hash,
+          extrinsic: { ...EXTRINSIC_ROW, signer: "postgres-signer" },
+          events: [],
+        }),
+      );
+      const res = await callTool("get_extrinsic", { ref: hash }, { env });
+      assert.equal(
+        res.body.result.structuredContent.extrinsic.signer,
+        "postgres-signer",
+      );
+      assert.deepEqual(capture, []);
+    });
+
+    test("get_extrinsic: flag=postgres falls back to D1 on failure", async () => {
+      const hash = "0x" + "c".repeat(64);
+      const env = chainD1({ extrinsic: EXTRINSIC_ROW });
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = {
+        fetch: async () => new Response("err", { status: 500 }),
+      };
+      const res = await callTool("get_extrinsic", { ref: hash }, { env });
+      assert.equal(
+        res.body.result.structuredContent.extrinsic.extrinsic_hash,
+        hash,
+      );
+    });
+
+    test("get_extrinsic: flag=postgres forwards the ref in the request path", async () => {
+      let seenUrl;
+      const env = chainD1({ extrinsic: EXTRINSIC_ROW });
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = {
+        fetch: async (request) => {
+          seenUrl = new URL(request.url);
+          return Response.json({
+            schema_version: 1,
+            ref: "4200000-3",
+            extrinsic: null,
+            events: [],
+          });
+        },
+      };
+      await callTool("get_extrinsic", { ref: "4200000-3" }, { env });
+      assert.equal(seenUrl.pathname, "/api/v1/extrinsics/4200000-3");
+    });
+  });
+
   test("block-explorer payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
     const validatorFor = (name) =>

--- a/workers/postgres-tier.mjs
+++ b/workers/postgres-tier.mjs
@@ -1,0 +1,62 @@
+// Gated D1 -> Postgres serving cutover (ADR 0013 Sequencing step 3, the
+// deploy/README.md "Serving cutover" runbook: "if FLAG[tier] == postgres: try
+// Postgres; on error -> D1"). Each tier has its own env flag so a rollback is a
+// single-flag flip, never a code change or redeploy of the fallback path.
+// `request` is forwarded UNCHANGED to the DATA_API service binding -- the caller
+// has already run the SAME validation the D1 path runs (or, for an MCP tool
+// caller, has already validated via its own inputSchema), so this trusts
+// well-formed params and treats ANY failure (binding absent, network error,
+// non-2xx, unparseable/malformed body) as "fall back to D1", never as a
+// client-facing error. Postgres never gets to independently fail a request the
+// D1 path would have served.
+//
+// Extracted from workers/request-handlers/entities.mjs (#4668/#4686) into this
+// neutral module so src/mcp-server.mjs (#4694) can share the identical
+// contract without importing a route-handler file or duplicating the fallback
+// logic -- REST's handleBlocks/handleExtrinsics and MCP's list_extrinsics/
+// get_extrinsic all call this same function.
+//
+// Every branch below logs before falling back (#4686) -- prior to this, a
+// canceled/failed DATA_API subrequest was indistinguishable from "the flag
+// isn't on," which let a silently-unreliable Postgres tier look shipped
+// while actually falling back to D1 on most requests (see the blocks-tier
+// incident this was added for: METAGRAPH_BLOCKS_SOURCE was flipped, live
+// re-testing found DATA_API subrequests reporting outcome "canceled" on a
+// real fraction of requests, and there was no signal anywhere to catch it
+// before a wider live-testing pass happened to notice).
+export async function tryPostgresTier(env, request, flagName) {
+  if (env[flagName] !== "postgres" || !env.DATA_API) return null;
+  let upstream;
+  try {
+    upstream = await env.DATA_API.fetch(request);
+  } catch (err) {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API fetch failed, falling back to D1:`,
+      err,
+    );
+    return null;
+  }
+  if (!upstream.ok) {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status}, falling back to D1`,
+    );
+    return null;
+  }
+  let body;
+  try {
+    body = await upstream.json();
+  } catch (err) {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API response body unparseable, falling back to D1:`,
+      err,
+    );
+    return null;
+  }
+  if (!body || typeof body !== "object") {
+    console.error(
+      `tryPostgresTier(${flagName}): DATA_API response was not a JSON object, falling back to D1`,
+    );
+    return null;
+  }
+  return body;
+}

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -34,6 +34,7 @@ import {
   envelopeResponse,
   publishedAt,
 } from "../responses.mjs";
+import { tryPostgresTier } from "../postgres-tier.mjs";
 import { csvRequested, csvResponse } from "../csv.mjs";
 import {
   analyticsQueryError,
@@ -3399,61 +3400,6 @@ export async function handleSubnetRecycled(request, env, netuid) {
     { data, meta: { contract_version: contractVersion(env) } },
     "short",
   );
-}
-
-// Gated D1 -> Postgres serving cutover (ADR 0013 Sequencing step 3, the
-// deploy/README.md "Serving cutover" runbook: "if FLAG[tier] == postgres: try
-// Postgres; on error -> D1"). Each tier has its own env flag so a rollback is a
-// single-flag flip, never a code change or redeploy of the fallback path.
-// `request` is forwarded UNCHANGED to the DATA_API service binding -- the caller
-// has already run the SAME validation the D1 path runs (analytics.mjs's
-// validateEntityQuery + friends), so this trusts well-formed params and treats
-// ANY failure (binding absent, network error, non-2xx, unparseable/malformed
-// body) as "fall back to D1", never as a client-facing error. Postgres never
-// gets to independently fail a request the D1 path would have served.
-// Every branch below logs before falling back (#4686) -- prior to this, a
-// canceled/failed DATA_API subrequest was indistinguishable from "the flag
-// isn't on," which let a silently-unreliable Postgres tier look shipped
-// while actually falling back to D1 on most requests (see the blocks-tier
-// incident this was added for: METAGRAPH_BLOCKS_SOURCE was flipped, live
-// re-testing found DATA_API subrequests reporting outcome "canceled" on a
-// real fraction of requests, and there was no signal anywhere to catch it
-// before a wider live-testing pass happened to notice).
-async function tryPostgresTier(env, request, flagName) {
-  if (env[flagName] !== "postgres" || !env.DATA_API) return null;
-  let upstream;
-  try {
-    upstream = await env.DATA_API.fetch(request);
-  } catch (err) {
-    console.error(
-      `tryPostgresTier(${flagName}): DATA_API fetch failed, falling back to D1:`,
-      err,
-    );
-    return null;
-  }
-  if (!upstream.ok) {
-    console.error(
-      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status}, falling back to D1`,
-    );
-    return null;
-  }
-  let body;
-  try {
-    body = await upstream.json();
-  } catch (err) {
-    console.error(
-      `tryPostgresTier(${flagName}): DATA_API response body unparseable, falling back to D1:`,
-      err,
-    );
-    return null;
-  }
-  if (!body || typeof body !== "object") {
-    console.error(
-      `tryPostgresTier(${flagName}): DATA_API response was not a JSON object, falling back to D1`,
-    );
-    return null;
-  }
-  return body;
 }
 
 // GET /api/v1/blocks: the recent-block feed (newest first), served live from the


### PR DESCRIPTION
## Summary

- `list_extrinsics`/`get_extrinsic` (MCP) were the last D1-only readers left after the blocks/extrinsics REST routes already had the D1 -> Postgres serving cutover (#4668/#4686/#4685). This wires them through the same `METAGRAPH_EXTRINSICS_SOURCE` flag, so the tool and `GET /api/v1/extrinsics` can no longer diverge on which tier answered a given request.
- Extracted `tryPostgresTier` out of `workers/request-handlers/entities.mjs` into a neutral `workers/postgres-tier.mjs` so both REST and MCP share the identical fallback contract (Postgres first, any failure falls back to D1, never a client-facing error) instead of duplicating it.
- MCP tool handlers receive structured `args`, not an inbound `Request` the way REST's `handleExtrinsics` does — `mcpExtrinsicsListRequest`/`mcpExtrinsicDetailRequest` reconstruct the identical query-string shape `workers/data-api.mjs`'s extrinsics routes parse (no `call_hash`, since that filter is REST-only per #4322 and isn't in `list_extrinsics`' inputSchema).
- Added the missing `URLSearchParams` ESLint global (genuine pre-existing gap — no code had constructed one from scratch before).

## Test plan

- [x] `npx vitest run tests/mcp-server.test.mjs tests/request-handlers-entities.test.mjs` — 1081 passed (the 369 pre-existing `entities.mjs` tests pass unchanged post-extraction, confirming byte-identical behavior)
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run validate` clean
- [x] `npm run test:coverage` — 7078 passed; `workers/postgres-tier.mjs` at 100% statements/branches/functions/lines; the two remaining uncovered lines in `mcp-server.mjs`/`entities.mjs` are both pre-existing gaps well outside this diff
- [x] `npm run build` — no unexpected artifact drift
- [x] Rebased onto latest `main` (post-#4725) before opening

Closes #4694