### PR TITLE
fix(ui): extract shared statPhase helper + StatUnavailable, apply to homepage KPIs (#3964)

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -228,6 +228,20 @@ export function Skeleton({ className = "h-4 w-full" }: { className?: string }) {
 }
 
 /**
+ * Compact inline "Unavailable" indicator for a KPI/stat cell whose source query
+ * failed — a distinct error affordance so failure reads differently from a
+ * loading skeleton or a legitimately-empty "—". Used in the homepage KPI panels
+ * (#3964) and the About "At a glance" sidebar (#3968).
+ */
+export function StatUnavailable({ iconClassName = "size-3.5" }: { iconClassName?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-sm font-medium text-health-down">
+      <AlertCircle className={iconClassName} /> Unavailable
+    </span>
+  );
+}
+
+/**
  * Standardized recovery links used by EmptyState / ErrorState across profile
  * pages. Keep labels identical everywhere so the UI feels consistent.
  */

--- a/apps/ui/src/lib/metagraphed/stat-phase.test.ts
+++ b/apps/ui/src/lib/metagraphed/stat-phase.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { statPhase } from "./stat-phase";
+
+describe("statPhase", () => {
+  it("reports pending while the query is loading", () => {
+    expect(statPhase({ isPending: true, isError: false })).toBe("pending");
+  });
+
+  it("reports error when the query failed", () => {
+    expect(statPhase({ isPending: false, isError: true })).toBe("error");
+  });
+
+  it("prefers error over pending when both are set", () => {
+    expect(statPhase({ isPending: true, isError: true })).toBe("error");
+  });
+
+  it("reports ready once the query settled successfully", () => {
+    expect(statPhase({ isPending: false, isError: false })).toBe("ready");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stat-phase.ts
+++ b/apps/ui/src/lib/metagraphed/stat-phase.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared loading/error/ready phase for compact KPI/stat cells that read from a
+ * non-suspense `useQuery`. Lets a cell distinguish "still loading" (skeleton)
+ * and "failed" (error indicator) from a legitimately-null value ("—"), instead
+ * of collapsing all three into a bare dash. Used by the homepage KPI panels
+ * (#3964) and the About "At a glance" sidebar (#3968).
+ */
+export type StatPhase = "pending" | "error" | "ready";
+
+/** Derive a {@link StatPhase} from a query result's pending/error flags. */
+export function statPhase(result: { isPending: boolean; isError: boolean }): StatPhase {
+  if (result.isError) return "error";
+  if (result.isPending) return "pending";
+  return "ready";
+}

--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import {
   Github,
   ArrowUpRight,
-  AlertCircle,
   FileCode2,
   Network as NetworkIcon,
   Activity,
@@ -17,7 +16,8 @@ import { PageHero } from "@/components/metagraphed/page-hero";
 import { API_BASE, GITHUB_REPO } from "@/lib/metagraphed/config";
 import { coverageQuery, freshnessQuery, healthQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
-import { Skeleton } from "@/components/metagraphed/states";
+import { Skeleton, StatUnavailable } from "@/components/metagraphed/states";
+import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 
 export const Route = createFileRoute("/about")({
   head: () => ({
@@ -167,8 +167,6 @@ function Term({ name, desc }: { name: string; desc: string }) {
   );
 }
 
-type StatPhase = "pending" | "error" | "ready";
-
 function AtAGlance() {
   // Track each source query's own loading/error state so the sidebar can
   // distinguish "still loading" (skeleton) and "failed" (error glyph) from a
@@ -185,8 +183,6 @@ function AtAGlance() {
   // surface first_party_subnet_count (73), which is a different metric.
   const curationCounts = (coverageRaw.curation_level_counts ?? {}) as Record<string, number>;
   const adapterBacked = curationCounts["adapter-backed"];
-  const phase = (r: { isPending: boolean; isError: boolean }): StatPhase =>
-    r.isError ? "error" : r.isPending ? "pending" : "ready";
   const stats: Array<{
     icon: React.ElementType;
     label: string;
@@ -199,28 +195,28 @@ function AtAGlance() {
       label: "Active subnets",
       value: coverage.netuids_active != null ? formatNumber(coverage.netuids_active) : "—",
       to: "/subnets",
-      phase: phase(coverageResult),
+      phase: statPhase(coverageResult),
     },
     {
       icon: FileCode2,
       label: "Adapter-backed",
       value: adapterBacked != null ? formatNumber(adapterBacked) : "—",
       to: "/providers",
-      phase: phase(coverageResult),
+      phase: statPhase(coverageResult),
     },
     {
       icon: Activity,
       label: "Healthy",
       value: health.ok != null && health.total ? `${health.ok}/${health.total}` : "—",
       to: "/health",
-      phase: phase(healthResult),
+      phase: statPhase(healthResult),
     },
     {
       icon: Clock,
       label: "Avg freshness",
       value: freshness.avg_age_seconds != null ? humaniseSeconds(freshness.avg_age_seconds) : "—",
       to: "/health",
-      phase: phase(freshnessResult),
+      phase: statPhase(freshnessResult),
     },
   ];
   return (
@@ -244,9 +240,7 @@ function AtAGlance() {
                   {phase === "pending" ? (
                     <Skeleton className="mt-1 h-4 w-16" />
                   ) : phase === "error" ? (
-                    <span className="inline-flex items-center gap-1 text-sm font-medium text-health-down">
-                      <AlertCircle className="size-3.5" /> Unavailable
-                    </span>
+                    <StatUnavailable />
                   ) : (
                     value
                   )}

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -7,7 +7,8 @@ import { AccentBand } from "@/components/metagraphed/accent-band";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { CurationChip, HealthPill } from "@/components/metagraphed/chips";
-import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, ErrorState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
+import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { Sparkline, type SparklinePoint } from "@/components/metagraphed/charts/sparkline";
 import { SubnetPulseGrid } from "@/components/metagraphed/charts/subnet-pulse-grid";
@@ -361,9 +362,16 @@ function HomeHero() {
 }
 
 function HeroKpis() {
-  const coverage = useQuery(coverageQuery()).data?.data;
-  const freshness = useQuery(freshnessQuery()).data?.data;
-  const health = useQuery(healthQuery()).data?.data;
+  // #3964: track each source query's phase so a cell shows a skeleton (loading)
+  // or a distinct "Unavailable" glyph (error) instead of collapsing loading /
+  // error / genuinely-null all into "—". Shared statPhase()/StatUnavailable
+  // keep this identical to the About "At a glance" sidebar.
+  const coverageResult = useQuery(coverageQuery());
+  const freshnessResult = useQuery(freshnessQuery());
+  const healthResult = useQuery(healthQuery());
+  const coverage = coverageResult.data?.data;
+  const freshness = freshnessResult.data?.data;
+  const health = healthResult.data?.data;
   const active = coverage?.netuids_active;
   const avgAge = freshness?.avg_age_seconds;
   const uptime = health?.uptime_24h;
@@ -383,7 +391,8 @@ function HeroKpis() {
   // above — useQuery (not suspense), so a slow/failed fetch degrades this one
   // cell instead of blocking the whole hero card. No fabricated fallback: the
   // sparkline hides via HeroStatCell's own hasSeries guard when there's no data.
-  const activity = useQuery(chainActivityQuery("7d")).data?.data;
+  const activityResult = useQuery(chainActivityQuery("7d"));
+  const activity = activityResult.data?.data;
   const activityChrono = activity?.days.length ? [...activity.days].reverse() : undefined;
   const latestExtrinsics = activityChrono?.at(-1)?.extrinsic_count;
   const activitySeries = activityChrono?.map((d) => d.extrinsic_count);
@@ -429,6 +438,7 @@ function HeroKpis() {
         <HeroStatCell
           label="Healthy now"
           value={uptime != null ? `${(uptime * 100).toFixed(1)}%` : "—"}
+          phase={statPhase(healthResult)}
           formatValue={(v) => `${v.toFixed(1)}%`}
           tooltip="Share of verified endpoints passing their most recent probe. Failures are non-2xx, timeouts, or schema-invalid responses. Source: /api/v1/health."
           accent
@@ -436,6 +446,7 @@ function HeroKpis() {
         <HeroStatCell
           label="Freshness"
           value={avgAge != null ? humaniseSeconds(avgAge) : "—"}
+          phase={statPhase(freshnessResult)}
           series={freshSeries}
           points={freshPoints}
           formatValue={(v) => humaniseSeconds(v)}
@@ -444,6 +455,7 @@ function HeroKpis() {
         <HeroStatCell
           label="Chain activity"
           value={latestExtrinsics != null ? formatNumber(latestExtrinsics) : "—"}
+          phase={statPhase(activityResult)}
           series={activitySeries}
           points={activityPoints}
           formatValue={(v) => formatNumber(v)}
@@ -498,6 +510,7 @@ function LegendDot({ tone, label }: { tone: string; label: string }) {
 function HeroStatCell({
   label,
   value,
+  phase = "ready",
   series,
   points,
   formatValue,
@@ -507,6 +520,8 @@ function HeroStatCell({
 }: {
   label: string;
   value: string;
+  /** Loading/error/ready phase of the cell's source query (#3964). */
+  phase?: StatPhase;
   /** Real data series. When absent, no sparkline is rendered (no fabrication). */
   series?: number[];
   points?: SparklinePoint[];
@@ -516,7 +531,9 @@ function HeroStatCell({
   /** Cadence label under the sparkline; defaults to the freshness cell's 24h/hourly cadence. */
   seriesCaption?: string;
 }) {
-  const hasSeries = !!series && series.length > 1;
+  // Hide the sparkline unless the value settled successfully — a skeleton or
+  // error glyph replaces the number, so a stale series would misrepresent state.
+  const hasSeries = phase === "ready" && !!series && series.length > 1;
   return (
     <div className="px-4 py-3">
       <div className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
@@ -528,7 +545,13 @@ function HeroStatCell({
           accent ? "text-accent" : "text-ink-strong"
         }`}
       >
-        {value}
+        {phase === "pending" ? (
+          <Skeleton className="h-5 w-14" />
+        ) : phase === "error" ? (
+          <StatUnavailable />
+        ) : (
+          value
+        )}
       </div>
       {hasSeries ? (
         <>
@@ -613,8 +636,8 @@ function SectionHeader({
 }
 
 function TrackedGrid() {
-  const coverage = useQuery(coverageQuery()).data?.data as
-    Record<string, number | undefined> | undefined;
+  const coverageResult = useQuery(coverageQuery());
+  const coverage = coverageResult.data?.data as Record<string, number | undefined> | undefined;
   // Endpoint/provider totals are not in /api/v1/coverage — read from their own
   // list endpoints. Use limit=1 for endpoints (1197 items) to get only the
   // pagination meta; providers are small enough to load in full (cached for /providers).
@@ -629,30 +652,40 @@ function TrackedGrid() {
     providersResult.data?.meta.total ??
     providersResult.data?.data.length;
 
-  const items: Array<{ label: string; to: string; value: number | undefined; desc: string }> = [
+  const items: Array<{
+    label: string;
+    to: string;
+    value: number | undefined;
+    desc: string;
+    phase: StatPhase;
+  }> = [
     {
       label: "Subnets",
       to: "/subnets",
       value: coverage?.netuids_active,
       desc: "Active Finney netuids with curated overlays.",
+      phase: statPhase(coverageResult),
     },
     {
       label: "Surfaces",
       to: "/surfaces",
       value: coverage?.surfaces_total,
       desc: "Verified public APIs, schemas, docs, dashboards.",
+      phase: statPhase(coverageResult),
     },
     {
       label: "Endpoints",
       to: "/endpoints",
       value: endpointsTotal,
       desc: "Tracked endpoint resources including root RPC pools.",
+      phase: statPhase(endpointsResult),
     },
     {
       label: "Providers",
       to: "/providers",
       value: providersTotal,
       desc: "Subnet teams and infrastructure operators.",
+      phase: statPhase(providersResult),
     },
   ];
   return (
@@ -667,7 +700,15 @@ function TrackedGrid() {
             {item.label}
           </div>
           <div className="mt-3 font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums text-ink-strong">
-            {item.value != null ? formatNumber(item.value) : "—"}
+            {item.phase === "pending" ? (
+              <Skeleton className="h-8 w-20" />
+            ) : item.phase === "error" ? (
+              <StatUnavailable iconClassName="size-4" />
+            ) : item.value != null ? (
+              formatNumber(item.value)
+            ) : (
+              "—"
+            )}
           </div>
           <p className="mt-3 text-xs text-ink-muted leading-relaxed flex-1">{item.desc}</p>
           <span className="mt-4 inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted group-hover:text-accent transition-colors">
@@ -681,8 +722,10 @@ function TrackedGrid() {
 }
 
 function LivePerformance() {
-  const freshness = useQuery(freshnessQuery()).data?.data;
-  const health = useQuery(healthQuery()).data?.data;
+  const freshnessResult = useQuery(freshnessQuery());
+  const healthResult = useQuery(healthQuery());
+  const freshness = freshnessResult.data?.data;
+  const health = healthResult.data?.data;
 
   const ages = (freshness?.sources ?? [])
     .map((s) => (s.last_seen ? (Date.now() - new Date(s.last_seen).getTime()) / 1000 : null))
@@ -718,12 +761,14 @@ function LivePerformance() {
             freshness?.avg_age_seconds != null ? humaniseSeconds(freshness.avg_age_seconds) : "—"
           }
           hint="avg poll lag"
+          phase={statPhase(freshnessResult)}
           series={ages.length ? ages : undefined}
         />
         <PerfCard
           label="Global health"
           value={`${okPct}%`}
           hint={`${health?.ok ?? 0}/${total} OK`}
+          phase={statPhase(healthResult)}
           accent
         />
       </div>
@@ -735,17 +780,20 @@ function PerfCard({
   label,
   value,
   hint,
+  phase = "ready",
   series,
   accent,
 }: {
   label: string;
   value: string;
   hint: string;
+  /** Loading/error/ready phase of the card's source query (#3964). */
+  phase?: StatPhase;
   /** Real data series. When absent, no sparkline is rendered (no fabrication). */
   series?: number[];
   accent?: boolean;
 }) {
-  const hasSeries = !!series && series.length > 1;
+  const hasSeries = phase === "ready" && !!series && series.length > 1;
   return (
     <div className="rounded-xl border border-border bg-card p-5">
       <div className="flex items-baseline justify-between mb-3">
@@ -757,7 +805,13 @@ function PerfCard({
       <div
         className={`font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums ${accent ? "text-accent" : "text-ink-strong"}`}
       >
-        {value}
+        {phase === "pending" ? (
+          <Skeleton className="h-9 w-24" />
+        ) : phase === "error" ? (
+          <StatUnavailable iconClassName="size-4" />
+        ) : (
+          value
+        )}
       </div>
       {hasSeries ? (
         <div className="mt-4">


### PR DESCRIPTION
## Summary

Fixes #3964 (homepage KPI panels collapsing loading / error / genuinely-null all into a bare "—"), and does so by **extracting the shared phase helper the reviewer asked for** rather than adding a second parallel copy.

A prior review of this fix noted that `apps/ui/src/routes/about.tsx` (`AtAGlance`, merged in #4675 / #3968) already had a structurally identical `StatPhase`/`phase()`/inline error-glyph implementation, and that the homepage change should reuse it instead of duplicating it. This PR does exactly that:

- **New shared helper** `apps/ui/src/lib/metagraphed/stat-phase.ts` — `type StatPhase` + `statPhase(result)` (pure, unit-tested).
- **New shared component** `StatUnavailable` in `components/metagraphed/states.tsx` (the red `AlertCircle` + "Unavailable" glyph), next to the existing `Skeleton`/`EmptyState`/`ErrorState`.
- **`about.tsx` refactored** to use both, removing its local duplicate `StatPhase`/`phase()`/inline glyph — no visual change.
- **`index.tsx` (`HeroKpis`, `TrackedGrid`, `LivePerformance`)** now use the shared helper to render a skeleton (loading), `StatUnavailable` (error), or the value / "—" (settled). Sparklines are gated on `phase === "ready"` so a stale series can't render under an error/loading cell.

Net effect: two independent copies become one shared, tested utility — the crux of the earlier feedback — while delivering the #3964 fix.

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 688 passed (incl. new stat-phase.test.ts, 4 cases)
npm run test:e2e --workspace=apps/ui    # 24 passed (incl. /)
```

Added `stat-phase.test.ts` covering pending / error / error-wins-over-pending / ready — addressing the prior "no test coverage" note. About's rendering is unchanged; the homepage now distinguishes the three states.

## Screenshots (homepage, /)

Source fetches blocked on `/`. **Before:** every KPI shows a silent "—". **After:** a distinct "Unavailable" glyph per KPI (via the shared `StatUnavailable`). About's sidebar is visually unchanged (same shared glyph), so it's not re-shot.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3964-dry/mobile-dark-after.png)<br><sub>after</sub> |

Closes #3964
