### PR TITLE
fix(ui): prevent yield percentile strip collision at tablet width

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/stat-tile.tsx
+++ b/apps/ui/src/components/metagraphed/charts/stat-tile.tsx
@@ -58,12 +58,12 @@ export function StatTile({
         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate">
           {eyebrow}
         </div>
-        <div className="mt-1 flex items-baseline gap-1.5">
-          <span className="font-display text-2xl font-semibold tabular-nums leading-none text-ink-strong">
+        <div className="mt-1 flex min-w-0 items-baseline gap-1.5">
+          <span className="min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
             {value}
           </span>
           {hint ? (
-            <span className="font-mono text-[10px] text-ink-muted truncate">{hint}</span>
+            <span className="min-w-0 font-mono text-[10px] text-ink-muted truncate">{hint}</span>
           ) : null}
         </div>
       </div>

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -13,6 +13,7 @@ import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { TableState } from "@/components/metagraphed/table-state";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
+import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
 import type {
   ConcentrationMetrics,
   ConcentrationHistoryPoint,
@@ -69,7 +70,7 @@ export function ConcentrationLoader({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-4">
       {/* KPI tiles — stake-weighted by default (the headline distribution). */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <div className={PROFILE_KPI_GRID_CLASS}>
         <StatTile
           icon={Scale}
           eyebrow="Stake Gini"
@@ -100,7 +101,7 @@ export function ConcentrationLoader({ netuid }: { netuid: number }) {
       </div>
 
       {/* Holders / entity context strip. */}
-      <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 min-[400px]:grid-cols-4">
         <Fact label="Stake holders" value={stake?.holders ?? "—"} />
         <Fact label="Emission holders" value={emission?.holders ?? "—"} />
         <Fact label="Entities" value={c.entity_count ?? "—"} />
@@ -154,11 +155,11 @@ function pctToBar(v?: number | null): number {
 
 function Fact({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <div>
-      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+    <div className="min-w-0">
+      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate">
         {label}
       </div>
-      <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong leading-none">
+      <div className="mt-1 min-w-0 truncate font-display text-base font-semibold tabular-nums text-ink-strong leading-none min-[400px]:text-lg">
         {value}
       </div>
     </div>
@@ -216,7 +217,7 @@ function DriftCard({ netuid }: { netuid: number }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Concentration drift
         </span>
@@ -282,11 +283,9 @@ function DriftRow({
 }) {
   const last = series[series.length - 1];
   return (
-    <div className="flex items-center gap-3">
-      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
-        {label}
-      </span>
-      <div className="flex-1 min-w-0">
+    <div className="grid grid-cols-1 gap-1 min-[400px]:grid-cols-[minmax(0,7rem)_1fr_auto] min-[400px]:items-center min-[400px]:gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-ink-muted">{label}</span>
+      <div className="min-w-0">
         <Sparkline
           values={series}
           color={color}
@@ -296,7 +295,7 @@ function DriftRow({
           ariaLabel={label}
         />
       </div>
-      <span className="w-20 shrink-0 text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
+      <span className="min-w-0 font-display text-sm font-semibold tabular-nums text-ink-strong min-[400px]:text-right">
         {last != null ? format(last) : "—"}
       </span>
     </div>
@@ -336,7 +335,7 @@ function PerformanceLoader({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-4">
       {/* KPI tiles — incentive-weighted (the headline reward distribution). */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <div className={PROFILE_KPI_GRID_CLASS}>
         <StatTile
           icon={Scale}
           eyebrow="Incentive Gini"

--- a/apps/ui/src/components/metagraphed/profile-kpi-grid.ts
+++ b/apps/ui/src/components/metagraphed/profile-kpi-grid.ts
@@ -1,0 +1,3 @@
+/** Subnet profile KPI strips (Yield, Concentration, …) — full-width on phones. */
+export const PROFILE_KPI_GRID_CLASS =
+  "grid grid-cols-1 gap-3 min-[400px]:grid-cols-2 sm:grid-cols-3";

--- a/apps/ui/src/components/metagraphed/yield-format.test.ts
+++ b/apps/ui/src/components/metagraphed/yield-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { fmtYield } from "./yield-panel";
+import { fmtYield } from "./yield-format";
 
-describe("fmtYield", () => {
+describe("fmtYield (yield-format)", () => {
   it("returns the em-dash fallback for nullish / non-finite input", () => {
     expect(fmtYield(null)).toBe("—");
     expect(fmtYield(undefined)).toBe("—");
@@ -18,16 +18,23 @@ describe("fmtYield", () => {
     expect(fmtYield(0.01)).toBe("1.00%");
   });
 
-  it("does not collapse distinct validator-scale yields to the same string (#3946)", () => {
-    // Real values observed on-chain for SN64 validators — under the previous
-    // toFixed(4) formatting these all rounded to "0.0041%" or "0.0042%"
-    // despite differing, making a ranked leaderboard look identical/broken.
+  it("preserves distinct strings for clustered validator-scale yields (#3946)", () => {
     const raw = [
       4.1721e-5, 4.1529e-5, 4.1496e-5, 4.1425e-5, 4.1359e-5, 4.1306e-5, 4.1225e-5, 4.1128e-5,
       4.0711e-5, 4.056e-5,
     ];
     const formatted = raw.map((v) => fmtYield(v));
     expect(new Set(formatted).size).toBe(formatted.length);
+  });
+
+  it("formats issue #3934 collision values with visible separation when split across cells", () => {
+    const p25 = fmtYield(0.000016);
+    const median = fmtYield(0.0000161);
+    const p75 = fmtYield(0.007467);
+    const p90 = fmtYield(0.007468);
+    expect(p25).not.toBe(median);
+    expect(p75).not.toBe(p90);
+    expect(`${p25}${median}${p75}${p90}`).not.toBe("0.0016%0.0016%0.7467%");
   });
 
   it("falls back to exponential notation below the 0.001% precision floor", () => {

--- a/apps/ui/src/components/metagraphed/yield-format.ts
+++ b/apps/ui/src/components/metagraphed/yield-format.ts
@@ -1,0 +1,17 @@
+// Yield is an emission/stake return rate — tiny fractions (~1e-5..1e-1). Render
+// as a percentage with adaptive precision; null/non-finite collapses to em-dash.
+//
+// The 0.001-1% band uses significant-figure precision (toPrecision), not a
+// fixed decimal count (toFixed) — validator yields in this subnet-scale range
+// commonly cluster within a few percent of each other (e.g. 0.0041529% vs
+// 0.0041496% vs 0.0041425%), and a fixed toFixed(4) rounds several of them to
+// the exact same displayed string even though the underlying values genuinely
+// differ, making an otherwise-ranked leaderboard look like a data bug.
+export function fmtYield(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "0%";
+  const pct = v * 100;
+  if (Math.abs(pct) >= 1) return `${pct.toFixed(2)}%`;
+  if (Math.abs(pct) >= 0.001) return `${pct.toPrecision(5)}%`;
+  return `${pct.toExponential(2)}%`;
+}

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -12,6 +12,7 @@ import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { YieldPercentileStrip } from "@/components/metagraphed/yield-percentile-strip";
+import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
 import type { SubnetYieldNeuron, YieldHistoryPoint } from "@/lib/metagraphed/types";
 
 type Win = "7d" | "30d" | "90d";
@@ -82,7 +83,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-4">
       {/* KPI tiles — the headline return + central tendency. */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <div className={PROFILE_KPI_GRID_CLASS}>
         <StatTile
           icon={Percent}
           eyebrow="Subnet yield"
@@ -242,7 +243,7 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Yield drift
         </span>
@@ -275,11 +276,9 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
 function DriftRow({ label, series, color }: { label: string; series: number[]; color: string }) {
   const last = series[series.length - 1];
   return (
-    <div className="flex items-center gap-3">
-      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
-        {label}
-      </span>
-      <div className="flex-1 min-w-0">
+    <div className="grid grid-cols-1 gap-1 min-[400px]:grid-cols-[minmax(0,7rem)_1fr_auto] min-[400px]:items-center min-[400px]:gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-ink-muted">{label}</span>
+      <div className="min-w-0">
         <Sparkline
           values={series}
           color={color}
@@ -289,7 +288,7 @@ function DriftRow({ label, series, color }: { label: string; series: number[]; c
           ariaLabel={label}
         />
       </div>
-      <span className="w-20 shrink-0 text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
+      <span className="min-w-0 font-display text-sm font-semibold tabular-nums text-ink-strong min-[400px]:text-right">
         {last != null ? fmtYield(last) : "—"}
       </span>
     </div>

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Percent, Activity, Users, ArrowUpRight, ArrowDownRight, Minus } from "lucide-react";
@@ -11,43 +11,14 @@ import { TableState } from "@/components/metagraphed/table-state";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { YieldPercentileStrip } from "@/components/metagraphed/yield-percentile-strip";
 import type { SubnetYieldNeuron, YieldHistoryPoint } from "@/lib/metagraphed/types";
 
 type Win = "7d" | "30d" | "90d";
 const WINDOWS: Win[] = ["7d", "30d", "90d"];
 const TOP_N = 15;
 
-// Yield is an emission/stake return rate — tiny fractions (~1e-5..1e-1). Render
-// as a percentage with adaptive precision; null/non-finite collapses to em-dash.
-//
-// The 0.001-1% band uses significant-figure precision (toPrecision), not a
-// fixed decimal count (toFixed) — validator yields in this subnet-scale range
-// commonly cluster within a few percent of each other (e.g. 0.0041529% vs
-// 0.0041496% vs 0.0041425%), and a fixed toFixed(4) rounds several of them to
-// the exact same displayed string even though the underlying values genuinely
-// differ, making an otherwise-ranked leaderboard look like a data bug.
-export function fmtYield(v?: number | null): string {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (v === 0) return "0%";
-  const pct = v * 100;
-  if (Math.abs(pct) >= 1) return `${pct.toFixed(2)}%`;
-  if (Math.abs(pct) >= 0.001) return `${pct.toPrecision(5)}%`;
-  return `${pct.toExponential(2)}%`;
-}
-
-function Fact({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <div>
-      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </div>
-      <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong leading-none">
-        {value}
-      </div>
-    </div>
-  );
-}
-
+import { fmtYield } from "@/components/metagraphed/yield-format";
 function VsMedian({ vs }: { vs: SubnetYieldNeuron["vs_median"] }) {
   if (vs === "above")
     return (
@@ -146,13 +117,13 @@ export function YieldLoader({ netuid }: { netuid: number }) {
           )}
         </div>
 
-        {/* Yield percentile spread. */}
-        <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Fact label="p25" value={fmtYield(y.p25_yield)} />
-          <Fact label="Median" value={fmtYield(y.median_yield)} />
-          <Fact label="p75" value={fmtYield(y.p75_yield)} />
-          <Fact label="p90" value={fmtYield(y.p90_yield)} />
-        </div>
+        {/* Yield percentile spread — container-query layout (#3934). */}
+        <YieldPercentileStrip
+          p25_yield={y.p25_yield}
+          median_yield={y.median_yield}
+          p75_yield={y.p75_yield}
+          p90_yield={y.p90_yield}
+        />
       </div>
 
       {/* Per-UID yield leaderboard (top yielders). */}

--- a/apps/ui/src/components/metagraphed/yield-percentile-layout.test.ts
+++ b/apps/ui/src/components/metagraphed/yield-percentile-layout.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH,
+  YIELD_PERCENTILE_STRIP_GRID_CLASS,
+  buildYieldPercentileData,
+  shouldUseYieldPercentileFourColumnLayout,
+} from "./yield-percentile-layout";
+
+describe("yield percentile layout tokens", () => {
+  it("pins the four-column container threshold at 28rem (#3934)", () => {
+    expect(YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH).toBe("28rem");
+  });
+
+  it("defaults to a 2-column grid and promotes to four columns via container query", () => {
+    expect(YIELD_PERCENTILE_STRIP_GRID_CLASS).toContain("grid-cols-2");
+    expect(YIELD_PERCENTILE_STRIP_GRID_CLASS).toContain("@min-[28rem]:grid-cols-4");
+    expect(YIELD_PERCENTILE_STRIP_GRID_CLASS).not.toContain("sm:grid-cols-4");
+  });
+});
+
+describe("shouldUseYieldPercentileFourColumnLayout", () => {
+  it("returns false below the 28rem threshold (tablet half-width card)", () => {
+    // 768px viewport, md two-up row → ~384px card interior minus padding.
+    expect(shouldUseYieldPercentileFourColumnLayout(360)).toBe(false);
+    expect(shouldUseYieldPercentileFourColumnLayout(447)).toBe(false);
+  });
+
+  it("returns true at and above the 28rem threshold", () => {
+    expect(shouldUseYieldPercentileFourColumnLayout(448)).toBe(true);
+    expect(shouldUseYieldPercentileFourColumnLayout(736)).toBe(true);
+  });
+
+  it("rejects non-finite widths", () => {
+    expect(shouldUseYieldPercentileFourColumnLayout(Number.NaN)).toBe(false);
+    expect(shouldUseYieldPercentileFourColumnLayout(-1)).toBe(false);
+    expect(shouldUseYieldPercentileFourColumnLayout(0)).toBe(false);
+  });
+});
+
+describe("buildYieldPercentileData", () => {
+  const formatYield = (v?: number | null) =>
+    v == null || !Number.isFinite(v) ? "—" : `${(v * 100).toPrecision(5)}%`;
+
+  it("emits four tiles in p25 → median → p75 → p90 order", () => {
+    const tiles = buildYieldPercentileData({
+      p25_yield: 0.000016,
+      median_yield: 0.000016,
+      p75_yield: 0.007467,
+      p90_yield: 0.012,
+      formatYield,
+    });
+    expect(tiles.map((t) => t.key)).toEqual(["p25", "median", "p75", "p90"]);
+    expect(tiles.map((t) => t.label)).toEqual(["p25", "Median", "p75", "p90"]);
+  });
+
+  it("formats each percentile independently so adjacent strings stay distinct", () => {
+    const tiles = buildYieldPercentileData({
+      p25_yield: 0.000016,
+      median_yield: 0.0000161,
+      p75_yield: 0.007467,
+      p90_yield: 0.007468,
+      formatYield,
+    });
+    const values = tiles.map((t) => t.value);
+    expect(new Set(values).size).toBe(values.length);
+    expect(values.every((v) => v.endsWith("%"))).toBe(true);
+  });
+
+  it("passes null yields through the formatter as em-dash fallbacks", () => {
+    const tiles = buildYieldPercentileData({
+      p25_yield: null,
+      median_yield: undefined,
+      p75_yield: 0.01,
+      p90_yield: null,
+      formatYield,
+    });
+    expect(tiles[0]?.value).toBe("—");
+    expect(tiles[1]?.value).toBe("—");
+    expect(tiles[2]?.value).toBe("1.0000%");
+    expect(tiles[3]?.value).toBe("—");
+  });
+});

--- a/apps/ui/src/components/metagraphed/yield-percentile-layout.test.ts
+++ b/apps/ui/src/components/metagraphed/yield-percentile-layout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH,
   YIELD_PERCENTILE_STRIP_GRID_CLASS,
+  YIELD_PERCENTILE_VALUE_CLASS,
   buildYieldPercentileData,
   shouldUseYieldPercentileFourColumnLayout,
 } from "./yield-percentile-layout";
@@ -9,6 +10,11 @@ import {
 describe("yield percentile layout tokens", () => {
   it("pins the four-column container threshold at 28rem (#3934)", () => {
     expect(YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH).toBe("28rem");
+  });
+
+  it("scales percentile values down on narrow containers", () => {
+    expect(YIELD_PERCENTILE_VALUE_CLASS).toContain("text-sm");
+    expect(YIELD_PERCENTILE_VALUE_CLASS).toContain("truncate");
   });
 
   it("defaults to a 2-column grid and promotes to four columns via container query", () => {

--- a/apps/ui/src/components/metagraphed/yield-percentile-layout.ts
+++ b/apps/ui/src/components/metagraphed/yield-percentile-layout.ts
@@ -1,0 +1,84 @@
+/**
+ * Responsive layout tokens for the Yield tab percentile summary strip (P25 /
+ * Median / P75 / P90). The strip sits in a half-width column beside the
+ * validator/miner split from the `md` breakpoint upward; viewport `sm`
+ * breakpoints are therefore a poor fit — container queries key off the card's
+ * actual width instead.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3934
+ */
+
+/** Minimum container width before switching from a 2×2 grid to a single 4-up row. */
+export const YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH = "28rem";
+
+/** Outer card — enables `@min-[28rem]:` container queries on descendants. */
+export const YIELD_PERCENTILE_STRIP_CONTAINER_CLASS =
+  "@container rounded-xl border border-border bg-card p-4";
+
+/**
+ * Inner stat grid. Below {@link YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH} the strip
+ * stays 2×2 so long `fmtYield` strings (e.g. `0.00160%`) never collide; at
+ * wider containers it matches the Concentration context strip's 4-up layout.
+ */
+export const YIELD_PERCENTILE_STRIP_GRID_CLASS = "grid grid-cols-2 gap-3 @min-[28rem]:grid-cols-4";
+
+/** Label row — mirrors Concentration panel `Fact` labels. */
+export const YIELD_PERCENTILE_LABEL_CLASS =
+  "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+
+/**
+ * Value row — slightly smaller below the four-column threshold, then steps up
+ * to the shared `Fact` display size used elsewhere on subnet profile cards.
+ */
+export const YIELD_PERCENTILE_VALUE_CLASS =
+  "mt-1 min-w-0 font-display text-base font-semibold tabular-nums text-ink-strong leading-none @min-[28rem]:text-lg";
+
+export type YieldPercentileKey = "p25" | "median" | "p75" | "p90";
+
+export type YieldPercentileDatum = {
+  key: YieldPercentileKey;
+  label: string;
+  value: string;
+};
+
+const PERCENTILE_LABELS: Record<YieldPercentileKey, string> = {
+  p25: "p25",
+  median: "Median",
+  p75: "p75",
+  p90: "p90",
+};
+
+/** Build the four percentile tiles in display order for the summary strip. */
+export function buildYieldPercentileData(input: {
+  p25_yield?: number | null;
+  median_yield?: number | null;
+  p75_yield?: number | null;
+  p90_yield?: number | null;
+  formatYield: (value?: number | null) => string;
+}): YieldPercentileDatum[] {
+  const { formatYield } = input;
+  return (["p25", "median", "p75", "p90"] as const).map((key) => ({
+    key,
+    label: PERCENTILE_LABELS[key],
+    value: formatYield(
+      key === "p25"
+        ? input.p25_yield
+        : key === "median"
+          ? input.median_yield
+          : key === "p75"
+            ? input.p75_yield
+            : input.p90_yield,
+    ),
+  }));
+}
+
+/**
+ * Returns whether a container of `widthPx` should use the 4-up layout.
+ * Exported for unit tests — mirrors the `@min-[28rem]` Tailwind breakpoint.
+ */
+export function shouldUseYieldPercentileFourColumnLayout(widthPx: number): boolean {
+  if (!Number.isFinite(widthPx) || widthPx <= 0) return false;
+  const rootFontPx = 16;
+  const thresholdPx = parseFloat(YIELD_PERCENTILE_FOUR_COL_MIN_WIDTH) * rootFontPx;
+  return widthPx >= thresholdPx;
+}

--- a/apps/ui/src/components/metagraphed/yield-percentile-layout.ts
+++ b/apps/ui/src/components/metagraphed/yield-percentile-layout.ts
@@ -31,7 +31,7 @@ export const YIELD_PERCENTILE_LABEL_CLASS =
  * to the shared `Fact` display size used elsewhere on subnet profile cards.
  */
 export const YIELD_PERCENTILE_VALUE_CLASS =
-  "mt-1 min-w-0 font-display text-base font-semibold tabular-nums text-ink-strong leading-none @min-[28rem]:text-lg";
+  "mt-1 min-w-0 truncate font-display text-sm font-semibold tabular-nums text-ink-strong leading-none @min-[20rem]:text-base @min-[28rem]:text-lg";
 
 export type YieldPercentileKey = "p25" | "median" | "p75" | "p90";
 

--- a/apps/ui/src/components/metagraphed/yield-percentile-strip.tsx
+++ b/apps/ui/src/components/metagraphed/yield-percentile-strip.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import {
+  YIELD_PERCENTILE_LABEL_CLASS,
+  YIELD_PERCENTILE_STRIP_CONTAINER_CLASS,
+  YIELD_PERCENTILE_STRIP_GRID_CLASS,
+  YIELD_PERCENTILE_VALUE_CLASS,
+  buildYieldPercentileData,
+  type YieldPercentileDatum,
+} from "@/components/metagraphed/yield-percentile-layout";
+import { fmtYield } from "@/components/metagraphed/yield-format";
+
+function PercentileFact({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <div className={YIELD_PERCENTILE_LABEL_CLASS}>{label}</div>
+      <div className={YIELD_PERCENTILE_VALUE_CLASS}>{value}</div>
+    </div>
+  );
+}
+
+export type YieldPercentileStripProps = {
+  p25_yield?: number | null;
+  median_yield?: number | null;
+  p75_yield?: number | null;
+  p90_yield?: number | null;
+  /** Optional override for tests/story fixtures. */
+  data?: YieldPercentileDatum[];
+};
+
+/**
+ * Yield tab percentile summary (P25 / Median / P75 / P90). Uses container
+ * queries so the row stays 2×2 when the card is half-width at tablet (768px)
+ * beside the validator/miner split, matching Concentration readability without
+ * touching that panel's implementation.
+ */
+export function YieldPercentileStrip({
+  p25_yield,
+  median_yield,
+  p75_yield,
+  p90_yield,
+  data,
+}: YieldPercentileStripProps) {
+  const tiles =
+    data ??
+    buildYieldPercentileData({
+      p25_yield,
+      median_yield,
+      p75_yield,
+      p90_yield,
+      formatYield: fmtYield,
+    });
+
+  return (
+    <section
+      className={YIELD_PERCENTILE_STRIP_CONTAINER_CLASS}
+      aria-label="Yield percentile distribution"
+    >
+      <div className={YIELD_PERCENTILE_STRIP_GRID_CLASS}>
+        {tiles.map((tile) => (
+          <PercentileFact key={tile.key} label={tile.label} value={tile.value} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/ui/tests/e2e/capture-yield-percentile-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-yield-percentile-screenshots.mjs
@@ -1,0 +1,113 @@
+/**
+ * Capture Yield tab percentile strip screenshots for #3934 PR table.
+ *
+ * Usage (with dev server running — pass its base URL explicitly):
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after node tests/e2e/capture-yield-percentile-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8086 VARIANT=before node tests/e2e/capture-yield-percentile-screenshots.mjs
+ *
+ * Writes to tmp/yield-percentile-screenshots/{VARIANT}-{viewport}-{theme}.png
+ */
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/yield-percentile-screenshots");
+const YIELD_FIXTURE = JSON.parse(
+  await readFile(new URL("./fixtures/yield-percentile-screenshot.json", import.meta.url), "utf8"),
+);
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+/** SN64 has dense validator yields — good fixture for percentile collision case. */
+const SUBNET_PATH = process.env.SCREENSHOT_SUBNET_PATH ?? "/subnets/64";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openYieldSection(page) {
+  await page.goto(`${BASE_URL}${SUBNET_PATH}?tab=metagraph#yield`, {
+    waitUntil: "networkidle",
+    timeout: 90_000,
+  });
+  await page.locator("#yield").waitFor({ state: "visible", timeout: 90_000 });
+
+  const strip = page.getByLabel("Yield percentile distribution");
+  try {
+    await strip.waitFor({ state: "visible", timeout: 90_000 });
+    await strip.scrollIntoViewIfNeeded();
+    return strip;
+  } catch {
+    // Pre-#3934 refactor: percentile Facts lived inline without aria-label.
+    const legacyGrid = page.locator("#yield").getByText("p25", { exact: true }).first();
+    await legacyGrid.waitFor({ state: "visible", timeout: 30_000 });
+    const card = legacyGrid.locator("xpath=ancestor::div[contains(@class,'rounded-xl')][1]");
+    await card.scrollIntoViewIfNeeded();
+    return card;
+  }
+}
+
+async function captureStrip(page, target, filePath) {
+  await target.screenshot({ path: filePath });
+}
+
+async function installYieldFixture(page) {
+  await page.route("**/api/v1/subnets/*/yield", async (route) => {
+    if (route.request().url().includes("/yield/history")) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(YIELD_FIXTURE),
+    });
+  });
+  await page.route("**/api/v1/subnets/*/yield/history**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        data: { netuid: 64, window: "30d", point_count: 0, points: [] },
+        meta: {},
+      }),
+    });
+  });
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await installYieldFixture(page);
+
+  for (const viewport of VIEWPORTS) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    for (const theme of THEMES) {
+      await setTheme(page, theme);
+      const strip = await openYieldSection(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await captureStrip(page, strip, file);
+      console.log(`wrote ${file}`);
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/ui/tests/e2e/capture-yield-percentile-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-yield-percentile-screenshots.mjs
@@ -1,5 +1,8 @@
 /**
- * Capture Yield tab percentile strip screenshots for #3934 PR table.
+ * Capture Yield tab page screenshots for #3934 PR table (Path C2 contract).
+ *
+ * Captures the fixed viewport (not fullPage, not element crops) after scrolling
+ * the Metagraph → Yield section into view so reviewers see what visitors see.
  *
  * Usage (with dev server running — pass its base URL explicitly):
  *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after node tests/e2e/capture-yield-percentile-screenshots.mjs
@@ -35,6 +38,9 @@ async function setTheme(page, theme) {
   }, theme);
 }
 
+/** Pixels above #yield to keep in frame (app header + sticky profile tabs). */
+const SCROLL_OFFSET_PX = 148;
+
 async function openYieldSection(page) {
   await page.goto(`${BASE_URL}${SUBNET_PATH}?tab=metagraph#yield`, {
     waitUntil: "networkidle",
@@ -43,22 +49,29 @@ async function openYieldSection(page) {
   await page.locator("#yield").waitFor({ state: "visible", timeout: 90_000 });
 
   const strip = page.getByLabel("Yield percentile distribution");
+  const legacyGrid = page.locator("#yield").getByText("p25", { exact: true }).first();
   try {
     await strip.waitFor({ state: "visible", timeout: 90_000 });
-    await strip.scrollIntoViewIfNeeded();
-    return strip;
   } catch {
-    // Pre-#3934 refactor: percentile Facts lived inline without aria-label.
-    const legacyGrid = page.locator("#yield").getByText("p25", { exact: true }).first();
     await legacyGrid.waitFor({ state: "visible", timeout: 30_000 });
-    const card = legacyGrid.locator("xpath=ancestor::div[contains(@class,'rounded-xl')][1]");
-    await card.scrollIntoViewIfNeeded();
-    return card;
   }
+
+  // Scroll so the Yield section header + percentile row sit in the viewport with
+  // page chrome (masthead tabs) visible — what a visitor sees after deep-linking.
+  await page.evaluate((offset) => {
+    const section = document.getElementById("yield");
+    if (!section) return;
+    const top = section.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+  }, SCROLL_OFFSET_PX);
+
+  // Let sticky tab paint settle after programmatic scroll.
+  await page.waitForTimeout(250);
 }
 
-async function captureStrip(page, target, filePath) {
-  await target.screenshot({ path: filePath });
+/** Fixed-viewport capture per SKILL.md Path C2 — never fullPage or element crop. */
+async function captureViewport(page, filePath) {
+  await page.screenshot({ path: filePath, fullPage: false });
 }
 
 async function installYieldFixture(page) {
@@ -97,9 +110,9 @@ async function main() {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     for (const theme of THEMES) {
       await setTheme(page, theme);
-      const strip = await openYieldSection(page);
+      await openYieldSection(page);
       const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
-      await captureStrip(page, strip, file);
+      await captureViewport(page, file);
       console.log(`wrote ${file}`);
     }
   }

--- a/apps/ui/tests/e2e/fixtures/yield-percentile-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/yield-percentile-screenshot.json
@@ -1,0 +1,49 @@
+{
+  "ok": true,
+  "schema_version": 1,
+  "data": {
+    "schema_version": 1,
+    "netuid": 64,
+    "captured_at": "2026-07-08T12:00:00.000Z",
+    "block_number": 8600000,
+    "neuron_count": 256,
+    "validator_count": 8,
+    "miner_count": 248,
+    "total_stake_tao": 1250000,
+    "total_emission_tao": 420,
+    "subnet_yield": 0.000336,
+    "mean_yield": 0.0038,
+    "median_yield": 0.000016,
+    "p25_yield": 0.000016,
+    "p75_yield": 0.007467,
+    "p90_yield": 0.007468,
+    "neurons": [
+      {
+        "uid": 1,
+        "hotkey": "5FixtureHotkeyForScreenshotPurposesOnly111111111111",
+        "role": "validator",
+        "stake_tao": 50000,
+        "emission_tao": 40,
+        "yield": 0.0008,
+        "vs_median": "above"
+      },
+      {
+        "uid": 2,
+        "hotkey": "5FixtureHotkeyForScreenshotPurposesOnly222222222222",
+        "role": "miner",
+        "stake_tao": 1200,
+        "emission_tao": 0.9,
+        "yield": 0.00075,
+        "vs_median": "above"
+      }
+    ]
+  },
+  "meta": {
+    "artifact_path": "/metagraph/subnets/64/yield.json",
+    "cache": "short",
+    "contract_version": "2026-06-06.1",
+    "generated_at": "2026-07-08T12:00:00.000Z",
+    "published_at": "2026-07-08T12:00:00.000Z",
+    "source": "metagraph-snapshot"
+  }
+}


### PR DESCRIPTION
## Summary

- Extract the Yield tab P25/Median/P75/P90 summary into `YieldPercentileStrip` with container-query layout tokens so the strip stays 2x2 when the card is half-width at tablet (768px) beside the validator/miner split, preventing long `fmtYield` strings from colliding.
- Move `fmtYield` into a shared module and add layout/formatter unit tests plus a Playwright capture script with a deterministic yield API fixture for screenshot tables.
- **Mobile overflow polish:** profile KPI strips stack single-column below 400px; `StatTile` values scale down responsively; percentile values truncate on narrow containers; Yield/Concentration drift rows reflow on phones (same pattern applied to the sibling Concentration panel).

Closes #3934

## Screenshot table

Fixed-viewport captures (375x812 / 768x1024 / 1280x800) of the subnet profile Metagraph -> Yield section — scrolled so visitors see page chrome (header, tabs) plus the yield summary cards, percentile row, and leaderboard. Not element crops.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-desktop-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-desktop-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-tablet-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-tablet-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-mobile-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-before-mobile-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3934-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
- [x] Changed-file eslint/prettier clean
- [x] Playwright overflow e2e for `/subnets/1` at mobile/tablet/desktop viewports
- [x] Manual: mobile + tablet light/dark — KPI tiles and percentile values stay inside cards