### PR TITLE
fix(ui): stop the block-production Throughput tile wrapping on mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/stat-tile.tsx
+++ b/apps/ui/src/components/metagraphed/charts/stat-tile.tsx
@@ -59,7 +59,12 @@ export function StatTile({
           {eyebrow}
         </div>
         <div className="mt-1 flex min-w-0 items-baseline gap-1.5">
-          <span className="min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
+          {/* #3940: shrink-0 so a long hint can't flex-shrink the value box
+              below its own content width -- without it, an unbreakable short
+              value (e.g. "24.85") still visibly overflows into the hint's
+              space once combined width exceeds the tile, since only the hint
+              (not the value) is truncate-clipped. */}
+          <span className="shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
             {value}
           </span>
           {hint ? (

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -172,9 +172,15 @@ function BlockProductionHeader() {
       <StatTile
         icon={Activity}
         eyebrow="Throughput"
-        value={throughput ? `${formatNumber(throughput.mean_extrinsics_per_block)} ext/block` : "—"}
+        // #3940: keep the value a bare number like the sibling tiles -- baking
+        // "ext/block" into it made the value itself wrap mid-word on narrow
+        // tiles. The unit + secondary metric both live in the (already
+        // truncating) hint instead.
+        value={throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
         hint={
-          throughput ? `${formatNumber(throughput.mean_events_per_block)} events/block` : undefined
+          throughput
+            ? `ext/block · ${formatNumber(throughput.mean_events_per_block)} events/block`
+            : undefined
         }
       />
       <StatTile


### PR DESCRIPTION
## Summary

- Verifies `BlockProductionHeader` (`apps/ui/src/routes/blocks.index.tsx`) at mobile (375px) and tablet (768px) in both themes — the PR that added it (#3887) only ever screenshotted desktop.
- Verification found a real bug, exactly matching what the issue predicted: the Throughput tile's *value* baked in a unit suffix ("24.85 ext/block"), an unbreakable string. Once the tile narrowed enough, that string wrapped mid-word onto a second line — and because only the tile's `hint` span truncates (the `value` span has no `overflow`/`truncate` protection), the value's overflowing glyphs visually bled into the hint text sitting next to it. This reproduced even right at the `md` (768px) breakpoint, not just at 375px.
- Root cause: `StatTile`'s value and hint spans both default to `flex-shrink: 1`, so a long hint can shrink the value's box below its own content width. Confirmed via `getBoundingClientRect`/`scrollWidth` — the value's rendered box (18px) was narrower than its content (39px) while `overflow: visible`, so the excess bled outward instead of wrapping or clipping.
- Fix, two parts:
  - `apps/ui/src/components/metagraphed/charts/stat-tile.tsx` — add `shrink-0` to the value span so it can never be squeezed below its own content width; only the (already-truncating) hint gives up space.
  - `apps/ui/src/routes/blocks.index.tsx` — keep the Throughput tile's `value` a bare number (`24.85`), matching its sibling tiles' shape, and move the unit + secondary metric into the `hint` (`ext/block · 416.33 events/block`), where truncation already degrades gracefully.
- `stat-tile.tsx`'s `shrink-0` addition only has any effect when combined value+hint content exceeds the available width — for every other existing call site (20+ across `accounts.$ss58.tsx`, `blocks.$ref.tsx`) it's a no-op since their content already fits; where it isn't a no-op, it's strictly the better trade-off (protect the primary number, truncate the secondary hint) rather than a regression.

Closes #3940

## Screenshots

Mocks `GET /api/v1/blocks/summary` with a realistic populated fixture (matching the real contract shape) so the real page/component code renders real pixels.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-light-before.png)<br><sub>value wraps mid-word, bleeds into hint</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-light-after.png)<br><sub>single line, hint truncates cleanly</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-dark-before.png)<br><sub>value wraps mid-word, bleeds into hint</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-mobile-dark-after.png)<br><sub>single line, hint truncates cleanly</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-light-before.png)<br><sub>value clips at row edge, cut off</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-light-after.png)<br><sub>fits comfortably, more of the hint visible</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-dark-before.png)<br><sub>value clips at row edge, cut off</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-tablet-dark-after.png)<br><sub>fits comfortably, more of the hint visible</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-light-before.png)<br><sub>already correct — value+hint fit on one line</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-light-after.png)<br><sub>unaffected — same layout, unit moved from value to hint</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-dark-before.png)<br><sub>already correct — value+hint fit on one line</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/block-production-header-3940-block-production-header-desktop-dark-after.png)<br><sub>unaffected — same layout, unit moved from value to hint</sub> |

Desktop was already correct per the issue; the before/after pair above confirms it stays that way — same one-line layout, no truncation needed, only the unit text shifting from the value to the hint.

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (701 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification: measured the value/hint spans' `getBoundingClientRect`/`scrollWidth` before and after to confirm the value box now always matches its content width (no more overflow bleed), plus visual screenshots per the table above; spot-checked `accounts.$ss58.tsx`'s StatTile usages and desktop `/blocks` for regressions
