### PR TITLE
feat(ui): add network-wide registrations leaderboard to /leaderboards

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-registrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-registrations.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainRegistrationsQuery, normalizeChainRegistrations } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/registrations",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainRegistrationsQuery(window as "7d" | "30d" | undefined, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainRegistrations", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainRegistrations({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          distinct_registrants: 5,
+          registrations: 70,
+          registrations_per_registrant: 14,
+        },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          {
+            netuid: 1,
+            distinct_registrants: 4,
+            registrations: 40,
+            registrations_per_registrant: 10,
+          },
+          {
+            netuid: 2,
+            distinct_registrants: 2,
+            registrations: 30,
+            registrations_per_registrant: 15,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: {
+        distinct_registrants: 5,
+        registrations: 70,
+        registrations_per_registrant: 14,
+      },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        {
+          netuid: 1,
+          distinct_registrants: 4,
+          registrations: 40,
+          registrations_per_registrant: 10,
+        },
+        {
+          netuid: 2,
+          distinct_registrants: 2,
+          registrations: 30,
+          registrations_per_registrant: 15,
+        },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainRegistrations(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.network.registrations).toBe(0);
+      expect(card.network.distinct_registrants).toBe(0);
+      expect(card.network.registrations_per_registrant).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+
+  it("drops malformed subnet rows", () => {
+    const card = normalizeChainRegistrations({
+      subnet_count: 2,
+      network: {},
+      subnets: [{ netuid: "bad" }, { netuid: 3, registrations: 5 }],
+    });
+    expect(card.subnets).toEqual([
+      {
+        netuid: 3,
+        distinct_registrants: 0,
+        registrations: 5,
+        registrations_per_registrant: null,
+      },
+    ]);
+  });
+});
+
+describe("chainRegistrationsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches with window and limit params", async () => {
+    resolveWith({ subnet_count: 0, network: {}, subnets: [] });
+    await runQuery("30d", 50);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/registrations", {
+      params: { window: "30d", limit: 50 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("defaults to 7d and limit 100", async () => {
+    resolveWith({ subnet_count: 0, network: {}, subnets: [] });
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/registrations", {
+      params: { window: "7d", limit: 100 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -90,6 +90,8 @@ import type {
   ChainAxonRemovalSubnet,
   ChainDeregistrations,
   ChainDeregistrationsSubnet,
+  ChainRegistrations,
+  ChainRegistrationsSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -266,6 +268,7 @@ const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
 const MAX_CHAIN_AXON_REMOVALS = 100;
 const MAX_CHAIN_DEREGISTRATIONS = 100;
+const MAX_CHAIN_REGISTRATIONS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3754,6 +3757,62 @@ export const chainDeregistrationsQuery = (window: ChainWindow = "7d", limit = 10
       });
       return {
         data: normalizeChainDeregistrations(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainRegistrationsSubnet(raw: unknown): ChainRegistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_registrants: firstFiniteNumber(raw.distinct_registrants) ?? 0,
+    registrations: firstFiniteNumber(raw.registrations) ?? 0,
+    registrations_per_registrant: firstFiniteNumber(raw.registrations_per_registrant) ?? null,
+  };
+}
+
+// #3465: network-wide neuron-registration leaderboard over a 7d/30d window — the
+// entry-side twin of /api/v1/chain/deregistrations. Every numeric cell coerces defensively:
+// counts fall through to 0, averages to null (never NaN), and malformed subnet rows are
+// dropped on a cold store or junk.
+export function normalizeChainRegistrations(raw: unknown): ChainRegistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_registrants: firstFiniteNumber(networkRec.distinct_registrants) ?? 0,
+      registrations: firstFiniteNumber(networkRec.registrations) ?? 0,
+      registrations_per_registrant:
+        firstFiniteNumber(networkRec.registrations_per_registrant) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_REGISTRATIONS,
+      normalizeChainRegistrationsSubnet,
+    ),
+  };
+}
+
+export const chainRegistrationsQuery = (window: ChainWindow = "7d", limit = 100) =>
+  queryOptions({
+    queryKey: k("chain-registrations", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainRegistrations>>("/api/v1/chain/registrations", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainRegistrations(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2613,6 +2613,37 @@ export interface ChainDeregistrations {
   subnets: ChainDeregistrationsSubnet[];
 }
 
+/** One subnet's row on the network-wide neuron-registration leaderboard (#3465). */
+export interface ChainRegistrationsSubnet {
+  netuid: number;
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number | null;
+}
+
+/** Network-wide registration rollup — true distinct-registrant count (not a per-subnet sum) + total registrations. */
+export interface ChainRegistrationsNetwork {
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number | null;
+}
+
+/**
+ * Network-wide neuron-registration activity over a 7d/30d window (#3465), from
+ * GET /api/v1/chain/registrations — subnets ranked by NeuronRegistered event count,
+ * plus the true network-wide distinct-registrant rollup and a distribution summary of
+ * per-subnet re-registration intensity. Zeroed with an empty subnets list when cold.
+ */
+export interface ChainRegistrations {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainRegistrationsNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainRegistrationsSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useMemo } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { UserMinus } from "lucide-react";
+import { UserMinus, UserPlus } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -12,7 +12,11 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
-import { chainDeregistrationsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import {
+  chainDeregistrationsQuery,
+  chainRegistrationsQuery,
+  subnetsQuery,
+} from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { Subnet } from "@/lib/metagraphed/types";
 
@@ -28,13 +32,13 @@ export const Route = createFileRoute("/leaderboards")({
       {
         name: "description",
         content:
-          "Network-wide Bittensor leaderboards — neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Network-wide Bittensor leaderboards — neuron registrations and deregistrations ranked by subnet over 7d and 30d windows.",
       },
       { property: "og:title", content: "Leaderboards — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Network-wide Bittensor leaderboards — neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Network-wide Bittensor leaderboards — neuron registrations and deregistrations ranked by subnet over 7d and 30d windows.",
       },
     ],
   }),
@@ -52,13 +56,173 @@ function LeaderboardsPage() {
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
-          <DeregistrationsLeaderboard />
-        </Suspense>
-      </QueryErrorBoundary>
-      <ApiSourceFooter paths={["/api/v1/chain/deregistrations"]} />
+      <div className="space-y-12">
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+            <RegistrationsLeaderboard />
+          </Suspense>
+        </QueryErrorBoundary>
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+            <DeregistrationsLeaderboard />
+          </Suspense>
+        </QueryErrorBoundary>
+      </div>
+      <ApiSourceFooter paths={["/api/v1/chain/registrations", "/api/v1/chain/deregistrations"]} />
     </AppShell>
+  );
+}
+
+function RegistrationsLeaderboard() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const win = search.window;
+
+  const { data: boardRes } = useSuspenseQuery(chainRegistrationsQuery(win));
+  const { data: snRes } = useSuspenseQuery(subnetsQuery());
+  const board = boardRes.data;
+
+  const subnetById = useMemo(() => {
+    const m = new Map<number, Subnet>();
+    for (const s of (snRes.data ?? []) as Subnet[]) m.set(s.netuid, s);
+    return m;
+  }, [snRes]);
+
+  const network = board.network;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Registrations
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Neuron joins ranked by subnet — raw NeuronRegistered events over the selected window.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {(["7d", "30d"] as const).map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() => navigate({ search: { window: w } })}
+              className={
+                w === win
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
+                  : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
+              }
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Registrations"
+          value={formatNumber(network.registrations)}
+          hint={`${win} network total`}
+          tone="accent"
+        />
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Distinct registrants"
+          value={formatNumber(network.distinct_registrants)}
+          hint="network-wide unique"
+        />
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Per registrant"
+          value={
+            network.registrations_per_registrant != null
+              ? network.registrations_per_registrant.toFixed(2)
+              : "—"
+          }
+          hint="network intensity"
+        />
+      </div>
+
+      {board.subnet_count === 0 || board.subnets.length === 0 ? (
+        <EmptyState
+          title="No registrations in this window"
+          description="The chain poller has not indexed any NeuronRegistered events for this window yet, or registration activity was zero."
+          lastChecked={board.observed_at ?? undefined}
+        />
+      ) : (
+        <section className="rounded-lg border border-border bg-card">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Per-subnet rankings
+            </span>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {formatNumber(board.subnet_count)} subnets
+              {board.observed_at ? (
+                <>
+                  {" "}
+                  · observed <TimeAgo at={board.observed_at} />
+                </>
+              ) : null}
+            </span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Rank</th>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Registrations</th>
+                  <th className={`${TH} text-right`}>Distinct registrants</th>
+                  <th className={`${TH} text-right`}>Per registrant</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {board.subnets.map((row, i) => {
+                  const subnet = subnetById.get(row.netuid);
+                  const name = subnet?.name ?? `Subnet ${row.netuid}`;
+                  return (
+                    <tr key={row.netuid} className="hover:bg-surface/40">
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: row.netuid }}
+                          className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                        >
+                          <BrandIcon
+                            size={18}
+                            name={name}
+                            fallback={row.netuid}
+                            netuid={row.netuid}
+                            subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                          />
+                          <span className="truncate text-sm text-ink-strong">{name}</span>
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                        {formatNumber(row.registrations)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatNumber(row.distinct_registrants)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {row.registrations_per_registrant != null
+                          ? row.registrations_per_registrant.toFixed(2)
+                          : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a **network-wide registrations leaderboard** to `/leaderboards`, mirroring the merged deregistrations leaderboard (#4611) for the registration side.

- New `chainRegistrationsQuery` + `normalizeChainRegistrations`/`normalizeChainRegistrationsSubnet` hitting `/api/v1/chain/registrations`.
- New `ChainRegistrations` / `ChainRegistrationsSubnet` types.
- New `RegistrationsLeaderboard` component (Neuron joins, ranked by subnet, 7d/30d windows) rendered above the existing Deregistrations board; both endpoints in the DATA SOURCES footer.
- New `queries.chain-registrations.test.ts` (5 cases mirroring the deregistrations tests).

## Screenshots

| Page | Before | After |
| --- | --- | --- |
| `/leaderboards` | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3465-assets/lb-before.png" width="320">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3465-assets/lb-before.png)<br><sub>before: only deregistrations</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3465-assets/lb-after.png" width="320">](https://raw.githubusercontent.com/davion-knight/metagraphed/fe-3465-assets/lb-after.png)<br><sub>after: registrations + deregistrations</sub> |

<sub>Captured from the real `/leaderboards` route (wrangler dev on the built output, live `api.metagraph.sh`). Empty-state render — current live registration data is zero — matching production.</sub>

## Testing

Full `ui` gate green locally: lint (0 errors), format:check, typecheck, test (689 passed incl. 5 new), build.

Closes #3465
