### PR TITLE
fix(api): normalize empty-string block author to null, document verification queries

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -148,6 +148,43 @@ Each needs a human who can verify/roll back (ADR 0013 _Sequencing_):
    project were already decommissioned 2026-07-04, ahead of and independent from
    this gated cutover — see the note above.)
 
+### `blocks` tier verification queries (#4687)
+
+Before ever re-flipping `METAGRAPH_BLOCKS_SOURCE` to `"postgres"`, re-run these
+against the indexer box's Postgres to confirm the historical gaps found in
+#4687 are actually closed — a single spot-checked block (as #4668's original
+flip relied on) does not prove this:
+
+```sh
+ssh indexeradmin@meta-indexer-01-us-lax1
+sudo docker exec -i metagraphed-indexer-postgres-1 psql -U metagraphed -d metagraphed
+```
+
+```sql
+-- 1. Zero empty-string authors (the spec_version 419/421/422 backfill-decode
+--    gap; src/blocks.mjs's formatBlock() already mitigates this at the
+--    serving layer regardless, but the underlying rows should be repaired).
+SELECT count(*) FROM blocks WHERE author = '';
+
+-- 2. Zero missing block_numbers across the known coverage hole.
+SELECT gs.block_number
+FROM generate_series(8471001, 8479999) AS gs(block_number)
+LEFT JOIN blocks b ON b.block_number = gs.block_number
+WHERE b.block_number IS NULL;
+
+-- 3. Same check across the full D1-retained window, as a general regression
+--    guard (adjust the lower bound to D1's current min if it has moved).
+SELECT gs.block_number
+FROM generate_series(8474393, (SELECT max(block_number) FROM blocks)) AS gs(block_number)
+LEFT JOIN blocks b ON b.block_number = gs.block_number
+WHERE b.block_number IS NULL;
+```
+
+All three must return zero rows before considering the `blocks` tier's
+historical coverage trustworthy again. Do **not** flag D1's own gap at block
+`8513820` as a Postgres regression — D1 is missing that block, not Postgres;
+it's expected and orthogonal (D1 is being decommissioned, not backfilled).
+
 ## Backup job (Postgres → R2)
 
 `deploy/backup/` is the scheduled durability job — `pg_dump | gzip | aws s3 cp` to

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -50,6 +50,19 @@ function toBlockNumber(value) {
   return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
+// Coerce a decoded-author cell to a non-empty string or null. Postgres's
+// backfilled blocks for spec_versions 419/421/422 (#4687 -- an indexer-rs
+// Aura-authority-digest decode gap for those three historical runtime
+// versions, not a live-ingestion defect) have `author = ""` instead of the
+// SS58 string D1 has for the same rows. A bare `row.author ?? null` only
+// catches null/undefined, so it was serving the empty string as if it were
+// a decoded value -- present-looking but wrong, worse than an honest null.
+function toAuthorOrNull(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  return value;
+}
+
 // Keep only well-formed blocks rows (a valid block_number primary key + a
 // non-empty hash + an integer timestamp). Shared by the staged-batch loader so
 // garbage is rejected before it touches D1.
@@ -122,7 +135,7 @@ export function formatBlock(row) {
     block_number: toBlockNumber(row.block_number),
     block_hash: row.block_hash ?? null,
     parent_hash: row.parent_hash ?? null,
-    author: row.author ?? null,
+    author: toAuthorOrNull(row.author),
     // extrinsic_count / event_count / spec_version (D1 INTEGER columns) — coerce
     // through toBlockNumber like block_number above, so a numeric string never
     // leaks the string form into these ["integer","null"] contract fields.

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -112,6 +112,33 @@ test("formatBlock maps a D1 row to an API block (ISO time)", () => {
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
 });
 
+test("formatBlock treats an empty-string author as null (Postgres backfill gap, not a valid value)", () => {
+  const out = formatBlock({
+    block_number: 1000,
+    block_hash: "0xhash",
+    author: "",
+  });
+  assert.equal(out.author, null);
+});
+
+test("formatBlock treats a whitespace-only author as null", () => {
+  const out = formatBlock({
+    block_number: 1000,
+    block_hash: "0xhash",
+    author: "   ",
+  });
+  assert.equal(out.author, null);
+});
+
+test("formatBlock preserves a real decoded author string unchanged", () => {
+  const out = formatBlock({
+    block_number: 1000,
+    block_hash: "0xhash",
+    author: "5HjhkCMa89QJbFULs8WPZBgVg8kMq5qdX1nx7CnQpZgoyKAN",
+  });
+  assert.equal(out.author, "5HjhkCMa89QJbFULs8WPZBgVg8kMq5qdX1nx7CnQpZgoyKAN");
+});
+
 test("formatBlock coerces string-typed observed_at cells to ISO timestamps", () => {
   const out = formatBlock({
     block_number: 1000,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -78,6 +78,27 @@
     // against a Postgres-only block with tail-based proof, not a block present
     // in both stores.
     //
+    // A SEPARATE, independent gap surfaced widening the parity check beyond
+    // that one spot-checked block (#4687): three scoped historical-only holes
+    // in Postgres, none present in live ingestion --
+    //   1. author = "" (not the correct SS58 string) for 1,380 rows across
+    //      three backfilled spec_versions (419/421/422) -- an indexer-rs
+    //      Aura-authority-decode gap for those specific historical runtime
+    //      versions. Mitigated at the serving layer regardless of flag state
+    //      (src/blocks.mjs's formatBlock now normalizes "" -> null, same
+    //      treatment as a blank observed_at), but the underlying Postgres
+    //      rows still need re-indexing -- see deploy/README.md's "blocks tier
+    //      verification queries" for the re-runnable check set.
+    //   2. A ~9,000-block coverage hole, 8471001-8479999, entirely missing
+    //      from Postgres (D1 still serves it).
+    //   3. Conversely Postgres has block #8513820 (a spec_version boundary)
+    //      that D1 is missing -- expected, not a regression; D1 is being
+    //      decommissioned, not backfilled.
+    // Root-cause repair is a cross-repo dependency (metagraphed-indexer-rs
+    // and/or a re-run of its historical backfill against the box's Postgres)
+    // tracked in #4687, not solved in this repo. Re-flip only after BOTH this
+    // and the canceled-subrequest issue above are resolved and re-verified.
+    //
     // extrinsics: still "d1". The call_args shape gap is BIGGER than
     // originally scoped here on 2026-07-09 -- that note covered only the
     // nested-call-shape and call_hash cases (#4669, fixed). A broader live


### PR DESCRIPTION
## Summary

Widening #4668's single-block parity spot check (block `#8586622`, "every column byte-identical") across the full retained window surfaces a real gap the narrow check missed:

- **Empty-string `author` — 1,380 rows across three backfilled spec_versions.** Postgres serves `author = ""` instead of the correct SS58 string for spec_versions 419/421/422 (an indexer-rs Aura-authority-digest decode gap for those specific historical runtime versions). Live ingestion (spec_versions 423/424, 70k+ rows) has **zero** empty-author rows — this is a backfill-path defect, not a live-ingestion one.
- A ~9,000-block coverage hole (`8471001`-`8479999`) with zero rows in Postgres, still served by D1.
- Conversely, Postgres has block `#8513820` (a spec_version boundary) that D1 is missing — expected, not a regression; D1 is being decommissioned, not backfilled.

`formatBlock`'s `author: row.author ?? null` only substitutes for `null`/`undefined`, not an empty string — so every one of the 1,380 affected rows was served as `"author": ""`, a value that looks present but is wrong, worse than an honest `null`.

## Fix

Adds `toAuthorOrNull` to `src/blocks.mjs`, mirroring the blank-string-to-null convention this file already uses for `observed_at`/`block_number` — the serving layer now never surfaces the empty string as if it were decoded data, independent of whether/when the underlying Postgres rows get re-indexed.

**Scoped as a serving-side mitigation only, per the issue's own requirements:** the actual repair (re-running indexer-rs's historical backfill for the affected spec_versions, closing the coverage hole) is a cross-repo dependency — this repo has no indexer source to patch. No flag changes (`METAGRAPH_BLOCKS_SOURCE` was already back to `"d1"`, reverted the same day it was flipped, for an unrelated canceled-subrequest reliability issue — independent of this bug).

## Also included

- A re-runnable verification query set in `deploy/README.md` (empty-author count, the specific coverage-hole check, and a full-window regression guard) so the cross-repo backfill work can be checked off mechanically rather than re-derived from scratch.
- Corrects `wrangler.jsonc`'s `METAGRAPH_BLOCKS_SOURCE` comment, which previously only documented the canceled-subrequest revert — now documents both known gaps before any future re-flip is considered.

## Test plan

- [x] 3 new tests in `tests/blocks.test.mjs`: empty-string author → null, whitespace-only author → null, real decoded author string preserved unchanged
- [x] `npx vitest run tests/blocks.test.mjs` — 75 passed
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run validate` clean
- [x] `npm run scan:public-safety` clean
- [x] `npm run test:coverage` — 7089 passed
- [x] `npm run build` — no unexpected artifact drift

**Not done (cross-repo, per the issue's own scope):** the actual indexer-rs backfill repair, and re-running the verification queries against the live indexer-box Postgres to confirm zero remaining empty-author rows / coverage gaps today. Tracked in the issue as follow-up.

Closes #4687