### PR TITLE
feat(ui): add weight-setting activity leaderboard to /leaderboards

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainWeightsQuery, normalizeChainWeights } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/weights",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainWeightsQuery(window as "7d" | "30d" | undefined, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainWeights", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainWeights({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          distinct_setters: 6,
+          weight_sets: 90,
+          sets_per_setter: 15,
+        },
+        intensity_distribution: {
+          count: 2,
+          mean: 13.5,
+          min: 12,
+          p25: 12,
+          median: 12,
+          p75: 15,
+          p90: 15,
+          max: 15,
+        },
+        subnets: [
+          { netuid: 1, distinct_setters: 4, weight_sets: 60, sets_per_setter: 15 },
+          { netuid: 2, distinct_setters: 2, weight_sets: 24, sets_per_setter: 12 },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: {
+        distinct_setters: 6,
+        weight_sets: 90,
+        sets_per_setter: 15,
+      },
+      intensity_distribution: {
+        count: 2,
+        mean: 13.5,
+        min: 12,
+        p25: 12,
+        median: 12,
+        p75: 15,
+        p90: 15,
+        max: 15,
+      },
+      subnets: [
+        { netuid: 1, distinct_setters: 4, weight_sets: 60, sets_per_setter: 15 },
+        { netuid: 2, distinct_setters: 2, weight_sets: 24, sets_per_setter: 12 },
+      ],
+    });
+  });
+
+  it("degrades a cold / junk store to a schema-stable zeroed leaderboard", () => {
+    for (const raw of [{}, null, "x", { subnet_count: "nope" }]) {
+      const card = normalizeChainWeights(raw);
+      expect(card.subnet_count).toBe(0);
+      expect(card.network.weight_sets).toBe(0);
+      expect(card.network.distinct_setters).toBe(0);
+      expect(card.network.sets_per_setter).toBeNull();
+      expect(card.intensity_distribution).toBeNull();
+      expect(card.subnets).toEqual([]);
+    }
+  });
+
+  it("drops malformed subnet rows", () => {
+    const card = normalizeChainWeights({
+      subnet_count: 2,
+      network: {},
+      subnets: [{ netuid: "bad" }, { netuid: 3, weight_sets: 5 }],
+    });
+    expect(card.subnets).toEqual([
+      { netuid: 3, distinct_setters: 0, weight_sets: 5, sets_per_setter: null },
+    ]);
+  });
+});
+
+describe("chainWeightsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches with window and limit params", async () => {
+    resolveWith({ subnet_count: 0, network: {}, subnets: [] });
+    await runQuery("30d", 50);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/weights", {
+      params: { window: "30d", limit: 50 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("defaults to 7d and limit 20", async () => {
+    resolveWith({ subnet_count: 0, network: {}, subnets: [] });
+    await runQuery();
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/weights", {
+      params: { window: "7d", limit: 20 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -92,6 +92,8 @@ import type {
   ChainAxonRemovalSubnet,
   ChainDeregistrations,
   ChainDeregistrationsSubnet,
+  ChainWeights,
+  ChainWeightsSubnet,
   ChainRegistrations,
   ChainRegistrationsSubnet,
   ChainIntensityDistribution,
@@ -272,6 +274,7 @@ const MAX_CHAIN_TRANSFER_PAIRS = 100;
 const MAX_CHAIN_STAKE_TRANSFERS = 100;
 const MAX_CHAIN_AXON_REMOVALS = 100;
 const MAX_CHAIN_DEREGISTRATIONS = 100;
+const MAX_CHAIN_WEIGHTS = 100;
 const MAX_CHAIN_REGISTRATIONS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
@@ -3872,6 +3875,57 @@ export const chainDeregistrationsQuery = (window: ChainWindow = "7d", limit = 10
       });
       return {
         data: normalizeChainDeregistrations(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainWeightsSubnet(raw: unknown): ChainWeightsSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_setters: firstFiniteNumber(raw.distinct_setters) ?? 0,
+    weight_sets: firstFiniteNumber(raw.weight_sets) ?? 0,
+    sets_per_setter: firstFiniteNumber(raw.sets_per_setter) ?? null,
+  };
+}
+
+// Network-wide validator weight-setting leaderboard over a 7d/30d window — the account_events
+// WeightsSet twin of /api/v1/chain/deregistrations. Every numeric cell coerces defensively:
+// counts fall through to 0, the per-setter average to null (never NaN), and malformed subnet
+// rows are dropped on a cold store or junk.
+export function normalizeChainWeights(raw: unknown): ChainWeights {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_setters: firstFiniteNumber(networkRec.distinct_setters) ?? 0,
+      weight_sets: firstFiniteNumber(networkRec.weight_sets) ?? 0,
+      sets_per_setter: firstFiniteNumber(networkRec.sets_per_setter) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(rec.subnets, MAX_CHAIN_WEIGHTS, normalizeChainWeightsSubnet),
+  };
+}
+
+export const chainWeightsQuery = (window: ChainWindow = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-weights", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainWeights>>("/api/v1/chain/weights", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainWeights(res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2647,6 +2647,37 @@ export interface ChainDeregistrations {
   subnets: ChainDeregistrationsSubnet[];
 }
 
+/** One subnet's row on the network-wide weight-setting activity leaderboard. */
+export interface ChainWeightsSubnet {
+  netuid: number;
+  distinct_setters: number;
+  weight_sets: number;
+  sets_per_setter: number | null;
+}
+
+/** Network-wide weight-setting rollup — true distinct-setter count (not a per-subnet sum) + total WeightsSet events. */
+export interface ChainWeightsNetwork {
+  distinct_setters: number;
+  weight_sets: number;
+  sets_per_setter: number | null;
+}
+
+/**
+ * Network-wide validator weight-setting activity over a 7d/30d window, from
+ * GET /api/v1/chain/weights — subnets ranked by WeightsSet event count, plus the true
+ * network-wide distinct-setter rollup and a distribution summary of per-subnet update
+ * intensity (WeightsSet events per validator). Zeroed with an empty subnets list when cold.
+ */
+export interface ChainWeights {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainWeightsNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainWeightsSubnet[];
+}
+
 /** One subnet's row on the network-wide neuron-registration leaderboard (#3465). */
 export interface ChainRegistrationsSubnet {
   netuid: number;

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useMemo } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { UserMinus } from "lucide-react";
+import { Scale, UserMinus } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -12,13 +12,19 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
-import { chainDeregistrationsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import {
+  chainDeregistrationsQuery,
+  chainWeightsQuery,
+  subnetsQuery,
+} from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { Subnet } from "@/lib/metagraphed/types";
 
 const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
 });
+
+type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
 
 export const Route = createFileRoute("/leaderboards")({
   validateSearch: zodValidator(leaderboardsSearchSchema),
@@ -28,13 +34,13 @@ export const Route = createFileRoute("/leaderboards")({
       {
         name: "description",
         content:
-          "Network-wide Bittensor leaderboards — neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Network-wide Bittensor leaderboards — validator weight-setting activity and neuron deregistrations ranked by subnet over 7d and 30d windows.",
       },
       { property: "og:title", content: "Leaderboards — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Network-wide Bittensor leaderboards — neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Network-wide Bittensor leaderboards — validator weight-setting activity and neuron deregistrations ranked by subnet over 7d and 30d windows.",
       },
     ],
   }),
@@ -42,8 +48,18 @@ export const Route = createFileRoute("/leaderboards")({
 });
 
 const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+const WINDOW_BTN_ACTIVE =
+  "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent";
+const WINDOW_BTN =
+  "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30";
 
+// Every board on this route ranks the same 7d/30d window, so the window control lives at the page
+// level and governs both sections rather than each board owning a duplicate toggle.
 function LeaderboardsPage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const win = search.window;
+
   return (
     <AppShell>
       <PageHero
@@ -52,61 +68,193 @@ function LeaderboardsPage() {
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
-          <DeregistrationsLeaderboard />
-        </Suspense>
-      </QueryErrorBoundary>
-      <ApiSourceFooter paths={["/api/v1/chain/deregistrations"]} />
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Window
+        </span>
+        {(["7d", "30d"] as const).map((w) => (
+          <button
+            key={w}
+            type="button"
+            onClick={() => navigate({ search: { window: w } })}
+            className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+      <div className="space-y-12">
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+            <WeightSettingLeaderboard win={win} />
+          </Suspense>
+        </QueryErrorBoundary>
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+            <DeregistrationsLeaderboard win={win} />
+          </Suspense>
+        </QueryErrorBoundary>
+      </div>
+      <ApiSourceFooter paths={["/api/v1/chain/weights", "/api/v1/chain/deregistrations"]} />
     </AppShell>
   );
 }
 
-function DeregistrationsLeaderboard() {
-  const search = Route.useSearch();
-  const navigate = useNavigate({ from: Route.fullPath });
-  const win = search.window;
-
-  const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
+// Shared subnet lookup so a board row can render the brand icon + name for its netuid. subnetsQuery
+// is cached per key, so both boards mounting it is a single shared fetch, not a waterfall.
+function useSubnetById(): Map<number, Subnet> {
   const { data: snRes } = useSuspenseQuery(subnetsQuery());
-  const board = boardRes.data;
-
-  const subnetById = useMemo(() => {
+  return useMemo(() => {
     const m = new Map<number, Subnet>();
     for (const s of (snRes.data ?? []) as Subnet[]) m.set(s.netuid, s);
     return m;
   }, [snRes]);
+}
 
+function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
+  const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win));
+  const subnetById = useSubnetById();
+  const board = boardRes.data;
+  const network = board.network;
+  const dist = board.intensity_distribution;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Weight-setting activity
+        </h2>
+        <p className="mt-1 text-sm text-ink-muted">
+          Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
+          window.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={Scale}
+          eyebrow="Weight-sets"
+          value={formatNumber(network.weight_sets)}
+          hint={`${win} network total`}
+          tone="accent"
+        />
+        <StatTile
+          icon={Scale}
+          eyebrow="Distinct setters"
+          value={formatNumber(network.distinct_setters)}
+          hint="network-wide unique validators"
+        />
+        <StatTile
+          icon={Scale}
+          eyebrow="Per setter"
+          value={network.sets_per_setter != null ? network.sets_per_setter.toFixed(2) : "—"}
+          hint="network intensity"
+        />
+      </div>
+
+      {dist ? (
+        <p className="text-xs text-ink-muted">
+          Update intensity across {formatNumber(dist.count)} subnets — median{" "}
+          {dist.median.toFixed(2)}, p90 {dist.p90.toFixed(2)}, max {dist.max.toFixed(2)} sets per
+          validator.
+        </p>
+      ) : null}
+
+      {board.subnet_count === 0 || board.subnets.length === 0 ? (
+        <EmptyState
+          title="No weight-setting activity in this window"
+          description="The chain poller has not indexed any WeightsSet events for this window yet, or no validators set weights."
+          lastChecked={board.observed_at ?? undefined}
+        />
+      ) : (
+        <section className="rounded-lg border border-border bg-card">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Per-subnet rankings
+            </span>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {formatNumber(board.subnet_count)} subnets
+              {board.observed_at ? (
+                <>
+                  {" "}
+                  · observed <TimeAgo at={board.observed_at} />
+                </>
+              ) : null}
+            </span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Rank</th>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Weight-sets</th>
+                  <th className={`${TH} text-right`}>Distinct setters</th>
+                  <th className={`${TH} text-right`}>Per setter</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {board.subnets.map((row, i) => {
+                  const subnet = subnetById.get(row.netuid);
+                  const name = subnet?.name ?? `Subnet ${row.netuid}`;
+                  return (
+                    <tr key={row.netuid} className="hover:bg-surface/40">
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: row.netuid }}
+                          className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                        >
+                          <BrandIcon
+                            size={18}
+                            name={name}
+                            fallback={row.netuid}
+                            netuid={row.netuid}
+                            subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                          />
+                          <span className="truncate text-sm text-ink-strong">{name}</span>
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                        {formatNumber(row.weight_sets)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatNumber(row.distinct_setters)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {row.sets_per_setter != null ? row.sets_per_setter.toFixed(2) : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
+  const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
+  const subnetById = useSubnetById();
+  const board = boardRes.data;
   const network = board.network;
 
   return (
     <div className="space-y-8">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-            Deregistrations
-          </h2>
-          <p className="mt-1 text-sm text-ink-muted">
-            Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
-            window.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {(["7d", "30d"] as const).map((w) => (
-            <button
-              key={w}
-              type="button"
-              onClick={() => navigate({ search: { window: w } })}
-              className={
-                w === win
-                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
-                  : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
-              }
-            >
-              {w}
-            </button>
-          ))}
-        </div>
+      <div>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Deregistrations
+        </h2>
+        <p className="mt-1 text-sm text-ink-muted">
+          Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
+          window.
+        </p>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">


### PR DESCRIPTION
Closes #3469

## Summary

The `/leaderboards` route already renders a `DeregistrationsLeaderboard` (from the sibling #3466), but `GET /api/v1/chain/weights` — the network-wide validator weight-setting board (`account_events` `WeightsSet` stream: per-subnet ranking, network rollup, and a per-subnet update-intensity distribution) — was live and routed yet **entirely unconsumed** by the UI. There was no `chainWeightsQuery` in `queries.ts` and no `ChainWeights` type. This PR wires that endpoint into a new weight-setting section on the existing route, mirroring the deregistrations board it sits beside.

## What changed

- **`apps/ui/src/lib/metagraphed/types.ts`** — new `ChainWeights` / `ChainWeightsNetwork` / `ChainWeightsSubnet` types, matching the builder output in `src/chain-weights.mjs` (`network.{distinct_setters,weight_sets,sets_per_setter}`, the shared `ChainIntensityDistribution`, and the per-subnet rows). Reuses the existing `ChainIntensityDistribution` type rather than adding a parallel one.
- **`apps/ui/src/lib/metagraphed/queries.ts`** — new `normalizeChainWeights` + `chainWeightsQuery(window = "7d", limit = 20)`, following the `chainDeregistrationsQuery` pattern exactly (`queryOptions` + `apiFetch<Partial<ChainWeights>>` + per-field coercion + `staleTime: STALE_MED`). The normalizer reuses the shared `normalizeChainIntensityDistribution` and `normalizeChainRows` helpers, so counts fall through to `0`, the per-setter average to `null` (never `NaN`), and malformed subnet rows are dropped on a cold store or junk payload.
- **`apps/ui/src/routes/leaderboards.tsx`** — new `WeightSettingLeaderboard` section reusing the same `StatTile` / `BrandIcon` / ranked-`<table>` structure as the deregistrations board: a network rollup (weight-sets, distinct setters, sets-per-setter), the update-intensity summary (median / p90 / max sets per validator), and a per-subnet ranking linking each row to `/subnets/$netuid`. Loading / empty / error states match the existing board's pattern. Because the route now hosts more than one board, the shared **7d / 30d window control was lifted from inside the deregistrations section up to the page level** so it governs both boards instead of each board carrying a duplicate toggle. `/api/v1/chain/weights` is added to the page's `ApiSourceFooter`.
- **`apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts`** — 5 tests covering the window/limit params, the defaults, a well-formed passthrough, cold/junk degradation to a schema-stable zeroed board, and dropping malformed subnet rows.

## Coordination note

Four sibling issues target the same `/leaderboards` route — #3465 (registrations), #3466 (deregistrations, already merged and the current route shell), #3470 (the validator-level `/api/v1/chain/weights/setters` board), #3473 (turnover). This PR extends the existing route file created by #3466 rather than re-creating it, and does **not** touch the separate `leaderboards.tsx` component / `leaderboardsQuery` (registry completeness boards, #1111) or the `/api/v1/chain/weights/setters` scope owned by #3470.

## Verification

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 errors (the only warnings on the file are the pre-existing `react-refresh/only-export-components` ones the route already had)
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 692 passed (99 files), including the 5 new tests above
- `npm run build --workspace=apps/ui` — clean
- The responsive-overflow e2e replays a fixed HAR route set (`/`, `/subnets/1`, `/endpoints`, `/status`, `/settings`, `/explorer`) that does not include `/leaderboards`, so this change needs no HAR re-record and cannot affect that check; the new section's responsiveness is shown across the three e2e viewports in the table below.

**On the data shown:** production's `chain/weights` prober currently flaps between populated and empty across loads. To keep the before/after deterministic — the same approach the repo's responsive-overflow e2e takes with recorded fixtures — the captures below serve one fixed, representative API payload for both boards (subnet names still resolve from the live registry). The section was additionally verified against live data: it renders the populated ranked board when the prober has data and the documented empty state (`No weight-setting activity in this window`) when it does not.

## Screenshots — desktop / tablet / mobile × light + dark

Before = the route with only the deregistrations board (window toggle inside that section). After = the new weight-setting board as the first section, with the window control lifted to the page level.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/c_metagraphed/screenshots/lb-weights-after-mobile-dark.png)<br><sub>after</sub> |
