### PR TITLE
feat(ui) network registrations leaderboard on explorer (#3465)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-registrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-registrations.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainRegistrationsQuery, normalizeChainRegistrations } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/registrations",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainRegistrationsQuery(window as "7d" | "30d" | undefined, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainRegistrations", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainRegistrations({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          distinct_registrants: 5,
+          registrations: 70,
+          registrations_per_registrant: 14,
+        },
+        intensity_distribution: {
+          count: 2,
+          mean: 12.5,
+          min: 10,
+          p25: 10,
+          median: 10,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          {
+            netuid: 1,
+            distinct_registrants: 4,
+            registrations: 40,
+            registrations_per_registrant: 10,
+          },
+          {
+            netuid: 2,
+            distinct_registrants: 2,
+            registrations: 30,
+            registrations_per_registrant: 15,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: {
+        distinct_registrants: 5,
+        registrations: 70,
+        registrations_per_registrant: 14,
+      },
+      intensity_distribution: {
+        count: 2,
+        mean: 12.5,
+        min: 10,
+        p25: 10,
+        median: 10,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        {
+          netuid: 1,
+          distinct_registrants: 4,
+          registrations: 40,
+          registrations_per_registrant: 10,
+        },
+        {
+          netuid: 2,
+          distinct_registrants: 2,
+          registrations: 30,
+          registrations_per_registrant: 15,
+        },
+      ],
+    });
+  });
+
+  it("zeroes a cold or malformed payload", () => {
+    expect(normalizeChainRegistrations(null)).toEqual({
+      schema_version: 1,
+      window: null,
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+});
+
+describe("chainRegistrationsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches and normalizes the network-wide registrations leaderboard", async () => {
+    resolveWith({
+      schema_version: 1,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 1,
+      network: { distinct_registrants: 3, registrations: 9, registrations_per_registrant: 3 },
+      intensity_distribution: null,
+      subnets: [
+        { netuid: 8, distinct_registrants: 3, registrations: 9, registrations_per_registrant: 3 },
+      ],
+    });
+
+    const res = await runQuery("30d", 50);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/registrations", {
+      params: { window: "30d", limit: 50 },
+      signal: expect.any(AbortSignal),
+    });
+    expect(res.data.subnets).toHaveLength(1);
+    expect(res.data.network.registrations).toBe(9);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -90,6 +90,8 @@ import type {
   ChainAxonRemovalSubnet,
   ChainDeregistrations,
   ChainDeregistrationsSubnet,
+  ChainRegistrations,
+  ChainRegistrationsSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -267,6 +269,7 @@ const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
 const MAX_CHAIN_AXON_REMOVALS = 100;
 const MAX_CHAIN_DEREGISTRATIONS = 100;
+const MAX_CHAIN_REGISTRATIONS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3717,6 +3720,62 @@ function normalizeChainDeregistrationsSubnet(raw: unknown): ChainDeregistrations
     deregistrations_per_hotkey: firstFiniteNumber(raw.deregistrations_per_hotkey) ?? null,
   };
 }
+
+function normalizeChainRegistrationsSubnet(raw: unknown): ChainRegistrationsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_registrants: firstFiniteNumber(raw.distinct_registrants) ?? 0,
+    registrations: firstFiniteNumber(raw.registrations) ?? 0,
+    registrations_per_registrant: firstFiniteNumber(raw.registrations_per_registrant) ?? null,
+  };
+}
+
+// #3465: network-wide neuron-registration leaderboard over a 7d/30d window — the
+// entry-side twin of /api/v1/chain/deregistrations. Every numeric cell coerces
+// defensively: counts fall through to 0, averages to null (never NaN), and
+// malformed subnet rows are dropped on a cold store or junk.
+export function normalizeChainRegistrations(raw: unknown): ChainRegistrations {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_registrants: firstFiniteNumber(networkRec.distinct_registrants) ?? 0,
+      registrations: firstFiniteNumber(networkRec.registrations) ?? 0,
+      registrations_per_registrant:
+        firstFiniteNumber(networkRec.registrations_per_registrant) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(
+      rec.subnets,
+      MAX_CHAIN_REGISTRATIONS,
+      normalizeChainRegistrationsSubnet,
+    ),
+  };
+}
+
+export const chainRegistrationsQuery = (window: ChainWindow = "7d", limit = 100) =>
+  queryOptions({
+    queryKey: k("chain-registrations", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainRegistrations>>("/api/v1/chain/registrations", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainRegistrations(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
 
 // #3466: network-wide neuron-deregistration leaderboard over a 7d/30d window — the
 // exit-side twin of /api/v1/chain/registrations. Every numeric cell coerces defensively:

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2628,6 +2628,37 @@ export interface ChainDeregistrations {
   subnets: ChainDeregistrationsSubnet[];
 }
 
+/** One subnet's row on the network-wide neuron-registration leaderboard (#3465). */
+export interface ChainRegistrationsSubnet {
+  netuid: number;
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number | null;
+}
+
+/** Network-wide registration rollup — true distinct-registrant count (not a per-subnet sum) + total registrations. */
+export interface ChainRegistrationsNetwork {
+  distinct_registrants: number;
+  registrations: number;
+  registrations_per_registrant: number | null;
+}
+
+/**
+ * Network-wide neuron-registration activity over a 7d/30d window (#3465), from
+ * GET /api/v1/chain/registrations — subnets ranked by NeuronRegistered event count,
+ * plus the true network-wide distinct-registrant rollup and a distribution summary of
+ * per-subnet re-registration intensity. Zeroed with an empty subnets list when cold.
+ */
+export interface ChainRegistrations {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainRegistrationsNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainRegistrationsSubnet[];
+}
+
 /** Network-wide stake/emission concentration from GET /api/v1/chain/concentration. */
 export interface ChainConcentration {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -3,7 +3,7 @@ import { useInfiniteQuery, useQuery, useSuspenseQueries } from "@tanstack/react-
 import { Suspense, useMemo, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Activity, Boxes, Coins, Layers, Zap } from "lucide-react";
+import { Activity, Boxes, Coins, Layers, UserPlus, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -24,6 +24,7 @@ import {
   chainFeesQuery,
   chainSignersQuery,
   chainWeightSettersQuery,
+  chainRegistrationsQuery,
   chainStakeFlowQuery,
   chainStakeMovesQuery,
   chainTurnoverQuery,
@@ -44,6 +45,7 @@ import type {
   ChainTurnover,
   EconomicsTrends,
   ChainAxonRemovals,
+  ChainRegistrations,
 } from "@/lib/metagraphed/types";
 
 const explorerSearchSchema = z.object({
@@ -105,6 +107,7 @@ function ExplorerPage() {
           "/api/v1/chain/calls",
           "/api/v1/chain/signers",
           "/api/v1/chain/weights/setters",
+          "/api/v1/chain/registrations",
           "/api/v1/chain/stake-flow",
           "/api/v1/chain/stake-moves",
           "/api/v1/chain/turnover",
@@ -580,6 +583,94 @@ function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
 }
 
 /**
+ * Network-wide neuron-registration leaderboard (#3465) — subnets ranked by
+ * NeuronRegistered volume over the window. Chain-direct: GET /api/v1/chain/registrations.
+ */
+function NetworkRegistrationsSection({ registrations }: { registrations: ChainRegistrations }) {
+  const net = registrations.network;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Network registrations
+        </h2>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(registrations.subnet_count)} subnets
+        </span>
+      </div>
+
+      <div className="mb-5 grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Registrations"
+          value={formatNumber(net.registrations)}
+          hint={`${registrations.window ?? "window"} total`}
+          tone="accent"
+        />
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Distinct registrants"
+          value={formatNumber(net.distinct_registrants)}
+          hint="network-wide hotkeys"
+        />
+        <StatTile
+          icon={UserPlus}
+          eyebrow="Per registrant"
+          value={
+            net.registrations_per_registrant != null
+              ? net.registrations_per_registrant.toFixed(2)
+              : "—"
+          }
+          hint="avg registrations"
+        />
+      </div>
+
+      {registrations.subnets.length > 0 ? (
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr>
+              <th className={TH}>Subnet</th>
+              <th className={`${TH} text-right`}>Registrations</th>
+              <th className={`${TH} text-right`}>Distinct registrants</th>
+              <th className={`${TH} text-right`}>Per registrant</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {registrations.subnets.map((s) => (
+              <tr key={s.netuid} className="hover:bg-surface/40">
+                <td className="px-4 py-2 font-mono text-[11px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: s.netuid }}
+                    className="text-ink-strong hover:text-accent hover:underline"
+                  >
+                    SN{s.netuid}
+                  </Link>
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  {formatNumber(s.registrations)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {formatNumber(s.distinct_registrants)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  {s.registrations_per_registrant != null
+                    ? s.registrations_per_registrant.toFixed(2)
+                    : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <EmptyState title="No registrations in this window yet." />
+      )}
+    </section>
+  );
+}
+
+/**
  * Network-wide validator-set turnover (#3473) — how much each subnet's validator
  * set churned over the window (entered / exited, retention, stability), plus the
  * most volatile subnets. Chain-direct: GET /api/v1/chain/turnover. Placed here
@@ -766,6 +857,7 @@ function ExplorerDashboard() {
     { data: callsRes },
     { data: signersRes },
     { data: weightSettersRes },
+    { data: registrationsRes },
     { data: stakeFlowRes },
     { data: stakeMovesRes },
     { data: turnoverRes },
@@ -780,6 +872,7 @@ function ExplorerDashboard() {
       chainCallsQuery(win),
       chainSignersQuery(win),
       chainWeightSettersQuery(win),
+      chainRegistrationsQuery(win),
       chainStakeFlowQuery(win),
       chainStakeMovesQuery(win),
       chainTurnoverQuery(win),
@@ -794,6 +887,7 @@ function ExplorerDashboard() {
   const calls = callsRes.data;
   const signers = signersRes.data;
   const weightSetters = weightSettersRes.data;
+  const registrations = registrationsRes.data;
   const stakeFlow = stakeFlowRes.data;
   const stakeMoves = stakeMovesRes.data;
   const turnover = turnoverRes.data;
@@ -1166,6 +1260,8 @@ function ExplorerDashboard() {
       <StakeMovesSection moves={stakeMoves} />
 
       <ValidatorTurnoverSection turnover={turnover} />
+
+      <NetworkRegistrationsSection registrations={registrations} />
 
       {/* stake-transfer leaderboard */}
       <section className="rounded-lg border border-border bg-card p-5">


### PR DESCRIPTION
## Summary

- Add `ChainRegistrations` types and `chainRegistrationsQuery(window)` fetching `GET /api/v1/chain/registrations`
- Render a **Network registrations** ranked leaderboard on `/explorer`, with network rollup `StatTile`s and per-subnet rows (registrations, distinct registrants, per registrant)
- Respect the page's existing `7d`/`30d` window toggle; add `/api/v1/chain/registrations` to `ApiSourceFooter`

Closes #3465 · Part of #2542

> **Scope note:** The issue title references `/leaderboards`, but main has no such route — this lands on `/explorer` per the issue deliverable.

## Screenshots

Captured on `/explorer?window=7d`. Theme forced via `localStorage.setItem("mg-theme", "dark"|"light")` before navigation. **Before:** `origin/main` (`:5173`). **After:** feature branch (`:5178`).

> **Where to look:** after adds a new **Network registrations** section (rollup tiles + ranked subnet table) between Validator turnover and Stake-transfer leaderboard.

### Full page

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3465-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `/explorer` shows **Network registrations** section below Validator turnover
- [x] Rollup tiles: Registrations, Distinct registrants, Per registrant
- [x] Table columns: Subnet (linked), Registrations, Distinct registrants, Per registrant
- [x] `7d`/`30d` toggle re-fetches via `chainRegistrationsQuery(win)`
- [x] Empty state: "No registrations in this window yet."
- [x] `ApiSourceFooter` includes `/api/v1/chain/registrations`
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
