### PR TITLE
feat(registry): add SN118 Ditto public API endpoint via TaoMarketCap

### DIFF
--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -268,6 +268,25 @@
         "https://github.com/ditto-assistant/dittobench-starter-kit/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/ditto-assistant/dittobench-starter-kit/main/fixtures/seed-user/memory_cases.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-118-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Ditto public subnet-state API (via TaoMarketCap)",
+      "notes": "Public no-auth GET https://api.taomarketcap.com/public/v1/subnets/118 from the TaoMarketCap developer API — returns machine-readable JSON for SN118's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields (verified live: HTTP 200, netuid 118). Ditto's own first-party endpoints under heyditto.ai are auth-gated, so this is the subnet's verified public no-auth API surface.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation",
+        "https://heyditto.ai/"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/118"
     }
   ],
   "website_url": "https://heyditto.ai/"


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/ditto.json` (SN118, Ditto). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 118
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/118
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://heyditto.ai/
- **Provider slug:** `taomarketcap`

Ditto's first-party endpoints under `heyditto.ai` are auth-gated (`api.heyditto.ai` requires a bearer token), so it exposes no verified first-party no-auth public API. The TaoMarketCap developer API documents a public no-auth `GET /public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 118.

## Test plan

- [x] `npm run surface:add` — OK reachable + public-safe
- [x] `npm run validate:surface -- registry/subnets/ditto.json` — passed (12 surfaces, 1 file)
- [x] `npm run scan:public-safety -- registry/subnets/ditto.json` — passed
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/118` returns HTTP 200 with valid JSON (`netuid: 118`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4163
