### PR TITLE
fix(ui): enable horizontal scroll in subnets compare drawer table

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer-layout.test.ts
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer-layout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPARE_GRID_OUTER_CLASS,
+  COMPARE_SUBNET_COLUMN_CLASS,
+  COMPARE_TABLE_CLASS,
+  COMPARE_TABLE_SCROLL_CLASS,
+} from "./subnets-compare-drawer-layout";
+
+describe("subnets compare drawer layout tokens (#3933)", () => {
+  it("keeps vertical scroll on the outer shell", () => {
+    expect(COMPARE_GRID_OUTER_CLASS).toContain("max-h-[55vh]");
+    expect(COMPARE_GRID_OUTER_CLASS).toContain("overflow-y-auto");
+  });
+
+  it("enables horizontal scroll via a dedicated inner wrapper", () => {
+    expect(COMPARE_TABLE_SCROLL_CLASS).toBe("overflow-x-auto");
+  });
+
+  it("lets the table grow past the drawer instead of pinning w-full", () => {
+    expect(COMPARE_TABLE_CLASS).toContain("w-max");
+    expect(COMPARE_TABLE_CLASS).toContain("min-w-full");
+    expect(COMPARE_TABLE_CLASS.split(/\s+/)).not.toContain("w-full");
+  });
+
+  it("reserves minimum width per subnet column", () => {
+    expect(COMPARE_SUBNET_COLUMN_CLASS).toContain("min-w-[8.5rem]");
+    expect(COMPARE_SUBNET_COLUMN_CLASS).toContain("whitespace-nowrap");
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer-layout.ts
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer-layout.ts
@@ -1,0 +1,21 @@
+/**
+ * Layout tokens for the subnets compare drawer grid (#3933).
+ *
+ * The comparison table grows one column per selected subnet. `w-full` on the
+ * table pins it to the drawer width and prevents horizontal scroll — use `w-max`
+ * inside an `overflow-x-auto` shell instead.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3933
+ */
+
+/** Vertical scroll shell — preserves the existing 55vh cap. */
+export const COMPARE_GRID_OUTER_CLASS = "border-t border-border max-h-[55vh] overflow-y-auto";
+
+/** Horizontal scroll shell — table may exceed drawer width as columns are added. */
+export const COMPARE_TABLE_SCROLL_CLASS = "overflow-x-auto";
+
+/** Intrinsic table width: at least full container, grows with column count. */
+export const COMPARE_TABLE_CLASS = "w-max min-w-full text-[12px]";
+
+/** Per-subnet columns — avoid squashing SN labels / metric values on narrow viewports. */
+export const COMPARE_SUBNET_COLUMN_CLASS = "min-w-[8.5rem] whitespace-nowrap";

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,6 +7,12 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "./chips";
+import {
+  COMPARE_GRID_OUTER_CLASS,
+  COMPARE_SUBNET_COLUMN_CLASS,
+  COMPARE_TABLE_CLASS,
+  COMPARE_TABLE_SCROLL_CLASS,
+} from "./subnets-compare-drawer-layout";
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
@@ -226,42 +232,47 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
   }
 
   return (
-    <div className="border-t border-border max-h-[55vh] overflow-auto">
-      <table className="w-full text-[12px]">
-        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
-          <tr>
-            <th className="px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted w-40">
-              Metric
-            </th>
-            {netuids.map((n) => (
-              <th
-                key={n}
-                className="px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
-              >
-                SN{n}
+    <div className={COMPARE_GRID_OUTER_CLASS}>
+      <div className={COMPARE_TABLE_SCROLL_CLASS}>
+        <table className={COMPARE_TABLE_CLASS}>
+          <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+            <tr>
+              <th className="sticky left-0 z-[2] bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted w-40">
+                Metric
               </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {rows.map((row) => (
-            <tr key={row.label}>
-              <td className="px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted bg-paper/30">
-                {row.label}
-              </td>
               {netuids.map((n) => (
-                <td key={n} className="px-3 py-2">
-                  {isPending ? (
-                    <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
-                  ) : (
-                    row.render(n)
+                <th
+                  key={n}
+                  className={classNames(
+                    "px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong",
+                    COMPARE_SUBNET_COLUMN_CLASS,
                   )}
-                </td>
+                >
+                  SN{n}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.map((row) => (
+              <tr key={row.label}>
+                <td className="sticky left-0 z-[1] bg-paper/95 px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  {row.label}
+                </td>
+                {netuids.map((n) => (
+                  <td key={n} className={classNames("px-3 py-2", COMPARE_SUBNET_COLUMN_CLASS)}>
+                    {isPending ? (
+                      <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
+                    ) : (
+                      row.render(n)
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/ui/tests/e2e/capture-compare-drawer-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-compare-drawer-screenshots.mjs
@@ -1,0 +1,127 @@
+/**
+ * Capture SubnetsCompareDrawer screenshots + horizontal-scroll demo for #3933.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after node tests/e2e/capture-compare-drawer-screenshots.mjs
+ */
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/compare-drawer-screenshots");
+const COMPARE_FIXTURE = JSON.parse(
+  await readFile(new URL("./fixtures/compare-drawer-screenshot.json", import.meta.url), "utf8"),
+);
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const COMPARE_NETUIDS = [1, 8, 19, 64];
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function installCompareFixture(page) {
+  await page.route("**/api/v1/compare**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(COMPARE_FIXTURE),
+    });
+  });
+}
+
+async function openExpandedCompare(page) {
+  await page.evaluate((netuids) => {
+    localStorage.setItem("metagraphed:compare", JSON.stringify(netuids));
+  }, COMPARE_NETUIDS);
+  await page.goto(`${BASE_URL}/subnets`, { waitUntil: "networkidle", timeout: 90_000 });
+  const compareBtn = page.getByRole("button", { name: /^Compare$/i }).last();
+  await compareBtn.click();
+  await page.getByRole("columnheader", { name: "SN64" }).waitFor({ timeout: 60_000 });
+}
+
+async function captureViewport(page, filePath) {
+  await page.screenshot({ path: filePath, fullPage: false });
+}
+
+async function getCompareScroller(page) {
+  return page
+    .locator("div.max-h-\\[55vh\\]")
+    .filter({ has: page.getByRole("columnheader", { name: "SN64" }) })
+    .locator(".overflow-x-auto, .overflow-auto")
+    .first();
+}
+
+async function recordHorizontalScroll(page) {
+  const scroller = await getCompareScroller(page);
+  await scroller.waitFor({ state: "visible" });
+  const box = await scroller.boundingBox();
+  if (!box) throw new Error("compare scroller not found");
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  for (let i = 0; i < 8; i++) {
+    await page.mouse.move(box.x + box.width / 2 - i * 28, box.y + box.height / 2, { steps: 4 });
+    await page.waitForTimeout(120);
+  }
+  await page.mouse.up();
+
+  await page.evaluate(
+    (el) => {
+      el.scrollLeft = el.scrollWidth;
+    },
+    await scroller.elementHandle(),
+  );
+  await page.waitForTimeout(400);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+        recordVideo: { dir: OUT_DIR, size: { width: viewport.width, height: viewport.height } },
+      });
+      const page = await context.newPage();
+      await installCompareFixture(page);
+      await setTheme(page, theme);
+      await openExpandedCompare(page);
+
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await captureViewport(page, file);
+      console.log(`wrote ${file}`);
+
+      if (VARIANT === "after" && viewport.name === "mobile" && theme === "light") {
+        await recordHorizontalScroll(page);
+      }
+
+      const video = page.video();
+      await context.close();
+      if (video) {
+        const videoPath = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.webm`);
+        await video.saveAs(videoPath);
+        console.log(`wrote ${videoPath}`);
+      }
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/ui/tests/e2e/fixtures/compare-drawer-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/compare-drawer-screenshot.json
@@ -1,0 +1,58 @@
+{
+  "ok": true,
+  "data": {
+    "dimensions": ["structure", "economics", "health"],
+    "requested_netuids": [1, 8, 19, 64],
+    "subnets": [
+      {
+        "netuid": 1,
+        "name": "Apex",
+        "found": true,
+        "structure": {
+          "surface_count": 12,
+          "operational_interface_count": 8,
+          "completeness_score": 88
+        },
+        "economics": { "validator_count": 8, "miner_count": 240 },
+        "health": { "surface_count": 12, "ok_count": 11 }
+      },
+      {
+        "netuid": 8,
+        "name": "Proprietary Trading Network",
+        "found": true,
+        "structure": {
+          "surface_count": 9,
+          "operational_interface_count": 6,
+          "completeness_score": 72
+        },
+        "economics": { "validator_count": 6, "miner_count": 180 },
+        "health": { "surface_count": 9, "ok_count": 8 }
+      },
+      {
+        "netuid": 19,
+        "name": "Nineteen.ai",
+        "found": true,
+        "structure": {
+          "surface_count": 7,
+          "operational_interface_count": 5,
+          "completeness_score": 65
+        },
+        "economics": { "validator_count": 5, "miner_count": 120 },
+        "health": { "surface_count": 7, "ok_count": 6 }
+      },
+      {
+        "netuid": 64,
+        "name": "Chutes",
+        "found": true,
+        "structure": {
+          "surface_count": 15,
+          "operational_interface_count": 10,
+          "completeness_score": 91
+        },
+        "economics": { "validator_count": 8, "miner_count": 248 },
+        "health": { "surface_count": 15, "ok_count": 14 }
+      }
+    ]
+  },
+  "meta": {}
+}


### PR DESCRIPTION
## Summary

- Split the compare drawer table wrapper into a vertical scroll shell (`max-h-[55vh] overflow-y-auto`) and an inner `overflow-x-auto` shell so the table can grow wider than the dock as subnets are added.
- Replace `w-full` on the table with `w-max min-w-full` and give each subnet column a minimum width so 4 compared subnets stay reachable via horizontal scroll on narrow viewports.
- Sticky metric column on horizontal scroll for readability while swiping through SN columns.

Closes #3933

## Screenshot table

Fixed-viewport captures on `/subnets` with 4 subnets in the compare dock (SN1, SN8, SN19, SN64), drawer expanded.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-desktop-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-desktop-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-tablet-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-tablet-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-mobile-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-before-mobile-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-mobile-dark.png)<br><sub>after</sub> |

## Scroll demo (mobile · light · after)

[3933-after-mobile-light.webm](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3933-after-mobile-light.webm) — horizontal swipe reveals SN64 after SN1–SN19 were off-screen.

## Test plan

- [x] `npm run typecheck --workspace=apps/ui`
- [x] `subnets-compare-drawer-layout.test.ts` (4 tests)
- [x] Changed-file eslint + prettier clean
- [x] Manual: 4 subnets at 375px — horizontal scroll reaches every column; vertical scroll unchanged