### PR TITLE
fix(data-api): guarantee connection affinity for Hyperdrive transactions

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -38,6 +38,14 @@ vi.mock("postgres", () => ({
       return Promise.resolve(mockRows.current);
     };
     sql.end = () => Promise.resolve();
+    // sql.begin(["read only",] cb) reserves a connection for cb in real
+    // postgres.js; the mock just invokes cb with this same sql function so
+    // every existing tagged-template assertion (sqlCalls, mockQueue) still
+    // sees the identical call stream, and resolves to whatever cb returns.
+    sql.begin = (optionsOrCb, maybeCb) => {
+      const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+      return cb(sql);
+    };
     return sql;
   },
 }));

--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -29,6 +29,11 @@ vi.mock("postgres", () => ({
     };
     sql.json = (value) => value;
     sql.end = () => Promise.resolve();
+    // sql.begin(cb) reserves a connection for cb in real postgres.js; the
+    // mock just invokes cb with this same sql function so every existing
+    // tagged-template assertion (sqlCalls) still sees the identical call
+    // stream, and resolves to (or rejects with) whatever cb does.
+    sql.begin = (cb) => cb(sql);
     return sql;
   },
 }));

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -7,8 +7,11 @@
 // tiers (chain_events / deep history); this exposes them to the public API.
 //
 // READ-ONLY. Every query is parameterized (postgres.js tagged templates). The
-// connection is opened per request through Hyperdrive (pooled + edge-cached) and
-// closed via ctx.waitUntil so it never blocks the response.
+// client is created fresh per request through Hyperdrive (Cloudflare's
+// documented pattern -- Hyperdrive itself is the warm connection pool, so
+// this is cheap) and every request's queries run inside a single read-only
+// sql.begin() transaction for connection affinity (#4686). Hyperdrive cleans
+// up the connection automatically when the request ends -- no sql.end().
 import postgres from "postgres";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
 import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
@@ -116,7 +119,7 @@ function coerceEvent(row) {
 }
 
 export default {
-  async fetch(request, env, ctx) {
+  async fetch(request, env, _ctx) {
     const url = new URL(request.url);
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
@@ -135,39 +138,51 @@ export default {
     });
 
     try {
-      await sql`SET statement_timeout = '3000ms'`;
+      // sql.begin() reserves ONE physical connection for every query below,
+      // including the SET -- Hyperdrive resets session state when a
+      // connection is returned to its pool, and a single Worker invocation
+      // can be handed different pooled connections across sequential
+      // queries, so a bare SET (no transaction) has no guarantee it applies
+      // to the query that follows it (Hyperdrive's connection-lifecycle
+      // docs; #4686's root cause). "read only" matches this Worker's own
+      // READ-ONLY invariant (top of file) at the database level too.
+      return await sql.begin("read only", async (sql) => {
+        await sql`SET statement_timeout = '3000ms'`;
 
-      // GET /api/v1/blocks (D1 serving-cutover, #4656 followup): the recent-block
-      // feed, mirroring src/blocks.mjs's loadBlocks filter set exactly (author,
-      // spec_version, block_start/block_end, from/to, min_extrinsics/min_events,
-      // cursor). The main Worker only calls this when its per-tier serving flag
-      // is on and forwards the SAME request it already validated -- this route
-      // trusts well-formed params rather than re-deriving 400s.
-      if (url.pathname === "/api/v1/blocks") {
-        const limit = clampLimit(url.searchParams.get("limit"));
-        const offset = clampOffset(url.searchParams.get("offset"));
-        const cursor = decodeCursor(url.searchParams.get("cursor"), 1);
-        const author = url.searchParams.get("author") || null;
-        const specVersion = nonNegativeIntegerParam(
-          url.searchParams,
-          "spec_version",
-        );
-        const blockStart = nonNegativeIntegerParam(
-          url.searchParams,
-          "block_start",
-        );
-        const blockEnd = nonNegativeIntegerParam(url.searchParams, "block_end");
-        const from = nonNegativeIntegerParam(url.searchParams, "from");
-        const to = nonNegativeIntegerParam(url.searchParams, "to");
-        const minExtrinsics = nonNegativeIntegerParam(
-          url.searchParams,
-          "min_extrinsics",
-        );
-        const minEvents = nonNegativeIntegerParam(
-          url.searchParams,
-          "min_events",
-        );
-        const rows = await sql`
+        // GET /api/v1/blocks (D1 serving-cutover, #4656 followup): the recent-block
+        // feed, mirroring src/blocks.mjs's loadBlocks filter set exactly (author,
+        // spec_version, block_start/block_end, from/to, min_extrinsics/min_events,
+        // cursor). The main Worker only calls this when its per-tier serving flag
+        // is on and forwards the SAME request it already validated -- this route
+        // trusts well-formed params rather than re-deriving 400s.
+        if (url.pathname === "/api/v1/blocks") {
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 1);
+          const author = url.searchParams.get("author") || null;
+          const specVersion = nonNegativeIntegerParam(
+            url.searchParams,
+            "spec_version",
+          );
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const from = nonNegativeIntegerParam(url.searchParams, "from");
+          const to = nonNegativeIntegerParam(url.searchParams, "to");
+          const minExtrinsics = nonNegativeIntegerParam(
+            url.searchParams,
+            "min_extrinsics",
+          );
+          const minEvents = nonNegativeIntegerParam(
+            url.searchParams,
+            "min_events",
+          );
+          const rows = await sql`
           SELECT block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at
           FROM blocks
           WHERE TRUE
@@ -183,78 +198,85 @@ export default {
           ORDER BY block_number DESC
           LIMIT ${limit}
           ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
-        const last = rows.length === limit ? rows[rows.length - 1] : null;
-        const nextCursor = last
-          ? encodeCursor([numberOrNull(last.block_number)])
-          : null;
-        return json(buildBlockFeed(rows, { limit, offset, nextCursor }));
-      }
-
-      // GET /api/v1/blocks/:ref — per-block detail + nearest stored neighbors,
-      // mirroring src/blocks.mjs's loadBlock. ref is a numeric block_number or a
-      // 0x block_hash (lowercased before binding, matching the D1 path's
-      // case-insensitivity workaround).
-      const blockRef = url.pathname.match(/^\/api\/v1\/blocks\/([^/]+)$/);
-      if (blockRef) {
-        const ref = decodeURIComponent(blockRef[1]);
-        const isHash = HASH_RE.test(ref);
-        const blockNumber =
-          !isHash && /^\d+$/.test(ref) && Number.isSafeInteger(Number(ref))
-            ? Number(ref)
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([numberOrNull(last.block_number)])
             : null;
-        if (!isHash && blockNumber === null) {
-          return json(buildBlock(undefined, ref));
+          return json(buildBlockFeed(rows, { limit, offset, nextCursor }));
         }
-        const rows = isHash
-          ? await sql`
+
+        // GET /api/v1/blocks/:ref — per-block detail + nearest stored neighbors,
+        // mirroring src/blocks.mjs's loadBlock. ref is a numeric block_number or a
+        // 0x block_hash (lowercased before binding, matching the D1 path's
+        // case-insensitivity workaround).
+        const blockRef = url.pathname.match(/^\/api\/v1\/blocks\/([^/]+)$/);
+        if (blockRef) {
+          const ref = decodeURIComponent(blockRef[1]);
+          const isHash = HASH_RE.test(ref);
+          const blockNumber =
+            !isHash && /^\d+$/.test(ref) && Number.isSafeInteger(Number(ref))
+              ? Number(ref)
+              : null;
+          if (!isHash && blockNumber === null) {
+            return json(buildBlock(undefined, ref));
+          }
+          const rows = isHash
+            ? await sql`
               SELECT block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at
               FROM blocks WHERE block_hash = ${ref.toLowerCase()} LIMIT 1`
-          : await sql`
+            : await sql`
               SELECT block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at
               FROM blocks WHERE block_number = ${blockNumber} LIMIT 1`;
-        let prev = null;
-        let next = null;
-        const resolvedNumber = numberOrNull(rows[0]?.block_number);
-        if (resolvedNumber != null) {
-          const nbr = await sql`
+          let prev = null;
+          let next = null;
+          const resolvedNumber = numberOrNull(rows[0]?.block_number);
+          if (resolvedNumber != null) {
+            const nbr = await sql`
             SELECT
               (SELECT MAX(block_number) FROM blocks WHERE block_number < ${resolvedNumber}) AS prev,
               (SELECT MIN(block_number) FROM blocks WHERE block_number > ${resolvedNumber}) AS next`;
-          prev = nbr[0]?.prev ?? null;
-          next = nbr[0]?.next ?? null;
+            prev = nbr[0]?.prev ?? null;
+            next = nbr[0]?.next ?? null;
+          }
+          return json(buildBlock(rows[0], ref, { prev, next }));
         }
-        return json(buildBlock(rows[0], ref, { prev, next }));
-      }
 
-      // GET /api/v1/extrinsics — the recent-extrinsic feed, mirroring
-      // src/extrinsics.mjs's loadExtrinsics filter set exactly (signer,
-      // call_module, call_function, call_hash, success, block, block_start/
-      // block_end, from/to, cursor). Index selection is left to Postgres'
-      // planner (schema.sql's idx_extrinsics_signer_block / idx_extrinsics_call
-      // cover the same access patterns D1's INDEXED BY hints targeted) --
-      // Postgres has no INDEXED BY equivalent.
-      if (url.pathname === "/api/v1/extrinsics") {
-        const limit = clampLimit(url.searchParams.get("limit"));
-        const offset = clampOffset(url.searchParams.get("offset"));
-        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
-        const block = nonNegativeIntegerParam(url.searchParams, "block");
-        const signer = url.searchParams.get("signer") || null;
-        const callModule = url.searchParams.get("call_module") || null;
-        const callFunction = url.searchParams.get("call_function") || null;
-        const callHashRaw = url.searchParams.get("call_hash");
-        const callHash =
-          callHashRaw && HASH_RE.test(callHashRaw) ? callHashRaw : null;
-        const successRaw = url.searchParams.get("success");
-        const success =
-          successRaw === "true" ? true : successRaw === "false" ? false : null;
-        const blockStart = nonNegativeIntegerParam(
-          url.searchParams,
-          "block_start",
-        );
-        const blockEnd = nonNegativeIntegerParam(url.searchParams, "block_end");
-        const from = nonNegativeIntegerParam(url.searchParams, "from");
-        const to = nonNegativeIntegerParam(url.searchParams, "to");
-        const rows = await sql`
+        // GET /api/v1/extrinsics — the recent-extrinsic feed, mirroring
+        // src/extrinsics.mjs's loadExtrinsics filter set exactly (signer,
+        // call_module, call_function, call_hash, success, block, block_start/
+        // block_end, from/to, cursor). Index selection is left to Postgres'
+        // planner (schema.sql's idx_extrinsics_signer_block / idx_extrinsics_call
+        // cover the same access patterns D1's INDEXED BY hints targeted) --
+        // Postgres has no INDEXED BY equivalent.
+        if (url.pathname === "/api/v1/extrinsics") {
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const block = nonNegativeIntegerParam(url.searchParams, "block");
+          const signer = url.searchParams.get("signer") || null;
+          const callModule = url.searchParams.get("call_module") || null;
+          const callFunction = url.searchParams.get("call_function") || null;
+          const callHashRaw = url.searchParams.get("call_hash");
+          const callHash =
+            callHashRaw && HASH_RE.test(callHashRaw) ? callHashRaw : null;
+          const successRaw = url.searchParams.get("success");
+          const success =
+            successRaw === "true"
+              ? true
+              : successRaw === "false"
+                ? false
+                : null;
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const from = nonNegativeIntegerParam(url.searchParams, "from");
+          const to = nonNegativeIntegerParam(url.searchParams, "to");
+          const rows = await sql`
           SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
           FROM extrinsics
           WHERE TRUE
@@ -272,92 +294,95 @@ export default {
           ORDER BY block_number DESC, extrinsic_index DESC
           LIMIT ${limit}
           ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
-        const last = rows.length === limit ? rows[rows.length - 1] : null;
-        const nextCursor = last
-          ? encodeCursor([
-              numberOrNull(last.block_number),
-              numberOrNull(last.extrinsic_index),
-            ])
-          : null;
-        return json(buildExtrinsicFeed(rows, { limit, offset, nextCursor }));
-      }
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.block_number),
+                numberOrNull(last.extrinsic_index),
+              ])
+            : null;
+          return json(buildExtrinsicFeed(rows, { limit, offset, nextCursor }));
+        }
 
-      // GET /api/v1/extrinsics/:ref — per-extrinsic detail + embedded
-      // account_events (up to MAX_EMBEDDED_EVENTS), mirroring
-      // src/extrinsic-detail.mjs's loadExtrinsicDetail. ref is a 0x hash or a
-      // composite "block_number-extrinsic_index".
-      const extrinsicRef = url.pathname.match(
-        /^\/api\/v1\/extrinsics\/([^/]+)$/,
-      );
-      if (extrinsicRef) {
-        const ref = decodeURIComponent(extrinsicRef[1]);
-        const isHash = HASH_RE.test(ref);
-        let rows;
-        if (isHash) {
-          rows = await sql`
+        // GET /api/v1/extrinsics/:ref — per-extrinsic detail + embedded
+        // account_events (up to MAX_EMBEDDED_EVENTS), mirroring
+        // src/extrinsic-detail.mjs's loadExtrinsicDetail. ref is a 0x hash or a
+        // composite "block_number-extrinsic_index".
+        const extrinsicRef = url.pathname.match(
+          /^\/api\/v1\/extrinsics\/([^/]+)$/,
+        );
+        if (extrinsicRef) {
+          const ref = decodeURIComponent(extrinsicRef[1]);
+          const isHash = HASH_RE.test(ref);
+          let rows;
+          if (isHash) {
+            rows = await sql`
             SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
             FROM extrinsics WHERE extrinsic_hash = ${ref.toLowerCase()}
             ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`;
-        } else {
-          const composite = COMPOSITE_REF_RE.exec(ref);
-          const blockNumber = composite ? Number(composite[1]) : NaN;
-          const extrinsicIndex = composite ? Number(composite[2]) : NaN;
-          rows =
-            composite &&
-            Number.isSafeInteger(blockNumber) &&
-            Number.isSafeInteger(extrinsicIndex)
-              ? await sql`
+          } else {
+            const composite = COMPOSITE_REF_RE.exec(ref);
+            const blockNumber = composite ? Number(composite[1]) : NaN;
+            const extrinsicIndex = composite ? Number(composite[2]) : NaN;
+            rows =
+              composite &&
+              Number.isSafeInteger(blockNumber) &&
+              Number.isSafeInteger(extrinsicIndex)
+                ? await sql`
                   SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
                   FROM extrinsics WHERE block_number = ${blockNumber} AND extrinsic_index = ${extrinsicIndex} LIMIT 1`
-              : [];
-        }
-        const resolved = rows[0];
-        let events = [];
-        const resolvedBlock = numberOrNull(resolved?.block_number);
-        const resolvedIndex = numberOrNull(resolved?.extrinsic_index);
-        if (resolvedBlock != null && resolvedIndex != null) {
-          const eventRows = await sql`
+                : [];
+          }
+          const resolved = rows[0];
+          let events = [];
+          const resolvedBlock = numberOrNull(resolved?.block_number);
+          const resolvedIndex = numberOrNull(resolved?.extrinsic_index);
+          if (resolvedBlock != null && resolvedIndex != null) {
+            const eventRows = await sql`
             SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
             FROM account_events
             WHERE block_number = ${resolvedBlock} AND extrinsic_index = ${resolvedIndex}
             ORDER BY event_index ASC LIMIT ${MAX_EMBEDDED_EVENTS}`;
-          events = eventRows.map(formatAccountEvent).filter(Boolean);
+            events = eventRows.map(formatAccountEvent).filter(Boolean);
+          }
+          return json(buildExtrinsic(resolved, ref, events));
         }
-        return json(buildExtrinsic(resolved, ref, events));
-      }
 
-      // GET /api/v1/accounts/:ss58/events — the per-account signed-event feed
-      // (#4696), mirroring src/account-events.mjs's loadAccountEvents filter
-      // set (kind, netuid, block_start/block_end, cursor). account_events has
-      // no shape-parity risk (11 scalar columns, its own dedicated writer,
-      // never a generic call_args/chain_events-style SCALE dump) -- unlike
-      // extrinsics/blocks, this tier only needed the query layer built, not a
-      // decode-shape reconciliation.
-      //
-      // D1's hotkey/coldkey union is two INDEXED BY branches combined with
-      // UNION ALL (each SQLite index can only ever seek ONE column), with a
-      // second-branch guard to stop UNION ALL from double-counting a row
-      // where both columns equal the same ss58. Postgres has no INDEXED BY
-      // equivalent and evaluates a flat `WHERE (hotkey = $1 OR coldkey = $1)`
-      // as one plan, so a matching row is naturally visited exactly once --
-      // the double-count guard has nothing to do here and is deliberately
-      // omitted, not an oversight.
-      const acctEvents = url.pathname.match(
-        /^\/api\/v1\/accounts\/([^/]+)\/events$/,
-      );
-      if (acctEvents) {
-        const ss58 = decodeURIComponent(acctEvents[1]);
-        const limit = clampLimit(url.searchParams.get("limit"));
-        const offset = clampOffset(url.searchParams.get("offset"));
-        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
-        const kind = url.searchParams.get("kind") || null;
-        const netuid = nonNegativeIntegerParam(url.searchParams, "netuid");
-        const blockStart = nonNegativeIntegerParam(
-          url.searchParams,
-          "block_start",
+        // GET /api/v1/accounts/:ss58/events — the per-account signed-event feed
+        // (#4696), mirroring src/account-events.mjs's loadAccountEvents filter
+        // set (kind, netuid, block_start/block_end, cursor). account_events has
+        // no shape-parity risk (11 scalar columns, its own dedicated writer,
+        // never a generic call_args/chain_events-style SCALE dump) -- unlike
+        // extrinsics/blocks, this tier only needed the query layer built, not a
+        // decode-shape reconciliation.
+        //
+        // D1's hotkey/coldkey union is two INDEXED BY branches combined with
+        // UNION ALL (each SQLite index can only ever seek ONE column), with a
+        // second-branch guard to stop UNION ALL from double-counting a row
+        // where both columns equal the same ss58. Postgres has no INDEXED BY
+        // equivalent and evaluates a flat `WHERE (hotkey = $1 OR coldkey = $1)`
+        // as one plan, so a matching row is naturally visited exactly once --
+        // the double-count guard has nothing to do here and is deliberately
+        // omitted, not an oversight.
+        const acctEvents = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/events$/,
         );
-        const blockEnd = nonNegativeIntegerParam(url.searchParams, "block_end");
-        const rows = await sql`
+        if (acctEvents) {
+          const ss58 = decodeURIComponent(acctEvents[1]);
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const kind = url.searchParams.get("kind") || null;
+          const netuid = nonNegativeIntegerParam(url.searchParams, "netuid");
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const rows = await sql`
           SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
           FROM account_events
           WHERE (hotkey = ${ss58} OR coldkey = ${ss58})
@@ -369,74 +394,75 @@ export default {
           ORDER BY block_number DESC, event_index DESC
           LIMIT ${limit}
           ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
-        const last = rows.length === limit ? rows[rows.length - 1] : null;
-        const nextCursor = last
-          ? encodeCursor([
-              numberOrNull(last.block_number),
-              numberOrNull(last.event_index),
-            ])
-          : null;
-        return json(
-          buildAccountEvents(rows, ss58, { limit, offset, nextCursor }),
-        );
-      }
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.block_number),
+                numberOrNull(last.event_index),
+              ])
+            : null;
+          return json(
+            buildAccountEvents(rows, ss58, { limit, offset, nextCursor }),
+          );
+        }
 
-      // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events
-      // tier). Distinct from the existing /blocks/:ref/events (curated, D1, #1852).
-      const block = url.pathname.match(
-        /^\/api\/v1\/blocks\/(\d+)\/chain-events$/,
-      );
-      if (block) {
-        const bn = Number(block[1]);
-        const rows = await sql`
+        // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events
+        // tier). Distinct from the existing /blocks/:ref/events (curated, D1, #1852).
+        const block = url.pathname.match(
+          /^\/api\/v1\/blocks\/(\d+)\/chain-events$/,
+        );
+        if (block) {
+          const bn = Number(block[1]);
+          const rows = await sql`
           SELECT event_index, pallet, method, args, phase, extrinsic_index, observed_at
           FROM chain_events
           WHERE block_number = ${bn}
           ORDER BY event_index ASC`;
-        return json({
-          block_number: bn,
-          count: rows.length,
-          events: rows.map(coerceEvent),
-        });
-      }
+          return json({
+            block_number: bn,
+            count: rows.length,
+            events: rows.map(coerceEvent),
+          });
+        }
 
-      // GET /api/v1/chain-events?pallet=&method=&block=&extrinsic=&cursor=&before=&limit=
-      // recent all-events feed. block= scopes to one block; block=+extrinsic= scopes to
-      // a single extrinsic's emitted events (explorer extrinsic-detail view). Ignore
-      // extrinsic without block to avoid an unindexed global extrinsic_index scan.
-      // cursor is the lossless keyset over (block_number,event_index); before is
-      // retained as the legacy block_number-only cursor for existing callers.
-      if (url.pathname === "/api/v1/chain-events") {
-        const limit = clampLimit(url.searchParams.get("limit"));
-        const pallet = url.searchParams.get("pallet");
-        const method = url.searchParams.get("method");
-        if (!validEventFilter(pallet) || !validEventFilter(method)) {
-          return json(
-            {
-              error:
-                "pallet and method must be 1-64 ASCII letters, digits, or underscores, starting with a letter",
-            },
-            400,
-          );
-        }
-        const blockN = nonNegativeIntegerParam(url.searchParams, "block");
-        const extrN =
-          blockN != null
-            ? nonNegativeIntegerParam(url.searchParams, "extrinsic")
-            : null;
-        const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
-        const beforeBn = cursor
-          ? null
-          : nonNegativeIntegerParam(url.searchParams, "before"); // legacy block_number cursor
-        if (method && !pallet && blockN == null) {
-          return json(
-            {
-              error: "method filter requires pallet unless block is specified",
-            },
-            400,
-          );
-        }
-        const rows = await sql`
+        // GET /api/v1/chain-events?pallet=&method=&block=&extrinsic=&cursor=&before=&limit=
+        // recent all-events feed. block= scopes to one block; block=+extrinsic= scopes to
+        // a single extrinsic's emitted events (explorer extrinsic-detail view). Ignore
+        // extrinsic without block to avoid an unindexed global extrinsic_index scan.
+        // cursor is the lossless keyset over (block_number,event_index); before is
+        // retained as the legacy block_number-only cursor for existing callers.
+        if (url.pathname === "/api/v1/chain-events") {
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const pallet = url.searchParams.get("pallet");
+          const method = url.searchParams.get("method");
+          if (!validEventFilter(pallet) || !validEventFilter(method)) {
+            return json(
+              {
+                error:
+                  "pallet and method must be 1-64 ASCII letters, digits, or underscores, starting with a letter",
+              },
+              400,
+            );
+          }
+          const blockN = nonNegativeIntegerParam(url.searchParams, "block");
+          const extrN =
+            blockN != null
+              ? nonNegativeIntegerParam(url.searchParams, "extrinsic")
+              : null;
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const beforeBn = cursor
+            ? null
+            : nonNegativeIntegerParam(url.searchParams, "before"); // legacy block_number cursor
+          if (method && !pallet && blockN == null) {
+            return json(
+              {
+                error:
+                  "method filter requires pallet unless block is specified",
+              },
+              400,
+            );
+          }
+          const rows = await sql`
           SELECT block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at
           FROM chain_events
           WHERE TRUE
@@ -453,52 +479,56 @@ export default {
             ${method ? sql`AND method = ${method}` : sql``}
           ORDER BY block_number DESC, event_index DESC
           LIMIT ${limit}`;
-        const last = rows.length === limit ? rows[rows.length - 1] : null;
-        const nextBlock = last ? numberOrNull(last.block_number) : null;
-        const nextCursor = last
-          ? encodeCursor([nextBlock, numberOrNull(last.event_index)])
-          : null;
-        return json({
-          count: rows.length,
-          next_before: nextBlock,
-          next_cursor: nextCursor,
-          events: rows.map(coerceEvent),
-        });
-      }
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextBlock = last ? numberOrNull(last.block_number) : null;
+          const nextCursor = last
+            ? encodeCursor([nextBlock, numberOrNull(last.event_index)])
+            : null;
+          return json({
+            count: rows.length,
+            next_before: nextBlock,
+            next_cursor: nextCursor,
+            events: rows.map(coerceEvent),
+          });
+        }
 
-      // GET /api/v1/chain-events/stats?blocks=N — chain-activity aggregate: the
-      // pallet.method event distribution over the most recent N blocks (default
-      // 1000, capped 5000). Bounded window + capped output keep it index-cheap.
-      if (url.pathname === "/api/v1/chain-events/stats") {
-        const blocks = clampStatsBlocks(url.searchParams.get("blocks"));
-        // count is a non-unique sort key, so ORDER BY count alone leaves ties
-        // unordered — and over Hyperdrive's pooled connections (prepare:false)
-        // Postgres can plan/scan identical requests differently, reshuffling
-        // equal-count groups and flipping which groups survive LIMIT 100 at the
-        // boundary. Tie-break on the GROUP BY key (unique per row) for a total,
-        // stable order, matching the keyset orders on the sibling queries above.
-        const rows = await sql`
+        // GET /api/v1/chain-events/stats?blocks=N — chain-activity aggregate: the
+        // pallet.method event distribution over the most recent N blocks (default
+        // 1000, capped 5000). Bounded window + capped output keep it index-cheap.
+        if (url.pathname === "/api/v1/chain-events/stats") {
+          const blocks = clampStatsBlocks(url.searchParams.get("blocks"));
+          // count is a non-unique sort key, so ORDER BY count alone leaves ties
+          // unordered — and over Hyperdrive's pooled connections (prepare:false)
+          // Postgres can plan/scan identical requests differently, reshuffling
+          // equal-count groups and flipping which groups survive LIMIT 100 at the
+          // boundary. Tie-break on the GROUP BY key (unique per row) for a total,
+          // stable order, matching the keyset orders on the sibling queries above.
+          const rows = await sql`
           SELECT pallet, method, count(*)::int AS count
           FROM chain_events
           WHERE block_number > (SELECT max(block_number) FROM chain_events) - ${blocks}
           GROUP BY pallet, method
           ORDER BY count DESC, pallet ASC, method ASC
           LIMIT 100`;
-        return json({
-          window_blocks: blocks,
-          groups: rows.length,
-          activity: rows,
-        });
-      }
+          return json({
+            window_blocks: blocks,
+            groups: rows.length,
+            activity: rows,
+          });
+        }
 
-      return json({ error: "not found" }, 404);
+        return json({ error: "not found" }, 404);
+      });
     } catch (err) {
       // Log internally (Wrangler observability) but NEVER leak DB error details
       // (schema, table, or connection info) to API clients.
       console.error("data-api query failed:", err);
       return json({ error: "data query failed" }, 502);
-    } finally {
-      ctx.waitUntil(sql.end({ timeout: 5 }).catch(() => {}));
     }
+    // No sql.end() here: Hyperdrive automatically cleans up the connection
+    // when the request/invocation ends (Cloudflare's documented pattern) --
+    // the previous ctx.waitUntil(sql.end(...)) was undocumented, unnecessary
+    // background work racing the response, right where #4686's subrequest-
+    // cancellation flakiness was observed.
   },
 };

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -116,11 +116,21 @@ export default {
       subnets_deleted: 0,
     };
     try {
-      await sql`SET statement_timeout = '10000ms'`;
+      // sql.begin() reserves ONE physical connection for the whole batch,
+      // including the SET -- Hyperdrive resets session state when a
+      // connection is returned to its pool, so a bare SET (no transaction)
+      // has no guarantee it applies to the writes that follow it (Hyperdrive's
+      // connection-lifecycle docs; same root cause as #4686). This also makes
+      // the batch atomic: previously a mid-batch failure left whatever had
+      // already been written committed and the rest silently never applied,
+      // a partial-sync state with no way to tell it happened; now the whole
+      // batch commits together or rolls back together.
+      return await sql.begin(async (sql) => {
+        await sql`SET statement_timeout = '10000ms'`;
 
-      for (const p of providers) {
-        if (!p.id || !p.overlay || !p.source_commit) continue;
-        await sql`
+        for (const p of providers) {
+          if (!p.id || !p.overlay || !p.source_commit) continue;
+          await sql`
           INSERT INTO providers (id, overlay, source_commit)
           VALUES (${p.id}, ${sql.json(p.overlay)}, ${p.source_commit})
           ON CONFLICT (id) DO UPDATE SET
@@ -128,20 +138,20 @@ export default {
             source_commit = EXCLUDED.source_commit,
             updated_at = now()
           WHERE providers.overlay IS DISTINCT FROM EXCLUDED.overlay`;
-        summary.providers_written += 1;
-      }
+          summary.providers_written += 1;
+        }
 
-      const writtenSubnetNetuids = new Set();
-      for (const s of subnets) {
-        if (
-          !Number.isInteger(s.netuid) ||
-          !s.slug ||
-          !s.name ||
-          !s.overlay ||
-          !s.source_commit
-        )
-          continue;
-        await sql`
+        const writtenSubnetNetuids = new Set();
+        for (const s of subnets) {
+          if (
+            !Number.isInteger(s.netuid) ||
+            !s.slug ||
+            !s.name ||
+            !s.overlay ||
+            !s.source_commit
+          )
+            continue;
+          await sql`
           INSERT INTO subnets (netuid, slug, name, source, overlay, source_commit)
           VALUES (${s.netuid}, ${s.slug}, ${s.name}, ${s.source || "community"}, ${sql.json(s.overlay)}, ${s.source_commit})
           ON CONFLICT (netuid) DO UPDATE SET
@@ -151,86 +161,86 @@ export default {
             overlay = EXCLUDED.overlay,
             source_commit = EXCLUDED.source_commit,
             updated_at = now()`;
-        summary.subnets_written += 1;
-        writtenSubnetNetuids.add(s.netuid);
-      }
+          summary.subnets_written += 1;
+          writtenSubnetNetuids.add(s.netuid);
+        }
 
-      for (const prune of pruneSurfaces) {
-        if (
-          !Number.isInteger(prune.subnet_netuid) ||
-          !Array.isArray(prune.current_surfaces) ||
-          !prune.source_commit
-        )
-          continue;
-        const keepKeys = prune.current_surfaces
-          .filter((surface) => surface?.kind && surface?.url)
-          .map((surface) => `${surface.kind}\u001f${surface.url}`);
-        // `authority_scope: "community"` (set by the merge-triggered fast path,
-        // scripts/sync-registry-to-postgres.mjs) bounds this prune to ONLY the
-        // community-authority rows for the subnet -- the fast path's
-        // current_surfaces comes from a single registry/subnets/<slug>.json file
-        // and has no visibility into machine-generated/candidate-promoted
-        // surfaces (authority: "registry-observed") the same subnet may also
-        // carry, so without this scope it would delete those rows on every
-        // merge that touches the file. The scheduled full resync
-        // (scripts/backfill-registry-postgres.mjs) computes current_surfaces
-        // from the complete baseline-augmented view and omits authority_scope,
-        // so it keeps pruning across every authority as before. Passed as a
-        // plain boolean parameter (not spliced SQL) so the condition is a
-        // no-op OR branch when unscoped, rather than composing raw fragments.
-        const scopeToCommunity = prune.authority_scope === "community";
-        const deleted = keepKeys.length
-          ? await sql`
+        for (const prune of pruneSurfaces) {
+          if (
+            !Number.isInteger(prune.subnet_netuid) ||
+            !Array.isArray(prune.current_surfaces) ||
+            !prune.source_commit
+          )
+            continue;
+          const keepKeys = prune.current_surfaces
+            .filter((surface) => surface?.kind && surface?.url)
+            .map((surface) => `${surface.kind}\u001f${surface.url}`);
+          // `authority_scope: "community"` (set by the merge-triggered fast path,
+          // scripts/sync-registry-to-postgres.mjs) bounds this prune to ONLY the
+          // community-authority rows for the subnet -- the fast path's
+          // current_surfaces comes from a single registry/subnets/<slug>.json file
+          // and has no visibility into machine-generated/candidate-promoted
+          // surfaces (authority: "registry-observed") the same subnet may also
+          // carry, so without this scope it would delete those rows on every
+          // merge that touches the file. The scheduled full resync
+          // (scripts/backfill-registry-postgres.mjs) computes current_surfaces
+          // from the complete baseline-augmented view and omits authority_scope,
+          // so it keeps pruning across every authority as before. Passed as a
+          // plain boolean parameter (not spliced SQL) so the condition is a
+          // no-op OR branch when unscoped, rather than composing raw fragments.
+          const scopeToCommunity = prune.authority_scope === "community";
+          const deleted = keepKeys.length
+            ? await sql`
               DELETE FROM surfaces
               WHERE subnet_netuid = ${prune.subnet_netuid}
                 AND (NOT ${scopeToCommunity} OR authority = ${"community"})
                 AND NOT (kind || ${"\u001f"} || url = ANY(${keepKeys}))
               RETURNING id, subnet_netuid, overlay`
-          : await sql`
+            : await sql`
               DELETE FROM surfaces
               WHERE subnet_netuid = ${prune.subnet_netuid}
                 AND (NOT ${scopeToCommunity} OR authority = ${"community"})
               RETURNING id, subnet_netuid, overlay`;
-        for (const row of deleted) {
-          await sql`
+          for (const row of deleted) {
+            await sql`
             INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
             VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${sql.json(row.overlay)}, ${prune.source_commit})`;
-          summary.surfaces_deleted += 1;
+            summary.surfaces_deleted += 1;
+          }
         }
-      }
 
-      for (const deletion of deleteSubnets) {
-        if (!Number.isInteger(deletion.netuid) || !deletion.source_commit)
-          continue;
-        if (writtenSubnetNetuids.has(deletion.netuid)) continue;
-        const deletedSurfaces = await sql`
+        for (const deletion of deleteSubnets) {
+          if (!Number.isInteger(deletion.netuid) || !deletion.source_commit)
+            continue;
+          if (writtenSubnetNetuids.has(deletion.netuid)) continue;
+          const deletedSurfaces = await sql`
           DELETE FROM surfaces
           WHERE subnet_netuid = ${deletion.netuid}
           RETURNING id, subnet_netuid, overlay`;
-        for (const row of deletedSurfaces) {
-          await sql`
+          for (const row of deletedSurfaces) {
+            await sql`
             INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)
             VALUES (${row.id}, ${row.subnet_netuid}, ${"delete"}, ${sql.json(row.overlay)}, ${deletion.source_commit})`;
-          summary.surfaces_deleted += 1;
-        }
-        const deletedSubnets = await sql`
+            summary.surfaces_deleted += 1;
+          }
+          const deletedSubnets = await sql`
           DELETE FROM subnets
           WHERE netuid = ${deletion.netuid}
           RETURNING netuid`;
-        summary.subnets_deleted += deletedSubnets.length;
-      }
+          summary.subnets_deleted += deletedSubnets.length;
+        }
 
-      for (const surf of surfaces) {
-        if (
-          !Number.isInteger(surf.subnet_netuid) ||
-          !surf.surface_key ||
-          !surf.kind ||
-          !surf.url ||
-          !surf.overlay ||
-          !surf.source_commit
-        )
-          continue;
-        const result = await sql`
+        for (const surf of surfaces) {
+          if (
+            !Number.isInteger(surf.subnet_netuid) ||
+            !surf.surface_key ||
+            !surf.kind ||
+            !surf.url ||
+            !surf.overlay ||
+            !surf.source_commit
+          )
+            continue;
+          const result = await sql`
           INSERT INTO surfaces (
             subnet_netuid, provider_id, surface_key, kind, url,
             authority, review_state, probe_eligible, public_safe,
@@ -254,21 +264,24 @@ export default {
             updated_at = now()
           WHERE surfaces.overlay IS DISTINCT FROM EXCLUDED.overlay
           RETURNING (xmax = 0) AS inserted`;
-        if (result.length) {
-          const action = result[0].inserted ? "insert" : "update";
-          await sql`
+          if (result.length) {
+            const action = result[0].inserted ? "insert" : "update";
+            await sql`
             INSERT INTO surface_history (subnet_netuid, action, overlay, source_commit)
             VALUES (${surf.subnet_netuid}, ${action}, ${sql.json(surf.overlay)}, ${surf.source_commit})`;
-          summary.surfaces_written += 1;
+            summary.surfaces_written += 1;
+          }
         }
-      }
 
-      return json({ ok: true, ...summary });
+        return json({ ok: true, ...summary });
+      });
     } catch (err) {
       console.error("registry-sync-api write failed:", err);
       return json({ error: "write failed" }, 502);
-    } finally {
-      await sql.end({ timeout: 5 });
     }
+    // No sql.end() here: Hyperdrive automatically cleans up the connection
+    // when the request/invocation ends (Cloudflare's documented pattern) --
+    // the previous await sql.end(...) was undocumented, unnecessary extra
+    // work that also delayed every response by however long teardown took.
   },
 };


### PR DESCRIPTION
## Summary

#4686 found the `DATA_API` service-binding subrequest reporting `outcome:
"canceled"` on a reproducible fraction of requests, plus occasional 404s
on requests that should have matched a route -- both without Postgres
itself being unhealthy. Root-cause research against Cloudflare's official
Hyperdrive documentation found two real, documented issues shared by
`workers/data-api.mjs` and `workers/registry-sync-api.mjs` (identical
pattern in both files):

1. Each request ran a standalone `SET statement_timeout` query, then one
   or more separate data queries, with **no transaction**. Hyperdrive
   resets session state when a connection is returned to its pool, and a
   single Worker invocation can be handed *different* pooled connections
   across sequential queries in the same request -- so the `SET` had no
   guarantee of applying to the query that followed it. For
   `registry-sync-api.mjs`'s multi-row write loop, this also meant a
   mid-batch failure left whatever had already been written committed
   while the rest silently never applied -- a partial-sync state with no
   signal it happened.
2. Both files explicitly called `sql.end()` on every request (`data-api.mjs`
   via `ctx.waitUntil`, `registry-sync-api.mjs` via a blocking `await`) to
   tear the connection down. Cloudflare's Hyperdrive docs are explicit this
   is **unsupported, unnecessary** background work -- Hyperdrive
   automatically cleans up the connection when the request/invocation ends.
   This is exactly the kind of extra in-flight work that could contribute
   to a subrequest looking "canceled" from the calling Worker's side.

Note: per-request client creation itself (`postgres(env.HYPERDRIVE...)`
inside the handler) is **not** the bug -- it's Cloudflare's own documented,
recommended pattern for Hyperdrive (Hyperdrive itself is the warm
connection pool), so that part is left unchanged.

## Change

- Wrap each request's queries in `sql.begin()` (`"read only"` for
  `data-api.mjs`, which only ever selects) so the `SET` and every
  subsequent query in that request run on one physical connection --
  and for `registry-sync-api.mjs`, so the whole write batch commits or
  rolls back together.
- Remove both files' `sql.end()` teardown entirely, matching Cloudflare's
  documented pattern.
- Updated both files' test mocks with a `sql.begin()` shim that invokes
  the callback with the same mock `sql`, preserving every existing
  call-stream assertion unchanged.

## Testing

- `npm run lint && npx prettier --check <changed files>` clean
- `npx vitest run tests/data-api.test.mjs tests/registry-sync-api.test.mjs` -- 67 passed
- Full suite: `npx vitest run` -- 7097 passed (258 files)
- `npm run validate` clean

No screenshot table -- data-api/registry-sync-api only, no `apps/ui` files touched.

Refs #4686 -- this addresses the two documented root-cause candidates found
in Cloudflare's own Hyperdrive guidance. Re-verifying the blocks-tier flip
against a Postgres-only block (the issue's own reproduction case) is the
next step before re-flipping `METAGRAPH_BLOCKS_SOURCE`.