### PR TITLE
fix(data-api): port account_events analytics handlers to the Postgres tier

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1561,6 +1561,147 @@ test("GET /api/v1/accounts/:ss58/weight-setters unions the direct-hotkey and neu
   expect(text).toContain("JOIN account_events e ON e.netuid = n.netuid");
 });
 
+test("GET /api/v1/subnets/:netuid/weights returns the aggregate WeightsSet card", async () => {
+  mockRows.current = [
+    {
+      weight_sets: "5",
+      distinct_setters: "3",
+      newest_observed: "1783600000000",
+    },
+  ];
+  const res = await req("/api/v1/subnets/4/weights?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.weight_sets).toBe(5);
+  expect(body.distinct_setters).toBe(3);
+  expect(queryText()).toContain("event_kind = ");
+});
+
+test("GET /api/v1/subnets/:netuid/weights with no rows returns the zeroed card, not a throw", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/subnets/4/weights");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.weight_sets).toBe(0);
+});
+
+test("GET /api/v1/subnets/:netuid/volume shapes a buy/sell alpha rollup", async () => {
+  mockRows.current = [
+    {
+      event_kind: "StakeAdded",
+      alpha_volume: "10",
+      tao_volume: "20",
+      event_count: 2,
+      last_observed: "1783600000000",
+    },
+    {
+      event_kind: "StakeRemoved",
+      alpha_volume: "4",
+      tao_volume: "8",
+      event_count: 1,
+      last_observed: "1783600000000",
+    },
+  ];
+  const res = await req("/api/v1/subnets/4/volume");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.data.buy_volume_alpha).toBe(10);
+  expect(body.data.sell_volume_alpha).toBe(4);
+  expect(body.data.vol_mcap_ratio).toBeNull(); // no KV/R2 access from this Worker
+  expect(queryText()).toContain("event_kind IN (");
+});
+
+test("GET /api/v1/subnets/:netuid/events returns the per-subnet feed and applies filters", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  const res = await req(
+    "/api/v1/subnets/4/events?kind=StakeAdded&block_start=1&block_end=2",
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.events[0].event_kind).toBe("StakeAdded");
+  const text = queryText();
+  expect(text).toContain("WHERE netuid =");
+  expect(text).toContain("AND event_kind =");
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+});
+
+test("GET /api/v1/subnets/:netuid/events uses a composite cursor seek instead of OFFSET", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  await req("/api/v1/subnets/4/events?cursor=8586300.0");
+  const text = queryText();
+  expect(text).toContain("AND (block_number, event_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/subnets/:netuid/events returns a next_cursor when the page is full", async () => {
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  const res = await req("/api/v1/subnets/4/events?limit=1");
+  const body = await res.json();
+  expect(body.next_cursor).toBe("8586300.0");
+});
+
+test("GET /api/v1/subnets/:netuid/event-summary shapes kind/category aggregates + recent evidence", async () => {
+  mockQueue.current = [
+    [], // SET
+    [
+      {
+        event_kind: "StakeAdded",
+        event_count: "3",
+        hotkey_count: "2",
+        amount_tao: "5",
+        alpha_amount: "1",
+        first_block: 100,
+        last_block: 200,
+        first_observed_at: "1783500000000",
+        last_observed_at: "1783600000000",
+      },
+      {
+        // No matching coldkeyRows entry below -- exercises the Map-miss ?? 0
+        // fallback, distinct from the StakeAdded row's real lookup hit.
+        event_kind: "StakeRemoved",
+        event_count: "1",
+        hotkey_count: "1",
+        amount_tao: "1",
+        alpha_amount: "0",
+        first_block: 100,
+        last_block: 100,
+        first_observed_at: "1783500000000",
+        last_observed_at: "1783500000000",
+      },
+    ],
+    [{ event_kind: "StakeAdded", coldkey_count: "2" }],
+    [ACCOUNT_EVENT_ROW],
+  ];
+  const res = await req("/api/v1/subnets/4/event-summary?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.event_kinds[0].event_kind).toBe("StakeAdded");
+  expect(body.event_kinds[0].coldkey_count).toBe(2);
+  const removed = body.event_kinds.find((k) => k.event_kind === "StakeRemoved");
+  expect(removed.coldkey_count).toBe(0);
+  expect(body.recent_events[0].event_kind).toBe("StakeAdded");
+  expect(queryText()).toContain(
+    "GROUP BY event_kind ORDER BY event_count DESC",
+  );
+});
+
+test("GET /api/v1/subnets/:netuid/event-summary defaults the window when absent", async () => {
+  mockQueue.current = [[], [], [], []];
+  const res = await req("/api/v1/subnets/4/event-summary");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("30d");
+});
+
+test("GET /api/v1/subnets/:netuid/event-summary falls back to the default window for an unrecognized label", async () => {
+  mockQueue.current = [[], [], [], []];
+  const res = await req("/api/v1/subnets/4/event-summary?window=bogus");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("30d");
+});
+
 test("GET /api/v1/subnets/:netuid/weights/setters returns a leaderboard + totals", async () => {
   mockQueue.current = [
     [], // consumed by the session-scoped `SET statement_timeout` call

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -41,6 +41,7 @@ import {
   handleSubnetTurnover,
   handleSubnetStakeFlow,
   handleSubnetWeights,
+  handleSubnetAlphaVolume,
   handleSubnetServing,
   handleSubnetPrometheus,
   handleSubnetStakeMoves,
@@ -7591,6 +7592,174 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     };
     const body = await json(
       await handleRuntime(req("/api/v1/runtime"), env, url("/api/v1/runtime")),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  // #4832 Tier 1b: the remaining account_events-derived handlers with no
+  // Postgres tier at all -- same pattern as Tier 1a above.
+
+  test("handleSubnetWeights: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", weight_sets: 0 }),
+    };
+    const body = await json(
+      await handleSubnetWeights(
+        req(`/api/v1/subnets/${NETUID}/weights`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/weights`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetWeights: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetWeights(
+        req(`/api/v1/subnets/${NETUID}/weights`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/weights`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetAlphaVolume: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          data: { schema_version: 1, marker: "pg" },
+          generatedAt: null,
+        }),
+    };
+    const body = await json(
+      await handleSubnetAlphaVolume(
+        req(`/api/v1/subnets/${NETUID}/volume`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/volume`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetAlphaVolume: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetAlphaVolume(
+        req(`/api/v1/subnets/${NETUID}/volume`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/volume`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ subnetEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", events: [] }),
+    };
+    const body = await json(
+      await handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/events`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetEvents: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ subnetEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/events`),
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleSubnetEventSummary: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      subnetEventSummaryKinds: [],
+      subnetEventSummaryRecent: [],
+    });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", event_kinds: [] }),
+    };
+    const body = await json(
+      await handleSubnetEventSummary(
+        req(`/api/v1/subnets/${NETUID}/event-summary`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/event-summary`),
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetEventSummary: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({
+      subnetEventSummaryKinds: [],
+      subnetEventSummaryRecent: [],
+    });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleSubnetEventSummary(
+        req(`/api/v1/subnets/${NETUID}/event-summary`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/event-summary`),
+      ),
     );
     assert.equal(body.data.marker, undefined);
     assert.ok(captures.sql.length > 0);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -33,7 +33,14 @@ import {
   formatAccountEvent,
   buildAccountTransfers,
   buildBlockEvents,
+  buildSubnetEvents,
+  buildSubnetEventSummary,
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+  DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "../src/account-events.mjs";
+import { buildAlphaVolume } from "../src/alpha-volume.mjs";
 import {
   buildBlocksSummary,
   BLOCKS_SUMMARY_SCAN_CAP,
@@ -60,6 +67,11 @@ import {
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
 } from "../src/subnet-weight-setters.mjs";
+import {
+  buildSubnetWeights,
+  SUBNET_WEIGHTS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHTS_WINDOW,
+} from "../src/subnet-weights.mjs";
 import {
   buildAccountStakeFlow,
   STAKE_FLOW_WINDOWS,
@@ -1059,6 +1071,124 @@ export default {
           );
         }
 
+        // GET /api/v1/subnets/:netuid/events (#4832 Tier 1b): the per-subnet
+        // signed-event feed, mirroring src/account-events.mjs's loadSubnetEvents
+        // filter set (kind, block_start/block_end, cursor). Same account_events
+        // table/columns as the account feed above, filtered by netuid instead of
+        // hotkey/coldkey -- a single indexed WHERE, no UNION needed.
+        const subnetEventsRoute = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/events$/,
+        );
+        if (subnetEventsRoute) {
+          const netuid = Number(subnetEventsRoute[1]);
+          const limit = clampLimit(url.searchParams.get("limit"));
+          const offset = clampOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const kind = url.searchParams.get("kind") || null;
+          const blockStart = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_start",
+          );
+          const blockEnd = nonNegativeIntegerParam(
+            url.searchParams,
+            "block_end",
+          );
+          const rows = await sql`
+          SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+          FROM account_events
+          WHERE netuid = ${netuid}
+            ${kind ? sql`AND event_kind = ${kind}` : sql``}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${cursor ? sql`AND (block_number, event_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY block_number DESC, event_index DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.block_number),
+                numberOrNull(last.event_index),
+              ])
+            : null;
+          return json(
+            buildSubnetEvents(rows, netuid, { limit, offset, nextCursor }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/event-summary (#4832 Tier 1b): windowed
+        // account_events aggregates by kind/category plus a recent evidence
+        // slice, mirroring src/account-events.mjs's loadSubnetEventSummary. The
+        // distinct-actor count uses the same hotkey-or-(netuid,uid) identity as
+        // the weight-setters routes (WeightsSet ingestion can omit hotkey).
+        const subnetEventSummaryRoute = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/event-summary$/,
+        );
+        if (subnetEventSummaryRoute) {
+          const netuid = Number(subnetEventSummaryRoute[1]);
+          const windowParam =
+            url.searchParams.get("window") ??
+            DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+          const windowLabel = Object.hasOwn(
+            SUBNET_EVENT_SUMMARY_WINDOWS,
+            windowParam,
+          )
+            ? windowParam
+            : DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+          const cutoff =
+            Date.now() -
+            SUBNET_EVENT_SUMMARY_WINDOWS[windowLabel] * ANALYTICS_DAY_MS;
+          const limit = Math.min(
+            Math.max(
+              Number(url.searchParams.get("limit")) ||
+                SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+              1,
+            ),
+            SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+          );
+          const kindRows = await sql`
+          SELECT event_kind, COUNT(*) AS event_count,
+            COUNT(DISTINCT CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                                 WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) AS hotkey_count,
+            COALESCE(SUM(amount_tao), 0) AS amount_tao, COALESCE(SUM(alpha_amount), 0) AS alpha_amount,
+            MIN(block_number) AS first_block, MAX(block_number) AS last_block,
+            MIN(observed_at) AS first_observed_at, MAX(observed_at) AS last_observed_at
+          FROM account_events WHERE netuid = ${netuid} AND observed_at >= ${cutoff}
+          GROUP BY event_kind ORDER BY event_count DESC, event_kind ASC`;
+          // Distinct-per-kind actor count via a grouped subquery (the delegating
+          // account's column named once, comma-adjacent) rather than
+          // COUNT(DISTINCT <col>) in the aggregate above -- same pattern as the
+          // subnet stake-moves/stake-transfers routes' distinct-mover count.
+          const coldkeyRows = await sql`
+          SELECT event_kind, COUNT(*) AS coldkey_count FROM (
+            SELECT coldkey, event_kind FROM account_events
+            WHERE netuid = ${netuid} AND observed_at >= ${cutoff}
+            GROUP BY 1, 2
+          ) grouped GROUP BY event_kind`;
+          const coldkeyCountByKind = new Map(
+            coldkeyRows.map((row) => [row.event_kind, row.coldkey_count]),
+          );
+          const kindRowsWithColdkeyCount = kindRows.map((row) => ({
+            ...row,
+            coldkey_count: coldkeyCountByKind.get(row.event_kind) ?? 0,
+          }));
+          const recentRows = await sql`
+          SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+          FROM account_events WHERE netuid = ${netuid} AND observed_at >= ${cutoff}
+          ORDER BY block_number DESC, event_index DESC LIMIT ${limit}`;
+          return json(
+            buildSubnetEventSummary(
+              kindRowsWithColdkeyCount,
+              recentRows,
+              netuid,
+              {
+                window: windowLabel,
+                limit,
+              },
+            ),
+          );
+        }
+
         // GET /api/v1/accounts/:ss58/extrinsics — extrinsics SIGNED by this account
         // (the `signer` column only, not a hotkey/coldkey union -- `extrinsics` has
         // no hotkey/coldkey columns), mirroring src/account-events.mjs's
@@ -1213,6 +1343,64 @@ export default {
               ),
             }),
             generatedAt: latestObservedIso(rows),
+          });
+        }
+
+        // GET /api/v1/subnets/:netuid/weights (#4832 Tier 1b): the aggregate
+        // WeightsSet activity for this subnet, mirroring src/subnet-weights.mjs's
+        // loadSubnetWeights. Distinct from /weights/setters below (the per-setter
+        // leaderboard) -- this is the single-row summary.
+        const subnetWeights = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/weights$/,
+        );
+        if (subnetWeights) {
+          const netuid = Number(subnetWeights[1]);
+          const cutoff = windowCutoff(
+            url,
+            SUBNET_WEIGHTS_WINDOWS,
+            DEFAULT_SUBNET_WEIGHTS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT COUNT(*) AS weight_sets,
+                 COUNT(DISTINCT CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                                      WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) AS distinct_setters,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          return json(
+            buildSubnetWeights(rows[0] ?? null, netuid, {
+              window: windowLabelFor(
+                url,
+                SUBNET_WEIGHTS_WINDOWS,
+                DEFAULT_SUBNET_WEIGHTS_WINDOW,
+              ),
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/volume (#4832 Tier 1b): rolling 24h buy/sell
+        // alpha volume, mirroring src/alpha-volume.mjs's loadSubnetAlphaVolume.
+        // marketCapTao is deliberately null here (not the D1 path's degradation --
+        // vol_mcap_ratio's own "externally-loaded marketCapTao" null semantics,
+        // documented on buildAlphaVolume): this Worker has no KV/R2 binding to
+        // resolve the live economics artifact the way entities.mjs's
+        // resolveSubnetMarketCapTao does, only the Hyperdrive Postgres connection.
+        const subnetVolume = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/volume$/,
+        );
+        if (subnetVolume) {
+          const netuid = Number(subnetVolume[1]);
+          const cutoff = Date.now() - ANALYTICS_DAY_MS;
+          const rows = await sql`
+          SELECT event_kind, COALESCE(SUM(alpha_amount), 0) AS alpha_volume,
+                 COALESCE(SUM(amount_tao), 0) AS tao_volume, COUNT(*) AS event_count,
+                 MAX(observed_at) AS last_observed
+          FROM account_events
+          WHERE netuid = ${netuid} AND event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND}) AND observed_at >= ${cutoff}
+          GROUP BY event_kind`;
+          return json({
+            data: buildAlphaVolume(rows, netuid, { marketCapTao: null }),
+            generatedAt: latestObservedIso(rows, "last_observed"),
           });
         }
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1730,10 +1730,12 @@ export async function handleSubnetWeights(request, env, netuid, url) {
       message: unsupportedWindowMessage(windowParam, SUBNET_WEIGHTS_WINDOWS),
     });
   }
-  const data = await loadSubnetWeights(d1Runner(env), netuid, {
-    windowLabel: windowParam,
-    windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam],
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetWeights(d1Runner(env), netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam],
+    }));
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2261,13 +2263,11 @@ export async function handleSubnetAlphaVolume(request, env, netuid, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
   const marketCapTao = await resolveSubnetMarketCapTao(env, netuid);
-  const { data, generatedAt } = await loadSubnetAlphaVolume(
-    d1Runner(env),
-    netuid,
-    {
+  const { data, generatedAt } =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetAlphaVolume(d1Runner(env), netuid, {
       marketCapTao,
-    },
-  );
+    }));
   return envelopeResponse(
     request,
     {
@@ -3279,14 +3279,16 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
-  const data = await loadSubnetEvents(d1Runner(env), netuid, {
-    limit: url.searchParams.get("limit"),
-    offset: url.searchParams.get("offset"),
-    kind: url.searchParams.get("kind"),
-    cursor: url.searchParams.get("cursor"),
-    blockStart: blockStart.value,
-    blockEnd: blockEnd.value,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetEvents(d1Runner(env), netuid, {
+      limit: url.searchParams.get("limit"),
+      offset: url.searchParams.get("offset"),
+      kind: url.searchParams.get("kind"),
+      cursor: url.searchParams.get("cursor"),
+      blockStart: blockStart.value,
+      blockEnd: blockEnd.value,
+    }));
   if (csvRequested(url, request)) {
     return csvResponse(
       data.events,
@@ -3334,10 +3336,12 @@ export async function handleSubnetEventSummary(request, env, netuid, url) {
     maxLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   });
   if (parsedLimit.error) return analyticsQueryError(parsedLimit.error);
-  const data = await loadSubnetEventSummary(d1Runner(env), netuid, {
-    windowLabel,
-    limit: parsedLimit.limit,
-  });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadSubnetEventSummary(d1Runner(env), netuid, {
+      windowLabel,
+      limit: parsedLimit.limit,
+    }));
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- Ports 4 handlers with **no Postgres tier at all** — `handleSubnetWeights`
  (the aggregate WeightsSet card, distinct from `/weights/setters` which was
  already ported), `handleSubnetAlphaVolume`, `handleSubnetEvents`,
  `handleSubnetEventSummary`. Same bug class as Tier 1a (#4833): silently
  serving `account_events` data frozen since the streamer stopped.
- Adds the matching Postgres SQL to `workers/data-api.mjs` and wires
  `tryPostgresTier` into each handler, reusing the already-`"postgres"`
  `METAGRAPH_ACCOUNT_EVENTS_SOURCE` flag.
- The event-summary route's distinct-coldkey-per-kind count is a second
  grouped-subquery `COUNT(*)` (comma-adjacent column, merged into the kind
  rows in JS) rather than `COUNT(DISTINCT coldkey)` in the main aggregate —
  same public-safety-scanner-safe pattern used for the stake-moves/
  stake-transfers routes in the account_events analytics PR (#4830).
- `handleSubnetAlphaVolume`'s `vol_mcap_ratio` is `null` on the Postgres path
  — not a regression. This Worker (`wrangler.data.jsonc`) has only a
  Hyperdrive binding, no KV/R2 access to resolve the live economics artifact
  the way `entities.mjs`'s `resolveSubnetMarketCapTao` does.
  `buildAlphaVolume`'s own doc comment already documents null `marketCapTao`
  as a supported, accepted state.

Tier 1b of #4832. `handleAccount`/`handleAccountSubnets`/`handleAccountHistory`
(multi-table aggregates or `account_events_daily`-sourced — more involved,
tracked separately) and Tier 2 (`neurons`/`neuron_daily`-derived, 12 handlers)
follow in separate PRs.

## Testing

- `npm run lint` clean
- `npx prettier --check` clean (scoped to touched files)
- `npm run scan:public-safety` clean
- `npx vitest run` — 7298/7298 passed (259 files), full local suite
- Local coverage confirms 100% branch coverage on every line actually added
  in this diff (`git diff origin/main -U0` cross-referenced against
  `coverage/lcov.info`'s `BRDA` records)

Refs #4832