### PR TITLE
fix(ui): expose selected state via ARIA on window/view toggle groups (#3953)

### DIFF
--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -198,11 +198,17 @@ function DriftCard({ netuid }: { netuid: number }) {
     0;
 
   const toggle = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="Concentration window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
@@ -415,11 +421,17 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
     0;
 
   const toggle = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="Concentration window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -46,11 +46,17 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
   const hasData = Object.values(series).some((s) => s.length > 0);
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -82,11 +82,13 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Per-surface reliability · uptime · latency percentiles
         </div>
-        <div className="flex items-center gap-1">
+        <div role="tablist" aria-label="Reliability window" className="flex items-center gap-1">
           {WINDOWS.map((w) => (
             <button
               key={w}
               type="button"
+              role="tab"
+              aria-selected={w === window}
               onClick={() => setWindow(w)}
               className={classNames(
                 "rounded px-2 py-0.5 font-mono text-[11px] transition-colors",

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -44,11 +44,17 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
     0;
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -224,11 +224,17 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
   const hasData = series.subnet.length + series.median.length + series.p90.length > 0;
 
   const toggle = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="Yield window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",


### PR DESCRIPTION
## Summary

The five window/view toggle groups in `subnet-history-chart.tsx`, `neuron-history-chart.tsx`, `yield-panel.tsx`, `reliability-panel.tsx`, and `concentration-panel.tsx` (two identical groups in the last) indicated their selected option by background-color class swap only, with no ARIA state — a screen-reader user tabbing through got no indication of the active window.

This applies the exact ARIA pattern already used by the codebase's correct reference components (`view-mode-toggle.tsx`, `density-toggle.tsx`, `endpoint-kind-tabs.tsx`): `role="tablist"` + `aria-label` on the container, `role="tab"` + `aria-selected={active}` on each button. Visual appearance is unchanged — this is an ARIA-attribute addition only (per the issue's non-goals, no redesign).

## Change

- 5 files, 6 toggle groups, +38/−6 — attributes applied independently to each group per the issue's smaller-footprint alternative.
- **Shared-primitive follow-up (flagged per the issue):** all six groups (plus the three reference components) share the same segmented-toggle shape; extracting one `ToggleGroup` primitive is a natural follow-up but disproportionate to this fix.

## Accessibility-tree verification (per the issue, in lieu of screenshots)

Verified in Chromium via the live accessibility tree on `/subnets/1` (dev server, Playwright `role=` locators — i.e. the AX tree, not the source):

```
tablist "History window":      7D:false  30D:false  90D:true  1Y:false  ALL:false
tablist "Reliability window":  7d:true   30d:false
— after clicking 30D in "History window" —
tablist "History window":      7D:false  30D:true   90D:false 1Y:false  ALL:false
```

Selection state is exposed and updates correctly on interaction. The `yield-panel`, `concentration-panel`, and `neuron-history-chart` groups are code-identical applications of the same pattern; their parent panels are data-gated behind the live metagraph/yield/concentration tiers, which currently return no data in this environment (they render their empty states, so the toggles don't mount to inspect live) — the attributes are the same three lines per group as the two verified above.

The three reference components are untouched (no regression).

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 706 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Visual appearance unchanged (color-based indicator kept as-is; attributes only).

Closes #3953
