### PR TITLE
fix(ui): make the endpoint-list HeaderHint tooltip trigger keyboard-operable

### DIFF
--- a/apps/ui/src/components/metagraphed/eligibility-chip.tsx
+++ b/apps/ui/src/components/metagraphed/eligibility-chip.tsx
@@ -35,6 +35,14 @@ export function EligibilityChip({
     <TooltipProvider delayDuration={120}>
       <Tooltip>
         <TooltipTrigger asChild>
+          {/* #3433: tabIndex is what makes this trigger keyboard-operable at
+              all -- Radix only opens the Tooltip on a focus event, and a
+              plain span never receives one without it. Verified via a
+              scripted focus/Escape check: focus opens the tooltip
+              (data-state instant-open) and Escape closes it while keeping
+              focus on the trigger, with no extra wiring needed beyond
+              this attribute. This is the reference HeaderHint
+              (endpoint-list.tsx) now matches -- don't drop it. */}
           <span
             tabIndex={0}
             className={classNames(

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -398,7 +398,14 @@ function HeaderHint({ label, hint }: { label: string; hint: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex items-center gap-1 cursor-help underline-offset-2 decoration-dotted decoration-ink-subtle hover:decoration-ink-muted">
+        {/* #3433: tabIndex so this trigger is reachable by keyboard at all --
+            without it, Radix's Tooltip never receives the focus event that
+            opens it, so it can't be opened (or Escape-dismissed) via
+            keyboard. Matches EligibilityChip's trigger. */}
+        <span
+          tabIndex={0}
+          className="inline-flex items-center gap-1 cursor-help rounded underline-offset-2 decoration-dotted decoration-ink-subtle hover:decoration-ink-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
           {label}
         </span>
       </TooltipTrigger>


### PR DESCRIPTION
## Summary

Before touching anything, I drove both triggers with real keyboard/DOM assertions (`getAttribute("data-state")`, `document.activeElement`, tooltip-role count) to establish exactly what was and wasn't broken, since the issue's premise ("neither trigger is fully keyboard-operable") turned out to only be half true:

- **`EligibilityChip`** (`apps/ui/src/components/metagraphed/eligibility-chip.tsx`) already had `tabIndex={0}` on its `TooltipTrigger` span. Verified: real Tab focus → `data-state="instant-open"` (tooltip opens) → `Escape` → `data-state="closed"`, focus retained on the trigger. This already worked correctly; no functional change was needed.
- **`HeaderHint`** (`apps/ui/src/components/metagraphed/endpoint-list.tsx`) had **no `tabIndex` at all**. Verified: calling `.focus()` on it never moved `document.activeElement` to it — it is not a focusable element, so Radix's Tooltip (which opens on a `focus` event) can never receive keyboard focus in the first place. This is the actual bug, and it's more fundamental than "Escape doesn't dismiss": the tooltip can't even be opened via keyboard, let alone dismissed.

Fix: add `tabIndex={0}` plus a `focus-visible` ring to `HeaderHint`'s trigger, mirroring `EligibilityChip`'s exact pattern. Re-verified after the fix: both triggers now behave identically — Tab reaches them, focus opens the tooltip (`instant-open`), Escape closes it, and focus stays on the trigger. `eligibility-chip.tsx` also appears in the diff (per the acceptance criteria) with a comment documenting the verified invariant, so a future edit doesn't accidentally drop the `tabIndex` that makes this work.

No visual output, props, `RULE`/`TONE`/`ELIGIBILITY_LABEL` content, or other `endpoint-list.tsx` tooltip usages (copy-URL, open-URL buttons) changed. No new shared component or file, per the issue's own non-goals.

Closes #3433

## Screenshots

Since the default (unfocused) appearance is unchanged, screenshots capture the *focused* state — the only state that visibly differs — at the `/subnets/1?tab=endpoints` table, both themes. Live endpoint data is used (no mocking needed here).

| Trigger · Theme | Before | After |
| --- | --- | --- |
| HeaderHint ("Eligibility" header) · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-light-before.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-light-before.png)<br><sub>real Tab presses skip right past it to the next control — no ring, no tooltip</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-light-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-light-after.png)<br><sub>focus ring + tooltip open, matching EligibilityChip</sub> |
| HeaderHint ("Eligibility" header) · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-dark-before.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-dark-before.png)<br><sub>no focus indicator anywhere near it</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-dark-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-header-hint-focused-dark-after.png)<br><sub>focus ring now visible (tooltip's open state confirmed separately via scripted DOM check — see test plan)</sub> |
| EligibilityChip (row chip) · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-light-before.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-light-before.png)<br><sub>already correct — unaffected by this PR</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-light-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-light-after.png)<br><sub>identical — no regression</sub> |
| EligibilityChip (row chip) · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-dark-before.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-dark-before.png)<br><sub>already correct — unaffected by this PR</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-dark-after.png" width="320">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433-eligibility-chip-focused-dark-after.png)<br><sub>identical — no regression</sub> |

(Programmatically forcing `:focus-visible` for a screenshot is inherently a little flaky in headless Chrome regardless of the fix — the dark HeaderHint capture shows the new ring reliably; the Radix `data-state="instant-open"` + tooltip-role assertions in the test plan below are the authoritative check that the tooltip content itself opens, and they pass consistently.)

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (706 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification via a scripted Playwright check against `/subnets/1?tab=endpoints`, before and after: real Tab navigation reaches `HeaderHint` only after the fix; focusing either trigger sets `data-state="instant-open"` and renders a `[role="tooltip"]`; `Escape` sets `data-state="closed"` and removes it; focus remains on the trigger throughout for both components
