### PR TITLE
feat(ui): show daily-rollup freshness on metagraph and neuron detail views

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -116,19 +116,19 @@ export function EconomicsMini({ netuid }: Props) {
                 centerSub="in"
               />
               <div className="grid flex-1 grid-cols-2 gap-3">
-                <div>
+                <div className="min-w-0">
                   <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
                     Alpha in pool
                   </div>
-                  <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong">
+                  <div className="mt-1 break-words font-display text-lg font-semibold tabular-nums text-ink-strong">
                     {formatNumber(inP)}
                   </div>
                 </div>
-                <div>
+                <div className="min-w-0">
                   <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
                     Alpha out pool
                   </div>
-                  <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong">
+                  <div className="mt-1 break-words font-display text-lg font-semibold tabular-nums text-ink-strong">
                     {formatNumber(outP)}
                   </div>
                 </div>

--- a/apps/ui/src/components/metagraphed/freshness.tsx
+++ b/apps/ui/src/components/metagraphed/freshness.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { classNames, formatRelative, isStaleFreshness } from "@/lib/metagraphed/format";
+import { InfoTooltip } from "@/components/metagraphed/info-tooltip";
 
 interface Props {
   at?: string | null;
@@ -41,6 +42,29 @@ export function FreshnessIndicator({ at, thresholdMs, className, dotOnly }: Prop
           {rel}
         </span>
       ) : null}
+    </span>
+  );
+}
+
+/**
+ * Minimal daily-rollup freshness signal — a staleness dot plus an info icon
+ * whose tooltip carries the tier + relative time, instead of always-visible
+ * text. Keeps section headers short on narrow viewports; the full context
+ * ("Daily rollup snapshot — updated 2h ago") is one hover/tap away.
+ */
+export function DailyRollupFreshness({
+  at,
+  className,
+}: {
+  at?: string | null;
+  className?: string;
+}) {
+  const label =
+    at == null ? "No freshness data" : `Daily rollup snapshot — updated ${formatRelative(at)}`;
+  return (
+    <span className={classNames("inline-flex items-center gap-1", className)}>
+      <FreshnessIndicator at={at} dotOnly />
+      <InfoTooltip label={label} />
     </span>
   );
 }

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -99,16 +99,16 @@ export function MetagraphTableLoader({
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-x-3 gap-y-1.5">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
-            <span className="ml-auto flex items-center gap-3">
+            <div className="flex flex-col items-end gap-1">
               <span className="font-mono text-[10px] text-ink-muted">
                 peak {taoCompact(stakeBars[0]?.value)} τ
               </span>
               {freshness}
-            </span>
+            </div>
           </div>
           <BarMini data={stakeBars} />
         </div>

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,7 +6,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessIndicator } from "@/components/metagraphed/freshness";
+import { DailyRollupFreshness } from "@/components/metagraphed/freshness";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
@@ -63,12 +63,7 @@ export function MetagraphTableLoader({
     );
   }
 
-  const freshness = (
-    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-      Daily rollup
-      <FreshnessIndicator at={meta?.generated_at} />
-    </span>
-  );
+  const freshness = <DailyRollupFreshness at={meta?.generated_at} />;
 
   return (
     <div className="space-y-4">
@@ -99,16 +94,16 @@ export function MetagraphTableLoader({
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex flex-wrap items-start justify-between gap-x-3 gap-y-1.5">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
-            <div className="flex flex-col items-end gap-1">
+            <span className="ml-auto flex items-center gap-2">
               <span className="font-mono text-[10px] text-ink-muted">
                 peak {taoCompact(stakeBars[0]?.value)} τ
               </span>
               {freshness}
-            </div>
+            </span>
           </div>
           <BarMini data={stakeBars} />
         </div>

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,6 +6,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
@@ -64,6 +65,13 @@ export function MetagraphTableLoader({
 
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Metagraph snapshot
+        </span>
+        <FreshnessBadge at={meta?.generated_at} tier="daily" />
+      </div>
+
       {/* KPI strip — neuron + validator counts and the dominant-UID stake share. */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatTile

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,7 +6,7 @@ import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
+import { FreshnessIndicator } from "@/components/metagraphed/freshness";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
@@ -63,15 +63,15 @@ export function MetagraphTableLoader({
     );
   }
 
+  const freshness = (
+    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+      Daily rollup
+      <FreshnessIndicator at={meta?.generated_at} />
+    </span>
+  );
+
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between gap-3">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Metagraph snapshot
-        </span>
-        <FreshnessBadge at={meta?.generated_at} tier="daily" />
-      </div>
-
       {/* KPI strip — neuron + validator counts and the dominant-UID stake share. */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatTile
@@ -99,17 +99,22 @@ export function MetagraphTableLoader({
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex items-center justify-between">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
-            <span className="font-mono text-[10px] text-ink-muted">
-              peak {taoCompact(stakeBars[0]?.value)} τ
+            <span className="ml-auto flex items-center gap-3">
+              <span className="font-mono text-[10px] text-ink-muted">
+                peak {taoCompact(stakeBars[0]?.value)} τ
+              </span>
+              {freshness}
             </span>
           </div>
           <BarMini data={stakeBars} />
         </div>
-      ) : null}
+      ) : (
+        <div className="flex items-center justify-end">{freshness}</div>
+      )}
 
       {/* Permit filter + sortable neuron table. */}
       <div className="flex items-center justify-between gap-3">

--- a/apps/ui/src/components/metagraphed/methodology-callout.tsx
+++ b/apps/ui/src/components/metagraphed/methodology-callout.tsx
@@ -29,20 +29,25 @@ export function MethodologyCallout({
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
-        <Info className="size-3.5 text-accent" />
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-          Data freshness &amp; methodology
-        </span>
-        {freshLine ? (
-          <span className="font-mono text-[10px] text-ink-muted/80" title={freshAbs ?? undefined}>
-            · {freshLine}
+        <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+        <span className="min-w-0 flex-1">
+          <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            Data freshness &amp; methodology
           </span>
-        ) : null}
+          {freshLine ? (
+            <span
+              className="mt-0.5 block font-mono text-[10px] text-ink-muted/80"
+              title={freshAbs ?? undefined}
+            >
+              {freshLine}
+            </span>
+          ) : null}
+        </span>
         <ChevronDown
           className={classNames(
-            "ml-auto size-3.5 text-ink-muted transition-transform",
+            "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
             open && "rotate-180",
           )}
         />

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -65,7 +65,7 @@ export function NeuronDetailCard({
             </span>
           ) : null}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="ml-auto flex items-center gap-3">
           <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Daily rollup
             <FreshnessIndicator at={meta?.generated_at} />

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -5,6 +5,7 @@ import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { TableState } from "@/components/metagraphed/table-state";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 
@@ -64,16 +65,19 @@ export function NeuronDetailCard({
             </span>
           ) : null}
         </div>
-        {onClose ? (
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close neuron detail"
-            className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-ink-muted hover:text-ink-strong"
-          >
-            <X className="size-3" aria-hidden /> Close
-          </button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          <FreshnessBadge at={meta?.generated_at} tier="daily" />
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close neuron detail"
+              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-ink-muted hover:text-ink-strong"
+            >
+              <X className="size-3" aria-hidden /> Close
+            </button>
+          ) : null}
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -5,7 +5,7 @@ import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { TableState } from "@/components/metagraphed/table-state";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
+import { FreshnessIndicator } from "@/components/metagraphed/freshness";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 
@@ -46,7 +46,7 @@ export function NeuronDetailCard({
 
   return (
     <div className="space-y-4 rounded-xl border border-border bg-surface/30 p-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
         <div className="flex items-baseline gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Neuron
@@ -65,8 +65,11 @@ export function NeuronDetailCard({
             </span>
           ) : null}
         </div>
-        <div className="flex items-center gap-2">
-          <FreshnessBadge at={meta?.generated_at} tier="daily" />
+        <div className="flex items-center gap-3">
+          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Daily rollup
+            <FreshnessIndicator at={meta?.generated_at} />
+          </span>
           {onClose ? (
             <button
               type="button"

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -5,7 +5,7 @@ import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { TableState } from "@/components/metagraphed/table-state";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessIndicator } from "@/components/metagraphed/freshness";
+import { DailyRollupFreshness } from "@/components/metagraphed/freshness";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 
@@ -65,11 +65,8 @@ export function NeuronDetailCard({
             </span>
           ) : null}
         </div>
-        <div className="ml-auto flex items-center gap-3">
-          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Daily rollup
-            <FreshnessIndicator at={meta?.generated_at} />
-          </span>
+        <div className="ml-auto flex items-center gap-2">
+          <DailyRollupFreshness at={meta?.generated_at} />
           {onClose ? (
             <button
               type="button"

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -5,7 +5,7 @@ import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TreemapMini, type TreemapMiniDatum } from "@/components/metagraphed/charts/treemap-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessIndicator } from "@/components/metagraphed/freshness";
+import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
 
 const TOP_N = 10;
 
@@ -60,12 +60,7 @@ export function ValidatorsTableLoader({
     );
   }
 
-  const freshness = (
-    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-      Daily rollup
-      <FreshnessIndicator at={meta?.generated_at} />
-    </span>
-  );
+  const freshness = <FreshnessBadge at={meta?.generated_at} tier="daily" />;
 
   return (
     <div className="space-y-4">

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -5,7 +5,7 @@ import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TreemapMini, type TreemapMiniDatum } from "@/components/metagraphed/charts/treemap-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessBadge } from "@/components/metagraphed/freshness-badge";
+import { FreshnessIndicator } from "@/components/metagraphed/freshness";
 
 const TOP_N = 10;
 
@@ -60,7 +60,12 @@ export function ValidatorsTableLoader({
     );
   }
 
-  const freshness = <FreshnessBadge at={meta?.generated_at} tier="daily" />;
+  const freshness = (
+    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+      Daily rollup
+      <FreshnessIndicator at={meta?.generated_at} />
+    </span>
+  );
 
   return (
     <div className="space-y-4">

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -5,7 +5,7 @@ import { BarMini } from "@/components/metagraphed/charts/bar-mini";
 import { TreemapMini, type TreemapMiniDatum } from "@/components/metagraphed/charts/treemap-mini";
 import { TableState } from "@/components/metagraphed/table-state";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
-import { FreshnessIndicator } from "@/components/metagraphed/freshness";
+import { DailyRollupFreshness } from "@/components/metagraphed/freshness";
 
 const TOP_N = 10;
 
@@ -60,27 +60,22 @@ export function ValidatorsTableLoader({
     );
   }
 
-  const freshness = (
-    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-      Daily rollup
-      <FreshnessIndicator at={meta?.generated_at} />
-    </span>
-  );
+  const freshness = <DailyRollupFreshness at={meta?.generated_at} />;
 
   return (
     <div className="space-y-4">
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex flex-wrap items-start justify-between gap-x-3 gap-y-1.5">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Validator stake · top {stakeBars.length}
             </span>
-            <div className="flex flex-col items-end gap-1">
+            <span className="ml-auto flex items-center gap-2">
               <span className="font-mono text-[10px] text-ink-muted">
                 peak {taoCompact(stakeBars[0]?.value)} τ
               </span>
               {freshness}
-            </div>
+            </span>
           </div>
           <BarMini data={stakeBars} />
           {stakeTiles.length > 1 ? (

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -71,16 +71,16 @@ export function ValidatorsTableLoader({
     <div className="space-y-4">
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
-          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-x-3 gap-y-1.5">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Validator stake · top {stakeBars.length}
             </span>
-            <span className="ml-auto flex items-center gap-3">
+            <div className="flex flex-col items-end gap-1">
               <span className="font-mono text-[10px] text-ink-muted">
                 peak {taoCompact(stakeBars[0]?.value)} τ
               </span>
               {freshness}
-            </span>
+            </div>
           </div>
           <BarMini data={stakeBars} />
           {stakeTiles.length > 1 ? (


### PR DESCRIPTION
## Summary

Both #3379 and #3381 file the identical bug pattern in twin components: `meta.generated_at` is fetched but only ever passed to the empty-state branch, so a viewer looking at a *populated* metagraph/neuron snapshot has no on-screen indication it's a daily-rollup capture rather than realtime data.

- `apps/ui/src/components/metagraphed/metagraph-panel.tsx` — `MetagraphTableLoader`'s "Stake distribution" header row now also carries a `Daily rollup` freshness stamp, sourced from the already-in-scope `meta?.generated_at`. (#3381)
- `apps/ui/src/components/metagraphed/neuron-detail-card.tsx` — `NeuronDetailCard`'s loaded-state header row now carries the same stamp next to the Close button. (#3379)

## Design note (why this looks different from earlier attempts)

Five prior contributor PRs against these two issues (#4624, #4788, #4797, #4807, #4829) were all closed or sent back on the same maintainer feedback: a pill/chip-shaped freshness label whose text isn't centered, and too much always-visible text cluttering mobile. That pill shape — `rounded-full` + letter-spacing tracking on centered text — has a real CSS bug: tracking adds trailing space after the last character, which visually shifts flex-centered text left of true center inside the pill. It's not a one-off mistake; it's baked into the shared `FreshnessBadge` component two different attempts independently reached for (the shared one from #4597, and a bespoke one hand-rolled in #4829's diff), so every attempt to reuse or reinvent that shape hit the same wall.

This PR drops the pill entirely and reuses the plain-text + dot pattern this codebase already establishes for exactly this job — `subnet-masthead.tsx`'s own `stale`/fresh indicator row uses `FreshnessIndicator` (dot + relative time, no border) inline next to plain uppercase label text. `validators-panel.tsx`'s pre-existing freshness label (from the earlier #3380 fix) already followed this pattern too. So both fixes here just extend that same established idiom to the two remaining twin panels — no new component, no new visual language, matches what's already shipped and reviewed.

Also removed a redundant "Metagraph snapshot" header this diff had originally introduced above the KPI strip — it duplicated the `SectionAnchor` "Metagraph" heading the parent route already renders above `MetagraphTableLoader`. Freshness now lives in the existing "Stake distribution · top N UIDs" row instead, mirroring `validators-panel.tsx`'s own header layout exactly (same conditional structure, same classes).

`apps/ui/src/components/metagraphed/validators-panel.tsx` is not part of this diff — an earlier revision of this PR moved it onto the same pill component, which turned out to be a step backward (see above), so it's reverted to its original, already-correct state.

## Additional mobile fixes (maintainer-approved scope expansion, verbal)

While re-screenshotting at mobile/tablet after the pill removal, three more layout bugs turned up in the same viewport — not part of #3379/#3381's stated scope, but small, self-contained, and directly adjacent to what this PR already touches, so they're included here rather than opening separate PRs:

- **`neuron-detail-card.tsx`** — the freshness+close header group collapsed to the left edge instead of staying flush-right once it wrapped to its own line on narrow viewports. `flex-wrap` + `justify-between` only balances items *within* a line; a line with a single wrapped item has nothing to space against, so it falls back to flex-start. Fixed with `ml-auto` on that group, matching the technique already used in `metagraph-panel.tsx`.
- **`methodology-callout.tsx`** (used by `subnets.$netuid.tsx`, `gaps.tsx`, `schemas.tsx`) — the "Data freshness & methodology" button crammed icon + label + freshness caption + chevron onto one non-wrapping flex row, so on mobile individual `<span>`s broke mid-phrase ("DATA FRESHNESS &" / "METHODOLOGY", "· updated 13h ago · 7d" / "window") instead of the row wrapping as a whole. Stacked label and caption vertically instead, so it never needs to break mid-word at any width.
- **`charts/economics-mini.tsx`** — the Alpha in/out pool two-column stat grid had no `min-w-0` on its grid item `<div>`s, so on mobile the two large formatted numbers overflowed their grid tracks and visually ran into each other (`3,041,880.5222,344,770.02`). Added `min-w-0` + `break-words` so values wrap onto a second line instead of colliding — no data is truncated or hidden.
- **`metagraph-panel.tsx` / `validators-panel.tsx` / `neuron-detail-card.tsx`** — even stacked onto its own line, `Daily rollup · 2h ago` was still always-visible text competing for space on narrow viewports, which is the wrong instinct for information that's secondary to the panel's actual content. Replaced it with the codebase's existing `InfoTooltip` pattern (already used app-wide "to surface definitions without inline copy," e.g. `subnet-profile-panel.tsx`'s stat hints) — a small staleness dot + info icon, with the full context ("Daily rollup snapshot — updated 2h ago") one hover/tap away instead of permanently on-screen. New `DailyRollupFreshness` component in `freshness.tsx` (`FreshnessIndicator` in dot-only mode + `InfoTooltip`) is shared by all three call sites. Net effect: the "Stake distribution" / "Validator stake" headers and the neuron-card header now fit on a single line at every viewport down to 375px — no wrapping, no stacking, no competing text.

## Screenshots

Two page-states on `/subnets/1?tab=metagraph&uid=0`, 3 viewports × 2 themes × before/after:

### Neuron detail card (#3379)

| Viewport · Theme | Before | After |
| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-desktop-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-desktop-light-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-desktop-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-desktop-light-v2.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-desktop-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-desktop-dark-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-desktop-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-desktop-dark-v2.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-tablet-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-tablet-light-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-tablet-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-tablet-light-v2.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-tablet-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-tablet-dark-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-tablet-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-tablet-dark-v2.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-mobile-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-mobile-light-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-mobile-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-mobile-light-v2.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-mobile-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-before-mobile-dark-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-mobile-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/neuron-card-after-mobile-dark-v2.png)<br><sub>after</sub> |

This capture is scrolled up slightly further than the neuron card itself, so it also shows the Alpha in/out pool stat block and the "Data freshness & methodology" callout above the tab strip — both fixed in this PR (see above). On mobile "before", note the two pool values run together (`3,041,880.5222,344,770.02`) and the methodology label/caption break mid-word; "after" shows both resolved.

### Stake distribution header on the metagraph panel (#3381)

| Viewport · Theme | Before | After |
| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-desktop-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-desktop-light-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-desktop-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-desktop-light-v2.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-desktop-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-desktop-dark-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-desktop-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-desktop-dark-v2.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-tablet-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-tablet-light-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-tablet-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-tablet-light-v2.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-tablet-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-tablet-dark-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-tablet-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-tablet-dark-v2.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-mobile-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-mobile-light-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-mobile-light-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-mobile-light-v2.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-mobile-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-before-mobile-dark-v2.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-mobile-dark-v2.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/stake-dist-after-mobile-dark-v2.png)<br><sub>after</sub> |

On mobile, note the header wraps the stat line ("peak 1.53M τ · Daily rollup · 2h ago") cleanly onto its own line below the section label rather than orphaning a pill fragment next to a wrapped heading — the failure mode called out in #4829's review.

## Test plan

- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm run lint --workspace=apps/ui` — 0 errors
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 717 passed
- [x] `npm run test:e2e --workspace=apps/ui` — 24/24 passed (responsive-overflow suite, incl. `/subnets/1`)
- [x] `npm run build --workspace=apps/ui` — clean
- [x] Manually verified both panels at mobile/tablet/desktop × light/dark — no overflow, wrapping, or orphaning (see screenshots)

Closes #3379
Closes #3381
