### PR TITLE
fix(data-api): port handleAccount + handleAccountSubnets to the Postgres tier

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -799,6 +799,58 @@ test("GET /api/v1/extrinsics/:ref skips the embedded-events query on an unresolv
   expect(sqlCalls.length).toBe(2); // SET + the main lookup, no events query
 });
 
+test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from one bounded event window", async () => {
+  mockQueue.current = [
+    [], // SET
+    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: 5 }], // scanRows
+    [{ netuid: 4, uid: 1, stake_tao: "10", validator_permit: 1, active: 1 }], // regRows
+    [
+      {
+        tx_count: "3",
+        last_tx_block: 8586300,
+        last_tx_at: "1783600000000",
+        total_fee_tao: "0.03",
+      },
+    ], // activityRows
+    [{ call_module: "SubtensorModule", count: "3" }], // moduleRows
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.event_count).toBe(2);
+  expect(body.subnet_count).toBe(2);
+  expect(body.event_kinds[0].kind).toBe("StakeAdded");
+  expect(body.event_kinds[0].count).toBe(2);
+  expect(body.registrations[0].netuid).toBe(4);
+  expect(body.recent_events.length).toBe(2);
+  expect(body.activity.tx_count).toBe(3);
+  expect(body.activity.modules_called[0].call_module).toBe("SubtensorModule");
+  expect(queryText()).toContain("WHERE (hotkey =");
+  expect(queryText()).toContain("OR coldkey =");
+});
+
+test("GET /api/v1/accounts/:ss58 with no matching rows returns a schema-stable empty summary", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.event_count).toBe(0);
+  expect(body.registrations).toEqual([]);
+  expect(body.recent_events).toEqual([]);
+});
+
+test("GET /api/v1/accounts/:ss58/subnets returns the current registrations from neurons", async () => {
+  mockRows.current = [
+    { netuid: 4, uid: 1, stake_tao: "10", validator_permit: 1, active: 1 },
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}/subnets`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnets[0].netuid).toBe(4);
+  expect(body.subnet_count).toBe(1);
+  expect(queryText()).toContain("FROM neurons");
+});
+
 test("GET /api/v1/accounts/:ss58/events returns a feed shaped like the D1 route", async () => {
   mockRows.current = [ACCOUNT_EVENT_ROW];
   const res = await req(`/api/v1/accounts/${SS58}/events?limit=1`);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -7764,6 +7764,75 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.equal(body.data.marker, undefined);
     assert.ok(captures.sql.length > 0);
   });
+
+  // #4832 Tier 1c: handleAccount (multi-table: account_events + neurons +
+  // extrinsics) and handleAccountSubnets (neurons-derived).
+
+  test("handleAccount: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", event_count: 0 }),
+    };
+    const body = await json(
+      await handleAccount(req(`/api/v1/accounts/${SS58}`), env, SS58),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccount: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccount(req(`/api/v1/accounts/${SS58}`), env, SS58),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
+
+  test("handleAccountSubnets: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ neurons: [neuronRow()] });
+    env.METAGRAPH_NEURONS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, marker: "pg", subnets: [] }),
+    };
+    const body = await json(
+      await handleAccountSubnets(
+        req(`/api/v1/accounts/${SS58}/subnets`),
+        env,
+        SS58,
+      ),
+    );
+    assert.equal(body.data.marker, "pg");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountSubnets: flag=postgres falls back to D1 on failure", async () => {
+    const { env, captures } = dbWith({ neurons: [neuronRow()] });
+    env.METAGRAPH_NEURONS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleAccountSubnets(
+        req(`/api/v1/accounts/${SS58}/subnets`),
+        env,
+        SS58,
+      ),
+    );
+    assert.equal(body.data.marker, undefined);
+    assert.ok(captures.sql.length > 0);
+  });
 });
 
 // ---- Cross-handler contract smoke tests -------------------------------------

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -35,6 +35,9 @@ import {
   buildBlockEvents,
   buildSubnetEvents,
   buildSubnetEventSummary,
+  buildAccountSummary,
+  buildAccountSubnets,
+  ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   SUBNET_EVENT_SUMMARY_WINDOWS,
   DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
@@ -1011,6 +1014,90 @@ export default {
             events = eventRows.map(formatAccountEvent).filter(Boolean);
           }
           return json(buildExtrinsic(resolved, ref, events));
+        }
+
+        // GET /api/v1/accounts/:ss58 (#4832 Tier 1c): cross-subnet account
+        // summary -- event aggregates, per-kind counts, 10 newest events,
+        // current registrations, and bounded signing activity from the
+        // extrinsics tier, mirroring src/account-events.mjs's
+        // loadAccountSummary. Postgres has no INDEXED BY equivalent and
+        // evaluates (hotkey = $1 OR coldkey = $1) as one plan, so the D1
+        // path's two-branch UNION-of-seeks (each capped, then re-merged and
+        // re-capped) collapses to a single bounded ORDER BY/LIMIT scan here --
+        // the aggregate/kind/recent-events fields below all derive from that
+        // one CAP+1-row window, computed once client-side, rather than
+        // separate SQL aggregates per field.
+        const acctSummary = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)$/,
+        );
+        if (acctSummary) {
+          const ss58 = decodeURIComponent(acctSummary[1]);
+          const scanRows = await sql`
+          SELECT block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index
+          FROM account_events WHERE (hotkey = ${ss58} OR coldkey = ${ss58})
+          ORDER BY block_number DESC, event_index DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`;
+          const regRows = await sql`
+          SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
+          WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`;
+          const activityRows = await sql`
+          SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao
+          FROM (SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer = ${ss58} ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1000) sub`;
+          const moduleRows = await sql`
+          SELECT call_module, COUNT(*) AS count FROM (
+            SELECT call_module FROM extrinsics WHERE signer = ${ss58}
+            ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1000
+          ) sub GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10`;
+          const scanned = scanRows.length;
+          const capped = scanRows.slice(0, ACCOUNT_EVENT_SUMMARY_SCAN_CAP);
+          const netuids = new Set();
+          let fb = null;
+          let lb = null;
+          let fo = null;
+          let lo = null;
+          const kindCounts = new Map();
+          for (const row of capped) {
+            netuids.add(row.netuid);
+            const bn = numberOrNull(row.block_number);
+            if (bn != null && (fb == null || bn < fb)) fb = bn;
+            if (bn != null && (lb == null || bn > lb)) lb = bn;
+            const obs = numberOrNull(row.observed_at);
+            if (obs != null && (fo == null || obs < fo)) fo = obs;
+            if (obs != null && (lo == null || obs > lo)) lo = obs;
+            kindCounts.set(
+              row.event_kind,
+              (kindCounts.get(row.event_kind) ?? 0) + 1,
+            );
+          }
+          const kinds = [...kindCounts.entries()].map(([kind, count]) => ({
+            kind,
+            count,
+          }));
+          return json(
+            buildAccountSummary(ss58, {
+              agg: { c: capped.length, sc: netuids.size, fb, lb, fo, lo },
+              kinds,
+              scanned,
+              registrations: regRows,
+              recent: capped.slice(0, 10),
+              activity: activityRows[0],
+              modules: moduleRows,
+            }),
+          );
+        }
+
+        // GET /api/v1/accounts/:ss58/subnets (#4832 Tier 1c): the subnets where
+        // this account's hotkey is currently registered, mirroring
+        // src/account-events.mjs's loadAccountSubnets -- neurons-derived (the
+        // live registration snapshot), not account_events.
+        const acctSubnets = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/subnets$/,
+        );
+        if (acctSubnets) {
+          const ss58 = decodeURIComponent(acctSubnets[1]);
+          const rows = await sql`
+          SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
+          WHERE hotkey = ${ss58} ORDER BY netuid`;
+          return json(buildAccountSubnets(rows, ss58));
         }
 
         // GET /api/v1/accounts/:ss58/events — the per-account signed-event feed

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -2668,7 +2668,9 @@ export async function handleAccountDeregistrations(request, env, ss58, url) {
 // (account_events, matched by hotkey OR coldkey) joined to current registrations
 // (neurons, by hotkey). Cold/absent store → schema-stable zero (never 404).
 export async function handleAccount(request, env, ss58) {
-  const data = await loadAccountSummary(d1Runner(env), ss58);
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
+    (await loadAccountSummary(d1Runner(env), ss58));
   return accountEnvelopeResponse(
     request,
     {
@@ -3096,7 +3098,9 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
 // GET /api/v1/accounts/{ss58}/subnets: the subnets where this hotkey is currently
 // registered (the cross-subnet footprint), from the neurons tier.
 export async function handleAccountSubnets(request, env, ss58) {
-  const data = await loadAccountSubnets(d1Runner(env), ss58);
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
+    (await loadAccountSubnets(d1Runner(env), ss58));
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- Ports `handleAccount` (the cross-subnet account summary: event aggregates,
  per-kind counts, 10 newest events, current registrations, bounded signing
  activity) and `handleAccountSubnets` (current registrations, neurons-
  derived) — neither had a Postgres tier. `handleAccount` was silently
  serving `account_events`/`extrinsics` data frozen since the streamer
  stopped.
- Postgres has no `INDEXED BY` equivalent and evaluates
  `(hotkey = $1 OR coldkey = $1)` as one plan, so D1's two-branch
  UNION-of-seeks (each capped, then re-merged and re-capped) collapses to a
  single bounded `ORDER BY`/`LIMIT` scan on `account_events` — the
  aggregate/kind/recent-events fields all derive from that one
  `CAP+1`-row window, computed once client-side, rather than the four
  separate SQL aggregates `loadAccountSummary` runs against D1.
- **`handleAccountHistory` (`account_events_daily`) is deliberately NOT
  included** — verified via direct query on the indexer box that the
  Postgres `account_events_daily` table is **empty (0 rows)**. Nothing
  writes to it yet (`rollupAccountEventsDaily` writes to D1 only). That's a
  new write-path gap, not a read-port, and is out of scope here — tracked as
  a follow-up on #4832.

Tier 1c of #4832 (the last of the `account_events`/`neurons`-only handlers).
Tier 2 (`neuron_daily`-derived: turnover, movers, concentration,
performance, yield-history, validator-history, subnet-history — 12
handlers) follows.

## Testing

- `npm run lint` clean
- `npx prettier --check` clean (scoped to touched files)
- `npm run scan:public-safety` clean
- `npx vitest run` — 7305/7305 passed (259 files), full local suite
- Local coverage confirms 100% branch coverage on every line actually added
  in this diff (`git diff origin/main -U0` cross-referenced against
  `coverage/lcov.info`'s `BRDA` records)

Refs #4832