### PR TITLE
fix(ui): restore the newest-first indicator on the blocks controls row

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -267,6 +267,12 @@ function BlocksTable() {
         inputMode="numeric"
         className="min-w-[120px] max-w-[140px] flex-none"
       />
+      <span
+        className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
+        title="Blocks are listed newest first"
+      >
+        ↓ Newest first
+      </span>
       <PageSizeSelect
         value={search.limit}
         onChange={(n) => setSearch({ limit: n, offset: 0 })}


### PR DESCRIPTION
## Summary

restore the "Newest first" sort-order indicator on the `/blocks` controls row. Closes #3988.

## What changed

#3699 ("add author/range filters to Blocks list") added the six-input filter bar and, in the same diff, deleted the sort-order label that had sat in the controls row. `git show 8eb7b8e2 -- apps/ui/src/routes/blocks.index.tsx` shows exactly one line removed there:

```
-      <span className="font-mono text-[11px] text-ink-muted">Newest first</span>
```

the feed still sorts newest-first — the `/api/v1/blocks` pages come back newest-first and the page never changed that — but nothing on screen communicated it. this restores a `↓ Newest first` indicator next to the per-page control (the arrow reads as descending order), reusing the existing `font-mono text-[11px] text-ink-muted` token. the six filter inputs are untouched.

## On the "empty gap" in the issue

the issue also reported a spacing gap above the filter bar. tracing it: #3699 changed only the label span and the query call — it introduced no margin/padding change (see the commit above). the vertical space above the controls row is the shared `PageHero` section margin plus the block-production stat header added later (#3488), which matches the section rhythm on the other list routes (`subnets`, `endpoints`). so there is no `/blocks`-specific spacing artifact to remove here; tightening the shared hero spacing globally would be a separate, cross-route change. i kept this PR to the one concrete, git-traceable regression — the missing indicator.

(the screenshots show the empty "No blocks indexed yet" state because this capture environment has no indexed blocks in the snapshot; the controls row — the subject of this change — renders identically regardless.)

## Screenshots

3 viewports × 2 themes, before/after, controls row centered:

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/boskodev790/metagraphed/screenshots/blocks3988-mobile-dark-after.png)<br><sub>after</sub> |

## Validation

```
npm run lint --workspace=apps/ui          # 0 errors
npm run format:check --workspace=apps/ui  # clean
npm run typecheck --workspace=apps/ui     # clean
npm test --workspace=apps/ui              # 687 passed
npm run build --workspace=apps/ui         # built
```
