### PR TITLE
fix(ui): raise the Developer-settings header icon to the 44px tap-target standard

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -150,7 +150,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                     <Link
                       to="/settings"
                       aria-label="Developer settings"
-                      className="hidden md:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                      className="hidden md:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
                     >
                       <Webhook className="size-3.5" aria-hidden="true" />
                     </Link>


### PR DESCRIPTION
## Summary

The Developer-settings icon-link in the app-shell header (`app-shell.tsx`, the `Webhook` `Link` near line 150) still used the old 28px tap target — `min-h-7 min-w-7` — while its two immediate header-row neighbours were raised to the codebase's documented 44px standard (`min-h-11`) by #3916 (`NetworkSwitcher` height-only, `SettingsPopover` `min-h-11 min-w-11`). That left one of three adjacent header icons visibly undersized and below the mobile tap-target accessibility guideline the sibling fix targeted.

This raises it to the same standard. The change is a single className: `min-h-7 min-w-7` → `min-h-11 min-w-11`, which makes the Developer-settings link's classes byte-identical to `SettingsPopover`'s corrected trigger. Icon glyph size (`size-3.5`), padding (`p-1.5`), colours, and the `hidden md:inline-flex` visibility are untouched — only the clickable box grows, and the existing `items-center justify-center` keeps the glyph centred.

## What changed

One className, one file:

```diff
 // apps/ui/src/components/metagraphed/app-shell.tsx — Developer settings Link
-          className="hidden md:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-7 min-w-7 text-ink-muted ..."
+          className="hidden md:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted ..."
```

Measured with `getBoundingClientRect()` on the live page: the Developer-settings box goes **28×28 → 44×44** at every width where it renders (Desktop 1280 `@x1156`, Tablet 768 `@x644` — both fully on-screen). `ShortcutsPopover`, the mobile hamburger, and the mobile menu's `/settings` text link are untouched, as the issue scopes.

## Screenshots

Captured on `/subnets`, fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes forced via `localStorage.setItem("mg-theme", …)`, `deviceScaleFactor: 1`.

Honest caveat (not caused by this PR): the Developer-settings icon is `hidden md:inline-flex`, so it does **not render below the `md` (768px) breakpoint** — on mobile the header shows the compact menu button instead. The two Mobile rows are included for the full viewport matrix and correctly show the icon absent in both before and after; the change is demonstrated at Tablet and Desktop, and proven at every width by the measured box above. A supplementary zoomed header-detail row (below the matrix) makes the 28→44 change and its alignment with the neighbouring gear unmistakable.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-mobile-light.png)<br><sub>before (icon hidden < md)</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-mobile-light.png)<br><sub>after (icon hidden < md)</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-mobile-dark.png)<br><sub>before (icon hidden < md)</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-mobile-dark.png)<br><sub>after (icon hidden < md)</sub> |

### Supplementary — zoomed header detail (Desktop, 2×)

Clearly labelled supplementary rows (not replacing the contract sizes above): the top-right header cluster magnified so the Developer-settings (webhook) button's 28→44 growth and its new alignment with the adjacent settings gear are unmistakable.

| Detail · Theme | Before | After |
| -------------- | ------ | ----- |
| **Header detail · Light** <br><sub>supplementary, 2× zoom</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-crop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-crop-light.png)<br><sub>before — webhook button shorter than the gear</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-crop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-crop-light.png)<br><sub>after — matches the gear</sub> |
| **Header detail · Dark** <br><sub>supplementary, 2× zoom</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-crop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-before-crop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-crop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3989-after-crop-dark.png)<br><sub>after</sub> |

## Validation

- `tsc --noEmit` — clean (after building `packages/client`, as CI does)
- `eslint` — 0 errors on the changed file
- `prettier --check` — clean
- `vitest run` — 101 files / 706 tests passed
- className-only change; no logic, type, import, or markup change; `git diff` touches only `app-shell.tsx`

Closes #3989
