### PR TITLE
fix(data-api): port blocks/extrinsics-derived handlers to the Postgres tier

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -582,6 +582,106 @@ test("GET /api/v1/blocks/:ref on an unknown block skips the neighbor query", asy
   expect(sqlCalls.length).toBe(2); // SET + the main lookup, no neighbor query
 });
 
+test("GET /api/v1/blocks/summary is matched before /blocks/:ref (never treats 'summary' as a ref)", async () => {
+  mockRows.current = [BLOCK_ROW];
+  const res = await req("/api/v1/blocks/summary");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block_count).toBe(1);
+  expect(body.last_block).toBe(8586300);
+  expect(queryText()).toContain("FROM blocks ORDER BY block_number DESC LIMIT");
+});
+
+test("GET /api/v1/blocks/summary with no rows returns the zeroed card, not a throw", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/blocks/summary");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block_count).toBe(0);
+});
+
+test("GET /api/v1/blocks/:ref/extrinsics resolves the ref then reads the block's extrinsics in index order", async () => {
+  mockQueue.current = [
+    [], // SET
+    [{ block_number: 8586300 }], // resolveBlockNumberPg
+    [EXTRINSIC_ROW],
+  ];
+  const res = await req("/api/v1/blocks/8586300/extrinsics");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBe(8586300);
+  expect(body.data.extrinsics[0].signer).toBe("5Signer");
+  expect(queryText()).toContain("ORDER BY extrinsic_index ASC");
+});
+
+test("GET /api/v1/blocks/:ref/extrinsics on an unresolved ref returns block_number:null, extrinsics:[] without querying extrinsics", async () => {
+  mockQueue.current = [[], []]; // SET, resolveBlockNumberPg finds nothing
+  const res = await req("/api/v1/blocks/999999999/extrinsics");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBeNull();
+  expect(body.data.extrinsics).toEqual([]);
+  expect(sqlCalls.length).toBe(2); // SET + the resolve query, no extrinsics query
+});
+
+test("GET /api/v1/blocks/:ref/events resolves the ref then reads the block's account_events in index order", async () => {
+  mockQueue.current = [
+    [], // SET
+    [{ block_number: 8586300 }], // resolveBlockNumberPg
+    [ACCOUNT_EVENT_ROW],
+  ];
+  const res = await req("/api/v1/blocks/8586300/events");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBe(8586300);
+  expect(body.data.events[0].event_kind).toBe("StakeAdded");
+  expect(queryText()).toContain("FROM account_events WHERE block_number");
+  expect(queryText()).toContain("ORDER BY event_index ASC");
+});
+
+test("GET /api/v1/blocks/:ref/events on an unresolved ref returns block_number:null, events:[] without querying account_events", async () => {
+  mockQueue.current = [[], []]; // SET, resolveBlockNumberPg finds nothing
+  const res = await req("/api/v1/blocks/999999999/events");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBeNull();
+  expect(body.data.events).toEqual([]);
+  expect(sqlCalls.length).toBe(2); // SET + the resolve query, no events query
+});
+
+test("GET /api/v1/blocks/:ref/extrinsics resolves a 0x block_hash ref", async () => {
+  const upperHash = `0x${"ABC".repeat(21)}D`; // 64 hex chars, mixed-case
+  mockQueue.current = [
+    [], // SET
+    [{ block_number: 8586300 }], // resolveBlockNumberPg
+    [EXTRINSIC_ROW],
+  ];
+  const res = await req(`/api/v1/blocks/${upperHash}/extrinsics`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBe(8586300);
+  expect(sqlCalls.some((c) => c.values.includes(upperHash.toLowerCase()))).toBe(
+    true,
+  );
+});
+
+test("GET /api/v1/blocks/:ref/extrinsics on a malformed ref skips every query but SET", async () => {
+  const res = await req("/api/v1/blocks/not-a-real-ref/extrinsics");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBeNull();
+  expect(body.data.extrinsics).toEqual([]);
+  expect(sqlCalls.length).toBe(1); // only the unconditional SET call
+});
+
+test("GET /api/v1/blocks/:ref/extrinsics on a numeric ref past MAX_SAFE_INTEGER skips every query but SET", async () => {
+  const res = await req("/api/v1/blocks/99999999999999999999/extrinsics");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.block_number).toBeNull();
+  expect(sqlCalls.length).toBe(1); // only the unconditional SET call
+});
+
 test("GET /api/v1/extrinsics returns a feed with call_args parsed from the ::text cast", async () => {
   mockRows.current = [EXTRINSIC_ROW];
   const res = await req("/api/v1/extrinsics?limit=1");
@@ -764,6 +864,134 @@ test("GET /api/v1/accounts/:ss58/events with no matching rows returns a schema-s
   expect(body.event_count).toBe(0);
   expect(body.events).toEqual([]);
   expect(body.next_cursor).toBeNull();
+});
+
+test("GET /api/v1/accounts/:ss58/extrinsics matches the signer column only, not hotkey/coldkey", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  const res = await req(`/api/v1/accounts/${SS58}/extrinsics`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsic_count).toBe(1);
+  expect(body.extrinsics[0].signer).toBe("5Signer");
+  expect(queryText()).toContain("WHERE signer =");
+});
+
+test("GET /api/v1/accounts/:ss58/extrinsics applies block_start/block_end bounds", async () => {
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/extrinsics?block_start=1&block_end=2`);
+  const text = queryText();
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+});
+
+test("GET /api/v1/accounts/:ss58/extrinsics with an inverted block range short-circuits to empty, never querying Postgres", async () => {
+  const res = await req(
+    `/api/v1/accounts/${SS58}/extrinsics?block_start=5&block_end=1`,
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsics).toEqual([]);
+  expect(sqlCalls.length).toBe(1); // only the unconditional SET call
+});
+
+test("GET /api/v1/accounts/:ss58/extrinsics uses a composite cursor seek instead of OFFSET", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  await req(`/api/v1/accounts/${SS58}/extrinsics?cursor=8586300.2`);
+  const text = queryText();
+  expect(text).toContain("AND (block_number, extrinsic_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/accounts/:ss58/extrinsics returns a next_cursor when the page is full", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  const res = await req(`/api/v1/accounts/${SS58}/extrinsics?limit=1`);
+  const body = await res.json();
+  expect(body.next_cursor).toBe("8586300.2");
+});
+
+test("GET /api/v1/sudo filters to call_module='Sudo' and never exposes signer/call_module params", async () => {
+  mockRows.current = [{ ...EXTRINSIC_ROW, call_module: "Sudo" }];
+  const res = await req("/api/v1/sudo?call_function=sudo&success=true");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsics[0].call_module).toBe("Sudo");
+  const text = queryText();
+  expect(text).toContain("WHERE call_module =");
+  expect(text).toContain("AND call_function =");
+  expect(text).toContain("AND success =");
+  const call = sqlCalls.find((c) => c.text.includes("WHERE call_module ="));
+  expect(call.values).toContain("Sudo");
+});
+
+test("GET /api/v1/governance/config-changes filters to call_module='AdminUtils'", async () => {
+  mockRows.current = [{ ...EXTRINSIC_ROW, call_module: "AdminUtils" }];
+  const res = await req("/api/v1/governance/config-changes");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.extrinsics[0].call_module).toBe("AdminUtils");
+  const call = sqlCalls.find((c) => c.text.includes("WHERE call_module ="));
+  expect(call.values).toContain("AdminUtils");
+});
+
+test("GET /api/v1/sudo applies block/block_start/block_end/from/to filters and a cursor seek", async () => {
+  mockRows.current = [];
+  await req(
+    "/api/v1/sudo?block=1&block_start=1&block_end=2&from=1&to=2&cursor=8586300.2",
+  );
+  const text = queryText();
+  expect(text).toContain("AND block_number =");
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+  expect(text).toContain("AND observed_at >=");
+  expect(text).toContain("AND observed_at <=");
+  expect(text).toContain("AND (block_number, extrinsic_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/sudo with success=false filters correctly, distinct from absent", async () => {
+  mockRows.current = [
+    { ...EXTRINSIC_ROW, call_module: "Sudo", success: false },
+  ];
+  const res = await req("/api/v1/sudo?success=false");
+  const body = await res.json();
+  expect(body.extrinsics[0].success).toBe(false);
+  expect(queryText()).toContain("AND success =");
+});
+
+test("GET /api/v1/sudo returns a next_cursor when the page is full", async () => {
+  mockRows.current = [{ ...EXTRINSIC_ROW, call_module: "Sudo" }];
+  const res = await req("/api/v1/sudo?limit=1");
+  const body = await res.json();
+  expect(body.next_cursor).toBe("8586300.2");
+});
+
+test("GET /api/v1/runtime returns the spec-version transition timeline", async () => {
+  mockQueue.current = [
+    [], // SET
+    [
+      {
+        spec_version: 423,
+        block_number: 8000000,
+        observed_at: "1783500000000",
+      },
+    ],
+    [{ spec_version: 424 }],
+  ];
+  const res = await req("/api/v1/runtime");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.transitions[0].spec_version).toBe(423);
+  expect(body.current_spec_version).toBe(424);
+  expect(queryText()).toContain("GROUP BY spec_version");
+});
+
+test("GET /api/v1/runtime with no readings returns the schema-stable empty timeline", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/runtime");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.transitions).toEqual([]);
+  expect(body.current_spec_version).toBeNull();
 });
 
 // #4771: per-UID metagraph tier, mirroring src/metagraph-neurons.mjs's D1

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -67,6 +67,10 @@ import {
   handleBlock,
   handleBlockExtrinsics,
   handleBlockEvents,
+  handleBlocksSummary,
+  handleSudo,
+  handleGovernanceConfigChanges,
+  handleRuntime,
   handleExtrinsics,
   handleExtrinsic,
   canonicalSubnetHistoryCachePath,
@@ -7252,6 +7256,341 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         SS58,
         url(`/api/v1/accounts/${SS58}/counterparties`),
       ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  // #4832 Tier 1a: blocks/extrinsics-derived handlers that were reading D1
+  // directly with no Postgres tier at all -- silently serving data frozen
+  // since the streamer stopped. Same pattern as the blocks above.
+
+  test("handleBlockExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg", extrinsics: [] },
+        }),
+    };
+    const body = await json(
+      await handleBlockExtrinsics(
+        req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleBlockExtrinsics: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({
+      blockDetail: blockRow(),
+      extrinsics: [extrinsicRow()],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleBlockExtrinsics(
+        req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleBlockEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ blockEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg", events: [] },
+        }),
+    };
+    const body = await json(
+      await handleBlockEvents(
+        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/events`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleBlockEvents: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({
+      blockDetail: blockRow(),
+      blockEvents: [accountEventRow()],
+    });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleBlockEvents(
+        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/events`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleBlocksSummary: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", block_count: 0 }),
+    };
+    const body = await json(
+      await handleBlocksSummary(
+        req("/api/v1/blocks/summary"),
+        env,
+        url("/api/v1/blocks/summary"),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleBlocksSummary: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleBlocksSummary(
+        req("/api/v1/blocks/summary"),
+        env,
+        url("/api/v1/blocks/summary"),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", extrinsics: [] }),
+    };
+    const body = await json(
+      await handleAccountExtrinsics(
+        req(`/api/v1/accounts/${SS58}/extrinsics`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/extrinsics`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountExtrinsics: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountExtrinsics(
+        req(`/api/v1/accounts/${SS58}/extrinsics`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/extrinsics`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSudo: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "Sudo" })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", extrinsics: [] }),
+    };
+    const body = await json(
+      await handleSudo(req("/api/v1/sudo"), env, url("/api/v1/sudo")),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSudo: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "Sudo" })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSudo(
+        req("/api/v1/sudo?success=true"),
+        env,
+        url("/api/v1/sudo?success=true"),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSudo: D1 fallback narrows to success=false, distinct from absent", async () => {
+    const { env } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "Sudo", success: 0 })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
+    const body = await json(
+      await handleSudo(
+        req("/api/v1/sudo?success=false"),
+        env,
+        url("/api/v1/sudo?success=false"),
+      ),
+    );
+    assert.equal(body.data.extrinsics[0].success, false);
+  });
+
+  test("handleSudo: D1 fallback with no success param leaves the filter unset", async () => {
+    const { env } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "Sudo" })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
+    const body = await json(
+      await handleSudo(req("/api/v1/sudo"), env, url("/api/v1/sudo")),
+    );
+    assert.equal(body.data.extrinsics[0].call_module, "Sudo");
+  });
+
+  test("handleGovernanceConfigChanges: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "AdminUtils" })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", extrinsics: [] }),
+    };
+    const body = await json(
+      await handleGovernanceConfigChanges(
+        req("/api/v1/governance/config-changes"),
+        env,
+        url("/api/v1/governance/config-changes"),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleGovernanceConfigChanges: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "AdminUtils" })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleGovernanceConfigChanges(
+        req("/api/v1/governance/config-changes?success=true"),
+        env,
+        url("/api/v1/governance/config-changes?success=true"),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleGovernanceConfigChanges: D1 fallback narrows to success=false, distinct from absent", async () => {
+    const { env } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "AdminUtils", success: 0 })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
+    const body = await json(
+      await handleGovernanceConfigChanges(
+        req("/api/v1/governance/config-changes?success=false"),
+        env,
+        url("/api/v1/governance/config-changes?success=false"),
+      ),
+    );
+    assert.equal(body.data.extrinsics[0].success, false);
+  });
+
+  test("handleGovernanceConfigChanges: D1 fallback with no success param leaves the filter unset", async () => {
+    const { env } = dbWith({
+      extrinsics: [extrinsicRow({ call_module: "AdminUtils" })],
+    });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
+    const body = await json(
+      await handleGovernanceConfigChanges(
+        req("/api/v1/governance/config-changes"),
+        env,
+        url("/api/v1/governance/config-changes"),
+      ),
+    );
+    assert.equal(body.data.extrinsics[0].call_module, "AdminUtils");
+  });
+
+  test("handleRuntime: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", transitions: [] }),
+    };
+    const body = await json(
+      await handleRuntime(req("/api/v1/runtime"), env, url("/api/v1/runtime")),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleRuntime: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleRuntime(req("/api/v1/runtime"), env, url("/api/v1/runtime")),
     );
     assert.equal(body.data.marker, undefined);
     assert.ok(captures.sql.length > 0);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -22,12 +22,23 @@
 import postgres from "postgres";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
 import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
-import { buildExtrinsic, buildExtrinsicFeed } from "../src/extrinsics.mjs";
+import {
+  buildExtrinsic,
+  buildExtrinsicFeed,
+  buildBlockExtrinsics,
+  buildAccountExtrinsics,
+} from "../src/extrinsics.mjs";
 import {
   buildAccountEvents,
   formatAccountEvent,
   buildAccountTransfers,
+  buildBlockEvents,
 } from "../src/account-events.mjs";
+import {
+  buildBlocksSummary,
+  BLOCKS_SUMMARY_SCAN_CAP,
+} from "../src/blocks-summary.mjs";
+import { buildRuntimeVersionHistory } from "../src/runtime-versions.mjs";
 import { decodeChainEventArgs } from "../src/chain-event-args.mjs";
 import {
   buildValidatorNominators,
@@ -568,6 +579,22 @@ const HASH_RE = /^0x[0-9a-fA-F]{64}$/;
 const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
 const MAX_EMBEDDED_EVENTS = 50;
 
+// Resolve a /blocks/:ref sub-resource's ref (numeric block_number or a 0x
+// block_hash) to its block_number, mirroring src/block-subresources.mjs's
+// resolveBlockNumber. Returns null for a malformed ref or an unknown block
+// (never throws) -- the two sub-resource routes below both need this ahead of
+// their own extrinsics/account_events query, same as the D1 path.
+async function resolveBlockNumberPg(sql, ref) {
+  const isHash = HASH_RE.test(ref);
+  if (!isHash && !/^\d+$/.test(ref)) return null;
+  const blockNumber = isHash ? null : Number(ref);
+  if (!isHash && !Number.isSafeInteger(blockNumber)) return null;
+  const rows = isHash
+    ? await sql`SELECT block_number FROM blocks WHERE block_hash = ${ref.toLowerCase()} LIMIT 1`
+    : await sql`SELECT block_number FROM blocks WHERE block_number = ${blockNumber} LIMIT 1`;
+  return numberOrNull(rows[0]?.block_number);
+}
+
 // The blocks/extrinsics SELECT column lists below must match src/blocks.mjs's
 // BLOCK_READ_COLUMNS / src/extrinsics.mjs's EXTRINSIC_READ_COLUMNS so
 // formatBlock/formatExtrinsic (reused unchanged, imported above) see the exact
@@ -697,6 +724,17 @@ export default {
           return json(buildBlockFeed(rows, { limit, offset, nextCursor }));
         }
 
+        // GET /api/v1/blocks/summary — block-production health over the most
+        // recent BLOCKS_SUMMARY_SCAN_CAP blocks, mirroring src/blocks-summary.mjs's
+        // loadBlocksSummary. Checked BEFORE the /blocks/:ref match below --
+        // "summary" would otherwise parse as a (invalid) ref.
+        if (url.pathname === "/api/v1/blocks/summary") {
+          const rows = await sql`
+          SELECT block_number, author, extrinsic_count, event_count, spec_version, observed_at
+          FROM blocks ORDER BY block_number DESC LIMIT ${BLOCKS_SUMMARY_SCAN_CAP}`;
+          return json(buildBlocksSummary(rows));
+        }
+
         // GET /api/v1/blocks/:ref — per-block detail + nearest stored neighbors,
         // mirroring src/blocks.mjs's loadBlock. ref is a numeric block_number or a
         // 0x block_hash (lowercased before binding, matching the D1 path's
@@ -731,6 +769,56 @@ export default {
             next = nbr[0]?.next ?? null;
           }
           return json(buildBlock(rows[0], ref, { prev, next }));
+        }
+
+        // GET /api/v1/blocks/:ref/extrinsics — the extrinsics in one block, natural
+        // read order (extrinsic_index ASC), mirroring src/block-subresources.mjs's
+        // loadBlockExtrinsics. block_number:null + extrinsics:[] for an unresolved
+        // ref (never throws).
+        const blockRefExtrinsics = url.pathname.match(
+          /^\/api\/v1\/blocks\/([^/]+)\/extrinsics$/,
+        );
+        if (blockRefExtrinsics) {
+          const ref = decodeURIComponent(blockRefExtrinsics[1]);
+          const limit = clampBlockLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const blockNumber = await resolveBlockNumberPg(sql, ref);
+          const rows =
+            blockNumber == null
+              ? []
+              : await sql`
+              SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
+              FROM extrinsics WHERE block_number = ${blockNumber}
+              ORDER BY extrinsic_index ASC LIMIT ${limit} OFFSET ${offset}`;
+          return json({
+            data: buildBlockExtrinsics(rows, ref, blockNumber, {
+              limit,
+              offset,
+            }),
+          });
+        }
+
+        // GET /api/v1/blocks/:ref/events — the decoded account_events in one block,
+        // natural read order (event_index ASC), mirroring
+        // src/block-subresources.mjs's loadBlockEvents.
+        const blockRefEvents = url.pathname.match(
+          /^\/api\/v1\/blocks\/([^/]+)\/events$/,
+        );
+        if (blockRefEvents) {
+          const ref = decodeURIComponent(blockRefEvents[1]);
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const blockNumber = await resolveBlockNumberPg(sql, ref);
+          const rows =
+            blockNumber == null
+              ? []
+              : await sql`
+              SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+              FROM account_events WHERE block_number = ${blockNumber}
+              ORDER BY event_index ASC LIMIT ${limit} OFFSET ${offset}`;
+          return json({
+            data: buildBlockEvents(rows, ref, blockNumber, { limit, offset }),
+          });
         }
 
         // GET /api/v1/extrinsics — the recent-extrinsic feed, mirroring
@@ -794,6 +882,79 @@ export default {
               ])
             : null;
           return json(buildExtrinsicFeed(rows, { limit, offset, nextCursor }));
+        }
+
+        // GET /api/v1/sudo and GET /api/v1/governance/config-changes share this
+        // shape: the same extrinsics feed as /extrinsics above, with call_module
+        // fixed rather than caller-supplied (mirroring src/extrinsics.mjs's
+        // loadExtrinsics({callModule: "Sudo"|"AdminUtils", ...}) call sites in
+        // entities.mjs) -- so neither accepts ?signer=/?call_module=/?call_hash=.
+        const SUDO_GOVERNANCE_ROUTES = {
+          "/api/v1/sudo": "Sudo",
+          "/api/v1/governance/config-changes": "AdminUtils",
+        };
+        if (Object.hasOwn(SUDO_GOVERNANCE_ROUTES, url.pathname)) {
+          const callModule = SUDO_GOVERNANCE_ROUTES[url.pathname];
+          const limit = clampBlockLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const block = nonNegativeIntegerParam(url.searchParams, "block");
+          const callFunction = url.searchParams.get("call_function") || null;
+          const successRaw = url.searchParams.get("success");
+          const success =
+            successRaw === "true"
+              ? true
+              : successRaw === "false"
+                ? false
+                : null;
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const from = nonNegativeIntegerParam(url.searchParams, "from");
+          const to = nonNegativeIntegerParam(url.searchParams, "to");
+          const rows = await sql`
+          SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
+          FROM extrinsics
+          WHERE call_module = ${callModule}
+            ${block != null ? sql`AND block_number = ${block}` : sql``}
+            ${callFunction ? sql`AND call_function = ${callFunction}` : sql``}
+            ${success != null ? sql`AND success = ${success}` : sql``}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${from != null ? sql`AND observed_at >= ${from}` : sql``}
+            ${to != null ? sql`AND observed_at <= ${to}` : sql``}
+            ${cursor ? sql`AND (block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY block_number DESC, extrinsic_index DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.block_number),
+                numberOrNull(last.extrinsic_index),
+              ])
+            : null;
+          return json(buildExtrinsicFeed(rows, { limit, offset, nextCursor }));
+        }
+
+        // GET /api/v1/runtime — the spec-version transition timeline, mirroring
+        // src/runtime-versions.mjs's loadRuntimeVersionHistory. Two small
+        // aggregate reads (GROUP BY's earliest-block-per-version, then the
+        // truly-latest reading), no filters/pagination.
+        if (url.pathname === "/api/v1/runtime") {
+          const rows = await sql`
+          SELECT spec_version, MIN(block_number) AS block_number, MIN(observed_at) AS observed_at
+          FROM blocks WHERE spec_version IS NOT NULL
+          GROUP BY spec_version ORDER BY block_number ASC`;
+          const latestRows = await sql`
+          SELECT spec_version FROM blocks WHERE spec_version IS NOT NULL
+          ORDER BY block_number DESC LIMIT 1`;
+          return json(buildRuntimeVersionHistory(rows, latestRows[0] ?? null));
         }
 
         // GET /api/v1/extrinsics/:ref — per-extrinsic detail + embedded
@@ -895,6 +1056,51 @@ export default {
             : null;
           return json(
             buildAccountEvents(rows, ss58, { limit, offset, nextCursor }),
+          );
+        }
+
+        // GET /api/v1/accounts/:ss58/extrinsics — extrinsics SIGNED by this account
+        // (the `signer` column only, not a hotkey/coldkey union -- `extrinsics` has
+        // no hotkey/coldkey columns), mirroring src/account-events.mjs's
+        // loadAccountExtrinsics.
+        const acctExtrinsics = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/extrinsics$/,
+        );
+        if (acctExtrinsics) {
+          const ss58 = decodeURIComponent(acctExtrinsics[1]);
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const rows =
+            blockStart != null && blockEnd != null && blockStart > blockEnd
+              ? []
+              : await sql`
+              SELECT block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args::text AS call_args, success, fee_tao, tip_tao, observed_at
+              FROM extrinsics
+              WHERE signer = ${ss58}
+                ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+                ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+                ${cursor ? sql`AND (block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
+              ORDER BY block_number DESC, extrinsic_index DESC
+              LIMIT ${limit}
+              ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.block_number),
+                numberOrNull(last.extrinsic_index),
+              ])
+            : null;
+          return json(
+            buildAccountExtrinsics(rows, ss58, { limit, offset, nextCursor }),
           );
         }
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -2913,13 +2913,15 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
-  const data = await loadAccountExtrinsics(d1Runner(env), ss58, {
-    limit: url.searchParams.get("limit"),
-    offset: url.searchParams.get("offset"),
-    cursor: url.searchParams.get("cursor"),
-    blockStart: blockStart.value,
-    blockEnd: blockEnd.value,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
+    (await loadAccountExtrinsics(d1Runner(env), ss58, {
+      limit: url.searchParams.get("limit"),
+      offset: url.searchParams.get("offset"),
+      cursor: url.searchParams.get("cursor"),
+      blockStart: blockStart.value,
+      blockEnd: blockEnd.value,
+    }));
   if (csvRequested(url, request)) {
     const csvRows = data.extrinsics.map((extrinsic) => ({
       ...extrinsic,
@@ -3534,7 +3536,9 @@ export async function handleBlocks(request, env, url) {
 export async function handleBlocksSummary(request, env, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
-  const data = await loadBlocksSummary(d1Runner(env));
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
+    (await loadBlocksSummary(d1Runner(env)));
   return envelopeResponse(
     request,
     {
@@ -3628,10 +3632,12 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
-  const { data } = await loadBlockExtrinsics(d1Runner(env), ref, {
-    limit,
-    offset,
-  });
+  const { data } =
+    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
+    (await loadBlockExtrinsics(d1Runner(env), ref, {
+      limit,
+      offset,
+    }));
   return envelopeResponse(
     request,
     {
@@ -3656,10 +3662,12 @@ export async function handleBlockEvents(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
-  const { data } = await loadBlockEvents(d1Runner(env), ref, {
-    limit,
-    offset,
-  });
+  const { data } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadBlockEvents(d1Runner(env), ref, {
+      limit,
+      offset,
+    }));
   return envelopeResponse(
     request,
     {
@@ -3822,20 +3830,26 @@ export async function handleSudo(request, env, url) {
       message: "success must be one of: true, false.",
     });
   }
-  const data = await loadExtrinsics(d1Runner(env), {
-    callModule: "Sudo",
-    block: numericFilters.block ?? undefined,
-    callFunction: sp.get("call_function") || undefined,
-    success:
-      successRaw === "true" ? true : successRaw === "false" ? false : undefined,
-    blockStart: numericFilters.block_start ?? undefined,
-    blockEnd: numericFilters.block_end ?? undefined,
-    from: numericFilters.from ?? undefined,
-    to: numericFilters.to ?? undefined,
-    limit,
-    offset,
-    cursor,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
+    (await loadExtrinsics(d1Runner(env), {
+      callModule: "Sudo",
+      block: numericFilters.block ?? undefined,
+      callFunction: sp.get("call_function") || undefined,
+      success:
+        successRaw === "true"
+          ? true
+          : successRaw === "false"
+            ? false
+            : undefined,
+      blockStart: numericFilters.block_start ?? undefined,
+      blockEnd: numericFilters.block_end ?? undefined,
+      from: numericFilters.from ?? undefined,
+      to: numericFilters.to ?? undefined,
+      limit,
+      offset,
+      cursor,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(data.extrinsics),
@@ -3897,20 +3911,26 @@ export async function handleGovernanceConfigChanges(request, env, url) {
       message: "success must be one of: true, false.",
     });
   }
-  const data = await loadExtrinsics(d1Runner(env), {
-    callModule: "AdminUtils",
-    block: numericFilters.block ?? undefined,
-    callFunction: sp.get("call_function") || undefined,
-    success:
-      successRaw === "true" ? true : successRaw === "false" ? false : undefined,
-    blockStart: numericFilters.block_start ?? undefined,
-    blockEnd: numericFilters.block_end ?? undefined,
-    from: numericFilters.from ?? undefined,
-    to: numericFilters.to ?? undefined,
-    limit,
-    offset,
-    cursor,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
+    (await loadExtrinsics(d1Runner(env), {
+      callModule: "AdminUtils",
+      block: numericFilters.block ?? undefined,
+      callFunction: sp.get("call_function") || undefined,
+      success:
+        successRaw === "true"
+          ? true
+          : successRaw === "false"
+            ? false
+            : undefined,
+      blockStart: numericFilters.block_start ?? undefined,
+      blockEnd: numericFilters.block_end ?? undefined,
+      from: numericFilters.from ?? undefined,
+      to: numericFilters.to ?? undefined,
+      limit,
+      offset,
+      cursor,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(data.extrinsics),
@@ -3943,7 +3963,9 @@ export async function handleGovernanceConfigChanges(request, env, url) {
 export async function handleRuntime(request, env, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
-  const data = await loadRuntimeVersionHistory(d1Runner(env));
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
+    (await loadRuntimeVersionHistory(d1Runner(env)));
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- Ports 7 handlers that were reading D1 directly with **no Postgres tier at
  all** — `handleBlockExtrinsics`, `handleBlockEvents`, `handleBlocksSummary`,
  `handleAccountExtrinsics`, `handleSudo`, `handleGovernanceConfigChanges`,
  `handleRuntime`.
- Found via a systematic cross-reference of every `handle*` export in
  `workers/request-handlers/entities.mjs` against `tryPostgresTier` call
  sites — these seven had none. Since `metagraphed-streamer` (D1's chain-data
  ingestion path) stopped ~16h ago, these routes were **silently serving data
  frozen at that point**, while sibling routes on the exact same underlying
  `blocks`/`extrinsics`/`account_events` tables (`/blocks/{ref}`,
  `/extrinsics`, `/accounts/{ss58}/events`) already correctly serve live
  Postgres data.
- Adds the matching Postgres SQL to `workers/data-api.mjs` (7 new routes,
  mirroring each D1 loader's query exactly) and wires `tryPostgresTier` into
  each handler, reusing the already-`"postgres"`
  `METAGRAPH_BLOCKS_SOURCE`/`METAGRAPH_EXTRINSICS_SOURCE`/
  `METAGRAPH_ACCOUNT_EVENTS_SOURCE` flags — no new flags, no flip needed.
- `tryPostgresTier` falls back to D1 on any failure (network error, non-2xx,
  unparseable body), so this is zero-downtime and instantly reversible.

Tier 1a of #4832 (issue stays OPEN — Tier 1b account_events-derived handlers
and Tier 2 neurons/neuron_daily-derived handlers still need separate PRs).

## Testing

- `npm run lint` clean
- `npx prettier --check` clean (scoped to touched files)
- `npm run scan:public-safety` clean
- `npx vitest run` — 7281/7281 passed (259 files), full local suite
- Local coverage confirms 100% branch coverage on every line actually added
  in this diff (`git diff origin/main -U0` cross-referenced against
  `coverage/lcov.info`'s `BRDA` records) — the only remaining uncovered
  branch in `workers/data-api.mjs` is pre-existing, unrelated code
  (`coerceEvent`, unchanged by this PR)

Refs #4832