### PR TITLE
fix(api): clamp postgres extrinsics pagination

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -584,6 +584,17 @@ test("GET /api/v1/extrinsics uses a composite cursor seek instead of OFFSET", as
   expect(text).not.toContain("OFFSET");
 });
 
+test("GET /api/v1/extrinsics clamps page size and offset before querying Postgres", async () => {
+  mockRows.current = [EXTRINSIC_ROW];
+  await req("/api/v1/extrinsics?limit=999999&offset=999999999");
+
+  const queryValues = sqlCalls.flatMap((call) => call.values);
+  expect(queryValues).toContain(BLOCK_PAGINATION.maxLimit);
+  expect(queryValues).toContain(MAX_OFFSET);
+  expect(queryValues).not.toContain(999999);
+  expect(queryValues).not.toContain(999999999);
+});
+
 test("GET /api/v1/extrinsics/:ref resolves a hash ref with embedded account_events", async () => {
   const eventRow = {
     block_number: "8586300",

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -257,7 +257,7 @@ export default {
         // cover the same access patterns D1's INDEXED BY hints targeted) --
         // Postgres has no INDEXED BY equivalent.
         if (url.pathname === "/api/v1/extrinsics") {
-          const limit = clampLimit(url.searchParams.get("limit"));
+          const limit = clampBlockLimit(url.searchParams.get("limit"));
           const offset = clampOffset(url.searchParams.get("offset"));
           const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
           const block = nonNegativeIntegerParam(url.searchParams, "block");


### PR DESCRIPTION
### Motivation

- Prevent Postgres/Hyerdrive resource exhaustion by ensuring the Postgres-backed DATA_API routes honor the same block-explorer pagination bounds D1 uses, so oversized `limit`/`offset` params cannot trigger deep OFFSET scans.

### Description

- Change the DATA_API `/api/v1/extrinsics` handler in `workers/data-api.mjs` to use the block-explorer pagination profile by replacing `clampLimit(...)` with `clampBlockLimit(...)`, preserving the shared offset clamp.
- Add a regression test in `tests/data-api.test.mjs` that requests oversized `limit` and `offset` and asserts the SQL-bound values contain the clamped `BLOCK_PAGINATION.maxLimit` and `MAX_OFFSET` (and not the raw huge values).
- Files modified: `workers/data-api.mjs`, `tests/data-api.test.mjs`.

### Testing

- Ran the focused unit tests: `npm test -- tests/data-api.test.mjs`, and all tests in that file passed.
- Ran formatting check: `npm run format:check -- tests/data-api.test.mjs workers/data-api.mjs`, and Prettier reported no style issues.
- The added regression test validates that oversized `limit`/`offset` are clamped before the Postgres query is composed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50bca3a4f0832ca7241435b5ef1701)