### PR TITLE
feat(registry): add SN128 ByteLeap public TaoMarketCap subnet API endpoint

### DIFF
--- a/registry/subnets/byteleap.json
+++ b/registry/subnets/byteleap.json
@@ -1,0 +1,35 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "ByteLeap",
+  "netuid": 128,
+  "schema_version": 1,
+  "slug": "sn-128",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-128-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "ByteLeap TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/128 on api.taomarketcap.com returning machine-readable JSON for SN128 ByteLeap on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. ByteLeap is the distributed-compute network on Bittensor SN128 (the official byteleapai validator/miner repositories declare \"Bittensor SN128 Compute Network\"). This indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/byteleapai/byteleap-Validator"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/128"
+    }
+  ],
+  "source_repo": "https://github.com/byteleapai/byteleap-Validator",
+  "website_url": "https://byteleap.ai"
+}


### PR DESCRIPTION
## Summary
Seeds the missing **SN128 ByteLeap** registry overlay with the public, no-auth **subnet-api** endpoint issue #672 requests.

- Endpoint: `GET https://api.taomarketcap.com/public/v1/subnets/128` — machine-readable JSON (on-chain subnet state, SubnetIdentitiesV3 metadata, economics, dTAO market fields).
- Documented in the TaoMarketCap developer API (`https://api.taomarketcap.com/developer/documentation/`).
- **Identity proof:** the official `byteleapai/byteleap-Validator` (and `byteleap-Miner`) READMEs declare *"Bittensor SN128 Compute Network"* — confirming this is genuinely SN128.

## Change
- One new file: `registry/subnets/byteleap.json` — a community-seeded overlay with a single `authority: community`, `review.state: community-submitted` surface. No other files touched.

Closes #672