### PR TITLE
feat(data-api): migrate subnet_hyperparams to Postgres (#4832)

### DIFF
--- a/.github/workflows/refresh-subnet-hyperparams.yml
+++ b/.github/workflows/refresh-subnet-hyperparams.yml
@@ -98,6 +98,27 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # #4832 gap-closure: ALSO write the same signed snapshot to the Postgres
+      # write path (workers/data-api.mjs's handleSubnetHyperparamsSync),
+      # alongside (not replacing) the R2/D1 step above -- mirrors
+      # refresh-metagraph.yml's neurons-sync step exactly, including the
+      # always-exit-0-and-::warning:: shape (a failure here must never fail
+      # the D1 path this job's real dependents rely on) and the skip-until-
+      # provisioned convention.
+      - name: Sync subnet hyperparameters to the Postgres write path (#4832 gap-closure)
+        run: |
+          if [ -z "$SUBNET_HYPERPARAMS_SYNC_SECRET" ]; then
+            echo "SUBNET_HYPERPARAMS_SYNC_SECRET not set; skipping Postgres sync"
+            exit 0
+          fi
+          curl -fsS -X POST "https://api.metagraph.sh/api/v1/internal/subnet-hyperparams-sync" \
+            -H "x-subnet-hyperparams-sync-token: ${SUBNET_HYPERPARAMS_SYNC_SECRET}" \
+            -H "content-type: application/json" \
+            --data-binary @dist/metagraph-subnet-hyperparams.json \
+            || echo "::warning::subnet-hyperparams-sync Postgres write failed; D1 path (this job's real dependency) is unaffected"
+        env:
+          SUBNET_HYPERPARAMS_SYNC_SECRET: ${{ secrets.SUBNET_HYPERPARAMS_SYNC_SECRET }}
+
   notify-on-failure:
     needs: [fetch, sign-and-stage]
     if: ${{ always() && (needs.fetch.result == 'failure' || needs.sign-and-stage.result == 'failure') }}

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -207,6 +207,101 @@ CREATE INDEX IF NOT EXISTS idx_account_position_daily_netuid_date
 CREATE INDEX IF NOT EXISTS idx_account_position_daily_date
   ON account_position_daily (snapshot_date);
 
+-- Subnet hyperparameters, latest-only (#4832 gap-closure; mirrors D1
+-- migrations/0036_subnet_hyperparams.sql). One row per netuid, upserted by
+-- the refresh-subnet-hyperparams workflow's direct POST to data-api.mjs.
+-- *_ratio columns and TAO-exact fields stay NUMERIC (not REAL) to match the
+-- D1 pure builders' round(value, 9) precision; the nine D1 0/1 flag columns
+-- become BOOLEAN here (see the SUM(boolean) landmine noted elsewhere in this
+-- file); bonds_moving_avg_raw is a raw on-chain integer, not a ratio.
+CREATE TABLE IF NOT EXISTS subnet_hyperparams (
+  netuid                       INTEGER NOT NULL,
+  kappa_ratio                  NUMERIC,
+  immunity_period               INTEGER,
+  min_allowed_weights           INTEGER,
+  max_weight_limit_ratio        NUMERIC,
+  tempo                        INTEGER,
+  weights_version               INTEGER,
+  weights_rate_limit            INTEGER,
+  activity_cutoff               INTEGER,
+  activity_cutoff_factor        INTEGER,
+  registration_allowed          BOOLEAN,
+  target_regs_per_interval      INTEGER,
+  min_burn_tao                 NUMERIC,
+  max_burn_tao                 NUMERIC,
+  burn_half_life                INTEGER,
+  burn_increase_mult            NUMERIC,
+  bonds_moving_avg_raw           BIGINT,
+  max_regs_per_block            INTEGER,
+  serving_rate_limit            INTEGER,
+  max_validators                INTEGER,
+  commit_reveal_period          INTEGER,
+  commit_reveal_enabled         BOOLEAN,
+  alpha_high_ratio              NUMERIC,
+  alpha_low_ratio               NUMERIC,
+  liquid_alpha_enabled          BOOLEAN,
+  alpha_sigmoid_steepness       NUMERIC,
+  yuma_version                  INTEGER,
+  subnet_is_active              BOOLEAN,
+  transfers_enabled             BOOLEAN,
+  bonds_reset_enabled           BOOLEAN,
+  user_liquidity_enabled        BOOLEAN,
+  owner_cut_enabled             BOOLEAN,
+  owner_cut_auto_lock_enabled   BOOLEAN,
+  min_childkey_take_ratio       NUMERIC,
+  block_number                 BIGINT,
+  captured_at                  BIGINT NOT NULL,
+  PRIMARY KEY (netuid)
+);
+
+-- Historical hyperparameter change tracking (#4832 gap-closure; mirrors D1
+-- migrations/0037_subnet_hyperparams_history.sql). Append-only, diffed by
+-- hyperparams_hash on each sync; live-forward only, same as the D1 table.
+CREATE TABLE IF NOT EXISTS subnet_hyperparams_history (
+  id                            BIGSERIAL PRIMARY KEY,
+  netuid                        INTEGER NOT NULL,
+  block_number                  BIGINT,
+  observed_at                   BIGINT NOT NULL,
+  kappa_ratio                   NUMERIC,
+  immunity_period                INTEGER,
+  min_allowed_weights            INTEGER,
+  max_weight_limit_ratio         NUMERIC,
+  tempo                         INTEGER,
+  weights_version                INTEGER,
+  weights_rate_limit             INTEGER,
+  activity_cutoff                INTEGER,
+  activity_cutoff_factor         INTEGER,
+  registration_allowed           BOOLEAN,
+  target_regs_per_interval       INTEGER,
+  min_burn_tao                  NUMERIC,
+  max_burn_tao                  NUMERIC,
+  burn_half_life                 INTEGER,
+  burn_increase_mult             NUMERIC,
+  bonds_moving_avg_raw            BIGINT,
+  max_regs_per_block             INTEGER,
+  serving_rate_limit             INTEGER,
+  max_validators                 INTEGER,
+  commit_reveal_period           INTEGER,
+  commit_reveal_enabled          BOOLEAN,
+  alpha_high_ratio                NUMERIC,
+  alpha_low_ratio                NUMERIC,
+  liquid_alpha_enabled           BOOLEAN,
+  alpha_sigmoid_steepness        NUMERIC,
+  yuma_version                   INTEGER,
+  subnet_is_active               BOOLEAN,
+  transfers_enabled              BOOLEAN,
+  bonds_reset_enabled            BOOLEAN,
+  user_liquidity_enabled         BOOLEAN,
+  owner_cut_enabled              BOOLEAN,
+  owner_cut_auto_lock_enabled    BOOLEAN,
+  min_childkey_take_ratio        NUMERIC,
+  hyperparams_hash               TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_subnet_hyperparams_history_netuid_observed
+  ON subnet_hyperparams_history (netuid, observed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_subnet_hyperparams_history_netuid_id
+  ON subnet_hyperparams_history (netuid, id DESC);
+
 -- Account daily rollup (#2079 / audit: removes the temp-sort on default account history).
 CREATE TABLE IF NOT EXISTS account_events_daily (
   hotkey           TEXT NOT NULL,

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4,6 +4,8 @@
 import { beforeEach, test, expect, vi } from "vitest";
 import { BLOCK_PAGINATION, MAX_OFFSET } from "../workers/request-params.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
+import { formatSubnetHyperparams } from "../src/subnet-hyperparams.mjs";
+import { hyperparamsHash } from "../src/subnet-hyperparams-history.mjs";
 
 const sqlCalls = vi.hoisted(() => []);
 const mockRows = vi.hoisted(() => ({
@@ -33,6 +35,14 @@ const neuronsSyncFailure = vi.hoisted(() => ({ error: null }));
 const neuronsSyncPruneRows = vi.hoisted(() => ({ current: [] }));
 // State for the account-events-daily rollup write route's tests only (#4832).
 const rollupFailure = vi.hoisted(() => ({ error: null }));
+// State for the subnet-hyperparams-sync write route's tests only (#4832
+// gap-closure): a failure hook mirroring neuronsSyncFailure/rollupFailure, a
+// prune-rows hook mirroring neuronsSyncPruneRows, and the "latest hash per
+// netuid" SELECT DISTINCT ON result the history diff reads before deciding
+// which rows changed.
+const subnetHyperparamsSyncFailure = vi.hoisted(() => ({ error: null }));
+const subnetHyperparamsPruneRows = vi.hoisted(() => ({ current: [] }));
+const subnetHyperparamsLatestHashes = vi.hoisted(() => ({ current: [] }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -83,8 +93,17 @@ vi.mock("postgres", () => ({
       ) {
         return Promise.reject(rollupFailure.error);
       }
+      if (
+        subnetHyperparamsSyncFailure.error &&
+        /INSERT INTO subnet_hyperparams\b/.test(text)
+      ) {
+        return Promise.reject(subnetHyperparamsSyncFailure.error);
+      }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
+      }
+      if (/SELECT DISTINCT ON \(netuid\)/.test(text)) {
+        return Promise.resolve(subnetHyperparamsLatestHashes.current);
       }
       if (mockQueue.current.length) {
         return Promise.resolve(mockQueue.current.shift());
@@ -103,6 +122,9 @@ vi.mock("postgres", () => ({
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
       }
+      if (/DELETE FROM subnet_hyperparams\b/.test(text)) {
+        return Promise.resolve(subnetHyperparamsPruneRows.current);
+      }
       return Promise.resolve(mockRows.current);
     };
     // sql.begin(["read only",] cb) reserves a connection for cb in real
@@ -120,10 +142,12 @@ vi.mock("postgres", () => ({
 const { default: worker } = await import("../workers/data-api.mjs");
 const NEURONS_SYNC_SECRET = "test-neurons-sync-secret";
 const ROLLUP_SYNC_SECRET = "test-rollup-sync-secret";
+const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
   ROLLUP_SYNC_SECRET,
+  SUBNET_HYPERPARAMS_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -136,6 +160,9 @@ beforeEach(() => {
   neuronsSyncFailure.error = null;
   neuronsSyncPruneRows.current = [];
   rollupFailure.error = null;
+  subnetHyperparamsSyncFailure.error = null;
+  subnetHyperparamsPruneRows.current = [];
+  subnetHyperparamsLatestHashes.current = [];
   mockRows.current = [
     {
       block_number: "123",
@@ -2749,6 +2776,387 @@ test("GET /api/v1/accounts/:ss58/history?limit=1 emits a next_cursor when the pa
     },
   ];
   const res = await req(`/api/v1/accounts/${SS58}/history?limit=1`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.next_cursor).not.toBeNull();
+});
+
+// #4832 gap-closure: POST /api/v1/internal/subnet-hyperparams-sync -- the
+// write path into subnet_hyperparams/subnet_hyperparams_history (see
+// workers/data-api.mjs's handleSubnetHyperparamsSync), plus its read paths,
+// GET /api/v1/subnets/:netuid/hyperparameters[/history].
+function hyperparamsSyncRow(overrides = {}) {
+  return {
+    netuid: 8,
+    kappa_ratio: 0.5,
+    immunity_period: 7200,
+    min_allowed_weights: 8,
+    max_weight_limit_ratio: 1,
+    tempo: 360,
+    weights_version: 1,
+    weights_rate_limit: 100,
+    activity_cutoff: 5000,
+    activity_cutoff_factor: 1,
+    registration_allowed: 1,
+    target_regs_per_interval: 1,
+    min_burn_tao: 0.001,
+    max_burn_tao: 100,
+    burn_half_life: 100_000,
+    burn_increase_mult: 1,
+    bonds_moving_avg_raw: 900_000,
+    max_regs_per_block: 1,
+    serving_rate_limit: 50,
+    max_validators: 64,
+    commit_reveal_period: 1,
+    commit_reveal_enabled: 0,
+    alpha_high_ratio: 0.9,
+    alpha_low_ratio: 0.1,
+    liquid_alpha_enabled: 0,
+    alpha_sigmoid_steepness: 10,
+    yuma_version: 3,
+    subnet_is_active: 1,
+    transfers_enabled: 1,
+    bonds_reset_enabled: 0,
+    user_liquidity_enabled: 0,
+    owner_cut_enabled: 1,
+    owner_cut_auto_lock_enabled: 1,
+    min_childkey_take_ratio: 0,
+    block_number: 5_000_000,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function postSubnetHyperparams(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-subnet-hyperparams-sync-token"] = secret;
+  return req("/api/v1/internal/subnet-hyperparams-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? []),
+  });
+}
+
+test("subnet-hyperparams-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postSubnetHyperparams([hyperparamsSyncRow()], {
+    secret: "wrong",
+  });
+  expect(wrong.status).toBe(401);
+  const missing = await postSubnetHyperparams([hyperparamsSyncRow()]);
+  expect(missing.status).toBe(401);
+});
+
+test("subnet-hyperparams-sync is disabled (503) when SUBNET_HYPERPARAMS_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/subnet-hyperparams-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-subnet-hyperparams-sync-token": SUBNET_HYPERPARAMS_SYNC_SECRET,
+      },
+      body: JSON.stringify([hyperparamsSyncRow()]),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("subnet-hyperparams-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/subnet-hyperparams-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-subnet-hyperparams-sync-token": SUBNET_HYPERPARAMS_SYNC_SECRET,
+      },
+      body: JSON.stringify([hyperparamsSyncRow()]),
+    }),
+    { SUBNET_HYPERPARAMS_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("subnet-hyperparams-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postSubnetHyperparams(null, {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+    raw: "[" + "1".repeat(2_000_000) + "]",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("subnet-hyperparams-sync rejects malformed JSON (400)", async () => {
+  const res = await postSubnetHyperparams(null, {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects a body that isn't an array or {rows:[...]} (400)", async () => {
+  const res = await postSubnetHyperparams(
+    { not: "an array" },
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync accepts the {rows:[...]} wrapped form, not just a bare array", async () => {
+  const res = await postSubnetHyperparams(
+    { rows: [hyperparamsSyncRow()] },
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_hyperparams_written).toBe(1);
+});
+
+test("subnet-hyperparams-sync rejects more than the row cap (413)", async () => {
+  const many = Array.from({ length: 2001 }, (_, i) =>
+    hyperparamsSyncRow({ netuid: i % 65_536 }),
+  );
+  const res = await postSubnetHyperparams(many, {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(413);
+});
+
+test("subnet-hyperparams-sync rejects a row with an out-of-range netuid (400)", async () => {
+  const res = await postSubnetHyperparams(
+    [hyperparamsSyncRow({ netuid: 70_000 })],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects a non-object row (400)", async () => {
+  const res = await postSubnetHyperparams(["not-an-object"], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects a row carrying an unknown column (400)", async () => {
+  const res = await postSubnetHyperparams(
+    [hyperparamsSyncRow({ unexpected_field: 1 })],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects a row with a non-numeric, non-null field (400)", async () => {
+  const res = await postSubnetHyperparams(
+    [hyperparamsSyncRow({ tempo: "360" })],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects a row with a numeric field that overflows to Infinity (400)", async () => {
+  const { tempo: _tempo, ...rest } = hyperparamsSyncRow();
+  const raw = JSON.stringify([rest]).replace(/}\]$/, `,"tempo":1e400}]`);
+  const res = await postSubnetHyperparams(null, {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+    raw,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects a row missing a valid captured_at (400)", async () => {
+  const res = await postSubnetHyperparams(
+    [hyperparamsSyncRow({ captured_at: 0 })],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync rejects an empty array (400)", async () => {
+  const res = await postSubnetHyperparams([], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-hyperparams-sync upserts subnet_hyperparams and reports written/pruned counts", async () => {
+  const res = await postSubnetHyperparams(
+    [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({ ok: true, subnet_hyperparams_written: 2 });
+  expect(queryText()).toMatch(/INSERT INTO subnet_hyperparams\b/);
+  expect(queryText()).toMatch(/DELETE FROM subnet_hyperparams\b/);
+});
+
+test("subnet-hyperparams-sync prunes with scalar positional binds, not a bound array", async () => {
+  await postSubnetHyperparams(
+    [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  const pruneCall = sqlCalls.find((c) =>
+    /DELETE FROM subnet_hyperparams\b/.test(c.text),
+  );
+  expect(pruneCall.values).toEqual([8, 9]);
+  expect(pruneCall.text).toMatch(/\$1::int, \$2::int/);
+});
+
+test("subnet-hyperparams-sync coerces 0/1 boolean-flag columns to real booleans", async () => {
+  await postSubnetHyperparams(
+    [
+      hyperparamsSyncRow({
+        registration_allowed: 1,
+        commit_reveal_enabled: 0,
+      }),
+    ],
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO subnet_hyperparams\b/.test(c.text),
+  );
+  expect(insert.values).toContain(true);
+  expect(insert.values).toContain(false);
+});
+
+test("subnet-hyperparams-sync defaults a missing optional column to null rather than undefined", async () => {
+  const { block_number: _blockNumber, ...withoutBlockNumber } =
+    hyperparamsSyncRow();
+  const res = await postSubnetHyperparams([withoutBlockNumber], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO subnet_hyperparams\b/.test(c.text),
+  );
+  expect(insert.values).toContain(null);
+});
+
+test("subnet-hyperparams-sync reports deregistered_pruned from the DELETE's returned row count", async () => {
+  subnetHyperparamsPruneRows.current = [{ netuid: 99 }];
+  const res = await postSubnetHyperparams([hyperparamsSyncRow()], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  const body = await res.json();
+  expect(body.deregistered_pruned).toBe(1);
+});
+
+test("subnet-hyperparams-sync appends to subnet_hyperparams_history when the hash changed (cold history)", async () => {
+  subnetHyperparamsLatestHashes.current = [];
+  const res = await postSubnetHyperparams([hyperparamsSyncRow()], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  const body = await res.json();
+  expect(body.history_appended).toBe(1);
+  expect(queryText()).toMatch(/INSERT INTO subnet_hyperparams_history/);
+});
+
+test("subnet-hyperparams-sync skips the history append when the hash is unchanged", async () => {
+  const row = hyperparamsSyncRow();
+  const hash = await hyperparamsHash(formatSubnetHyperparams(row));
+  subnetHyperparamsLatestHashes.current = [
+    { netuid: row.netuid, hyperparams_hash: hash },
+  ];
+  const res = await postSubnetHyperparams([row], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  const body = await res.json();
+  expect(body.history_appended).toBe(0);
+  expect(queryText()).not.toMatch(/INSERT INTO subnet_hyperparams_history/);
+});
+
+test("subnet-hyperparams-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  subnetHyperparamsSyncFailure.error = new Error("connection reset");
+  const res = await postSubnetHyperparams([hyperparamsSyncRow()], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+test("GET /api/v1/subnets/:netuid/hyperparameters returns the latest row", async () => {
+  mockRows.current = [
+    {
+      kappa_ratio: 0.5,
+      tempo: 360,
+      registration_allowed: true,
+      commit_reveal_enabled: false,
+      liquid_alpha_enabled: false,
+      subnet_is_active: true,
+      transfers_enabled: true,
+      bonds_reset_enabled: false,
+      user_liquidity_enabled: false,
+      owner_cut_enabled: true,
+      owner_cut_auto_lock_enabled: true,
+      block_number: "5000000",
+      captured_at: "1780000000000",
+    },
+  ];
+  const res = await req("/api/v1/subnets/8/hyperparameters");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.netuid).toBe(8);
+  expect(body.hyperparameters.tempo).toBe(360);
+  expect(body.hyperparameters.registration_allowed).toBe(true);
+});
+
+test("GET /api/v1/subnets/:netuid/hyperparameters on a cold store returns hyperparameters:null", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/subnets/8/hyperparameters");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.hyperparameters).toBeNull();
+});
+
+test("GET /api/v1/subnets/:netuid/hyperparameters/history returns the change timeline", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      block_number: "100",
+      observed_at: "1780000000000",
+      kappa_ratio: 0.5,
+      tempo: 360,
+      registration_allowed: true,
+      commit_reveal_enabled: false,
+      liquid_alpha_enabled: false,
+      subnet_is_active: true,
+      transfers_enabled: true,
+      bonds_reset_enabled: false,
+      user_liquidity_enabled: false,
+      owner_cut_enabled: true,
+      owner_cut_auto_lock_enabled: true,
+      hyperparams_hash: "abc123",
+    },
+  ];
+  const res = await req("/api/v1/subnets/8/hyperparameters/history");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.entry_count).toBe(1);
+  expect(body.entries[0].hyperparams_hash).toBe("abc123");
+  expect(body.entries[0].hyperparameters.tempo).toBe(360);
+});
+
+test("GET /api/v1/subnets/:netuid/hyperparameters/history uses a cursor seek instead of OFFSET", async () => {
+  mockRows.current = [];
+  const cursor = encodeCursor([1780000000000, 10]);
+  const res = await req(
+    `/api/v1/subnets/8/hyperparameters/history?cursor=${cursor}`,
+  );
+  expect(res.status).toBe(200);
+  expect(queryText()).toContain("AND (observed_at, id) <");
+  expect(queryText()).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/subnets/:netuid/hyperparameters/history?limit=1 emits a next_cursor when the page is full", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      block_number: "100",
+      observed_at: "1780000000000",
+      hyperparams_hash: "abc123",
+    },
+  ];
+  const res = await req("/api/v1/subnets/8/hyperparameters/history?limit=1");
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.next_cursor).not.toBeNull();

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -33,6 +33,7 @@ import {
   handleNeuronHistory,
   handleSubnetHistory,
   handleSubnetIdentityHistory,
+  handleSubnetHyperparams,
   handleSubnetHyperparamsHistory,
   handleSubnetConcentration,
   handleSubnetPerformance,
@@ -266,6 +267,47 @@ function identityHistoryRow(overrides = {}) {
   };
 }
 
+function hyperparamsRow(overrides = {}) {
+  return {
+    block_number: 100,
+    captured_at: OBSERVED_AT,
+    kappa_ratio: 0.5,
+    immunity_period: 7200,
+    min_allowed_weights: 8,
+    max_weight_limit_ratio: 1,
+    tempo: 360,
+    weights_version: 1,
+    weights_rate_limit: 100,
+    activity_cutoff: 5000,
+    activity_cutoff_factor: 1,
+    registration_allowed: 1,
+    target_regs_per_interval: 1,
+    min_burn_tao: 0.001,
+    max_burn_tao: 100,
+    burn_half_life: 100_000,
+    burn_increase_mult: 1,
+    bonds_moving_avg_raw: 900_000,
+    max_regs_per_block: 1,
+    serving_rate_limit: 50,
+    max_validators: 64,
+    commit_reveal_period: 1,
+    commit_reveal_enabled: 0,
+    alpha_high_ratio: 0.9,
+    alpha_low_ratio: 0.1,
+    liquid_alpha_enabled: 0,
+    alpha_sigmoid_steepness: 10,
+    yuma_version: 3,
+    subnet_is_active: 1,
+    transfers_enabled: 1,
+    bonds_reset_enabled: 0,
+    user_liquidity_enabled: 0,
+    owner_cut_enabled: 1,
+    owner_cut_auto_lock_enabled: 1,
+    min_childkey_take_ratio: 0,
+    ...overrides,
+  };
+}
+
 function hyperparamsHistoryRow(overrides = {}) {
   return {
     id: 10,
@@ -327,6 +369,7 @@ function dbWith({
   accountEvents,
   accountEventsDaily,
   subnetIdentityHistory,
+  subnetHyperparams,
   subnetHyperparamsHistory,
   accountIdentity,
   accountIdentityHistory,
@@ -463,6 +506,10 @@ function dbWith({
                   // Historical hyperparameter change tracking (#4309).
                   if (/FROM subnet_hyperparams_history/.test(sql)) {
                     return { results: subnetHyperparamsHistory || [] };
+                  }
+                  // Subnet hyperparameters, latest-only (#4307/1.4).
+                  if (/FROM subnet_hyperparams WHERE netuid = \?/.test(sql)) {
+                    return { results: subnetHyperparams || [] };
                   }
                   // Personal chain identity, latest-only (epic #4301/5.4) —
                   // checked before the history branch below (both match
@@ -1205,6 +1252,48 @@ describe("handleSubnetIdentityHistory", () => {
     assert.equal(body.data.entry_count, 1);
     assert.equal(body.data.entries[0].subnet_name, "MIAO");
     assert.equal(body.data.limit, 20);
+  });
+});
+
+describe("handleSubnetHyperparams", () => {
+  test("rejects an unsupported query param with 400", async () => {
+    const res = await handleSubnetHyperparams(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters?bogus=1`),
+    );
+    await errorJson(res);
+  });
+
+  test("returns schema-stable hyperparameters:null on cold D1", async () => {
+    const body = await assertColdSchema(
+      handleSubnetHyperparams,
+      req(`/api/v1/subnets/${NETUID}/hyperparameters`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters`),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.hyperparameters, null);
+    assert.equal(body.data.captured_at, null);
+  });
+
+  test("happy path returns the latest hyperparameters row", async () => {
+    const { env } = dbWith({
+      subnetHyperparams: [hyperparamsRow()],
+    });
+    const body = await json(
+      await handleSubnetHyperparams(
+        req(`/api/v1/subnets/${NETUID}/hyperparameters`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/hyperparameters`),
+      ),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.hyperparameters.tempo, 360);
+    assert.equal(body.data.block_number, 100);
   });
 });
 
@@ -6337,6 +6426,85 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       ),
     );
     assert.equal(body.data.neuron.hotkey, SS58);
+  });
+
+  // #4832 gap-closure: subnet_hyperparams/subnet_hyperparams_history's new
+  // Postgres tier, own dedicated flag (METAGRAPH_SUBNET_HYPERPARAMS_SOURCE)
+  // since it has an independent write path from neurons/neuron_daily above.
+  test("handleSubnetHyperparams: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({ subnetHyperparams: [hyperparamsRow()] });
+    env.METAGRAPH_SUBNET_HYPERPARAMS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        netuid: NETUID,
+        captured_at: null,
+        block_number: null,
+        hyperparameters: { tempo: 999 },
+      }),
+    );
+    const path = `/api/v1/subnets/${NETUID}/hyperparameters`;
+    const body = await json(
+      await handleSubnetHyperparams(req(path), env, NETUID, url(path)),
+    );
+    assert.equal(body.data.hyperparameters.tempo, 999);
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetHyperparams: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({ subnetHyperparams: [hyperparamsRow()] });
+    env.METAGRAPH_SUBNET_HYPERPARAMS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const path = `/api/v1/subnets/${NETUID}/hyperparameters`;
+    const body = await json(
+      await handleSubnetHyperparams(req(path), env, NETUID, url(path)),
+    );
+    assert.equal(body.data.hyperparameters.tempo, 360);
+  });
+
+  test("handleSubnetHyperparamsHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      subnetHyperparamsHistory: [hyperparamsHistoryRow()],
+    });
+    env.METAGRAPH_SUBNET_HYPERPARAMS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        netuid: NETUID,
+        entry_count: 1,
+        limit: null,
+        offset: null,
+        next_cursor: null,
+        entries: [{ hyperparams_hash: "pg-hash" }],
+      }),
+    );
+    const path = `/api/v1/subnets/${NETUID}/hyperparameters/history`;
+    const body = await json(
+      await handleSubnetHyperparamsHistory(req(path), env, NETUID, url(path)),
+    );
+    assert.equal(body.data.entries[0].hyperparams_hash, "pg-hash");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetHyperparamsHistory: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({
+      subnetHyperparamsHistory: [hyperparamsHistoryRow()],
+    });
+    env.METAGRAPH_SUBNET_HYPERPARAMS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const path = `/api/v1/subnets/${NETUID}/hyperparameters/history`;
+    const body = await json(
+      await handleSubnetHyperparamsHistory(req(path), env, NETUID, url(path)),
+    );
+    assert.equal(body.data.entries[0].hyperparams_hash, "abc");
   });
 
   test("handleSubnetValidators: flag=postgres uses Postgres data, D1 never queried", async () => {

--- a/tests/subnet-hyperparams-sync-proxy.test.mjs
+++ b/tests/subnet-hyperparams-sync-proxy.test.mjs
@@ -1,0 +1,119 @@
+// Unit tests for the /api/v1/internal/subnet-hyperparams-sync proxy
+// (workers/api.mjs's handleSubnetHyperparamsSyncProxy, #4832 gap-closure),
+// which forwards to workers/data-api.mjs's handleSubnetHyperparamsSync via
+// the EXISTING DATA_API service binding (shares proxyToDataApi with
+// handleNeuronsSyncProxy/handleRollupAccountEventsDailyProxy -- see
+// tests/neurons-sync-proxy.test.mjs for that sibling route's equivalent
+// coverage). The downstream sync logic itself is covered by
+// tests/data-api.test.mjs.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+
+function post({ method = "POST" } = {}) {
+  return new Request(
+    "https://api.metagraph.sh/api/v1/internal/subnet-hyperparams-sync",
+    { method },
+  );
+}
+
+test("rejects non-POST before reaching the binding (405)", async () => {
+  let calls = 0;
+  const res = await handleRequest(
+    post({ method: "GET" }),
+    {
+      DATA_API: {
+        fetch() {
+          calls += 1;
+          return new Response("{}", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 405);
+  assert.equal(calls, 0);
+});
+
+test("returns 503 when DATA_API is not bound", async () => {
+  const res = await handleRequest(post(), {}, {});
+  assert.equal(res.status, 503);
+});
+
+test("forwards the request to DATA_API and relays its response body + status", async () => {
+  let receivedToken;
+  let receivedPath;
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/internal/subnet-hyperparams-sync",
+      {
+        method: "POST",
+        headers: { "x-subnet-hyperparams-sync-token": "shared-secret" },
+      },
+    ),
+    {
+      DATA_API: {
+        fetch(req) {
+          receivedToken = req.headers.get("x-subnet-hyperparams-sync-token");
+          receivedPath = new URL(req.url).pathname;
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              subnet_hyperparams_written: 129,
+              deregistered_pruned: 0,
+              history_appended: 3,
+            }),
+            { status: 200 },
+          );
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedToken, "shared-secret");
+  assert.equal(receivedPath, "/api/v1/internal/subnet-hyperparams-sync");
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), {
+    ok: true,
+    subnet_hyperparams_written: 129,
+    deregistered_pruned: 0,
+    history_appended: 3,
+  });
+});
+
+test("relays a non-2xx upstream status (e.g. 401) unchanged", async () => {
+  const res = await handleRequest(
+    post(),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(JSON.stringify({ error: "unauthorized" }), {
+            status: 401,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.deepEqual(await res.json(), { error: "unauthorized" });
+});
+
+test("returns 502 when the upstream response body is unreadable", async () => {
+  const res = await handleRequest(
+    post(),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response("not json", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal(
+    (await res.json()).error.code,
+    "subnet_hyperparams_sync_unavailable",
+  );
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1220,6 +1220,19 @@ async function handleRollupAccountEventsDailyProxy(request, env) {
   });
 }
 
+// Proxies POST /api/v1/internal/subnet-hyperparams-sync -- the write path
+// into subnet_hyperparams/subnet_hyperparams_history (#4832 gap-closure).
+// Same DATA_API service binding as neurons-sync/rollup above.
+async function handleSubnetHyperparamsSyncProxy(request, env) {
+  return proxyToDataApi(request, env, {
+    code: "subnet_hyperparams_sync_unavailable",
+    notBoundMessage:
+      "The subnet-hyperparams sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The subnet-hyperparams sync tier returned an unreadable response.",
+  });
+}
+
 export async function handleRequest(request, env = {}, ctx = {}) {
   let url = new URL(request.url);
 
@@ -1340,6 +1353,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // neurons-sync above). Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/rollup-account-events-daily") {
     return handleRollupAccountEventsDailyProxy(request, env);
+  }
+  // The write path into subnet_hyperparams/subnet_hyperparams_history
+  // (#4832 gap-closure) -- refresh-subnet-hyperparams.yml's sign-and-stage
+  // job calls this the same way refresh-metagraph.yml calls neurons-sync
+  // above. Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/subnet-hyperparams-sync") {
+    return handleSubnetHyperparamsSyncProxy(request, env);
   }
 
   // GraphQL read-only query layer over existing artifacts (issue #751). Runs

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -215,6 +215,15 @@ import {
   buildCounterpartyRelationship,
   COUNTERPARTIES_SCAN_CAP,
 } from "../src/counterparties.mjs";
+import {
+  SUBNET_HYPERPARAMS_INSERT_COLUMNS,
+  formatSubnetHyperparams,
+  buildSubnetHyperparams,
+} from "../src/subnet-hyperparams.mjs";
+import {
+  hyperparamsHash,
+  buildSubnetHyperparamsHistory,
+} from "../src/subnet-hyperparams-history.mjs";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
@@ -753,6 +762,264 @@ async function handleRollupAccountEventsDaily(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/subnet-hyperparams-sync (#4832 gap-closure) -----
+//
+// The write path into subnet_hyperparams + subnet_hyperparams_history,
+// reached only via workers/api.mjs's handleSubnetHyperparamsSyncProxy (the
+// same proxyToDataApi shape as neurons-sync/rollup-account-events-daily
+// above). .github/workflows/refresh-subnet-hyperparams.yml's sign-and-stage
+// job POSTs the SAME signed envelope it already produces for the D1 R2-stage
+// path (scripts/sign-staged-neurons.mjs's {schema_version, hmac_sha256,
+// rows} shape) directly here -- the hmac_sha256 field is ignored (unlike
+// workers/request-handlers/staging.mjs's loadStagedSubnetHyperparams, which
+// verifies it): that verification exists to authenticate an R2 object drop
+// across an untrusted intermediate step, and is unnecessary to replicate
+// here since the POST itself is independently authenticated by the token
+// header below, matching handleNeuronsSync's own request/{rows:[...]} shape.
+//
+// Every successful upstream fetch covers ALL active subnets in one run (no
+// partial-coverage concept -- see loadStagedSubnetHyperparams's own header
+// comment), so the prune below is a plain NOT IN against this batch's
+// netuids, unlike neurons-sync's per-netuid captured_at-scoped prune.
+const SUBNET_HYPERPARAMS_SYNC_TOKEN_HEADER = "x-subnet-hyperparams-sync-token";
+// ~129 rows today (one per active subnet); generous headroom, matching the
+// D1 staging path's MAX_STAGED_SUBNET_HYPERPARAMS_ROWS/_BYTES.
+const SUBNET_HYPERPARAMS_SYNC_MAX_BODY_BYTES = 2_000_000;
+const SUBNET_HYPERPARAMS_SYNC_MAX_ROWS = 2_000;
+const SUBNET_HYPERPARAMS_SYNC_MAX_NETUID = 65_535;
+const SUBNET_HYPERPARAMS_BOOLEAN_COLUMNS = new Set([
+  "registration_allowed",
+  "commit_reveal_enabled",
+  "liquid_alpha_enabled",
+  "subnet_is_active",
+  "transfers_enabled",
+  "bonds_reset_enabled",
+  "user_liquidity_enabled",
+  "owner_cut_enabled",
+  "owner_cut_auto_lock_enabled",
+]);
+// The 33 hyperparameter field names, same derivation as
+// src/subnet-hyperparams-history.mjs's own (unexported) HYPERPARAM_FIELDS --
+// strips netuid (front) and block_number/captured_at (back).
+const SUBNET_HYPERPARAMS_HISTORY_FIELDS =
+  SUBNET_HYPERPARAMS_INSERT_COLUMNS.slice(1, -2);
+
+// Bounds-check one incoming row against SUBNET_HYPERPARAMS_INSERT_COLUMNS --
+// same trust posture as staging.mjs's validStagedSubnetHyperparamsRow (every
+// field but netuid is null-or-finite-number; the fetch script emits 0/1 for
+// the boolean-flag columns, not JSON booleans).
+function validSubnetHyperparamsSyncRow(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  if (
+    !Number.isInteger(row.netuid) ||
+    row.netuid < 0 ||
+    row.netuid > SUBNET_HYPERPARAMS_SYNC_MAX_NETUID
+  )
+    return false;
+  if (!Number.isInteger(row.captured_at) || row.captured_at <= 0) return false;
+  for (const [key, value] of Object.entries(row)) {
+    if (!SUBNET_HYPERPARAMS_INSERT_COLUMNS.includes(key)) return false;
+    if (typeof value === "number" && !Number.isFinite(value)) return false;
+    if (value !== null && typeof value !== "number") return false;
+  }
+  return true;
+}
+
+// 0/1 -> boolean for the BOOLEAN columns (see NEURONS_SYNC_BOOLEAN_COLUMNS'
+// identical reasoning above); everything else passes through unchanged.
+function coerceSubnetHyperparamsSyncRow(row) {
+  const out = {};
+  for (const col of SUBNET_HYPERPARAMS_INSERT_COLUMNS) {
+    const value = row[col] ?? null;
+    out[col] = SUBNET_HYPERPARAMS_BOOLEAN_COLUMNS.has(col)
+      ? Boolean(Number(value))
+      : value;
+  }
+  return out;
+}
+
+async function handleSubnetHyperparamsSync(request, env) {
+  if (!env.SUBNET_HYPERPARAMS_SYNC_SECRET) {
+    return writeJson(
+      {
+        error: "subnet-hyperparams sync is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(SUBNET_HYPERPARAMS_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.SUBNET_HYPERPARAMS_SYNC_SECRET)
+  ) {
+    return writeJson(
+      {
+        error: `provide a valid ${SUBNET_HYPERPARAMS_SYNC_TOKEN_HEADER} header`,
+      },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > SUBNET_HYPERPARAMS_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${SUBNET_HYPERPARAMS_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of subnet-hyperparams rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > SUBNET_HYPERPARAMS_SYNC_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${SUBNET_HYPERPARAMS_SYNC_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validSubnetHyperparamsSyncRow)) {
+    return writeJson(
+      { error: "rows must match the subnet-hyperparams row shape" },
+      400,
+    );
+  }
+
+  const rows = incoming.map(coerceSubnetHyperparamsSyncRow);
+  const netuids = incoming.map((row) => row.netuid);
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    return await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+
+      await sql`
+        INSERT INTO subnet_hyperparams ${sql(rows, ...SUBNET_HYPERPARAMS_INSERT_COLUMNS)}
+        ON CONFLICT (netuid) DO UPDATE SET
+          kappa_ratio = EXCLUDED.kappa_ratio,
+          immunity_period = EXCLUDED.immunity_period,
+          min_allowed_weights = EXCLUDED.min_allowed_weights,
+          max_weight_limit_ratio = EXCLUDED.max_weight_limit_ratio,
+          tempo = EXCLUDED.tempo,
+          weights_version = EXCLUDED.weights_version,
+          weights_rate_limit = EXCLUDED.weights_rate_limit,
+          activity_cutoff = EXCLUDED.activity_cutoff,
+          activity_cutoff_factor = EXCLUDED.activity_cutoff_factor,
+          registration_allowed = EXCLUDED.registration_allowed,
+          target_regs_per_interval = EXCLUDED.target_regs_per_interval,
+          min_burn_tao = EXCLUDED.min_burn_tao,
+          max_burn_tao = EXCLUDED.max_burn_tao,
+          burn_half_life = EXCLUDED.burn_half_life,
+          burn_increase_mult = EXCLUDED.burn_increase_mult,
+          bonds_moving_avg_raw = EXCLUDED.bonds_moving_avg_raw,
+          max_regs_per_block = EXCLUDED.max_regs_per_block,
+          serving_rate_limit = EXCLUDED.serving_rate_limit,
+          max_validators = EXCLUDED.max_validators,
+          commit_reveal_period = EXCLUDED.commit_reveal_period,
+          commit_reveal_enabled = EXCLUDED.commit_reveal_enabled,
+          alpha_high_ratio = EXCLUDED.alpha_high_ratio,
+          alpha_low_ratio = EXCLUDED.alpha_low_ratio,
+          liquid_alpha_enabled = EXCLUDED.liquid_alpha_enabled,
+          alpha_sigmoid_steepness = EXCLUDED.alpha_sigmoid_steepness,
+          yuma_version = EXCLUDED.yuma_version,
+          subnet_is_active = EXCLUDED.subnet_is_active,
+          transfers_enabled = EXCLUDED.transfers_enabled,
+          bonds_reset_enabled = EXCLUDED.bonds_reset_enabled,
+          user_liquidity_enabled = EXCLUDED.user_liquidity_enabled,
+          owner_cut_enabled = EXCLUDED.owner_cut_enabled,
+          owner_cut_auto_lock_enabled = EXCLUDED.owner_cut_auto_lock_enabled,
+          min_childkey_take_ratio = EXCLUDED.min_childkey_take_ratio,
+          block_number = EXCLUDED.block_number,
+          captured_at = EXCLUDED.captured_at
+        WHERE subnet_hyperparams.captured_at <= EXCLUDED.captured_at`;
+
+      // Prune subnets no longer in the snapshot (deregistered/removed) --
+      // scalar positional binds via sql.unsafe, not a bound array, avoiding
+      // the same fetch_types:false ANY()/array-bind landmine documented on
+      // handleNeuronsSync's own prune above. `netuids` is never empty here
+      // -- the earlier `!incoming.length` check guarantees at least one row.
+      const placeholders = netuids.map((_, i) => `$${i + 1}::int`).join(", ");
+      const pruned = await sql.unsafe(
+        `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${placeholders}) RETURNING netuid`,
+        netuids,
+      );
+
+      // Diff-and-append into subnet_hyperparams_history (mirrors D1's
+      // recordSubnetHyperparamsChanges) -- hashed on the RAW incoming rows
+      // (pre-coercion): formatSubnetHyperparams' toD1Flag(value) already
+      // tolerates either a 0/1 number or a real boolean, so the hash stays
+      // domain-identical to the D1 path regardless of which shape reaches it.
+      const latest = await sql`
+        SELECT DISTINCT ON (netuid) netuid, hyperparams_hash
+        FROM subnet_hyperparams_history
+        ORDER BY netuid, id DESC`;
+      const latestByNetuid = new Map(
+        latest.map((row) => [Number(row.netuid), row.hyperparams_hash]),
+      );
+      const now = Date.now();
+      const changedRows = [];
+      for (const row of incoming) {
+        const hyperparameters = formatSubnetHyperparams(row);
+        const hash = await hyperparamsHash(hyperparameters);
+        if (latestByNetuid.get(row.netuid) === hash) continue;
+        changedRows.push({
+          netuid: row.netuid,
+          block_number: row.block_number ?? null,
+          observed_at: now,
+          ...hyperparameters,
+          hyperparams_hash: hash,
+        });
+        latestByNetuid.set(row.netuid, hash);
+      }
+      if (changedRows.length) {
+        await sql`
+          INSERT INTO subnet_hyperparams_history ${sql(
+            changedRows,
+            "netuid",
+            "block_number",
+            "observed_at",
+            ...SUBNET_HYPERPARAMS_HISTORY_FIELDS,
+            "hyperparams_hash",
+          )}`;
+      }
+
+      return writeJson({
+        ok: true,
+        subnet_hyperparams_written: rows.length,
+        deregistered_pruned: pruned.length,
+        history_appended: changedRows.length,
+      });
+    });
+  } catch (err) {
+    console.error("data-api subnet-hyperparams-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -877,6 +1144,12 @@ export default {
       url.pathname === "/api/v1/internal/rollup-account-events-daily"
     ) {
       return handleRollupAccountEventsDaily(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/subnet-hyperparams-sync"
+    ) {
+      return handleSubnetHyperparamsSync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
@@ -2416,6 +2689,63 @@ export default {
           SELECT uid, hotkey, validator_permit, stake_tao, emission_tao, captured_at, block_number
           FROM neurons WHERE netuid = ${netuid} ORDER BY uid`;
           return json(buildSubnetYield(rows, netuid));
+        }
+
+        // GET /api/v1/subnets/:netuid/hyperparameters (#4832 gap-closure,
+        // Phase B): latest-only, mirroring src/subnet-hyperparams.mjs's
+        // loadSubnetHyperparams. Column list matches that file's own
+        // SUBNET_HYPERPARAMS_COLUMNS (every INSERT column except netuid,
+        // itself already known from the WHERE clause).
+        const subnetHyperparams = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/hyperparameters$/,
+        );
+        if (subnetHyperparams) {
+          const netuid = Number(subnetHyperparams[1]);
+          const rows = await sql`
+          SELECT kappa_ratio, immunity_period, min_allowed_weights, max_weight_limit_ratio, tempo, weights_version, weights_rate_limit, activity_cutoff, activity_cutoff_factor, registration_allowed, target_regs_per_interval, min_burn_tao, max_burn_tao, burn_half_life, burn_increase_mult, bonds_moving_avg_raw, max_regs_per_block, serving_rate_limit, max_validators, commit_reveal_period, commit_reveal_enabled, alpha_high_ratio, alpha_low_ratio, liquid_alpha_enabled, alpha_sigmoid_steepness, yuma_version, subnet_is_active, transfers_enabled, bonds_reset_enabled, user_liquidity_enabled, owner_cut_enabled, owner_cut_auto_lock_enabled, min_childkey_take_ratio, block_number, captured_at
+          FROM subnet_hyperparams WHERE netuid = ${netuid} LIMIT 1`;
+          return json(buildSubnetHyperparams(rows[0] ?? null, netuid));
+        }
+
+        // GET /api/v1/subnets/:netuid/hyperparameters/history?limit=&offset=
+        // &cursor= (#4832 gap-closure, Phase B): append-only change timeline,
+        // mirroring src/subnet-hyperparams-history.mjs's
+        // loadSubnetHyperparamsHistory. observed_at/id are plain BIGINT
+        // columns (not DATE), so no ::text cast is needed for the cursor
+        // comparison the way snapshot_date/day require elsewhere in this file.
+        const subnetHyperparamsHistory = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/hyperparameters\/history$/,
+        );
+        if (subnetHyperparamsHistory) {
+          const netuid = Number(subnetHyperparamsHistory[1]);
+          const limit = clampRequestLimit(
+            url.searchParams.get("limit"),
+            FEED_PAGINATION,
+          );
+          const offset = clampRequestOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const rows = await sql`
+          SELECT id, block_number, observed_at, kappa_ratio, immunity_period, min_allowed_weights, max_weight_limit_ratio, tempo, weights_version, weights_rate_limit, activity_cutoff, activity_cutoff_factor, registration_allowed, target_regs_per_interval, min_burn_tao, max_burn_tao, burn_half_life, burn_increase_mult, bonds_moving_avg_raw, max_regs_per_block, serving_rate_limit, max_validators, commit_reveal_period, commit_reveal_enabled, alpha_high_ratio, alpha_low_ratio, liquid_alpha_enabled, alpha_sigmoid_steepness, yuma_version, subnet_is_active, transfers_enabled, bonds_reset_enabled, user_liquidity_enabled, owner_cut_enabled, owner_cut_auto_lock_enabled, min_childkey_take_ratio, hyperparams_hash
+          FROM subnet_hyperparams_history
+          WHERE netuid = ${netuid}
+            ${cursor ? sql`AND (observed_at, id) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY observed_at DESC, id DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.observed_at),
+                numberOrNull(last.id),
+              ])
+            : null;
+          return json(
+            buildSubnetHyperparamsHistory(rows, netuid, {
+              limit,
+              offset,
+              nextCursor,
+            }),
+          );
         }
 
         // GET /api/v1/accounts/:ss58/portfolio (#4832 Tier 2): one wallet's

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -599,7 +599,12 @@ export async function handleNeuron(request, env, netuid, uid) {
 export async function handleSubnetHyperparams(request, env, netuid, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
-  const data = await loadSubnetHyperparams(d1Runner(env), netuid);
+  const data =
+    (await tryPostgresTier(
+      env,
+      request,
+      "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+    )) ?? (await loadSubnetHyperparams(d1Runner(env), netuid));
   return envelopeResponse(
     request,
     {
@@ -632,11 +637,19 @@ export async function handleSubnetHyperparamsHistory(
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
-  const data = await loadSubnetHyperparamsHistory(d1Runner(env), netuid, {
-    limit,
-    offset,
-    cursor,
-  });
+  async function fromD1() {
+    return loadSubnetHyperparamsHistory(d1Runner(env), netuid, {
+      limit,
+      offset,
+      cursor,
+    });
+  }
+  const data =
+    (await tryPostgresTier(
+      env,
+      request,
+      "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+    )) ?? (await fromD1());
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
- Adds `subnet_hyperparams` + `subnet_hyperparams_history` to the Postgres schema (Phase B, table 1 of 3 in the #4832 completeness-sweep gap-closure).
- New token-authenticated write route `POST /api/v1/internal/subnet-hyperparams-sync` (`handleSubnetHyperparamsSync` in `workers/data-api.mjs`): upserts the latest-only table, diff-appends into the history table by reusing the existing `formatSubnetHyperparams`/`hyperparamsHash` pure functions the D1 path already uses, and prunes deregistered subnets. The same signed envelope `refresh-subnet-hyperparams.yml` already produces for the D1/R2 path is POSTed here directly (no HMAC re-verification needed — the token header is the transport's own auth).
- New read routes `GET /api/v1/subnets/:netuid/hyperparameters` and `.../hyperparameters/history`.
- `handleSubnetHyperparamsSyncProxy` in `workers/api.mjs` (reuses the existing `proxyToDataApi` helper), and `tryPostgresTier` wiring into `handleSubnetHyperparams`/`handleSubnetHyperparamsHistory` in `entities.mjs`, gated on its own `METAGRAPH_SUBNET_HYPERPARAMS_SOURCE` flag (independent from `METAGRAPH_NEURONS_SOURCE` since this write path is unrelated to neurons/neuron_daily).
- `refresh-subnet-hyperparams.yml` gets a new sync step mirroring `refresh-metagraph.yml`'s neurons-sync step exactly.

## Test plan
- [x] `npm run lint` / `npm run format:check` (touched files)
- [x] `npm run scan:public-safety`
- [x] `npm test` — 7433/7433 passing (261 files)
- [x] `npm run test:coverage` + `git diff origin/main -U0` cross-referenced against `coverage/lcov.info` — zero uncovered lines/branches in every added range across `workers/data-api.mjs`, `workers/api.mjs`, `workers/request-handlers/entities.mjs`
- [x] `npm run validate` / `npm run validate:contract-drift`
- [x] `RUN_WORKFLOWS_VALIDATION=true node scripts/validate-workflows.mjs`

Refs #4832