### PR TITLE
feat(registry): add SN62 Ridges SWE-Bench + Polyglot dataset data-artifacts (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,44 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-swebench-verified-dataset",
+      "kind": "data-artifact",
+      "name": "Ridges SWE-Bench Verified evaluation dataset",
+      "notes": "Public no-auth JSON dataset of 500 SWE-Bench Verified instances (repo, instance_id, base_commit, patch, test metadata) that Ridges evaluates its coding agents against. Committed to the official ridgesai/abstract-agent-runner repository under datasets/swebench_verified/; the repo README documents the framework running on 'SWE-Bench Verified real-world software engineering tasks'.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/abstract-agent-runner/blob/main/README.md",
+        "https://github.com/ridgesai/abstract-agent-runner/blob/main/datasets/swebench_verified/swebench_verified.json"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/swebench_verified/swebench_verified.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-polyglot-dataset",
+      "kind": "data-artifact",
+      "name": "Ridges Polyglot benchmark dataset",
+      "notes": "Public no-auth JSON dataset of 33 Polyglot programming-challenge tasks (each with a name and its list of tests) used to evaluate Ridges coding agents. Committed to the official ridgesai/abstract-agent-runner repository under datasets/polyglot/ and documented in the repo README.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/abstract-agent-runner/blob/main/README.md",
+        "https://github.com/ridgesai/abstract-agent-runner/blob/main/datasets/polyglot/polyglot.json"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/polyglot/polyglot.json"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

Registers the two public **evaluation datasets** SN62 Ridges publishes as `data-artifact` community surfaces — resolving the registry's own gap note ("No verified standalone static data artifact yet"). One file changed: `registry/subnets/ridges.json` (two appended surfaces for the one subnet).

## Surfaces

| Field | SWE-Bench Verified | Polyglot |
| --- | --- | --- |
| `kind` | `data-artifact` | `data-artifact` |
| `url` | `.../abstract-agent-runner/main/datasets/swebench_verified/swebench_verified.json` | `.../abstract-agent-runner/main/datasets/polyglot/polyglot.json` |
| content | 500 SWE-Bench Verified instances (repo, base_commit, patch, tests) | 33 Polyglot programming-challenge tasks |
| `authority` | `community` | `community` |
| `review.state` | `community-submitted` | `community-submitted` |

## Proof

- **SWE-Bench Verified:** `https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/swebench_verified/swebench_verified.json` → **HTTP 200**, valid JSON array of 500 real SWE-Bench Verified instances — the benchmark Ridges evaluates coding agents against.
- **Polyglot:** `https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/polyglot/polyglot.json` → **HTTP 200**, valid JSON array of 33 Polyglot tasks.
- Both are committed to the official **`ridgesai`** org repo `abstract-agent-runner`, no auth. The repo README independently documents the framework running on "SWE-Bench Verified real-world software engineering tasks" and the polyglot dataset.
- Not duplicates: SN62's existing surfaces are a source-repo, a subnet-api, and an openapi — no data-artifact yet.

## Validation

```
npm run validate:surface -- registry/subnets/ridges.json   # passed (5 surfaces)
npm run build && npm run validate                          # passed (full CI validate suite)
npm run scan:public-safety                                 # passed
```

Closes #4069
