### PR TITLE
feat(registry): add SN107 Minos TaoMarketCap subnet snapshot data-artifact (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-taomarketcap-subnet-snapshot",
+      "kind": "data-artifact",
+      "name": "SN107 on-chain subnet snapshot",
+      "notes": "Public no-auth GET /public/v1/subnets/107 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN107 Minos on-chain subnet state (owner, emission, registration/burn parameters, and dTAO market fields) for netuid 107. This is the indexed public JSON feed for netuid 107 documented in the TaoMarketCap developer API, filling the subnet's standalone-data-artifact gap.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://taomarketcap.com/subnets/107"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/107"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Registers SN107 Minos's public **TaoMarketCap on-chain subnet snapshot** as a `data-artifact` community surface — the indexed public JSON feed for netuid 107, directly answering the issue's ask for a public data artifact. One file changed: `registry/subnets/minos.json` (single appended surface).

Same accepted pattern as the merged SN38 ChronoLLM (#4789), SN119 Satori, SN73 MetaHash (#4730), SN116 TaoLend (#4670), SN84 ansuz (#4737), and SN16 BitAds (#4734) TaoMarketCap subnet-snapshot surfaces.

## Surface

| Field | Value |
| --- | --- |
| `kind` | `data-artifact` |
| `url` | `https://api.taomarketcap.com/public/v1/subnets/107` |
| `provider` | `taomarketcap` |
| `source_urls` | `https://api.taomarketcap.com/developer/documentation/` , `https://taomarketcap.com/subnets/107` |
| `authority` | `community` |

## Proof

- `url` → **HTTP 200**, `application/json`, no auth — the machine-readable on-chain snapshot for **netuid 107** (`"netuid":107,"is_active":true`, owner/emission/burn/dTAO fields).
- Documented in the public TaoMarketCap developer API (`/developer/documentation/`).
- Not a duplicate: SN107's only existing surface is its first-party `/health` subnet-api; no data-artifact yet.

## Validation

```
npm run validate:surface -- registry/subnets/minos.json   # passed (2 surfaces)
npm run build && npm run validate                         # passed (full CI validate suite)
npx vitest run tests/artifacts.test.mjs                   # 21 passed (artifact-consistency suite)
npm run scan:public-safety                                # passed
```

Closes #4141
