### PR TITLE
fix(ui): lift loading skeleton to bg-surface-2 for dark-mode visibility (#3993)

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -224,7 +224,10 @@ export function StaleBanner({
 }
 
 export function Skeleton({ className = "h-4 w-full" }: { className?: string }) {
-  return <div className={`animate-pulse rounded bg-surface ${className}`} />;
+  // #3993: bg-surface-2 (a step lifted from bg-surface) keeps the pulse visible
+  // against the similarly-dark page background in dark mode, where plain
+  // bg-surface blended into invisibility.
+  return <div className={`animate-pulse rounded bg-surface-2 ${className}`} />;
 }
 
 /**


### PR DESCRIPTION
## Summary

The shared `Skeleton` loading placeholder (`apps/ui/src/components/metagraphed/states.tsx`) used `bg-surface`, which in **dark mode** (`--surface` = `oklch(0.175…)`) sits almost on top of the page background — the pulse placeholder blended into an unexplained blank void rather than reading as a loading indicator (as seen on the account page's Signed Extrinsics / Transfers sections mid-load).

This lifts the skeleton to **`bg-surface-2`** (`--surface-2` = `oklch(0.215…)` in dark, a step lighter), so the placeholder is visibly distinguishable from the page background while keeping the `animate-pulse` shimmer. In light mode `--surface-2` is a light gray (vs pure-white `--surface`), so the skeleton stays clearly visible there too.

## Change

- One file, +4/−1: `bg-surface` → `bg-surface-2` on the `Skeleton` component.
- `bg-surface-2` is an existing token already used for skeletons elsewhere (e.g. `subnet-health-matrix.tsx`). No shape/size/usage change (issue non-goals).

## Screenshots (captured mid-load in dark mode, per the issue)

Account page during a genuinely-pending load (account queries held open, so the `DetailSkeleton` stays on screen). **Dark · Before:** the skeleton blocks are near-invisible dark voids. **Dark · After:** the same blocks read as distinct lifted panels against the page background. Light mode is unaffected.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3993/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 717 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Verified mid-load in-browser: the rendered skeletons carry `bg-surface-2` in both themes.

Closes #3993
