### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap subnet snapshot API (#4032)

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-snapshot",
+      "kind": "data-artifact",
+      "name": "SN31 on-chain subnet snapshot",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN31 Recall on-chain subnet state (owner, emission, registration/burn parameters, and dTAO market fields) for netuid 31. SN31 exposes no verified first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 31 documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://taomarketcap.com/subnets/31"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Registers SN31 Recall's public **TaoMarketCap on-chain subnet snapshot API** as a `data-artifact` community surface — the indexed public JSON feed for netuid 31, and SN31's **first registered surface** (the manifest's `surfaces` array was empty, with gap notes listing no verified API, repo, or data artifact).

Same accepted pattern as the merged SN38 ChronoLLM (#4789), SN119 Satori, SN73 MetaHash (#4730), SN116 TaoLend (#4670), SN84 ansuz (#4737), and SN16 BitAds (#4734) TaoMarketCap subnet-snapshot surfaces.

## Surface

| Field | Value |
| --- | --- |
| `kind` | `data-artifact` |
| `url` | `https://api.taomarketcap.com/public/v1/subnets/31` |
| `provider` | `taomarketcap` |
| `source_urls` | `https://api.taomarketcap.com/developer/documentation/` , `https://taomarketcap.com/subnets/31` |
| `authority` | `community` |

## Proof

- `url` → **HTTP 200**, `application/json`, no auth — the machine-readable on-chain snapshot for **netuid 31** (`"netuid":31,"is_active":true`, owner/emission/burn/dTAO fields).
- Documented in the public TaoMarketCap developer API (`/developer/documentation/`).
- SN31 exposes no verified first-party API/repo/dataset (per the manifest's own maintainer-reviewed gap notes), making the indexed public feed the right community surface — mirroring the accepted SN119 Satori precedent.
- Not a duplicate: SN31 had zero surfaces.

## Validation

```
npm run validate:surface -- registry/subnets/recall.json   # passed (1 surface)
npm run build && npm run validate                          # passed (full CI validate suite)
npm run scan:public-safety                                 # passed
```

Closes #4032
