### PR TITLE
fix(ui): expose selected state via ARIA on window/view toggle groups (#3953)

### DIFF
--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -198,11 +198,17 @@ function DriftCard({ netuid }: { netuid: number }) {
     0;
 
   const toggle = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="Concentration window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
@@ -415,11 +421,17 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
     0;
 
   const toggle = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="Concentration window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -46,11 +46,17 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
   const hasData = Object.values(series).some((s) => s.length > 0);
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -82,11 +82,13 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Per-surface reliability · uptime · latency percentiles
         </div>
-        <div className="flex items-center gap-1">
+        <div role="tablist" aria-label="Reliability window" className="flex items-center gap-1">
           {WINDOWS.map((w) => (
             <button
               key={w}
               type="button"
+              role="tab"
+              aria-selected={w === window}
               onClick={() => setWindow(w)}
               className={classNames(
                 "rounded px-2 py-0.5 font-mono text-[11px] transition-colors",

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -44,11 +44,17 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
     0;
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -224,11 +224,17 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
   const hasData = series.subnet.length + series.median.length + series.p90.length > 0;
 
   const toggle = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="Yield window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",


### PR DESCRIPTION
> Resubmit of #4805, which was auto-closed by the screenshot-completeness check. Issue #3953's own acceptance criteria call for accessibility-tree verification "instead of a screenshot" since the change is ARIA-only with no visual component — but the automated check requires the table for any UI-code PR regardless, so the full 12-image table is now included below (before/after are visually identical by design, which is itself the issue's "visual appearance unchanged" criterion). The a11y-tree evidence follows the table.

## Summary

The five window/view toggle groups in `subnet-history-chart.tsx`, `neuron-history-chart.tsx`, `yield-panel.tsx`, `reliability-panel.tsx`, and `concentration-panel.tsx` (two identical groups in the last) indicated their selected option by background-color class swap only, with no ARIA state — a screen-reader user tabbing through got no indication of the active window.

This applies the exact ARIA pattern already used by the codebase's correct reference components (`view-mode-toggle.tsx`, `density-toggle.tsx`, `endpoint-kind-tabs.tsx`): `role="tablist"` + `aria-label` on the container, `role="tab"` + `aria-selected={active}` on each button. Visual appearance is unchanged — ARIA attributes only (per the issue's non-goals, no redesign).

**Shared-primitive follow-up (flagged per the issue):** all six groups (plus the three reference components) share the same segmented-toggle shape; extracting one `ToggleGroup` primitive is a natural follow-up but disproportionate to this fix.

## Screenshots (before/after visually identical — ARIA-only change)

Captured on `/subnets/1` framed on the affected Network-history window toggle (7D/30D/90D/1Y/ALL) and Reliability window toggle (7d/30d). Identical rendering before/after is the expected, correct result.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3953/mobile-dark-after.png)<br><sub>after</sub> |

## Accessibility-tree verification (the issue's stated acceptance evidence)

Verified in Chromium via the live accessibility tree on `/subnets/1` (Playwright `role=` locators — the AX tree, not source):

```
tablist "History window":      7D:false  30D:false  90D:true  1Y:false  ALL:false
tablist "Reliability window":  7d:true   30d:false
— after clicking 30D in "History window" —
tablist "History window":      7D:false  30D:true   90D:false 1Y:false  ALL:false
```

Selection state is exposed and updates on interaction. The `yield-panel`, `concentration-panel`, and `neuron-history-chart` groups are code-identical applications of the same three attributes; their parent panels are data-gated behind the live metagraph/yield/concentration tiers (currently empty in this environment), so those groups render only with data — the attributes are identical to the two verified above. The three reference components are untouched (no regression).

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 706 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Closes #3953
