### PR TITLE
feat(ui): label account last-seen/first-indexed as near-realtime tier

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -262,7 +262,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           icon={Clock}
           eyebrow="Last seen"
           value={<TimeAgo at={account.last_seen_at ?? undefined} />}
-          hint="chain-direct index"
+          hint="near-realtime · chain-direct index"
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
       </div>
@@ -2183,7 +2183,7 @@ function AccountHeroAside({
           icon={Clock}
           label="First indexed"
           value={firstSeenAt ? <TimeAgo at={firstSeenAt} /> : "—"}
-          accent="chain-direct"
+          accent="near-realtime"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Label the account detail page's "Last seen" tile and its "First indexed" hero-aside counterpart with an explicit **near-realtime** tier, so a reader can tell at a glance that this data is continuously chain-indexed (poller-lag-bound) rather than fully live/RPC-realtime like the adjacent Balance tile, or a periodic daily-batch snapshot like the metagraph tier. Presentation-only — the underlying `last_seen_at` / `first_seen_at` fields are unchanged.

## What Changed

`apps/ui/src/routes/accounts.$ss58.tsx` only — two label swaps:

- **"Last seen" `StatTile`** — `hint` changed from `"chain-direct index"` to `"near-realtime · chain-direct index"`, so the tier is named rather than just showing a bare relative time.
- **"First indexed" `HeroAsideRow`** — `accent` changed from `"chain-direct"` to `"near-realtime"`, giving it matching tier language instead of an unlabeled source tag.

The shared `FreshnessBadge` (`components/metagraphed/freshness-badge.tsx`) only models `"realtime"` (→ "Live") and `"daily"` (→ "Daily rollup") tiers — both reserved words this page must avoid — so, as the issue sanctions, this ships an inline plain-text tier label that can be swapped for the shared component once it grows a `near-realtime` tier. The tier wording deliberately avoids bare "live"/"realtime" (reserved for the RPC-backed Balance tile) and "daily" (the metagraph-snapshot tier).

No backend/API/type/query changes; the Balance, Events, and Subnets tiles are untouched.

## Screenshots

Account detail page (`/accounts/<ss58>`). Mobile stacks the stat tiles and hides the hero aside, so the "First indexed" row is desktop/tablet-only there; the "Last seen" tile hint change is visible on every viewport.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3378-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

All run with `--workspace=apps/ui` (Node 22):

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — changed file clean
- [x] `npm run typecheck`
- [x] `npm test` — 706 passed
- [x] `npm run build`
- [x] `git diff --check`

## Registry Safety

- [x] Links a tracked, currently-open issue — `Closes #3378`.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts hand-edited; scoped to a single route file.
- [x] No public API/OpenAPI/schema surface changed — display-only.

Closes #3378
