### PR TITLE
fix(nav): point Subnets mega-menu filters at params the route reads

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
@@ -109,6 +109,38 @@ describe("MEGA_PANELS catalogue", () => {
       }
     }
   });
+
+  it("only links to route-consumed filter params/values on /subnets", () => {
+    // /subnets (routes/subnets.index.tsx) filters rows on the params its
+    // predicate actually reads — q / curation / health / serviceKind /
+    // readiness — and its facet chips enumerate the allowed values. The old
+    // kind=api|docs|sse links used a `kind` field that lives in the schema but
+    // the predicate never consumes, and stale=1 wasn't in the schema at all —
+    // both silently rendered the full unfiltered list. Pin every /subnets
+    // filter link to a param+value the predicate applies.
+    const CONSUMED_KEYS = new Set(["q", "curation", "health", "serviceKind", "readiness"]);
+    const FACET_VALUES: Record<string, Set<string>> = {
+      curation: new Set([
+        "native",
+        "candidate-discovered",
+        "machine-verified",
+        "maintainer-reviewed",
+        "adapter-backed",
+      ]),
+      health: new Set(["ok", "warn", "down", "unknown"]),
+      serviceKind: new Set(["subnet-api", "openapi", "sse", "data-artifact"]),
+      readiness: new Set(["buildable", "emerging", "identity-only", "dormant"]),
+    };
+    const subnets = MEGA_PANELS.find((p) => p.key === "subnets");
+    expect(subnets).toBeDefined();
+    for (const l of [...subnets!.browse, ...subnets!.filters]) {
+      for (const [param, value] of Object.entries(l.search ?? {})) {
+        expect(CONSUMED_KEYS.has(param)).toBe(true);
+        const allowed = FACET_VALUES[param];
+        if (allowed) expect(allowed.has(value)).toBe(true);
+      }
+    }
+  });
 });
 
 describe("storage helpers (SSR/node-safe)", () => {

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -46,10 +46,10 @@ export const MEGA_PANELS: MegaPanel[] = [
       { to: "/subnets/74", label: "Gittensor · SN74", hint: "Adapter-backed pilot" },
     ],
     filters: [
-      { to: "/subnets", search: { kind: "api" }, label: "Has APIs" },
-      { to: "/subnets", search: { kind: "docs" }, label: "Has docs" },
-      { to: "/subnets", search: { kind: "sse" }, label: "Has SSE" },
-      { to: "/subnets", search: { stale: "1" }, label: "Stale > 24h" },
+      { to: "/subnets", search: { serviceKind: "subnet-api" }, label: "Has APIs" },
+      { to: "/subnets", search: { serviceKind: "openapi" }, label: "Has docs" },
+      { to: "/subnets", search: { serviceKind: "sse" }, label: "Has SSE" },
+      { to: "/subnets", search: { health: "unknown" }, label: "Stale > 24h" },
     ],
   },
   {


### PR DESCRIPTION
## Problem

The primary-nav **Subnets** mega-panel builds four "quick filter" links whose search params the `/subnets` route's filter predicate never reads, so every one is a silent no-op — the page loads unfiltered regardless of which was clicked (`nav-mega-menu-data.ts`, the subnets panel):

| Link (label) | Old param | `/subnets` predicate reads it? |
| --- | --- | --- |
| Has APIs | `kind=api` | no — `kind` is in the schema but the predicate never consumes it |
| Has docs | `kind=docs` | no — same |
| Has SSE | `kind=sse` | no — same |
| Stale > 24h | `stale=1` | no — `stale` isn't in the schema at all |

`subnets.index.tsx`'s filter predicate reads `q` / `curation` / `health` / `serviceKind` / `readiness` (confirmed by grepping `search.` — `kind` never appears in the predicate, and `stale` isn't a `tableSearchSchema` field at all), and the facet chips enumerate the real values. Clicking any of these four lands on an unfiltered `/subnets` list with no cue the filter failed. This is the same class as the already-merged Endpoints mega-menu fix (#3972).

## Fix

Repoint each link to a param + value the predicate actually applies. **Only the `search` params change — every visible `label` is untouched**, so this is a pure data correction with no rendered-text change.

- `kind: "api"` → `serviceKind: "subnet-api"` and `kind: "sse"` → `serviceKind: "sse"` — the exact values in `s.service_kinds` that the capability predicate matches (`(s.service_kinds ?? []).includes(search.serviceKind)`); the `service` facet enumerates `["subnet-api", "openapi", "sse", "data-artifact"]`.
- `kind: "docs"` → `serviceKind: "openapi"` — OpenAPI specs are the registry's machine-readable API-docs surface, so "Has docs" maps to the `openapi` service kind.
- `stale: "1"` → `health: "unknown"` — there is no dedicated staleness *filter* on `/subnets` (staleness drives probe recency, not the predicate); `health: "unknown"` is the probe bucket for un/under-probed subnets, matching the mapping the merged Endpoints fix used for its own "Stale probes" link.

The adjacent, already-working `curation=machine-verified` / `curation=maintainer-reviewed` browse links are untouched.

## Test

Adds a `nav-mega-menu-data.test.ts` case mirroring the existing `/endpoints` guard: every `/subnets` mega-menu link must carry a param the route predicate consumes (`q` / `curation` / `health` / `serviceKind` / `readiness`) with a value in the facet enum — so a future param/value drift (like the old `kind` / `stale`) fails CI instead of silently rendering the unfiltered list.

Local: `tsc --noEmit` clean, `eslint` 0 errors, `prettier --check` clean, `vitest` (nav-mega-menu-data) 7 pass. Only `nav-mega-menu-data.ts` + its test change; no rendered output changes.

Closes #3973
