### PR TITLE
feat(registry): add SN24 Quasar public API endpoint via TaoMarketCap

### DIFF
--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -39,6 +39,9 @@
   "notes": "Reviewed overlay for SN24 using the official SILX Labs website, Quasar source repository, README, and public model artifacts.",
   "schema_version": 1,
   "slug": "sn-24",
+  "social": {
+    "x": "https://x.com/quasarmodels"
+  },
   "source_repo": "https://github.com/SILX-LABS/QUASAR-SUBNET",
   "status": "active",
   "surfaces": [
@@ -218,10 +221,26 @@
         "https://huggingface.co/silx-ai"
       ],
       "url": "https://huggingface.co/datasets/silx-ai/Quasar-SN3"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-24-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Quasar public subnet-state API (via TaoMarketCap)",
+      "notes": "Public no-auth GET https://api.taomarketcap.com/public/v1/subnets/24 from the TaoMarketCap developer API — returns machine-readable JSON for SN24's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields (verified live: HTTP 200, netuid 24). Quasar's first-party site (silxinc.com) and repo expose no verified no-auth public subnet API, so this is its verified public no-auth API surface.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation",
+        "https://silxinc.com/"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/24"
     }
   ],
-  "website_url": "https://silxinc.com/",
-  "social": {
-    "x": "https://x.com/quasarmodels"
-  }
+  "website_url": "https://silxinc.com/"
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/quasar.json` (SN24, Quasar). Append-only — existing surfaces and top-level fields are unchanged.

## Surface

- **Netuid:** 24
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/24
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://silxinc.com/
- **Provider slug:** `taomarketcap`

Quasar's first-party site (`silxinc.com`) and repo (`SILX-LABS/QUASAR-SUBNET`) expose no verified no-auth public subnet API. The TaoMarketCap developer API documents a public no-auth `GET /public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 24.

## Test plan

- [x] `npm run surface:add` — OK reachable + public-safe
- [x] `npm run validate:surface -- registry/subnets/quasar.json` — passed
- [x] `npm run scan:public-safety -- registry/subnets/quasar.json` — passed
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/24` returns HTTP 200 with valid JSON (`netuid: 24`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #577
