### PR TITLE
feat(ui): add a daily-rollup freshness label to the neuron detail card

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -4,6 +4,7 @@ import { Coins, Flame, Award, Server, X } from "lucide-react";
 import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { TableState } from "@/components/metagraphed/table-state";
+import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -45,7 +46,7 @@ export function NeuronDetailCard({
 
   return (
     <div className="space-y-4 rounded-xl border border-border bg-surface/30 p-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-baseline gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Neuron
@@ -64,16 +65,20 @@ export function NeuronDetailCard({
             </span>
           ) : null}
         </div>
-        {onClose ? (
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close neuron detail"
-            className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-ink-muted hover:text-ink-strong"
-          >
-            <X className="size-3" aria-hidden /> Close
-          </button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {/* #3379: loaded-state must surface meta.generated_at as daily rollup */}
+          <FreshnessBadge at={meta?.generated_at} tier="daily" />
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close neuron detail"
+              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-ink-muted hover:text-ink-strong"
+            >
+              <X className="size-3" aria-hidden /> Close
+            </button>
+          ) : null}
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">


### PR DESCRIPTION
Closes #3379

`NeuronDetailCard` already had `meta.generated_at` from `subnetNeuronQuery`, but only passed it into the empty-state `TableState`. The loaded card (stake/emission/rank tiles + keys) never showed when the per-UID metagraph snapshot was captured. Twin of the metagraph-panel fix (#3381); `FreshnessBadge` (#3370) is already available.

## What changed

`apps/ui/src/components/metagraphed/neuron-detail-card.tsx` only:

- Loaded-state header renders `<FreshnessBadge at={meta?.generated_at} tier="daily" />` beside the optional Close control.
- Empty-state `TableState` freshness behavior unchanged.
- No new query or backend change.

Did not touch `metagraph-panel.tsx` (#3381) or `validators-panel.tsx` (#3380).

## Verification

Functionally verified on `/subnets/18?tab=metagraph&uid=84` (populated UID): "Daily rollup" badge + `as of … · N ago` appear in the neuron detail card header next to Close. Empty UID path still uses `TableState` only. No console errors.

Local validation runs (apps/ui workspace):

- `npm run typecheck --workspace=apps/ui` — clean
- `npm run lint --workspace=apps/ui` — clean, 0 errors
- `npm run format:check --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — passed
- `npm run build --workspace=apps/ui` — clean

## Screenshots — desktop / tablet / mobile × light + dark

Framed on `/subnets/18?tab=metagraph&uid=84#neuron` so the neuron detail card header (Daily rollup badge vs Close-only) is visible.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/c57fa252-c9f5-403d-96de-21cea4629ba6" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/916a44c1-58a6-4131-b2e6-9dd0dfdcf182" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/dd3126fe-9c7f-40c9-b718-cc7e052873e7" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/808a810c-dcad-4f68-a2dc-ffe8dbf40eb9" /> |
| Tablet · Light   | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/80d3d6d2-f68a-41e1-9db3-e58b871fc881" /> | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/fee1c650-cb69-4ac1-8688-605513cd0df6" /> |
| Tablet · Dark    | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/c8d18fe3-7695-4719-a179-3f24c0c79dc6" /> | <img width="1204" height="760" alt="image" src="https://github.com/user-attachments/assets/0d1054a8-dd03-4eca-bb1e-42f06ffeb368" /> |
| Mobile · Light   | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/1ce5ce8e-c89b-4811-8a88-b7ef1302f7f5" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/ec70fa2a-bcc0-4093-9a65-500c8c158d7c" /> |
| Mobile · Dark    | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/1bc18816-57ec-4a00-b1aa-e4e9003ac052" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/17ecbdeb-8c7c-4687-b417-5e2640265cc7" /> |