### PR TITLE
fix(ui): make the /endpoints table horizontally scrollable on mobile

### DIFF
--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -973,173 +973,175 @@ function EndpointsTable() {
               })}
             </div>
           ) : (
-            <div className="rounded border border-border bg-card overflow-x-clip">
-              <table className="w-full text-sm">
-                <thead className="sticky top-[6.75rem] z-10 bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85 text-[10px] font-mono uppercase tracking-widest text-ink-muted shadow-[0_1px_0_0_var(--border)]">
-                  <tr>
-                    <Th
-                      label="Netuid"
-                      k="netuid"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <Th
-                      label="Kind"
-                      k="kind"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <th className="px-3 py-2 text-left">URL</th>
-                    <Th
-                      label="Provider"
-                      k="provider"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <Th
-                      label="Region"
-                      k="region"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <Th
-                      label="Health"
-                      k="health"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                      align="center"
-                    />
-                    <Th
-                      label="Latency"
-                      k="latency"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                      align="right"
-                    />
-                    <Th
-                      label="Probed"
-                      k="probed"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                      align="right"
-                    />
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {pageRows.map((e) => {
-                    const provSlug = e.provider_slug;
-                    const prov = provSlug ? providerById.get(provSlug) : undefined;
-                    const sn = e.netuid != null ? subnetById.get(e.netuid) : undefined;
-                    return (
-                      <tr key={e.id} className="mg-row-accent hover:bg-surface/40">
-                        <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                          {e.netuid != null ? (
-                            <Link
-                              to="/subnets/$netuid"
-                              params={{ netuid: e.netuid }}
-                              className="inline-flex items-center gap-1.5 hover:text-ink-strong"
-                            >
-                              <BrandIcon
-                                url={sn?.website}
-                                iconUrl={sn?.icon_url}
-                                netuid={e.netuid}
-                                name={sn?.name}
-                                fallback={e.netuid}
-                                size={14}
-                              />
-                              {String(e.netuid).padStart(3, "0")}
-                            </Link>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-[11px]">{e.kind ?? "—"}</td>
-                        <td className="px-3 py-2 font-mono text-[11px] max-w-[36ch]">
-                          {e.url ? (
-                            <div className="flex items-center gap-1.5 min-w-0">
-                              <ExternalLink href={e.url} className="truncate text-[11px]">
-                                {e.url}
-                              </ExternalLink>
-                              <CopyButton value={e.url} label="URL" />
-                            </div>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-[12px]">
-                          {provSlug ? (
-                            <Link
-                              to="/providers/$slug"
-                              params={{ slug: provSlug }}
-                              className="inline-flex items-center gap-1.5 hover:underline min-w-0"
-                            >
-                              <BrandIcon
-                                url={prov?.website ?? prov?.homepage}
-                                iconUrl={prov?.icon_url}
-                                repoUrl={prov?.repo}
-                                providerSlug={provSlug}
-                                name={prov?.name ?? e.provider ?? provSlug}
-                                fallback={provSlug}
-                                size={16}
-                              />
-                              <span className="truncate">
-                                {e.provider ?? prov?.name ?? provSlug}
-                              </span>
-                            </Link>
-                          ) : (
-                            (e.provider ?? "—")
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-[12px]">{e.region ?? "—"}</td>
-                        <td className="px-3 py-2 text-center">
-                          <SparkLegend
-                            metric="Endpoint health"
-                            source="/api/v1/endpoints"
-                            windowLabel={windowLabel}
-                            updatedAt={e.last_probed_at}
-                            staleness="Falls back to last known state when the probe hasn't completed."
-                          >
-                            <HealthPill state={e.health} />
-                          </SparkLegend>
-                        </td>
-                        <td className="px-3 py-2 text-right font-mono text-[11px]">
-                          {e.latency_ms != null ? (
+            <div className="rounded border border-border bg-card overflow-hidden">
+              <div className="overflow-x-auto overflow-y-clip">
+                <table className="w-full text-sm">
+                  <thead className="sticky top-[6.75rem] z-10 bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85 text-[10px] font-mono uppercase tracking-widest text-ink-muted shadow-[0_1px_0_0_var(--border)]">
+                    <tr>
+                      <Th
+                        label="Netuid"
+                        k="netuid"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                      />
+                      <Th
+                        label="Kind"
+                        k="kind"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                      />
+                      <th className="px-3 py-2 text-left">URL</th>
+                      <Th
+                        label="Provider"
+                        k="provider"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                      />
+                      <Th
+                        label="Region"
+                        k="region"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                      />
+                      <Th
+                        label="Health"
+                        k="health"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                        align="center"
+                      />
+                      <Th
+                        label="Latency"
+                        k="latency"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                        align="right"
+                      />
+                      <Th
+                        label="Probed"
+                        k="probed"
+                        sortKey={search.sort}
+                        sortOrder={search.order}
+                        onSort={toggleSort}
+                        align="right"
+                      />
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {pageRows.map((e) => {
+                      const provSlug = e.provider_slug;
+                      const prov = provSlug ? providerById.get(provSlug) : undefined;
+                      const sn = e.netuid != null ? subnetById.get(e.netuid) : undefined;
+                      return (
+                        <tr key={e.id} className="mg-row-accent hover:bg-surface/40">
+                          <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                            {e.netuid != null ? (
+                              <Link
+                                to="/subnets/$netuid"
+                                params={{ netuid: e.netuid }}
+                                className="inline-flex items-center gap-1.5 hover:text-ink-strong"
+                              >
+                                <BrandIcon
+                                  url={sn?.website}
+                                  iconUrl={sn?.icon_url}
+                                  netuid={e.netuid}
+                                  name={sn?.name}
+                                  fallback={e.netuid}
+                                  size={14}
+                                />
+                                {String(e.netuid).padStart(3, "0")}
+                              </Link>
+                            ) : (
+                              "—"
+                            )}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-[11px]">{e.kind ?? "—"}</td>
+                          <td className="px-3 py-2 font-mono text-[11px] max-w-[36ch]">
+                            {e.url ? (
+                              <div className="flex items-center gap-1.5 min-w-0">
+                                <ExternalLink href={e.url} className="truncate text-[11px]">
+                                  {e.url}
+                                </ExternalLink>
+                                <CopyButton value={e.url} label="URL" />
+                              </div>
+                            ) : (
+                              "—"
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-[12px]">
+                            {provSlug ? (
+                              <Link
+                                to="/providers/$slug"
+                                params={{ slug: provSlug }}
+                                className="inline-flex items-center gap-1.5 hover:underline min-w-0"
+                              >
+                                <BrandIcon
+                                  url={prov?.website ?? prov?.homepage}
+                                  iconUrl={prov?.icon_url}
+                                  repoUrl={prov?.repo}
+                                  providerSlug={provSlug}
+                                  name={prov?.name ?? e.provider ?? provSlug}
+                                  fallback={provSlug}
+                                  size={16}
+                                />
+                                <span className="truncate">
+                                  {e.provider ?? prov?.name ?? provSlug}
+                                </span>
+                              </Link>
+                            ) : (
+                              (e.provider ?? "—")
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-[12px]">{e.region ?? "—"}</td>
+                          <td className="px-3 py-2 text-center">
                             <SparkLegend
-                              metric="Latency"
-                              source="/api/v1/endpoints (last probe)"
+                              metric="Endpoint health"
+                              source="/api/v1/endpoints"
                               windowLabel={windowLabel}
                               updatedAt={e.last_probed_at}
-                              staleness="No new measurement is taken between probes — last measured value is shown."
+                              staleness="Falls back to last known state when the probe hasn't completed."
                             >
-                              <span>{e.latency_ms}ms</span>
+                              <HealthPill state={e.health} />
                             </SparkLegend>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
-                          <SparkLegend
-                            metric="Last probe"
-                            source="/api/v1/endpoints"
-                            windowLabel={windowLabel}
-                            updatedAt={e.last_probed_at}
-                            staleness="Rows older than the probe cycle are dimmed in tooltips elsewhere."
-                          >
-                            <TimeAgo at={e.last_probed_at} />
-                          </SparkLegend>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                          </td>
+                          <td className="px-3 py-2 text-right font-mono text-[11px]">
+                            {e.latency_ms != null ? (
+                              <SparkLegend
+                                metric="Latency"
+                                source="/api/v1/endpoints (last probe)"
+                                windowLabel={windowLabel}
+                                updatedAt={e.last_probed_at}
+                                staleness="No new measurement is taken between probes — last measured value is shown."
+                              >
+                                <span>{e.latency_ms}ms</span>
+                              </SparkLegend>
+                            ) : (
+                              "—"
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
+                            <SparkLegend
+                              metric="Last probe"
+                              source="/api/v1/endpoints"
+                              windowLabel={windowLabel}
+                              updatedAt={e.last_probed_at}
+                              staleness="Rows older than the probe cycle are dimmed in tooltips elsewhere."
+                            >
+                              <TimeAgo at={e.last_probed_at} />
+                            </SparkLegend>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

`/endpoints` defaults to `view=table`, and the table branch wrapped its 8-column table in `overflow-x-clip`. At mobile width the trailing columns (Health, Latency, Probed — plus the wide `max-w-[36ch]` URL column) were **clipped and unreachable**, with no card fallback and no scroll: a first-time mobile visitor lands on an unusable view.

## Change

- One file: `apps/ui/src/routes/endpoints.tsx` (table branch only).
- Wrap the `<table>` in an inner `overflow-x-auto overflow-y-clip` scroll container inside an `overflow-hidden` card shell — the same treatment `ListShell` uses (see merged #4739).
- **Why `overflow-y-clip`, not a plain `overflow-x-auto` on the card:** this table's `<thead>` is `sticky top-[6.75rem]` (unlike the non-sticky `overflow-x-auto` pool tables above it). A vertical scroll container would break that sticky-against-page-scroll behavior; `overflow-y-clip` keeps it intact while letting the header + body scroll horizontally together.
- No query/logic change. Desktop and tablet rendering are unchanged (the table already fits); only narrow viewports gain reachability.

Closes #3931

## Screenshots

Captured at three viewports × both themes on `/endpoints` (default table view). Theme forced via `localStorage.setItem("mg-theme", …)` before navigation. **Before** = `upstream/main`; **After** = this branch.

> **Where to look:** the fix is a mobile/tablet **scroll affordance** — at rest (scroll-x 0) the before/after render identically, but on `before` the table's trailing columns are clipped with no way to reach them, while on `after` the table sits in a horizontally-scrollable container. Desktop rows are included to show no regression at width.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/before-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/before-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/before-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3931-assets/3931/after-mobile-dark.png) |

## Validation

- `tsc --noEmit` clean; `prettier --check` clean; `eslint` no new errors (only pre-existing react-refresh warnings).