### PR TITLE
fix(data-api): widen subnet_hyperparams.weights_rate_limit to NUMERIC

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -214,6 +214,15 @@ CREATE INDEX IF NOT EXISTS idx_account_position_daily_date
 -- D1 pure builders' round(value, 9) precision; the nine D1 0/1 flag columns
 -- become BOOLEAN here (see the SUM(boolean) landmine noted elsewhere in this
 -- file); bonds_moving_avg_raw is a raw on-chain integer, not a ratio.
+-- weights_rate_limit is NUMERIC, not INTEGER/BIGINT: confirmed live
+-- 2026-07-11 that netuid 0 (root) carries the chain's u64::MAX "unlimited"
+-- sentinel (18446744073709551615) for this field -- larger than even
+-- Postgres BIGINT's signed 64-bit range, which SQLite's flexible INTEGER
+-- storage class silently tolerates (falls back to a REAL) but Postgres'
+-- strict typing rejects outright. formatSubnetHyperparams' nonNegativeInt
+-- already nulls any non-safe-integer value on read, so NUMERIC here only
+-- needs to hold the value long enough to round-trip without erroring the
+-- whole upsert -- it never needs its own precision/display logic.
 CREATE TABLE IF NOT EXISTS subnet_hyperparams (
   netuid                       INTEGER NOT NULL,
   kappa_ratio                  NUMERIC,
@@ -222,7 +231,7 @@ CREATE TABLE IF NOT EXISTS subnet_hyperparams (
   max_weight_limit_ratio        NUMERIC,
   tempo                        INTEGER,
   weights_version               INTEGER,
-  weights_rate_limit            INTEGER,
+  weights_rate_limit            NUMERIC,
   activity_cutoff               INTEGER,
   activity_cutoff_factor        INTEGER,
   registration_allowed          BOOLEAN,
@@ -268,7 +277,7 @@ CREATE TABLE IF NOT EXISTS subnet_hyperparams_history (
   max_weight_limit_ratio         NUMERIC,
   tempo                         INTEGER,
   weights_version                INTEGER,
-  weights_rate_limit             INTEGER,
+  weights_rate_limit             NUMERIC,
   activity_cutoff                INTEGER,
   activity_cutoff_factor         INTEGER,
   registration_allowed           BOOLEAN,


### PR DESCRIPTION
## Summary
- Live verification of #4841 (subnet_hyperparams Postgres migration) surfaced a real production bug: netuid 0 (root subnet) carries the chain's `u64::MAX` "unlimited" sentinel (`18446744073709551615`) for `weights_rate_limit` — larger than Postgres' signed-64-bit `BIGINT` range. SQLite's flexible `INTEGER` storage class silently tolerates this (falls back to a REAL), but Postgres' strict typing rejected it outright, 502-ing the entire 129-row upsert.
- Widens `weights_rate_limit` to `NUMERIC` (arbitrary precision) in both `subnet_hyperparams` and `subnet_hyperparams_history`. The read-side `nonNegativeInt` in `src/subnet-hyperparams.mjs` already nulls any non-safe-integer value, so this column only needs to round-trip the write without erroring — no other code changes needed.
- Already applied live via `ALTER TABLE ... TYPE NUMERIC` on both tables and confirmed: re-POSTing the real staged envelope now writes all 129 rows successfully (previously 502).

## Test plan
- [x] `npm run lint` / `npm run format:check`
- [x] `git diff --check`
- [x] Live-verified: `ALTER TABLE` applied, real 129-row envelope re-synced successfully (previously 502 on netuid 0's sentinel value)
- Schema-only change; no application code touched, no new test surface

Refs #4832