### PR TITLE
fix(ui): stop formatRelative overflowing the unit at boundaries

### DIFF
--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -114,6 +114,24 @@ describe("formatRelative", () => {
   it("labels future timestamps with 'in'", () => {
     expect(formatRelative(new Date(Date.now() + 5 * 60_000).toISOString())).toMatch(/^in \d+m$/);
   });
+
+  it("promotes to the next unit instead of overflowing at a boundary", () => {
+    // ~59.7s must read "1m ago", not the overflowed "60s ago".
+    expect(formatRelative(new Date(Date.now() - 59_700).toISOString())).toBe("1m ago");
+    // ~59.7m must read "1h ago", not "60m ago".
+    expect(formatRelative(new Date(Date.now() - 59_700 * 60).toISOString())).toBe("1h ago");
+    // ~23.95h must read "1d ago", not "24h ago".
+    expect(formatRelative(new Date(Date.now() - 86_220_000).toISOString())).toBe("1d ago");
+  });
+
+  it("never renders an overflowed unit value", () => {
+    for (const ms of [59_500, 59_999, 3_595_000, 3_599_000, 86_100_000, 86_399_000]) {
+      const label = formatRelative(new Date(Date.now() - ms).toISOString());
+      expect(label).not.toMatch(/\b60s\b/);
+      expect(label).not.toMatch(/\b60m\b/);
+      expect(label).not.toMatch(/\b24h\b/);
+    }
+  });
 });
 
 describe("isStaleFreshness", () => {

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -39,22 +39,24 @@ export function formatRelative(iso?: string | null): string {
   const diff = Date.now() - t;
   const abs = Math.abs(diff);
   const past = diff >= 0;
-  let value: number;
-  let unit: string;
-  if (abs < 60_000) {
-    value = Math.max(1, Math.round(abs / 1000));
-    unit = "s";
-  } else if (abs < 3_600_000) {
-    value = Math.round(abs / 60_000);
-    unit = "m";
-  } else if (abs < 86_400_000) {
-    value = Math.round(abs / 3_600_000);
-    unit = "h";
+  // Pick the unit from the *rounded* value, cascading upward: choosing the unit
+  // from the raw `abs` before rounding let a value that rounds up to the next
+  // unit's boundary overflow it — e.g. 59.5s rendered as "60s" instead of "1m",
+  // ~59.9m as "60m" instead of "1h", and ~23.9h as "24h" instead of "1d".
+  let label: string;
+  const s = Math.round(abs / 1000);
+  if (s < 60) {
+    label = `${Math.max(1, s)}s`;
   } else {
-    value = Math.round(abs / 86_400_000);
-    unit = "d";
+    const m = Math.round(abs / 60_000);
+    if (m < 60) {
+      label = `${m}m`;
+    } else {
+      const h = Math.round(abs / 3_600_000);
+      label = h < 24 ? `${h}h` : `${Math.round(abs / 86_400_000)}d`;
+    }
   }
-  return past ? `${value}${unit} ago` : `in ${value}${unit}`;
+  return past ? `${label} ago` : `in ${label}`;
 }
 
 export function isStaleFreshness(iso?: string | null, thresholdMs = 12 * 60 * 60_000): boolean {


### PR DESCRIPTION
## Summary
`formatRelative` (`apps/ui/src/lib/metagraphed/format.ts`) selected the display unit from the raw elapsed `abs` **before** rounding, so a value that rounds up to the next unit's boundary overflowed that unit instead of promoting to it:

| Elapsed | Before | After |
| --- | --- | --- |
| ~59.5s | `60s ago` | `1m ago` |
| ~59.9m | `60m ago` | `1h ago` |
| ~23.9h | `24h ago` | `1d ago` |

These boundaries are hit constantly — freshness timestamps drift through the second/minute/hour marks on the ~6h refresh cycle — and the helper feeds `freshness`, `freshness-badge`, `time-ago`, `evidence-panel`, and `uptime-timeline`.

## Fix
Pick the unit from the **rounded** value, cascading `s → m → h → d`, so a boundary value promotes to the next unit rather than rendering the overflowed count (`60s`/`60m`/`24h`). Normal-case output is unchanged.

## Change
- `format.ts` — restructure the unit selection (logic only; no signature/behaviour change outside the boundary case).
- `format.test.ts` — regression tests asserting boundary values promote, and that no overflowed unit (`60s`/`60m`/`24h`) is ever rendered.

Confined to `apps/ui/src/lib/**` — no visual/route change. `tsc`, `eslint`, `prettier` clean; all 26 format tests pass.