### PR TITLE
feat(registry): add SN62 Ridges problem-statistics data artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "id": "sn-62-ridges-data-artifact",
+      "name": "Ridges SWE-bench problem statistics",
+      "kind": "data-artifact",
+      "url": "https://agent-upload.ridges.ai/statistics/problem-statistics",
+      "provider": "ridges",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/main/api/endpoints/statistics.py",
+        "https://github.com/ridgesai/ridges/blob/main/miners/cli/commands/upload.py"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jaytbarimbao-collab"
+      },
+      "notes": "Public, unauthenticated read endpoint on the Ridges backend API: per-problem SWE-bench evaluation statistics for the active problem set (pass rate, evaluation run counts, average cost/time, per-test pass/fail breakdown). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py); /statistics/problem-statistics is defined in api/endpoints/statistics.py (no auth) and mounted at /statistics in api/src/main.py."
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends a surface to exactly one subnet manifest — `registry/subnets/ridges.json`. This is a resubmission of #4852 with a minimal diff (pure append, no reformatting of existing entries) after that PR was closed citing a duplicate check that its own review summary confirmed was a false positive from full-file key reordering, not a real content duplicate.

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/statistics/problem-statistics
- Source URL (proves the claim): https://github.com/ridgesai/ridges/blob/main/api/endpoints/statistics.py , https://github.com/ridgesai/ridges/blob/main/miners/cli/commands/upload.py
- Provider slug: ridges

## Summary

Adds the Ridges (SN62) SWE-bench problem-statistics endpoint as a `data-artifact` surface — a public, unauthenticated read endpoint returning per-problem evaluation statistics (pass rate, run counts, average cost/time, per-test pass/fail breakdown) for the currently active problem set.

`agent-upload.ridges.ai` is the `DEFAULT_API_BASE_URL` used by the official Ridges CLI (`miners/cli/commands/upload.py`, line 21), and `/statistics/problem-statistics` is defined with no auth requirement in `api/endpoints/statistics.py`, mounted at `/statistics` in `api/src/main.py`. This is a distinct endpoint/kind from the subnet's existing `subnet-api` (`/retrieval/top-agents`) and `openapi` surfaces already in the file — it fills the "no verified standalone static data artifact yet" gap noted in the subnet's own curation notes.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only, minimal diff — 19 insertions, 0 deletions).
- [x] Lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`s independently prove the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface — new `id`/`kind`/`url` distinct from the file's existing `source-repo`, `subnet-api`, and `openapi` surfaces.
- [x] Links a tracked issue that is still OPEN (`Closes #4069`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json` — passed
- [x] `npm run scan:public-safety` — passed

Closes #4069