### PR TITLE
fix(registry-sync): add smart placement, matching data-api's sibling config

### DIFF
--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -12,6 +12,14 @@
   "main": "workers/registry-sync-api.mjs",
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
+  // Smart placement: run the Worker close to the Hyperdrive origin (the registry
+  // Postgres instance, reached via Cloudflare Tunnel) rather than at the nearest
+  // edge to the caller (GitHub Actions) -- the case for this is if anything
+  // stronger than wrangler.data.jsonc's read-only sibling: a single sync run
+  // does a whole batch of sequential INSERT/UPDATE/DELETE round-trips (one per
+  // provider/subnet/surface), so shaving latency off each round-trip compounds
+  // across the whole batch rather than mattering once per request.
+  "placement": { "mode": "smart" },
   // This is a write path into a database, unlike wrangler.data.jsonc's
   // read-only sibling -- explicitly disabled (wrangler otherwise defaults
   // workers.dev to enabled) so the shared-secret check is the only way in,


### PR DESCRIPTION
## Summary

`wrangler.data.jsonc` (the read-only chain-data Postgres worker) has
`"placement": { "mode": "smart" }` so it runs close to the Hyperdrive
origin rather than the nearest edge to the client, minimizing per-request
DB round-trip latency. `wrangler.registry.jsonc` (its write-path sibling)
never got this -- simply missed when the file was created.

The case for smart placement is if anything stronger here:
`registry-sync-api.mjs` runs a whole batch of sequential
INSERT/UPDATE/DELETE round-trips per invocation (one per
provider/subnet/surface, potentially hundreds in one sync run), so
shaving latency off each round-trip compounds across the batch rather
than mattering once per request.

## Change

Add `"placement": { "mode": "smart" }` to `wrangler.registry.jsonc`,
matching `wrangler.data.jsonc`'s pattern.

## Testing

- `npx wrangler deploy -c wrangler.registry.jsonc --dry-run` confirms
  valid config
- `npm run lint && npx prettier --check wrangler.registry.jsonc` clean
- `npm run scan:public-safety` clean

No screenshot table -- config only, no `apps/ui` files touched.