### PR TITLE
feat(ui): surface the review gap-priorities board on the gaps page (#3356)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.review-gap-priorities.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.review-gap-priorities.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { reviewGapPrioritiesQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/review/gaps",
+  });
+}
+
+// fetchList calls apiFetch and lifts the named collection; invoke the queryFn directly.
+function runQuery() {
+  const opts = reviewGapPrioritiesQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("reviewGapPrioritiesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("reads the `priorities` collection from /api/v1/review/gaps and normalizes a row", async () => {
+    resolveWith({
+      priorities: [
+        {
+          netuid: 64,
+          name: "Chutes",
+          curation_level: "maintainer-reviewed",
+          priority_score: 190.6,
+          missing_kinds: ["openapi", "sdk"],
+          surface_count: 38,
+          candidate_count: 4,
+          verified_candidate_count: 2,
+        },
+      ],
+    });
+    const res = await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/review/gaps",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data[0]).toEqual({
+      id: "64",
+      netuid: 64,
+      name: "Chutes",
+      curationLevel: "maintainer-reviewed",
+      missingKinds: ["openapi", "sdk"],
+      surfaceCount: 38,
+      candidateCount: 4,
+      verifiedCandidateCount: 2,
+      priority: "191", // rounded from 190.6
+    });
+  });
+
+  it("defaults array/number fields and rounds priority; missing values stay undefined", async () => {
+    resolveWith({ priorities: [{ netuid: 3, missing_kinds: "nope" }] });
+    const res = await runQuery();
+    expect(res.data[0]).toMatchObject({
+      netuid: 3,
+      missingKinds: [], // non-array coerced to []
+      surfaceCount: undefined,
+      priority: undefined,
+    });
+  });
+
+  it("returns an empty list when the artifact has no priorities", async () => {
+    resolveWith({});
+    const res = await runQuery();
+    expect(res.data).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -7050,6 +7050,45 @@ export const reviewEnrichmentEvidenceQuery = () =>
     staleTime: STALE_LONG,
   });
 
+// #3356: network-wide priority-scored gap board (GET /api/v1/review/gaps), a
+// distinct backend surface from the interface-facet /api/v1/gaps list and from
+// the enrichment-queue/adapter-candidate sections. Same fetchList + inline
+// normalize idiom as reviewEnrichmentEvidenceQuery above.
+export const reviewGapPrioritiesQuery = () =>
+  queryOptions({
+    queryKey: k("review-gap-priorities"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<Record<string, unknown>>(
+        "/api/v1/review/gaps",
+        "priorities",
+        undefined,
+        signal,
+      );
+      // API rows: { netuid, name, curation_level, priority_score, missing_kinds,
+      // surface_count, candidate_count, verified_candidate_count, ... }.
+      const rows = res.data.map((r) => ({
+        id: String(r.netuid ?? (r.name as string) ?? ""),
+        netuid: r.netuid as number | undefined,
+        name: r.name as string | undefined,
+        curationLevel: r.curation_level as string | undefined,
+        missingKinds: Array.isArray(r.missing_kinds) ? (r.missing_kinds as string[]) : [],
+        surfaceCount: typeof r.surface_count === "number" ? (r.surface_count as number) : undefined,
+        candidateCount:
+          typeof r.candidate_count === "number" ? (r.candidate_count as number) : undefined,
+        verifiedCandidateCount:
+          typeof r.verified_candidate_count === "number"
+            ? (r.verified_candidate_count as number)
+            : undefined,
+        priority:
+          typeof r.priority_score === "number"
+            ? String(Math.round(r.priority_score as number))
+            : undefined,
+      }));
+      return { ...res, data: rows };
+    },
+    staleTime: STALE_LONG,
+  });
+
 function normalizeSchema(raw: unknown): SchemaInfo {
   if (!raw || typeof raw !== "object") return raw as SchemaInfo;
   const s = raw as Record<string, unknown>;

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -31,6 +31,7 @@ import {
   reviewEnrichmentQueueQuery,
   reviewEnrichmentTargetsQuery,
   reviewEnrichmentEvidenceQuery,
+  reviewGapPrioritiesQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
@@ -229,6 +230,19 @@ function GapsPage() {
             </Suspense>
           </QueryErrorBoundary>
         </PageSection>
+
+        <PageSection
+          id="gap-priorities"
+          eyebrow="Priorities"
+          title="Gap priorities"
+          description="Network-wide, priority-scored curation board — the subnets with the highest-value missing surfaces first."
+        >
+          <QueryErrorBoundary>
+            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+              <GapPriorityList />
+            </Suspense>
+          </QueryErrorBoundary>
+        </PageSection>
       </main>
 
       <ApiSourceFooter
@@ -239,6 +253,7 @@ function GapsPage() {
           "/api/v1/review/enrichment-queue",
           "/api/v1/review/enrichment-targets",
           "/api/v1/review/enrichment-evidence",
+          "/api/v1/review/gaps",
         ]}
       />
     </AppShell>
@@ -1091,6 +1106,70 @@ function EnrichmentTargets() {
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
                 <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// #3356: network-wide priority-scored gap board, sourced from /api/v1/review/gaps.
+// Same table idiom as EnrichmentEvidence — highest-value missing surfaces first.
+function GapPriorityList() {
+  const { data } = useSuspenseQuery(reviewGapPrioritiesQuery());
+  const meta = data.meta;
+  const rows = data.data ?? [];
+  if (rows.length === 0)
+    return (
+      <TableState
+        variant="empty"
+        title="No gap priorities"
+        description="No priority-scored curation gaps are outstanding right now."
+        cta={{ label: "Browse registry", href: "/subnets" }}
+        generatedAt={meta?.generated_at}
+      />
+    );
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-3 py-2.5 text-left sm:px-4">Netuid</th>
+              <th className="px-3 py-2.5 text-left sm:px-4">Name</th>
+              <th className="hidden px-3 py-2.5 text-left sm:table-cell sm:px-4">Curation</th>
+              <th className="hidden px-3 py-2.5 text-left md:table-cell sm:px-4">Missing kinds</th>
+              <th className="px-3 py-2.5 text-right sm:px-4">Priority</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((r) => (
+              <tr key={r.id} className="mg-row-hover">
+                <td className="px-3 py-2.5 font-mono text-[11px] sm:px-4">
+                  {r.netuid != null ? (
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="hover:text-accent"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-[12px] text-ink-strong sm:px-4">{r.name ?? "—"}</td>
+                <td className="hidden px-3 py-2.5 font-mono text-[11px] text-ink-muted sm:table-cell sm:px-4">
+                  {r.curationLevel ?? "—"}
+                </td>
+                <td className="hidden px-3 py-2.5 text-[12px] text-ink-muted md:table-cell sm:px-4">
+                  {r.missingKinds.length > 0 ? r.missingKinds.join(", ") : "—"}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong sm:px-4">
+                  {r.priority ?? "—"}
+                </td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
Closes #3356

Adds a **Gap priorities** section to `/gaps` from the already-live `GET /api/v1/review/gaps`: a new `reviewGapPrioritiesQuery` (fetchList `priorities`) + a `GapPriorityList` component — one row per subnet (netuid link, name, curation, missing kinds, priority). Suspense/empty/error + `ApiSourceFooter` path. Responsive: mobile shows Netuid/Name/Priority; more columns at `sm`/`md`. No backend change. typecheck ✓ · 687 tests ✓ · eslint ✓.

### Before / after — /gaps (before = production, no section)

| View · Theme | Before | After |
|---|---|---|
| Desktop·Light | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri-desktop-light-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri2-desktop-light-after.png) |
| Desktop·Dark | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri-desktop-dark-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri2-desktop-dark-after.png) |
| Tablet·Light | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri-tablet-light-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri2-tablet-light-after.png) |
| Tablet·Dark | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri-tablet-dark-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri2-tablet-dark-after.png) |
| Mobile·Light | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri-mobile-light-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri2-mobile-light-after.png) |
| Mobile·Dark | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri-mobile-dark-before.png) | ![](https://raw.githubusercontent.com/peter-minion/metagraphed/screenshots/gappri2-mobile-dark-after.png) |
