### PR TITLE
feat(ui) network operations leaderboard on explorer (#3463)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-prometheus.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-prometheus.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainPrometheusQuery, normalizeChainPrometheus } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/prometheus",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainPrometheusQuery(window as "7d" | "30d" | undefined, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainPrometheus", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainPrometheus({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          distinct_exporters: 6,
+          announcements: 90,
+          announcements_per_exporter: 15,
+        },
+        intensity_distribution: null,
+        subnets: [
+          {
+            netuid: 1,
+            distinct_exporters: 4,
+            announcements: 60,
+            announcements_per_exporter: 15,
+          },
+          {
+            netuid: 19,
+            distinct_exporters: 2,
+            announcements: 30,
+            announcements_per_exporter: 15,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: {
+        distinct_exporters: 6,
+        announcements: 90,
+        announcements_per_exporter: 15,
+      },
+      intensity_distribution: null,
+      subnets: [
+        {
+          netuid: 1,
+          distinct_exporters: 4,
+          announcements: 60,
+          announcements_per_exporter: 15,
+        },
+        {
+          netuid: 19,
+          distinct_exporters: 2,
+          announcements: 30,
+          announcements_per_exporter: 15,
+        },
+      ],
+    });
+  });
+
+  it("zeroes a cold or malformed payload", () => {
+    expect(normalizeChainPrometheus(null)).toEqual({
+      schema_version: 1,
+      window: null,
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_exporters: 0,
+        announcements: 0,
+        announcements_per_exporter: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+});
+
+describe("chainPrometheusQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches and normalizes the network-wide prometheus leaderboard", async () => {
+    resolveWith({
+      schema_version: 1,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 1,
+      network: { distinct_exporters: 3, announcements: 45, announcements_per_exporter: 15 },
+      intensity_distribution: null,
+      subnets: [
+        { netuid: 8, distinct_exporters: 3, announcements: 45, announcements_per_exporter: 15 },
+      ],
+    });
+
+    const res = await runQuery("30d", 50);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/prometheus", {
+      params: { window: "30d", limit: 50 },
+      signal: expect.any(AbortSignal),
+    });
+    expect(res.data.subnets).toHaveLength(1);
+    expect(res.data.network.announcements).toBe(45);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.chain-serving.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-serving.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainServingQuery, normalizeChainServing } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/serving",
+  });
+}
+
+async function runQuery(window?: string, limit?: number) {
+  const opts = chainServingQuery(window as "7d" | "30d" | undefined, limit);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeChainServing", () => {
+  it("passes a well-formed leaderboard through", () => {
+    expect(
+      normalizeChainServing({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00Z",
+        subnet_count: 2,
+        network: {
+          distinct_servers: 8,
+          announcements: 120,
+          announcements_per_server: 15,
+        },
+        intensity_distribution: null,
+        subnets: [
+          {
+            netuid: 1,
+            distinct_servers: 5,
+            announcements: 80,
+            announcements_per_server: 16,
+          },
+          {
+            netuid: 19,
+            distinct_servers: 3,
+            announcements: 40,
+            announcements_per_server: 13.33,
+          },
+        ],
+      }),
+    ).toEqual({
+      schema_version: 1,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 2,
+      network: {
+        distinct_servers: 8,
+        announcements: 120,
+        announcements_per_server: 15,
+      },
+      intensity_distribution: null,
+      subnets: [
+        {
+          netuid: 1,
+          distinct_servers: 5,
+          announcements: 80,
+          announcements_per_server: 16,
+        },
+        {
+          netuid: 19,
+          distinct_servers: 3,
+          announcements: 40,
+          announcements_per_server: 13.33,
+        },
+      ],
+    });
+  });
+
+  it("zeroes a cold or malformed payload", () => {
+    expect(normalizeChainServing(null)).toEqual({
+      schema_version: 1,
+      window: null,
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_servers: 0,
+        announcements: 0,
+        announcements_per_server: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+});
+
+describe("chainServingQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("fetches and normalizes the network-wide serving leaderboard", async () => {
+    resolveWith({
+      schema_version: 1,
+      window: "30d",
+      observed_at: "2026-07-01T00:00:00Z",
+      subnet_count: 1,
+      network: { distinct_servers: 4, announcements: 60, announcements_per_server: 15 },
+      intensity_distribution: null,
+      subnets: [
+        { netuid: 8, distinct_servers: 4, announcements: 60, announcements_per_server: 15 },
+      ],
+    });
+
+    const res = await runQuery("30d", 50);
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/v1/chain/serving", {
+      params: { window: "30d", limit: 50 },
+      signal: expect.any(AbortSignal),
+    });
+    expect(res.data.subnets).toHaveLength(1);
+    expect(res.data.network.announcements).toBe(60);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -96,6 +96,10 @@ import type {
   ChainWeightsSubnet,
   ChainRegistrations,
   ChainRegistrationsSubnet,
+  ChainServing,
+  ChainServingSubnet,
+  ChainPrometheus,
+  ChainPrometheusSubnet,
   ChainIntensityDistribution,
   ChainConcentration,
   ChainPerformance,
@@ -276,6 +280,8 @@ const MAX_CHAIN_AXON_REMOVALS = 100;
 const MAX_CHAIN_DEREGISTRATIONS = 100;
 const MAX_CHAIN_WEIGHTS = 100;
 const MAX_CHAIN_REGISTRATIONS = 100;
+const MAX_CHAIN_SERVING = 100;
+const MAX_CHAIN_PROMETHEUS = 100;
 
 function coerceFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -3836,6 +3842,102 @@ export const chainRegistrationsQuery = (window: ChainWindow = "7d", limit = 100)
       };
     },
     staleTime: STALE_MED,
+  });
+
+function normalizeChainServingSubnet(raw: unknown): ChainServingSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_servers: firstFiniteNumber(raw.distinct_servers) ?? 0,
+    announcements: firstFiniteNumber(raw.announcements) ?? 0,
+    announcements_per_server: firstFiniteNumber(raw.announcements_per_server) ?? null,
+  };
+}
+
+// #3463: network-wide axon-serving leaderboard over a 7d/30d window.
+export function normalizeChainServing(raw: unknown): ChainServing {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_servers: firstFiniteNumber(networkRec.distinct_servers) ?? 0,
+      announcements: firstFiniteNumber(networkRec.announcements) ?? 0,
+      announcements_per_server: firstFiniteNumber(networkRec.announcements_per_server) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(rec.subnets, MAX_CHAIN_SERVING, normalizeChainServingSubnet),
+  };
+}
+
+export const chainServingQuery = (window: ChainWindow = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-serving", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainServing>>("/api/v1/chain/serving", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainServing(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeChainPrometheusSubnet(raw: unknown): ChainPrometheusSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  return {
+    netuid,
+    distinct_exporters: firstFiniteNumber(raw.distinct_exporters) ?? 0,
+    announcements: firstFiniteNumber(raw.announcements) ?? 0,
+    announcements_per_exporter: firstFiniteNumber(raw.announcements_per_exporter) ?? null,
+  };
+}
+
+// #3463: network-wide Prometheus-telemetry leaderboard over a 7d/30d window.
+export function normalizeChainPrometheus(raw: unknown): ChainPrometheus {
+  const rec = isRecord(raw) ? raw : {};
+  const networkRec = isRecord(rec.network) ? rec.network : {};
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? 0,
+    network: {
+      distinct_exporters: firstFiniteNumber(networkRec.distinct_exporters) ?? 0,
+      announcements: firstFiniteNumber(networkRec.announcements) ?? 0,
+      announcements_per_exporter: firstFiniteNumber(networkRec.announcements_per_exporter) ?? null,
+    },
+    intensity_distribution: normalizeChainIntensityDistribution(rec.intensity_distribution),
+    subnets: normalizeChainRows(rec.subnets, MAX_CHAIN_PROMETHEUS, normalizeChainPrometheusSubnet),
+  };
+}
+
+export const chainPrometheusQuery = (window: ChainWindow = "7d", limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-prometheus", window, limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainPrometheus>>("/api/v1/chain/prometheus", {
+        params: { window, limit },
+        signal,
+      });
+      return {
+        data: normalizeChainPrometheus(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
   });
 
 // #3466: network-wide neuron-deregistration leaderboard over a 7d/30d window — the

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2678,6 +2678,68 @@ export interface ChainWeights {
   subnets: ChainWeightsSubnet[];
 }
 
+/** One subnet's row on the network-wide axon-serving leaderboard (#3463). */
+export interface ChainServingSubnet {
+  netuid: number;
+  distinct_servers: number;
+  announcements: number;
+  announcements_per_server: number | null;
+}
+
+/** Network-wide axon-serving rollup from GET /api/v1/chain/serving. */
+export interface ChainServingNetwork {
+  distinct_servers: number;
+  announcements: number;
+  announcements_per_server: number | null;
+}
+
+/**
+ * Network-wide axon-serving activity over a 7d/30d window (#3463), from
+ * GET /api/v1/chain/serving — subnets ranked by AxonServed announcement volume,
+ * plus the true network-wide distinct-server rollup and intensity distribution.
+ * Zeroed when cold.
+ */
+export interface ChainServing {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainServingNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainServingSubnet[];
+}
+
+/** One subnet's row on the network-wide Prometheus-telemetry leaderboard (#3463). */
+export interface ChainPrometheusSubnet {
+  netuid: number;
+  distinct_exporters: number;
+  announcements: number;
+  announcements_per_exporter: number | null;
+}
+
+/** Network-wide Prometheus-telemetry rollup from GET /api/v1/chain/prometheus. */
+export interface ChainPrometheusNetwork {
+  distinct_exporters: number;
+  announcements: number;
+  announcements_per_exporter: number | null;
+}
+
+/**
+ * Network-wide Prometheus-endpoint telemetry over a 7d/30d window (#3463), from
+ * GET /api/v1/chain/prometheus — subnets ranked by PrometheusServed announcement
+ * volume, plus the true network-wide distinct-exporter rollup and intensity
+ * distribution. Zeroed when cold.
+ */
+export interface ChainPrometheus {
+  schema_version: number;
+  window: string | null;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainPrometheusNetwork;
+  intensity_distribution: ChainIntensityDistribution | null;
+  subnets: ChainPrometheusSubnet[];
+}
+
 /** One subnet's row on the network-wide neuron-registration leaderboard (#3465). */
 export interface ChainRegistrationsSubnet {
   netuid: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -25,6 +25,8 @@ import {
   chainSignersQuery,
   chainWeightSettersQuery,
   chainRegistrationsQuery,
+  chainServingQuery,
+  chainPrometheusQuery,
   chainStakeFlowQuery,
   chainStakeMovesQuery,
   chainTurnoverQuery,
@@ -47,6 +49,8 @@ import type {
   EconomicsTrends,
   ChainAxonRemovals,
   ChainRegistrations,
+  ChainServing,
+  ChainPrometheus,
   ChainTransfers,
 } from "@/lib/metagraphed/types";
 
@@ -110,6 +114,8 @@ function ExplorerPage() {
           "/api/v1/chain/signers",
           "/api/v1/chain/weights/setters",
           "/api/v1/chain/registrations",
+          "/api/v1/chain/serving",
+          "/api/v1/chain/prometheus",
           "/api/v1/chain/stake-flow",
           "/api/v1/chain/stake-moves",
           "/api/v1/chain/turnover",
@@ -516,6 +522,173 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
           in the busiest subnet, across {formatNumber(dist.count)} subnets.
         </p>
       ) : null}
+    </section>
+  );
+}
+
+/**
+ * #3463: network-wide axon-serving and Prometheus-telemetry leaderboards side
+ * by side — which subnets are actively announcing operational endpoints. The
+ * wrapping section leaves room for #3464's axon-removals panel to slot in later.
+ */
+function NetworkOperationsSection({
+  serving,
+  prometheus,
+}: {
+  serving: ChainServing;
+  prometheus: ChainPrometheus;
+}) {
+  return (
+    <section>
+      <h2 className="mb-6 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+        Network operations
+      </h2>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ChainServingLeaderboard board={serving} />
+        <ChainPrometheusLeaderboard board={prometheus} />
+      </div>
+    </section>
+  );
+}
+
+function ChainServingLeaderboard({ board }: { board: ChainServing }) {
+  const net = board.network;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Axon serving
+        </h3>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(board.subnet_count)} subnets
+        </span>
+      </div>
+
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StakeFlowMetric label="Announcements" value={formatNumber(net.announcements)} />
+        <StakeFlowMetric label="Distinct servers" value={formatNumber(net.distinct_servers)} />
+        <StakeFlowMetric
+          label="Per server"
+          value={
+            net.announcements_per_server != null ? net.announcements_per_server.toFixed(2) : "—"
+          }
+        />
+      </div>
+
+      {board.subnets.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={`${TH} text-right`}>Announcements</th>
+                <th className={`${TH} text-right`}>Distinct servers</th>
+                <th className={`${TH} text-right`}>Per server</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {board.subnets.map((s) => (
+                <tr key={s.netuid} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: s.netuid }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{s.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(s.announcements)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(s.distinct_servers)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {s.announcements_per_server != null
+                      ? s.announcements_per_server.toFixed(2)
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <EmptyState title="No serving activity in this window yet." />
+      )}
+    </section>
+  );
+}
+
+function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
+  const net = board.network;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Prometheus telemetry
+        </h3>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(board.subnet_count)} subnets
+        </span>
+      </div>
+
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StakeFlowMetric label="Announcements" value={formatNumber(net.announcements)} />
+        <StakeFlowMetric label="Distinct exporters" value={formatNumber(net.distinct_exporters)} />
+        <StakeFlowMetric
+          label="Per exporter"
+          value={
+            net.announcements_per_exporter != null ? net.announcements_per_exporter.toFixed(2) : "—"
+          }
+        />
+      </div>
+
+      {board.subnets.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={`${TH} text-right`}>Announcements</th>
+                <th className={`${TH} text-right`}>Distinct exporters</th>
+                <th className={`${TH} text-right`}>Per exporter</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {board.subnets.map((s) => (
+                <tr key={s.netuid} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: s.netuid }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{s.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(s.announcements)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(s.distinct_exporters)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {s.announcements_per_exporter != null
+                      ? s.announcements_per_exporter.toFixed(2)
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <EmptyState title="No Prometheus telemetry in this window yet." />
+      )}
     </section>
   );
 }
@@ -976,6 +1149,8 @@ function ExplorerDashboard() {
     { data: signersRes },
     { data: weightSettersRes },
     { data: registrationsRes },
+    { data: servingRes },
+    { data: prometheusRes },
     { data: stakeFlowRes },
     { data: stakeMovesRes },
     { data: turnoverRes },
@@ -992,6 +1167,8 @@ function ExplorerDashboard() {
       chainSignersQuery(win),
       chainWeightSettersQuery(win),
       chainRegistrationsQuery(win),
+      chainServingQuery(win),
+      chainPrometheusQuery(win),
       chainStakeFlowQuery(win),
       chainStakeMovesQuery(win),
       chainTurnoverQuery(win),
@@ -1008,6 +1185,8 @@ function ExplorerDashboard() {
   const signers = signersRes.data;
   const weightSetters = weightSettersRes.data;
   const registrations = registrationsRes.data;
+  const serving = servingRes.data;
+  const prometheus = prometheusRes.data;
   const stakeFlow = stakeFlowRes.data;
   const stakeMoves = stakeMovesRes.data;
   const turnover = turnoverRes.data;
@@ -1376,6 +1555,8 @@ function ExplorerDashboard() {
           )}
         </section>
       </div>
+
+      <NetworkOperationsSection serving={serving} prometheus={prometheus} />
 
       <TransferPairsSection win={win} />
 


### PR DESCRIPTION
## Summary

- Add `ChainServing` / `ChainPrometheus` types and `chainServingQuery(window)` + `chainPrometheusQuery(window)` fetching `GET /api/v1/chain/serving` and `GET /api/v1/chain/prometheus`
- Render a **Network operations** section on `/explorer` with side-by-side per-subnet leaderboards: axon serving (announcements, distinct servers, per server) and Prometheus telemetry (announcements, distinct exporters, per exporter)
- Each panel surfaces network rollup totals above its table; respects the page's existing `7d`/`30d` window toggle; adds both API paths to `ApiSourceFooter`

Closes #3463 · Part of #2542

## Screenshots

Captured on `/explorer?window=7d`. Theme forced via `localStorage.setItem("mg-theme", "dark"|"light")` before navigation. **Before:** `origin/main` (`:5173`). **After:** feature branch (`:5178`).

> **Where to look:** after inserts a new **Network operations** section (axon serving + Prometheus telemetry) between **Most active accounts** and **Transfer pairs**. Before goes straight from the call-mix/signers row to Transfer pairs with nothing in between. The API may be warm (populated subnet rows) or cold (empty state) — the structural addition is the change either way.

### Transition detail (desktop · light) — clearest contrast

| Before (signers row → Transfer pairs, no operations) | After (signers row → **Network operations** → Transfer pairs) |
| ---------------------------------------------------- | ------------------------------------------------------------- |
| [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-before-transition-detail.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-before-transition-detail.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-after-transition-detail.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-after-transition-detail.png) |

**Before:** Call mix / Most active accounts, then **Transfer pairs** immediately below — no Network operations section.  
**After:** **Network operations** appears (axon serving + Prometheus telemetry panels) between signers and Transfer pairs.

### Section detail (desktop · light)

| After — Network operations panels |
| --------------------------------- |
| [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-after-section-detail.png" width="720">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-after-section-detail.png) |

### Full page

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3463-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `/explorer` shows **Network operations** below Call mix / Most active accounts
- [x] Left panel: Axon serving rollup + table (Subnet, Announcements, Distinct servers, Per server)
- [x] Right panel: Prometheus telemetry rollup + table (Subnet, Announcements, Distinct exporters, Per exporter)
- [x] Subnet rows link to `/subnets/$netuid`
- [x] `7d`/`30d` toggle re-fetches via `chainServingQuery(win)` and `chainPrometheusQuery(win)`
- [x] Empty states: "No serving activity in this window yet." / "No Prometheus telemetry in this window yet."
- [x] `ApiSourceFooter` includes `/api/v1/chain/serving` and `/api/v1/chain/prometheus`
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
