### PR TITLE
feat(data-api): migrate subnet_identity_history to Postgres

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -352,6 +352,31 @@ CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_observed
 CREATE INDEX IF NOT EXISTS idx_account_identity_history_account_id
   ON account_identity_history (account, id DESC);
 
+-- On-chain subnet identity history (#4832 gap-closure Phase B; mirrors D1
+-- migrations/0031_subnet_identity_history.sql). Append-only, diffed by
+-- identity_hash on each sync; no latest-only sibling table -- the current
+-- identity lives in the profiles.json artifact itself, not a dedicated
+-- table. Written from the main Worker's own hourly cron (writeSubnetSnapshot,
+-- src/health-prober.mjs), not an external GitHub Actions workflow.
+CREATE TABLE IF NOT EXISTS subnet_identity_history (
+  id            BIGSERIAL PRIMARY KEY,
+  netuid        INTEGER NOT NULL,
+  block_number  BIGINT,
+  observed_at   BIGINT NOT NULL,
+  subnet_name   TEXT,
+  symbol        TEXT,
+  description   TEXT,
+  github_repo   TEXT,
+  subnet_url    TEXT,
+  discord       TEXT,
+  logo_url      TEXT,
+  identity_hash TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_subnet_identity_history_netuid_observed
+  ON subnet_identity_history (netuid, observed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_subnet_identity_history_netuid_id
+  ON subnet_identity_history (netuid, id DESC);
+
 -- Account daily rollup (#2079 / audit: removes the temp-sort on default account history).
 CREATE TABLE IF NOT EXISTS account_events_daily (
   hotkey           TEXT NOT NULL,

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -24,7 +24,10 @@ import {
 } from "./health-probe-core.mjs";
 import { latencyStatColumns, rankedChecksCte } from "./health-sql.mjs";
 import { ipv6EmbeddedIpv4 } from "./ip-safety.mjs";
-import { recordSubnetIdentityChanges } from "./subnet-identity-history.mjs";
+import {
+  recordSubnetIdentityChanges,
+  syncSubnetIdentityToPostgres,
+} from "./subnet-identity-history.mjs";
 import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
@@ -828,6 +831,11 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
     now: capturedAt,
     db,
   });
+  // #4832 gap-closure: best-effort Postgres mirror of the D1 write above --
+  // never awaited-and-thrown into the caller, see syncSubnetIdentityToPostgres's
+  // own header comment for why this is a direct service-binding call rather
+  // than routing through the public proxy layer.
+  await syncSubnetIdentityToPostgres(env, { profiles });
 
   // Per-subnet economics for the time series (#1307). Best-effort: a missing
   // economics artifact just leaves those columns null (structural trajectory

--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -195,6 +195,48 @@ async function latestBlockNumber(db) {
 }
 
 /**
+ * #4832 gap-closure: mirror recordSubnetIdentityChanges' D1 write into
+ * Postgres via the DATA_API service binding, called directly from
+ * writeSubnetSnapshot (src/health-prober.mjs) rather than through
+ * workers/api.mjs's public proxy layer -- this runs from WITHIN the main
+ * Worker's own hourly cron tick, a pure internal RPC hop, not a public-
+ * internet crossing (unlike the other three #4832 sync routes, which are
+ * driven by external GitHub Actions workflows and therefore cross the
+ * public internet through the proxy). Best-effort: never throws, and a
+ * failure here must never block the D1 write above (the primary contract)
+ * or the rest of writeSubnetSnapshot's own work.
+ */
+export async function syncSubnetIdentityToPostgres(env, { profiles } = {}) {
+  if (!env?.DATA_API || !env?.SUBNET_IDENTITY_SYNC_SECRET) {
+    return { synced: false, reason: "unavailable" };
+  }
+  if (!Array.isArray(profiles) || profiles.length === 0) {
+    return { synced: false, reason: "no_profiles" };
+  }
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/subnet-identity-sync",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-subnet-identity-sync-token": env.SUBNET_IDENTITY_SYNC_SECRET,
+          },
+          body: JSON.stringify(profiles),
+        },
+      ),
+    );
+    if (!upstream.ok) {
+      return { synced: false, reason: `status_${upstream.status}` };
+    }
+    return { synced: true };
+  } catch {
+    return { synced: false, reason: "fetch_failed" };
+  }
+}
+
+/**
  * Diff profiles.json native_identity against the last stored hash per netuid;
  * append a row when any tracked field changes. Idempotent when unchanged.
  */

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -859,6 +859,48 @@ describe("writeSubnetSnapshot", () => {
     assert.equal(r.date, "2026-06-10");
     assert.equal(db.calls.batched[0].length, 2);
   });
+  // #4832 gap-closure: syncSubnetIdentityToPostgres is called best-effort
+  // right after the D1 write, via env.DATA_API -- an absent/failing binding
+  // must never affect writeSubnetSnapshot's own D1-derived result.
+  test("mirrors the same profiles into Postgres via DATA_API, without affecting the D1 result", async () => {
+    const db = fakeBatchDb();
+    let receivedBody;
+    const env = {
+      DATA_API: {
+        fetch: async (request) => {
+          receivedBody = await request.json();
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        },
+      },
+      SUBNET_IDENTITY_SYNC_SECRET: "shh",
+    };
+    const r = await writeSubnetSnapshot(env, {
+      db,
+      readArtifact: reader(profiles),
+      now: () => Date.UTC(2026, 5, 10),
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.rows, 2);
+    assert.deepEqual(receivedBody, profiles.data.profiles);
+  });
+  test("still returns the D1 result when the Postgres mirror fails", async () => {
+    const db = fakeBatchDb();
+    const env = {
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("network down");
+        },
+      },
+      SUBNET_IDENTITY_SYNC_SECRET: "shh",
+    };
+    const r = await writeSubnetSnapshot(env, {
+      db,
+      readArtifact: reader(profiles),
+      now: () => Date.UTC(2026, 5, 10),
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.rows, 2);
+  });
   test("chunks large subnet snapshot writes into bounded D1 batches", async () => {
     const db = fakeBatchDb();
     const manyProfiles = {

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -8,6 +8,10 @@ import { formatSubnetHyperparams } from "../src/subnet-hyperparams.mjs";
 import { hyperparamsHash } from "../src/subnet-hyperparams-history.mjs";
 import { IDENTITY_FIELDS } from "../src/account-identity.mjs";
 import { identityHash } from "../src/account-identity-history.mjs";
+import {
+  identityHash as subnetIdentityHash,
+  identitySnapshotFromProfile,
+} from "../src/subnet-identity-history.mjs";
 
 const sqlCalls = vi.hoisted(() => []);
 const mockRows = vi.hoisted(() => ({
@@ -50,6 +54,14 @@ const subnetHyperparamsLatestHashes = vi.hoisted(() => ({ current: [] }));
 // has no purge step (see handleAccountIdentitySync's own header comment).
 const accountIdentitySyncFailure = vi.hoisted(() => ({ error: null }));
 const accountIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
+// State for the subnet-identity-sync write route's tests only (#4832
+// gap-closure). No prune-rows hook -- like account_identity, this table has
+// no purge step. Its "latest hash per netuid" query shares subnet_hyperparams'
+// `SELECT DISTINCT ON (netuid)` shape, so the mock below disambiguates on the
+// hash column name (hyperparams_hash vs identity_hash) rather than the netuid
+// grouping alone.
+const subnetIdentitySyncFailure = vi.hoisted(() => ({ error: null }));
+const subnetIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -112,11 +124,20 @@ vi.mock("postgres", () => ({
       ) {
         return Promise.reject(accountIdentitySyncFailure.error);
       }
+      if (
+        subnetIdentitySyncFailure.error &&
+        /INSERT INTO subnet_identity_history\b/.test(text)
+      ) {
+        return Promise.reject(subnetIdentitySyncFailure.error);
+      }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
       }
-      if (/SELECT DISTINCT ON \(netuid\)/.test(text)) {
+      if (/SELECT DISTINCT ON \(netuid\) netuid, hyperparams_hash/.test(text)) {
         return Promise.resolve(subnetHyperparamsLatestHashes.current);
+      }
+      if (/SELECT DISTINCT ON \(netuid\) netuid, identity_hash/.test(text)) {
+        return Promise.resolve(subnetIdentityLatestHashes.current);
       }
       if (/SELECT DISTINCT ON \(account\)/.test(text)) {
         return Promise.resolve(accountIdentityLatestHashes.current);
@@ -160,12 +181,14 @@ const NEURONS_SYNC_SECRET = "test-neurons-sync-secret";
 const ROLLUP_SYNC_SECRET = "test-rollup-sync-secret";
 const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
 const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
+const SUBNET_IDENTITY_SYNC_SECRET = "test-subnet-identity-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
   ROLLUP_SYNC_SECRET,
   SUBNET_HYPERPARAMS_SYNC_SECRET,
   ACCOUNT_IDENTITY_SYNC_SECRET,
+  SUBNET_IDENTITY_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -183,6 +206,8 @@ beforeEach(() => {
   subnetHyperparamsLatestHashes.current = [];
   accountIdentitySyncFailure.error = null;
   accountIdentityLatestHashes.current = [];
+  subnetIdentitySyncFailure.error = null;
+  subnetIdentityLatestHashes.current = [];
   mockRows.current = [
     {
       block_number: "123",
@@ -3523,6 +3548,250 @@ test("GET /api/v1/accounts/:ss58/identity-history?limit=1 emits a next_cursor wh
   ];
   const res = await req(
     `/api/v1/accounts/${IDENTITY_SS58}/identity-history?limit=1`,
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.next_cursor).not.toBeNull();
+});
+
+const SUBNET_IDENTITY_NETUID = 8;
+
+function subnetIdentityProfile(overrides = {}) {
+  return {
+    netuid: SUBNET_IDENTITY_NETUID,
+    symbol: "MIAO",
+    native_identity: {
+      subnet_name: "Miao Subnet",
+      description: "An example subnet operator.",
+      github_url: "https://github.com/miao-team/miao-repo",
+      website_url: "https://miao.example/",
+      discord: "examplehandle",
+      logo_url: "https://miao.example/logo.png",
+    },
+    ...overrides,
+  };
+}
+
+function postSubnetIdentity(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-subnet-identity-sync-token"] = secret;
+  return req("/api/v1/internal/subnet-identity-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? []),
+  });
+}
+
+test("subnet-identity-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postSubnetIdentity([subnetIdentityProfile()], {
+    secret: "wrong",
+  });
+  expect(wrong.status).toBe(401);
+  const missing = await postSubnetIdentity([subnetIdentityProfile()]);
+  expect(missing.status).toBe(401);
+});
+
+test("subnet-identity-sync is disabled (503) when SUBNET_IDENTITY_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/subnet-identity-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-subnet-identity-sync-token": SUBNET_IDENTITY_SYNC_SECRET,
+      },
+      body: JSON.stringify([subnetIdentityProfile()]),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("subnet-identity-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/subnet-identity-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-subnet-identity-sync-token": SUBNET_IDENTITY_SYNC_SECRET,
+      },
+      body: JSON.stringify([subnetIdentityProfile()]),
+    }),
+    { SUBNET_IDENTITY_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("subnet-identity-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postSubnetIdentity(null, {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+    raw: "[" + "1".repeat(5_000_000) + "]",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("subnet-identity-sync rejects malformed JSON (400)", async () => {
+  const res = await postSubnetIdentity(null, {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-identity-sync rejects a body that isn't an array or {profiles:[...]} (400)", async () => {
+  const res = await postSubnetIdentity(
+    { not: "an array" },
+    { secret: SUBNET_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-identity-sync accepts the {profiles:[...]} wrapped form, not just a bare array", async () => {
+  const res = await postSubnetIdentity(
+    { profiles: [subnetIdentityProfile()] },
+    { secret: SUBNET_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.history_appended).toBe(1);
+});
+
+test("subnet-identity-sync rejects more than the row cap (413)", async () => {
+  const many = Array.from({ length: 2_001 }, (_, i) => ({ netuid: i }));
+  const res = await postSubnetIdentity(many, {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(413);
+});
+
+test("subnet-identity-sync rejects an empty array (400)", async () => {
+  const res = await postSubnetIdentity([], {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-identity-sync silently skips a profile with a non-integer netuid, no error", async () => {
+  const res = await postSubnetIdentity(
+    [subnetIdentityProfile({ netuid: "not-a-number" })],
+    { secret: SUBNET_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.history_appended).toBe(0);
+});
+
+test("subnet-identity-sync silently skips a profile with no native_identity, no error", async () => {
+  // No dedicated per-field row validator here (unlike subnet-hyperparams-sync
+  // and account-identity-sync) -- profiles.json is the same trust boundary
+  // D1's own recordSubnetIdentityChanges reads directly, and
+  // identitySnapshotFromProfile's own null-guard already skips a malformed
+  // profile without erroring the batch.
+  const res = await postSubnetIdentity(
+    [subnetIdentityProfile({ native_identity: undefined })],
+    { secret: SUBNET_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.history_appended).toBe(0);
+});
+
+test("subnet-identity-sync appends to subnet_identity_history when the hash changed (cold history)", async () => {
+  subnetIdentityLatestHashes.current = [];
+  const res = await postSubnetIdentity([subnetIdentityProfile()], {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({ ok: true, history_appended: 1 });
+  expect(queryText()).toMatch(/INSERT INTO subnet_identity_history\b/);
+});
+
+test("subnet-identity-sync skips the history append when the hash is unchanged", async () => {
+  const profile = subnetIdentityProfile();
+  const snapshot = identitySnapshotFromProfile(profile);
+  const hash = await subnetIdentityHash(snapshot);
+  subnetIdentityLatestHashes.current = [
+    { netuid: profile.netuid, identity_hash: hash },
+  ];
+  const res = await postSubnetIdentity([profile], {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+  });
+  const body = await res.json();
+  expect(body.history_appended).toBe(0);
+  expect(queryText()).not.toMatch(/INSERT INTO subnet_identity_history\b/);
+});
+
+test("subnet-identity-sync resolves block_number from MAX(block_number), null when blocks is empty", async () => {
+  subnetIdentityLatestHashes.current = [];
+  mockRows.current = [];
+  const res = await postSubnetIdentity([subnetIdentityProfile()], {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO subnet_identity_history\b/.test(c.text),
+  );
+  expect(insert.values).toContain(null);
+});
+
+test("subnet-identity-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  subnetIdentitySyncFailure.error = new Error("connection reset");
+  const res = await postSubnetIdentity([subnetIdentityProfile()], {
+    secret: SUBNET_IDENTITY_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+test("GET /api/v1/subnets/:netuid/identity-history returns the change timeline", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      block_number: "100",
+      observed_at: "1780000000000",
+      subnet_name: "Miao Subnet",
+      symbol: "MIAO",
+      description: "old",
+      github_repo: null,
+      subnet_url: null,
+      discord: null,
+      logo_url: null,
+      identity_hash: "abc123",
+    },
+  ];
+  const res = await req(
+    `/api/v1/subnets/${SUBNET_IDENTITY_NETUID}/identity-history`,
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.entry_count).toBe(1);
+  expect(body.entries[0].identity_hash).toBe("abc123");
+  expect(body.entries[0].subnet_name).toBe("Miao Subnet");
+});
+
+test("GET /api/v1/subnets/:netuid/identity-history uses a cursor seek instead of OFFSET", async () => {
+  mockRows.current = [];
+  const cursor = encodeCursor([1780000000000, 10]);
+  const res = await req(
+    `/api/v1/subnets/${SUBNET_IDENTITY_NETUID}/identity-history?cursor=${cursor}`,
+  );
+  expect(res.status).toBe(200);
+  expect(queryText()).toContain("AND (observed_at, id) <");
+  expect(queryText()).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/subnets/:netuid/identity-history?limit=1 emits a next_cursor when the page is full", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      observed_at: "1780000000000",
+      identity_hash: "abc123",
+    },
+  ];
+  const res = await req(
+    `/api/v1/subnets/${SUBNET_IDENTITY_NETUID}/identity-history?limit=1`,
   );
   expect(res.status).toBe(200);
   const body = await res.json();

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -6612,6 +6612,51 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.equal(body.data.entries[0].identity_hash, "abc");
   });
 
+  // #4832 gap-closure: subnet_identity_history's new Postgres tier, own
+  // dedicated flag (METAGRAPH_SUBNET_IDENTITY_SOURCE). Written from the main
+  // Worker's own hourly cron (writeSubnetSnapshot), not an external GitHub
+  // Actions workflow -- but served the same way as every other tier here.
+  test("handleSubnetIdentityHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
+    const { env, captures } = dbWith({
+      subnetIdentityHistory: [identityHistoryRow()],
+    });
+    env.METAGRAPH_SUBNET_IDENTITY_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        netuid: NETUID,
+        entry_count: 1,
+        limit: null,
+        offset: null,
+        next_cursor: null,
+        entries: [{ identity_hash: "pg-hash" }],
+      }),
+    );
+    const path = `/api/v1/subnets/${NETUID}/identity-history`;
+    const body = await json(
+      await handleSubnetIdentityHistory(req(path), env, NETUID, url(path)),
+    );
+    assert.equal(body.data.entries[0].identity_hash, "pg-hash");
+    assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleSubnetIdentityHistory: flag=postgres falls back to D1 on failure", async () => {
+    const { env } = dbWith({
+      subnetIdentityHistory: [identityHistoryRow()],
+    });
+    env.METAGRAPH_SUBNET_IDENTITY_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const path = `/api/v1/subnets/${NETUID}/identity-history`;
+    const body = await json(
+      await handleSubnetIdentityHistory(req(path), env, NETUID, url(path)),
+    );
+    assert.equal(body.data.entries[0].identity_hash, "abc");
+  });
+
   test("handleSubnetValidators: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -12,6 +12,7 @@ import {
   loadSubnetIdentityHistory,
   overlayPreviouslyKnownAs,
   recordSubnetIdentityChanges,
+  syncSubnetIdentityToPostgres,
 } from "../src/subnet-identity-history.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
 
@@ -1011,5 +1012,93 @@ describe("loadPreviouslyKnownAsForNetuids", () => {
       [{ netuid: 86, name: "Current" }],
     );
     assert.deepEqual(map.get(86), ["System   [scrubbed] ."]);
+  });
+});
+
+// #4832 gap-closure: syncSubnetIdentityToPostgres is called directly from
+// writeSubnetSnapshot (src/health-prober.mjs) via the DATA_API service
+// binding, not through workers/api.mjs's public proxy layer -- see that
+// function's own header comment for why.
+describe("syncSubnetIdentityToPostgres", () => {
+  const profiles = [{ netuid: 8, native_identity: { subnet_name: "MIAO" } }];
+
+  test("returns unavailable when DATA_API is not bound", async () => {
+    const result = await syncSubnetIdentityToPostgres(
+      { SUBNET_IDENTITY_SYNC_SECRET: "shh" },
+      { profiles },
+    );
+    assert.deepEqual(result, { synced: false, reason: "unavailable" });
+  });
+
+  test("returns unavailable when the secret is not configured", async () => {
+    const result = await syncSubnetIdentityToPostgres(
+      { DATA_API: { fetch: async () => new Response("{}", { status: 200 }) } },
+      { profiles },
+    );
+    assert.deepEqual(result, { synced: false, reason: "unavailable" });
+  });
+
+  test("returns no_profiles for an empty or missing profiles array", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("{}", { status: 200 }) },
+      SUBNET_IDENTITY_SYNC_SECRET: "shh",
+    };
+    assert.deepEqual(
+      await syncSubnetIdentityToPostgres(env, { profiles: [] }),
+      {
+        synced: false,
+        reason: "no_profiles",
+      },
+    );
+    assert.deepEqual(await syncSubnetIdentityToPostgres(env, {}), {
+      synced: false,
+      reason: "no_profiles",
+    });
+  });
+
+  test("POSTs the profiles array with the token header and reports synced:true on 200", async () => {
+    let receivedToken;
+    let receivedPath;
+    let receivedBody;
+    const env = {
+      DATA_API: {
+        fetch: async (request) => {
+          receivedToken = request.headers.get("x-subnet-identity-sync-token");
+          receivedPath = new URL(request.url).pathname;
+          receivedBody = await request.json();
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        },
+      },
+      SUBNET_IDENTITY_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetIdentityToPostgres(env, { profiles });
+    assert.deepEqual(result, { synced: true });
+    assert.equal(receivedToken, "shh");
+    assert.equal(receivedPath, "/api/v1/internal/subnet-identity-sync");
+    assert.deepEqual(receivedBody, profiles);
+  });
+
+  test("reports the upstream status when the response is not ok, never throws", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => new Response("{}", { status: 502 }),
+      },
+      SUBNET_IDENTITY_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetIdentityToPostgres(env, { profiles });
+    assert.deepEqual(result, { synced: false, reason: "status_502" });
+  });
+
+  test("reports fetch_failed and never throws when the binding call rejects", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("network down");
+        },
+      },
+      SUBNET_IDENTITY_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetIdentityToPostgres(env, { profiles });
+    assert.deepEqual(result, { synced: false, reason: "fetch_failed" });
   });
 });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -233,6 +233,11 @@ import {
   identityHash,
   buildAccountIdentityHistory,
 } from "../src/account-identity-history.mjs";
+import {
+  identitySnapshotFromProfile,
+  identityHash as subnetIdentityHash,
+  buildSubnetIdentityHistory,
+} from "../src/subnet-identity-history.mjs";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
@@ -1237,6 +1242,158 @@ async function handleAccountIdentitySync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/subnet-identity-sync (#4832 gap-closure) -------
+//
+// The write path into subnet_identity_history -- architecturally different
+// from the three internal sync routes above: this one is triggered from
+// WITHIN the main Worker's own hourly cron (writeSubnetSnapshot,
+// src/health-prober.mjs), not an external GitHub Actions workflow, so it's
+// called via a direct env.DATA_API.fetch() service-binding call rather than
+// crossing the public internet through workers/api.mjs's proxy layer (see
+// that function's own comment). No latest-only sibling table exists here
+// (mirrors D1's own shape -- the current identity lives in the profiles.json
+// artifact itself): only diff-and-append against the last recorded hash per
+// netuid, reusing identitySnapshotFromProfile/identityHash UNCHANGED from
+// src/subnet-identity-history.mjs so the hash stays domain-identical to the
+// D1 path. No dedicated per-field row validator (unlike the other three
+// sync routes): profiles.json is the SAME trust boundary D1's own
+// recordSubnetIdentityChanges reads from directly with no staging-style
+// validation either -- identitySnapshotFromProfile's own null-guard already
+// skips a malformed individual profile without erroring the batch.
+const SUBNET_IDENTITY_SYNC_TOKEN_HEADER = "x-subnet-identity-sync-token";
+// ~129 subnets today; generous headroom, matching the other sync routes'
+// convention.
+const SUBNET_IDENTITY_SYNC_MAX_BODY_BYTES = 5_000_000;
+const SUBNET_IDENTITY_SYNC_MAX_ROWS = 2_000;
+
+async function handleSubnetIdentitySync(request, env) {
+  if (!env.SUBNET_IDENTITY_SYNC_SECRET) {
+    return writeJson(
+      { error: "subnet-identity sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(SUBNET_IDENTITY_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.SUBNET_IDENTITY_SYNC_SECRET)
+  ) {
+    return writeJson(
+      { error: `provide a valid ${SUBNET_IDENTITY_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > SUBNET_IDENTITY_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${SUBNET_IDENTITY_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const profiles = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.profiles)
+      ? parsed.profiles
+      : null;
+  if (!profiles) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of subnet profiles (or {profiles:[...]})",
+      },
+      400,
+    );
+  }
+  if (profiles.length > SUBNET_IDENTITY_SYNC_MAX_ROWS) {
+    return writeJson(
+      {
+        error: `at most ${SUBNET_IDENTITY_SYNC_MAX_ROWS} profiles per request`,
+      },
+      413,
+    );
+  }
+  if (!profiles.length) {
+    return writeJson({ error: "profiles must be a non-empty array" }, 400);
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    return await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+
+      const latest = await sql`
+        SELECT DISTINCT ON (netuid) netuid, identity_hash
+        FROM subnet_identity_history
+        ORDER BY netuid, id DESC`;
+      const latestByNetuid = new Map(
+        latest.map((row) => [Number(row.netuid), row.identity_hash]),
+      );
+      const [blockRow] = await sql`
+        SELECT MAX(block_number) AS block_number FROM blocks`;
+      const blockNumber =
+        blockRow?.block_number == null ? null : Number(blockRow.block_number);
+
+      const now = Date.now();
+      const changedRows = [];
+      for (const profile of profiles) {
+        if (!Number.isInteger(profile?.netuid)) continue;
+        const snapshot = identitySnapshotFromProfile(profile);
+        if (!snapshot) continue;
+        const hash = await subnetIdentityHash(snapshot);
+        if (latestByNetuid.get(profile.netuid) === hash) continue;
+        changedRows.push({
+          netuid: profile.netuid,
+          block_number: blockNumber,
+          observed_at: now,
+          ...snapshot,
+          identity_hash: hash,
+        });
+        latestByNetuid.set(profile.netuid, hash);
+      }
+      if (changedRows.length) {
+        await sql`
+          INSERT INTO subnet_identity_history ${sql(
+            changedRows,
+            "netuid",
+            "block_number",
+            "observed_at",
+            "subnet_name",
+            "symbol",
+            "description",
+            "github_repo",
+            "subnet_url",
+            "discord",
+            "logo_url",
+            "identity_hash",
+          )}`;
+      }
+
+      return writeJson({
+        ok: true,
+        history_appended: changedRows.length,
+      });
+    });
+  } catch (err) {
+    console.error("data-api subnet-identity-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -1373,6 +1530,12 @@ export default {
       url.pathname === "/api/v1/internal/account-identity-sync"
     ) {
       return handleAccountIdentitySync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/subnet-identity-sync"
+    ) {
+      return handleSubnetIdentitySync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
@@ -2964,6 +3127,46 @@ export default {
             : null;
           return json(
             buildSubnetHyperparamsHistory(rows, netuid, {
+              limit,
+              offset,
+              nextCursor,
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/identity-history?limit=&offset=&cursor=
+        // (#4832 gap-closure, Phase B): append-only on-chain identity
+        // timeline, mirroring src/subnet-identity-history.mjs's
+        // loadSubnetIdentityHistory. observed_at/id are plain BIGINT
+        // columns, no ::text cast needed.
+        const subnetIdentityHistory = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/identity-history$/,
+        );
+        if (subnetIdentityHistory) {
+          const netuid = Number(subnetIdentityHistory[1]);
+          const limit = clampRequestLimit(
+            url.searchParams.get("limit"),
+            FEED_PAGINATION,
+          );
+          const offset = clampRequestOffset(url.searchParams.get("offset"));
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const rows = await sql`
+          SELECT id, block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash
+          FROM subnet_identity_history
+          WHERE netuid = ${netuid}
+            ${cursor ? sql`AND (observed_at, id) < (${cursor[0]}, ${cursor[1]})` : sql``}
+          ORDER BY observed_at DESC, id DESC
+          LIMIT ${limit}
+          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          const last = rows.length === limit ? rows[rows.length - 1] : null;
+          const nextCursor = last
+            ? encodeCursor([
+                numberOrNull(last.observed_at),
+                numberOrNull(last.id),
+              ])
+            : null;
+          return json(
+            buildSubnetIdentityHistory(rows, netuid, {
               limit,
               offset,
               nextCursor,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1095,11 +1095,16 @@ export async function handleSubnetIdentityHistory(request, env, netuid, url) {
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
-  const data = await loadSubnetIdentityHistory(d1Runner(env), netuid, {
-    limit,
-    offset,
-    cursor,
-  });
+  async function fromD1() {
+    return loadSubnetIdentityHistory(d1Runner(env), netuid, {
+      limit,
+      offset,
+      cursor,
+    });
+  }
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_SUBNET_IDENTITY_SOURCE")) ??
+    (await fromD1());
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Third and final table in the #4832 D1-completeness sweep (following subnet_hyperparams #4841/#4843/#4844 and account_identity #4847/#4849/#4850). Architecturally distinct from the other two:

- No external GitHub Actions workflow produces the source data. This table is written from the main Worker's own hourly cron (`writeSubnetSnapshot` in `src/health-prober.mjs`), so the new `syncSubnetIdentityToPostgres` mirror calls `env.DATA_API.fetch()` directly via the service binding rather than crossing the public internet through `workers/api.mjs`'s proxy layer — no changes to `workers/api.mjs` in this PR.
- No latest-only sibling table. `subnet_identity_history` is append-only, diffed by `identity_hash` per netuid, mirroring D1's own shape (the current identity lives in the `profiles.json` artifact, not a dedicated table).
- No dedicated per-field row validator on the write route (unlike the other two sync routes) — `profiles.json` is the same trust boundary D1's own `recordSubnetIdentityChanges` already reads from directly with no staging-style validation, and `identitySnapshotFromProfile`'s own null-guard already skips a malformed profile without erroring the batch.
- The mirror is best-effort and never throws — a failure never blocks `writeSubnetSnapshot`'s own D1-derived return value.

Adds:
- `subnet_identity_history` table to `deploy/postgres/schema.sql`
- `handleSubnetIdentitySync` internal write route + `GET /api/v1/subnets/:netuid/identity-history` Postgres-serving in `workers/data-api.mjs`
- `syncSubnetIdentityToPostgres` in `src/subnet-identity-history.mjs`, called from `writeSubnetSnapshot` in `src/health-prober.mjs`
- `tryPostgresTier` wiring for `handleSubnetIdentityHistory` behind its own `METAGRAPH_SUBNET_IDENTITY_SOURCE` flag (not yet added to `wrangler.jsonc` — deferred until live-parity verification, per the established pattern for the prior two tables)

Refs #4832

## Test plan

- `npm run lint` clean
- `npx prettier --check` clean on all touched files
- `npm run scan:public-safety` clean
- `npx vitest run` — 7497/7497 tests passing across 262 files
- `npm run test:coverage` + patch-diff isolation against `origin/main` for all touched JS files — zero uncovered added lines/branches
- `npm run validate` + `npm run validate:contract-drift` clean (no public contract change — the internal sync route isn't part of the OpenAPI surface, matching the other two sync routes)