### PR TITLE
feat(registry): add SN16 BitAds TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -117,6 +117,25 @@
         "https://github.com/study-service/BitAds.ai/blob/main/min_compute.yml"
       ],
       "url": "https://raw.githubusercontent.com/study-service/BitAds.ai/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-16-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "BitAds TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/16 on api.taomarketcap.com returning machine-readable JSON for SN16 BitAds on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/study-service/BitAds.ai"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/16"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Enriches **SN16 BitAds** with a public no-auth subnet-state API as a `subnet-api` surface.

- **url:** `https://api.taomarketcap.com/public/v1/subnets/16` — public, no-auth JSON (on-chain state, SubnetIdentitiesV3 metadata, economics, dTAO market fields), documented in the TaoMarketCap developer API.

## Why it's safe

- One file, one `subnet-api` surface (provider `taomarketcap` already registered); purely additive.
- Not a duplicate (SN16 has no existing taomarketcap surface).
- Same accepted pattern as the merged SN52 Dojo (#4655) and SN83 CliqueAI (#4666) TaoMarketCap subnet-api surfaces.
- `validate:surface` + `scan:public-safety` pass locally.

Closes #720