### PR TITLE
feat(registry): add SN38 ChronoLLM TaoMarketCap subnet snapshot API (#4039)

### DIFF
--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -60,6 +60,25 @@
         "https://huggingface.co/manelalab"
       ],
       "url": "https://huggingface.co/datasets/manelalab/ChronoInstruct-SFT-v1"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-38-taomarketcap-subnet-snapshot",
+      "kind": "data-artifact",
+      "name": "SN38 on-chain subnet snapshot",
+      "notes": "Public no-auth GET /public/v1/subnets/38 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN38 ChronoLLM on-chain subnet state (owner, emission, registration/burn parameters, and dTAO market fields) for netuid 38. This is the indexed public JSON feed for netuid 38 documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://taomarketcap.com/subnets/38"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/38"
     }
   ],
   "source_repo": "https://github.com/chronollm/sn38",


### PR DESCRIPTION
## Summary

Registers SN38 ChronoLLM's public **TaoMarketCap on-chain subnet snapshot API** as a `data-artifact` community surface — the indexed public JSON feed for netuid 38. One file changed: `registry/subnets/chronollm.json` (single appended surface).

Same accepted pattern as the merged SN119 Satori, SN73 MetaHash (#4730), SN116 TaoLend (#4670), SN84 ansuz (#4737), and SN16 BitAds (#4734) TaoMarketCap subnet-snapshot surfaces.

## Surface

| Field | Value |
| --- | --- |
| `kind` | `data-artifact` |
| `url` | `https://api.taomarketcap.com/public/v1/subnets/38` |
| `provider` | `taomarketcap` |
| `source_urls` | `https://api.taomarketcap.com/developer/documentation/` , `https://taomarketcap.com/subnets/38` |
| `authority` | `community` |

## Proof

- `url` → **HTTP 200**, `application/json`, no auth — returns the machine-readable on-chain snapshot for **netuid 38** (`"netuid":38,"is_active":true`, owner/emission/burn/dTAO fields).
- Documented in the public TaoMarketCap developer API (`/developer/documentation/`).
- Not a duplicate: SN38's existing surfaces are docs + two HuggingFace data-artifacts — no TaoMarketCap snapshot yet.

## Validation

```
npm run validate:surface -- registry/subnets/chronollm.json   # passed (4 surfaces)
npm run build && npm run validate                             # passed (full CI validate suite)
npm run scan:public-safety                                    # passed
```

Closes #4039
