### PR TITLE
fix(api): drop unreachable guard in netuidStorageKeySuffix

### DIFF
--- a/src/subnet-recycled.mjs
+++ b/src/subnet-recycled.mjs
@@ -49,10 +49,9 @@ export function isU16Netuid(netuid) {
   return Number.isInteger(netuid) && netuid >= 0 && netuid <= MAX_U16_NETUID;
 }
 
+// Callers (loadSubnetRecycled) validate netuid via isU16Netuid before
+// reaching here, so no redundant guard.
 function netuidStorageKeySuffix(netuid) {
-  if (!isU16Netuid(netuid)) {
-    throw new RangeError("netuid must be an integer in the u16 range 0..65535");
-  }
   const lo = (netuid % 256).toString(16).padStart(2, "0");
   const hi = Math.floor(netuid / 256)
     .toString(16)


### PR DESCRIPTION
Follow-up to #4519 (merged before its codecov/patch check went green).

`netuidStorageKeySuffix`'s inner `isU16Netuid` guard is unreachable: its only caller, `loadSubnetRecycled`, already validates and throws on the same condition before ever calling it. The dead branch is what tripped `codecov/patch` (80% patch coverage) on #4519. This removes the redundant check -- no behavior change, `netuidStorageKeySuffix` is only ever called with an already-validated netuid.

Verified locally: 23/23 tests pass, 100% statement/branch coverage on src/subnet-recycled.mjs.