### PR TITLE
feat(ui): add an RSS feed discovery link to the site footer (#3351)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Compass, Github, Menu, Webhook, X } from "lucide-react";
+import { ChevronRight, Compass, Github, Menu, Rss, Webhook, X } from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -307,6 +307,20 @@ function SiteFooter() {
               className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
             >
               <DiscordIcon className="size-4" />
+            </a>
+            {/* #3351: discoverable RSS/Atom feed for the registry-changes feed
+                (/api/v1/feeds/registry, content-negotiated; .rss for a predictable
+                browser click). Same guarded external-link pattern as the openapi
+                link and the GitHub/Discord icons above. */}
+            <a
+              href={safeExternalUrl(`${API_BASE}/api/v1/feeds/registry.rss`)}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Registry changes RSS feed"
+              title="Subscribe to the registry-changes feed (RSS)"
+              className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+            >
+              <Rss className="size-4" />
             </a>
           </div>
         </div>


### PR DESCRIPTION
Closes #3351

Adds a discoverable RSS feed icon-link to `SiteFooter` (beside GitHub/Discord) → `${API_BASE}/api/v1/feeds/registry.rss`, via the same `safeExternalUrl()` + `target=_blank rel=noopener` + `aria-label` pattern as the neighbours. UI-only, 1 file. Rebased onto latest `main` so the navbar in the after-shots matches production.

### Before / after — site footer (adds the RSS icon; before = production)

| View · Theme | Before | After |
|---|---|---|
| Desktop·Light | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-desktop-light-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-desktop-light-after.png) |
| Desktop·Dark | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-desktop-dark-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-desktop-dark-after.png) |
| Tablet·Light | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-tablet-light-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-tablet-light-after.png) |
| Tablet·Dark | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-tablet-dark-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-tablet-dark-after.png) |
| Mobile·Light | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-mobile-light-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-mobile-light-after.png) |
| Mobile·Dark | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-mobile-dark-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/footerv2-mobile-dark-after.png) |
