### PR TITLE
feat(registry): add SN12 Compute Horde TaoMarketCap subnet snapshot API (#4010)

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -132,6 +132,25 @@
         "submitted_by": "galuis116"
       },
       "notes": "Official ComputeHorde Facilitator API (the SDK's DEFAULT_FACILITATOR_URL, https://facilitator.computehorde.io/) — auth/nonce is the live, public, no-auth endpoint of the same API; job submission/listing (api/v1/jobs) then requires bittensor-hotkey-signed auth via this nonce + /auth/login."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-12-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Compute Horde TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/12 on api.taomarketcap.com returning machine-readable JSON for SN12 Compute Horde on-chain subnet state, economics, registration/burn parameters, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API and provides the standalone public JSON data for netuid 12 alongside the subnet's first-party facilitator API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://taomarketcap.com/subnets/12"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/12"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers SN12 Compute Horde's public **TaoMarketCap on-chain subnet snapshot API** as a `subnet-api` community surface — the indexed public JSON feed for netuid 12, providing the standalone public machine-readable data issue #4010 asks for. One file changed: `registry/subnets/compute-horde.json` (single appended surface).

Same accepted pattern as the merged SN107 Minos (#4796), SN38 ChronoLLM (#4789), SN115 HashiChain, SN73 MetaHash (#4730), SN116 TaoLend (#4670), SN84 ansuz (#4737), and SN16 BitAds (#4734) TaoMarketCap surfaces — including the registry-wide `kind: "subnet-api"` convention for this endpoint.

## Surface

| Field | Value |
| --- | --- |
| `kind` | `subnet-api` (registry-wide convention for this endpoint) |
| `url` | `https://api.taomarketcap.com/public/v1/subnets/12` |
| `provider` | `taomarketcap` |
| `source_urls` | `https://api.taomarketcap.com/developer/documentation/` , `https://taomarketcap.com/subnets/12` |
| `authority` | `community` |

## Proof

- `url` → **HTTP 200**, `application/json`, no auth — the machine-readable on-chain snapshot for **netuid 12** (`"netuid":12,"is_active":true`, owner/emission/burn/dTAO fields).
- Documented in the public TaoMarketCap developer API (`/developer/documentation/`).
- Not a duplicate: SN12's existing surfaces are its website, source-repo, dashboard, SDK, and first-party facilitator subnet-api — no TaoMarketCap snapshot and no standalone data surface yet.

## Validation

```
npm run validate:surface -- registry/subnets/compute-horde.json   # passed (6 surfaces)
npm run build && npm run validate                                 # passed (full CI validate suite)
npx vitest run tests/artifacts.test.mjs                           # 21 passed (artifact-consistency suite)
npm run scan:public-safety                                        # passed
```

Closes #4010
