### PR TITLE
feat(ui): add a kind filter dropdown to the subnet on-chain activity table (#3369)

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -91,11 +91,16 @@ export function SelectFilter({
   onChange,
   options,
   label,
+  align = "left",
 }: {
   value: string;
   onChange: (v: string) => void;
   options: Array<{ value: string; label: string }>;
   label: string;
+  // The native select sizes to its widest option, so a short selection (e.g.
+  // "all") can float far from the chevron. `align="right"` sits the value beside
+  // the arrow instead. Opt-in — existing callers are unchanged.
+  align?: "left" | "right";
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
@@ -105,7 +110,9 @@ export function SelectFilter({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className={`bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring${
+          align === "right" ? " text-right" : ""
+        }`}
       >
         <option value="">all</option>
         {options.map((o) => (

--- a/apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { subnetEventsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/1/events",
+  });
+}
+
+function runQuery(netuid: number, kind?: string) {
+  const opts = subnetEventsQuery(netuid, kind);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("subnetEventsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches the events route with only the fixed limit when no kind is given", async () => {
+    resolveWith({
+      event_count: 2,
+      events: [
+        { block_number: 10, event_index: 0, event_kind: "StakeAdded" },
+        { block_number: 9, event_index: 1, event_kind: "WeightsSet" },
+      ],
+    });
+    const res = await runQuery(64);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/64/events",
+      expect.objectContaining({ params: { limit: 100 }, signal: expect.anything() }),
+    );
+    expect(res.data.netuid).toBe(64);
+    expect(res.data.event_count).toBe(2);
+    expect(res.data.events).toHaveLength(2);
+  });
+
+  it("forwards the kind param and keys the cache on it", async () => {
+    resolveWith({ events: [] });
+    const opts = subnetEventsQuery(64, "StakeAdded");
+    // kind is part of the query key so a filtered feed caches separately.
+    expect(opts.queryKey).toContain("StakeAdded");
+    await runQuery(64, "StakeAdded");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/64/events",
+      expect.objectContaining({ params: { limit: 100, kind: "StakeAdded" } }),
+    );
+  });
+
+  it("degrades a cold subnet to an empty feed (never throws)", async () => {
+    for (const raw of [{}, null, { events: "not-an-array" }]) {
+      resolveWith(raw);
+      const res = await runQuery(1);
+      expect(res.data.netuid).toBe(1);
+      expect(res.data.events).toEqual([]);
+      expect(res.data.event_count).toBe(0);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4213,14 +4213,18 @@ export const subnetStakeFlowQuery = (netuid: number, window = "30d") =>
     staleTime: STALE_MED,
   });
 
-export const subnetEventsQuery = (netuid: number) =>
+export const subnetEventsQuery = (netuid: number, kind?: string) =>
   queryOptions({
-    queryKey: k("subnet-events", netuid),
+    queryKey: k("subnet-events", netuid, kind ?? null),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Record<string, unknown>>(
-        `/api/v1/subnets/${netuid}/events?limit=100`,
-        { signal },
-      );
+      // The backend validates `kind` against INGESTED_EVENT_KINDS server-side
+      // (handleSubnetEvents); forward it alongside the fixed limit when set.
+      const params: Record<string, string | number> = { limit: 100 };
+      if (kind) params.kind = kind;
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/subnets/${netuid}/events`, {
+        params,
+        signal,
+      });
       const d = (res.data ?? {}) as Record<string, unknown>;
       const events = normalizeAccountEvents(d.events);
       return {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -60,8 +60,10 @@ import {
   eventKindCategory,
   eventKindCategoryLabel,
   eventKindLabel,
+  EVENT_KIND_LABELS,
   type EventKindCategory,
 } from "@/lib/metagraphed/event-kinds";
+import { SelectFilter } from "@/components/metagraphed/table-controls";
 import { TableState } from "@/components/metagraphed/table-state";
 import type {
   AccountEvent,
@@ -91,6 +93,9 @@ type SearchParams = {
   tab?: string;
   sev?: string;
   uid?: number;
+  // On-chain activity feed: filter by event kind (#3369). Named to match the
+  // accounts page's ev_kind so the kind-filter UX stays consistent site-wide.
+  ev_kind?: string;
 };
 
 export const Route = createFileRoute("/subnets/$netuid")({
@@ -100,6 +105,7 @@ export const Route = createFileRoute("/subnets/$netuid")({
       tab: typeof s.tab === "string" ? s.tab : undefined,
       sev: typeof s.sev === "string" ? s.sev : undefined,
       uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined,
+      ev_kind: typeof s.ev_kind === "string" && s.ev_kind ? s.ev_kind : undefined,
     };
   },
   parseParams: ({ netuid }) => {
@@ -666,22 +672,48 @@ function StakeFlowScorecard({ netuid }: { netuid: number }) {
 }
 
 function ActivityPanel({ netuid }: { netuid: number }) {
+  const { ev_kind: kind } = Route.useSearch();
+  const navigate = Route.useNavigate();
+
   return (
     <SectionAnchor
       id="activity"
       title="On-chain activity"
       subtitle="First-party chain events for this subnet, newest first."
       info="Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
+      right={
+        <SelectFilter
+          label="Kind"
+          align="right"
+          value={kind ?? ""}
+          onChange={(v) =>
+            navigate({
+              to: ".",
+              search: (prev: SearchParams) => ({ ...prev, ev_kind: v || undefined }),
+              replace: true,
+              resetScroll: false,
+            })
+          }
+          options={SUBNET_EVENT_KIND_OPTIONS}
+        />
+      }
     >
       <StakeFlowScorecard netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <ActivityTableLoader netuid={netuid} />
+          <ActivityTableLoader netuid={netuid} kind={kind} />
         </Suspense>
       </QueryErrorBoundary>
     </SectionAnchor>
   );
 }
+
+// #3369: subnets expose no per-subnet event_kinds summary to derive filter
+// options from (unlike AccountSummary.event_kinds), so source the kind dropdown
+// from the shared label map, ordered by human-readable label.
+const SUBNET_EVENT_KIND_OPTIONS = Object.entries(EVENT_KIND_LABELS)
+  .map(([value, label]) => ({ value, label }))
+  .sort((a, b) => a.label.localeCompare(b.label));
 
 const EVENT_KIND_CATEGORY_DOT: Record<EventKindCategory, string> = {
   registration: "var(--chart-1)",
@@ -719,15 +751,19 @@ function EventKindCell({ kind }: { kind: string | null | undefined }) {
   );
 }
 
-function ActivityTableLoader({ netuid }: { netuid: number }) {
-  const { data } = useSuspenseQuery(subnetEventsQuery(netuid));
+function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }) {
+  const { data } = useSuspenseQuery(subnetEventsQuery(netuid, kind));
   const events = (data.data.events ?? []) as AccountEvent[];
   if (events.length === 0) {
     return (
       <TableState
         variant="empty"
-        title="No recent on-chain activity"
-        description="No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+        title={kind ? `No ${eventKindLabel(kind)} events` : "No recent on-chain activity"}
+        description={
+          kind
+            ? "No events of this kind are indexed for this subnet in the current window. Clear the filter to see the full activity feed."
+            : "No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+        }
         generatedAt={data.meta?.generated_at}
       />
     );


### PR DESCRIPTION
Closes #3369

Adds a **Kind** filter to the "On-chain activity" table on `/subnets/$netuid`, wiring the already-live server-side `?kind=` through the frontend, mirroring the accounts page: `subnetEventsQuery(netuid, kind?)` forwards `kind`, and a new `ev_kind` URL param drives a `SelectFilter` sourced from `EVENT_KIND_LABELS`. Selecting refetches filtered; clearing restores the feed. Frontend only. typecheck ✓ · 690 tests ✓ · eslint ✓.

> Prod's event window is empty now, so shots inject a representative sample (mock honours `?kind=`). Filtered `?ev_kind=StakeAdded`: [light](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-dl-f.png) · [dark](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-dd-f.png).

### Before / after — On-chain activity

| View · Theme | Before | After |
|---|---|---|
| Desktop·Light | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak-dl-b.png) | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-dl-a.png) |
| Desktop·Dark | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak-dd-b.png) | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-dd-a.png) |
| Tablet·Light | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak-tl-b.png) | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-tl-a.png) |
| Tablet·Dark | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak-td-b.png) | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-td-a.png) |
| Mobile·Light | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak-ml-b.png) | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-ml-a.png) |
| Mobile·Dark | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak-md-b.png) | ![](https://raw.githubusercontent.com/kevin8600/metagraphed/screenshots/ak2-md-a.png) |
