### PR TITLE
feat(registry): add SN15 ORO validators subnet-api surface

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -298,6 +298,22 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/health/deep"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-validators-api",
+      "kind": "subnet-api",
+      "name": "ORO validators API",
+      "notes": "Public no-auth GET /v1/public/validators on api.oroagents.com returning the subnet's registered validators — identity, availability status, and registration / last-seen timestamps. Documented in the subnet OpenAPI on the same host as existing ORO public API surfaces.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "real-venus"
+      },
+      "source_urls": ["https://api.oroagents.com/openapi.json", "https://oroagents.com/"],
+      "url": "https://api.oroagents.com/v1/public/validators"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Summary

Closes #427

Registers one community surface on SN15 (ORO): the public, unauthenticated `GET /v1/public/validators` on `api.oroagents.com`, which returns the subnet's registered validator set — identity, availability status, and registration / last-seen timestamps.

The endpoint is declared in the subnet's own OpenAPI document (`api.oroagents.com/openapi.json`) and is served from the same host that already backs ORO's seven merged public API surfaces, so ownership is established rather than asserted. It is a distinct read path from the existing leaderboard, suites, and races surfaces — not a re-title or a near-duplicate.

## Surface

| field | value |
|---|---|
| kind | `subnet-api` |
| url | https://api.oroagents.com/v1/public/validators |
| source | https://api.oroagents.com/openapi.json, https://oroagents.com/ |
| auth_required | `false` |
| public_safe | `true` |
| review.state | `community-submitted` |

## Scope & validation

- Single file touched — `registry/subnets/oro.json`, append-only (one surface added).
- `npm run validate:surface -- registry/subnets/oro.json` → pass (15 surfaces, 1 file).
- `npm run scan:public-safety` → pass.
- Endpoint verified live (HTTP 200, public JSON) prior to submission.
- No health/uptime/verification fields set — those remain probe-derived.
