### PR TITLE
feat(data): flip METAGRAPH_NEURONS_SOURCE to postgres

### DIFF
--- a/docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md
+++ b/docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md
@@ -247,23 +247,29 @@ silently drift from each other.
    quantify what step 4's accepted gap covers, now that it's no longer a
    precondition for the flip — do this to inform step 7's backfill scope,
    not to re-gate a decision already made.
-10. 🔲 **neurons/neuron_daily write path built (#4771), not yet flipped.**
-    Unlike blocks/extrinsics/account_events, this tier had NO Postgres
-    equivalent at all before #4771 — `workers/data-api.mjs` gained one write
-    route (`POST /api/v1/internal/neurons-sync`, `handleNeuronsSync`) that
-    upserts both tables from the same daily `refresh-metagraph.yml` fetch,
-    alongside (not replacing) the existing R2-stage-to-D1 path. Deliberately
-    NOT a fifth dedicated Worker: it targets the IDENTICAL Postgres instance
+10. ✅ **neurons/neuron_daily write path built + flipped (#4771).** Unlike
+    blocks/extrinsics/account_events, this tier had NO Postgres equivalent at
+    all before #4771 — `workers/data-api.mjs` gained one write route
+    (`POST /api/v1/internal/neurons-sync`, `handleNeuronsSync`) that upserts
+    both tables from the same daily `refresh-metagraph.yml` fetch, alongside
+    (not replacing) the existing R2-stage-to-D1 path. Deliberately NOT a
+    fifth dedicated Worker: it targets the IDENTICAL Postgres instance
     `data-api.mjs` already reads from, unlike `registry-sync-api.mjs`'s split
     (a genuinely separate database, isolated on purpose) — splitting read and
     write for the same database would have added a whole Worker/config/
     binding/secret for zero bundle-budget benefit.
-    `METAGRAPH_NEURONS_SOURCE` gates a new read tier the same way the other
-    three flags do. Left at `"d1"` until a live parity pass proves the two
-    tiers agree — this step is intentionally NOT bundled into item 4's
-    relaxed-gate decision, since that item was about accepting known gaps in
-    already-populated Postgres data, not about flipping a tier with zero
-    verification history yet.
+    A real live-cron run hit a genuine bug the first time (a bound JS array
+    serializing incorrectly under this Worker's `fetch_types: false`
+    Hyperdrive setting — fixed by binding scalars via `sql.unsafe` instead;
+    caught via `wrangler tail` against a real production payload, not a
+    guess). Once fixed, `METAGRAPH_NEURONS_SOURCE` flipped to `"postgres"`
+    the same day: the daily cron synced 30,323 rows into a Postgres that
+    started completely empty, and a sampled row (netuid=8, uid=0) matched D1
+    field-for-field, including full-precision decimals and the 0/1-to-boolean
+    mapping. Stronger than the other three tiers' first (reverted) attempt,
+    which compared a row present in BOTH stores and couldn't distinguish
+    genuine Postgres serving from a silently masked D1 fallback (#4686) —
+    here Postgres had no prior data at all, so a correct row is unambiguous.
 
 ## Links/resources
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -190,14 +190,20 @@
     // turnover/analytics) remain D1-only, portable one at a time under this
     // same flag in follow-up work.
     "METAGRAPH_ACCOUNT_EVENTS_SOURCE": "postgres",
-    // neurons/neuron_daily (#4771): the per-UID metagraph pipeline has NO
-    // Postgres equivalent yet as of this flag's addition -- refresh-metagraph.yml
-    // writes to the new neurons-sync Worker alongside its existing D1 path
-    // (verification window), but nothing has confirmed Postgres and D1 agree
-    // yet. Left "d1" (the tryPostgresTier fallback is a no-op at "d1") until a
-    // live verification pass proves parity, per ADR 0014's flip criteria --
-    // do NOT flip this alongside the other three just because they're nearby.
-    "METAGRAPH_NEURONS_SOURCE": "d1",
+    // neurons/neuron_daily (#4771): FLIPPED to "postgres" 2026-07-10, after a
+    // live parity pass. refresh-metagraph.yml's real daily-cron run (not just
+    // a manual trigger) synced 30,323 rows into a Postgres that started
+    // completely empty; a sampled row (netuid=8, uid=0) matched D1 field-for-
+    // field, including full-precision decimals (dividends) and the 0/1-to-
+    // boolean mapping (active/validator_permit/is_immunity_period) -- a
+    // stronger check than the other three tiers' first (reverted) attempt,
+    // which compared a row present in BOTH stores and couldn't distinguish
+    // genuine Postgres serving from a silently masked D1 fallback (#4686).
+    // Here Postgres had no prior data at all, so a correct sampled row is
+    // unambiguous proof the new pipeline (workers/data-api.mjs's
+    // handleNeuronsSync) actually works end-to-end. tryPostgresTier still
+    // falls back to D1 on any failure, so this remains a single-flag revert.
+    "METAGRAPH_NEURONS_SOURCE": "postgres",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
   // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the


### PR DESCRIPTION
## Summary

Live verification complete for #4771's Postgres write path — flipping the
serving flag now that it's genuinely proven, not just built.

**What was verified** (see #4771 and the #4821 hotfix for the build/bugfix
history):

- `refresh-metagraph.yml`'s real daily-cron run (not a synthetic test) synced
  30,323 rows into a Postgres `neurons`/`neuron_daily` that started
  **completely empty**.
- A sampled row (`netuid=8, uid=0`) queried directly via SQL from **both**
  D1 and Postgres matches **field-for-field** — including full-precision
  decimals (`dividends: 0.005661097123674372`) and the D1-integer-to-
  Postgres-boolean mapping (`active: 0 → f`, `validator_permit: 1 → t`).
- Row counts agree: D1 `COUNT(*) = 30323`, Postgres sync response
  `neurons_written: 30323`.

This is a **stronger** check than blocks/extrinsics/account_events' first
(reverted) cutover attempt, which compared a row present in *both* stores
and couldn't distinguish genuine Postgres serving from a silently-masked D1
fallback (#4686's root cause). Here Postgres had **zero** prior data, so a
correct sampled row is unambiguous proof the new write+read pipeline
actually works end-to-end.

`tryPostgresTier` still falls back to D1 on any failure, so this remains a
single-flag, instantly-reversible change — same posture as the other three
tiers.

## Test plan

- [x] `npm run lint` / `npm run format:check` clean.
- [x] Full suite: `npm test` — 7158/7158 passing (config/doc-only change, no
      code touched).
- [x] Live verification performed directly against production D1 + Postgres
      (documented above and in ADR 0014's updated Sequencing item 10).

Closes #4771