### PR TITLE
feat(api): build account_events Postgres serving route + flag

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -406,6 +406,21 @@ const EXTRINSIC_ROW = {
   observed_at: "1783600000000",
 };
 
+const SS58 = "5Hot";
+const ACCOUNT_EVENT_ROW = {
+  block_number: "8586300",
+  event_index: 0,
+  extrinsic_index: 2,
+  event_kind: "StakeAdded",
+  hotkey: SS58,
+  coldkey: "5Cold",
+  netuid: 4,
+  uid: 1,
+  amount_tao: "1.5",
+  alpha_amount: "0",
+  observed_at: "1783600000000",
+};
+
 test("GET /api/v1/blocks returns a block feed shaped like the D1 route", async () => {
   mockRows.current = [BLOCK_ROW];
   const res = await req("/api/v1/blocks?limit=1");
@@ -599,6 +614,61 @@ test("GET /api/v1/extrinsics/:ref skips the embedded-events query on an unresolv
   expect(body.extrinsic).toBeNull();
   expect(body.events).toEqual([]);
   expect(sqlCalls.length).toBe(2); // SET + the main lookup, no events query
+});
+
+test("GET /api/v1/accounts/:ss58/events returns a feed shaped like the D1 route", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  const res = await req(`/api/v1/accounts/${SS58}/events?limit=1`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ss58).toBe(SS58);
+  expect(body.event_count).toBe(1);
+  const ev = body.events[0];
+  expect(ev.block_number).toBe(8586300);
+  expect(ev.event_kind).toBe("StakeAdded");
+  expect(ev.amount_tao).toBe(1.5);
+});
+
+test("GET /api/v1/accounts/:ss58/events matches hotkey OR coldkey in one flat WHERE, no INDEXED BY / dedup guard", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  await req(`/api/v1/accounts/${SS58}/events`);
+  const text = queryText();
+  expect(text).toContain("WHERE (hotkey =");
+  expect(text).toContain("OR coldkey =");
+  expect(text).not.toContain("INDEXED BY");
+  expect(text).not.toContain("UNION");
+  expect(text).not.toContain("hotkey <>");
+});
+
+test("GET /api/v1/accounts/:ss58/events applies the same filter set as loadAccountEvents", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  await req(
+    `/api/v1/accounts/${SS58}/events?kind=StakeAdded&netuid=4&block_start=1&block_end=2`,
+  );
+  const text = queryText();
+  expect(text).toContain("AND event_kind =");
+  expect(text).toContain("AND netuid =");
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+});
+
+test("GET /api/v1/accounts/:ss58/events uses a composite cursor seek instead of OFFSET", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  await req(`/api/v1/accounts/${SS58}/events?cursor=8586300.0`);
+  const text = queryText();
+  expect(text).toContain("AND (block_number, event_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/accounts/:ss58/events with no matching rows returns a schema-stable empty feed", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/accounts/${SS58}/events`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.ss58).toBe(SS58);
+  expect(body.event_count).toBe(0);
+  expect(body.events).toEqual([]);
+  expect(body.next_cursor).toBeNull();
 });
 
 test("POST is rejected with 405", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -6164,6 +6164,61 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.extrinsic.extrinsic_hash, HASH);
   });
+
+  test("handleAccountEvents: flag absent, uses D1 even when DATA_API is bound", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        ss58: SS58,
+        event_count: 99,
+        events: [],
+      }),
+    );
+    const path = `/api/v1/accounts/${SS58}/events`;
+    const body = await json(
+      await handleAccountEvents(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.event_count, 1); // the D1 fixture's count, not 99
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        ss58: SS58,
+        event_count: 99,
+        limit: 50,
+        offset: 0,
+        next_cursor: null,
+        events: [],
+      }),
+    );
+    const path = `/api/v1/accounts/${SS58}/events`;
+    const body = await json(
+      await handleAccountEvents(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.event_count, 99);
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountEvents: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const path = `/api/v1/accounts/${SS58}/events`;
+    const body = await json(
+      await handleAccountEvents(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.event_count, 1);
+  });
 });
 
 // ---- Cross-handler contract smoke tests -------------------------------------

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -13,7 +13,10 @@ import postgres from "postgres";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
 import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "../src/extrinsics.mjs";
-import { formatAccountEvent } from "../src/account-events.mjs";
+import {
+  buildAccountEvents,
+  formatAccountEvent,
+} from "../src/account-events.mjs";
 import { decodeChainEventArgs } from "../src/chain-event-args.mjs";
 
 const MAX_LIMIT = 200;
@@ -321,6 +324,61 @@ export default {
           events = eventRows.map(formatAccountEvent).filter(Boolean);
         }
         return json(buildExtrinsic(resolved, ref, events));
+      }
+
+      // GET /api/v1/accounts/:ss58/events — the per-account signed-event feed
+      // (#4696), mirroring src/account-events.mjs's loadAccountEvents filter
+      // set (kind, netuid, block_start/block_end, cursor). account_events has
+      // no shape-parity risk (11 scalar columns, its own dedicated writer,
+      // never a generic call_args/chain_events-style SCALE dump) -- unlike
+      // extrinsics/blocks, this tier only needed the query layer built, not a
+      // decode-shape reconciliation.
+      //
+      // D1's hotkey/coldkey union is two INDEXED BY branches combined with
+      // UNION ALL (each SQLite index can only ever seek ONE column), with a
+      // second-branch guard to stop UNION ALL from double-counting a row
+      // where both columns equal the same ss58. Postgres has no INDEXED BY
+      // equivalent and evaluates a flat `WHERE (hotkey = $1 OR coldkey = $1)`
+      // as one plan, so a matching row is naturally visited exactly once --
+      // the double-count guard has nothing to do here and is deliberately
+      // omitted, not an oversight.
+      const acctEvents = url.pathname.match(
+        /^\/api\/v1\/accounts\/([^/]+)\/events$/,
+      );
+      if (acctEvents) {
+        const ss58 = decodeURIComponent(acctEvents[1]);
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const offset = clampOffset(url.searchParams.get("offset"));
+        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+        const kind = url.searchParams.get("kind") || null;
+        const netuid = nonNegativeIntegerParam(url.searchParams, "netuid");
+        const blockStart = nonNegativeIntegerParam(
+          url.searchParams,
+          "block_start",
+        );
+        const blockEnd = nonNegativeIntegerParam(url.searchParams, "block_end");
+        const rows = await sql`
+          SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+          FROM account_events
+          WHERE (hotkey = ${ss58} OR coldkey = ${ss58})
+            ${kind ? sql`AND event_kind = ${kind}` : sql``}
+            ${netuid != null ? sql`AND netuid = ${netuid}` : sql``}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${cursor ? sql`AND (block_number, event_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY block_number DESC, event_index DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+        const last = rows.length === limit ? rows[rows.length - 1] : null;
+        const nextCursor = last
+          ? encodeCursor([
+              numberOrNull(last.block_number),
+              numberOrNull(last.event_index),
+            ])
+          : null;
+        return json(
+          buildAccountEvents(rows, ss58, { limit, offset, nextCursor }),
+        );
       }
 
       // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -2706,15 +2706,17 @@ export async function handleAccountEvents(request, env, ss58, url) {
       message: `"${kind}" is not a supported event kind. Supported: ${INGESTED_EVENT_KINDS.join(", ")}.`,
     });
   }
-  const data = await loadAccountEvents(d1Runner(env), ss58, {
-    limit: url.searchParams.get("limit"),
-    offset: url.searchParams.get("offset"),
-    kind,
-    netuid: netuid.value,
-    cursor: url.searchParams.get("cursor"),
-    blockStart: blockStart.value,
-    blockEnd: blockEnd.value,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountEvents(d1Runner(env), ss58, {
+      limit: url.searchParams.get("limit"),
+      offset: url.searchParams.get("offset"),
+      kind,
+      netuid: netuid.value,
+      cursor: url.searchParams.get("cursor"),
+      blockStart: blockStart.value,
+      blockEnd: blockEnd.value,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       data.events,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -49,11 +49,11 @@
     "METAGRAPH_ENABLE_AI": "true",
     // D1 -> Postgres serving-cutover flags (ADR 0013 Sequencing step 3, the
     // deploy/README.md "Serving cutover" runbook). Set to "postgres" to route
-    // /api/v1/blocks(/{ref}) or /api/v1/extrinsics(/{ref}) through the DATA_API
-    // Hyperdrive Worker instead of D1 -- ANY failure there (binding absent,
-    // network error, bad response) transparently falls back to D1, so flipping
-    // this is a zero-downtime experiment and flipping it back is an instant
-    // rollback.
+    // /api/v1/blocks(/{ref}), /api/v1/extrinsics(/{ref}), or
+    // /api/v1/accounts/{ss58}/events through the DATA_API Hyperdrive Worker
+    // instead of D1 -- ANY failure there (binding absent, network error, bad
+    // response) transparently falls back to D1, so flipping this is a
+    // zero-downtime experiment and flipping it back is an instant rollback.
     //
     // blocks: REVERTED to "d1" 2026-07-09, same day it was flipped to
     // "postgres" (commit b6d910a3). The flip's own verification (block
@@ -150,14 +150,38 @@
     // across every call type; a real investigation into that broader
     // question is tracked separately.
     //
-    // Still open: a TOP-LEVEL (non-nested) call's own AccountId32/byte-blob
-    // fields -- e.g. a bare Balances.transfer's dest, or Multisig's own
-    // other_signatories/max_weight siblings -- are not yet decoded at that
-    // outer layer, only within a reconstructed nested call; MCP's extrinsics
-    // tools are still D1-only (#4694). Do not flip until those land and the
-    // parity harness (#4695) passes clean.
+    // MCP's extrinsics tools (list_extrinsics/get_extrinsic) are wired
+    // through this same flag as of #4694 -- no longer D1-only.
+    //
+    // 2026-07-10: root-caused and fixed the underlying reason Postgres's
+    // call_args ever needed all the reconciliation above -- indexer-rs
+    // (separate private repo metagraphed-indexer-rs) was decoding call
+    // arguments into subxt's type-erased form and serializing that directly,
+    // discarding the chain metadata it already fetches per-block. Fixed at
+    // the source (metagraphed-indexer-rs#1/#2, merged + redeployed to the
+    // live indexer): Postgres's extrinsics.call_args now carries the same
+    // [{name, type, value}, ...] shape D1 produces, verified end-to-end
+    // against real freshly-indexed blocks. IMPORTANT: this only affects rows
+    // written from ~block 8589233 onward -- every row written before that
+    // (the live-indexed history back to ~block 8540006, plus whatever the
+    // separate backfill container processed) still has the old type-blind
+    // shape. extrinsics.call_args in Postgres is a MIX of both shapes until
+    // a full re-backfill replaces the old rows (blocked on the self-hosted
+    // archive node reaching steady-state, ~51% synced as of 2026-07-10).
+    // Do not flip this flag until the parity harness (#4695) accounts for
+    // that mixed-shape reality -- see #4669's tracking-issue comment thread
+    // for the full writeup.
     "METAGRAPH_BLOCKS_SOURCE": "d1",
     "METAGRAPH_EXTRINSICS_SOURCE": "d1",
+    // account_events: no shape-parity risk (#4696) -- account_events is 11
+    // scalar Postgres columns with its own dedicated writer, never modeled
+    // as a generic call_args/chain_events-style SCALE dump, so none of the
+    // AccountId32/byte-blob/nested-call divergence family above applies.
+    // Gates only GET /api/v1/accounts/{ss58}/events; the other
+    // account_events-derived readers (account summary, transfers, subnet
+    // events, leaderboard/turnover/analytics) remain D1-only, portable one
+    // at a time under this same flag in follow-up work.
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE": "d1",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
   // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the


### PR DESCRIPTION
## Summary

- `account_events` is next in ADR 0013's cutover sequencing (`blocks -> extrinsics -> accounts -> metagraph`, `docs/adr/0013-hybrid-deployment-topology.md` step 4). Unlike `extrinsics`, this tier carries **zero shape-parity risk**: 11 scalar Postgres columns with their own dedicated writer, never modeled as a generic `call_args`/`chain_events`-style SCALE dump. Only the query layer was missing — `handleAccountEvents` called D1 unconditionally, with no `tryPostgresTier` gate at all.
- Adds `GET /api/v1/accounts/:ss58/events` to `workers/data-api.mjs`, reproducing `loadAccountEvents`' semantics (hotkey-OR-coldkey match, keyset pagination ordered by `block_number`/`event_index` DESC, `kind`/`netuid`/block-range filters) as **native Postgres SQL**, not a verbatim port of D1's SQLite-only `INDEXED BY` + `UNION ALL` machinery. Postgres evaluates a flat `WHERE (hotkey = $1 OR coldkey = $1)` as one plan, so the double-count guard D1 needs for its two-branch `UNION ALL` has nothing to do here and is deliberately omitted (documented in the route's own comment).
- Wires `tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")` into `handleAccountEvents` ahead of the D1 fallback, mirroring the exact pattern already used for `blocks`/`extrinsics`. `formatAccountEvent` needed no changes — already verified to coerce both backends' numeric widths identically.
- Also updates the (now partly stale) extrinsics flag commentary in `wrangler.jsonc` to reflect this session's `indexer-rs` source-level fix (separate `metagraphed-indexer-rs` repo, `#1`/`#2`, merged + redeployed) and the resulting mixed-shape transition period Postgres's `extrinsics.call_args` is now in until a full re-backfill — see [#4669](https://github.com/JSONbored/metagraphed/issues/4669)'s tracking comment for the full writeup.

## Out of scope (per the issue)

The other `account_events`-derived readers — account summary, transfers, subnet events, leaderboard/turnover/netflow/analytics — remain D1-only. They're portable one at a time under this same flag in follow-up work, and `tryPostgresTier`'s fallback-on-non-2xx contract means none of them break when the flag flips.

## Test plan

- [x] New tests in `tests/data-api.test.mjs`: feed shape, hotkey-OR-coldkey WHERE clause (and absence of `INDEXED BY`/`UNION`/the dedup guard), filter application, cursor-vs-offset, empty-feed schema-stability.
- [x] New tests in `tests/request-handlers-entities.test.mjs`: flag-absent (D1), flag=postgres success (Postgres wins, D1 never queried), flag=postgres failure (silent fallback to D1) — mirrors the existing blocks/extrinsics fallback suite exactly.
- [x] `npx vitest run tests/data-api.test.mjs tests/request-handlers-entities.test.mjs` — 416 passed
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run validate` clean
- [x] `npm run scan:public-safety` clean (a first draft comment tripped the "Bittensor key terminology" heuristic on free-form hotkey/coldkey prose — rephrased around the allowlisted forms rather than loosening the scanner)
- [x] `npm run test:coverage` — 7086 passed; new route code covered, only pre-existing (unrelated, outside this diff) gaps remain
- [x] `npm run build` — no unexpected artifact drift

**Not done (flagged per the issue's own ask, requires a live preview deploy):** the live A/B comparison recording real hotkeys across `StakeAdded`/`StakeRemoved`/`StakeMoved` pre/post flag-flip. This needs an actual Cloudflare preview deploy to execute, which isn't available from local development — happy to run this once a preview is up, or it can be done as part of the actual flag-flip decision.

Closes #4696