### PR TITLE
fix(ui): collapse the weight-setting KPI strip on mobile

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1115,7 +1115,11 @@ function WeightsSummaryLoader({ netuid }: { netuid: number }) {
     },
   ];
   return (
-    <div className="mb-4 grid grid-cols-3 divide-x divide-border overflow-hidden rounded-xl border border-border bg-card">
+    // #3939: stack to a single column below `sm`, matching the breakpoint
+    // AccountWeightSettingSection (accounts.$ss58.tsx) already uses for its
+    // sibling weight-setting KPI strip -- divide-y/divide-x swap with it so
+    // the stacked cells still get a separator line at mobile.
+    <div className="mb-4 grid grid-cols-1 divide-y divide-border overflow-hidden rounded-xl border border-border bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0">
       {cells.map((c) => (
         <div key={c.label} className="px-4 py-3">
           <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">


### PR DESCRIPTION
## Summary

- `WeightsSummaryLoader` (`apps/ui/src/routes/subnets.$netuid.tsx`, subnet Validators tab, from #3905) rendered its 3-cell KPI strip (Distinct setters / Weight-sets (30d) / Avg per setter) with a hard `grid-cols-3` and no responsive breakpoint at all, unlike its same-week sibling.
- Sibling identified: `AccountWeightSettingSection` in `apps/ui/src/routes/accounts.$ss58.tsx` (added one day earlier, same "weight-setting activity" feature area) already stacks its KPI tiles to a single column below `sm` via `grid ... sm:grid-cols-2` (no `grid-cols-N` at the base, `sm:grid-cols-N` at 640px+).
- Fix: apply the same breakpoint convention — `grid-cols-1` at the base, `sm:grid-cols-3` at 640px+. Since this strip additionally uses adjoining `divide-x` borders (rather than the sibling's gap-separated cards), the divider also has to flip with it — `divide-y` while stacked, switching to `divide-x`/`divide-y-0` at `sm:`, mirroring the identical divide-swap already used by another sibling KPI strip in this same file's `subnet-profile-panel.tsx` (`divide-y md:divide-y-0 md:divide-x`).
- No KPI values, data source, or table below the strip changed — text-only responsive-class fix, matching the issue's non-goals.

Closes #3939

## Screenshots

Mocks `GET /api/v1/subnets/{netuid}/weights` with a representative fixture so the real page renders real pixels; every other query on this tab is left to its default response.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-light-before.png)<br><sub>3 cramped columns, no breakpoint</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-light-after.png)<br><sub>stacks to one column per sibling convention</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-dark-before.png)<br><sub>3 cramped columns, no breakpoint</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-mobile-dark-after.png)<br><sub>stacks to one column per sibling convention</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-light-before.png)<br><sub>3-up, unaffected</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-light-after.png)<br><sub>3-up, unaffected</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-dark-before.png)<br><sub>3-up, unaffected</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-tablet-dark-after.png)<br><sub>3-up, unaffected</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-light-before.png)<br><sub>3-up, unaffected</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-light-after.png)<br><sub>3-up, unaffected</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-dark-before.png)<br><sub>3-up, unaffected</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/weights-summary-mobile-3939-weights-summary-desktop-dark-after.png)<br><sub>3-up, unaffected</sub> |

(The exact KPI numbers differ between the before/after captures — both point at the same live-backend endpoint, which returned different sampled data between the two capture runs; the fixture override applies identically to both, and the layout being demonstrated is unaffected by the underlying values.)

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (706 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification: confirmed `getComputedStyle(...).gridTemplateColumns` collapses to a single track below `sm` and expands to three at `sm:` via a scripted DOM check, plus the screenshots above at all three viewports in both themes
