### PR TITLE
feat(ui): show a daily-rollup freshness badge on the loaded metagraph panel (#3381)

### DIFF
--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,6 +6,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
@@ -64,6 +65,13 @@ export function MetagraphTableLoader({
 
   return (
     <div className="space-y-4">
+      {/* #3381: tier/freshness label for the loaded view — this metagraph is a
+          periodic ("daily rollup") capture, not live block data, so surface that
+          alongside the snapshot's generated-at stamp (previously shown only on the
+          empty state). */}
+      <div className="flex items-center justify-end">
+        <FreshnessBadge at={meta?.generated_at} tier="daily" />
+      </div>
       {/* KPI strip — neuron + validator counts and the dominant-UID stake share. */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatTile


### PR DESCRIPTION
## Summary

Closes #3381

The metagraph panel's `MetagraphTableLoader` already threads `meta.generated_at` into its **empty** state, but the **loaded** KPI/table view gave no freshness or tier cue — so a periodic ("daily rollup") metagraph capture was indistinguishable
from live block data. This adds a `FreshnessBadge` (`tier="daily"`) to the top of the loaded view, reusing the shared badge that renders the tier label ("Daily rollup"), a staleness dot, and the snapshot's absolute + relative timestamp.

## Changes

- `components/metagraphed/metagraph-panel.tsx` — render `<FreshnessBadge tier="daily" />`  from `meta.generated_at` in the loaded-data branch of `MetagraphTableLoader`  (top-right, above the KPI strip), so the tier/freshness signal shows on the
  populated view and not only on the empty state.

## Screenshots

Subnet metagraph panel (`/subnets/1?tab=metagraph`) — the new **"Daily rollup"** freshness badge at the top-right of the loaded panel, above the Neurons / Validators / Stake-share KPI strip.

| Viewport / Theme | Before | After |
|---|---|---|
| Desktop 1280×800 · light | <img width="1400" height="579" alt="dek-lg-be" src="https://github.com/user-attachments/assets/2156ca3f-ae75-4800-8ae6-1cb47867dc2c" /> | <img width="1369" height="580" alt="dek-lg-af" src="https://github.com/user-attachments/assets/429ba37e-4c01-4b26-8787-dfcee750d5ec" /> |
| Desktop 1280×800 · dark | <img width="1369" height="581" alt="dek-dk-be" src="https://github.com/user-attachments/assets/6823e247-e38f-4d4e-9ea7-126cbe913742" /> | <img width="1372" height="589" alt="dek-dk-af" src="https://github.com/user-attachments/assets/ade26103-fedc-4fd6-b580-4c286e8c0fbb" /> |
| Tablet 768×1024 · light | <img width="642" height="875" alt="tab-lg-be" src="https://github.com/user-attachments/assets/f384e406-1a12-4d65-a059-46c8b76d443e" /> | <img width="635" height="870" alt="tab-lg-af" src="https://github.com/user-attachments/assets/59a378bd-5c4d-49ab-a47a-6d1f011e6bfd" /> |
| Tablet 768×1024 · dark | <img width="607" height="867" alt="tab-dk-be" src="https://github.com/user-attachments/assets/8ea5de22-1dac-4fe3-aedf-fb33619b1817" /> | <img width="624" height="871" alt="tab-dk-af" src="https://github.com/user-attachments/assets/5f9e6696-ba05-4352-ac28-10f01e125042" /> |
| Mobile 375×812 · light | <img width="418" height="912" alt="mb-lg-be" src="https://github.com/user-attachments/assets/9e989201-8a5c-4290-b139-acf684e9b59e" /> | <img width="421" height="914" alt="mb-lg-af" src="https://github.com/user-attachments/assets/d91d5004-866d-491e-b89b-30696aaabfba" /> |
| Mobile 375×812 · dark | <img width="422" height="916" alt="mb-dk-be" src="https://github.com/user-attachments/assets/7fea9971-e49f-4d88-a670-663d77246929" /> | <img width="425" height="914" alt="mb-dk-af" src="https://github.com/user-attachments/assets/e5da6834-dd61-4b37-a643-29e48516c913" /> |

## Validation

- `tsc --noEmit` ✓ · `prettier --check` (3.9.4) ✓ · `eslint` (0 errors) ✓
- `vitest run` — 706/706 pass ✓ · `build` ✓ (cloudflare-module preset)
- Pure additions (no pre-existing lines changed); 1 file, +8


