### PR TITLE
feat(registry): add SN118 Ditto taomarketcap subnet-api surface (#4163)

### DIFF
--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -268,6 +268,25 @@
         "https://github.com/ditto-assistant/dittobench-starter-kit/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/ditto-assistant/dittobench-starter-kit/main/fixtures/seed-user/memory_cases.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-118-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Ditto TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/118 on api.taomarketcap.com returning machine-readable JSON for SN118 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Ditto exposes source repositories, docs, and an SDK but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "cleanjunc"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/ditto-assistant/dittobench-starter-kit"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/118"
     }
   ],
   "website_url": "https://heyditto.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `subnet-api` surface to exactly one subnet manifest — `registry/subnets/ditto.json` (SN118, Ditto). Append-only; no other files, no generated artifacts.

## Surface

- Netuid: 118
- Kind: subnet-api
- Public URL: https://api.taomarketcap.com/public/v1/subnets/118
- Source URL (proves the claim): https://api.taomarketcap.com/developer/documentation/ (documents the public no-auth `GET /public/v1/subnets/{id}` endpoint) + https://github.com/ditto-assistant/dittobench-starter-kit (Ditto's own repo, self-declares "Bittensor subnet 118")
- Provider slug: taomarketcap

## Summary

SN118 (Ditto) has no verified first-party public API endpoint. TaoMarketCap's developer API indexes SN118 and serves a public, no-auth JSON snapshot of the subnet's on-chain state at `GET /public/v1/subnets/118`. Verified live: returns HTTP 200 `application/json` with `"netuid":118` and `subnet_identities_v3.subnetName":"Ditto"`, covering on-chain state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Mirrors the already-merged TaoMarketCap `subnet-api` surfaces for SN109 (academia) and SN101 (eni).

## Checklist

- [x] Changes exactly one `registry/subnets/ditto.json` file (append-only).
- [x] Lands `authority: community` + `review.state: community-submitted`.
- [x] `url` is public and safe for read-only probes; the `source_url`s independently prove the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #4163`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/ditto.json` → passed
- [x] `npm run scan:public-safety` → passed

Closes #4163