### PR TITLE
Enrich SN31 Recall — add public API endpoint

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Recall TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning machine-readable JSON for SN31 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Recall (formerly Halftime) has no verified first-party website, repository, or public API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/31-recall"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Appends one `subnet-api` surface to `registry/subnets/recall.json` (SN31, Recall). Append-only — existing top-level fields are unchanged; this is the subnet's first registered surface.

## Surface

- **Netuid:** 31
- **Kind:** `subnet-api`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/31
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://backprop.finance/dtao/subnets/31-recall
- **Provider slug:** `taomarketcap`

Recall (formerly Halftime) has no verified first-party website, repository, or public API endpoint. The TaoMarketCap developer API documents a public no-auth GET `/public/v1/subnets/{netuid}` feed returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 31.

## Test plan

- [x] `npm run surface:add` dry-run — OK reachable + public-safe
- [x] `npm run scan:public-safety -- registry/subnets/recall.json`
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/31` returns HTTP 200 with valid JSON (`netuid: 31`)
- [x] Confirmed no existing registry surface `url` uses this endpoint (avoids duplicate-surface rejection)

Closes #4032

Made with [Cursor](https://cursor.com)