### PR TITLE
feat(registry): add SN108 TalkHead OpenAPI/Swagger docs surface (#4142)

### DIFF
--- a/registry/subnets/talkhead.json
+++ b/registry/subnets/talkhead.json
@@ -50,6 +50,25 @@
         "https://github.com/talkheadai/talkhead-subnet/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/talkheadai/talkhead-executor/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-108-talkhead-openapi",
+      "kind": "openapi",
+      "name": "TalkHead API OpenAPI/Swagger docs",
+      "notes": "Public no-auth Swagger UI for the TalkHead API on api.talkhead.ai (the same first-party host as the registered /health subnet-api). The machine-readable OpenAPI 3.0 document is served inline via the Swagger UI init script (swagger-ui-init.js), enumerating the API paths and the /api/v1 server. The TalkHead Studio web app (studio.talkhead.ai, linked from the official website) uses this same api.talkhead.ai host as its backend.",
+      "provider": "talkhead",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://api.talkhead.ai/api/docs/swagger-ui-init.js",
+        "https://www.talkhead.ai/"
+      ],
+      "url": "https://api.talkhead.ai/api/docs/"
     }
   ],
   "source_repo": "https://github.com/talkheadai/talkhead-subnet",


### PR DESCRIPTION
## Summary

Registers the public **OpenAPI/Swagger docs** for SN108 TalkHead's API as an `openapi` community surface. One file changed: `registry/subnets/talkhead.json` (single appended surface).

## Surface

| Field | Value |
| --- | --- |
| `kind` | `openapi` |
| `url` | https://api.talkhead.ai/api/docs/ |
| `source_urls` | https://api.talkhead.ai/api/docs/swagger-ui-init.js , https://www.talkhead.ai/ |
| `authority` | `community` |
| `review.state` | `community-submitted` |

## Proof

- **Swagger UI** at `https://api.talkhead.ai/api/docs/` returns **HTTP 200** (`text/html`), fully public — no auth.
- The **machine-readable OpenAPI 3.0 document** is served inline via `https://api.talkhead.ai/api/docs/swagger-ui-init.js` (**HTTP 200**, `application/javascript`) — its `swaggerDoc` contains the `openapi` version, the API `paths`, and the `/api/v1` server.
- Same first-party host as the already-registered `subnet-api` (`https://api.talkhead.ai/health`), and the TalkHead Studio web app (`studio.talkhead.ai`, linked from the official site) uses `api.talkhead.ai` as its backend — establishing this is TalkHead's own API.
- Not a duplicate: SN108 had no `openapi` surface; the existing surfaces are the `/health` subnet-api and the `min_compute.yml` data-artifact.

## Validation

```
npm run validate:surface -- registry/subnets/talkhead.json   # passed (3 surfaces)
npm run scan:public-safety                                   # passed
```

Closes #4142
