### PR TITLE
fix(ui): let ListShell tables scroll horizontally at tablet width

### DIFF
--- a/apps/ui/src/components/metagraphed/list-shell.tsx
+++ b/apps/ui/src/components/metagraphed/list-shell.tsx
@@ -37,10 +37,11 @@ export function ListShell({
   isStale?: boolean;
   stickyHeader?: boolean;
 }) {
-  // `overflow-x-clip` keeps the rounded corners tidy without establishing a
-  // vertical scroll container, so `position: sticky` on the table's <thead>
-  // anchors against the page scroll.
-  const innerOverflow = stickyHeader ? "overflow-x-clip" : "overflow-x-auto";
+  // Horizontal scroll lives on an inner wrapper so wide tables stay reachable at
+  // tablet widths. `overflow-y-clip` avoids a vertical scroll container (which
+  // would break `position: sticky` on <thead> against page scroll); the outer
+  // card uses `overflow-hidden` only to clip rounded corners.
+  const tableScroll = stickyHeader ? "overflow-x-auto overflow-y-clip" : "overflow-x-auto";
   return (
     <div>
       <div
@@ -61,8 +62,8 @@ export function ListShell({
         <div className={isStale ? "opacity-70 transition-opacity" : undefined}>
           {cards ? <div className="md:hidden space-y-2">{cards}</div> : null}
           <div className={cards ? "hidden md:block" : undefined}>
-            <div className={classNames("rounded border border-border bg-card", innerOverflow)}>
-              <div className={innerOverflow}>{table}</div>
+            <div className="rounded border border-border bg-card overflow-hidden">
+              <div className={tableScroll}>{table}</div>
               {footer}
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Fix `ListShell`'s table wrapper so wide tables scroll horizontally at tablet widths instead of clipping unreachable columns
- Replace `overflow-x-clip` (applied to every sticky-header table) with an inner `overflow-x-auto overflow-y-clip` scroll container inside an `overflow-hidden` card shell
- Preserves sticky `<thead>` behavior against page scroll while letting header + body scroll together horizontally

Closes #3930 · Part of #2542

> **Scope:** One shared-component change in `list-shell.tsx` — fixes `/subnets`, `/surfaces`, `/extrinsics`, `/blocks`, and explorer chain-events at `md`+ without per-route patches.

## Screenshots

Captured on `/subnets?view=table` and `/surfaces`. Fixed viewports only — no full-page capture. Theme forced via `localStorage.setItem("mg-theme", "dark"|"light")` before navigation. **Before:** `origin/main` @ `d46ec5e5` (`:5173`). **After:** feature branch (`:5178`).

> **Where to look:** at **768px tablet**, the before state clips trailing columns (Health / Updated on `/subnets`); after lets you scroll right to reach them. Mobile (`<768px`) still uses the existing card fallback — unchanged.

### Tablet scroll demo — `/subnets` @ 768px · light (clearest contrast)

| Before (scroll-left = scroll-right — clipped) | After (scrolled right — Surfaces / Readiness / Health / Updated visible) |
| --------------------------------------------- | ------------------------------------------------------------------------ |
| [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-before-scroll-left.png" width="360">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-before-scroll-left.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-after-scroll-right.png" width="360">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-after-scroll-right.png) |

**Scroll recording (after, 768px):** [3930-subnets-tablet-scroll-after.gif](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-scroll-after.gif)

### `/subnets` — full page

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-subnets-mobile-dark-after.png)<br><sub>after</sub> |

### `/surfaces` — second ListShell consumer

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3930-surfaces-tablet-dark-after.png)<br><sub>after</sub> |

## Test plan

- [ ] At 768px on `/subnets?view=table`, scroll right to reach Health and Updated columns
- [ ] At 768px on `/surfaces`, `/extrinsics`, `/blocks`, and `/explorer` chain-events — horizontal scroll works, no silent clip
- [ ] Sticky `<thead>` still tracks during page scroll (not detached)
- [ ] Desktop (≥1024px) layout unchanged
- [ ] Mobile card fallback (`<768px`) unchanged
- [ ] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui`
- [ ] `npm test --workspace=apps/ui`
- [ ] `npm run build --workspace=apps/ui`
