### PR TITLE
feat(ui): wire account hover-cards onto blocks and extrinsics ss58 cells

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -11,6 +11,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ListShell } from "@/components/metagraphed/list-shell";
+import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import {
@@ -26,6 +27,7 @@ import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { Block } from "@/lib/metagraphed/types";
 
@@ -400,7 +402,19 @@ function BlocksTable() {
                   className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
                   title={b.author ?? undefined}
                 >
-                  {shortHash(b.author) ?? "—"}
+                  {b.author && isValidSs58(b.author) ? (
+                    <EntityHoverCard kind="account" ss58={b.author}>
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: b.author }}
+                        className="hover:underline"
+                      >
+                        {shortHash(b.author)}
+                      </Link>
+                    </EntityHoverCard>
+                  ) : (
+                    (shortHash(b.author) ?? "—")
+                  )}
                 </td>
                 <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
                   {formatNumber(b.extrinsic_count ?? 0)}

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -20,6 +20,7 @@ import {
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import { CopyButton } from "@/components/metagraphed/copy-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
@@ -27,6 +28,7 @@ import { chainFeesQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { Extrinsic } from "@/lib/metagraphed/types";
@@ -338,7 +340,22 @@ function ExtrinsicsTable() {
                   {extrinsicCall(x.call_module, x.call_function)}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"}
+                  {x.signer && isValidSs58(x.signer) ? (
+                    <EntityHoverCard kind="account" ss58={x.signer}>
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: x.signer }}
+                        className="hover:underline"
+                        title={x.signer}
+                      >
+                        {shortHash(x.signer)}
+                      </Link>
+                    </EntityHoverCard>
+                  ) : x.signer ? (
+                    <CopyableCode value={x.signer} className="max-w-full" />
+                  ) : (
+                    "—"
+                  )}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">
                   <SuccessBadge success={x.success} />


### PR DESCRIPTION
## Summary

The block-author cell (`blocks.index.tsx`) and extrinsic-signer cell (`extrinsics.index.tsx`) in the desktop explorer tables now render as `/accounts/$ss58` links wrapped in `EntityHoverCard kind="account"`, so hovering previews the account — matching the ss58 treatment every other route already has. Reuses the `account` variant from #3397 and mirrors the subnet-hover pattern in `routes/index.tsx`. Invalid/missing values keep the prior `shortHash`/`CopyableCode`/`—` fallback; mobile cards are untouched.

No backend, type, or query changes — `b.author` / `x.signer` already flow through `blocksQuery` / `extrinsicsQuery`.

## Validation

- `lint` (0 errors) · `format:check` · `typecheck` · `test` (706 passed) · `build` — all green (`--workspace=apps/ui`)

## Screenshots

Mobile (375px) is provably unaffected: the change lives only in the desktop table (`ListShell` renders the untouched `cards` variant below the `md` breakpoint), so those combos are omitted. The at-rest author/signer cell is now a link (underline on hover); the hover-card popover is shown in the "hover" rows.

### Blocks — block-author cell

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light (hover) | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png)<br><sub>before (plain text)</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hovercard-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hovercard-desktop-light-after.png)<br><sub>after (account hover card)</sub> |

### Extrinsics — signer cell

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light (hover) | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png)<br><sub>before (CopyableCode)</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hovercard-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hovercard-desktop-light-after.png)<br><sub>after (account hover card)</sub> |

Closes #3398
