### PR TITLE
fix(ui): wrap the stake-transfer leaderboard in overflow-x-auto

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1184,40 +1184,42 @@ function ExplorerDashboard() {
           </span>
         </div>
         {stakeTransfers.subnets.length > 0 ? (
-          <table className="w-full text-left text-sm">
-            <thead>
-              <tr>
-                <th className={TH}>Subnet</th>
-                <th className={`${TH} text-right`}>Transfers</th>
-                <th className={`${TH} text-right`}>Distinct senders</th>
-                <th className={`${TH} text-right`}>Transfers per sender</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {stakeTransfers.subnets.map((s) => (
-                <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
-                    <Link
-                      to="/subnets/$netuid"
-                      params={{ netuid: s.netuid }}
-                      className="text-ink-strong hover:text-accent hover:underline"
-                    >
-                      SN{s.netuid}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {formatNumber(s.transfers)}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatNumber(s.distinct_senders)}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
-                  </td>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Transfers</th>
+                  <th className={`${TH} text-right`}>Distinct senders</th>
+                  <th className={`${TH} text-right`}>Transfers per sender</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {stakeTransfers.subnets.map((s) => (
+                  <tr key={s.netuid} className="hover:bg-surface/40">
+                    <td className="px-4 py-2 font-mono text-[11px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: s.netuid }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                      >
+                        SN{s.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(s.transfers)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber(s.distinct_senders)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         ) : (
           <EmptyState title="No stake transfers in this window yet." />
         )}


### PR DESCRIPTION
## Summary

- Verifies the stake-transfer leaderboard on `/explorer` (`apps/ui/src/routes/explorer.tsx`) with real populated data at every viewport this app supports, per the issue's ask. It had never been screenshotted non-empty before (#3906's 12 screenshots all landed on the empty-state fallback because the live compute tier was cold).
- The populated-state verification surfaced exactly the layout bug the issue anticipated: the table was missing the `overflow-x-auto` wrapper its sibling network leaderboards already use (`AxonChurnSection`, `TransferPairsSection` in the same file). On mobile the "Transfers per sender" column was clipped off-screen with no way to reach it — not just visually tight, genuinely inaccessible (no scrollbar, no swipe-to-reveal).
- Fix: wrap the table in `<div className="overflow-x-auto">`, identical to the sibling sections' existing treatment. No other markup, columns, or empty-state copy changed (the empty-state branch is untouched, per the issue's explicit non-goal).

Closes #3941

## Screenshots

Live stake-transfer data was unavailable from the shared API at capture time (`/api/v1/chain/stake-transfers` currently returns `subnet_count: 0` in this environment). To still verify the real populated-table code path, each capture mocks that one endpoint with a representative fixture (6 subnets, varied transfer/sender counts) matching the exact `ChainStakeTransfers` contract shape in `apps/ui/src/lib/metagraphed/types.ts` — every other query on this data-heavy dashboard is left to its real (currently empty) response, so only the leaderboard itself is under test. The "Mobile · scrolled" rows additionally prove the fix is a real fix and not just a repaint: they scroll the "Transfers per sender" header into view — before the fix this has no effect (no scrollable ancestor exists, so the column stays off-screen and its values stay truncated, e.g. "35.8" instead of "35.82"); after the fix the table's own container scrolls, the Subnet column moves off the left edge, and the full values become visible.

Column alignment and number formatting are correct at all three viewports in both themes — no bugs found beyond the overflow wrapper itself.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-dark-after.png)<br><sub>after</sub> |
| Mobile · Light · scrolled to last column | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-light-before.png)<br><sub>before — no effect, column still clipped</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-light-after.png)<br><sub>after — column fully reachable</sub> |
| Mobile · Dark · scrolled to last column | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-dark-before.png)<br><sub>before — no effect, column still clipped</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941-stake-transfer-mobile-scrolled-dark-after.png)<br><sub>after — column fully reachable</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (684 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification: ran two dev servers (upstream/main vs. this branch) with an identical mocked populated-data response and captured real before/after screenshots per the table above, including a scroll-interaction check proving the column is genuinely reachable after the fix
