### PR TITLE
fix(data): stop a single stuck day from freezing the neuron_daily backlog prune

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -10,6 +10,7 @@ import {
   NEURON_COLUMNS,
   formatNeuron,
 } from "./metagraph-neurons.mjs";
+import { logEvent } from "../workers/storage.mjs";
 
 // Columns copied verbatim from `neurons` into `neuron_daily` (identical shape).
 const ROLLUP_COLUMNS = NEURON_INSERT_COLUMNS;
@@ -119,7 +120,19 @@ export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
 export const NEURON_DAILY_RETENTION_DAYS = 90;
 // Bound cold-archive work per cron tick so a large retention cut/backlog cannot
 // consume the whole Worker invocation before any D1 space is recovered.
-export const NEURON_DAILY_ARCHIVE_BATCH_DAYS = 7;
+//
+// Was 7 -- but the 400->90 day cut above (2026-07-04) left a ~200+ day backlog,
+// and confirmed 2026-07-10: the backlog-clearing path had made ZERO progress in
+// the 6 days since, while the single-current-day archive (~129 R2 puts, one per
+// subnet) kept working every day in that same window. 7 days is ~900 R2 puts in
+// one invocation, on top of the rollup + current-day archive that precede it in
+// the same cron tick (workers/api.mjs's NEURON_HISTORY_ROLLUP_CRON handler) --
+// a plausible fit for a Workers subrequest/CPU-time ceiling. Cut to 2: still
+// bounded well under the proven-working single-day footprint's neighborhood,
+// while keeping enough per-tick width that archivePrunableNeuronDaily's
+// skip-and-continue (below) can make progress past one persistently-failing day
+// within the same tick, not just get stuck retrying it forever.
+export const NEURON_DAILY_ARCHIVE_BATCH_DAYS = 2;
 
 // R2 cold-archive key: one immutable gzip-NDJSON object per subnet per UTC day.
 export function coldArchiveKey(netuid, day) {
@@ -215,6 +228,20 @@ async function prunableDays(
  * Archive a bounded batch of neuron_daily days eligible for the retention prune.
  * This closes the data-loss gap where a successful latest-day archive could gate
  * deletion of older days that had never been written to R2.
+ *
+ * A single day's failure (including a THROWN exception, e.g. a Workers
+ * subrequest/CPU-time limit -- archiveNeuronDaily has no try/catch of its own)
+ * no longer aborts the whole batch: it's logged and skipped, and the loop
+ * continues to the next day. This is deliberate -- confirmed 2026-07-10 that a
+ * single persistently-failing old day (the oldest is always re-returned by
+ * prunableDays() until it's archived) had silently frozen the ENTIRE backlog
+ * for 6+ days, since the old all-or-nothing behavior meant nothing past that
+ * one day ever got a chance to archive+prune. Returns `archived: true` only if
+ * at least one day actually succeeded -- pruneNeuronDaily's caller must never
+ * see `archived: true` with an EMPTY `days` array, since its own fallback for
+ * "no explicit days list" is a blanket `DELETE ... WHERE snapshot_date < cutoff`
+ * with no R2-archive check at all (see pruneNeuronDaily below) -- exactly the
+ * data-loss gap this function's own docstring says it exists to close.
  */
 export async function archivePrunableNeuronDaily(
   env,
@@ -235,31 +262,53 @@ export async function archivePrunableNeuronDaily(
   let rows = 0;
   let subnets = 0;
   const archivedDays = [];
+  const skippedDays = [];
   for (const day of days) {
-    const res = await archiveNeuronDaily(env, {
-      day,
-      db: database,
-      bucket: r2,
-    });
-    if (!res.archived) {
-      return {
-        archived: false,
-        reason: "archive-failed",
-        cutoff,
+    let res;
+    try {
+      res = await archiveNeuronDaily(env, {
         day,
-        days: archivedDays,
-        failed: res,
-      };
+        db: database,
+        bucket: r2,
+      });
+    } catch (err) {
+      logEvent(env, "error", "neuron_daily_archive_threw", {
+        day,
+        message: String(err?.message ?? err),
+      });
+      skippedDays.push(day);
+      continue;
+    }
+    if (!res.archived) {
+      logEvent(env, "error", "neuron_daily_archive_failed", {
+        day,
+        reason: res.reason,
+      });
+      skippedDays.push(day);
+      continue;
     }
     archivedDays.push(day);
     rows += res.rows ?? 0;
     subnets += res.subnets ?? 0;
   }
   return {
-    archived: true,
+    // Vacuously true when there was nothing to archive (an empty backlog is
+    // the steady-state norm -- see prunableDays), otherwise true only once at
+    // least one day actually succeeded. False exclusively when there WERE
+    // prunable days and every single one failed, so the caller's gate
+    // correctly withholds the prune rather than risk the blanket-delete path.
+    archived: days.length === 0 || archivedDays.length > 0,
     cutoff,
     days: archivedDays,
-    complete: days.length < limit,
+    skippedDays,
+    // `complete` gates the caller's choice between a targeted delete (specific
+    // `days`) and the blanket `snapshot_date < cutoff` delete (see
+    // pruneNeuronDaily) -- it must mean "every prunable day through cutoff is
+    // now archived", not just "no more backlog was fetched". A batch with any
+    // skippedDays is never complete, even if it exhausted the backlog, so the
+    // caller falls back to deleting only archivedDays and retries the skipped
+    // ones next tick instead of blanket-deleting unarchived rows.
+    complete: skippedDays.length === 0 && days.length < limit,
     subnets,
     rows,
   };

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -945,7 +945,50 @@ describe("R2 cold archive + prune (PR-A2)", () => {
     assert.equal(res.subnets, 0);
   });
 
-  test("archivePrunableNeuronDaily stops and reports the first day that fails to archive", async () => {
+  test("archivePrunableNeuronDaily skips a day that fails to archive and reports it, rather than aborting the batch", async () => {
+    const emptyDay = "2026-03-19";
+    const goodDay = "2026-03-20";
+    const db = {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            return {
+              all: () => {
+                if (sql.includes("DISTINCT snapshot_date")) {
+                  return Promise.resolve({
+                    results: [{ day: emptyDay }, { day: goodDay }],
+                  });
+                }
+                // The emptyDay archive read finds no rows → archiveNeuronDaily
+                // returns {archived:false}; goodDay finds one row and succeeds.
+                if (params[0] === emptyDay) {
+                  return Promise.resolve({ results: [] });
+                }
+                return Promise.resolve({
+                  results: [{ netuid: 7, uid: 0, snapshot_date: goodDay }],
+                });
+              },
+            };
+          },
+        };
+      },
+    };
+    const bucket = { put: () => Promise.resolve() };
+    const now = Date.parse("2026-06-22T00:00:00Z");
+    const res = await archivePrunableNeuronDaily({}, { db, bucket, now });
+    // One day succeeded, so the batch as a whole is still archived:true --
+    // but the failed day is reported separately, never silently dropped, and
+    // never counted as archived (see pruneNeuronDaily: it must not be deleted).
+    assert.equal(res.archived, true);
+    assert.deepEqual(res.days, [goodDay]);
+    assert.deepEqual(res.skippedDays, [emptyDay]);
+    assert.equal(res.complete, false); // a skip always means incomplete
+  });
+
+  test("archivePrunableNeuronDaily reports archived:false when every day in the batch fails", async () => {
+    // All-fail must never regress to archived:true with an empty days array --
+    // pruneNeuronDaily's caller gates the entire prune on this flag, and an
+    // empty-days blanket delete would drop unarchived rows (see pruneNeuronDaily).
     const emptyDay = "2026-03-19";
     const db = {
       prepare(sql) {
@@ -956,8 +999,6 @@ describe("R2 cold archive + prune (PR-A2)", () => {
                 if (sql.includes("DISTINCT snapshot_date")) {
                   return Promise.resolve({ results: [{ day: emptyDay }] });
                 }
-                // The per-day archive read finds no rows → archiveNeuronDaily
-                // returns {archived:false} and the loop bails out.
                 return Promise.resolve({ results: [] });
               },
             };
@@ -969,10 +1010,71 @@ describe("R2 cold archive + prune (PR-A2)", () => {
     const now = Date.parse("2026-06-22T00:00:00Z");
     const res = await archivePrunableNeuronDaily({}, { db, bucket, now });
     assert.equal(res.archived, false);
-    assert.equal(res.reason, "archive-failed");
-    assert.equal(res.day, emptyDay);
     assert.deepEqual(res.days, []);
-    assert.equal(res.failed.archived, false);
+    assert.deepEqual(res.skippedDays, [emptyDay]);
+    assert.equal(res.complete, false);
+  });
+
+  test("archivePrunableNeuronDaily skips a day whose archive call throws, and continues the batch", async () => {
+    const throwingDay = "2026-03-19";
+    const goodDay = "2026-03-20";
+    const db = {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            return {
+              all: () => {
+                if (sql.includes("DISTINCT snapshot_date")) {
+                  return Promise.resolve({
+                    results: [{ day: throwingDay }, { day: goodDay }],
+                  });
+                }
+                if (params[0] === throwingDay) {
+                  return Promise.reject(new Error("subrequest limit"));
+                }
+                return Promise.resolve({
+                  results: [{ netuid: 7, uid: 0, snapshot_date: goodDay }],
+                });
+              },
+            };
+          },
+        };
+      },
+    };
+    const bucket = { put: () => Promise.resolve() };
+    const now = Date.parse("2026-06-22T00:00:00Z");
+    const res = await archivePrunableNeuronDaily({}, { db, bucket, now });
+    assert.equal(res.archived, true);
+    assert.deepEqual(res.days, [goodDay]);
+    assert.deepEqual(res.skippedDays, [throwingDay]);
+  });
+
+  test("archivePrunableNeuronDaily logs a non-Error throw via the String(err) fallback", async () => {
+    // Workers CPU/subrequest-limit failures aren't guaranteed to surface as a
+    // proper Error instance -- exercises the `err?.message ?? err` fallback
+    // when the rejection is a bare string with no `.message`.
+    const throwingDay = "2026-03-19";
+    const db = {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              all: () => {
+                if (sql.includes("DISTINCT snapshot_date")) {
+                  return Promise.resolve({ results: [{ day: throwingDay }] });
+                }
+                return Promise.reject("Exceeded CPU time limit");
+              },
+            };
+          },
+        };
+      },
+    };
+    const bucket = { put: () => Promise.resolve() };
+    const now = Date.parse("2026-06-22T00:00:00Z");
+    const res = await archivePrunableNeuronDaily({}, { db, bucket, now });
+    assert.equal(res.archived, false);
+    assert.deepEqual(res.skippedDays, [throwingDay]);
   });
 
   test("pruneNeuronDaily deletes below the 90-day retention cutoff", async () => {
@@ -1255,6 +1357,76 @@ describe("handleScheduled rollup cron (#1345)", () => {
     assert.deepEqual(result.pruned.days, oldDays);
     assert.match(capturedDeletes[0].sql, /snapshot_date IN/);
     assert.deepEqual(capturedDeletes[0].params, oldDays);
+  });
+
+  test("a partially-skipped backlog batch prunes only the succeeded days, never a blanket delete (#4770)", async () => {
+    // The backlog is fully drained in one batch (fewer prunable days than the
+    // limit), but one of them fails to archive. `complete` must still be false
+    // here so the caller passes the explicit archived-only `days` list to
+    // pruneNeuronDaily rather than `undefined` -- otherwise pruneNeuronDaily's
+    // no-explicit-days fallback (`DELETE ... WHERE snapshot_date < cutoff`)
+    // would blanket-delete the skipped day's still-unarchived D1 rows.
+    const latestDay = "2026-06-21";
+    const failingDay = "2026-03-19";
+    const goodDay = "2026-03-20";
+    const capturedDeletes = [];
+    const db = {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            return {
+              run: () => {
+                if (sql.startsWith("DELETE")) {
+                  capturedDeletes.push({ sql, params });
+                }
+                return Promise.resolve({ meta: { changes: 1 } });
+              },
+              all: () => {
+                if (sql.includes("MAX(snapshot_date)")) {
+                  return Promise.resolve({ results: [{ day: latestDay }] });
+                }
+                if (sql.includes("DISTINCT snapshot_date")) {
+                  return Promise.resolve({
+                    results: [{ day: failingDay }, { day: goodDay }],
+                  });
+                }
+                if (params[0] === failingDay) {
+                  return Promise.resolve({ results: [] }); // archive-failed
+                }
+                return Promise.resolve({
+                  results: [
+                    {
+                      netuid: 7,
+                      uid: 0,
+                      snapshot_date: params[0],
+                      stake_tao: 1,
+                    },
+                  ],
+                });
+              },
+            };
+          },
+        };
+      },
+    };
+    const env = {
+      METAGRAPH_HEALTH_DB: db,
+      METAGRAPH_ARCHIVE: { put: () => Promise.resolve() },
+    };
+
+    const result = await handleScheduled(
+      { cron: NEURON_HISTORY_ROLLUP_CRON },
+      env,
+      ctx,
+    );
+
+    assert.equal(result.archivedPrunable.archived, true);
+    assert.equal(result.archivedPrunable.complete, false);
+    assert.deepEqual(result.archivedPrunable.skippedDays, [failingDay]);
+    assert.equal(result.pruned.pruned, true);
+    assert.deepEqual(result.pruned.days, [goodDay]);
+    assert.match(capturedDeletes[0].sql, /snapshot_date IN/);
+    assert.deepEqual(capturedDeletes[0].params, [goodDay]);
   });
 
   test("isolates a rejected backlog archive and skips the gated prune", async () => {


### PR DESCRIPTION
## Summary

- `archivePrunableNeuronDaily` used to abort its entire batch on the first day
  that failed (or threw) to archive to R2. Since `prunableDays()` always
  re-returns the oldest outstanding day first, one persistently-failing day
  silently froze the whole retention-prune backlog — confirmed stuck for 6+
  days since the 400→90 day retention cut left a large backlog.
- A failing or throwing day is now logged (`logEvent`) and skipped; the loop
  continues to the next day instead of bailing out.
- `archived` is `true` whenever at least one day succeeds this batch, or
  vacuously `true` when there was no backlog at all — but never `true` with
  an empty archived-days list, since `pruneNeuronDaily`'s own
  no-explicit-days fallback is a blanket `DELETE ... WHERE snapshot_date <
  cutoff` with no R2-archive check. That invariant is what keeps an
  unarchived day from being dropped from D1.
- `complete` now also requires zero skipped days: a batch that drains the
  backlog but skips a day still forces the caller to pass the explicit
  archived-only `days` list to `pruneNeuronDaily`, rather than falling back to
  the blanket delete that would sweep up the skipped day's still-unarchived
  rows too.
- Cut `NEURON_DAILY_ARCHIVE_BATCH_DAYS` 7→2 so skip-and-continue can make
  real progress within a Workers subrequest/CPU-time ceiling in the same
  cron tick, rather than repeatedly retrying one oversized batch.

## Test plan

- [x] `npx vitest run tests/neuron-history.test.mjs` — 65/65 passing, including
      new coverage for: a partial-failure batch, an all-fail batch, a thrown
      (Error and non-Error) exception mid-batch, and a `handleScheduled`-level
      test proving a partially-skipped batch prunes only the succeeded days
      (never the blanket delete).
- [x] `npm run lint` / `npm run format:check` clean on touched files.
- [x] `npm run validate` green.
- [x] Patch coverage on `src/neuron-history.mjs`: 100% lines/functions, 99.46%
      statements, 96.02% branches — the only uncovered branches are
      pre-existing, outside this diff.

Closes #4770