### PR TITLE
fix(ui): interpolate live windowLabel in account activity subtitles (#3948)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1373,7 +1373,7 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
       <AccountFeedSectionSkeleton
         id="teardown"
         title="Teardown activity"
-        subtitle="Axon endpoint removals (AxonInfoRemoved) for this account over the trailing 30-day window."
+        subtitle={`Axon endpoint removals (AxonInfoRemoved) for this account over the trailing ${windowLabel} window.`}
       />
     );
   }
@@ -1383,7 +1383,7 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
       <SectionAnchor
         id="teardown"
         title="Teardown activity"
-        subtitle="Axon endpoint removals (AxonInfoRemoved) for this account over the trailing 30-day window."
+        subtitle={`Axon endpoint removals (AxonInfoRemoved) for this account over the trailing ${windowLabel} window.`}
         tone="accent"
       >
         <TableState
@@ -1405,7 +1405,7 @@ function AccountTeardownActivitySection({ ss58 }: { ss58: string }) {
     <SectionAnchor
       id="teardown"
       title="Teardown activity"
-      subtitle="Axon endpoint removals (AxonInfoRemoved) for this account over the trailing 30-day window."
+      subtitle={`Axon endpoint removals (AxonInfoRemoved) for this account over the trailing ${windowLabel} window.`}
       tone="accent"
       info="The account-level companion to subnet axon-removal activity — counts how often this hotkey removed an announced axon endpoint, and on how many distinct subnets."
       right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
@@ -1446,7 +1446,7 @@ function AccountRegistrationActivitySection({ ss58 }: { ss58: string }) {
       <AccountFeedSectionSkeleton
         id="registrations"
         title="Registration activity"
-        subtitle="Neuron registrations (NeuronRegistered) for this account over the trailing 30-day window."
+        subtitle={`Neuron registrations (NeuronRegistered) for this account over the trailing ${windowLabel} window.`}
       />
     );
   }
@@ -1456,7 +1456,7 @@ function AccountRegistrationActivitySection({ ss58 }: { ss58: string }) {
       <SectionAnchor
         id="registrations"
         title="Registration activity"
-        subtitle="Neuron registrations (NeuronRegistered) for this account over the trailing 30-day window."
+        subtitle={`Neuron registrations (NeuronRegistered) for this account over the trailing ${windowLabel} window.`}
         tone="accent"
       >
         <TableState
@@ -1478,7 +1478,7 @@ function AccountRegistrationActivitySection({ ss58 }: { ss58: string }) {
     <SectionAnchor
       id="registrations"
       title="Registration activity"
-      subtitle="Neuron registrations (NeuronRegistered) for this account over the trailing 30-day window."
+      subtitle={`Neuron registrations (NeuronRegistered) for this account over the trailing ${windowLabel} window.`}
       tone="accent"
       info="The account-level companion to subnet registration activity — counts how often this hotkey was registered into a subnet, and on how many distinct subnets."
       right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
@@ -1514,7 +1514,7 @@ function AccountDeregistrationActivitySection({ ss58 }: { ss58: string }) {
       <AccountFeedSectionSkeleton
         id="deregistrations"
         title="Deregistration activity"
-        subtitle="Neuron deregistrations (NeuronDeregistered) for this account over the trailing 30-day window."
+        subtitle={`Neuron deregistrations (NeuronDeregistered) for this account over the trailing ${windowLabel} window.`}
       />
     );
   }
@@ -1524,7 +1524,7 @@ function AccountDeregistrationActivitySection({ ss58 }: { ss58: string }) {
       <SectionAnchor
         id="deregistrations"
         title="Deregistration activity"
-        subtitle="Neuron deregistrations (NeuronDeregistered) for this account over the trailing 30-day window."
+        subtitle={`Neuron deregistrations (NeuronDeregistered) for this account over the trailing ${windowLabel} window.`}
         tone="accent"
       >
         <TableState
@@ -1546,7 +1546,7 @@ function AccountDeregistrationActivitySection({ ss58 }: { ss58: string }) {
     <SectionAnchor
       id="deregistrations"
       title="Deregistration activity"
-      subtitle="Neuron deregistrations (NeuronDeregistered) for this account over the trailing 30-day window."
+      subtitle={`Neuron deregistrations (NeuronDeregistered) for this account over the trailing ${windowLabel} window.`}
       tone="accent"
       info="The account-level companion to subnet deregistration activity — counts how often this hotkey was deregistered (evicted) from a subnet, and on how many distinct subnets."
       right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
@@ -1590,7 +1590,7 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
       <AccountFeedSectionSkeleton
         id="weight-setting"
         title="Weight-setting activity"
-        subtitle="Validator WeightsSet events for this account over the trailing 30-day window."
+        subtitle={`Validator WeightsSet events for this account over the trailing ${windowLabel} window.`}
       />
     );
   }
@@ -1600,7 +1600,7 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
       <SectionAnchor
         id="weight-setting"
         title="Weight-setting activity"
-        subtitle="Validator WeightsSet events for this account over the trailing 30-day window."
+        subtitle={`Validator WeightsSet events for this account over the trailing ${windowLabel} window.`}
         tone="accent"
       >
         <TableState
@@ -1618,7 +1618,7 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
     <SectionAnchor
       id="weight-setting"
       title="Weight-setting activity"
-      subtitle="Validator WeightsSet events for this account over the trailing 30-day window — per-subnet breakdown when this hotkey submits weights."
+      subtitle={`Validator WeightsSet events for this account over the trailing ${windowLabel} window — per-subnet breakdown when this hotkey submits weights.`}
       tone="accent"
       info="The account-level companion to subnet weight-setter leaderboards — keyed on the validator hotkey submitting its weight vector."
       right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}
@@ -1708,7 +1708,7 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
       <AccountFeedSectionSkeleton
         id="endpoint-announcements"
         title="Endpoint announcements"
-        subtitle="Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing 30-day window."
+        subtitle={`Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing ${windowLabel} window.`}
       />
     );
   }
@@ -1718,7 +1718,7 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
       <SectionAnchor
         id="endpoint-announcements"
         title="Endpoint announcements"
-        subtitle="Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing 30-day window."
+        subtitle={`Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing ${windowLabel} window.`}
         tone="accent"
       >
         <TableState
@@ -1749,7 +1749,7 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
     <SectionAnchor
       id="endpoint-announcements"
       title="Endpoint announcements"
-      subtitle="Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing 30-day window."
+      subtitle={`Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing ${windowLabel} window.`}
       tone="accent"
       info="The account-level companion to subnet serving + prometheus activity — counts how often this hotkey announced axon and Prometheus endpoints."
       right={<SectionBadge tone="accent">{windowLabel}</SectionBadge>}


### PR DESCRIPTION
## Summary

The four account activity-footprint sections in `apps/ui/src/routes/accounts.$ss58.tsx` (teardown, registration/deregistration, weight-setting, endpoint-announcement) each compute a live `windowLabel` from the API response (`card?.window ?? "30d"`) and render it in a visible `SectionBadge` and hint — but every `subtitle` prop hardcoded the literal "over the trailing **30-day** window". If the API's window value is anything other than 30d, the badge shows the true window while the subtitle prose keeps claiming "30-day" — a visible self-contradiction on the same card.

This interpolates the already-computed `windowLabel` into all 12 subtitle occurrences (across the skeleton / error / loaded branches of all four sections), so the prose always tracks the real window.

## Change

- One file, +15/−15: each `subtitle="…over the trailing 30-day window…"` → `subtitle={`…over the trailing \${windowLabel} window…`}`.
- `windowLabel` is already declared at the top of each section (in scope for all three render branches), so no data threading is needed.
- No change to the API window default or options (issue non-goal). Two mentions of "30-day window" remain in code **comments** (not rendered prose) and are intentionally left as-is.

## Behavioral verification

- **Default (30d):** subtitle renders "over the trailing 30d window" — matching the `30D` badge (see screenshots).
- **Non-30d:** mocked the `/weight-setters` response with `window: "7d"` in a live browser — the subtitle correctly rendered "over the trailing **7d** window" and the "WeightsSet · 7d" hint matched, confirming the prose now tracks the window instead of a literal.

## Screenshots

Account activity page framed on the Weight-setting section. The only difference is the subtitle wording: **before** "trailing **30-day** window" (hardcoded) → **after** "trailing **30d** window" (from `windowLabel`, matching the badge). Default 30d case; layout otherwise identical.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3948/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 706 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Closes #3948
