### PR TITLE
feat(registry): normalize legacy source_url vs source_urls for the overlay read path

### DIFF
--- a/deploy/postgres/registry-schema.sql
+++ b/deploy/postgres/registry-schema.sql
@@ -77,7 +77,9 @@ CREATE TABLE IF NOT EXISTS surfaces (
   -- source_urls lives only in `overlay` (JSONB array) -- real registry files
   -- use both a legacy singular `source_url` and the current plural
   -- `source_urls` shape, so normalizing it to one dedicated column here would
-  -- misrepresent one of the two. Query it from `overlay` when needed.
+  -- misrepresent one of the two. Query it from `overlay` when needed, via
+  -- src/registry-overlay.mjs's normalizeSurfaceSourceUrls() (#4697) -- the one
+  -- place this reconciliation lives, rather than re-deriving it per route.
   authority        TEXT NOT NULL DEFAULT 'community',
   review_state     TEXT NOT NULL DEFAULT 'community-submitted',
   probe_eligible   BOOLEAN NOT NULL DEFAULT false,

--- a/src/registry-overlay.mjs
+++ b/src/registry-overlay.mjs
@@ -1,0 +1,34 @@
+// Reconciles the registry's surfaces.overlay JSONB shape ahead of the (not
+// yet wired) registry-overlay read path (#4697). deploy/postgres/registry-
+// schema.sql's surfaces table comment flags a dual-shape risk: overlay's
+// write path (workers/registry-sync-api.mjs's isValidRow) does no shape
+// enforcement on a surface's citation field, so a row could in principle
+// carry the current plural `source_urls` array, a legacy singular
+// `source_url` string, or both -- schema-illegal for git-committed
+// registry/subnets/*.json today (schemas/subnet-manifest.schema.json's
+// surface $def only defines source_urls), but not something Postgres itself
+// rejects. Mirrors two existing precedents for the SAME field elsewhere in
+// this codebase (scripts/generated-overlays.mjs's promoteCandidate,
+// scripts/build-artifacts.mjs's AI-claims artifact) rather than inventing a
+// third convention -- this is the one place future overlay-reading code
+// should import from instead of re-deriving the fallback chain.
+//
+// Deliberately scoped to a surface's OWN source_url(s) only. A subnet's
+// links[] array has its own, unrelated source_url field (schemas/subnet-
+// manifest.schema.json's link $def) -- never consulted here.
+
+/** Returns the source-citation URL(s) for one surface, tolerant of every
+ * shape overlay's un-enforced write path could hand back: the current
+ * plural `source_urls` array (100% of git-committed data today), a legacy
+ * singular `source_url` string, or both present at once (plural wins, since
+ * it's the actively-validated current shape). Returns [] when neither key is
+ * present -- never falls back to the surface's own `.url` or a parent
+ * subnet's `links[].source_url`, which are different fields entirely. */
+export function normalizeSurfaceSourceUrls(surface) {
+  if (!surface || typeof surface !== "object") return [];
+  if (Array.isArray(surface.source_urls)) return surface.source_urls;
+  if (typeof surface.source_url === "string" && surface.source_url) {
+    return [surface.source_url];
+  }
+  return [];
+}

--- a/tests/registry-overlay.test.mjs
+++ b/tests/registry-overlay.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { normalizeSurfaceSourceUrls } from "../src/registry-overlay.mjs";
+
+// ---- Surface source_url(s) shape reconciliation (#4697) --------------------
+
+test("surface with only source_urls (current shape) returns the array unchanged", () => {
+  const surface = { source_urls: ["https://example.com/readme"] };
+  assert.deepEqual(normalizeSurfaceSourceUrls(surface), [
+    "https://example.com/readme",
+  ]);
+});
+
+test("surface with only legacy source_url (theoretical/historical shape) returns [source_url]", () => {
+  const surface = { source_url: "https://example.com/legacy" };
+  assert.deepEqual(normalizeSurfaceSourceUrls(surface), [
+    "https://example.com/legacy",
+  ]);
+});
+
+test("surface with both keys present: plural wins, singular ignored", () => {
+  const surface = {
+    source_urls: ["https://example.com/current"],
+    source_url: "https://example.com/legacy",
+  };
+  assert.deepEqual(normalizeSurfaceSourceUrls(surface), [
+    "https://example.com/current",
+  ]);
+});
+
+test("surface with neither key returns [] and does not fall through to .url", () => {
+  const surface = { url: "https://example.com/api" };
+  assert.deepEqual(normalizeSurfaceSourceUrls(surface), []);
+});
+
+test("does not pick up a subnet's links[].source_url when the surface itself has neither key", () => {
+  // A surface object never legitimately contains its parent subnet's links[]
+  // array, but assert explicitly that a same-shaped sibling field is never
+  // consulted -- links[].source_url is a distinct, unrelated field
+  // (schemas/subnet-manifest.schema.json's link $def), not an alternate
+  // spelling of a surface's own citation.
+  const surface = {
+    url: "https://example.com/api",
+    links: [{ label: "Docs", source_url: "https://example.com/docs-src" }],
+  };
+  assert.deepEqual(normalizeSurfaceSourceUrls(surface), []);
+});
+
+test('an empty-string legacy source_url is treated as absent, not [""]', () => {
+  assert.deepEqual(normalizeSurfaceSourceUrls({ source_url: "" }), []);
+});
+
+test("a non-array source_urls (malformed) falls through to the singular check", () => {
+  const surface = {
+    source_urls: "not-an-array",
+    source_url: "https://example.com/legacy",
+  };
+  assert.deepEqual(normalizeSurfaceSourceUrls(surface), [
+    "https://example.com/legacy",
+  ]);
+});
+
+test("null/undefined/non-object input returns [] without throwing", () => {
+  assert.deepEqual(normalizeSurfaceSourceUrls(null), []);
+  assert.deepEqual(normalizeSurfaceSourceUrls(undefined), []);
+  assert.deepEqual(normalizeSurfaceSourceUrls("not-an-object"), []);
+});


### PR DESCRIPTION
## Summary

- `deploy/postgres/registry-schema.sql`'s `surfaces` table flags a shape landmine: overlay's write path (`workers/registry-sync-api.mjs`'s `isValidRow`) does no schema enforcement on a surface's citation field, so a row could in principle carry the current plural `source_urls` array, a legacy singular `source_url` string, or both — schema-illegal for git-committed `registry/subnets/*.json` today (confirmed: 0/745 surfaces use the legacy singular key; `schemas/subnet-manifest.schema.json`'s surface `$def` only defines `source_urls`), but not something Postgres itself rejects.
- Adds `normalizeSurfaceSourceUrls(surface)` in a new `src/registry-overlay.mjs` as the **one place** this reconciliation lives: prefers `source_urls`, falls back to `[source_url]`, returns `[]` when neither is present, and never falls through to the surface's own `.url` or a parent subnet's unrelated `links[].source_url` field.
- Mirrors the two existing precedents for this exact field (`scripts/generated-overlays.mjs`'s `promoteCandidate`, `scripts/build-artifacts.mjs`'s AI-claims artifact) rather than inventing a third convention.
- Adds a one-line pointer comment near the existing dual-shape warning in `deploy/postgres/registry-schema.sql`.

## Scope

Prep work only, per the issue — no route wiring, no behavior change to any live endpoint. Confirmed no route in `workers/api.mjs`, `workers/data-api.mjs`, or `workers/registry-sync-api.mjs` currently selects `overlay` back out for serving; the registry-overlay read path isn't built yet. Whoever builds that route next imports this function instead of re-deriving the fallback chain under route-shipping pressure — the same trap `call_args` handling fell into across three call sites before #4669 consolidated it.

## Test plan

- [x] 8 new tests in `tests/registry-overlay.test.mjs` covering all cases from the issue: only `source_urls`, only legacy `source_url`, both present (plural wins), neither present (returns `[]`, does not fall through to `.url`), plus edge cases (empty-string `source_url`, malformed non-array `source_urls`, `links[].source_url` never consulted, null/undefined/non-object input)
- [x] `npx vitest run tests/registry-overlay.test.mjs` — 8 passed, 100% statements/branches/functions/lines on the new module
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run validate` clean
- [x] `npm run scan:public-safety` clean
- [x] `npm run test:coverage` — 7086 passed
- [x] `npm run build` — no unexpected artifact drift

**Not done (explicitly optional per the issue, no connection access to the registry Postgres instance in this environment):** the live `SELECT count(*) FROM surfaces WHERE overlay ? 'source_url' AND NOT overlay ? 'source_urls'` check against the actual registry Postgres mirror, to see whether any legacy-only rows exist there beyond git's confirmed 0/745. Flagged as a follow-up, not blocking.

Closes #4697