### PR TITLE
feat(registry): add SN24 Quasar public TaoMarketCap subnet API endpoint

### DIFF
--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -218,6 +218,25 @@
         "https://huggingface.co/silx-ai"
       ],
       "url": "https://huggingface.co/datasets/silx-ai/Quasar-SN3"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-24-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Quasar TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/24 on api.taomarketcap.com returning machine-readable JSON for SN24 Quasar on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/24"
     }
   ],
   "website_url": "https://silxinc.com/",


### PR DESCRIPTION
## Summary
Enriches SN24 **Quasar** with the public, no-auth **subnet-api** endpoint exposed through the TaoMarketCap indexed feed — the `subnet-api` surface issue #577 requests.

- Endpoint: `GET https://api.taomarketcap.com/public/v1/subnets/24` — machine-readable JSON (on-chain subnet state, SubnetIdentitiesV3 metadata, economics, dTAO market fields).
- Documented in the TaoMarketCap developer API (`https://api.taomarketcap.com/developer/documentation/`).
- Distinct from the existing TaoMarketCap **dashboard** (HTML page) surface; this is the machine-readable API.

## Change
- One file: `registry/subnets/quasar.json` — appends a single `authority: community`, `review.state: community-submitted` surface. Purely additive.

Closes #577