### PR TITLE
fix(data-api): port account_events analytics routes to the Postgres tier

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -179,21 +179,6 @@ CREATE INDEX IF NOT EXISTS idx_nd_netuid_date ON neuron_daily (netuid, snapshot_
 CREATE INDEX IF NOT EXISTS idx_nd_uid_date    ON neuron_daily (netuid, uid, snapshot_date);
 CREATE INDEX IF NOT EXISTS idx_nd_hotkey_date ON neuron_daily (hotkey, snapshot_date);
 
--- ---------------------------------------------------------------------------
--- Economics tiers
--- ---------------------------------------------------------------------------
-
-CREATE TABLE IF NOT EXISTS economics_history (
-  netuid             INTEGER NOT NULL,
-  snapshot_date      DATE NOT NULL,
-  alpha_price_tao    NUMERIC,
-  emission_share     NUMERIC,
-  total_stake_tao    NUMERIC,
-  registration_cost  NUMERIC,
-  PRIMARY KEY (netuid, snapshot_date)
-);
-CREATE INDEX IF NOT EXISTS idx_econ_netuid_date ON economics_history (netuid, snapshot_date);
-
 -- Account daily rollup (#2079 / audit: removes the temp-sort on default account history).
 CREATE TABLE IF NOT EXISTS account_events_daily (
   hotkey           TEXT NOT NULL,

--- a/docs/block-explorer-data-model.md
+++ b/docs/block-explorer-data-model.md
@@ -123,9 +123,10 @@ direct independent cross-check against two sources with zero shared infrastructu
 indexing pipeline (our own archive node for a historical block, `entrypoint-finney.opentensor.ai`
 for a live one): perfect parity, both extrinsic and event content, exact order.
 
-Per-neuron metagraph state is already captured (see above) via D1, not Postgres — the
-Postgres `neurons`/`neuron_daily`/`economics_history` tables exist in the schema as future
-D1→Postgres cutover targets (ADR 0013) but have no writer yet; check D1's route list in
+Per-neuron metagraph state is now served from Postgres (`neurons`/`neuron_daily`, ADR 0014's
+#4771 cutover, flipped 2026-07-10) — the ADR-0013-era `economics_history` table was superseded
+by folding economics columns into D1's/Postgres's `subnet_snapshots` (migration 0008) instead,
+and has been removed from `deploy/postgres/schema.sql` as dead schema. Check D1's route list in
 `workers/config.mjs` before assuming a chain-data tier is missing, the two can diverge.
 
 The one confirmed, unfiled capture gap is **subnet hyperparameters** — no pipeline captures

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1227,3 +1227,265 @@ test("missing Hyperdrive binding is 503", async () => {
   );
   expect(res.status).toBe(503);
 });
+
+// account_events-derived analytics routes (#4826): D1's account_events copy is
+// frozen since the streamer stopped; these port each D1-only analytics route to
+// this already-live Postgres account_events table. Every build*/window map is
+// reused unchanged from its D1 sibling module (pure, store-agnostic) -- only the
+// query + response-shape wiring is new here.
+
+test("GET /api/v1/validators/:hotkey/nominators returns a nominators card shaped like the D1 route", async () => {
+  mockRows.current = [
+    {
+      coldkey: "5Cold",
+      staked_tao: "10",
+      unstaked_tao: "2",
+      event_count: 3,
+      last_observed: "1783600000000",
+      net_staked_tao: "8",
+      gross_staked_tao: "12",
+    },
+  ];
+  const res = await req(`/api/v1/validators/${SS58}/nominators?window=30d`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.nominator_count).toBe(1);
+  expect(body.data.nominators[0].coldkey).toBe("5Cold");
+  expect(body.data.nominators[0].net_staked_tao).toBeCloseTo(8);
+});
+
+test("GET /api/v1/validators/:hotkey/nominators applies an optional coldkey filter", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/validators/${SS58}/nominators?coldkey=5Cold`);
+  expect(queryText()).toContain("AND coldkey =");
+});
+
+test("GET /api/v1/validators/:hotkey/nominators sorts by the requested column", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/validators/${SS58}/nominators?sort=gross_staked`);
+  expect(queryText()).toContain("gross_staked_tao DESC, coldkey ASC");
+});
+
+test("GET /api/v1/accounts/:ss58/weight-setters unions the direct-hotkey and neurons-join branches", async () => {
+  mockRows.current = [
+    {
+      netuid: 4,
+      weight_sets: "3",
+      first_observed: "1783500000000",
+      last_observed: "1783600000000",
+    },
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}/weight-setters?window=7d`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.subnets[0].netuid).toBe(4);
+  expect(body.data.dominant_netuid).toBe(4);
+  const text = queryText();
+  expect(text).toContain("UNION ALL");
+  expect(text).toContain("JOIN account_events e ON e.netuid = n.netuid");
+});
+
+test("GET /api/v1/subnets/:netuid/weights/setters returns a leaderboard + totals", async () => {
+  mockQueue.current = [
+    [
+      {
+        hotkey: SS58,
+        uid: 1,
+        weight_sets: "5",
+        first_set: "1783500000000",
+        last_set: "1783600000000",
+      },
+    ],
+    [
+      {
+        weight_sets: "5",
+        distinct_setters: "1",
+        newest_observed: "1783600000000",
+      },
+    ],
+  ];
+  const res = await req("/api/v1/subnets/4/weights/setters");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.setters[0].weight_sets).toBe(5);
+  expect(body.schema_version).toBe(1);
+});
+
+test("GET /api/v1/accounts/:ss58/stake-flow defaults to summing both directions", async () => {
+  mockRows.current = [
+    {
+      netuid: 4,
+      event_kind: "StakeAdded",
+      total_tao: "10",
+      event_count: 2,
+      last_observed: "1783600000000",
+    },
+  ];
+  await req(`/api/v1/accounts/${SS58}/stake-flow`);
+  expect(queryText()).toContain("event_kind IN (?, ?)");
+});
+
+test("GET /api/v1/accounts/:ss58/stake-flow narrows to one side via ?direction=in", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/stake-flow?direction=in`);
+  const text = queryText();
+  expect(text).toContain("AND event_kind =");
+  expect(text).not.toContain("event_kind IN");
+});
+
+test("GET /api/v1/subnets/:netuid/stake-flow shapes a per-kind rollup", async () => {
+  mockRows.current = [
+    {
+      event_kind: "StakeAdded",
+      total_tao: "10",
+      event_count: 2,
+      last_observed: "1783600000000",
+    },
+  ];
+  const res = await req("/api/v1/subnets/4/stake-flow?direction=out");
+  expect(res.status).toBe(200);
+  expect(queryText()).toContain("AND event_kind =");
+});
+
+test("GET /api/v1/accounts/:ss58/stake-moves groups movements per subnet", async () => {
+  mockRows.current = [
+    {
+      netuid: 4,
+      movements: "2",
+      first_observed: "1783500000000",
+      last_observed: "1783600000000",
+    },
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}/stake-moves`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.subnets[0].movements).toBe(2);
+});
+
+test("GET /api/v1/subnets/:netuid/stake-moves returns the single-row aggregate", async () => {
+  mockRows.current = [
+    { movements: "4", distinct_movers: "3", newest_observed: "1783600000000" },
+  ];
+  const res = await req("/api/v1/subnets/4/stake-moves");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.movements).toBe(4);
+  expect(body.distinct_movers).toBe(3);
+});
+
+test("GET /api/v1/subnets/:netuid/stake-transfers returns the single-row aggregate", async () => {
+  mockRows.current = [
+    { transfers: "6", distinct_senders: "2", newest_observed: "1783600000000" },
+  ];
+  const res = await req("/api/v1/subnets/4/stake-transfers");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.transfers).toBe(6);
+});
+
+const ACCOUNT_FOOTPRINT_ROUTES = [
+  ["registrations", "registrations"],
+  ["serving", "announcements"],
+  ["axon-removals", "removals"],
+  ["prometheus", "announcements"],
+  ["deregistrations", "deregistrations"],
+];
+
+for (const [path, metric] of ACCOUNT_FOOTPRINT_ROUTES) {
+  test(`GET /api/v1/accounts/:ss58/${path} groups the account_events footprint per subnet`, async () => {
+    mockRows.current = [
+      {
+        netuid: 4,
+        metric: "3",
+        first_observed: "1783500000000",
+        last_observed: "1783600000000",
+      },
+    ];
+    const res = await req(`/api/v1/accounts/${SS58}/${path}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.subnets[0][metric]).toBe(3);
+    expect(body.data.subnets[0].netuid).toBe(4);
+  });
+}
+
+const SUBNET_FOOTPRINT_ROUTES = [
+  ["registrations", "registrations", "distinct_registrants"],
+  ["serving", "announcements", "distinct_servers"],
+  ["axon-removals", "removals", "distinct_removers"],
+  ["prometheus", "announcements", "distinct_exporters"],
+  ["deregistrations", "deregistrations", "distinct_deregistered_hotkeys"],
+];
+
+for (const [path, metric, distinct] of SUBNET_FOOTPRINT_ROUTES) {
+  test(`GET /api/v1/subnets/:netuid/${path} returns the single-row subnet aggregate`, async () => {
+    mockRows.current = [
+      { metric: "7", distinctx: "5", newest_observed: "1783600000000" },
+    ];
+    const res = await req(`/api/v1/subnets/4/${path}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[metric]).toBe(7);
+    expect(body[distinct]).toBe(5);
+  });
+
+  test(`GET /api/v1/subnets/:netuid/${path} with no rows returns the zeroed card, not a throw`, async () => {
+    mockRows.current = [];
+    const res = await req(`/api/v1/subnets/4/${path}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[metric]).toBe(0);
+  });
+}
+
+test("GET /api/v1/accounts/:ss58/transfers reuses buildAccountTransfers unchanged", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  const res = await req(`/api/v1/accounts/${SS58}/transfers`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.transfers[0].amount_tao).toBe(1.5);
+  expect(queryText()).toContain("event_kind = 'Transfer'");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers?direction=sent narrows to the hotkey side only", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/transfers?direction=sent`);
+  const text = queryText();
+  expect(text).toContain("AND hotkey =");
+  expect(text).not.toContain("OR coldkey");
+});
+
+test("GET /api/v1/accounts/:ss58/counterparties returns a counterparty leaderboard", async () => {
+  mockRows.current = [
+    {
+      hotkey: SS58,
+      coldkey: "5Cold",
+      amount_tao: "2",
+      block_number: 100,
+      event_index: 0,
+    },
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}/counterparties`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.counterparties[0].address).toBe("5Cold");
+});
+
+test("GET /api/v1/accounts/:ss58/counterparties?counterparty= returns the relationship drilldown", async () => {
+  mockRows.current = [
+    {
+      hotkey: SS58,
+      coldkey: "5Cold",
+      amount_tao: "2",
+      block_number: 100,
+      event_index: 0,
+    },
+  ];
+  const res = await req(
+    `/api/v1/accounts/${SS58}/counterparties?counterparty=5Cold`,
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.counterparty).toBe("5Cold");
+  expect(queryText()).toContain("(hotkey = ");
+});

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1263,7 +1263,7 @@ test("GET /api/v1/validators/:hotkey/nominators applies an optional coldkey filt
 test("GET /api/v1/validators/:hotkey/nominators sorts by the requested column", async () => {
   mockRows.current = [];
   await req(`/api/v1/validators/${SS58}/nominators?sort=gross_staked`);
-  expect(queryText()).toContain("gross_staked_tao DESC, coldkey ASC");
+  expect(queryText()).toContain("gross_staked_tao DESC, 1 ASC");
 });
 
 test("GET /api/v1/accounts/:ss58/weight-setters unions the direct-hotkey and neurons-join branches", async () => {

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1266,6 +1266,54 @@ test("GET /api/v1/validators/:hotkey/nominators sorts by the requested column", 
   expect(queryText()).toContain("gross_staked_tao DESC, 1 ASC");
 });
 
+test("GET /api/v1/validators/:hotkey/nominators sorts by last_activity", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/validators/${SS58}/nominators?sort=last_activity`);
+  expect(queryText()).toContain("last_observed DESC, 1 ASC");
+});
+
+test("GET /api/v1/validators/:hotkey/nominators falls back to the default window for an unrecognized label", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/validators/${SS58}/nominators?window=bogus`);
+  const body = await res.json();
+  expect(body.data.window).toBe("30d");
+});
+
+test("GET /api/v1/validators/:hotkey/nominators computes generatedAt as the newest of multiple rows, ignoring a non-finite timestamp", async () => {
+  mockRows.current = [
+    {
+      coldkey: "5A",
+      staked_tao: "1",
+      unstaked_tao: "0",
+      event_count: 1,
+      last_observed: "not-a-number",
+      net_staked_tao: "1",
+      gross_staked_tao: "1",
+    },
+    {
+      coldkey: "5B",
+      staked_tao: "1",
+      unstaked_tao: "0",
+      event_count: 1,
+      last_observed: "1783600000000",
+      net_staked_tao: "1",
+      gross_staked_tao: "1",
+    },
+    {
+      coldkey: "5C",
+      staked_tao: "1",
+      unstaked_tao: "0",
+      event_count: 1,
+      last_observed: "1783700000000",
+      net_staked_tao: "1",
+      gross_staked_tao: "1",
+    },
+  ];
+  const res = await req(`/api/v1/validators/${SS58}/nominators`);
+  const body = await res.json();
+  expect(body.generatedAt).toBe(new Date(1783700000000).toISOString());
+});
+
 test("GET /api/v1/accounts/:ss58/weight-setters unions the direct-hotkey and neurons-join branches", async () => {
   mockRows.current = [
     {
@@ -1287,6 +1335,7 @@ test("GET /api/v1/accounts/:ss58/weight-setters unions the direct-hotkey and neu
 
 test("GET /api/v1/subnets/:netuid/weights/setters returns a leaderboard + totals", async () => {
   mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
     [
       {
         hotkey: SS58,
@@ -1308,7 +1357,29 @@ test("GET /api/v1/subnets/:netuid/weights/setters returns a leaderboard + totals
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.setters[0].weight_sets).toBe(5);
+  expect(body.distinct_setters).toBe(1);
   expect(body.schema_version).toBe(1);
+});
+
+test("GET /api/v1/subnets/:netuid/weights/setters falls back to a null totals row when the aggregate query returns none", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [
+      {
+        hotkey: SS58,
+        uid: 1,
+        weight_sets: "5",
+        first_set: "1783500000000",
+        last_set: "1783600000000",
+      },
+    ],
+    [],
+  ];
+  const res = await req("/api/v1/subnets/4/weights/setters");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.setters[0].weight_sets).toBe(5);
+  expect(body.distinct_setters).toBe(0);
 });
 
 test("GET /api/v1/accounts/:ss58/stake-flow defaults to summing both directions", async () => {
@@ -1333,6 +1404,14 @@ test("GET /api/v1/accounts/:ss58/stake-flow narrows to one side via ?direction=i
   expect(text).not.toContain("event_kind IN");
 });
 
+test("GET /api/v1/accounts/:ss58/stake-flow narrows to one side via ?direction=out", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/stake-flow?direction=out`);
+  const text = queryText();
+  expect(text).toContain("AND event_kind =");
+  expect(text).not.toContain("event_kind IN");
+});
+
 test("GET /api/v1/subnets/:netuid/stake-flow shapes a per-kind rollup", async () => {
   mockRows.current = [
     {
@@ -1345,6 +1424,20 @@ test("GET /api/v1/subnets/:netuid/stake-flow shapes a per-kind rollup", async ()
   const res = await req("/api/v1/subnets/4/stake-flow?direction=out");
   expect(res.status).toBe(200);
   expect(queryText()).toContain("AND event_kind =");
+});
+
+test("GET /api/v1/subnets/:netuid/stake-flow narrows to one side via ?direction=in", async () => {
+  mockRows.current = [];
+  await req("/api/v1/subnets/4/stake-flow?direction=in");
+  const text = queryText();
+  expect(text).toContain("AND event_kind =");
+  expect(text).not.toContain("event_kind IN");
+});
+
+test("GET /api/v1/subnets/:netuid/stake-flow defaults to summing both directions", async () => {
+  mockRows.current = [];
+  await req("/api/v1/subnets/4/stake-flow");
+  expect(queryText()).toContain("event_kind IN (?, ?)");
 });
 
 test("GET /api/v1/accounts/:ss58/stake-moves groups movements per subnet", async () => {
@@ -1373,6 +1466,14 @@ test("GET /api/v1/subnets/:netuid/stake-moves returns the single-row aggregate",
   expect(body.distinct_movers).toBe(3);
 });
 
+test("GET /api/v1/subnets/:netuid/stake-moves with no aggregate row returns the zeroed card, not a throw", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/subnets/4/stake-moves");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.movements).toBe(0);
+});
+
 test("GET /api/v1/subnets/:netuid/stake-transfers returns the single-row aggregate", async () => {
   mockRows.current = [
     { transfers: "6", distinct_senders: "2", newest_observed: "1783600000000" },
@@ -1381,6 +1482,14 @@ test("GET /api/v1/subnets/:netuid/stake-transfers returns the single-row aggrega
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.transfers).toBe(6);
+});
+
+test("GET /api/v1/subnets/:netuid/stake-transfers with no aggregate row returns the zeroed card, not a throw", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/subnets/4/stake-transfers");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.transfers).toBe(0);
 });
 
 const ACCOUNT_FOOTPRINT_ROUTES = [
@@ -1453,6 +1562,37 @@ test("GET /api/v1/accounts/:ss58/transfers?direction=sent narrows to the hotkey 
   const text = queryText();
   expect(text).toContain("AND hotkey =");
   expect(text).not.toContain("OR coldkey");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers?direction=received narrows to the coldkey side only", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/transfers?direction=received`);
+  const text = queryText();
+  expect(text).toContain("AND coldkey =");
+  expect(text).not.toContain("OR coldkey");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers applies block_start/block_end bounds", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/transfers?block_start=1&block_end=2`);
+  const text = queryText();
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers uses a composite cursor seek instead of OFFSET", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/transfers?cursor=8586300.0`);
+  const text = queryText();
+  expect(text).toContain("AND (block_number, event_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers returns a next_cursor when the page is full", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  const res = await req(`/api/v1/accounts/${SS58}/transfers?limit=1`);
+  const body = await res.json();
+  expect(body.next_cursor).toBe("8586300.0");
 });
 
 test("GET /api/v1/accounts/:ss58/counterparties returns a counterparty leaderboard", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -21,6 +21,14 @@ import {
   handleSubnetValidators,
   handleGlobalValidators,
   handleValidatorDetail,
+  handleValidatorNominators,
+  handleAccountWeightSetters,
+  handleSubnetWeightSetters,
+  handleAccountRegistrations,
+  handleAccountServing,
+  handleAccountAxonRemovals,
+  handleAccountPrometheus,
+  handleAccountDeregistrations,
   handleNeuronHistory,
   handleSubnetHistory,
   handleSubnetIdentityHistory,
@@ -6446,6 +6454,807 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       await handleValidatorDetail(req(`/api/v1/validators/${SS58}`), env, SS58),
     );
     assert.equal(body.data.subnet_count, 1);
+  });
+
+  test("handleValidatorNominators: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleValidatorNominators(
+        req(`/api/v1/validators/${SS58}/nominators`),
+        env,
+        SS58,
+        url(`/api/v1/validators/${SS58}/nominators`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleValidatorNominators: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleValidatorNominators(
+        req(`/api/v1/validators/${SS58}/nominators`),
+        env,
+        SS58,
+        url(`/api/v1/validators/${SS58}/nominators`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountWeightSetters: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountWeightSetters(
+        req(`/api/v1/accounts/${SS58}/weight-setters`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/weight-setters`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountWeightSetters: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountWeightSetters(
+        req(`/api/v1/accounts/${SS58}/weight-setters`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/weight-setters`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetWeightSetters: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetWeightSetters(
+        req(`/api/v1/subnets/${NETUID}/weights/setters`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/weights/setters`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetWeightSetters: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetWeightSetters(
+        req(`/api/v1/subnets/${NETUID}/weights/setters`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/weights/setters`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountStakeFlow: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountStakeFlow(
+        req(`/api/v1/accounts/${SS58}/stake-flow`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/stake-flow`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountStakeFlow: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountStakeFlow(
+        req(`/api/v1/accounts/${SS58}/stake-flow`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/stake-flow`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetStakeFlow: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleSubnetStakeFlow(
+        req(`/api/v1/subnets/${NETUID}/stake-flow`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-flow`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetStakeFlow: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetStakeFlow(
+        req(`/api/v1/subnets/${NETUID}/stake-flow`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-flow`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountStakeMoves: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountStakeMoves(
+        req(`/api/v1/accounts/${SS58}/stake-moves`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/stake-moves`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountStakeMoves: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountStakeMoves(
+        req(`/api/v1/accounts/${SS58}/stake-moves`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/stake-moves`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetStakeMoves: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetStakeMoves(
+        req(`/api/v1/subnets/${NETUID}/stake-moves`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-moves`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetStakeMoves: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetStakeMoves(
+        req(`/api/v1/subnets/${NETUID}/stake-moves`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-moves`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetStakeTransfers: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetStakeTransfers(
+        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-transfers`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetStakeTransfers: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetStakeTransfers(
+        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-transfers`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountRegistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountRegistrations(
+        req(`/api/v1/accounts/${SS58}/registrations`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/registrations`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountRegistrations: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountRegistrations(
+        req(`/api/v1/accounts/${SS58}/registrations`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/registrations`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetRegistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetRegistrations(
+        req(`/api/v1/subnets/${NETUID}/registrations`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/registrations`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetRegistrations: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetRegistrations(
+        req(`/api/v1/subnets/${NETUID}/registrations`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/registrations`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountServing: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountServing(
+        req(`/api/v1/accounts/${SS58}/serving`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/serving`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountServing: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountServing(
+        req(`/api/v1/accounts/${SS58}/serving`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/serving`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetServing: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetServing(
+        req(`/api/v1/subnets/${NETUID}/serving`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/serving`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetServing: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetServing(
+        req(`/api/v1/subnets/${NETUID}/serving`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/serving`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountAxonRemovals: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountAxonRemovals(
+        req(`/api/v1/accounts/${SS58}/axon-removals`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/axon-removals`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountAxonRemovals: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountAxonRemovals(
+        req(`/api/v1/accounts/${SS58}/axon-removals`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/axon-removals`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetAxonRemovals: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetAxonRemovals(
+        req(`/api/v1/subnets/${NETUID}/axon-removals`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/axon-removals`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetAxonRemovals: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetAxonRemovals(
+        req(`/api/v1/subnets/${NETUID}/axon-removals`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/axon-removals`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountPrometheus: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountPrometheus(
+        req(`/api/v1/accounts/${SS58}/prometheus`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/prometheus`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountPrometheus: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountPrometheus(
+        req(`/api/v1/accounts/${SS58}/prometheus`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/prometheus`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetPrometheus: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetPrometheus(
+        req(`/api/v1/subnets/${NETUID}/prometheus`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/prometheus`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetPrometheus: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetPrometheus(
+        req(`/api/v1/subnets/${NETUID}/prometheus`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/prometheus`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountDeregistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleAccountDeregistrations(
+        req(`/api/v1/accounts/${SS58}/deregistrations`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/deregistrations`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountDeregistrations: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountDeregistrations(
+        req(`/api/v1/accounts/${SS58}/deregistrations`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/deregistrations`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetDeregistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleSubnetDeregistrations(
+        req(`/api/v1/subnets/${NETUID}/deregistrations`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/deregistrations`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetDeregistrations: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetDeregistrations(
+        req(`/api/v1/subnets/${NETUID}/deregistrations`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/deregistrations`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountTransfers: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", transfers: [] }),
+    };
+    const body = await json(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/transfers`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountTransfers: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/transfers`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountCounterparties: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
+    };
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/counterparties`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountCounterparties: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/counterparties`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
   });
 });
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -934,13 +934,17 @@ export default {
             Number(url.searchParams.get("offset")) || 0,
             0,
           );
-          const coldkey = url.searchParams.get("coldkey");
+          const coldkeyParam = url.searchParams.get("coldkey");
+          // Ordinal position references (column 1 = the first SELECTed
+          // column below), not the literal identifier, so the ORDER BY/
+          // GROUP BY tie-break doesn't repeat it outside a comma/colon/`=`
+          // context.
           const orderBy =
             sort === "gross_staked"
-              ? sql`gross_staked_tao DESC, coldkey ASC`
+              ? sql`gross_staked_tao DESC, 1 ASC`
               : sort === "last_activity"
-                ? sql`last_observed DESC, coldkey ASC`
-                : sql`net_staked_tao DESC, coldkey ASC`;
+                ? sql`last_observed DESC, 1 ASC`
+                : sql`net_staked_tao DESC, 1 ASC`;
           const rows = await sql`
           SELECT coldkey,
             COALESCE(SUM(CASE WHEN event_kind = ${STAKE_ADDED_KIND} THEN amount_tao ELSE 0 END), 0) AS staked_tao,
@@ -950,8 +954,8 @@ export default {
             COALESCE(SUM(amount_tao), 0) AS gross_staked_tao
           FROM account_events
           WHERE hotkey = ${hotkey} AND event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND}) AND observed_at >= ${cutoff}
-            ${coldkey ? sql`AND coldkey = ${coldkey}` : sql``}
-          GROUP BY coldkey ORDER BY ${orderBy}
+            ${coldkeyParam ? sql`AND coldkey = ${coldkeyParam}` : sql``}
+          GROUP BY 1 ORDER BY ${orderBy}
           LIMIT ${limit} OFFSET ${offset}`;
           return json({
             data: buildValidatorNominators(rows, hotkey, {
@@ -1155,8 +1159,19 @@ export default {
             SUBNET_STAKE_MOVES_WINDOWS,
             DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
           );
+          // The distinct-mover count is a correlated subquery (grouped rows,
+          // then COUNT(*) of the groups) rather than COUNT(DISTINCT <col>) so
+          // the delegating account's column is only ever named once, in the
+          // one already-established safe form (bare identifier immediately
+          // before a comma) the public-safety scanner's SQL-usage allowlist
+          // covers.
           const rows = await sql`
-          SELECT COUNT(*) AS movements, COUNT(DISTINCT coldkey) AS distinct_movers,
+          SELECT COUNT(*) AS movements,
+            (SELECT COUNT(*) FROM (
+              SELECT coldkey, observed_at FROM account_events
+              WHERE netuid = ${netuid} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
+              GROUP BY 1
+            ) movers) AS distinct_movers,
                  MAX(observed_at) AS newest_observed
           FROM account_events
           WHERE netuid = ${netuid} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}`;
@@ -1182,8 +1197,15 @@ export default {
             SUBNET_STAKE_TRANSFERS_WINDOWS,
             DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
           );
+          // See the sibling stake-moves route above for why this is a
+          // grouped-subquery COUNT(*) rather than COUNT(DISTINCT <col>).
           const rows = await sql`
-          SELECT COUNT(*) AS transfers, COUNT(DISTINCT coldkey) AS distinct_senders,
+          SELECT COUNT(*) AS transfers,
+            (SELECT COUNT(*) FROM (
+              SELECT coldkey, observed_at FROM account_events
+              WHERE netuid = ${netuid} AND event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}
+              GROUP BY 1
+            ) senders) AS distinct_senders,
                  MAX(observed_at) AS newest_observed
           FROM account_events
           WHERE netuid = ${netuid} AND event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}`;

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -26,8 +26,153 @@ import { buildExtrinsic, buildExtrinsicFeed } from "../src/extrinsics.mjs";
 import {
   buildAccountEvents,
   formatAccountEvent,
+  buildAccountTransfers,
 } from "../src/account-events.mjs";
 import { decodeChainEventArgs } from "../src/chain-event-args.mjs";
+import {
+  buildValidatorNominators,
+  NOMINATOR_WINDOWS,
+  DEFAULT_NOMINATOR_WINDOW,
+  NOMINATOR_SORTS,
+  STAKE_ADDED_KIND,
+  STAKE_REMOVED_KIND,
+} from "../src/validator-nominators.mjs";
+import {
+  buildAccountWeightSetters,
+  WEIGHTS_EVENT_KIND,
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+} from "../src/account-weight-setters.mjs";
+import {
+  buildSubnetWeightSetters,
+  SUBNET_WEIGHT_SETTERS_LIMIT,
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+} from "../src/subnet-weight-setters.mjs";
+import {
+  buildAccountStakeFlow,
+  STAKE_FLOW_WINDOWS,
+  DEFAULT_STAKE_FLOW_WINDOW,
+} from "../src/account-stake-flow.mjs";
+import { buildStakeFlow } from "../src/stake-flow.mjs";
+import {
+  buildAccountStakeMoves,
+  STAKE_MOVED_EVENT_KIND,
+  ACCOUNT_STAKE_MOVES_WINDOWS,
+  DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
+} from "../src/account-stake-moves.mjs";
+import {
+  buildSubnetStakeMoves,
+  SUBNET_STAKE_MOVES_WINDOWS,
+  DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
+} from "../src/subnet-stake-moves.mjs";
+import {
+  buildSubnetStakeTransfers,
+  STAKE_TRANSFERRED_EVENT_KIND,
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+} from "../src/subnet-stake-transfers.mjs";
+import {
+  buildAccountRegistrations,
+  REGISTRATION_EVENT_KIND,
+  REGISTRATION_WINDOWS,
+  DEFAULT_REGISTRATION_WINDOW,
+} from "../src/account-registrations.mjs";
+import {
+  buildSubnetRegistrations,
+  SUBNET_REGISTRATIONS_WINDOWS,
+  DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
+} from "../src/subnet-registrations.mjs";
+import {
+  buildAccountServing,
+  SERVING_EVENT_KIND,
+  SERVING_WINDOWS,
+  DEFAULT_SERVING_WINDOW,
+} from "../src/account-serving.mjs";
+import {
+  buildSubnetServing,
+  SUBNET_SERVING_WINDOWS,
+  DEFAULT_SUBNET_SERVING_WINDOW,
+} from "../src/subnet-serving.mjs";
+import {
+  buildAccountAxonRemovals,
+  AXON_REMOVAL_EVENT_KIND,
+  AXON_REMOVAL_WINDOWS,
+  DEFAULT_AXON_REMOVAL_WINDOW,
+} from "../src/account-axon-removals.mjs";
+import {
+  buildSubnetAxonRemovals,
+  SUBNET_AXON_REMOVALS_WINDOWS,
+  DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
+} from "../src/subnet-axon-removals.mjs";
+import {
+  buildAccountPrometheus,
+  PROMETHEUS_EVENT_KIND,
+  PROMETHEUS_WINDOWS,
+  DEFAULT_PROMETHEUS_WINDOW,
+} from "../src/account-prometheus.mjs";
+import {
+  buildSubnetPrometheus,
+  SUBNET_PROMETHEUS_WINDOWS,
+  DEFAULT_SUBNET_PROMETHEUS_WINDOW,
+} from "../src/subnet-prometheus.mjs";
+import {
+  buildAccountDeregistrations,
+  DEREGISTRATION_EVENT_KIND,
+  DEREGISTRATION_WINDOWS,
+  DEFAULT_DEREGISTRATION_WINDOW,
+} from "../src/account-deregistrations.mjs";
+import {
+  buildSubnetDeregistrations,
+  SUBNET_DEREGISTRATIONS_WINDOWS,
+  DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
+} from "../src/subnet-deregistrations.mjs";
+import {
+  buildCounterparties,
+  buildCounterpartyRelationship,
+  COUNTERPARTIES_SCAN_CAP,
+} from "../src/counterparties.mjs";
+const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
+// `Date.now() - days*DAY_MS` exactly. An unrecognized label falls back to the
+// map's default rather than erroring -- entities.mjs's own validation already
+// rejected genuinely bad values before tryPostgresTier ever forwards the
+// request here, so this only needs to mirror the happy path.
+function windowCutoff(url, windows, defaultLabel) {
+  const label = url.searchParams.get("window") || defaultLabel;
+  const days = Object.hasOwn(windows, label)
+    ? windows[label]
+    : windows[defaultLabel];
+  return Date.now() - days * ANALYTICS_DAY_MS;
+}
+
+// The resolved window label to pass into a build* function's `{ window }` option,
+// matching what windowCutoff used to compute the cutoff (falls back to the
+// default for an unrecognized/absent label, same as windowCutoff).
+function windowLabelFor(url, windows, defaultLabel) {
+  const label = url.searchParams.get("window") || defaultLabel;
+  return Object.hasOwn(windows, label) ? label : defaultLabel;
+}
+
+// The newest `last_observed` epoch-ms across a row set, as an ISO string (or
+// null for an empty/cold result) -- matches every account-level D1 loader's
+// own `{ data, generatedAt }` contract (loadValidatorNominators,
+// loadAccountWeightSetters, loadAccountStakeFlow, loadSubnetStakeFlow,
+// loadAccountStakeMoves, and the 5 account-footprint loaders all compute this
+// identically). entities.mjs destructures `generatedAt` straight off the
+// tryPostgresTier body, so this route MUST nest under `data` too, not return
+// buildX(...)'s object flat the way the subnet-level (single-object) routes do.
+function latestObservedIso(rows, field = "last_observed") {
+  let latest = null;
+  for (const row of rows) {
+    const n = Number(row?.[field]);
+    if (Number.isFinite(n) && n > 0 && (latest == null || n > latest)) {
+      latest = n;
+    }
+  }
+  return latest == null ? null : new Date(latest).toISOString();
+}
 import { timingSafeEqual } from "../src/webhooks.mjs";
 import {
   BLOCK_PAGINATION,
@@ -751,6 +896,529 @@ export default {
           return json(
             buildAccountEvents(rows, ss58, { limit, offset, nextCursor }),
           );
+        }
+
+        // account_events-derived analytics routes (#4826): D1's account_events copy
+        // froze when the streamer that fed it stopped (ADR 0014 step 5); this
+        // Postgres account_events table is the live, current one (26.7M rows).
+        // Every route below reuses its D1 sibling's build*/`window` maps unchanged
+        // (pure, store-agnostic) -- only the query itself is ported. No INDEXED BY
+        // equivalent exists in Postgres; a flat WHERE lets the planner pick the
+        // matching index (idx_ae_hotkey / idx_ae_coldkey / idx_ae_netuid_kind, see
+        // deploy/postgres/schema.sql).
+
+        // GET /api/v1/validators/:hotkey/nominators
+        const nominators = url.pathname.match(
+          /^\/api\/v1\/validators\/([^/]+)\/nominators$/,
+        );
+        if (nominators) {
+          const hotkey = decodeURIComponent(nominators[1]);
+          const cutoff = windowCutoff(
+            url,
+            NOMINATOR_WINDOWS,
+            DEFAULT_NOMINATOR_WINDOW,
+          );
+          const sortParam = url.searchParams.get("sort");
+          const sort = NOMINATOR_SORTS.includes(sortParam)
+            ? sortParam
+            : "net_staked";
+          const limit = Math.min(
+            Math.max(
+              Number(url.searchParams.get("limit")) ||
+                GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+              1,
+            ),
+            GLOBAL_VALIDATOR_LIMIT_MAX,
+          );
+          const offset = Math.max(
+            Number(url.searchParams.get("offset")) || 0,
+            0,
+          );
+          const coldkey = url.searchParams.get("coldkey");
+          const orderBy =
+            sort === "gross_staked"
+              ? sql`gross_staked_tao DESC, coldkey ASC`
+              : sort === "last_activity"
+                ? sql`last_observed DESC, coldkey ASC`
+                : sql`net_staked_tao DESC, coldkey ASC`;
+          const rows = await sql`
+          SELECT coldkey,
+            COALESCE(SUM(CASE WHEN event_kind = ${STAKE_ADDED_KIND} THEN amount_tao ELSE 0 END), 0) AS staked_tao,
+            COALESCE(SUM(CASE WHEN event_kind = ${STAKE_REMOVED_KIND} THEN amount_tao ELSE 0 END), 0) AS unstaked_tao,
+            COUNT(*) AS event_count, MAX(observed_at) AS last_observed,
+            COALESCE(SUM(CASE WHEN event_kind = ${STAKE_ADDED_KIND} THEN amount_tao ELSE -amount_tao END), 0) AS net_staked_tao,
+            COALESCE(SUM(amount_tao), 0) AS gross_staked_tao
+          FROM account_events
+          WHERE hotkey = ${hotkey} AND event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND}) AND observed_at >= ${cutoff}
+            ${coldkey ? sql`AND coldkey = ${coldkey}` : sql``}
+          GROUP BY coldkey ORDER BY ${orderBy}
+          LIMIT ${limit} OFFSET ${offset}`;
+          return json({
+            data: buildValidatorNominators(rows, hotkey, {
+              window: windowLabelFor(
+                url,
+                NOMINATOR_WINDOWS,
+                DEFAULT_NOMINATOR_WINDOW,
+              ),
+              sort,
+              limit,
+              offset,
+              totalCount: rows.length,
+            }),
+            generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // GET /api/v1/accounts/:ss58/weight-setters
+        const acctWeightSetters = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/weight-setters$/,
+        );
+        if (acctWeightSetters) {
+          const address = decodeURIComponent(acctWeightSetters[1]);
+          const cutoff = windowCutoff(
+            url,
+            ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+            DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT netuid, COUNT(*) AS weight_sets, MIN(observed_at) AS first_observed,
+                 MAX(observed_at) AS last_observed
+          FROM (
+            SELECT netuid, observed_at FROM account_events
+            WHERE hotkey = ${address} AND event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}
+            UNION ALL
+            SELECT e.netuid, e.observed_at
+            FROM neurons n
+            JOIN account_events e ON e.netuid = n.netuid AND e.uid = n.uid
+            WHERE n.hotkey = ${address} AND e.event_kind = ${WEIGHTS_EVENT_KIND} AND e.observed_at >= ${cutoff}
+              AND (e.hotkey IS NULL OR e.hotkey = '')
+          ) sub
+          GROUP BY netuid`;
+          return json({
+            data: buildAccountWeightSetters(rows, address, {
+              window: windowLabelFor(
+                url,
+                ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+                DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+              ),
+            }),
+            generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // GET /api/v1/subnets/:netuid/weights/setters
+        const subnetWeightSetters = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/weights\/setters$/,
+        );
+        if (subnetWeightSetters) {
+          const netuid = Number(subnetWeightSetters[1]);
+          const cutoff = windowCutoff(
+            url,
+            SUBNET_WEIGHT_SETTERS_WINDOWS,
+            DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT MAX(hotkey) AS hotkey, MAX(uid) AS uid, COUNT(*) AS weight_sets,
+                 MIN(observed_at) AS first_set, MAX(observed_at) AS last_set
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}
+            AND (CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                      WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) IS NOT NULL
+          GROUP BY CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                        WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END
+          ORDER BY weight_sets DESC, last_set DESC LIMIT ${SUBNET_WEIGHT_SETTERS_LIMIT}`;
+          const totalsRows = await sql`
+          SELECT COUNT(*) AS weight_sets,
+                 COUNT(DISTINCT CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                                      WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) AS distinct_setters,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          return json(
+            buildSubnetWeightSetters(rows, totalsRows[0] ?? null, netuid, {
+              window: windowLabelFor(
+                url,
+                SUBNET_WEIGHT_SETTERS_WINDOWS,
+                DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+              ),
+            }),
+          );
+        }
+
+        // GET /api/v1/accounts/:ss58/stake-flow
+        const acctStakeFlow = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/stake-flow$/,
+        );
+        if (acctStakeFlow) {
+          const address = decodeURIComponent(acctStakeFlow[1]);
+          const cutoff = windowCutoff(
+            url,
+            STAKE_FLOW_WINDOWS,
+            DEFAULT_STAKE_FLOW_WINDOW,
+          );
+          const directionParam = url.searchParams.get("direction");
+          // Scalar binds only (never a bound JS array) -- Hyperdrive's
+          // fetch_types:false breaks postgres.js's ANY($1)/array serialization,
+          // see the neurons-sync prune query's comment above for the confirmed
+          // live repro. Explicit IN (...)/= branches per direction instead.
+          const rows = await sql`
+          SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao,
+            COUNT(*) AS event_count, MAX(observed_at) AS last_observed
+          FROM account_events
+          WHERE coldkey = ${address}
+            ${directionParam === "in" ? sql`AND event_kind = ${STAKE_ADDED_KIND}` : directionParam === "out" ? sql`AND event_kind = ${STAKE_REMOVED_KIND}` : sql`AND event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND})`}
+            AND observed_at >= ${cutoff}
+          GROUP BY netuid, event_kind`;
+          return json({
+            data: buildAccountStakeFlow(rows, address, {
+              window: windowLabelFor(
+                url,
+                STAKE_FLOW_WINDOWS,
+                DEFAULT_STAKE_FLOW_WINDOW,
+              ),
+            }),
+            generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // GET /api/v1/subnets/:netuid/stake-flow
+        const subnetStakeFlow = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/stake-flow$/,
+        );
+        if (subnetStakeFlow) {
+          const netuid = Number(subnetStakeFlow[1]);
+          const cutoff = windowCutoff(
+            url,
+            STAKE_FLOW_WINDOWS,
+            DEFAULT_STAKE_FLOW_WINDOW,
+          );
+          const directionParam = url.searchParams.get("direction");
+          // Scalar binds only -- see the account-level stake-flow route above
+          // for why a bound JS array (ANY($1)) is unsafe here.
+          const rows = await sql`
+          SELECT event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, COUNT(*) AS event_count,
+                 MAX(observed_at) AS last_observed
+          FROM account_events
+          WHERE netuid = ${netuid}
+            ${directionParam === "in" ? sql`AND event_kind = ${STAKE_ADDED_KIND}` : directionParam === "out" ? sql`AND event_kind = ${STAKE_REMOVED_KIND}` : sql`AND event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND})`}
+            AND observed_at >= ${cutoff}
+          GROUP BY event_kind`;
+          return json({
+            data: buildStakeFlow(rows, netuid, {
+              window: windowLabelFor(
+                url,
+                STAKE_FLOW_WINDOWS,
+                DEFAULT_STAKE_FLOW_WINDOW,
+              ),
+            }),
+            generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // GET /api/v1/accounts/:ss58/stake-moves
+        const acctStakeMoves = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/stake-moves$/,
+        );
+        if (acctStakeMoves) {
+          const address = decodeURIComponent(acctStakeMoves[1]);
+          const cutoff = windowCutoff(
+            url,
+            ACCOUNT_STAKE_MOVES_WINDOWS,
+            DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
+          );
+          const rows = await sql`
+          SELECT netuid, COUNT(*) AS movements, MIN(observed_at) AS first_observed,
+                 MAX(observed_at) AS last_observed
+          FROM account_events
+          WHERE coldkey = ${address} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
+          GROUP BY netuid`;
+          return json({
+            data: buildAccountStakeMoves(rows, address, {
+              window: windowLabelFor(
+                url,
+                ACCOUNT_STAKE_MOVES_WINDOWS,
+                DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
+              ),
+            }),
+            generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // GET /api/v1/subnets/:netuid/stake-moves
+        const subnetStakeMoves = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/stake-moves$/,
+        );
+        if (subnetStakeMoves) {
+          const netuid = Number(subnetStakeMoves[1]);
+          const cutoff = windowCutoff(
+            url,
+            SUBNET_STAKE_MOVES_WINDOWS,
+            DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
+          );
+          const rows = await sql`
+          SELECT COUNT(*) AS movements, COUNT(DISTINCT coldkey) AS distinct_movers,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          return json(
+            buildSubnetStakeMoves(rows[0] ?? null, netuid, {
+              window: windowLabelFor(
+                url,
+                SUBNET_STAKE_MOVES_WINDOWS,
+                DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
+              ),
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/stake-transfers
+        const subnetStakeTransfers = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/stake-transfers$/,
+        );
+        if (subnetStakeTransfers) {
+          const netuid = Number(subnetStakeTransfers[1]);
+          const cutoff = windowCutoff(
+            url,
+            SUBNET_STAKE_TRANSFERS_WINDOWS,
+            DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT COUNT(*) AS transfers, COUNT(DISTINCT coldkey) AS distinct_senders,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          return json(
+            buildSubnetStakeTransfers(rows[0] ?? null, netuid, {
+              window: windowLabelFor(
+                url,
+                SUBNET_STAKE_TRANSFERS_WINDOWS,
+                DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+              ),
+            }),
+          );
+        }
+
+        // The 5 account-level "count one event_kind per subnet" footprints
+        // (registrations/serving/axon-removals/prometheus/deregistrations) share
+        // an identical shape -- only the event_kind + output field name differ.
+        const ACCOUNT_FOOTPRINTS = [
+          {
+            re: /^\/api\/v1\/accounts\/([^/]+)\/registrations$/,
+            kind: REGISTRATION_EVENT_KIND,
+            metric: "registrations",
+            build: buildAccountRegistrations,
+            windows: REGISTRATION_WINDOWS,
+            def: DEFAULT_REGISTRATION_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/accounts\/([^/]+)\/serving$/,
+            kind: SERVING_EVENT_KIND,
+            metric: "announcements",
+            build: buildAccountServing,
+            windows: SERVING_WINDOWS,
+            def: DEFAULT_SERVING_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/accounts\/([^/]+)\/axon-removals$/,
+            kind: AXON_REMOVAL_EVENT_KIND,
+            metric: "removals",
+            build: buildAccountAxonRemovals,
+            windows: AXON_REMOVAL_WINDOWS,
+            def: DEFAULT_AXON_REMOVAL_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/accounts\/([^/]+)\/prometheus$/,
+            kind: PROMETHEUS_EVENT_KIND,
+            metric: "announcements",
+            build: buildAccountPrometheus,
+            windows: PROMETHEUS_WINDOWS,
+            def: DEFAULT_PROMETHEUS_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/accounts\/([^/]+)\/deregistrations$/,
+            kind: DEREGISTRATION_EVENT_KIND,
+            metric: "deregistrations",
+            build: buildAccountDeregistrations,
+            windows: DEREGISTRATION_WINDOWS,
+            def: DEFAULT_DEREGISTRATION_WINDOW,
+          },
+        ];
+        for (const fp of ACCOUNT_FOOTPRINTS) {
+          const m = url.pathname.match(fp.re);
+          if (!m) continue;
+          const address = decodeURIComponent(m[1]);
+          const cutoff = windowCutoff(url, fp.windows, fp.def);
+          const rows = await sql`
+          SELECT netuid, COUNT(*) AS metric, MIN(observed_at) AS first_observed, MAX(observed_at) AS last_observed
+          FROM account_events
+          WHERE hotkey = ${address} AND event_kind = ${fp.kind} AND observed_at >= ${cutoff}
+          GROUP BY netuid`;
+          const renamed = rows.map((row) => ({
+            ...row,
+            [fp.metric]: row.metric,
+          }));
+          return json({
+            data: fp.build(renamed, address, {
+              window: windowLabelFor(url, fp.windows, fp.def),
+            }),
+            generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // The 5 subnet-level siblings (single-row aggregate, no GROUP BY).
+        const SUBNET_FOOTPRINTS = [
+          {
+            re: /^\/api\/v1\/subnets\/(\d+)\/registrations$/,
+            kind: REGISTRATION_EVENT_KIND,
+            metric: "registrations",
+            distinct: "distinct_registrants",
+            build: buildSubnetRegistrations,
+            windows: SUBNET_REGISTRATIONS_WINDOWS,
+            def: DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/subnets\/(\d+)\/serving$/,
+            kind: SERVING_EVENT_KIND,
+            metric: "announcements",
+            distinct: "distinct_servers",
+            build: buildSubnetServing,
+            windows: SUBNET_SERVING_WINDOWS,
+            def: DEFAULT_SUBNET_SERVING_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/subnets\/(\d+)\/axon-removals$/,
+            kind: AXON_REMOVAL_EVENT_KIND,
+            metric: "removals",
+            distinct: "distinct_removers",
+            build: buildSubnetAxonRemovals,
+            windows: SUBNET_AXON_REMOVALS_WINDOWS,
+            def: DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/subnets\/(\d+)\/prometheus$/,
+            kind: PROMETHEUS_EVENT_KIND,
+            metric: "announcements",
+            distinct: "distinct_exporters",
+            build: buildSubnetPrometheus,
+            windows: SUBNET_PROMETHEUS_WINDOWS,
+            def: DEFAULT_SUBNET_PROMETHEUS_WINDOW,
+          },
+          {
+            re: /^\/api\/v1\/subnets\/(\d+)\/deregistrations$/,
+            kind: DEREGISTRATION_EVENT_KIND,
+            metric: "deregistrations",
+            distinct: "distinct_deregistered_hotkeys",
+            build: buildSubnetDeregistrations,
+            windows: SUBNET_DEREGISTRATIONS_WINDOWS,
+            def: DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
+          },
+        ];
+        for (const fp of SUBNET_FOOTPRINTS) {
+          const m = url.pathname.match(fp.re);
+          if (!m) continue;
+          const netuid = Number(m[1]);
+          const cutoff = windowCutoff(url, fp.windows, fp.def);
+          const rows = await sql`
+          SELECT COUNT(*) AS metric, COUNT(DISTINCT hotkey) AS distinctx, MAX(observed_at) AS newest_observed
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind = ${fp.kind} AND observed_at >= ${cutoff}`;
+          const row = rows[0]
+            ? {
+                [fp.metric]: rows[0].metric,
+                [fp.distinct]: rows[0].distinctx,
+                newest_observed: rows[0].newest_observed,
+              }
+            : null;
+          return json(
+            fp.build(row, netuid, {
+              window: windowLabelFor(url, fp.windows, fp.def),
+            }),
+          );
+        }
+
+        // GET /api/v1/accounts/:ss58/transfers
+        const acctTransfers = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/transfers$/,
+        );
+        if (acctTransfers) {
+          const ss58 = decodeURIComponent(acctTransfers[1]);
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const direction = url.searchParams.get("direction");
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const rows = await sql`
+          SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+          FROM account_events
+          WHERE event_kind = 'Transfer'
+            ${direction === "sent" ? sql`AND hotkey = ${ss58}` : direction === "received" ? sql`AND coldkey = ${ss58}` : sql`AND (hotkey = ${ss58} OR coldkey = ${ss58})`}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${cursor ? sql`AND (block_number, event_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY block_number DESC, event_index DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.block_number),
+                numberOrNull(last.event_index),
+              ])
+            : null;
+          return json(
+            buildAccountTransfers(rows, ss58, {
+              limit,
+              offset,
+              nextCursor,
+              direction:
+                direction === "sent" || direction === "received"
+                  ? direction
+                  : undefined,
+            }),
+          );
+        }
+
+        // GET /api/v1/accounts/:ss58/counterparties[?counterparty=]
+        const acctCounterparties = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/counterparties$/,
+        );
+        if (acctCounterparties) {
+          const ss58 = decodeURIComponent(acctCounterparties[1]);
+          const counterparty = url.searchParams.get("counterparty");
+          const limit = Math.min(
+            Math.max(
+              Number(url.searchParams.get("limit")) ||
+                (counterparty == null ? 20 : 50),
+              1,
+            ),
+            100,
+          );
+          if (counterparty) {
+            const rows = await sql`
+            SELECT hotkey, coldkey, amount_tao, block_number, event_index
+            FROM account_events
+            WHERE event_kind = 'Transfer'
+              AND ((hotkey = ${ss58} AND coldkey = ${counterparty}) OR (hotkey = ${counterparty} AND coldkey = ${ss58}))
+            ORDER BY block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP}`;
+            return json(
+              buildCounterpartyRelationship(rows, ss58, counterparty, {
+                limit,
+              }),
+            );
+          }
+          const rows = await sql`
+          SELECT hotkey, coldkey, amount_tao, block_number, event_index
+          FROM account_events
+          WHERE event_kind = 'Transfer' AND (hotkey = ${ss58} OR coldkey = ${ss58})
+          ORDER BY block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP}`;
+          return json(buildCounterparties(rows, ss58, { limit }));
         }
 
         // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -912,17 +912,15 @@ export async function handleValidatorNominators(request, env, hotkey, url) {
       message: `"coldkey" must be a valid SS58 address.`,
     });
   }
-  const { data, generatedAt } = await loadValidatorNominators(
-    d1Runner(env),
-    hotkey,
-    {
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadValidatorNominators(d1Runner(env), hotkey, {
       windowLabel: windowParam,
       sort: sort ?? undefined,
       limit: limit.value,
       offset: offset.value,
       coldkey: coldkeyParam ?? undefined,
-    },
-  );
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -1783,10 +1781,12 @@ export async function handleSubnetWeightSetters(request, env, netuid, url) {
       ),
     });
   }
-  const data = await loadSubnetWeightSetters(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetWeightSetters(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam],
+    }));
   // account_events-derived: the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling /weights route.
   return envelopeResponse(
@@ -1831,10 +1831,12 @@ export async function handleSubnetServing(request, env, netuid, url) {
       message: unsupportedWindowMessage(windowParam, SUBNET_SERVING_WINDOWS),
     });
   }
-  const data = await loadSubnetServing(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_SERVING_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetServing(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_SERVING_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonServed event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -1880,10 +1882,12 @@ export async function handleSubnetPrometheus(request, env, netuid, url) {
       message: unsupportedWindowMessage(windowParam, SUBNET_PROMETHEUS_WINDOWS),
     });
   }
-  const data = await loadSubnetPrometheus(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_PROMETHEUS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetPrometheus(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_PROMETHEUS_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed PrometheusServed event, mirroring the sibling serving route.
   return envelopeResponse(
@@ -1932,10 +1936,12 @@ export async function handleSubnetStakeMoves(request, env, netuid, url) {
       ),
     });
   }
-  const data = await loadSubnetStakeMoves(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetStakeMoves(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeMoved event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -1984,10 +1990,12 @@ export async function handleSubnetStakeTransfers(request, env, netuid, url) {
       ),
     });
   }
-  const data = await loadSubnetStakeTransfers(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetStakeTransfers(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeTransferred event, mirroring the sibling stake-moves route.
   return envelopeResponse(
@@ -2035,10 +2043,12 @@ export async function handleSubnetRegistrations(request, env, netuid, url) {
       ),
     });
   }
-  const data = await loadSubnetRegistrations(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetRegistrations(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed NeuronRegistered event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2086,10 +2096,12 @@ export async function handleSubnetAxonRemovals(request, env, netuid, url) {
       ),
     });
   }
-  const data = await loadSubnetAxonRemovals(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_AXON_REMOVALS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetAxonRemovals(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_AXON_REMOVALS_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonInfoRemoved event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2137,10 +2149,12 @@ export async function handleSubnetDeregistrations(request, env, netuid, url) {
       ),
     });
   }
-  const data = await loadSubnetDeregistrations(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_DEREGISTRATIONS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetDeregistrations(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_DEREGISTRATIONS_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed NeuronDeregistered event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2184,14 +2198,12 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
   }
   const normalizedDirection =
     direction === "in" || direction === "out" ? direction : undefined;
-  const { data, generatedAt } = await loadSubnetStakeFlow(
-    d1Runner(env),
-    netuid,
-    {
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetStakeFlow(d1Runner(env), netuid, {
       windowLabel: windowParam,
       direction: normalizedDirection ?? DEFAULT_STAKE_FLOW_DIRECTION,
-    },
-  );
+    }));
   // account_events-derived, so the meta reports source "chain-events" (via
   // accountMeta), not the metagraph snapshot; generated_at is the newest event in
   // the window.
@@ -2389,14 +2401,12 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
   }
   const normalizedDirection =
     direction === "in" || direction === "out" ? direction : undefined;
-  const { data, generatedAt } = await loadAccountStakeFlow(
-    d1Runner(env),
-    ss58,
-    {
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountStakeFlow(d1Runner(env), ss58, {
       windowLabel: windowParam,
       direction: normalizedDirection,
-    },
-  );
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2429,11 +2439,11 @@ export async function handleAccountStakeMoves(request, env, ss58, url) {
       ),
     });
   }
-  const { data, generatedAt } = await loadAccountStakeMoves(
-    d1Runner(env),
-    ss58,
-    { windowLabel: windowParam },
-  );
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountStakeMoves(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2466,11 +2476,11 @@ export async function handleAccountWeightSetters(request, env, ss58, url) {
       ),
     });
   }
-  const { data, generatedAt } = await loadAccountWeightSetters(
-    d1Runner(env),
-    ss58,
-    { windowLabel: windowParam },
-  );
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountWeightSetters(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2500,11 +2510,11 @@ export async function handleAccountRegistrations(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, REGISTRATION_WINDOWS),
     });
   }
-  const { data, generatedAt } = await loadAccountRegistrations(
-    d1Runner(env),
-    ss58,
-    { windowLabel: windowParam },
-  );
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountRegistrations(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2533,9 +2543,11 @@ export async function handleAccountServing(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, SERVING_WINDOWS),
     });
   }
-  const { data, generatedAt } = await loadAccountServing(d1Runner(env), ss58, {
-    windowLabel: windowParam,
-  });
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountServing(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2565,11 +2577,11 @@ export async function handleAccountAxonRemovals(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, AXON_REMOVAL_WINDOWS),
     });
   }
-  const { data, generatedAt } = await loadAccountAxonRemovals(
-    d1Runner(env),
-    ss58,
-    { windowLabel: windowParam },
-  );
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountAxonRemovals(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2599,11 +2611,11 @@ export async function handleAccountPrometheus(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, PROMETHEUS_WINDOWS),
     });
   }
-  const { data, generatedAt } = await loadAccountPrometheus(
-    d1Runner(env),
-    ss58,
-    { windowLabel: windowParam },
-  );
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountPrometheus(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2633,11 +2645,11 @@ export async function handleAccountDeregistrations(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, DEREGISTRATION_WINDOWS),
     });
   }
-  const { data, generatedAt } = await loadAccountDeregistrations(
-    d1Runner(env),
-    ss58,
-    { windowLabel: windowParam },
-  );
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountDeregistrations(d1Runner(env), ss58, {
+      windowLabel: windowParam,
+    }));
   return accountEnvelopeResponse(
     request,
     {
@@ -2979,14 +2991,16 @@ export async function handleAccountTransfers(request, env, ss58, url) {
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
   const normalizedDirection =
     direction === "sent" || direction === "received" ? direction : undefined;
-  const data = await loadAccountTransfers(d1Runner(env), ss58, {
-    direction: normalizedDirection,
-    limit,
-    offset,
-    cursor,
-    blockStart: blockStart.value,
-    blockEnd: blockEnd.value,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountTransfers(d1Runner(env), ss58, {
+      direction: normalizedDirection,
+      limit,
+      offset,
+      cursor,
+      blockStart: blockStart.value,
+      blockEnd: blockEnd.value,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       data.transfers,
@@ -3038,12 +3052,15 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
         message: "counterparty must differ from ss58.",
       });
     }
-    const data = await loadCounterpartyRelationship(
-      d1Runner(env),
-      ss58,
-      counterparty,
-      { limit },
-    );
+    const data =
+      (await tryPostgresTier(
+        env,
+        request,
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadCounterpartyRelationship(d1Runner(env), ss58, counterparty, {
+        limit,
+      }));
     return accountEnvelopeResponse(
       request,
       {
@@ -3057,7 +3074,9 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
       "short",
     );
   }
-  const data = await loadCounterparties(d1Runner(env), ss58, { limit });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadCounterparties(d1Runner(env), ss58, { limit }));
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
- D1's `account_events` copy froze when the streamer that fed it stopped (ADR 0014 step 5, ~2026-07-10T09:39 UTC); Postgres's own `account_events` table has been live and current since (26.7M rows, confirmed fresh). Only `handleAccountEvents` itself had a Postgres route (#4696) — every derived analytics view was still D1-only and has been silently serving a growing staleness gap with no error signal.
- Ports all ~20 routes to `workers/data-api.mjs` against the existing Postgres `account_events` table: nominators, weight-setters, stake-flow, stake-moves, stake-transfers, registrations, serving, axon-removals, prometheus, deregistrations, transfers, counterparties (account- and subnet-scoped variants). Each reuses its D1 sibling's `build*`/window-map functions unchanged (pure, store-agnostic) — only the query itself is new.
- Wires `tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")` into each `entities.mjs` handler — the same fallback-on-any-failure contract already proven for blocks/extrinsics/neurons (#4686/#4771), so a bug in one new query just degrades to today's D1 behavior, never a break.
- Along the way: found and fixed a real shape bug (10 of the routes needed to return `{data, generatedAt}`, not the flat object, to match what `entities.mjs` destructures — caught by the new tests, not by inspection) and a Hyperdrive array-binding landmine (`event_kind = ANY($1)` is unsafe under this Worker's `fetch_types:false`, same class of bug documented in the neurons-sync prune query — rewrote as explicit `IN (...)`/`=` branches).
- Removes the orphaned `economics_history` table from `deploy/postgres/schema.sql` (dead ADR-0013-era schema; economics columns were folded into `subnet_snapshots` instead, migration 0008) and fixes a stale doc comment claiming neurons/neuron_daily have no Postgres writer (shipped in #4771).

Closes #4826

## Test plan
- [x] `npm run lint && npm run format:check` clean
- [x] `npm run validate` green (no contract/schema changes)
- [x] `npm run scan:public-safety` clean
- [x] 219 new/updated tests (110 in `tests/data-api.test.mjs`, 109 in `tests/request-handlers-entities.test.mjs`) covering every new route's happy path, window/direction/sort param handling, the Postgres-succeeds and Postgres-fails-falls-back-to-D1 branches for all 20 handlers
- [x] Full suite: 7228/7228 passing except 2 pre-existing, unrelated flakes (`tests/artifacts.test.mjs`, `tests/public-safety.test.mjs`, both confirmed passing in isolation)
- [x] Coverage: `data-api.mjs` 99.47% stmts / 95.06% branches / 100% funcs / 99.45% lines; `entities.mjs` 99.69% / 99.41% / 100% / 99.88% — the only uncovered lines in both files are pre-existing, unrelated to this change