### PR TITLE
feat(registry): add SN126 Poker44 training benchmark docs and releases API

### DIFF
--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -51,6 +51,44 @@
         "https://api.poker44.net/api/v1/benchmark"
       ],
       "url": "https://api.poker44.net/api/v1/benchmark"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-training-benchmark-docs",
+      "kind": "docs",
+      "name": "Poker44 training benchmark docs",
+      "notes": "Official SN126 Poker44 public benchmark guide covering the api.poker44.net benchmark endpoints, release metadata fields, and chunk fetch workflow for miner parser and model regression testing.",
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "Lang-bt"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md",
+        "https://github.com/Poker44/Poker44-subnet"
+      ],
+      "url": "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-benchmark-releases-api",
+      "kind": "subnet-api",
+      "name": "Poker44 benchmark releases API",
+      "notes": "Public no-auth GET /api/v1/benchmark/releases on api.poker44.net returning the published shadow-training benchmark release catalog (releaseVersion, schemaVersion, per-date chunk/hand counts). Documented alongside GET /api/v1/benchmark in the official Poker44-subnet training-benchmark guide; distinct from the aggregate status endpoint already listed as a data-artifact.",
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "Lang-bt"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md",
+        "https://api.poker44.net/api/v1/benchmark/releases"
+      ],
+      "url": "https://api.poker44.net/api/v1/benchmark/releases"
     }
   ],
   "website_url": "https://poker44.net/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends surface(s) on exactly one subnet manifest —
`registry/subnets/poker44.json`.

## Surface

- Netuid: 126
- Kind: docs, subnet-api
- Public URL:
  - https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md
  - https://api.poker44.net/api/v1/benchmark/releases
- Source URL (proves the claim):
  - https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md
  - https://api.poker44.net/api/v1/benchmark/releases
- Provider slug: poker44

## Summary

Adds two public-safe SN126 Poker44 surfaces backed by the official subnet
training-benchmark guide:

1. **docs** — the public benchmark integration guide (`docs/training-benchmark.md`).
2. **subnet-api** — the live no-auth `GET /api/v1/benchmark/releases` catalog
   endpoint (distinct from the aggregate `/api/v1/benchmark` data-artifact already
   listed).

Both URLs are public, reachable, and independently documented in the official
Poker44-subnet repository.

## Checklist

- [x] Changes exactly one `registry/subnets/poker44.json` file: append-only for an
      existing manifest.
- [x] Generated with `npm run surface:add` — lands `authority: community` and
      `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`
      independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data,
      private URLs, private dashboards, validator internals, or generated
      `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [ ] Links a tracked issue (`Closes #<n>`) — no matching issue for these specific
      surfaces; SN126 OpenAPI issue #4178 remains open because Poker44 does not
      publish an OpenAPI schema.

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be
merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/poker44.json`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)