### PR TITLE
fix(data): stop binding a JS array for neurons-sync's per-netuid prune

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -83,6 +83,19 @@ vi.mock("postgres", () => ({
       return Promise.resolve(mockRows.current);
     }
     sql.end = () => Promise.resolve();
+    // sql.unsafe(text, params) -- the neurons-sync prune's per-netuid VALUES
+    // join (#4771 hotfix: a bound JS array broke under this Worker's real
+    // Hyperdrive `fetch_types: false` setting, so the prune builds its own
+    // placeholder text instead of relying on tagged-template array binding).
+    // Recorded into the SAME sqlCalls list so existing assertions work
+    // unchanged regardless of which call form produced them.
+    sql.unsafe = (text, params = []) => {
+      sqlCalls.push({ text, values: params });
+      if (/DELETE FROM neurons/.test(text)) {
+        return Promise.resolve(neuronsSyncPruneRows.current);
+      }
+      return Promise.resolve(mockRows.current);
+    };
     // sql.begin(["read only",] cb) reserves a connection for cb in real
     // postgres.js; the mock just invokes cb with this same sql function so
     // every existing tagged-template assertion (sqlCalls, mockQueue) still
@@ -1067,6 +1080,24 @@ test("neurons-sync upserts neurons + neuron_daily and reports written counts", a
   expect(queryText()).toMatch(/DELETE FROM neurons/);
 });
 
+test("neurons-sync computes one max captured_at per netuid across its many UID rows (the realistic multi-UID-per-subnet case)", async () => {
+  // Real payloads have ~256 UID rows per netuid sharing one captured_at; a
+  // later row for a netuid already seen must not incorrectly lower or
+  // duplicate its recorded threshold.
+  await postNeurons(
+    [
+      neuronSyncRow({ netuid: 8, uid: 0, captured_at: 1000 }),
+      neuronSyncRow({ netuid: 8, uid: 1, captured_at: 1000 }),
+      neuronSyncRow({ netuid: 8, uid: 2, captured_at: 1000 }),
+    ],
+    { secret: NEURONS_SYNC_SECRET },
+  );
+  const pruneCall = sqlCalls.find((c) => /DELETE FROM neurons/.test(c.text));
+  // One (netuid, captured_at) pair, not three -- the repeat rows for netuid 8
+  // collapse to a single threshold entry.
+  expect(pruneCall.values).toEqual([8, 1000]);
+});
+
 test("neurons-sync coerces 0/1 active/validator_permit/is_immunity_period to real booleans", async () => {
   await postNeurons(
     [
@@ -1114,8 +1145,11 @@ test("neurons-sync scopes the deregistered-UID prune to only the netuids present
     { secret: NEURONS_SYNC_SECRET },
   );
   const pruneCall = sqlCalls.find((c) => /DELETE FROM neurons/.test(c.text));
-  expect(pruneCall.values[0]).toEqual(expect.arrayContaining([8, 9]));
-  expect(pruneCall.values[0]).toHaveLength(2);
+  // Flat (netuid, captured_at) pairs -- sql.unsafe positional params, not a
+  // bound array (see the #4771 hotfix comment in handleNeuronsSync).
+  expect(pruneCall.values).toEqual(expect.arrayContaining([8, 9]));
+  expect(pruneCall.values).toHaveLength(4);
+  expect(pruneCall.text).toMatch(/\$1::int, \$2::bigint/);
 });
 
 // REGRESSION (Gittensory Gate finding, 2026-07-10): the prune threshold must
@@ -1133,12 +1167,16 @@ test("neurons-sync prunes each netuid against its OWN max captured_at, not the b
     { secret: NEURONS_SYNC_SECRET },
   );
   const pruneCall = sqlCalls.find((c) => /DELETE FROM neurons/.test(c.text));
-  const [netuids, thresholds] = pruneCall.values;
-  expect(netuids).toEqual(expect.arrayContaining([8, 9]));
+  // Flat (netuid, captured_at) pairs, in netuid-first-seen order.
+  const pairs = [];
+  for (let i = 0; i < pruneCall.values.length; i += 2) {
+    pairs.push([pruneCall.values[i], pruneCall.values[i + 1]]);
+  }
+  const byNetuid = new Map(pairs);
   // Each netuid's threshold must equal ITS OWN captured_at from this batch --
   // never the other netuid's (which the old shared-max bug would have used).
-  expect(thresholds[netuids.indexOf(8)]).toBe(1000);
-  expect(thresholds[netuids.indexOf(9)]).toBe(2000);
+  expect(byNetuid.get(8)).toBe(1000);
+  expect(byNetuid.get(9)).toBe(2000);
 });
 
 test("neurons-sync reports deregistered_pruned from the DELETE's returned row count", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -235,7 +235,6 @@ async function handleNeuronsSync(request, env) {
       netuidMaxCapturedAt.set(row.netuid, row.captured_at);
   }
   const netuids = [...netuidMaxCapturedAt.keys()];
-  const netuidThresholds = netuids.map((n) => netuidMaxCapturedAt.get(n));
 
   const sql = postgres(env.HYPERDRIVE.connectionString, {
     max: 5,
@@ -323,17 +322,32 @@ async function handleNeuronsSync(request, env) {
       // `!incoming.length` check guarantees at least one row, and every row
       // has a netuid.
       //
-      // unnest() zips netuids/netuidThresholds positionally into a per-netuid
-      // threshold table -- each netuid is only pruned against ITS OWN max
-      // captured_at, never another netuid's, closing the cross-netuid
-      // data-loss gap a single shared threshold would open.
-      const pruned = await sql`
-          DELETE FROM neurons n
-          USING unnest(${netuids}::int[], ${netuidThresholds}::bigint[])
-            AS batch(netuid, captured_at)
-          WHERE n.netuid = batch.netuid
-            AND n.captured_at < batch.captured_at
-          RETURNING n.netuid`;
+      // The VALUES join builds a per-netuid threshold table -- each netuid is
+      // only pruned against ITS OWN max captured_at, never another netuid's,
+      // closing the cross-netuid data-loss gap a single shared threshold
+      // would open. Built via sql.unsafe with explicit-cast positional
+      // placeholders (plain scalar binds, one per cell) rather than a bound
+      // JS array -- confirmed live 2026-07-10 that Hyperdrive's recommended
+      // `fetch_types: false` (this Worker's own setting, above) breaks
+      // postgres.js's automatic ARRAY-literal serialization (`ANY($1)`/
+      // `unnest($1::int[])` sent a malformed literal with no braces), while
+      // scalar binds -- the only kind every other query in this Worker
+      // uses -- are unaffected.
+      const valuesSql = netuids
+        .map((_, i) => `($${i * 2 + 1}::int, $${i * 2 + 2}::bigint)`)
+        .join(", ");
+      const pruneParams = netuids.flatMap((netuid) => [
+        netuid,
+        netuidMaxCapturedAt.get(netuid),
+      ]);
+      const pruned = await sql.unsafe(
+        `DELETE FROM neurons n
+         USING (VALUES ${valuesSql}) AS batch(netuid, captured_at)
+         WHERE n.netuid = batch.netuid
+           AND n.captured_at < batch.captured_at
+         RETURNING n.netuid`,
+        pruneParams,
+      );
 
       return writeJson({
         ok: true,


### PR DESCRIPTION
## Summary

Live incident discovered during #4771's first real production run (after
#4777 merged and the Cloudflare Workers Builds deploy-command typo was
fixed): every neurons-sync request's prune step failed with

```
PostgresError: malformed array literal: "0,1,2,3,...,128"
```

D1 was unaffected (the sync step is designed to degrade to a `::warning::`
annotation on failure, never blocking the daily cron's real dependency), but
the new Postgres write path's deregistered-UID prune never actually ran on
any live request.

**Root cause**: this Worker's Hyperdrive-recommended `fetch_types: false`
setting disables the type-introspection round trip postgres.js needs to
serialize a bound JS array as a Postgres `ARRAY` parameter — confirmed via
`wrangler tail` against a real ~30k-row production payload (downloaded from
the workflow run's own artifact) that scalar binds work fine (the INSERT/
UPDATE statements never errored), but the array-bound `unnest($1::int[], ...)`
in the prune DELETE sent a bare `Array.prototype.toString()` — no braces,
not a valid Postgres array literal.

## Fix

Build the per-netuid threshold table as a literal `VALUES ($1::int, $2::bigint), ...`
list via `sql.unsafe(text, params)` with manually-numbered placeholders,
binding each `(netuid, captured_at)` pair as plain scalar parameters instead
of one bound array — the same kind of bind every other query in this file
already uses successfully.

## Test plan

- [x] `npx vitest run tests/data-api.test.mjs` — 79/79 passing, including
      updated assertions for the new flat-params shape and a new test for
      the realistic case (~256 UID rows per netuid, all sharing one
      `captured_at`) confirming the per-netuid max collapses correctly.
- [x] `npm run lint` / `npm run format:check` clean.
- [x] Patch coverage on the changed lines: 99.65% branches (only pre-existing,
      unrelated gaps remain).
- [x] Full suite: `npm test` — 7158/7158 passing.

Once merged and deployed, will re-verify live via `wrangler tail` against a
manually-triggered `refresh-metagraph.yml` run before considering this fully
closed out.

Closes #4771 (follow-up)