### PR TITLE
feat(registry): add SN107 Minos TaoMarketCap subnet snapshot API (#4141)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -38,6 +38,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Minos TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/107 on api.taomarketcap.com returning machine-readable JSON for SN107 Minos on-chain subnet state, economics, registration/burn parameters, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API and provides the standalone public JSON data for netuid 107 alongside the subnet's first-party /health endpoint.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://taomarketcap.com/subnets/107"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/107"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
> Resubmit: the prior attempt used `kind: "data-artifact"` and was closed for kind-classification inconsistency with the registry-wide convention. Per that review's remedy, this version uses **`kind: "subnet-api"`** — matching the already-merged TaoMarketCap snapshot surfaces in `hashichain.json`, `eni.json`, `for-sale-burn-to-uid1.json`, and `subnet-86.json` (same id/name/notes shape).

## Summary

Registers SN107 Minos's public **TaoMarketCap on-chain subnet snapshot API** as a `subnet-api` community surface — the indexed public JSON feed for netuid 107. It provides the standalone public machine-readable data issue #4141 asks for (the JSON snapshot), classified per the established registry-wide convention for this endpoint pattern. One file changed: `registry/subnets/minos.json` (single appended surface).

Same accepted pattern as the merged SN115 HashiChain, SN38 ChronoLLM (#4789), SN73 MetaHash (#4730), SN116 TaoLend (#4670), SN84 ansuz (#4737), and SN16 BitAds (#4734) TaoMarketCap surfaces.

## Surface

| Field | Value |
| --- | --- |
| `kind` | `subnet-api` (registry-wide convention for this endpoint) |
| `url` | `https://api.taomarketcap.com/public/v1/subnets/107` |
| `provider` | `taomarketcap` |
| `source_urls` | `https://api.taomarketcap.com/developer/documentation/` , `https://taomarketcap.com/subnets/107` |
| `authority` | `community` |

## Proof

- `url` → **HTTP 200**, `application/json`, no auth — the machine-readable on-chain snapshot for **netuid 107** (`"netuid":107,"is_active":true`, owner/emission/burn/dTAO fields).
- Documented in the public TaoMarketCap developer API (`/developer/documentation/`).
- Not a duplicate: SN107's only existing surface is its first-party `/health` subnet-api (different provider + endpoint); no TaoMarketCap surface yet.

## Validation

```
npm run validate:surface -- registry/subnets/minos.json   # passed (2 surfaces)
npm run build && npm run validate                         # passed (full CI validate suite)
npx vitest run tests/artifacts.test.mjs                   # 21 passed (artifact-consistency suite)
npm run scan:public-safety                                # passed
```

Closes #4141
