### PR TITLE
feat(ui): wire account hover-cards onto blocks and extrinsics ss58 cells

### DIFF
--- a/apps/ui/src/components/metagraphed/account-cell.tsx
+++ b/apps/ui/src/components/metagraphed/account-cell.tsx
@@ -1,0 +1,25 @@
+import { Link } from "@tanstack/react-router";
+import { type ReactNode } from "react";
+import { EntityHoverCard } from "./entity-hover-card";
+import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { shortHash } from "@/lib/metagraphed/blocks";
+
+/**
+ * Renders an ss58 account value as a truncated `/accounts/$ss58` link wrapped in
+ * the account hover-card preview — the treatment ss58 addresses get elsewhere in
+ * the app. When the value is missing or not a valid ss58, renders `fallback`
+ * (each table keeps its own prior rendering there). Shared by the blocks and
+ * extrinsics explorer tables so the cell markup lives in one place.
+ */
+export function AccountCell({ ss58, fallback }: { ss58?: string | null; fallback: ReactNode }) {
+  if (ss58 && isValidSs58(ss58)) {
+    return (
+      <EntityHoverCard kind="account" ss58={ss58}>
+        <Link to="/accounts/$ss58" params={{ ss58 }} className="hover:underline" title={ss58}>
+          {shortHash(ss58)}
+        </Link>
+      </EntityHoverCard>
+    );
+  }
+  return <>{fallback}</>;
+}

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -11,6 +11,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { PageHero } from "@/components/metagraphed/page-hero";
 import { ListShell } from "@/components/metagraphed/list-shell";
+import { AccountCell } from "@/components/metagraphed/account-cell";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
 import {
@@ -400,7 +401,7 @@ function BlocksTable() {
                   className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
                   title={b.author ?? undefined}
                 >
-                  {shortHash(b.author) ?? "—"}
+                  <AccountCell ss58={b.author} fallback={shortHash(b.author) ?? "—"} />
                 </td>
                 <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
                   {formatNumber(b.extrinsic_count ?? 0)}

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -20,6 +20,7 @@ import {
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { AccountCell } from "@/components/metagraphed/account-cell";
 import { CopyButton } from "@/components/metagraphed/copy-button";
 import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { Sparkline } from "@/components/metagraphed/charts/sparkline";
@@ -338,7 +339,12 @@ function ExtrinsicsTable() {
                   {extrinsicCall(x.call_module, x.call_function)}
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"}
+                  <AccountCell
+                    ss58={x.signer}
+                    fallback={
+                      x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"
+                    }
+                  />
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px]">
                   <SuccessBadge success={x.success} />


### PR DESCRIPTION
## Summary

The block-author cell (`blocks.index.tsx`) and extrinsic-signer cell (`extrinsics.index.tsx`) in the desktop explorer tables now render as `/accounts/$ss58` links wrapped in `EntityHoverCard kind="account"`, so hovering previews the account — matching the ss58 treatment every other route already has. Invalid/missing values keep the prior `shortHash`/`CopyableCode`/`—` fallback; mobile card layouts are untouched.

The link + hover-card + fallback markup is shared through a small `AccountCell` component (`components/metagraphed/account-cell.tsx`) consumed by both tables, so the cell lives in one place (following the shared-component pattern of `call-module-extrinsics-table.tsx`). Reuses the `account` hover-card variant from #3397; no backend, type, or query changes — `b.author` / `x.signer` already flow through `blocksQuery` / `extrinsicsQuery`.

## Review feedback addressed

- Extracted the duplicated per-cell JSX into the shared `AccountCell`, which also gives both cells a consistent per-link `title` tooltip.
- The valid-vs-fallback decision is `isValidSs58`, already unit-tested in `lib/metagraphed/accounts.test.ts`; `apps/ui` has no component-render harness (vitest runs in a `node` env, no testing-library), so route/cell render tests don't exist repo-wide.
- Added the missing Mobile · Light / Mobile · Dark screenshot rows (below). Mobile renders the untouched `cards` variant, so before ≡ after there.

## Validation

- `lint` (0 errors) · `format:check` · `typecheck` · `test` (706 passed) · `build` — all green (`--workspace=apps/ui`)

## Screenshots

### Hover interaction (animated)

Per review, here are before/after recordings of the actual hover behaviour (static images can't show the pointer-driven popover). The cursor glides across the author/signer cells: **before** nothing happens (plain text / `CopyableCode`); **after** each cell is a `/accounts/$ss58` link that opens the account preview card.

| Table | Before | After |
| --- | --- | --- |
| Blocks · author cell | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hover-before.gif" width="380">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hover-before.gif) | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hover-after.gif" width="380">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hover-after.gif) |
| Extrinsics · signer cell | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hover-before.gif" width="380">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hover-before.gif) | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hover-after.gif" width="380">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hover-after.gif) |

### Static states (viewport × theme)

The at-rest author/signer cell is now a link (underline on hover); the hover row shows the account-preview popover. Mobile is unchanged (desktop-table-only change).

### Blocks — block-author cell

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-light-before.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-light-after.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-light-after.png)<br><sub>after (cards unchanged)</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-dark-before.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-dark-after.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-mobile-dark-after.png)<br><sub>after (cards unchanged)</sub> |
| Desktop · Light (hover) | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-desktop-light-before.png)<br><sub>before (plain text)</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hovercard-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/blocks-hovercard-desktop-light-after.png)<br><sub>after (account hover card)</sub> |

### Extrinsics — signer cell

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-light-before.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-light-after.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-light-after.png)<br><sub>after (cards unchanged)</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-dark-before.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-dark-after.png" width="200">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-mobile-dark-after.png)<br><sub>after (cards unchanged)</sub> |
| Desktop · Light (hover) | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-desktop-light-before.png)<br><sub>before (CopyableCode)</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hovercard-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/extrinsics-hovercard-desktop-light-after.png)<br><sub>after (account hover card)</sub> |

Closes #3398
