### PR TITLE
style(docs): collapse comment-only JSON object body per prettier

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -17,7 +17,9 @@ Every `/api/v1/*` response is a JSON envelope:
 {
   "ok": true,
   "schema_version": 1,
-  "data": {/* artifact payload, possibly filtered/paginated */},
+  "data": {
+    /* artifact payload, possibly filtered/paginated */
+  },
   "meta": {
     "artifact_path": "/metagraph/subnets.json",
     "cache": "standard",
@@ -25,7 +27,9 @@ Every `/api/v1/*` response is a JSON envelope:
     "generated_at": "1970-01-01T00:00:00.000Z",
     "published_at": "2026-06-09T13:57:16.231Z",
     "source": "static-assets",
-    "pagination": {/* present on list routes; see below */},
+    "pagination": {
+      /* present on list routes; see below */
+    },
   },
 }
 ```


### PR DESCRIPTION
Found while sweeping open PRs for CI health: `docs/api-stability.md` was the only file on main failing `npx prettier --check .` -- same collapse-comment-only-object pattern already fixed elsewhere in #4190, just missed this occurrence. No content change, formatting only.