### PR TITLE
fix(data-api): cap blocks/extrinsics D1 retention before it hits the size cap

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -10,9 +10,19 @@ import {
 } from "../workers/request-params.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 
-// D1 safety-valve: 365-day retention prevents unbounded growth before the
-// Postgres cold tier (#1519) ships. pruneBlocks runs in the HEALTH_PRUNE_CRON.
-export const BLOCK_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
+// D1 safety-valve, ORIGINALLY 365 days -- but blocks is small per-row (a header,
+// not a payload) so at measured volume (~4k rows/day) even a full 365-day
+// window is only ~600MB, nowhere near D1's 10GB cap on its own. 30 days keeps a
+// generous "recent blocks" hot window (comfortably longer than the pruned
+// extrinsics/account_events retention below it) while still being a real,
+// enforced bound rather than the effectively-unbounded 365 days that let
+// extrinsics (same table family, same cron) grow unchecked into the exact
+// D1_ERROR: Exceeded maximum DB size outage account_events already hit once
+// (see EVENT_RETENTION_MS in account-events.mjs). Raise it once the raw/
+// long-history chain data lives in Postgres (self-hosted, no cap) instead of
+// D1, per ADR 0013's "demote/retire D1" end state. pruneBlocks runs in the
+// HEALTH_PRUNE_CRON.
+export const BLOCK_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 // Columns written to blocks — THE load contract. scripts/fetch-events.py emits
 // rows with exactly these keys; loadStagedBlocks binds them in this order. Values

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -20,9 +20,22 @@ import {
 import { parseJsonPreservingBigInts } from "./big-int-safe-json.mjs";
 import { decodeBTreeSetFields } from "./postgres-collection-normalize.mjs";
 
-// D1 safety-valve: 365-day retention prevents unbounded growth before the
-// Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
-export const EXTRINSIC_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
+// D1 safety-valve, ORIGINALLY 365 days ("prevents unbounded growth before the
+// Postgres cold tier (#1519) ships") -- but #1519 never shipped, and like
+// account_events before its own emergency cut (see EVENT_RETENTION_MS in
+// account-events.mjs), 365 days of retention never actually got old enough to
+// prune: the table is younger than that, so the "safety valve" never engaged
+// and extrinsics grew unbounded. Measured 2026-07-10: ~101k rows/day, ~900
+// bytes/row of call_args alone, and the shared D1 database was already at
+// ~9.0GB of its hard, unraisable 10GB-per-database cap with this table still
+// growing -- a full 365 days at this rate would be ~45GB, many times over the
+// cap on its own. 5 days is what the measured ingestion rate can sustainably
+// fit with real headroom under 10GB across all tables sharing this database --
+// this is an emergency-driven number, not an arbitrary product decision; raise
+// it only once the raw/long-history chain data lives in Postgres (self-hosted,
+// no cap) instead of D1, per ADR 0013's own "demote/retire D1" end state.
+// pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
+export const EXTRINSIC_RETENTION_MS = 5 * 24 * 60 * 60 * 1000;
 
 // Columns written to extrinsics — THE load contract. scripts/fetch-events.py
 // emits rows with exactly these keys; loadStagedExtrinsics binds them in this

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -10,6 +10,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import { buildOpenApiArtifact } from "../src/contracts.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
+import { EXTRINSIC_RETENTION_MS } from "../src/extrinsics.mjs";
 import { MOVERS_WINDOWS } from "../src/movers.mjs";
 import { unsupportedWindowMessage } from "../src/neuron-history.mjs";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
@@ -5748,9 +5749,7 @@ describe("handleExtrinsics", () => {
       await handleExtrinsics(
         req("/api/v1/extrinsics"),
         env,
-        url(
-          `/api/v1/extrinsics?to=${now - 365 * 24 * 60 * 60 * 1000 + 60_000}`,
-        ),
+        url(`/api/v1/extrinsics?to=${now - EXTRINSIC_RETENTION_MS + 60_000}`),
       );
       const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
       assert.ok(sql, "a near-floor one-sided to filter must reach D1");


### PR DESCRIPTION
## Summary

D1's `metagraphed-health` database is currently at ~9.0GB of its hard,
unraisable 10GB cap. `account_events` already had an emergency retention
cut (365d -> 3d, 2026-07-04) after its 365-day window never actually got
old enough to prune, and the table grew until it hit the cap -- a live
outage where every write into this D1 failed with `D1_ERROR: Exceeded
maximum DB size`.

`blocks` and `extrinsics` were never given the same fix and are in the
identical state: direct query today shows their oldest row is only ~16
days old (both tables younger than any retention window that's ever
engaged), with extrinsics ingesting ~101k rows/day. At a true 365-day
steady state extrinsics alone would be ~45GB -- more than 4x the entire
database's cap on its own.

This is the retention half of #4746 (D1 write-path reliability), where
the same capacity pressure was traced to sustained `ingest_write_failed`
errors from the realtime streamer. The other half of that issue (the
streamer's push-retry-blocks-the-subscription coupling) is separate,
ongoing work and is not closed by this PR.

## Change

- `BLOCK_RETENTION_MS`: 365 days -> 30 days (blocks are small per-row;
  even a full 365-day window is only ~600MB, so this is a generous
  "recent blocks" window, not a tight emergency cut)
- `EXTRINSIC_RETENTION_MS`: 365 days -> 5 days (mirrors the
  `EVENT_RETENTION_MS` emergency-cut methodology; extrinsics is the
  actual space-pressure driver)
- Updated a test that hardcoded the old 365-day literal to import
  `EXTRINSIC_RETENTION_MS` instead, so it tracks the real constant

Both comments document the same "raise later once Postgres/Hyperdrive is
trusted for live serving" path already established for `account_events`.

## Testing

- `npm run lint && npx prettier --check <changed files>` clean
- `npx vitest run tests/blocks.test.mjs tests/extrinsics.test.mjs tests/request-handlers-entities.test.mjs` -- 512 passed
- Direct D1 query confirming current state: blocks/extrinsics oldest row ~16 days old, DB at ~9.0GB/10GB, extrinsics ~101k rows/day

No screenshot table -- data-api/config only, no `apps/ui` files touched.

Refs #4746 (partial -- retention side only; streamer architecture fix tracked separately in that issue).