### PR TITLE
feat(ui): wire the global review/gaps queue into the gaps review surface

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -126,6 +126,7 @@ import type {
   FixtureIndexEntry,
   Freshness,
   Gap,
+  ReviewGapPriority,
   GlobalIncident,
   GlobalIncidents,
   GlobalIncidentSurface,
@@ -7044,6 +7045,37 @@ export const reviewEnrichmentEvidenceQuery = () =>
           typeof r.priority_score === "number"
             ? String(Math.round(r.priority_score as number))
             : undefined,
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
+// #3356: the priority-scored per-subnet gap board -- distinct from gapsQuery()
+// (/api/v1/gaps, the interface-facet dataset already on this page) and from
+// the enrichment-queue/-targets/-evidence sections above. GET
+// /api/v1/review/gaps, flat `priorities` list.
+export const reviewGapPrioritiesQuery = () =>
+  queryOptions({
+    queryKey: k("review-gap-priorities"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/gaps",
+        "priorities",
+        undefined,
+        signal,
+      );
+      // API rows: { netuid, name, curation_level, priority_score, missing_kinds,
+      // surface_count, verified_candidate_count, candidate_count, ... }.
+      const rows: ReviewGapPriority[] = res.data.map((r) => ({
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        curation_level: r.curation_level as CurationLevel | string | undefined,
+        priority_score: r.priority_score as number | undefined,
+        missing_kinds: Array.isArray(r.missing_kinds) ? (r.missing_kinds as string[]) : [],
+        surface_count: r.surface_count as number | undefined,
+        candidate_count: r.candidate_count as number | undefined,
+        verified_candidate_count: r.verified_candidate_count as number | undefined,
       }));
       return { ...res, data: rows };
     },

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -535,6 +535,21 @@ export interface Gap {
   [key: string]: unknown;
 }
 
+// #3356: the priority-scored per-subnet gap board from GET /api/v1/review/gaps
+// (artifact /metagraph/review/gap-priorities.json) -- distinct from Gap above,
+// which is sourced from the unrelated /api/v1/gaps interface-facet dataset.
+export interface ReviewGapPriority {
+  netuid?: number;
+  name?: string;
+  curation_level?: CurationLevel | string;
+  priority_score?: number;
+  missing_kinds?: string[];
+  surface_count?: number;
+  candidate_count?: number;
+  verified_candidate_count?: number;
+  [key: string]: unknown;
+}
+
 export interface HealthSummary {
   total?: number;
   ok?: number;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -31,11 +31,13 @@ import {
   reviewEnrichmentQueueQuery,
   reviewEnrichmentTargetsQuery,
   reviewEnrichmentEvidenceQuery,
+  reviewGapPrioritiesQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
+import { CurationChip } from "@/components/metagraphed/chips";
 import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
 import type { CurationLevel, Gap, Subnet } from "@/lib/metagraphed/types";
 
@@ -229,6 +231,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="gap-priorities"
+          eyebrow="Priorities"
+          title="Gap priorities"
+          description="Priority-scored per-subnet gap board — ranked separately from the interface-facet gaps above."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <GapPriorityList />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -239,6 +254,7 @@ function GapsPage() {
           "/api/v1/review/enrichment-queue",
           "/api/v1/review/enrichment-targets",
           "/api/v1/review/enrichment-evidence",
+          "/api/v1/review/gaps",
         ]}
       />
     </AppShell>
@@ -1166,5 +1182,60 @@ function EnrichmentEvidence() {
         </table>
       </div>
     </div>
+  );
+}
+
+// #3356: the priority-scored per-subnet gap board -- distinct from the
+// interface-facet OpenGapsSection above and from the enrichment-queue/
+// -targets/-evidence sections, which are enrichment-pipeline data, not
+// gap-priority scoring. Mirrors AdapterCandidates's row-list idiom.
+function GapPriorityList() {
+  const { data } = useSuspenseQuery(reviewGapPrioritiesQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No gap priorities"
+        description="The priority-scored gap board is empty — nothing currently ranked."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <ul className="space-y-1.5">
+      {rows.map((r, i) => (
+        <li
+          key={`${r.netuid}-${i}`}
+          className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5"
+        >
+          {r.netuid != null ? (
+            <Link
+              to="/subnets/$netuid"
+              params={{ netuid: r.netuid }}
+              className="font-mono text-[11px] text-ink-muted hover:text-accent w-12 shrink-0"
+            >
+              SN{r.netuid}
+            </Link>
+          ) : (
+            <span className="font-mono text-[11px] text-ink-muted w-12 shrink-0">—</span>
+          )}
+          <span className="flex-1 text-[13px] text-ink truncate">{r.name ?? "—"}</span>
+          <CurationChip level={r.curation_level} />
+          <span className="hidden sm:block max-w-[240px] truncate text-[11px] text-ink-muted">
+            {r.missing_kinds && r.missing_kinds.length > 0 ? r.missing_kinds.join(", ") : "—"}
+          </span>
+          {r.priority_score != null ? (
+            <span
+              className="font-mono text-[11px] text-ink-strong tabular-nums shrink-0"
+              title="Priority score"
+            >
+              {Math.round(r.priority_score)}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
   );
 }


### PR DESCRIPTION
Closes #3356

`gaps.tsx` already wires `reviewProfileCompletenessQuery`, `reviewAdapterCandidatesQuery`, `reviewEnrichmentQueueQuery`, `reviewEnrichmentTargetsQuery`, and `reviewEnrichmentEvidenceQuery`, but nothing consumed the priority-scored per-subnet gap board at `GET /api/v1/review/gaps` — distinct from `gapsQuery()` (`/api/v1/gaps`, the interface-facet dataset already on this page via `OpenGapsSection`/`MissingKindsAtAGlance`) and from the enrichment-pipeline sections.

## What changed

- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `reviewGapPrioritiesQuery()`, following the exact `reviewEnrichmentQueueQuery`/`reviewAdapterCandidatesQuery` pattern: `fetchList` against `/api/v1/review/gaps` on the `priorities` collection key, normalizing `netuid`, `name`, `curation_level`, `priority_score`, `missing_kinds`, `surface_count`, `candidate_count`, `verified_candidate_count`.
- **`apps/ui/src/lib/metagraphed/types.ts`** — new `ReviewGapPriority` interface next to `Gap`, documented as sourced from the distinct `/api/v1/review/gaps` endpoint.
- **`apps/ui/src/routes/gaps.tsx`** — new `GapPriorityList` component + `<PageSection id="gap-priorities">` mounted after the `enrichment-evidence` section, mirroring `AdapterCandidates`'s row-list idiom (not a table, matching the issue's own suggestion): netuid link → `/subnets/$netuid`, subnet name, a `CurationChip` for `curation_level` (reusing the existing shared chip component from `@/components/metagraphed/chips` rather than inventing new styling), a compact comma-joined `missing_kinds` column that hides below `sm` to keep the row legible on mobile, and a right-aligned `priority_score`. Same `TableState` empty-state convention as every sibling section. `/api/v1/review/gaps` added to `ApiSourceFooter`.

## Verification

- Confirmed end-to-end against **live production data**: real rows render correctly across the full priority range (e.g. `SN64 Chutes` at 191 down to low-priority entries), curation chips color-code correctly (`REVIEWED`/`ADAPTER`/`CANDIDATE`/`COMMUNITY`), `missing_kinds` comma-joins when populated and shows `—` when empty, netuid links resolve to `/subnets/$netuid`. Confirmed the mobile layout: the missing-kinds column correctly collapses at narrow widths (`hidden sm:block`), leaving netuid/name/chip/score fully legible with no overflow or truncation.
- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, +1 warning (the same `react-refresh/only-export-components` class every sibling section in this file already carries — 216 → 217, confirmed via a before/after diff of the lint output)
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 684 passed, no regressions (no dedicated test file added — the sibling `review*Query` functions in this file have no existing test coverage to extend either, consistent with this area's convention)
- `npm run test:e2e --workspace=apps/ui` (deterministic responsive-overflow check) — 24/24 passed; `/gaps` isn't one of the HAR-checked routes so no fixture re-record was needed
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/gaps-priorities-after-mobile-dark.png)<br><sub>after</sub> |
