### PR TITLE
fix(ui): give the stake-transfer leaderboard a mobile card layout

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1184,40 +1184,72 @@ function ExplorerDashboard() {
           </span>
         </div>
         {stakeTransfers.subnets.length > 0 ? (
-          <table className="w-full text-left text-sm">
-            <thead>
-              <tr>
-                <th className={TH}>Subnet</th>
-                <th className={`${TH} text-right`}>Transfers</th>
-                <th className={`${TH} text-right`}>Distinct senders</th>
-                <th className={`${TH} text-right`}>Transfers per sender</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
+          <>
+            {/* < md: a squeezed 4-column table either clips its last column or
+                requires an undiscoverable horizontal scroll, so narrow
+                viewports get a stacked card per subnet instead (mirrors the
+                cards/table split ListShell uses for paginated lists). */}
+            <div className="md:hidden space-y-2">
               {stakeTransfers.subnets.map((s) => (
-                <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                <div key={s.netuid} className="rounded border border-border bg-card p-3">
+                  <div className="flex items-center justify-between gap-2">
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: s.netuid }}
-                      className="text-ink-strong hover:text-accent hover:underline"
+                      className="font-mono text-[12px] font-medium text-ink-strong hover:text-accent hover:underline"
                     >
                       SN{s.netuid}
                     </Link>
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {formatNumber(s.transfers)}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatNumber(s.distinct_senders)}
-                  </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
-                  </td>
-                </tr>
+                    <span className="font-mono text-[11px] tabular-nums text-ink-muted">
+                      {s.transfers_per_sender != null
+                        ? `${s.transfers_per_sender.toFixed(2)} / sender`
+                        : "—"}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between font-mono text-[11px] tabular-nums text-ink-muted">
+                    <span>{formatNumber(s.transfers)} transfers</span>
+                    <span>{formatNumber(s.distinct_senders)} senders</span>
+                  </div>
+                </div>
               ))}
-            </tbody>
-          </table>
+            </div>
+            <div className="hidden md:block overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr>
+                    <th className={TH}>Subnet</th>
+                    <th className={`${TH} text-right`}>Transfers</th>
+                    <th className={`${TH} text-right`}>Distinct senders</th>
+                    <th className={`${TH} text-right`}>Transfers per sender</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {stakeTransfers.subnets.map((s) => (
+                    <tr key={s.netuid} className="hover:bg-surface/40">
+                      <td className="px-4 py-2 font-mono text-[11px]">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: s.netuid }}
+                          className="text-ink-strong hover:text-accent hover:underline"
+                        >
+                          SN{s.netuid}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                        {formatNumber(s.transfers)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatNumber(s.distinct_senders)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         ) : (
           <EmptyState title="No stake transfers in this window yet." />
         )}


### PR DESCRIPTION
## Summary

Follow-up to #4745, which the maintainer closed with: *"Still pretty mangled, all of the visible issues/wrapping/overflows/etc need to be properly resolved"* (a screenshot showed the "Transfers per sender" column still visibly clipped to "TRA" on mobile). That PR only wrapped the table in `overflow-x-auto` — technically scrollable, but the default (unscrolled) view still looked exactly as broken, since nothing hinted the column was reachable.

This PR properly resolves it instead of patching around it: below `md` (768px), the stake-transfer leaderboard now renders a stacked card per subnet — no horizontal overflow is possible because there's no wide row to clip in the first place. At `md` and up the table is unchanged (it already fit its 4 columns comfortably at 768px+, confirmed in the previous PR's tablet/desktop screenshots). This mirrors the exact `cards` (< md) / `table` (>= md) split `ListShell` already uses for paginated list routes (`apps/ui/src/components/metagraphed/list-shell.tsx:62-63`), so this table now fails the same way the rest of the app already avoids failing, rather than inventing a new pattern.

- `apps/ui/src/routes/explorer.tsx` — stake-transfer leaderboard section: `md:hidden` card list (Subnet + a compact "X.XX / sender" stat up top, transfers/senders counts below) alongside the existing `hidden md:block` table, wrapped in the previous PR's `overflow-x-auto` as a second line of defense for anything wider than the viewport even at `md`+.
- No columns, data logic, or empty-state branch changed beyond that.

Closes #3941

## Screenshots

Same mocking approach as #4745 (live `/api/v1/chain/stake-transfers` still returns `subnet_count: 0` in this environment) — a fixture matching the real `ChainStakeTransfers` contract shape drives the actual page code.

| Viewport · Theme | Before (still open bug — unfixed baseline) | After (this PR) |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-light-after.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-desktop-dark-after.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-light-before.png) | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-light-after.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-dark-before.png) | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-tablet-dark-after.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-light-before.png)<br><sub>column clipped to "TRA…", not just scrolled-past</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-light-after.png)<br><sub>card layout — nothing to clip</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-dark-before.png)<br><sub>column clipped to "TRA…", not just scrolled-past</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/stake-transfer-leaderboard-3941v2-stake-transfer-mobile-dark-after.png)<br><sub>card layout — nothing to clip</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (684 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests, incl. `/explorer` at all 4 recorded viewports)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification: two dev servers (upstream/main vs. this branch) with an identical mocked populated-data response, screenshots per the table above confirming the mobile column is no longer clippable at all (not merely scrollable)
