### PR TITLE
feat(ui): render human-readable event-kind labels in the block + account + extrinsic event tables

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -62,6 +62,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
+import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import type {
   AccountCounterparty,
   AccountStakeFlowSubnet,
@@ -2043,8 +2044,11 @@ function AccountEventsSection({
                       "—"
                     )}
                   </td>
-                  <td className="px-5 py-4 font-mono text-[11px] text-ink-strong">
-                    {ev.event_kind ?? "—"}
+                  <td
+                    className="px-5 py-4 font-mono text-[11px] text-ink-strong"
+                    title={ev.event_kind ?? undefined}
+                  >
+                    {eventKindLabel(ev.event_kind)}
                   </td>
                   <td className="px-5 py-4 font-mono text-[11px] text-ink-muted">
                     {ev.netuid != null ? (

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -24,6 +24,7 @@ import { formatNumber } from "@/lib/metagraphed/format";
 import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
+import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 
 export const Route = createFileRoute("/blocks/$ref")({
   // #3422: validate the ref at the router level so an invalid one renders the
@@ -388,8 +389,11 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                       key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
                       className="hover:bg-surface/40"
                     >
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                        {event.event_kind ?? "—"}
+                      <td
+                        className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
+                        title={event.event_kind ?? undefined}
+                      >
+                        {eventKindLabel(event.event_kind)}
                       </td>
                       <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
                         {event.hotkey ? (

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -17,6 +17,7 @@ import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { unwrapByteArray, decodeBytesField } from "@/lib/metagraphed/bytes";
+import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import {
   asDecodedCall,
   extrinsicCall,
@@ -359,8 +360,11 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                         "—"
                       )}
                     </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                      {ev.event_kind ?? "—"}
+                    <td
+                      className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
+                      title={ev.event_kind ?? undefined}
+                    >
+                      {eventKindLabel(ev.event_kind)}
                     </td>
                     <td className="px-4 py-2.5 font-mono text-[11px]">
                       {ev.hotkey ? (


### PR DESCRIPTION
Closes #3368

Three separate event tables (`blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `accounts.$ss58.tsx`'s `AccountEventsSection`) each rendered the raw on-chain `event_kind` string (`StakeAdded`, `HotkeySwapped`, etc.) with no humanization — the same `event.event_kind ?? "—"` pattern duplicated three times. #3366 (PR #3563) already merged `apps/ui/src/lib/metagraphed/event-kinds.ts`'s `eventKindLabel()` helper, but nothing imported it yet.

## What changed

All three files, identically:
- Import `eventKindLabel` from `@/lib/metagraphed/event-kinds` (no reimplementation — `event-kinds.ts` itself is untouched).
- Replace the raw `event.event_kind ?? "—"` / `ev.event_kind ?? "—"` render with `eventKindLabel(event.event_kind)`, preserving each file's existing cell classes exactly (`blocks.$ref.tsx`/`extrinsics.$hash.tsx` use `px-4 py-2.5 font-mono text-[11px] text-ink-strong`; `accounts.$ss58.tsx` uses its own `px-5 py-4 font-mono text-[11px] text-ink-strong` — kept as-is, not unified).
- Add `title={event.event_kind ?? undefined}` on each `<td>` so the raw kind is still inspectable on hover (React omits the attribute entirely when `event_kind` is null, since there's nothing to show).

Text only — no category color/chip styling (that's #3367's separate scope on `subnets.$netuid.tsx`, untouched here) and no filter UI (#3369).

## Verification

**Production's block/extrinsic/account-event data is currently empty** (`/api/v1/blocks` returns `block_count: 0`, block-detail lookups return `block: null`) — a transient chain-indexer gap unrelated to this PR. To get a meaningful before/after (not two empty-state screenshots), I mocked realistic API responses — the same schema `blockEventsQuery`/`extrinsicQuery`/`accountEventsQuery` actually normalize — behind **both** a before-worktree dev server (running the unmodified merge-base code) and my branch's dev server, so the only difference between the two renders is this PR's code change, not live-data variance. Verified this way against all four label cases the helper defines: a mapped kind (`StakeAdded` → `Stake added`), a second mapped kind in a different category (`HotkeySwapped` → `Hotkey swapped`, `ColdkeySwapped` → `Coldkey swapped`), an unmapped kind (`SomeUnmappedFutureEvent`/`SomeFutureKind` → humanized fallback `Some Unmapped Future Event`), and `null` (→ `Unknown event`, no `title` attribute). Confirmed no console errors introduced (one pre-existing unrelated React nesting warning on the account page reproduces identically on the unmodified baseline — not caused by this diff).

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 new warnings
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 684 passed, no regressions
- `npm run test:e2e --workspace=apps/ui` (deterministic responsive-overflow check) — 24/24 passed; none of the three touched routes are in the HAR-checked list so no fixture re-record was needed
- `npm run build --workspace=apps/ui` — clean

## Screenshot scope note

The underlying change is textually identical across all three files (one table column, one substitution). Per Phase C2 I've provided the **full 12-image contract (3 viewports × 2 themes × before/after)** for the block-detail page — the clearest single demo since it exercises all four label cases at once — plus **supplementary desktop-only before/after pairs** for the extrinsic-detail and account-detail pages, since their visual delta is the identical single-column text substitution and doesn't need separate per-viewport verification to prove the mechanism works.

### Block detail — full contract

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/block-after-mobile-dark.png)<br><sub>after</sub> |

### Extrinsic detail — supplementary (desktop only)

| Theme | Before | After |
|---|---|---|
| Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-after-desktop-light.png)<br><sub>after</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsic-after-desktop-dark.png)<br><sub>after</sub> |

### Account detail — supplementary (desktop only)

| Theme | Before | After |
|---|---|---|
| Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-after-desktop-light.png)<br><sub>after</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/account-after-desktop-dark.png)<br><sub>after</sub> |
