### PR TITLE
Enrich SN107 Minos — add public data artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "Minos minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official minos-protocol/minos_subnet repository as min_compute.yml. Documents SN107 operator CPU/GPU/memory/storage/network floors referenced by subnet setup documentation.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kiannidev"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/min_compute.yml",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/main/min_compute.yml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary
- Append a `data-artifact` surface for SN107 Minos pointing at the official `min_compute.yml` hardware spec in `minos-protocol/minos_subnet`.
- Closes #4141.

## Safety checks
- Append-only edit to a single file: `registry/subnets/minos.json`
- No TaoMarketCap duplicate URL (distinct from existing health API surface)
- Avoids SN31 blocked-subnet fixture and SN38 enrichment-queue fixture
- Avoids ByteLeap SN128 PR conflicts (#4780/#4782 already open)

## Test plan
- [x] `validate-surface` passes locally
- [x] `scan:public-safety` passes locally
- [ ] CI: `checks`, `test`, `codecov/patch` green


Made with [Cursor](https://cursor.com)