### PR TITLE
feat(registry): add SN38 ChronoLLM public API endpoint via TaoMarketCap

### DIFF
--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -1,5 +1,6 @@
 {
   "categories": [],
+  "contact": "crew@crunchdao.com",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
@@ -8,6 +9,10 @@
   "netuid": 38,
   "schema_version": 1,
   "slug": "sn-38",
+  "social": {
+    "x": "https://x.com/chronollm"
+  },
+  "source_repo": "https://github.com/chronollm/sn38",
   "status": "active",
   "surfaces": [
     {
@@ -60,12 +65,26 @@
         "https://huggingface.co/manelalab"
       ],
       "url": "https://huggingface.co/datasets/manelalab/ChronoInstruct-SFT-v1"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-38-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "ChronoLLM public subnet-state API (via TaoMarketCap)",
+      "notes": "Public no-auth GET https://api.taomarketcap.com/public/v1/subnets/38 from the TaoMarketCap developer API — returns machine-readable JSON for SN38's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields (verified live: HTTP 200, netuid 38). ChronoLLM publishes docs and HuggingFace datasets but no first-party no-auth public subnet API, so this is its verified public no-auth API surface.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation",
+        "https://chronollm.crunchdao.com/"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/38"
     }
   ],
-  "source_repo": "https://github.com/chronollm/sn38",
-  "contact": "crew@crunchdao.com",
-  "website_url": "https://chronollm.crunchdao.com/",
-  "social": {
-    "x": "https://x.com/chronollm"
-  }
+  "website_url": "https://chronollm.crunchdao.com/"
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/chronollm.json` (SN38, ChronoLLM). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 38
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/38
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://chronollm.crunchdao.com/
- **Provider slug:** `taomarketcap`

ChronoLLM publishes docs (`github.com/chronollm/sn38`) and HuggingFace datasets but exposes no first-party no-auth public subnet API. The TaoMarketCap developer API documents a public no-auth `GET /public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 38.

## Test plan

- [x] `npm run surface:add` — OK reachable + public-safe
- [x] `npm run validate:surface -- registry/subnets/chronollm.json` — passed (4 surfaces, 1 file)
- [x] `npm run scan:public-safety -- registry/subnets/chronollm.json` — passed
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/38` returns HTTP 200 with valid JSON (`netuid: 38`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4039
