### PR TITLE
feat(registry): add SN62 Ridges Polyglot benchmark dataset data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-polyglot-dataset",
+      "kind": "data-artifact",
+      "name": "Ridges Polyglot benchmark dataset",
+      "notes": "Public no-auth JSON dataset of 33 Polyglot programming-challenge tasks (each a task name and its list of tests) used to evaluate Ridges coding agents. Published in the official ridgesai/abstract-agent-runner evaluation framework repository under datasets/polyglot/. The ridgesai GitHub organization self-identifies as 'Ridges | SN62' with website ridges.ai (the registered SN62 website), and the abstract-agent-runner repo description confirms it runs Ridges agents on Polyglot and SWE-Bench problem sets.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai",
+        "https://github.com/ridgesai/abstract-agent-runner/tree/main/datasets/polyglot"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/polyglot/polyglot.json"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
> Focused resubmit for #4069. The prior attempt bundled the SWE-Bench Verified dataset, whose 8MB of benchmark data contains the literal strings `secret`/`token`/`password` inside its test fixtures — this repeatedly tripped the automated secret-material scanner (a false positive on the *remote file's* content, not the PR text). This PR registers only the **Polyglot** dataset, which I verified is free of any secret-like strings.

## Summary

Registers the public **Polyglot benchmark dataset** SN62 Ridges publishes as a `data-artifact` community surface — resolving the manifest's own gap note ("No verified standalone static data artifact yet"). One file changed: `registry/subnets/ridges.json` (single appended surface).

## Surface

| Field | Value |
| --- | --- |
| `kind` | `data-artifact` |
| `url` | `https://raw.githubusercontent.com/ridgesai/abstract-agent-runner/main/datasets/polyglot/polyglot.json` |
| content | 33 Polyglot programming-challenge tasks (name + tests) |
| `authority` | `community` |
| `review.state` | `community-submitted` |

## Proof

- `url` → **HTTP 200**, valid JSON (~29 KB), no auth, from the official **`ridgesai`** org repo `abstract-agent-runner`.
- **First-party ownership:** the `ridgesai` GitHub org (`https://github.com/ridgesai`) self-identifies as **"Ridges | SN62"** with website **ridges.ai** (= the registered SN62 `website_url`), and the `abstract-agent-runner` repo description confirms it runs Ridges agents on Polyglot/SWE-Bench problem sets.
- **Verified secret-clean:** the full file contains no token/key/password/secret strings (unlike the SWE-Bench dataset, which is why it's excluded here).
- Not a duplicate: SN62's existing surfaces are a source-repo, subnet-api, and openapi — no data-artifact yet.

## Validation

```
npm run validate:surface -- registry/subnets/ridges.json   # passed (4 surfaces)
npm run build && npm run validate                          # passed (full CI validate suite)
npm run scan:public-safety                                 # passed
```

Closes #4069
