### PR TITLE
feat(registry): add SN84 ansuz TaoMarketCap subnet snapshot API

### DIFF
--- a/registry/subnets/ansuz.json
+++ b/registry/subnets/ansuz.json
@@ -110,6 +110,25 @@
         "https://github.com/TatsuProject/ChipForge_SN84/blob/master/README.md"
       ],
       "url": "https://docs.chipforge.io/llms.txt"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-84-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "ansuz TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/84 on api.taomarketcap.com returning machine-readable JSON for SN84 ansuz on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/TatsuProject/ChipForge_SN84"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/84"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN84 ansuz** with a public no-auth subnet-state API as a `subnet-api` surface.

- **url:** `https://api.taomarketcap.com/public/v1/subnets/84` — public, no-auth JSON (on-chain state, SubnetIdentitiesV3 metadata, economics, dTAO market fields), documented in the TaoMarketCap developer API.

## Why it's safe

- One file, one `subnet-api` surface (provider `taomarketcap` already registered); purely additive.
- Not a duplicate (SN84 has no existing taomarketcap surface).
- Same accepted pattern as the merged SN52 Dojo (#4655), SN83 CliqueAI (#4666), and SN16 BitAds (#4734) TaoMarketCap subnet-api surfaces.
- `validate:surface` + `scan:public-safety` pass locally.

Closes #728