### PR TITLE
fix(ui): contain explorer leaderboard tables in horizontal scroll shells

### DIFF
--- a/apps/ui/src/components/metagraphed/explorer-leaderboard-layout.test.ts
+++ b/apps/ui/src/components/metagraphed/explorer-leaderboard-layout.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXPLORER_LEADERBOARD_IDS,
+  EXPLORER_LEADERBOARD_SCROLL_CLASS,
+  EXPLORER_LEADERBOARD_TABLE_CLASS,
+  EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS,
+  explorerLeaderboardScrollClass,
+} from "./explorer-leaderboard-layout";
+
+describe("explorer leaderboard layout tokens (#3932)", () => {
+  it("enables horizontal scroll via a dedicated inner wrapper", () => {
+    expect(EXPLORER_LEADERBOARD_SCROLL_CLASS).toBe("overflow-x-auto");
+  });
+
+  it("keeps the default table full-width inside the scroll shell", () => {
+    expect(EXPLORER_LEADERBOARD_TABLE_CLASS).toContain("w-full");
+    expect(EXPLORER_LEADERBOARD_TABLE_CLASS).toContain("text-left");
+  });
+
+  it("hides the stake-transfer table below md while preserving scroll on tablet+", () => {
+    expect(EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS).toContain("hidden");
+    expect(EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS).toContain("md:block");
+    expect(EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS).toContain("overflow-x-auto");
+  });
+
+  it("names all three in-scope leaderboards for stable hooks", () => {
+    expect(EXPLORER_LEADERBOARD_IDS).toEqual({
+      feePayers: "fee-payers",
+      activeAccounts: "active-accounts",
+      stakeTransfers: "stake-transfers",
+    });
+  });
+
+  it("resolves scroll class from visibility mode", () => {
+    expect(explorerLeaderboardScrollClass("always")).toBe(EXPLORER_LEADERBOARD_SCROLL_CLASS);
+    expect(explorerLeaderboardScrollClass("desktop-only")).toBe(
+      EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS,
+    );
+    expect(explorerLeaderboardScrollClass()).toBe(EXPLORER_LEADERBOARD_SCROLL_CLASS);
+  });
+});

--- a/apps/ui/src/components/metagraphed/explorer-leaderboard-layout.ts
+++ b/apps/ui/src/components/metagraphed/explorer-leaderboard-layout.ts
@@ -1,0 +1,44 @@
+/**
+ * Layout tokens for explorer leaderboard tables (#3932).
+ *
+ * Three chain-direct leaderboards on `/explorer` render wide monospace account /
+ * subnet columns beside several right-aligned numeric columns. Without a
+ * dedicated horizontal scroll shell the table pins to the section width and
+ * forces the page body to overflow on narrow viewports — the same treatment
+ * `ListShell` applies to paginated list tables.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3932
+ */
+
+/** Horizontal scroll shell — table scrolls inside the card, not the page. */
+export const EXPLORER_LEADERBOARD_SCROLL_CLASS = "overflow-x-auto";
+
+/** Default table width inside the scroll shell. */
+export const EXPLORER_LEADERBOARD_TABLE_CLASS = "w-full text-left text-sm";
+
+/**
+ * Stake-transfer leaderboard uses stacked mobile cards below `md`; the table
+ * variant only renders from tablet up and still needs its own scroll shell.
+ */
+export const EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS = "hidden md:block overflow-x-auto";
+
+/** data-attribute values for the three in-scope leaderboards (screenshot + e2e hooks). */
+export const EXPLORER_LEADERBOARD_IDS = {
+  feePayers: "fee-payers",
+  activeAccounts: "active-accounts",
+  stakeTransfers: "stake-transfers",
+} as const;
+
+export type ExplorerLeaderboardId =
+  (typeof EXPLORER_LEADERBOARD_IDS)[keyof typeof EXPLORER_LEADERBOARD_IDS];
+
+export type ExplorerLeaderboardVisibility = "always" | "desktop-only";
+
+/** Resolve the scroll-shell class for a leaderboard table visibility mode. */
+export function explorerLeaderboardScrollClass(
+  visibility: ExplorerLeaderboardVisibility = "always",
+): string {
+  return visibility === "desktop-only"
+    ? EXPLORER_LEADERBOARD_TABLE_DESKTOP_ONLY_CLASS
+    : EXPLORER_LEADERBOARD_SCROLL_CLASS;
+}

--- a/apps/ui/src/components/metagraphed/explorer-leaderboard-table-shell.tsx
+++ b/apps/ui/src/components/metagraphed/explorer-leaderboard-table-shell.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import {
+  EXPLORER_LEADERBOARD_TABLE_CLASS,
+  explorerLeaderboardScrollClass,
+  type ExplorerLeaderboardId,
+} from "./explorer-leaderboard-layout";
+
+type ExplorerLeaderboardTableShellProps = {
+  children: ReactNode;
+  /** Stable hook for screenshot scripts and overflow regression tests. */
+  leaderboardId: ExplorerLeaderboardId;
+  /**
+   * `always` — scroll shell at every viewport (fee payers, active accounts).
+   * `desktop-only` — hidden below `md` when a mobile card fallback is shown.
+   */
+  visibility?: "always" | "desktop-only";
+  tableClassName?: string;
+};
+
+/**
+ * Horizontally scrollable wrapper for explorer leaderboard `<table>` blocks.
+ * Mirrors `ListShell`'s inner `overflow-x-auto` treatment without pulling in
+ * sort/pagination/mobile-card machinery these static boards do not use.
+ */
+export function ExplorerLeaderboardTableShell({
+  children,
+  leaderboardId,
+  visibility = "always",
+  tableClassName = EXPLORER_LEADERBOARD_TABLE_CLASS,
+}: ExplorerLeaderboardTableShellProps) {
+  const scrollClass = explorerLeaderboardScrollClass(visibility);
+
+  return (
+    <div className={scrollClass} data-explorer-leaderboard={leaderboardId}>
+      <table className={tableClassName}>{children}</table>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -14,6 +14,8 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
+import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
+import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
 import { SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
 import {
@@ -1204,7 +1206,7 @@ function ExplorerDashboard() {
                 formatValue={formatTao}
                 ariaLabel="Top fee payers ranked by total fees paid this window"
               />
-              <table className="w-full text-left text-sm">
+              <ExplorerLeaderboardTableShell leaderboardId={EXPLORER_LEADERBOARD_IDS.feePayers}>
                 <thead>
                   <tr>
                     <th className={TH}>Account</th>
@@ -1238,7 +1240,7 @@ function ExplorerDashboard() {
                     </tr>
                   ))}
                 </tbody>
-              </table>
+              </ExplorerLeaderboardTableShell>
             </>
           ) : (
             <EmptyState title="No fee payers in this window yet." />
@@ -1322,7 +1324,7 @@ function ExplorerDashboard() {
             Most active accounts
           </h2>
           {signers.signers.length > 0 ? (
-            <table className="w-full text-left text-sm">
+            <ExplorerLeaderboardTableShell leaderboardId={EXPLORER_LEADERBOARD_IDS.activeAccounts}>
               <thead>
                 <tr>
                   <th className={TH}>Account</th>
@@ -1370,7 +1372,7 @@ function ExplorerDashboard() {
                   </tr>
                 ))}
               </tbody>
-            </table>
+            </ExplorerLeaderboardTableShell>
           ) : (
             <EmptyState title="No signers in this window yet." />
           )}
@@ -1433,42 +1435,43 @@ function ExplorerDashboard() {
                 </div>
               ))}
             </div>
-            <div className="hidden md:block overflow-x-auto">
-              <table className="w-full text-left text-sm">
-                <thead>
-                  <tr>
-                    <th className={TH}>Subnet</th>
-                    <th className={`${TH} text-right`}>Transfers</th>
-                    <th className={`${TH} text-right`}>Distinct senders</th>
-                    <th className={`${TH} text-right`}>Transfers per sender</th>
+            <ExplorerLeaderboardTableShell
+              leaderboardId={EXPLORER_LEADERBOARD_IDS.stakeTransfers}
+              visibility="desktop-only"
+            >
+              <thead>
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Transfers</th>
+                  <th className={`${TH} text-right`}>Distinct senders</th>
+                  <th className={`${TH} text-right`}>Transfers per sender</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {stakeTransfers.subnets.map((s) => (
+                  <tr key={s.netuid} className="hover:bg-surface/40">
+                    <td className="px-4 py-2 font-mono text-[11px]">
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: s.netuid }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                      >
+                        SN{s.netuid}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(s.transfers)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber(s.distinct_senders)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
+                    </td>
                   </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {stakeTransfers.subnets.map((s) => (
-                    <tr key={s.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/subnets/$netuid"
-                          params={{ netuid: s.netuid }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                        >
-                          SN{s.netuid}
-                        </Link>
-                      </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                        {formatNumber(s.transfers)}
-                      </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                        {formatNumber(s.distinct_senders)}
-                      </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                        {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                ))}
+              </tbody>
+            </ExplorerLeaderboardTableShell>
           </>
         ) : (
           <EmptyState title="No stake transfers in this window yet." />

--- a/apps/ui/tests/e2e/capture-explorer-leaderboard-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-explorer-leaderboard-screenshots.mjs
@@ -1,0 +1,130 @@
+/**
+ * Capture explorer leaderboard overflow screenshots for #3932 (Path C2 contract).
+ *
+ * Replays the recorded `/explorer` HAR so captures are deterministic, scrolls
+ * the "Top fee payers" section into the fixed viewport, and writes 12 images
+ * (3 viewports × 2 themes × before/after).
+ *
+ * Usage (with dev server running — pass its base URL explicitly):
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after node tests/e2e/capture-explorer-leaderboard-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8086 VARIANT=before node tests/e2e/capture-explorer-leaderboard-screenshots.mjs
+ *
+ * Writes to tmp/explorer-leaderboard-screenshots/{VARIANT}-{viewport}-{theme}.png
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { DATED_ENDPOINT_PATTERNS, findHarFixture, harPathForRoute } from "./har-path.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/explorer-leaderboard-screenshots");
+const HAR_PATH = harPathForRoute("/explorer");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+/** Pixels above the fee-payers section to keep app chrome visible. */
+const SCROLL_OFFSET_PX = 120;
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function installHarReplay(page) {
+  await page.routeFromHAR(HAR_PATH, {
+    url: "**/api.metagraph.sh/**",
+    notFound: "fallback",
+    update: false,
+  });
+  for (const pattern of DATED_ENDPOINT_PATTERNS) {
+    const fixture = findHarFixture(HAR_PATH, pattern);
+    if (fixture) {
+      await page.route(pattern, (route) => route.fulfill(fixture));
+    }
+  }
+}
+
+async function openFeePayersSection(page) {
+  await page.goto(`${BASE_URL}/explorer`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 5000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+
+  const heading = page.getByRole("heading", { name: "Top fee payers" });
+  await heading.waitFor({ state: "visible", timeout: 90_000 });
+
+  await page.evaluate((offset) => {
+    const headings = [...document.querySelectorAll("h2")];
+    const target = headings.find((h) => h.textContent?.trim() === "Top fee payers");
+    if (!target) return;
+    const top = target.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+  }, SCROLL_OFFSET_PX);
+
+  await page.waitForTimeout(250);
+}
+
+/** Fixed-viewport capture per SKILL.md Path C2 — never fullPage or element crop. */
+async function captureViewport(page, filePath) {
+  await page.screenshot({ path: filePath, fullPage: false });
+}
+
+async function recordTableScroll(page) {
+  const scroller = page.locator('[data-explorer-leaderboard="fee-payers"]').first();
+  const count = await scroller.count();
+  if (count === 0) return;
+
+  await scroller.evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+  });
+  await page.waitForTimeout(400);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await installHarReplay(page);
+      await setTheme(page, theme);
+      await openFeePayersSection(page);
+
+      if (VARIANT === "after" && viewport.name === "mobile" && theme === "light") {
+        await recordTableScroll(page);
+      }
+
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await captureViewport(page, file);
+      console.log(`wrote ${file}`);
+
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/ui/tests/e2e/fixtures/explorer-leaderboard-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/explorer-leaderboard-screenshot.json
@@ -1,0 +1,101 @@
+{
+  "fees": {
+    "ok": true,
+    "schema_version": 1,
+    "data": {
+      "schema_version": 1,
+      "window": "7d",
+      "observed_at": "2026-07-08T12:00:00.000Z",
+      "day_count": 7,
+      "daily": [
+        {
+          "day": "2026-07-08",
+          "extrinsic_count": 42000,
+          "total_fee_tao": 12.5,
+          "avg_fee_tao": 0.000298,
+          "total_tip_tao": 3.2,
+          "avg_tip_tao": 0.000076
+        }
+      ],
+      "top_fee_payers": [
+        {
+          "signer": "5FixtureExplorerFeePayerAccountForScreenshotPurposesOnly11111111",
+          "total_fee_tao": 2.45,
+          "total_tip_tao": 0.88,
+          "extrinsic_count": 1842
+        },
+        {
+          "signer": "5FixtureExplorerFeePayerAccountForScreenshotPurposesOnly22222222",
+          "total_fee_tao": 1.92,
+          "total_tip_tao": 0.41,
+          "extrinsic_count": 1204
+        }
+      ]
+    }
+  },
+  "signers": {
+    "ok": true,
+    "schema_version": 1,
+    "data": {
+      "schema_version": 1,
+      "window": "7d",
+      "observed_at": "2026-07-08T12:00:00.000Z",
+      "signer_count": 12,
+      "signers": [
+        {
+          "signer": "5FixtureExplorerActiveAccountForScreenshotPurposesOnly111111111",
+          "tx_count": 3204,
+          "total_fee_tao": 1.12,
+          "total_tip_tao": 0.34,
+          "last_tx_block": 8600123
+        },
+        {
+          "signer": "5FixtureExplorerActiveAccountForScreenshotPurposesOnly222222222",
+          "tx_count": 2891,
+          "total_fee_tao": 0.98,
+          "total_tip_tao": 0.22,
+          "last_tx_block": 8600118
+        }
+      ]
+    }
+  },
+  "stakeTransfers": {
+    "ok": true,
+    "schema_version": 1,
+    "data": {
+      "schema_version": 1,
+      "window": "7d",
+      "observed_at": "2026-07-08T12:00:00.000Z",
+      "subnet_count": 3,
+      "network": {
+        "distinct_senders": 128,
+        "transfers": 2048,
+        "transfers_per_sender": 16
+      },
+      "intensity_distribution": {
+        "count": 3,
+        "mean": 12.5,
+        "min": 4,
+        "p25": 8,
+        "median": 12,
+        "p75": 16,
+        "p90": 20,
+        "max": 24
+      },
+      "subnets": [
+        {
+          "netuid": 1,
+          "distinct_senders": 64,
+          "transfers": 1024,
+          "transfers_per_sender": 16
+        },
+        {
+          "netuid": 8,
+          "distinct_senders": 48,
+          "transfers": 768,
+          "transfers_per_sender": 16
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Wrap the three `/explorer` leaderboard tables (Top fee payers, Most active accounts, Stake-transfer leaderboard) in `ExplorerLeaderboardTableShell` with `overflow-x-auto`, matching the `ListShell` treatment used by chain-events on the same page.
- Extract shared layout tokens (`explorer-leaderboard-layout.ts`) plus a Playwright capture script for Path C2 screenshots.
- Stake-transfer keeps its existing mobile card fallback; the table variant uses `desktop-only` visibility with the same scroll shell from `md` up.

Closes #3932

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-desktop-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-desktop-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-tablet-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-tablet-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-mobile-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-before-mobile-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3932-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npm test --workspace=apps/ui` (711 tests green, including 5 new layout-token tests)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run build --workspace=apps/ui`
- [x] Changed-file eslint + prettier pass locally
- [x] `/explorer` responsive-overflow e2e: mobile, tablet, desktop-md pass locally
- [ ] CI: `lint`, `format:check`, `test`, `test:e2e`, `build`, codecov