### PR TITLE
feat(ui): add event-kind filter to the subnet on-chain activity table (#3369)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { subnetEventsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/events",
+  });
+}
+
+async function runQuery(netuid: number, params?: { kind?: string }) {
+  const opts = subnetEventsQuery(netuid, params);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("subnetEventsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("requests limit=100 with no kind when unfiltered", async () => {
+    resolveWith({ events: [] });
+    await runQuery(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/events",
+      expect.objectContaining({ params: { limit: 100, kind: undefined } }),
+    );
+  });
+
+  it("forwards the kind param and separates it in the query key", async () => {
+    expect(subnetEventsQuery(7, { kind: "StakeAdded" }).queryKey).toContain("StakeAdded");
+    expect(subnetEventsQuery(7).queryKey).not.toContain("StakeAdded");
+
+    resolveWith({ events: [] });
+    await runQuery(7, { kind: "StakeAdded" });
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/events",
+      expect.objectContaining({ params: { limit: 100, kind: "StakeAdded" } }),
+    );
+  });
+
+  it("normalizes well-formed events and preserves the server event_count", async () => {
+    resolveWith({
+      event_count: 2,
+      events: [
+        { block_number: 100, event_index: 0, event_kind: "StakeAdded", amount_tao: 1.5 },
+        { block_number: 101, event_index: 1, event_kind: "WeightsSet" },
+      ],
+    });
+    const res = await runQuery(7, { kind: "StakeAdded" });
+    expect(res.data.netuid).toBe(7);
+    expect(res.data.event_count).toBe(2);
+    expect(res.data.events).toHaveLength(2);
+    expect(res.data.events[0]?.event_kind).toBe("StakeAdded");
+  });
+
+  it("drops malformed rows and falls back event_count to the kept length", async () => {
+    resolveWith({
+      events: [
+        { block_number: 100, event_index: 0, event_kind: "StakeAdded" },
+        { block_number: null, event_kind: "WeightsSet" },
+        "nope",
+      ],
+    });
+    const res = await runQuery(7);
+    expect(res.data.events).toHaveLength(1);
+    expect(res.data.event_count).toBe(1);
+  });
+
+  it("degrades a cold / junk store to a schema-stable empty feed", async () => {
+    for (const raw of [{}, null, "x", { events: "nope" }]) {
+      resolveWith(raw);
+      const res = await runQuery(7);
+      expect(res.data.netuid).toBe(7);
+      expect(res.data.events).toEqual([]);
+      expect(res.data.event_count).toBe(0);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4488,14 +4488,14 @@ export const subnetStakeFlowQuery = (netuid: number, window = "30d") =>
     staleTime: STALE_MED,
   });
 
-export const subnetEventsQuery = (netuid: number) =>
+export const subnetEventsQuery = (netuid: number, params: { kind?: string } = {}) =>
   queryOptions({
-    queryKey: k("subnet-events", netuid),
+    queryKey: k("subnet-events", netuid, params.kind ?? null),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Record<string, unknown>>(
-        `/api/v1/subnets/${netuid}/events?limit=100`,
-        { signal },
-      );
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/subnets/${netuid}/events`, {
+        params: { limit: 100, kind: params.kind },
+        signal,
+      });
       const d = (res.data ?? {}) as Record<string, unknown>;
       const events = normalizeAccountEvents(d.events);
       return {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -60,8 +60,10 @@ import {
   eventKindCategory,
   eventKindCategoryLabel,
   eventKindLabel,
+  EVENT_KIND_LABELS,
   type EventKindCategory,
 } from "@/lib/metagraphed/event-kinds";
+import { SelectFilter } from "@/components/metagraphed/table-controls";
 import { TableState } from "@/components/metagraphed/table-state";
 import type {
   AccountEvent,
@@ -91,6 +93,9 @@ type SearchParams = {
   tab?: string;
   sev?: string;
   uid?: number;
+  // Kind filter for the on-chain-activity feed. Mirrors the accounts page's
+  // `ev_kind` so the naming stays consistent across event tables.
+  ev_kind?: string;
 };
 
 export const Route = createFileRoute("/subnets/$netuid")({
@@ -100,6 +105,7 @@ export const Route = createFileRoute("/subnets/$netuid")({
       tab: typeof s.tab === "string" ? s.tab : undefined,
       sev: typeof s.sev === "string" ? s.sev : undefined,
       uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined,
+      ev_kind: typeof s.ev_kind === "string" && s.ev_kind ? s.ev_kind : undefined,
     };
   },
   parseParams: ({ netuid }) => {
@@ -665,18 +671,43 @@ function StakeFlowScorecard({ netuid }: { netuid: number }) {
   );
 }
 
+// Kind-filter options for the activity feed. Subnets have no per-subnet
+// event_kinds summary to source options from (unlike the accounts page), so the
+// shared label map is the option source; every key is a server-accepted kind.
+const EVENT_KIND_OPTIONS = Object.entries(EVENT_KIND_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}));
+
 function ActivityPanel({ netuid }: { netuid: number }) {
+  const { ev_kind } = Route.useSearch();
+  const navigate = Route.useNavigate();
   return (
     <SectionAnchor
       id="activity"
       title="On-chain activity"
       subtitle="First-party chain events for this subnet, newest first."
       info="Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
+      right={
+        <SelectFilter
+          label="Kind"
+          value={ev_kind ?? ""}
+          onChange={(v) =>
+            navigate({
+              to: ".",
+              search: (prev: SearchParams) => ({ ...prev, ev_kind: v || undefined }),
+              replace: true,
+              resetScroll: false,
+            })
+          }
+          options={EVENT_KIND_OPTIONS}
+        />
+      }
     >
       <StakeFlowScorecard netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <ActivityTableLoader netuid={netuid} />
+          <ActivityTableLoader netuid={netuid} kind={ev_kind} />
         </Suspense>
       </QueryErrorBoundary>
     </SectionAnchor>
@@ -719,15 +750,19 @@ function EventKindCell({ kind }: { kind: string | null | undefined }) {
   );
 }
 
-function ActivityTableLoader({ netuid }: { netuid: number }) {
-  const { data } = useSuspenseQuery(subnetEventsQuery(netuid));
+function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }) {
+  const { data } = useSuspenseQuery(subnetEventsQuery(netuid, { kind }));
   const events = (data.data.events ?? []) as AccountEvent[];
   if (events.length === 0) {
     return (
       <TableState
         variant="empty"
-        title="No recent on-chain activity"
-        description="No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+        title={kind ? `No ${eventKindLabel(kind)} events` : "No recent on-chain activity"}
+        description={
+          kind
+            ? "No events of this kind are indexed for this subnet in the current window — clear the filter to see all recent activity."
+            : "No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+        }
         generatedAt={data.meta?.generated_at}
       />
     );


### PR DESCRIPTION
## Summary

Adds a **Kind filter dropdown** to the "On-chain activity" table on `/subnets/$netuid`, wiring the UI through to the server-side `?kind=` support that `handleSubnetEvents` already validates and applies — a capability that was live on the backend but unconsumed by the frontend.

Selecting a kind refetches `/api/v1/subnets/{netuid}/events?kind=<Kind>&limit=100` and re-renders the table filtered to that kind; the selection round-trips through the URL (`?ev_kind=<Kind>`) so the filtered view is shareable and reloadable — mirroring the existing kind-filter UX on `/accounts/$ss58`. Clearing the selection ("all") returns to the unfiltered feed and drops the param from the URL.

### Changes
- `apps/ui/src/lib/metagraphed/queries.ts` — `subnetEventsQuery` now accepts an optional `{ kind }` and forwards it (alongside `limit=100`) via `apiFetch`'s `params`, matching `accountEventsQuery`; the kind is folded into the query key so filtered results cache independently.
- `apps/ui/src/routes/subnets.$netuid.tsx` — adds an `ev_kind` search param (typed + validated like the accounts page), renders a `SelectFilter` in the "On-chain activity" section header sourced from the shared `EVENT_KIND_LABELS` map (subnets have no per-subnet `event_kinds` summary to source from), and passes the selected kind to the events query. The empty state is kind-aware ("No `<Kind>` events — clear the filter…").
- `apps/ui/src/lib/metagraphed/queries.subnet-events.test.ts` — new unit test: param forwarding, query-key separation, well-formed passthrough, malformed-row drops, and cold/junk → schema-stable empty feed.

Every option in the dropdown is a server-accepted kind (verified `EVENT_KIND_LABELS` keys ⊆ `INGESTED_EVENT_KINDS`), so no selection can 400. No backend files touched — `?kind=` support already ships in `handleSubnetEvents`.

### Validation
- `npm run typecheck --workspace=apps/ui` ✓
- `npm run lint --workspace=apps/ui` ✓ (0 errors)
- `npm run format:check` on changed files ✓
- `npm test --workspace=apps/ui` ✓ (722 tests, incl. the 5 new)
- `npm run build --workspace=apps/ui` ✓

`test:e2e` (responsive-overflow) is unaffected: it exercises the default `/subnets/1` render (Overview tab), which does not mount the Activity panel, so no new element enters the checked routes and no HAR re-record is needed.

## Screenshots

_On-chain activity section on `/subnets/1`, before/after, 3 viewports × 2 themes._

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-desktop-light.png)<br><sub>no filter control</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-desktop-light.png)<br><sub>Kind dropdown added</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-desktop-dark.png)<br><sub>no filter control</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-desktop-dark.png)<br><sub>Kind dropdown added</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-tablet-light.png)<br><sub>no filter control</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-tablet-light.png)<br><sub>Kind dropdown added</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-tablet-dark.png)<br><sub>no filter control</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-tablet-dark.png)<br><sub>Kind dropdown added</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-mobile-light.png)<br><sub>no filter control</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-mobile-light.png)<br><sub>Kind dropdown added</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/before-mobile-dark.png)<br><sub>no filter control</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/after-mobile-dark.png)<br><sub>Kind dropdown added</sub> |

### Interaction (filter → table updates)

_Selecting "Stake added" filters the feed to that kind and updates the URL; clearing returns to all._

![Kind filter interaction](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/sn-events-kind/kind-filter.gif)

_Screenshots use a fixed fixture for the events/stake-flow responses so before/after differ only by the code change._

Closes #3369
