### PR TITLE
fix(ui): give the per-UID yield leaderboard a mobile card layout

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -129,7 +129,57 @@ export function YieldLoader({ netuid }: { netuid: number }) {
 
       {/* Per-UID yield leaderboard (top yielders). */}
       <div className="rounded-xl border border-border bg-card overflow-hidden">
-        <div className="overflow-x-auto">
+        {/* < md: the 7-column table needs an undiscoverable horizontal scroll to
+            reach its rightmost Yield / vs-median columns — the entire point of
+            this leaderboard — so narrow viewports get a stacked card per UID
+            that surfaces yield + vs-median prominently (mirrors the cards/table
+            split ListShell uses for paginated lists). */}
+        <div className="md:hidden divide-y divide-border/60">
+          {ranked.map((n) => (
+            <div key={n.uid} className="px-3 py-2.5">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="font-mono text-[12px] tabular-nums text-ink-strong">
+                    #{n.uid}
+                  </span>
+                  {n.role === "validator" ? (
+                    <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                      Validator
+                    </span>
+                  ) : (
+                    <span className="font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                      Miner
+                    </span>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <span className="font-mono text-[13px] tabular-nums text-ink-strong">
+                    {fmtYield(n.yield)}
+                  </span>
+                  <VsMedian vs={n.vs_median} />
+                </div>
+              </div>
+              <div className="mt-1.5 flex items-center justify-between gap-3 font-mono text-[11px] tabular-nums text-ink-muted">
+                {n.hotkey ? (
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: n.hotkey }}
+                    className="truncate text-ink-muted hover:text-ink hover:underline"
+                    title={n.hotkey}
+                  >
+                    {shortHash(n.hotkey) ?? n.hotkey}
+                  </Link>
+                ) : (
+                  <span>—</span>
+                )}
+                <span className="shrink-0">
+                  {taoCompact(n.stake_tao)} τ · {taoCompact(n.emission_tao)} τ
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
               <tr>


### PR DESCRIPTION
## Summary

The per-UID Yield leaderboard (`yield-panel.tsx`, Metagraph tab) renders a 7-column table (UID / Hotkey / Role / Stake / Emission / **Yield** / **vs median**) inside an `overflow-hidden` card. At mobile width the table is wider than the viewport, so its two rightmost columns — **Yield %** and the **vs-median** indicator, the entire point of a *ranked yield* page — are clipped off-screen. The table sits in an `overflow-x-auto` wrapper, so it is technically scrollable, but the default (unscrolled) mobile view still hides yield/vs-median behind an undiscoverable horizontal scroll (#3708).

This re-flows each row into a **stacked card below `md`** that surfaces yield + vs-median prominently per UID, mirroring the same cards-below-`md` / table-at-`md`+ split `ListShell` already uses for the app's paginated leaderboards (and the merged stake-transfer leaderboard fix). At `md` and up the existing table is unchanged — it comfortably fits its 7 columns at ≥768px.

## What changed

- `apps/ui/src/components/metagraphed/yield-panel.tsx` — the leaderboard block only: added a `md:hidden` card list (UID + role badge, **yield % + vs-median arrow** top-right, hotkey + stake·emission below) alongside the existing table, now wrapped `hidden md:block`. No columns, data, sorting, `TOP_N`, or the `overflow-x-auto` table fallback changed — a `< md`-only presentation change.

## Screenshots

Captured on `/subnets/64?tab=metagraph` (per-UID yield leaderboard) with a fixture matching the real `SubnetYield` contract shape driving the actual component code (the live `/api/v1/subnets/{netuid}/yield` returns an empty neuron set in this environment, same approach as the merged stake-transfer fix). Fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes forced via `localStorage.setItem("mg-theme", …)`, `deviceScaleFactor: 1`.

The change is scoped to `< md`, so the **Mobile** rows carry the fix (before: table clipped at Emission, Yield/vs-median gone → after: cards surfacing yield + vs-median per UID). Tablet/Desktop keep the identical table and are included for the full matrix (before = after there).

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-desktop-light.png)<br><sub>after (table unchanged)</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-desktop-dark.png)<br><sub>after (table unchanged)</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-tablet-light.png)<br><sub>after (table unchanged)</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-tablet-dark.png)<br><sub>after (table unchanged)</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-mobile-light.png)<br><sub>before — Yield / vs-median clipped</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-mobile-light.png)<br><sub>after — cards surface yield + vs-median</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-before-mobile-dark.png)<br><sub>before — Yield / vs-median clipped</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3935-after-mobile-dark.png)<br><sub>after — cards surface yield + vs-median</sub> |

## Validation

- `tsc --noEmit` — clean (after building `packages/client`, as CI does)
- `eslint` — 0 errors on the changed file
- `prettier --check` — clean
- `vitest run` — yield-format + yield-percentile-layout suites pass (15 tests)
- `git diff` touches only `yield-panel.tsx`; no columns/data/logic changed, only the `< md` presentation.

Closes #3935
