### PR TITLE
fix(data-api): strip embedded NUL bytes before account_identity writes

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3388,6 +3388,33 @@ test("account-identity-sync defaults a missing optional column (e.g. additional)
   expect(insert.values).toContain(null);
 });
 
+// REGRESSION (live-verified 2026-07-11): a real staged row's discord/
+// additional fields were a literal U+0000 placeholder. SQLite tolerates an
+// embedded NUL byte in TEXT storage (the D1 path never needed to guard
+// against it), but Postgres rejects it outright ("invalid byte sequence for
+// encoding UTF8: 0x00"), 502-ing the entire upsert -- confirmed by POSTing
+// the real 455-row production envelope directly.
+test("account-identity-sync strips embedded NUL bytes from string fields (Postgres TEXT can't store them)", async () => {
+  const res = await postAccountIdentity(
+    [
+      accountIdentitySyncRow({
+        discord: "\u0000",
+        additional: "before\u0000after",
+      }),
+    ],
+    { secret: ACCOUNT_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO account_identity\b/.test(c.text),
+  );
+  expect(
+    insert.values.some((v) => typeof v === "string" && v.includes("\u0000")),
+  ).toBe(false);
+  expect(insert.values).toContain("");
+  expect(insert.values).toContain("beforeafter");
+});
+
 test("account-identity-sync appends to account_identity_history when the hash changed (cold history)", async () => {
   accountIdentityLatestHashes.current = [];
   const res = await postAccountIdentity([accountIdentitySyncRow()], {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1067,6 +1067,26 @@ function validAccountIdentitySyncRow(row) {
   return true;
 }
 
+// Postgres' TEXT type rejects any embedded NUL byte outright ("invalid byte
+// sequence for encoding UTF8: 0x00") -- confirmed live 2026-07-11 against a
+// real staged row whose discord/additional fields were a literal U+0000
+// placeholder. SQLite's byte-oriented TEXT storage tolerates this silently
+// (the D1 path never needed to guard against it), so this is a Postgres-only
+// concern: strip rather than reject, matching the "sanitize a chain-data
+// value the sink genuinely can't represent" precedent set by
+// weights_rate_limit's u64::MAX widening in subnet-hyperparams-sync.
+function stripNullBytes(value) {
+  return typeof value === "string" ? value.replaceAll("\u0000", "") : value;
+}
+
+function sanitizeAccountIdentitySyncRow(row) {
+  const out = {};
+  for (const [key, value] of Object.entries(row)) {
+    out[key] = stripNullBytes(value);
+  }
+  return out;
+}
+
 function coerceAccountIdentitySyncRow(row) {
   const out = {};
   for (const col of ACCOUNT_IDENTITY_INSERT_COLUMNS) {
@@ -1137,7 +1157,12 @@ async function handleAccountIdentitySync(request, env) {
     );
   }
 
-  const rows = incoming.map(coerceAccountIdentitySyncRow);
+  // Sanitize BEFORE both the upsert and the history hash so the two stay
+  // consistent with each other -- a raw NUL byte would otherwise reach the
+  // history INSERT below via the untouched `incoming` rows even after the
+  // latest-only table's own values were cleaned.
+  const sanitized = incoming.map(sanitizeAccountIdentitySyncRow);
+  const rows = sanitized.map(coerceAccountIdentitySyncRow);
 
   const sql = postgres(env.HYPERDRIVE.connectionString, {
     max: 5,
@@ -1163,8 +1188,9 @@ async function handleAccountIdentitySync(request, env) {
         WHERE account_identity.captured_at <= EXCLUDED.captured_at`;
 
       // Diff-and-append into account_identity_history (mirrors D1's
-      // recordAccountIdentityChanges) -- hashed on the RAW incoming rows,
-      // matching identitySnapshotFromRow's own field selection.
+      // recordAccountIdentityChanges) -- hashed on the sanitized rows (NUL
+      // bytes already stripped above), matching identitySnapshotFromRow's
+      // own field selection.
       const latest = await sql`
         SELECT DISTINCT ON (account) account, identity_hash
         FROM account_identity_history
@@ -1174,7 +1200,7 @@ async function handleAccountIdentitySync(request, env) {
       );
       const now = Date.now();
       const changedRows = [];
-      for (const row of incoming) {
+      for (const row of sanitized) {
         const snapshot = {};
         for (const field of IDENTITY_FIELDS)
           snapshot[field] = row[field] ?? null;


### PR DESCRIPTION
## Summary
- Live verification of #4847 (account_identity Postgres migration) surfaced a real production bug: a real staged account's `discord`/`additional` fields carried a literal `U+0000` placeholder. SQLite tolerates an embedded NUL byte in TEXT storage (the D1 path never needed to guard against it), but Postgres rejects it outright (`invalid byte sequence for encoding "UTF8": 0x00`), 502-ing the entire 455-row upsert — confirmed by POSTing the real production envelope directly (captured via `wrangler tail`).
- Adds `stripNullBytes`/`sanitizeAccountIdentitySyncRow` in `workers/data-api.mjs`, applied once before both the latest-only upsert and the history hash so the two stay consistent with each other.
- Regression test added reproducing the exact field/value shape from the real failing row.

## Test plan
- [x] `npm run lint` / `npm run format:check`
- [x] `npm test` — 7469/7469 passing (262 files)
- [x] `npm run test:coverage` + `git diff origin/main -U0` cross-referenced against `coverage/lcov.info` — zero uncovered lines/branches in the added range
- [x] Live-verified: `wrangler tail` captured the real `PostgresError: invalid byte sequence for encoding "UTF8": 0x00` from the actual failing row before this fix

Refs #4832