### PR TITLE
feat(data-api): flip subnet_identity_history serving to Postgres

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -230,6 +230,23 @@
     // tryPostgresTier still falls back to D1 on any failure, so this remains
     // a single-flag revert.
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE": "postgres",
+    // subnet_identity_history (#4832 gap-closure, final table): FLIPPED to
+    // "postgres" 2026-07-11, after a live parity pass with an unexpected
+    // finding -- D1's own write path (recordSubnetIdentityChanges) had never
+    // successfully appended a single row to production D1's
+    // subnet_identity_history table (confirmed empty via direct `wrangler d1
+    // execute`, both before and after a live cron tick), despite running
+    // every hour as part of writeSubnetSnapshot. In that SAME cron tick, the
+    // new Postgres mirror (syncSubnetIdentityToPostgres, called with the
+    // identical `profiles` array right after the D1 write) successfully
+    // appended 124 real rows across 124 distinct subnets, using the exact
+    // same identitySnapshotFromProfile/identityHash pure functions -- proving
+    // the new pipeline works end-to-end where the D1 path had a pre-existing,
+    // silent bug (filed as a follow-up, unrelated to this migration itself).
+    // tryPostgresTier still falls back to D1 on any failure, so this remains
+    // a single-flag revert -- though note D1's fallback is currently a no-op
+    // for reads (empty) until that bug is fixed.
+    "METAGRAPH_SUBNET_IDENTITY_SOURCE": "postgres",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
   // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the


### PR DESCRIPTION
## Summary

Flips `METAGRAPH_SUBNET_IDENTITY_SOURCE` to `"postgres"`, completing the #4832 D1-completeness sweep (third and final table, following #4844 and #4850).

Live-parity check performed before this flip:

1. Applied the `subnet_identity_history` schema to production Postgres.
2. Provisioned `SUBNET_IDENTITY_SYNC_SECRET` on both `metagraphed` (constructs the outbound service-binding request) and `metagraphed-data-api` (verifies it).
3. Watched the natural top-of-hour `HEALTH_PRUNE_CRON` tick (`0 * * * *`) fire `writeSubnetSnapshot` — confirmed via `wrangler tail metagraphed-data-api` that the internal sync POST landed `Ok`.
4. Verified via direct `psql` that Postgres received 124 real rows across 124 distinct subnets, with correctly resolved `block_number` (from `SELECT MAX(block_number) FROM blocks`) and correct `identity_hash` values.
5. Unexpected finding: D1's own equivalent write path (`recordSubnetIdentityChanges`) has never successfully appended a row to production D1 — confirmed empty via `wrangler d1 execute` both before and after the same cron tick. This is a pre-existing bug unrelated to this migration (D1's write logic wasn't touched here) — filed as a follow-up. It doesn't block this flip: the new Postgres pipeline is proven working end-to-end with real data, and `tryPostgresTier` still falls back to D1 (a currently-empty no-op) on any failure, so this remains a single-flag revert with no regression risk.

Refs #4832

## Test plan

- `npx prettier --check wrangler.jsonc` clean
- `npm run lint` clean
- `npm run validate` clean
- Live: `psql` confirms 124 real Postgres rows; production cron confirmed to write successfully via `wrangler tail`