### PR TITLE
fix(data): disable public data worker exposure

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -17,6 +17,10 @@
   // box Postgres, reached via Cloudflare Tunnel) to minimize the per-request DB round-trip,
   // not at the nearest edge to the client.
   "placement": { "mode": "smart" },
+  // This Worker owns an internal write path plus uncached Postgres read routes;
+  // keep it reachable only through the main Worker's DATA_API service binding.
+  "workers_dev": false,
+  "preview_urls": false,
   // Full observability — logs AND traces (matches the main Worker).
   "observability": {
     "enabled": true,


### PR DESCRIPTION
### Motivation
- The dedicated data API Worker now owns an internal write route and uncached Postgres read routes but its Wrangler config left `workers.dev`/preview URLs enabled, which makes internal routes directly reachable instead of reachable only via the main Worker's `DATA_API` service binding.

### Description
- Harden `wrangler.data.jsonc` by setting `"workers_dev": false` and `"preview_urls": false` and adding a short comment explaining the rationale so the data Worker remains service-binding-only.

### Testing
- Ran `npx prettier --check wrangler.data.jsonc` and it passed. 
- Ran `npx wrangler deploy -c wrangler.data.jsonc --dry-run` and the dry-run completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5166d8f22c832c9e608a553c7b401f)