### PR TITLE
fix(ssrf): block IPv6 discard-only and NAT64 local-use in webhook and probe guards

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -99,7 +99,13 @@ function isUnsafeIpv6Literal(host) {
     host.startsWith("fe") ||
     host.startsWith("fc") ||
     host.startsWith("fd") ||
-    host.startsWith("ff")
+    host.startsWith("ff") ||
+    // 0100::/8 discard-only (RFC 6666) and NAT64 local-use 64:ff9b:1::/48
+    // (RFC 8215, which can tunnel a v4 like 169.254.169.254 past the well-known
+    // 64:ff9b::/96 check) were missing here while the prober guard already
+    // rejects both — close the parity gap (#1538/#2375).
+    host.startsWith("100:") ||
+    host.startsWith("64:ff9b:1:")
   );
 }
 

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -105,6 +105,8 @@ export function isPublicWebhookAddress(value) {
       host.startsWith("fc") || // unique-local fc00::/7
       host.startsWith("fd") ||
       host.startsWith("ff") || // ff00::/8 multicast — not global unicast (2000::/3), matching the prober guard (#1538)
+      host.startsWith("100:") || // 0100::/8 discard-only (RFC 6666) — not routable, matching the prober guard
+      host.startsWith("64:ff9b:1:") || // NAT64 local-use 64:ff9b:1::/48 (RFC 8215) tunnels a v4 the well-known-prefix check below can't see (e.g. 64:ff9b:1::a9fe:a9fe = 169.254.169.254)
       host.startsWith("::ffff:") // IPv4-mapped
     ) {
       return false;

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -191,6 +191,20 @@ describe("isUnsafePublicUrl", () => {
     }
   });
 
+  test("blocks IPv6 discard-only (0100::/8) and NAT64 local-use (64:ff9b:1::/48)", () => {
+    // Both are non-public ranges the prober guard already rejects. 64:ff9b:1::/48
+    // (RFC 8215) can tunnel a v4 the well-known-prefix (64:ff9b::/96) decoder can't
+    // see — [64:ff9b:1::a9fe:a9fe] is 169.254.169.254 (cloud metadata).
+    for (const url of [
+      "http://[100::1]/x",
+      "http://[64:ff9b:1::a9fe:a9fe]/x",
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+    // The well-known-prefix NAT64 of a public v4 stays allowed (no over-block).
+    assert.equal(isUnsafePublicUrl("https://[64:ff9b::808:808]/x"), false);
+  });
+
   test("blocks a reserved/multicast v4 tunnelled inside an IPv6 literal host", () => {
     for (const url of [
       "http://[2002:e000:1::]/x", // 6to4 of 224.0.0.1 multicast

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -75,6 +75,17 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("64:ff9b::808:808"), true);
   });
 
+  test("IPv6 discard-only (0100::/8) and NAT64 local-use (64:ff9b:1::/48) → false", () => {
+    // 0100::/8 is RFC 6666 discard-only — not routable. 64:ff9b:1::/48 is RFC 8215
+    // NAT64 local-use: unlike the well-known 64:ff9b::/96 (caught by the embedded-v4
+    // check), it tunnels a v4 the guard can't decode — e.g. 64:ff9b:1::a9fe:a9fe is
+    // 169.254.169.254 (cloud metadata). The prober guard rejects both; this must too.
+    assert.equal(isPublicWebhookAddress("100::1"), false);
+    assert.equal(isPublicWebhookAddress("64:ff9b:1::a9fe:a9fe"), false);
+    // The well-known-prefix NAT64 of a public v4 is unaffected (stays routable).
+    assert.equal(isPublicWebhookAddress("64:ff9b::808:808"), true);
+  });
+
   test("private IPv4 literals → false", () => {
     assert.equal(isPublicWebhookAddress("10.0.0.1"), false);
     assert.equal(isPublicWebhookAddress("127.0.0.1"), false);


### PR DESCRIPTION
## Summary
- Align `isPublicWebhookAddress` (webhooks) and `isUnsafeIpv6Literal` (health-probe-core) with the prober guard by rejecting two non-public IPv6 ranges already blocked elsewhere:
  - `0100::/8` — RFC 6666 discard-only (not routable)
  - `64:ff9b:1::/48` — RFC 8215 NAT64 local-use; unlike the well-known `64:ff9b::/96` prefix, this form tunnels an IPv4 address the embedded-v4 check cannot decode (e.g. `64:ff9b:1::a9fe:a9fe` → 169.254.169.254 / cloud metadata)
- Add regression tests for both guards; well-known-prefix NAT64 of a public v4 (`64:ff9b::808:808` = 8.8.8.8) remains allowed.

## Test plan
- [x] `npm test -- tests/health-probe-core.test.mjs tests/webhooks-core.test.mjs`
- [ ] CI Validate (test, checks, changes, ui, python)
- [ ] Superagent Security Scan
- [ ] codecov/patch
