### PR TITLE
fix(ui): URL-back the /status probe-history drill-down state

### DIFF
--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useMemo, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import {
   healthHistoryQuery,
   sourceHealthProvidersQuery,
@@ -46,7 +46,13 @@ export function HealthHistoryDrilldown() {
   const { data: hRes } = useSuspenseQuery(healthQuery());
   const latest = hRes.meta?.generated_at ?? hRes.data.generated_at;
   const defaultDate = (latest ?? new Date().toISOString()).slice(0, 10);
-  const [date, setDate] = useState(defaultDate);
+  // #3977: URL-backed so a picked date survives reload + is shareable. An empty
+  // `date` param means "most recent", so we omit it from the URL in that case.
+  const search = useSearch({ from: "/status" });
+  const navigate = useNavigate({ from: "/status" });
+  const date = search.date || defaultDate;
+  const setDate = (next: string) =>
+    navigate({ search: (prev) => ({ ...prev, date: next === defaultDate ? "" : next }) });
 
   return (
     <div className="space-y-3">
@@ -81,18 +87,25 @@ export function HealthHistoryDrilldown() {
 function HealthHistoryBody({ date }: { date: string }) {
   const { data: res } = useSuspenseQuery(healthHistoryQuery(date));
   const summary = res.data.summary;
-  const [kind, setKind] = useState("");
-  const [status, setStatus] = useState("");
-  const [sort, setSort] = useState<SurfaceSortField>("status");
-  const [order, setOrder] = useState<"asc" | "desc">("asc");
+  // #3977: the table's kind/status filters + sort are URL-backed alongside the
+  // date so the whole drill-down state is shareable and reload-stable.
+  const search = useSearch({ from: "/status" });
+  const navigate = useNavigate({ from: "/status" });
+  const kind = search.kind;
+  const status = search.status;
+  const sort: SurfaceSortField = search.sort;
+  const order = search.order;
+  const setKind = (next: string) => navigate({ search: (prev) => ({ ...prev, kind: next }) });
+  const setStatus = (next: string) => navigate({ search: (prev) => ({ ...prev, status: next }) });
 
   const onSort = (field: string) => {
     const f = field as SurfaceSortField;
-    if (f === sort) setOrder((o) => (o === "asc" ? "desc" : "asc"));
-    else {
-      setSort(f);
-      setOrder("asc");
-    }
+    navigate({
+      search: (prev) =>
+        f === prev.sort
+          ? { ...prev, order: prev.order === "asc" ? "desc" : "asc" }
+          : { ...prev, sort: f, order: "asc" },
+    });
   };
 
   const classData: BarMiniDatum[] = useMemo(

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,4 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
@@ -48,7 +50,23 @@ function isGlobalIncidentOngoing(s: GlobalIncidentSurface, observedAt?: string |
   return latest > 0 && observedMs - latest < ONGOING_MS;
 }
 
+// #3977: the probe-history drill-down's date + its nested table controls are
+// URL-backed so a picked date, kind/status filters, and sort survive a reload
+// and are shareable — the component is explicitly named as a `/health/history/
+// {date}` resource but previously kept all of this in local state. Empty `date`
+// falls back to the most-recent probe day in the component.
+const SURFACE_SORT_FIELDS = ["netuid", "provider", "kind", "status", "latency_ms"] as const;
+
+const statusSearchSchema = z.object({
+  date: fallback(z.string(), "").default(""),
+  kind: fallback(z.string(), "").default(""),
+  status: fallback(z.string(), "").default(""),
+  sort: fallback(z.enum(SURFACE_SORT_FIELDS), "status").default("status"),
+  order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+});
+
 export const Route = createFileRoute("/status")({
+  validateSearch: zodValidator(statusSearchSchema),
   head: () => ({
     meta: [
       { title: "Status — Metagraphed" },


### PR DESCRIPTION
## Summary
The `/status` **Probe history** drill-down is explicitly commented as a `/health/history/{date}` resource, but its selected date lived in local `useState` with no route wiring, and its nested table's `kind`/`status`/`sort`/`order` controls were local too. Reloading or sharing a `/status` URL always dropped the user back to the most-recent date with default filters — the state wasn't shareable or reload-stable despite the component's own stated intent.

## Change
- `apps/ui/src/routes/status.tsx` — add a `validateSearch` schema to the `/status` route (`date`, `kind`, `status`, `sort`, `order`) with safe `fallback`/`default` values.
- `apps/ui/src/components/metagraphed/status-diagnostics.tsx` — `HealthHistoryDrilldown` + `HealthHistoryBody` now read/write those controls through the route search via `useSearch`/`useNavigate` (the app's existing cross-file pattern) instead of local state.
- Empty `date` falls back to the most-recent probe day, so the default view keeps a clean URL; a picked date + filters + sort now survive reload and are shareable. No data-fetch or visual-layout change.

Two files, `apps/ui` only. `tsc`, `eslint`, `prettier` clean.

Closes #3977

## Screenshots
The shared drill-down link `/status?sort=latency_ms&order=desc` — **before** ignores it (table falls back to the default **Status** sort); **after** restores it (table sorted by **Latency ↓**). Same URL in every cell; theme forced via `localStorage`.

| Viewport · Theme | Before (state dropped) | After (state restored) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/before-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/before-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/before-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3977-assets/3977/after-mobile-dark.png) |