### PR TITLE
feat(ui): wire the review/enrichment-evidence queue into the gaps review surface

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -7014,6 +7014,42 @@ export const reviewEnrichmentTargetsQuery = () =>
     staleTime: STALE_LONG,
   });
 
+// #3354: the per-subnet evidence behind the enrichment queue -- distinct from
+// the enrichment-queue rollup and the enrichment-targets board above (per the
+// MCP tool description, "distinct from list_enrichment_queue"). GET
+// /api/v1/review/enrichment-evidence, flat `entries` list.
+export const reviewEnrichmentEvidenceQuery = () =>
+  queryOptions({
+    queryKey: k("review-enrichment-evidence"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/enrichment-evidence",
+        "entries",
+        undefined,
+        signal,
+      );
+      // API rows: { netuid, name, slug, lane, evidence_action, missing_kinds,
+      // direct_submission_kinds, priority_score, ... }.
+      const rows = res.data.map((r) => ({
+        id: (r.slug as string) ?? (r.name as string) ?? String(r.netuid ?? ""),
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        lane: r.lane as string | undefined,
+        evidenceAction: r.evidence_action as string | undefined,
+        missingKinds: Array.isArray(r.missing_kinds) ? (r.missing_kinds as string[]) : [],
+        directSubmissionKinds: Array.isArray(r.direct_submission_kinds)
+          ? (r.direct_submission_kinds as string[])
+          : [],
+        priority:
+          typeof r.priority_score === "number"
+            ? String(Math.round(r.priority_score as number))
+            : undefined,
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
 function normalizeSchema(raw: unknown): SchemaInfo {
   if (!raw || typeof raw !== "object") return raw as SchemaInfo;
   const s = raw as Record<string, unknown>;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -30,6 +30,7 @@ import {
   reviewAdapterCandidatesQuery,
   reviewEnrichmentQueueQuery,
   reviewEnrichmentTargetsQuery,
+  reviewEnrichmentEvidenceQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
@@ -215,6 +216,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="enrichment-evidence"
+          eyebrow="Evidence"
+          title="Enrichment evidence"
+          description="The detailed candidate evidence behind the enrichment queue — one level down from the summary above."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <EnrichmentEvidence />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -224,6 +238,7 @@ function GapsPage() {
           "/api/v1/review/adapter-candidates",
           "/api/v1/review/enrichment-queue",
           "/api/v1/review/enrichment-targets",
+          "/api/v1/review/enrichment-evidence",
         ]}
       />
     </AppShell>
@@ -1076,6 +1091,75 @@ function EnrichmentTargets() {
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// #3354: the detailed candidate evidence behind the enrichment queue -- one
+// level down from EnrichmentQueue's summary rollup. Mirrors the same table
+// idiom, sourced from /api/v1/review/enrichment-evidence.
+function EnrichmentEvidence() {
+  const { data } = useSuspenseQuery(reviewEnrichmentEvidenceQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No enrichment evidence"
+        description="No candidate evidence is currently behind the enrichment queue."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-4 py-2.5 text-left">Netuid</th>
+              <th className="px-4 py-2.5 text-left">Lane</th>
+              <th className="px-4 py-2.5 text-left">Evidence action</th>
+              <th className="px-4 py-2.5 text-left">Missing kinds</th>
+              <th className="px-4 py-2.5 text-left">Direct submission kinds</th>
+              <th className="px-4 py-2.5 text-left">Priority</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => (
+              <tr key={r.id} className="mg-row-hover">
+                <td className="px-4 py-2.5 font-mono text-[11px]">
+                  {r.netuid != null ? (
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="hover:text-accent"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.lane ?? "—"}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {r.evidenceAction ?? "—"}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                  {r.missingKinds.length > 0 ? r.missingKinds.join(", ") : "—"}
+                </td>
+                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                  {r.directSubmissionKinds.length > 0 ? r.directSubmissionKinds.join(", ") : "—"}
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
Closes #3354

`gaps.tsx` already wires the queue-summary sibling (`reviewEnrichmentQueueQuery`, `EnrichmentQueue` section) and the per-target board (`reviewEnrichmentTargetsQuery`, `EnrichmentTargets` section, #3355), but had no query for the more granular `GET /api/v1/review/enrichment-evidence` — distinct from both per the MCP tool description ("distinct from list_enrichment_queue").

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `reviewEnrichmentEvidenceQuery`, following the exact `reviewEnrichmentQueueQuery`/`reviewEnrichmentTargetsQuery` pattern: `fetchList` against `/api/v1/review/enrichment-evidence` on the `entries` collection key, normalizing `netuid`, `lane`, `evidence_action`, `missing_kinds`, `direct_submission_kinds`, `priority_score`.
- **`apps/ui/src/routes/gaps.tsx`** — new `EnrichmentEvidence` component + `<PageSection id="enrichment-evidence">` mounted after the `enrichment-targets` section, mirroring the sibling table idiom exactly (same `TableState` empty state, same `Suspense`/`QueryErrorBoundary` wrapper, same `mg-row-hover` row styling), and `/api/v1/review/enrichment-evidence` appended to `ApiSourceFooter`.

## Scope note — column set matches the issue's acceptance criteria exactly

The issue's acceptance criteria lists six fields to render: netuid (linked), lane, evidence_action, missing_kinds, direct_submission_kinds, priority_score. This PR renders exactly those six and nothing more — no additional `name`/subnet-label column. That's a deliberate scoping decision, not an oversight: a 7th column crowds the table at the 375px mobile viewport (confirmed by testing) enough that column headers start truncating mid-word before the horizontal-scroll boundary, whereas six columns keep every header fully legible within the same sibling-table mobile convention (`EnrichmentQueue`/`EnrichmentTargets` already scroll horizontally on mobile — this table does the same, just with headers that don't clip).

**Coordination note:** I'm aware of another open PR against this same issue/file (#4682). Flagging for the maintainer's awareness in case both are still live at review time — whichever lands, the other should be closed as superseded rather than both merging.

## Verification

- Confirmed end-to-end against live production data: real rows render correctly across the full priority range (e.g. SN64 at 380, down through low-priority entries), `missing_kinds`/`direct_submission_kinds` comma-join correctly when populated and show `—` when empty, netuid links resolve to `/subnets/$netuid`.
- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, +1 warning (the same `react-refresh/only-export-components` class every sibling section in this file already carries — 215 → 216, confirmed via a before/after diff of the lint output)
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 684 passed, no regressions (no dedicated test file added — `reviewEnrichmentQueueQuery`/`reviewEnrichmentTargetsQuery`/`reviewAdapterCandidatesQuery` have no existing test coverage to extend either, consistent with this area's convention)
- `npm run test:e2e --workspace=apps/ui` (deterministic responsive-overflow check) — 24/24 passed; `/gaps` isn't one of the HAR-checked routes so no fixture re-record was needed
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-after-mobile-dark.png)<br><sub>after</sub> |
