### PR TITLE
Enrich SN128 ByteLeap — add public API endpoint

### DIFF
--- a/registry/subnets/byteleap.json
+++ b/registry/subnets/byteleap.json
@@ -1,0 +1,35 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "ByteLeap",
+  "netuid": 128,
+  "schema_version": 1,
+  "slug": "sn-128",
+  "source_repo": "https://github.com/byteleapai/byteleap-Miner",
+  "status": "active",
+  "website_url": "http://byteleap.ai/",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-128-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "ByteLeap TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/128 on api.taomarketcap.com returning machine-readable JSON for SN128 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. ByteLeap's official miner repository documents validator coordination but exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/byteleapai/byteleap-Miner"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/128"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Scaffold `registry/subnets/byteleap.json` for SN128 ByteLeap (new subnet manifest).
- Add a community `subnet-api` surface pointing at the live TaoMarketCap indexed feed (`/public/v1/subnets/128`).
- Closes #672 (public API endpoint portion).

## Why not SN31 Recall (#4032)
PR #4779 failed CI because `tests/artifacts.test.mjs` hardcodes SN31 as a **blocked** subnet with `missing-callable-service`. Adding any callable surface to `recall.json` breaks the `public artifacts are internally consistent` test — and test fixes cannot ship in the same PR (`.gittensory.yml` blocks `tests/**`).

## Test plan
- [x] `npm run scan:public-safety` passes locally
- [x] `validate-surface` + `validate-intake` pass on `byteleap.json`
- [ ] CI: `checks`, `test`, `codecov/patch` green
- [ ] Gittensory orb review passes (append-only, one subnet file, live URL, no duplicate)


Made with [Cursor](https://cursor.com)