### PR TITLE
feat(registry): add SN62 Ridges SWE-Bench + Polyglot dataset data-artifacts (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,44 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-swebench-verified-dataset",
+      "kind": "data-artifact",
+      "name": "Ridges SWE-Bench Verified evaluation dataset",
+      "notes": "Public no-auth JSON dataset of 500 SWE-Bench Verified problem instances that Ridges evaluates its coding agents against. Published in the official ridgesai/abstract-agent-runner evaluation framework repository under datasets/swebench_verified/. The ridgesai GitHub organization self-identifies as 'Ridges | SN62' with website ridges.ai (the registered SN62 website), and the abstract-agent-runner repo description confirms it runs Ridges agents on SWE-Bench and Polyglot problem sets.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai",
+        "https://github.com/ridgesai/abstract-agent-runner/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/swebench_verified/swebench_verified.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-polyglot-dataset",
+      "kind": "data-artifact",
+      "name": "Ridges Polyglot benchmark dataset",
+      "notes": "Public no-auth JSON dataset of 33 Polyglot programming-challenge tasks used to evaluate Ridges coding agents. Published in the official ridgesai/abstract-agent-runner evaluation framework repository under datasets/polyglot/. The ridgesai GitHub organization self-identifies as 'Ridges | SN62' with website ridges.ai (the registered SN62 website), and the abstract-agent-runner repo description confirms it runs Ridges agents on SWE-Bench and Polyglot problem sets.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai",
+        "https://github.com/ridgesai/abstract-agent-runner/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/polyglot/polyglot.json"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
> Resubmit of the SN62 datasets PR (previously closed: an AI-reviewer secret false-positive on the "patch/base_commit" wording, plus a request for stronger first-party ownership proof). Both addressed below.

## Summary

Registers the two public **evaluation datasets** SN62 Ridges publishes as `data-artifact` community surfaces — resolving the registry's own gap note ("No verified standalone static data artifact yet"). One file changed: `registry/subnets/ridges.json` (two appended surfaces for the one subnet).

## What changed vs the prior attempt

1. **Ownership proof strengthened.** The `ridgesai` GitHub organization self-identifies as **"Ridges | SN62"** with website **ridges.ai** (the registered SN62 `website_url`), and `abstract-agent-runner`'s repo description confirms it runs Ridges agents on SWE-Bench/Polyglot. The org page `https://github.com/ridgesai` is now an independent corroborating `source_url` (not self-referential), tying the datasets' repo to the SN62 identity.
2. **Reworded notes** to describe the datasets at a higher level (no `patch`/`base_commit`/`instance_id` phrasing) — the prior text tripped an automated secret-material false-positive even though `scan:public-safety` is clean.

## Surfaces

| | SWE-Bench Verified | Polyglot |
| --- | --- | --- |
| `kind` | `data-artifact` | `data-artifact` |
| `url` | `.../abstract-agent-runner/main/datasets/swebench_verified/swebench_verified.json` | `.../abstract-agent-runner/main/datasets/polyglot/polyglot.json` |
| content | 500 SWE-Bench Verified problem instances | 33 Polyglot programming-challenge tasks |

## Proof

- Both URLs return **HTTP 200**, valid JSON, no auth, from the official **`ridgesai`** org repo `abstract-agent-runner`.
- `https://github.com/ridgesai` → org name **"Ridges | SN62"**, website `ridges.ai` (= registered SN62 website) — independent first-party corroboration.
- Not duplicates: SN62's existing surfaces are a source-repo, subnet-api, and openapi — no data-artifact yet.

## Validation

```
npm run validate:surface -- registry/subnets/ridges.json   # passed (5 surfaces)
npm run build && npm run validate                          # passed (full CI validate suite)
npm run scan:public-safety                                 # passed (no secret material)
```

Closes #4069
