### PR TITLE
feat(ui) daily rollup freshness label on metagraph panel (#3381)

### DIFF
--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,6 +6,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { FreshnessIndicator } from "@/components/metagraphed/freshness";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
@@ -62,6 +63,13 @@ export function MetagraphTableLoader({
     );
   }
 
+  const freshness = (
+    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+      Daily rollup
+      <FreshnessIndicator at={meta?.generated_at} />
+    </span>
+  );
+
   return (
     <div className="space-y-4">
       {/* KPI strip — neuron + validator counts and the dominant-UID stake share. */}
@@ -91,17 +99,22 @@ export function MetagraphTableLoader({
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex items-center justify-between">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
-            <span className="font-mono text-[10px] text-ink-muted">
-              peak {taoCompact(stakeBars[0]?.value)} τ
+            <span className="ml-auto flex items-center gap-3">
+              <span className="font-mono text-[10px] text-ink-muted">
+                peak {taoCompact(stakeBars[0]?.value)} τ
+              </span>
+              {freshness}
             </span>
           </div>
           <BarMini data={stakeBars} />
         </div>
-      ) : null}
+      ) : (
+        <div className="flex items-center justify-end">{freshness}</div>
+      )}
 
       {/* Permit filter + sortable neuron table. */}
       <div className="flex items-center justify-between gap-3">

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Boxes, Layers, ShieldCheck } from "lucide-react";
 import { subnetMetagraphQuery } from "@/lib/metagraphed/queries";
@@ -63,12 +63,7 @@ export function MetagraphTableLoader({
     );
   }
 
-  const freshness = (
-    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-      Daily rollup
-      <FreshnessIndicator at={meta?.generated_at} />
-    </span>
-  );
+  const freshnessBadge = <DailyRollupFreshness at={meta?.generated_at} />;
 
   return (
     <div className="space-y-4">
@@ -99,25 +94,21 @@ export function MetagraphTableLoader({
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Stake distribution · top {stakeBars.length} UIDs
-            </span>
-            <span className="ml-auto flex items-center gap-3">
-              <span className="font-mono text-[10px] text-ink-muted">
-                peak {taoCompact(stakeBars[0]?.value)} τ
-              </span>
-              {freshness}
-            </span>
-          </div>
+          <StakeDistributionHeader
+            count={stakeBars.length}
+            peakValue={stakeBars[0]?.value}
+            freshness={freshnessBadge}
+          />
           <BarMini data={stakeBars} />
         </div>
       ) : (
-        <div className="flex items-center justify-end">{freshness}</div>
+        <div className="flex justify-end rounded-xl border border-border bg-card px-4 py-3">
+          {freshnessBadge}
+        </div>
       )}
 
       {/* Permit filter + sortable neuron table. */}
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           {filtered.length} of {neurons.length} neurons
         </span>
@@ -145,6 +136,49 @@ export function MetagraphTableLoader({
         selectedUid={selectedUid}
       />
     </div>
+  );
+}
+
+function DailyRollupFreshness({ at }: { at?: string | null }) {
+  return (
+    <div className="flex items-center gap-2 self-start shrink-0">
+      <span className="inline-flex items-center rounded-full border border-border bg-surface/50 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-ink-muted">
+        Daily rollup
+      </span>
+      <FreshnessIndicator at={at} />
+    </div>
+  );
+}
+
+function StakeDistributionHeader({
+  count,
+  peakValue,
+  freshness,
+}: {
+  count: number;
+  peakValue?: number;
+  freshness: ReactNode;
+}) {
+  return (
+    <header className="mb-3 space-y-2 border-b border-border/60 pb-3 sm:space-y-0">
+      <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0">
+          <p className="mg-label">Stake distribution</p>
+          <p className="mt-1 font-mono text-[11px] leading-snug text-ink-subtle">
+            Top {count} UIDs
+            {peakValue != null ? (
+              <>
+                <span aria-hidden className="mx-1.5 text-ink-subtle/40">
+                  ·
+                </span>
+                Peak <span className="text-ink-muted">{taoCompact(peakValue)} τ</span>
+              </>
+            ) : null}
+          </p>
+        </div>
+        {freshness}
+      </div>
+    </header>
   );
 }
 


### PR DESCRIPTION
## Summary

- Surface `meta.generated_at` in the populated metagraph view — not only the empty-state `TableState`
- Add **Daily rollup** + `FreshnessIndicator` in a reworked stake-distribution header — title/subtitle stacked, freshness on its own row on mobile (chip + relative time), border separator before chart
- When stake bars are empty, show the freshness row alone so the label is still visible

Closes #3381 · Part of #2542

## Screenshots

Captured on `/subnets/1?tab=metagraph` (populated metagraph). Fixed viewport only (no full-page scroll). **Before:** `origin/main` (`:5173`). **After:** feature branch (`:5178`).

> **Where to look:** stake-distribution card — after splits title (`Stake distribution`), stats (`Top 12 UIDs · Peak …`), and freshness (`Daily rollup` chip + `4h ago`) onto separate lines; before crams `peak … DAILY ROLLUP 3H AGO` into one messy row.

### Change zone — stake-distribution card (detail crop)

| Before (`peak` only) | After (`Daily rollup` + time) |
| -------------------- | ----------------------------- |
| [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-before-stake-header.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-after-stake-header.png" width="480">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-after-stake-header.png) |

**DOM check @ desktop light:** before `hasDailyRollup: false`, `hasPeakOnly: true`; after `hasDailyRollup: true`.

### Full page context

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-after.png)<br><sub>after</sub> |

### Detail crops — all viewports (stake-distribution card)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-before-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-after-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-light-after-stake-header.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-before-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-after-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-desktop-dark-after-stake-header.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-before-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-after-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-light-after-stake-header.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-before-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-after-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-tablet-dark-after-stake-header.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-before-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-after-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-light-after-stake-header.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-before-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-before-stake-header.png) | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-after-stake-header.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3381-mobile-dark-after-stake-header.png) |

## Test plan

- [ ] Open `/subnets/1?tab=metagraph` with populated neurons
- [ ] See **Daily rollup** + relative time in stake-distribution header
- [ ] Empty metagraph state still shows `TableState` with `generatedAt` — unchanged
- [ ] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui`
- [ ] `npm run build --workspace=apps/ui`