### PR TITLE
fix(ui): interpolate live windowLabel in subnet economics/masthead prose (#3949)

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -48,7 +48,7 @@ function StakeMovesTile({ netuid }: { netuid: number }) {
       chart={
         <SparkLegend
           metric="Stake moves"
-          source={`On-chain StakeMoved (re-delegation) events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          source={`On-chain StakeMoved (re-delegation) events for SN${netuid} over the trailing ${card?.window ?? "30d"} window — ${m.summary}.`}
           windowLabel={card?.window ?? "30d"}
           updatedAt={card?.observed_at ?? null}
           staleness="Counts settle as the chain-events indexer catches up; the bar hides when no re-delegations occurred in the window."
@@ -87,7 +87,7 @@ function StakeTransfersTile({ netuid }: { netuid: number }) {
       chart={
         <SparkLegend
           metric="Stake transfers"
-          source={`On-chain stake-transfer events for SN${netuid} over the trailing 30-day window — ${m.summary}.`}
+          source={`On-chain stake-transfer events for SN${netuid} over the trailing ${card?.window ?? "30d"} window — ${m.summary}.`}
           windowLabel={card?.window ?? "30d"}
           updatedAt={card?.observed_at ?? null}
           staleness="Counts settle as the chain-events indexer catches up; the bar hides when no transfers occurred in the window."

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -422,7 +422,7 @@ export function SubnetMasthead({
           label="Registrations"
           value={formatNumber(reg?.registrations)}
           hint={`${formatNumber(reg?.distinct_registrants ?? 0)} registrants`}
-          full="Neuron-registration events on this subnet over the trailing 30-day window."
+          full={`Neuron-registration events on this subnet over the trailing ${reg?.window ?? "30d"} window.`}
           updatedAt={reg?.observed_at ?? null}
           windowLabel={reg?.window ?? "30d"}
         />
@@ -430,7 +430,7 @@ export function SubnetMasthead({
           label="Deregistrations"
           value={formatNumber(dereg?.deregistrations)}
           hint={`${formatNumber(dereg?.distinct_deregistered_hotkeys ?? 0)} hotkeys`}
-          full="Neuron-deregistration (eviction) events on this subnet over the trailing 30-day window."
+          full={`Neuron-deregistration (eviction) events on this subnet over the trailing ${dereg?.window ?? "30d"} window.`}
           updatedAt={dereg?.observed_at ?? null}
           windowLabel={dereg?.window ?? "30d"}
         />


### PR DESCRIPTION
## Summary

The subnet-scoped twin of the account-page fix (#3948, merged). `economics-panel.tsx` (`StakeMovesTile`, `StakeTransfersTile`) and `subnet-masthead.tsx` (registration/deregistration `StatWithSpark` tiles) each pass a live `windowLabel={…?.window ?? "30d"}` prop that renders correctly — but the `source`/`full` prose strings passed alongside were separate hardcoded literals reading "over the trailing **30-day** window" instead of interpolating the same in-scope window value.

This interpolates the matching `…?.window ?? "30d"` value into all four prose strings, so the prose tracks the real window instead of a literal (matching the sibling account-page fix).

## Change

- 2 files, +4/−4: `economics-panel.tsx` (2 `source` strings) and `subnet-masthead.tsx` (2 `full` strings) → interpolate `\${…?.window ?? "30d"}`.
- Uses the exact same window expression already passed to the adjacent `windowLabel` prop; no new variables.
- Account-page sections untouched (sibling issue's scope, per non-goals).

## Behavioral verification

Verified live on `/subnets/1`: after the fix the DOM contains "trailing **30d** window" and no longer contains "trailing 30-day window". Mocking the registrations endpoint with `window: "7d"` renders "trailing **7d** window" in the tile popover — confirming the prose now tracks a non-default window instead of a literal.

## Screenshots

Subnet masthead Registrations tile popover (the affected prose). **Before:** "over the trailing **30-day** window." **After:** "over the trailing **30d** window." — matching the "· 30d window" line beneath it. Default 30d case; page otherwise identical.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3949/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 717 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Closes #3949
