### PR TITLE
fix(ui): make the endpoint-list HeaderHint tooltip trigger keyboard-operable

### DIFF
--- a/apps/ui/src/components/metagraphed/eligibility-chip.tsx
+++ b/apps/ui/src/components/metagraphed/eligibility-chip.tsx
@@ -35,6 +35,14 @@ export function EligibilityChip({
     <TooltipProvider delayDuration={120}>
       <Tooltip>
         <TooltipTrigger asChild>
+          {/* #3433: tabIndex is what makes this trigger keyboard-operable at
+              all -- Radix only opens the Tooltip on a focus event, and a
+              plain span never receives one without it. Verified via a
+              scripted focus/Escape check: focus opens the tooltip
+              (data-state instant-open) and Escape closes it while keeping
+              focus on the trigger, with no extra wiring needed beyond
+              this attribute. This is the reference HeaderHint
+              (endpoint-list.tsx) now matches -- don't drop it. */}
           <span
             tabIndex={0}
             className={classNames(

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -398,7 +398,14 @@ function HeaderHint({ label, hint }: { label: string; hint: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex items-center gap-1 cursor-help underline-offset-2 decoration-dotted decoration-ink-subtle hover:decoration-ink-muted">
+        {/* #3433: tabIndex so this trigger is reachable by keyboard at all --
+            without it, Radix's Tooltip never receives the focus event that
+            opens it, so it can't be opened (or Escape-dismissed) via
+            keyboard. Matches EligibilityChip's trigger. */}
+        <span
+          tabIndex={0}
+          className="inline-flex items-center gap-1 cursor-help rounded underline-offset-2 decoration-dotted decoration-ink-subtle hover:decoration-ink-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
           {label}
         </span>
       </TooltipTrigger>


### PR DESCRIPTION
## Summary

Follow-up to #4815, which the automated screenshot check closed for using non-standard row labels ("HeaderHint · Light" instead of "Desktop · Light") instead of the required viewport × theme table. Same fix, now with the full standard screenshot matrix.

Before touching anything, I drove both triggers with real keyboard/DOM assertions (`getAttribute("data-state")`, `document.activeElement`, tooltip-role count) to establish exactly what was and wasn't broken, since the issue's premise ("neither trigger is fully keyboard-operable") turned out to only be half true:

- **`EligibilityChip`** (`apps/ui/src/components/metagraphed/eligibility-chip.tsx`) already had `tabIndex={0}` on its `TooltipTrigger` span. Verified: real Tab focus → `data-state="instant-open"` (tooltip opens) → `Escape` → `data-state="closed"`, focus retained on the trigger. This already worked correctly; no functional change was needed.
- **`HeaderHint`** (`apps/ui/src/components/metagraphed/endpoint-list.tsx`) had **no `tabIndex` at all**. Verified: calling `.focus()` on it never moved `document.activeElement` to it — it is not a focusable element, so Radix's Tooltip (which opens on a `focus` event) can never receive keyboard focus in the first place. This is the actual bug, and it's more fundamental than "Escape doesn't dismiss": the tooltip can't even be opened via keyboard, let alone dismissed.

Fix: add `tabIndex={0}` plus a `focus-visible` ring to `HeaderHint`'s trigger, mirroring `EligibilityChip`'s exact pattern. Re-verified after the fix: both triggers now behave identically — Tab reaches them, focus opens the tooltip (`instant-open`), Escape closes it, and focus stays on the trigger. `eligibility-chip.tsx` also appears in the diff (per the acceptance criteria) with a comment documenting the verified invariant, so a future edit doesn't accidentally drop the `tabIndex` that makes this work.

No visual output, props, `RULE`/`TONE`/`ELIGIBILITY_LABEL` content, or other `endpoint-list.tsx` tooltip usages (copy-URL, open-URL buttons) changed. No new shared component or file, per the issue's own non-goals.

Closes #3433

## Screenshots

`/subnets/1?tab=endpoints`, real live endpoint data (no mocking needed). At each viewport/theme, the shot is taken right after focusing the "Eligibility" column header (`>= md`, table layout) or, at Mobile where the table collapses to a card list with no column headers at all, the equivalent `EligibilityChip` inside the first card.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-light-before.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-light-before.png)<br><sub>no ring — not focusable</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-light-after.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-light-after.png)<br><sub>ring appears — now focusable</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-dark-before.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-dark-before.png)<br><sub>no ring — not focusable</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-dark-after.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-desktop-dark-after.png)<br><sub>ring appears — now focusable</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-light-before.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-light-before.png)<br><sub>no ring — not focusable</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-light-after.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-light-after.png)<br><sub>ring appears — now focusable</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-dark-before.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-dark-before.png)<br><sub>no ring — not focusable</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-dark-after.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-tablet-dark-after.png)<br><sub>ring appears — now focusable</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-light-before.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-light-before.png)<br><sub>EligibilityChip only — no `<table>`/`<th>` exists below `md`, so HeaderHint has no mobile equivalent to change; identical before/after confirms no regression here</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-light-after.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-light-after.png)<br><sub>identical to before</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-dark-before.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-dark-before.png)<br><sub>EligibilityChip only, same reasoning as above</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-dark-after.png" width="280">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/eligibility-chip-tooltip-keyboard-3433v2-mobile-dark-after.png)<br><sub>identical to before</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (706 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual verification via a scripted Playwright check against `/subnets/1?tab=endpoints`, before and after: real Tab navigation reaches `HeaderHint` only after the fix; focusing either trigger sets `data-state="instant-open"` and renders a `[role="tooltip"]`; `Escape` sets `data-state="closed"` and removes it; focus remains on the trigger throughout for both components
