### PR TITLE
feat(data-api): migrate account_identity to Postgres (#4832)

### DIFF
--- a/.github/workflows/refresh-account-identity.yml
+++ b/.github/workflows/refresh-account-identity.yml
@@ -99,6 +99,24 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # #4832 gap-closure: ALSO write the same signed snapshot to the Postgres
+      # write path (workers/data-api.mjs's handleAccountIdentitySync),
+      # alongside (not replacing) the R2/D1 step above -- mirrors
+      # refresh-subnet-hyperparams.yml's sync step exactly.
+      - name: Sync account identities to the Postgres write path (#4832 gap-closure)
+        run: |
+          if [ -z "$ACCOUNT_IDENTITY_SYNC_SECRET" ]; then
+            echo "ACCOUNT_IDENTITY_SYNC_SECRET not set; skipping Postgres sync"
+            exit 0
+          fi
+          curl -fsS -X POST "https://api.metagraph.sh/api/v1/internal/account-identity-sync" \
+            -H "x-account-identity-sync-token: ${ACCOUNT_IDENTITY_SYNC_SECRET}" \
+            -H "content-type: application/json" \
+            --data-binary @dist/metagraph-account-identity.json \
+            || echo "::warning::account-identity-sync Postgres write failed; D1 path (this job's real dependency) is unaffected"
+        env:
+          ACCOUNT_IDENTITY_SYNC_SECRET: ${{ secrets.ACCOUNT_IDENTITY_SYNC_SECRET }}
+
   notify-on-failure:
     needs: [fetch, sign-and-stage]
     if: ${{ always() && (needs.fetch.result == 'failure' || needs.sign-and-stage.result == 'failure') }}

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -311,6 +311,47 @@ CREATE INDEX IF NOT EXISTS idx_subnet_hyperparams_history_netuid_observed
 CREATE INDEX IF NOT EXISTS idx_subnet_hyperparams_history_netuid_id
   ON subnet_hyperparams_history (netuid, id DESC);
 
+-- Personal (coldkey) chain identity, latest-only (#4832 gap-closure Phase B;
+-- mirrors D1 migrations/0039_account_identity.sql). One row per account,
+-- upserted by the refresh-account-identity workflow's direct POST to
+-- data-api.mjs. Deliberately NO purge step (unlike subnet_hyperparams above):
+-- an identity is a property of the owning account, not of currently having
+-- an active neuron -- see loadStagedAccountIdentity's own header comment.
+CREATE TABLE IF NOT EXISTS account_identity (
+  account       TEXT NOT NULL,
+  name          TEXT,
+  url           TEXT,
+  github        TEXT,
+  image         TEXT,
+  discord       TEXT,
+  description   TEXT,
+  additional    TEXT,
+  captured_at   BIGINT NOT NULL,
+  PRIMARY KEY (account)
+);
+
+-- Personal chain identity history (#4832 gap-closure Phase B; mirrors D1
+-- migrations/0041_account_identity_history.sql). Append-only, diffed by
+-- identity_hash on each sync; no block_number column, matching D1 (an
+-- account carries no chain block height, only captured_at).
+CREATE TABLE IF NOT EXISTS account_identity_history (
+  id            BIGSERIAL PRIMARY KEY,
+  account       TEXT NOT NULL,
+  observed_at   BIGINT NOT NULL,
+  name          TEXT,
+  url           TEXT,
+  github        TEXT,
+  image         TEXT,
+  discord       TEXT,
+  description   TEXT,
+  additional    TEXT,
+  identity_hash TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_observed
+  ON account_identity_history (account, observed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_id
+  ON account_identity_history (account, id DESC);
+
 -- Account daily rollup (#2079 / audit: removes the temp-sort on default account history).
 CREATE TABLE IF NOT EXISTS account_events_daily (
   hotkey           TEXT NOT NULL,

--- a/tests/account-identity-sync-proxy.test.mjs
+++ b/tests/account-identity-sync-proxy.test.mjs
@@ -1,0 +1,116 @@
+// Unit tests for the /api/v1/internal/account-identity-sync proxy
+// (workers/api.mjs's handleAccountIdentitySyncProxy, #4832 gap-closure),
+// which forwards to workers/data-api.mjs's handleAccountIdentitySync via the
+// EXISTING DATA_API service binding (shares proxyToDataApi with the sibling
+// sync routes -- see tests/neurons-sync-proxy.test.mjs for the pattern this
+// mirrors). The downstream sync logic itself is covered by
+// tests/data-api.test.mjs.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+
+function post({ method = "POST" } = {}) {
+  return new Request(
+    "https://api.metagraph.sh/api/v1/internal/account-identity-sync",
+    { method },
+  );
+}
+
+test("rejects non-POST before reaching the binding (405)", async () => {
+  let calls = 0;
+  const res = await handleRequest(
+    post({ method: "GET" }),
+    {
+      DATA_API: {
+        fetch() {
+          calls += 1;
+          return new Response("{}", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 405);
+  assert.equal(calls, 0);
+});
+
+test("returns 503 when DATA_API is not bound", async () => {
+  const res = await handleRequest(post(), {}, {});
+  assert.equal(res.status, 503);
+});
+
+test("forwards the request to DATA_API and relays its response body + status", async () => {
+  let receivedToken;
+  let receivedPath;
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/internal/account-identity-sync",
+      {
+        method: "POST",
+        headers: { "x-account-identity-sync-token": "shared-secret" },
+      },
+    ),
+    {
+      DATA_API: {
+        fetch(req) {
+          receivedToken = req.headers.get("x-account-identity-sync-token");
+          receivedPath = new URL(req.url).pathname;
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              account_identity_written: 460,
+              history_appended: 2,
+            }),
+            { status: 200 },
+          );
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedToken, "shared-secret");
+  assert.equal(receivedPath, "/api/v1/internal/account-identity-sync");
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), {
+    ok: true,
+    account_identity_written: 460,
+    history_appended: 2,
+  });
+});
+
+test("relays a non-2xx upstream status (e.g. 401) unchanged", async () => {
+  const res = await handleRequest(
+    post(),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(JSON.stringify({ error: "unauthorized" }), {
+            status: 401,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.deepEqual(await res.json(), { error: "unauthorized" });
+});
+
+test("returns 502 when the upstream response body is unreadable", async () => {
+  const res = await handleRequest(
+    post(),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response("not json", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal(
+    (await res.json()).error.code,
+    "account_identity_sync_unavailable",
+  );
+});

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -6,6 +6,8 @@ import { BLOCK_PAGINATION, MAX_OFFSET } from "../workers/request-params.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
 import { formatSubnetHyperparams } from "../src/subnet-hyperparams.mjs";
 import { hyperparamsHash } from "../src/subnet-hyperparams-history.mjs";
+import { IDENTITY_FIELDS } from "../src/account-identity.mjs";
+import { identityHash } from "../src/account-identity-history.mjs";
 
 const sqlCalls = vi.hoisted(() => []);
 const mockRows = vi.hoisted(() => ({
@@ -43,6 +45,11 @@ const rollupFailure = vi.hoisted(() => ({ error: null }));
 const subnetHyperparamsSyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetHyperparamsPruneRows = vi.hoisted(() => ({ current: [] }));
 const subnetHyperparamsLatestHashes = vi.hoisted(() => ({ current: [] }));
+// State for the account-identity-sync write route's tests only (#4832
+// gap-closure). No prune-rows hook -- unlike subnet_hyperparams, this table
+// has no purge step (see handleAccountIdentitySync's own header comment).
+const accountIdentitySyncFailure = vi.hoisted(() => ({ error: null }));
+const accountIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -99,11 +106,20 @@ vi.mock("postgres", () => ({
       ) {
         return Promise.reject(subnetHyperparamsSyncFailure.error);
       }
+      if (
+        accountIdentitySyncFailure.error &&
+        /INSERT INTO account_identity\b/.test(text)
+      ) {
+        return Promise.reject(accountIdentitySyncFailure.error);
+      }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
       }
       if (/SELECT DISTINCT ON \(netuid\)/.test(text)) {
         return Promise.resolve(subnetHyperparamsLatestHashes.current);
+      }
+      if (/SELECT DISTINCT ON \(account\)/.test(text)) {
+        return Promise.resolve(accountIdentityLatestHashes.current);
       }
       if (mockQueue.current.length) {
         return Promise.resolve(mockQueue.current.shift());
@@ -143,11 +159,13 @@ const { default: worker } = await import("../workers/data-api.mjs");
 const NEURONS_SYNC_SECRET = "test-neurons-sync-secret";
 const ROLLUP_SYNC_SECRET = "test-rollup-sync-secret";
 const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
+const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
   ROLLUP_SYNC_SECRET,
   SUBNET_HYPERPARAMS_SYNC_SECRET,
+  ACCOUNT_IDENTITY_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -163,6 +181,8 @@ beforeEach(() => {
   subnetHyperparamsSyncFailure.error = null;
   subnetHyperparamsPruneRows.current = [];
   subnetHyperparamsLatestHashes.current = [];
+  accountIdentitySyncFailure.error = null;
+  accountIdentityLatestHashes.current = [];
   mockRows.current = [
     {
       block_number: "123",
@@ -3157,6 +3177,326 @@ test("GET /api/v1/subnets/:netuid/hyperparameters/history?limit=1 emits a next_c
     },
   ];
   const res = await req("/api/v1/subnets/8/hyperparameters/history?limit=1");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.next_cursor).not.toBeNull();
+});
+
+// #4832 gap-closure: POST /api/v1/internal/account-identity-sync -- the
+// write path into account_identity/account_identity_history (see
+// workers/data-api.mjs's handleAccountIdentitySync), plus its read paths,
+// GET /api/v1/accounts/:ss58/identity[-history]. Unlike subnet-hyperparams-
+// sync, this route has NO prune step (see that handler's own comment).
+const IDENTITY_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function accountIdentitySyncRow(overrides = {}) {
+  return {
+    account: IDENTITY_SS58,
+    name: "Example Team",
+    url: "https://miao.example/",
+    github: "https://github.com/miao-team/miao-repo",
+    image: "https://miao.example/logo.png",
+    discord: "examplehandle",
+    description: "An example subnet operator.",
+    additional: null,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function postAccountIdentity(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-account-identity-sync-token"] = secret;
+  return req("/api/v1/internal/account-identity-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? []),
+  });
+}
+
+test("account-identity-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postAccountIdentity([accountIdentitySyncRow()], {
+    secret: "wrong",
+  });
+  expect(wrong.status).toBe(401);
+  const missing = await postAccountIdentity([accountIdentitySyncRow()]);
+  expect(missing.status).toBe(401);
+});
+
+test("account-identity-sync is disabled (503) when ACCOUNT_IDENTITY_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/account-identity-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-account-identity-sync-token": ACCOUNT_IDENTITY_SYNC_SECRET,
+      },
+      body: JSON.stringify([accountIdentitySyncRow()]),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("account-identity-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/account-identity-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-account-identity-sync-token": ACCOUNT_IDENTITY_SYNC_SECRET,
+      },
+      body: JSON.stringify([accountIdentitySyncRow()]),
+    }),
+    { ACCOUNT_IDENTITY_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("account-identity-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postAccountIdentity(null, {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+    raw: "[" + "1".repeat(5_000_000) + "]",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("account-identity-sync rejects malformed JSON (400)", async () => {
+  const res = await postAccountIdentity(null, {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects a body that isn't an array or {rows:[...]} (400)", async () => {
+  const res = await postAccountIdentity(
+    { not: "an array" },
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync accepts the {rows:[...]} wrapped form, not just a bare array", async () => {
+  const res = await postAccountIdentity(
+    { rows: [accountIdentitySyncRow()] },
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.account_identity_written).toBe(1);
+});
+
+test("account-identity-sync rejects more than the row cap (413)", async () => {
+  // Minimal rows (account + captured_at only, no other fields) so the total
+  // body stays well under the byte cap -- otherwise a full accountIdentitySyncRow()
+  // fixture repeated 20,001x would trip the byte-cap 413 first and mask
+  // whether the row-cap check itself is reachable.
+  const many = Array.from({ length: 20_001 }, () => ({
+    account: "5X",
+    captured_at: 1_780_000_000_000,
+  }));
+  const res = await postAccountIdentity(many, {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(413);
+});
+
+test("account-identity-sync rejects a row with a missing/empty account (400)", async () => {
+  const res = await postAccountIdentity(
+    [accountIdentitySyncRow({ account: "" })],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects a non-object row (400)", async () => {
+  const res = await postAccountIdentity(["not-an-object"], {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects a row carrying an unknown column (400)", async () => {
+  const res = await postAccountIdentity(
+    [accountIdentitySyncRow({ unexpected_field: "nope" })],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects a row with a numeric identity field (400)", async () => {
+  // Unlike subnet-hyperparams-sync, every column but account/captured_at is
+  // TEXT-only -- a bare number must be actively rejected here.
+  const res = await postAccountIdentity(
+    [accountIdentitySyncRow({ name: 123 })],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects a row with a string field over the byte cap (400)", async () => {
+  const res = await postAccountIdentity(
+    [accountIdentitySyncRow({ name: "x".repeat(1100) })],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects a row missing a finite captured_at (400)", async () => {
+  const res = await postAccountIdentity(
+    [accountIdentitySyncRow({ captured_at: "not-a-number" })],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync rejects an empty array (400)", async () => {
+  const res = await postAccountIdentity([], {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("account-identity-sync upserts account_identity and reports written counts, no prune", async () => {
+  const res = await postAccountIdentity(
+    [
+      accountIdentitySyncRow({ account: "5Account1" }),
+      accountIdentitySyncRow({ account: "5Account2" }),
+    ],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({ ok: true, account_identity_written: 2 });
+  expect(queryText()).toMatch(/INSERT INTO account_identity\b/);
+  expect(queryText()).not.toMatch(/DELETE FROM account_identity/);
+});
+
+test("account-identity-sync defaults a missing optional column (e.g. additional) to null rather than undefined", async () => {
+  const { additional: _additional, ...withoutAdditional } =
+    accountIdentitySyncRow();
+  const res = await postAccountIdentity([withoutAdditional], {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO account_identity\b/.test(c.text),
+  );
+  expect(insert.values).toContain(null);
+});
+
+test("account-identity-sync appends to account_identity_history when the hash changed (cold history)", async () => {
+  accountIdentityLatestHashes.current = [];
+  const res = await postAccountIdentity([accountIdentitySyncRow()], {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  const body = await res.json();
+  expect(body.history_appended).toBe(1);
+  expect(queryText()).toMatch(/INSERT INTO account_identity_history/);
+});
+
+test("account-identity-sync skips the history append when the hash is unchanged", async () => {
+  const row = accountIdentitySyncRow();
+  const snapshot = {};
+  for (const field of IDENTITY_FIELDS) snapshot[field] = row[field] ?? null;
+  const hash = await identityHash(snapshot);
+  accountIdentityLatestHashes.current = [
+    { account: row.account, identity_hash: hash },
+  ];
+  const res = await postAccountIdentity([row], {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  const body = await res.json();
+  expect(body.history_appended).toBe(0);
+  expect(queryText()).not.toMatch(/INSERT INTO account_identity_history/);
+});
+
+test("account-identity-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  accountIdentitySyncFailure.error = new Error("connection reset");
+  const res = await postAccountIdentity([accountIdentitySyncRow()], {
+    secret: ACCOUNT_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+test("GET /api/v1/accounts/:ss58/identity returns the latest row", async () => {
+  mockRows.current = [
+    {
+      account: IDENTITY_SS58,
+      name: "Example Team",
+      url: "https://miao.example/",
+      github: null,
+      image: null,
+      discord: null,
+      description: null,
+      additional: null,
+      captured_at: "1780000000000",
+    },
+  ];
+  const res = await req(`/api/v1/accounts/${IDENTITY_SS58}/identity`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.has_identity).toBe(true);
+  expect(body.name).toBe("Example Team");
+});
+
+test("GET /api/v1/accounts/:ss58/identity on a cold store returns has_identity:false", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/accounts/${IDENTITY_SS58}/identity`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.has_identity).toBe(false);
+});
+
+test("GET /api/v1/accounts/:ss58/identity-history returns the change timeline", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      observed_at: "1780000000000",
+      name: "Example Team",
+      url: null,
+      github: null,
+      image: null,
+      discord: null,
+      description: null,
+      additional: null,
+      identity_hash: "abc123",
+    },
+  ];
+  const res = await req(`/api/v1/accounts/${IDENTITY_SS58}/identity-history`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.entry_count).toBe(1);
+  expect(body.entries[0].identity_hash).toBe("abc123");
+  expect(body.entries[0].name).toBe("Example Team");
+});
+
+test("GET /api/v1/accounts/:ss58/identity-history uses a cursor seek instead of OFFSET", async () => {
+  mockRows.current = [];
+  const cursor = encodeCursor([1780000000000, 10]);
+  const res = await req(
+    `/api/v1/accounts/${IDENTITY_SS58}/identity-history?cursor=${cursor}`,
+  );
+  expect(res.status).toBe(200);
+  expect(queryText()).toContain("AND (observed_at, id) <");
+  expect(queryText()).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/accounts/:ss58/identity-history?limit=1 emits a next_cursor when the page is full", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      observed_at: "1780000000000",
+      identity_hash: "abc123",
+    },
+  ];
+  const res = await req(
+    `/api/v1/accounts/${IDENTITY_SS58}/identity-history?limit=1`,
+  );
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.next_cursor).not.toBeNull();

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -6507,6 +6507,111 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.equal(body.data.entries[0].hyperparams_hash, "abc");
   });
 
+  // #4832 gap-closure: account_identity/account_identity_history's new
+  // Postgres tier, own dedicated flag (METAGRAPH_ACCOUNT_IDENTITY_SOURCE).
+  test("handleAccountIdentity: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      accountIdentity: [accountIdentityRow()],
+    });
+    env.METAGRAPH_ACCOUNT_IDENTITY_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        account: SS58,
+        has_identity: true,
+        name: "Postgres Team",
+      }),
+    );
+    const path = `/api/v1/accounts/${SS58}/identity`;
+    const body = await json(
+      await handleAccountIdentity(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.name, "Postgres Team");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountIdentity: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({ accountIdentity: [accountIdentityRow()] });
+    env.METAGRAPH_ACCOUNT_IDENTITY_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const path = `/api/v1/accounts/${SS58}/identity`;
+    const body = await json(
+      await handleAccountIdentity(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.name, "Example Team");
+  });
+
+  test("handleAccountIdentityHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      accountIdentityHistory: [
+        {
+          id: 10,
+          observed_at: OBSERVED_AT,
+          name: "Example Team",
+          url: null,
+          github: null,
+          image: null,
+          discord: null,
+          description: null,
+          additional: null,
+          identity_hash: "abc",
+        },
+      ],
+    });
+    env.METAGRAPH_ACCOUNT_IDENTITY_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        account: SS58,
+        entry_count: 1,
+        limit: null,
+        offset: null,
+        next_cursor: null,
+        entries: [{ identity_hash: "pg-hash" }],
+      }),
+    );
+    const path = `/api/v1/accounts/${SS58}/identity-history`;
+    const body = await json(
+      await handleAccountIdentityHistory(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.entries[0].identity_hash, "pg-hash");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleAccountIdentityHistory: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({
+      accountIdentityHistory: [
+        {
+          id: 10,
+          observed_at: OBSERVED_AT,
+          name: "Example Team",
+          url: null,
+          github: null,
+          image: null,
+          discord: null,
+          description: null,
+          additional: null,
+          identity_hash: "abc",
+        },
+      ],
+    });
+    env.METAGRAPH_ACCOUNT_IDENTITY_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const path = `/api/v1/accounts/${SS58}/identity-history`;
+    const body = await json(
+      await handleAccountIdentityHistory(req(path), env, SS58, url(path)),
+    );
+    assert.equal(body.data.entries[0].identity_hash, "abc");
+  });
+
   test("handleSubnetValidators: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1233,6 +1233,19 @@ async function handleSubnetHyperparamsSyncProxy(request, env) {
   });
 }
 
+// Proxies POST /api/v1/internal/account-identity-sync -- the write path into
+// account_identity/account_identity_history (#4832 gap-closure). Same
+// DATA_API service binding as the other internal sync routes above.
+async function handleAccountIdentitySyncProxy(request, env) {
+  return proxyToDataApi(request, env, {
+    code: "account_identity_sync_unavailable",
+    notBoundMessage:
+      "The account-identity sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The account-identity sync tier returned an unreadable response.",
+  });
+}
+
 export async function handleRequest(request, env = {}, ctx = {}) {
   let url = new URL(request.url);
 
@@ -1360,6 +1373,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // above. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/subnet-hyperparams-sync") {
     return handleSubnetHyperparamsSyncProxy(request, env);
+  }
+  // The write path into account_identity/account_identity_history (#4832
+  // gap-closure) -- refresh-account-identity.yml's sign-and-stage job calls
+  // this the same way. Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/account-identity-sync") {
+    return handleAccountIdentitySyncProxy(request, env);
   }
 
   // GraphQL read-only query layer over existing artifacts (issue #751). Runs

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -224,6 +224,15 @@ import {
   hyperparamsHash,
   buildSubnetHyperparamsHistory,
 } from "../src/subnet-hyperparams-history.mjs";
+import {
+  ACCOUNT_IDENTITY_INSERT_COLUMNS,
+  IDENTITY_FIELDS,
+  buildAccountIdentity,
+} from "../src/account-identity.mjs";
+import {
+  identityHash,
+  buildAccountIdentityHistory,
+} from "../src/account-identity-history.mjs";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
@@ -1020,6 +1029,188 @@ async function handleSubnetHyperparamsSync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/account-identity-sync (#4832 gap-closure) ------
+//
+// The write path into account_identity + account_identity_history, mirroring
+// handleSubnetHyperparamsSync's shape above -- same signed-envelope-direct-
+// POST rationale (see that function's own header comment). Two real
+// differences from the hyperparams path: (1) every column but account/
+// captured_at is TEXT, no boolean-flag coercion needed; (2) NO prune step --
+// an identity is a property of the owning account, not of currently having
+// an active neuron, matching loadStagedAccountIdentity's own D1 behavior
+// (workers/request-handlers/staging.mjs) -- an account missing from one
+// snapshot pass hasn't necessarily lost its identity.
+const ACCOUNT_IDENTITY_SYNC_TOKEN_HEADER = "x-account-identity-sync-token";
+// ~460 rows live-observed 2026-07-09 (~1.5% of ~30k active neurons); generous
+// headroom, matching the D1 staging path's MAX_STAGED_ACCOUNT_IDENTITY_ROWS/
+// _BYTES.
+const ACCOUNT_IDENTITY_SYNC_MAX_BODY_BYTES = 5_000_000;
+const ACCOUNT_IDENTITY_SYNC_MAX_ROWS = 20_000;
+const ACCOUNT_IDENTITY_SYNC_MAX_STRING_BYTES = 1024;
+
+// Bounds-check one incoming row against ACCOUNT_IDENTITY_INSERT_COLUMNS --
+// same trust posture as staging.mjs's validStagedAccountIdentityRow. Unlike
+// validSubnetHyperparamsSyncRow, every column but account/captured_at is
+// TEXT-only, so a bare number must be actively REJECTED here, not tolerated.
+function validAccountIdentitySyncRow(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  if (typeof row.account !== "string" || row.account.length === 0) return false;
+  if (!Number.isFinite(row.captured_at)) return false;
+  for (const [key, value] of Object.entries(row)) {
+    if (!ACCOUNT_IDENTITY_INSERT_COLUMNS.includes(key)) return false;
+    if (key === "account" || key === "captured_at") continue;
+    if (value === null) continue;
+    if (typeof value !== "string") return false;
+    if (utf8Bytes(value).length > ACCOUNT_IDENTITY_SYNC_MAX_STRING_BYTES)
+      return false;
+  }
+  return true;
+}
+
+function coerceAccountIdentitySyncRow(row) {
+  const out = {};
+  for (const col of ACCOUNT_IDENTITY_INSERT_COLUMNS) {
+    out[col] = row[col] ?? null;
+  }
+  return out;
+}
+
+async function handleAccountIdentitySync(request, env) {
+  if (!env.ACCOUNT_IDENTITY_SYNC_SECRET) {
+    return writeJson(
+      { error: "account-identity sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(ACCOUNT_IDENTITY_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.ACCOUNT_IDENTITY_SYNC_SECRET)
+  ) {
+    return writeJson(
+      { error: `provide a valid ${ACCOUNT_IDENTITY_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > ACCOUNT_IDENTITY_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${ACCOUNT_IDENTITY_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of account-identity rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > ACCOUNT_IDENTITY_SYNC_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${ACCOUNT_IDENTITY_SYNC_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validAccountIdentitySyncRow)) {
+    return writeJson(
+      { error: "rows must match the account-identity row shape" },
+      400,
+    );
+  }
+
+  const rows = incoming.map(coerceAccountIdentitySyncRow);
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    return await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+
+      await sql`
+        INSERT INTO account_identity ${sql(rows, ...ACCOUNT_IDENTITY_INSERT_COLUMNS)}
+        ON CONFLICT (account) DO UPDATE SET
+          name = EXCLUDED.name,
+          url = EXCLUDED.url,
+          github = EXCLUDED.github,
+          image = EXCLUDED.image,
+          discord = EXCLUDED.discord,
+          description = EXCLUDED.description,
+          additional = EXCLUDED.additional,
+          captured_at = EXCLUDED.captured_at
+        WHERE account_identity.captured_at <= EXCLUDED.captured_at`;
+
+      // Diff-and-append into account_identity_history (mirrors D1's
+      // recordAccountIdentityChanges) -- hashed on the RAW incoming rows,
+      // matching identitySnapshotFromRow's own field selection.
+      const latest = await sql`
+        SELECT DISTINCT ON (account) account, identity_hash
+        FROM account_identity_history
+        ORDER BY account, id DESC`;
+      const latestByAccount = new Map(
+        latest.map((row) => [row.account, row.identity_hash]),
+      );
+      const now = Date.now();
+      const changedRows = [];
+      for (const row of incoming) {
+        const snapshot = {};
+        for (const field of IDENTITY_FIELDS)
+          snapshot[field] = row[field] ?? null;
+        const hash = await identityHash(snapshot);
+        if (latestByAccount.get(row.account) === hash) continue;
+        changedRows.push({
+          account: row.account,
+          observed_at: now,
+          ...snapshot,
+          identity_hash: hash,
+        });
+        latestByAccount.set(row.account, hash);
+      }
+      if (changedRows.length) {
+        await sql`
+          INSERT INTO account_identity_history ${sql(
+            changedRows,
+            "account",
+            "observed_at",
+            ...IDENTITY_FIELDS,
+            "identity_hash",
+          )}`;
+      }
+
+      return writeJson({
+        ok: true,
+        account_identity_written: rows.length,
+        history_appended: changedRows.length,
+      });
+    });
+  } catch (err) {
+    console.error("data-api account-identity-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -1150,6 +1341,12 @@ export default {
       url.pathname === "/api/v1/internal/subnet-hyperparams-sync"
     ) {
       return handleSubnetHyperparamsSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/account-identity-sync"
+    ) {
+      return handleAccountIdentitySync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
@@ -2760,6 +2957,60 @@ export default {
           SELECT netuid, uid, stake_tao, emission_tao, rank, trust, incentive, dividends, validator_permit, active, captured_at
           FROM neurons WHERE hotkey = ${ss58} ORDER BY netuid`;
           return json(buildAccountPortfolio(rows, ss58));
+        }
+
+        // GET /api/v1/accounts/:ss58/identity (#4832 gap-closure, Phase B):
+        // latest-only, mirroring src/account-identity.mjs's
+        // loadAccountIdentity. Column list matches that file's own SELECT.
+        const acctIdentity = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/identity$/,
+        );
+        if (acctIdentity) {
+          const ss58 = decodeURIComponent(acctIdentity[1]);
+          const rows = await sql`
+          SELECT account, name, url, github, image, discord, description, additional, captured_at
+          FROM account_identity WHERE account = ${ss58}`;
+          return json(buildAccountIdentity(rows[0] ?? null, ss58));
+        }
+
+        // GET /api/v1/accounts/:ss58/identity-history?limit=&offset=&cursor=
+        // (#4832 gap-closure, Phase B): append-only change timeline,
+        // mirroring src/account-identity-history.mjs's
+        // loadAccountIdentityHistory. observed_at/id are plain BIGINT
+        // columns, no ::text cast needed.
+        const acctIdentityHistory = url.pathname.match(
+          /^\/api\/v1\/accounts\/([^/]+)\/identity-history$/,
+        );
+        if (acctIdentityHistory) {
+          const ss58 = decodeURIComponent(acctIdentityHistory[1]);
+          const limit = clampRequestLimit(
+            url.searchParams.get("limit"),
+            FEED_PAGINATION,
+          );
+          const offset = clampRequestOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const rows = await sql`
+          SELECT id, observed_at, name, url, github, image, discord, description, additional, identity_hash
+          FROM account_identity_history
+          WHERE account = ${ss58}
+            ${cursor ? sql`AND (observed_at, id) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY observed_at DESC, id DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.observed_at),
+                numberOrNull(last.id),
+              ])
+            : null;
+          return json(
+            buildAccountIdentityHistory(rows, ss58, {
+              limit,
+              offset,
+              nextCursor,
+            }),
+          );
         }
 
         // GET /api/v1/accounts?sort=&limit= (#4832 Tier 2): the global accounts

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -3265,7 +3265,12 @@ export async function handleAccountPositionHistory(
 export async function handleAccountIdentity(request, env, ss58, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
-  const data = await loadAccountIdentity(d1Runner(env), ss58);
+  const data =
+    (await tryPostgresTier(
+      env,
+      request,
+      "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+    )) ?? (await loadAccountIdentity(d1Runner(env), ss58));
   return envelopeResponse(
     request,
     {
@@ -3293,11 +3298,19 @@ export async function handleAccountIdentityHistory(request, env, ss58, url) {
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
-  const data = await loadAccountIdentityHistory(d1Runner(env), ss58, {
-    limit,
-    offset,
-    cursor,
-  });
+  async function fromD1() {
+    return loadAccountIdentityHistory(d1Runner(env), ss58, {
+      limit,
+      offset,
+      cursor,
+    });
+  }
+  const data =
+    (await tryPostgresTier(
+      env,
+      request,
+      "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+    )) ?? (await fromD1());
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
- Adds `account_identity` + `account_identity_history` to the Postgres schema (Phase B, table 2 of 3 in the #4832 completeness-sweep gap-closure).
- New token-authenticated write route `POST /api/v1/internal/account-identity-sync` (`handleAccountIdentitySync` in `workers/data-api.mjs`): upserts the latest-only table, diff-appends into the history table by reusing the existing `IDENTITY_FIELDS`/`identityHash` pure functions the D1 path already uses. **No prune step** (unlike `subnet_hyperparams`) — an identity is a property of the owning account, not of currently having an active neuron, matching `loadStagedAccountIdentity`'s own D1 behavior.
- New read routes `GET /api/v1/accounts/:ss58/identity` and `.../identity-history`.
- `handleAccountIdentitySyncProxy` in `workers/api.mjs` (reuses `proxyToDataApi`), and `tryPostgresTier` wiring into `handleAccountIdentity`/`handleAccountIdentityHistory` in `entities.mjs`, gated on its own `METAGRAPH_ACCOUNT_IDENTITY_SOURCE` flag.
- `refresh-account-identity.yml` gets a new sync step mirroring `refresh-subnet-hyperparams.yml`'s pattern exactly.

## Test plan
- [x] `npm run lint` / `npm run format:check` (touched files)
- [x] `npm run scan:public-safety`
- [x] `npm test` — 7468/7468 passing (262 files)
- [x] `npm run test:coverage` + `git diff origin/main -U0` cross-referenced against `coverage/lcov.info` — zero uncovered lines/branches in every added range across `workers/data-api.mjs`, `workers/api.mjs`, `workers/request-handlers/entities.mjs` (caught and fixed one masked branch: the row-cap 413 test was accidentally tripping the byte-cap check first)
- [x] `npm run validate` / `npm run validate:contract-drift`
- [x] `RUN_WORKFLOWS_VALIDATION=true node scripts/validate-workflows.mjs`

Refs #4832