### PR TITLE
feat(registry): add SN73 MetaHash TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/metahash.json
+++ b/registry/subnets/metahash.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-73-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "MetaHash TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/73 on api.taomarketcap.com returning machine-readable JSON for SN73 MetaHash on-chain subnet state, hyperparameters, economics, and dTAO market fields. MetaHash's previously discovered docs and source URLs do not resolve and no first-party public API endpoint is verified; this indexed on-chain feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/73"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #4087

Adds a community `subnet-api` surface for SN73 MetaHash: the TaoMarketCap subnet snapshot API.

**What it is:** `GET https://api.taomarketcap.com/public/v1/subnets/73` — public, no-auth, machine-readable JSON covering SN73's on-chain subnet state, hyperparameters, economics, and dTAO market fields. Verified live (HTTP 200, JSON) at submission time.

**Why this surface:** SN73 MetaHash currently has no verified first-party surfaces at all — the manifest's curation notes record that its previously discovered docs domain does not resolve and its source repository returns 404. The indexed on-chain feed reports chain state for netuid 73 regardless of the team's own web presence, and it is the same provider/URL pattern already accepted in this registry for SN20, SN30, SN40, SN52, SN69, SN72, SN83, SN86, SN89, SN101, SN109, SN111, and SN116.

**Provenance:** the endpoint family is documented in the TaoMarketCap developer API (first `source_urls` entry); the tensorplex-labs subnet-docs entry for netuid 73 cross-references the subnet identity (the provenance pattern accepted for the EfficientFrontier, SN30, and SN69 surfaces).

One file touched (`registry/subnets/metahash.json`), append-only; no `curation`/top-level metadata changes. `npm run validate`, `npm run validate:surface`, and the full artifact test suites (27/27, including the internal-consistency and R2-upload checks) pass locally.