### PR TITLE
feat(ui): add a daily-rollup freshness label to the metagraph panel

### DIFF
--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,6 +6,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
@@ -62,8 +63,14 @@ export function MetagraphTableLoader({
     );
   }
 
+  // #3381: loaded-data branch must surface meta.generated_at as a daily-rollup
+  // tier (not just the empty-state TableState). FreshnessBadge landed via #3370.
+  const freshness = <FreshnessBadge at={meta?.generated_at} tier="daily" />;
+
   return (
     <div className="space-y-4">
+      <div className="flex justify-end">{freshness}</div>
+
       {/* KPI strip — neuron + validator counts and the dominant-UID stake share. */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatTile
@@ -91,11 +98,11 @@ export function MetagraphTableLoader({
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex items-center justify-between">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
-            <span className="font-mono text-[10px] text-ink-muted">
+            <span className="ml-auto font-mono text-[10px] text-ink-muted">
               peak {taoCompact(stakeBars[0]?.value)} τ
             </span>
           </div>


### PR DESCRIPTION
Closes #3381

`MetagraphTableLoader` already had `meta.generated_at` from `subnetMetagraphQuery`, but only passed it into the empty-state `TableState`. A populated metagraph (KPI strip + stake chart + neuron table) gave no signal that the snapshot is a daily rollup rather than live chain data. The twin validators panel (#3380) already surfaces this; `FreshnessBadge` (#3370) has since landed and was unused here.

## What changed

`apps/ui/src/components/metagraphed/metagraph-panel.tsx` only:

- Loaded-data branch renders `<FreshnessBadge at={meta?.generated_at} tier="daily" />` above the KPI strip.
- Empty-state `TableState` freshness behavior unchanged.
- No new query or backend change — reuses `meta` already returned by `subnetMetagraphQuery`.

Did not touch `validators-panel.tsx` (#3380) or `neuron-detail-card.tsx` (#3379).

## Verification

Functionally verified against the live API on `/subnets/18?tab=metagraph` (populated snapshot): "Daily rollup" badge + relative time appear above the neuron KPIs. Empty metagraph path (e.g. subnet 1) still uses `TableState` only — badge intentionally absent there. No console errors.

Local validation runs (apps/ui workspace):

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — passed
- `npm run build --workspace=apps/ui` — clean

Also checked the touched file directly:

- `npx eslint apps/ui/src/components/metagraphed/metagraph-panel.tsx` — clean
- `npx prettier --check apps/ui/src/components/metagraphed/metagraph-panel.tsx` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Framed on `/subnets/18?tab=metagraph` so the new Daily rollup badge (or its absence, in "before") is visible directly above the Neurons / Validators / Top-UID stake KPI strip.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/bc9da050-d071-4d65-aa66-a7f462823288" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/d5aab20b-7c11-4920-a762-4c29a558ab04" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/b10abd4f-322e-4bd0-9656-8070ac4ca6d5" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/c69a44ce-4d21-4c4a-a3de-86bebcc62e48" /> |
| Tablet · Light   | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/0a57a84d-7b4b-479c-9242-e942bda20b39" /> | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/5db18aeb-28f9-4936-8da2-ab1a5f63ceca" /> |
| Tablet · Dark    | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/657c4fb2-a19d-4216-97bf-3fdc85b6f5a2" /> | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/b32e7ead-6283-4887-bf05-cdb0b7b0aaa7" /> |
| Mobile · Light   | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/3815d63b-9c6d-4833-9cc2-3aa49c555052" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/d0fd53d7-f87c-422a-906c-4136b260c7f2" /> |
| Mobile · Dark    | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/d7307e5e-58c0-4d2f-8ea8-13cda197bbe3" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/0e28fe66-4fc7-49cb-bc83-5bce293efa16" /> |