### PR TITLE
fix(ui): distinguish loading/error/empty in homepage KPI panels (#3964)

### DIFF
--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
-import { ArrowUpRight, FileCode2 } from "lucide-react";
+import { AlertCircle, ArrowUpRight, FileCode2 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { AccentBand } from "@/components/metagraphed/accent-band";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
@@ -360,10 +360,30 @@ function HomeHero() {
   );
 }
 
+// #3964: homepage KPI cells collapsed loading / error / genuinely-null all into
+// "—". Track each source query's phase so a cell can show a skeleton (loading),
+// a distinct "Unavailable" glyph (error), or the value / "—" (settled).
+type KpiPhase = "pending" | "error" | "ready";
+
+function kpiPhase(r: { isPending: boolean; isError: boolean }): KpiPhase {
+  return r.isError ? "error" : r.isPending ? "pending" : "ready";
+}
+
+function KpiErrorGlyph() {
+  return (
+    <span className="inline-flex items-center gap-1 text-base font-medium text-health-down">
+      <AlertCircle className="size-4" /> Unavailable
+    </span>
+  );
+}
+
 function HeroKpis() {
-  const coverage = useQuery(coverageQuery()).data?.data;
-  const freshness = useQuery(freshnessQuery()).data?.data;
-  const health = useQuery(healthQuery()).data?.data;
+  const coverageResult = useQuery(coverageQuery());
+  const freshnessResult = useQuery(freshnessQuery());
+  const healthResult = useQuery(healthQuery());
+  const coverage = coverageResult.data?.data;
+  const freshness = freshnessResult.data?.data;
+  const health = healthResult.data?.data;
   const active = coverage?.netuids_active;
   const avgAge = freshness?.avg_age_seconds;
   const uptime = health?.uptime_24h;
@@ -383,7 +403,8 @@ function HeroKpis() {
   // above — useQuery (not suspense), so a slow/failed fetch degrades this one
   // cell instead of blocking the whole hero card. No fabricated fallback: the
   // sparkline hides via HeroStatCell's own hasSeries guard when there's no data.
-  const activity = useQuery(chainActivityQuery("7d")).data?.data;
+  const activityResult = useQuery(chainActivityQuery("7d"));
+  const activity = activityResult.data?.data;
   const activityChrono = activity?.days.length ? [...activity.days].reverse() : undefined;
   const latestExtrinsics = activityChrono?.at(-1)?.extrinsic_count;
   const activitySeries = activityChrono?.map((d) => d.extrinsic_count);
@@ -429,6 +450,7 @@ function HeroKpis() {
         <HeroStatCell
           label="Healthy now"
           value={uptime != null ? `${(uptime * 100).toFixed(1)}%` : "—"}
+          phase={kpiPhase(healthResult)}
           formatValue={(v) => `${v.toFixed(1)}%`}
           tooltip="Share of verified endpoints passing their most recent probe. Failures are non-2xx, timeouts, or schema-invalid responses. Source: /api/v1/health."
           accent
@@ -436,6 +458,7 @@ function HeroKpis() {
         <HeroStatCell
           label="Freshness"
           value={avgAge != null ? humaniseSeconds(avgAge) : "—"}
+          phase={kpiPhase(freshnessResult)}
           series={freshSeries}
           points={freshPoints}
           formatValue={(v) => humaniseSeconds(v)}
@@ -444,6 +467,7 @@ function HeroKpis() {
         <HeroStatCell
           label="Chain activity"
           value={latestExtrinsics != null ? formatNumber(latestExtrinsics) : "—"}
+          phase={kpiPhase(activityResult)}
           series={activitySeries}
           points={activityPoints}
           formatValue={(v) => formatNumber(v)}
@@ -498,6 +522,7 @@ function LegendDot({ tone, label }: { tone: string; label: string }) {
 function HeroStatCell({
   label,
   value,
+  phase = "ready",
   series,
   points,
   formatValue,
@@ -507,6 +532,8 @@ function HeroStatCell({
 }: {
   label: string;
   value: string;
+  /** Loading/error/ready phase of the cell's source query (#3964). */
+  phase?: KpiPhase;
   /** Real data series. When absent, no sparkline is rendered (no fabrication). */
   series?: number[];
   points?: SparklinePoint[];
@@ -516,7 +543,9 @@ function HeroStatCell({
   /** Cadence label under the sparkline; defaults to the freshness cell's 24h/hourly cadence. */
   seriesCaption?: string;
 }) {
-  const hasSeries = !!series && series.length > 1;
+  // Hide the sparkline unless the value settled successfully — a skeleton or
+  // error glyph replaces the number, so a stale series would misrepresent state.
+  const hasSeries = phase === "ready" && !!series && series.length > 1;
   return (
     <div className="px-4 py-3">
       <div className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
@@ -528,7 +557,13 @@ function HeroStatCell({
           accent ? "text-accent" : "text-ink-strong"
         }`}
       >
-        {value}
+        {phase === "pending" ? (
+          <Skeleton className="h-5 w-14" />
+        ) : phase === "error" ? (
+          <KpiErrorGlyph />
+        ) : (
+          value
+        )}
       </div>
       {hasSeries ? (
         <>
@@ -613,8 +648,8 @@ function SectionHeader({
 }
 
 function TrackedGrid() {
-  const coverage = useQuery(coverageQuery()).data?.data as
-    Record<string, number | undefined> | undefined;
+  const coverageResult = useQuery(coverageQuery());
+  const coverage = coverageResult.data?.data as Record<string, number | undefined> | undefined;
   // Endpoint/provider totals are not in /api/v1/coverage — read from their own
   // list endpoints. Use limit=1 for endpoints (1197 items) to get only the
   // pagination meta; providers are small enough to load in full (cached for /providers).
@@ -629,30 +664,40 @@ function TrackedGrid() {
     providersResult.data?.meta.total ??
     providersResult.data?.data.length;
 
-  const items: Array<{ label: string; to: string; value: number | undefined; desc: string }> = [
+  const items: Array<{
+    label: string;
+    to: string;
+    value: number | undefined;
+    desc: string;
+    phase: KpiPhase;
+  }> = [
     {
       label: "Subnets",
       to: "/subnets",
       value: coverage?.netuids_active,
       desc: "Active Finney netuids with curated overlays.",
+      phase: kpiPhase(coverageResult),
     },
     {
       label: "Surfaces",
       to: "/surfaces",
       value: coverage?.surfaces_total,
       desc: "Verified public APIs, schemas, docs, dashboards.",
+      phase: kpiPhase(coverageResult),
     },
     {
       label: "Endpoints",
       to: "/endpoints",
       value: endpointsTotal,
       desc: "Tracked endpoint resources including root RPC pools.",
+      phase: kpiPhase(endpointsResult),
     },
     {
       label: "Providers",
       to: "/providers",
       value: providersTotal,
       desc: "Subnet teams and infrastructure operators.",
+      phase: kpiPhase(providersResult),
     },
   ];
   return (
@@ -667,7 +712,15 @@ function TrackedGrid() {
             {item.label}
           </div>
           <div className="mt-3 font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums text-ink-strong">
-            {item.value != null ? formatNumber(item.value) : "—"}
+            {item.phase === "pending" ? (
+              <Skeleton className="h-8 w-20" />
+            ) : item.phase === "error" ? (
+              <KpiErrorGlyph />
+            ) : item.value != null ? (
+              formatNumber(item.value)
+            ) : (
+              "—"
+            )}
           </div>
           <p className="mt-3 text-xs text-ink-muted leading-relaxed flex-1">{item.desc}</p>
           <span className="mt-4 inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted group-hover:text-accent transition-colors">
@@ -681,8 +734,10 @@ function TrackedGrid() {
 }
 
 function LivePerformance() {
-  const freshness = useQuery(freshnessQuery()).data?.data;
-  const health = useQuery(healthQuery()).data?.data;
+  const freshnessResult = useQuery(freshnessQuery());
+  const healthResult = useQuery(healthQuery());
+  const freshness = freshnessResult.data?.data;
+  const health = healthResult.data?.data;
 
   const ages = (freshness?.sources ?? [])
     .map((s) => (s.last_seen ? (Date.now() - new Date(s.last_seen).getTime()) / 1000 : null))
@@ -718,12 +773,14 @@ function LivePerformance() {
             freshness?.avg_age_seconds != null ? humaniseSeconds(freshness.avg_age_seconds) : "—"
           }
           hint="avg poll lag"
+          phase={kpiPhase(freshnessResult)}
           series={ages.length ? ages : undefined}
         />
         <PerfCard
           label="Global health"
           value={`${okPct}%`}
           hint={`${health?.ok ?? 0}/${total} OK`}
+          phase={kpiPhase(healthResult)}
           accent
         />
       </div>
@@ -735,17 +792,20 @@ function PerfCard({
   label,
   value,
   hint,
+  phase = "ready",
   series,
   accent,
 }: {
   label: string;
   value: string;
   hint: string;
+  /** Loading/error/ready phase of the card's source query (#3964). */
+  phase?: KpiPhase;
   /** Real data series. When absent, no sparkline is rendered (no fabrication). */
   series?: number[];
   accent?: boolean;
 }) {
-  const hasSeries = !!series && series.length > 1;
+  const hasSeries = phase === "ready" && !!series && series.length > 1;
   return (
     <div className="rounded-xl border border-border bg-card p-5">
       <div className="flex items-baseline justify-between mb-3">
@@ -757,7 +817,13 @@ function PerfCard({
       <div
         className={`font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums ${accent ? "text-accent" : "text-ink-strong"}`}
       >
-        {value}
+        {phase === "pending" ? (
+          <Skeleton className="h-9 w-24" />
+        ) : phase === "error" ? (
+          <KpiErrorGlyph />
+        ) : (
+          value
+        )}
       </div>
       {hasSeries ? (
         <div className="mt-4">


### PR DESCRIPTION
> Resubmit of #4678 (auto-closed only because it exceeded the 2-open-PR limit — no code issue). Rebased onto current main; CI green.

## Summary

On the homepage, `HeroKpis`, `TrackedGrid`, and `LivePerformance` (`apps/ui/src/routes/index.tsx`) all rendered a bare `—` whether their source query was **loading**, **errored**, or **genuinely null** — there was no way to tell "still loading", "failed", and "no data" apart, unlike the sibling homepage sections that already branch on state.

This adds a shared `kpiPhase()` helper (`pending | error | ready`) driven by each source query's own `isPending`/`isError`, and threads a `phase` through the KPI cells. Each value slot now renders a **skeleton** while loading, a distinct red **"Unavailable"** glyph (`KpiErrorGlyph`) on error, and the value (or `—`) only once settled. Sparklines are suppressed unless the cell settled successfully, so a stale series never misrepresents an error/loading cell.

## Change

- One file: `apps/ui/src/routes/index.tsx`.
- New shared `type KpiPhase`, `kpiPhase(result)`, and `KpiErrorGlyph` (reusing the existing `Skeleton` + `health-down` token + `AlertCircle`).
- `TrackedGrid` (per-item phase), `HeroKpis` → `HeroStatCell` (per-cell `phase` prop), `LivePerformance` → `PerfCard` (per-card `phase` prop) all updated. Default `phase="ready"` keeps any other caller unchanged.
- No change to the KPI data sources or metrics (issue non-goal); sibling sections that already handle state are untouched.

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors (pre-existing react-refresh warnings only)
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 654 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (incl. /)
```

States reproduced by aborting the coverage/freshness/health/endpoints/providers/chain-activity requests on `/`; each cell surfaces "Unavailable" after its query's retry backoff, distinct from a slow load (skeleton) and from a settled `—`.

## Screenshots

Homepage KPI source fetches blocked on `/` (framing the `TrackedGrid` + `LivePerformance` sections). **Before:** every KPI shows a silent `—` (and Global health even shows a misleading `0%`), indistinguishable from loading. **After:** a distinct red "Unavailable" indicator per KPI.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964/mobile-dark-after.png)<br><sub>after</sub> |

Closes #3964
