### PR TITLE
fix(ui): document and align empty-state component usage

### DIFF
--- a/apps/ui/src/components/metagraphed/empty-state-usage.test.ts
+++ b/apps/ui/src/components/metagraphed/empty-state-usage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_STATE_COMPONENT_RULES, emptyStateComponentFor } from "./empty-state-usage";
+
+describe("empty-state-usage", () => {
+  it("documents all three components", () => {
+    expect(Object.keys(EMPTY_STATE_COMPONENT_RULES).sort()).toEqual([
+      "EmptyState",
+      "RegistryEmpty",
+      "TableState",
+    ]);
+  });
+
+  it("maps UI contexts to the correct component", () => {
+    expect(emptyStateComponentFor("inline-section")).toBe("EmptyState");
+    expect(emptyStateComponentFor("data-table")).toBe("TableState");
+    expect(emptyStateComponentFor("registry-catalog")).toBe("RegistryEmpty");
+  });
+});

--- a/apps/ui/src/components/metagraphed/empty-state-usage.ts
+++ b/apps/ui/src/components/metagraphed/empty-state-usage.ts
@@ -1,0 +1,35 @@
+/**
+ * Empty-state component selection rules (#3962).
+ *
+ * - **EmptyState** — lightweight dashed-border emptiness for inline sections,
+ *   charts, side panels, and simple one-off blocks that are not data tables and
+ *   do not need registry provenance (freshness/evidence/actions rows).
+ * - **TableState** — empty / stale / error blocks for data tables and
+ *   table-adjacent lists (including paginated registry tables). Supports retry,
+ *   CTA, and ApiError wiring with the shared rounded-xl table chrome.
+ * - **RegistryEmpty** — registry catalog surfaces where users need provenance:
+ *   freshness hints, evidence/source links, and multiple next-action chips
+ *   (e.g. /endpoints, /surfaces, /gaps, subnet gaps panel).
+ */
+export const EMPTY_STATE_COMPONENT_RULES = {
+  EmptyState: "Inline sections, charts, and lightweight panels outside data tables.",
+  TableState: "Empty, stale, and error states for data tables and table-adjacent lists.",
+  RegistryEmpty: "Registry catalog surfaces with provenance, freshness hints, and evidence links.",
+} as const;
+
+export type EmptyStateComponent = keyof typeof EMPTY_STATE_COMPONENT_RULES;
+
+export type EmptyStateContext = "inline-section" | "data-table" | "registry-catalog";
+
+/** Maps a UI context to the component mandated by #3962. */
+export function emptyStateComponentFor(context: EmptyStateContext): EmptyStateComponent {
+  switch (context) {
+    case "data-table":
+      return "TableState";
+    case "registry-catalog":
+      return "RegistryEmpty";
+    case "inline-section":
+    default:
+      return "EmptyState";
+  }
+}

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -93,6 +93,11 @@ export function ErrorState({
   );
 }
 
+/**
+ * Lightweight dashed-border empty block for inline sections, charts, and simple
+ * panels — not for data-table shells (use `TableState`) or registry catalog
+ * surfaces with provenance (use `RegistryEmpty`). See `empty-state-usage.ts`.
+ */
 export function EmptyState({
   title = "Nothing here yet",
   description,

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -57,9 +57,11 @@ const TONE = {
 } as const;
 
 /**
- * Unified empty/error/stale state for registry surfaces. Surfaces a clear
- * headline, a plain-language explainer, an optional freshness hint, and a
- * compact row of "next actions" so users always know what to do next.
+ * Registry-catalog empty/error/stale state with provenance affordances:
+ * freshness hints, evidence links, and next-action chips. Use on /endpoints,
+ * /surfaces, /gaps, and subnet gaps — not for generic table emptiness
+ * (`TableState`) or lightweight inline sections (`EmptyState`).
+ * See `empty-state-usage.ts`.
  */
 export function RegistryEmpty({
   variant,

--- a/apps/ui/src/components/metagraphed/table-state.tsx
+++ b/apps/ui/src/components/metagraphed/table-state.tsx
@@ -34,9 +34,11 @@ interface Props {
 }
 
 /**
- * Unified empty / stale / error block for every registry table. Identical
- * padding, copy column, and CTA style so empty states feel consistent across
- * /endpoints, /surfaces, /providers, subnet detail tables.
+ * Empty / stale / error block for data tables and table-adjacent lists — the
+ * rounded-xl chrome shared across /endpoints pool tables, subnet activity tables,
+ * /schemas contracts, and paginated registry tables. For inline chart/section
+ * emptiness use `EmptyState`; for registry catalog provenance (freshness,
+ * evidence, action chips) use `RegistryEmpty`. See `empty-state-usage.ts`.
  */
 export function TableState({
   variant,

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -10,7 +10,8 @@ import { TimeAgo } from "@/components/metagraphed/time-ago";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { HealthPill, HealthDot } from "@/components/metagraphed/chips";
 import { CopyButton } from "@/components/metagraphed/copy-button";
-import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
+import { TableState } from "@/components/metagraphed/table-state";
+import { Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
 import { BrandIcon } from "@/components/metagraphed/brand-icon";
 import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
@@ -275,7 +276,8 @@ function PoolsTable() {
   const stale = isStaleFreshness(data.meta?.generated_at);
   if (rows.length === 0)
     return (
-      <EmptyState
+      <TableState
+        variant="empty"
         title="No RPC pools tracked"
         description="The proxy routes across registered pools — pool members and their eligibility appear here once registered."
       />
@@ -352,7 +354,8 @@ function EndpointPoolsTable() {
   const stale = isStaleFreshness(data.meta?.generated_at);
   if (rows.length === 0)
     return (
-      <EmptyState
+      <TableState
+        variant="empty"
         title="No endpoint pools tracked"
         description="Generalized pool composition across subtensor-rpc, subtensor-wss, and archive kinds appears here once pools are scored."
       />
@@ -442,7 +445,8 @@ function RpcEndpointsTable() {
   const stale = isStaleFreshness(data.meta?.generated_at);
   if (rows.length === 0)
     return (
-      <EmptyState
+      <TableState
+        variant="empty"
         title="No RPC endpoints tracked"
         description="The base-layer Subtensor RPC/WSS registry appears here once endpoints are registered."
       />

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -368,8 +368,8 @@ function SchemaExplorer() {
           </div>
           <ul className="flex-1 overflow-y-auto divide-y divide-border/60">
             {filtered.length === 0 ? (
-              <li className="p-8 text-center">
-                <EmptyState title="No schemas match" />
+              <li className="p-4">
+                <TableState variant="empty" title="No schemas match" className="!py-8" />
               </li>
             ) : (
               filtered.map((s) => {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -12,6 +12,7 @@ import {
   StaleBanner,
   RECOVERY,
 } from "@/components/metagraphed/states";
+import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { TimeAgo } from "@/components/metagraphed/time-ago";
@@ -1306,10 +1307,11 @@ function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
   if (error) {
     return (
       <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
-        <EmptyState
+        <RegistryEmpty
+          variant="error"
           title="Gaps unavailable"
           description="The subnet gaps endpoint did not respond."
-          action={RECOVERY.gaps}
+          actions={[{ label: RECOVERY.gaps.label, to: RECOVERY.gaps.href, primary: true }]}
         />
       </SectionAnchor>
     );
@@ -1317,10 +1319,11 @@ function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
   if (missing.length === 0 && notes.length === 0) {
     return (
       <SectionAnchor id="gaps" title="Gaps">
-        <EmptyState
+        <RegistryEmpty
+          variant="empty"
           title="No outstanding gaps"
           description="Profile looks complete."
-          action={RECOVERY.gaps}
+          actions={[{ label: RECOVERY.gaps.label, to: RECOVERY.gaps.href }]}
         />
       </SectionAnchor>
     );

--- a/apps/ui/tests/e2e/capture-empty-state-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-empty-state-screenshots.mjs
@@ -1,0 +1,120 @@
+/**
+ * Capture empty-state migration screenshots for #3962 (Path C2 contract).
+ *
+ * Usage (dev server must be running; pass its base URL explicitly):
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after node tests/e2e/capture-empty-state-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8086 VARIANT=before node tests/e2e/capture-empty-state-screenshots.mjs
+ *
+ * Writes to tmp/empty-state-screenshots/{VARIANT}-{scene}-{viewport}-{theme}.png
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/empty-state-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+const SCENES = [
+  {
+    id: "endpoints-rpc-pools-empty",
+    path: "/endpoints",
+    heading: "RPC pools",
+    routes: [
+      {
+        pattern: "**/api/v1/rpc/pools",
+        body: { ok: true, data: [], meta: { generated_at: new Date().toISOString() } },
+      },
+    ],
+  },
+  {
+    id: "subnet-gaps-complete",
+    path: "/subnets/1?tab=registry#gaps",
+    heading: "Gaps",
+    routes: [
+      {
+        pattern: "**/api/v1/subnets/1/gaps",
+        body: {
+          ok: true,
+          data: { netuid: 1, missing_kinds: [], gap_notes: [] },
+          meta: {},
+        },
+      },
+    ],
+  },
+  {
+    id: "schemas-filter-empty",
+    path: "/schemas?q=__nomatch3962__",
+    heading: "No schemas match",
+    routes: [],
+  },
+];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function installRoutes(page, routes) {
+  for (const route of routes) {
+    await page.route(route.pattern, async (r) => {
+      await r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(route.body),
+      });
+    });
+  }
+}
+
+async function captureScene(browser, scene, viewport, theme) {
+  const page = await browser.newPage({
+    viewport: { width: viewport.width, height: viewport.height },
+  });
+  await setTheme(page, theme);
+  await installRoutes(page, scene.routes);
+  await page.goto(`${BASE_URL}${scene.path}`, { waitUntil: "networkidle", timeout: 120_000 });
+
+  if (scene.heading) {
+    const locator =
+      scene.id === "schemas-filter-empty"
+        ? page.getByText(scene.heading, { exact: true }).first()
+        : page.getByRole("heading", { name: scene.heading }).first();
+    await locator.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(300);
+  }
+
+  const file = path.join(OUT_DIR, `${VARIANT}-${scene.id}-${viewport.name}-${theme}.png`);
+  await page.screenshot({ path: file, fullPage: false });
+  await page.close();
+  console.log("wrote", file);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  for (const scene of SCENES) {
+    for (const viewport of VIEWPORTS) {
+      for (const theme of THEMES) {
+        await captureScene(browser, scene, viewport, theme);
+      }
+    }
+  }
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #3962

Audited the three competing empty-state components and documented when to use each:

| Component | Use when |
|---|---|
| `EmptyState` | Inline sections, charts, and lightweight panels outside data tables |
| `TableState` | Empty / stale / error states for data tables and table-adjacent lists |
| `RegistryEmpty` | Registry catalog surfaces needing provenance (freshness, evidence, action chips) |

Rules live in `empty-state-usage.ts` with comments on each component definition.

### Migrated call sites (wrong component → correct)

| Route | Before | After | Why |
|---|---|---|---|
| `/endpoints` RPC pools table | `EmptyState` | `TableState` | Table-empty chrome |
| `/endpoints` endpoint pools table | `EmptyState` | `TableState` | Table-empty chrome |
| `/endpoints` root RPC/WSS table | `EmptyState` | `TableState` | Table-empty chrome |
| `/subnets/$netuid` gaps panel (error + complete) | `EmptyState` | `RegistryEmpty` | Registry provenance surface |
| `/schemas` filter rail (no matches) | `EmptyState` | `TableState` | Table-adjacent list empty |

Broader app-wide consolidation is out of scope for this PR (issue allows follow-ups).

## Screenshots

### `/endpoints` — RPC pools empty (desktop)

| Theme | Before | After |
|---|---|---|
| Light | ![before endpoints light](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/before-endpoints-rpc-pools-empty-desktop-light.png) | ![after endpoints light](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/after-endpoints-rpc-pools-empty-desktop-light.png) |
| Dark | ![before endpoints dark](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/before-endpoints-rpc-pools-empty-desktop-dark.png) | ![after endpoints dark](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/after-endpoints-rpc-pools-empty-desktop-dark.png) |

### `/subnets/1` — gaps complete (desktop)

| Theme | Before | After |
|---|---|---|
| Light | ![before gaps light](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/before-subnet-gaps-complete-desktop-light.png) | ![after gaps light](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/after-subnet-gaps-complete-desktop-light.png) |
| Dark | ![before gaps dark](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/before-subnet-gaps-complete-desktop-dark.png) | ![after gaps dark](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/after-subnet-gaps-complete-desktop-dark.png) |

### `/schemas` — filter empty (desktop)

| Theme | Before | After |
|---|---|---|
| Light | ![before schemas light](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/before-schemas-filter-empty-desktop-light.png) | ![after schemas light](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/after-schemas-filter-empty-desktop-light.png) |
| Dark | ![before schemas dark](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/before-schemas-filter-empty-desktop-dark.png) | ![after schemas dark](https://raw.githubusercontent.com/jimcody1995/metagraphed/screenshots-empty-state-3962/after-schemas-filter-empty-desktop-dark.png) |

Mobile + tablet captures: [screenshots branch](https://github.com/jimcody1995/metagraphed/tree/screenshots-empty-state-3962) (36 PNGs).

## Validation

```sh
npm run lint --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui
```

## Test plan

- [x] Documented component selection rules (`empty-state-usage.ts` + component comments)
- [x] Migrated 6 wrong call sites across 3 routes
- [x] Before/after screenshots (mobile, tablet, desktop; light + dark)
- [x] Unit tests for selection rules

Made with [Cursor](https://cursor.com)