### PR TITLE
feat(data-api): migrate 12 chain-wide analytics routes to Postgres

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -98,6 +98,12 @@ CREATE INDEX IF NOT EXISTS idx_ae_observed ON account_events (observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_ae_extrinsic ON account_events (block_number, extrinsic_index);
 -- #2079: covers the /subnets/{netuid}/events ?kind filter (unindexed post-filter today).
 CREATE INDEX IF NOT EXISTS idx_ae_netuid_kind ON account_events (netuid, event_kind, block_number DESC);
+-- #4832 Tier 2: covers the network-wide (no netuid filter) `event_kind = ? AND
+-- observed_at >= ?` scans the 12 /chain/* analytics routes in data-api.mjs run
+-- -- idx_ae_netuid_kind above only helps once a netuid filter is also present.
+-- Applied live via a plain (non-concurrent) CREATE INDEX -- TimescaleDB
+-- hypertables reject CREATE INDEX CONCURRENTLY.
+CREATE INDEX IF NOT EXISTS idx_ae_kind_observed ON account_events (event_kind, observed_at DESC);
 
 -- Generic all-events tier (audit gap: only ~8 kinds of 2 pallets decoded today).
 -- Stores EVERY decoded event; the curated account_events stays the fast path.

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -849,6 +849,78 @@ test("GET /api/v1/chain/transfers rejects non-canonical limits", async () => {
   }
 });
 
+// #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+// table this handler already reads, no new flag) -- tryPostgresTier's own
+// fallback contract is unit-tested in workers/postgres-tier.mjs's own tests,
+// so these two just prove the wiring: a Postgres hit is served as-is with D1
+// never queried, and a Postgres failure falls back to D1.
+test("GET /api/v1/chain/transfers: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+  let d1Called = false;
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          window: "7d",
+          observed_at: "2026-01-01T00:00:00.000Z",
+          total_volume_tao: 999,
+          transfer_count: 1,
+          unique_senders: 1,
+          unique_receivers: 1,
+          top_sender_share: null,
+          top_senders: [],
+          top_receivers: [],
+        }),
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        d1Called = true;
+        throw new Error(
+          "D1 must not be queried when Postgres serves the request",
+        );
+      },
+    },
+  };
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/chain/transfers?window=7d"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.total_volume_tao, 999);
+  assert.equal(d1Called, false);
+});
+
+test("GET /api/v1/chain/transfers: flag=postgres falls back to D1 when DATA_API fails", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return {
+          bind: () => ({ all: () => Promise.resolve({ results: [] }) }),
+        };
+      },
+    },
+  };
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/chain/transfers?window=7d"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.total_volume_tao, 0);
+});
+
 test("GET /api/v1/chain/transfer-pairs ranks directed transfer corridors", async () => {
   const captured = [];
   const env = {
@@ -1094,6 +1166,82 @@ test("GET /api/v1/chain/transfer-pairs validates sort, limit, and query keys", a
     const body = await res.json();
     assert.equal(body.error.code, "invalid_query");
   }
+});
+
+// #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+// table this handler already reads, no new flag) -- tryPostgresTier's own
+// fallback contract is unit-tested in workers/postgres-tier.mjs's own tests,
+// so these two just prove the wiring: a Postgres hit is served as-is with D1
+// never queried, and a Postgres failure falls back to D1.
+test("GET /api/v1/chain/transfer-pairs: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+  let d1Called = false;
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          window: "7d",
+          sort: "volume",
+          observed_at: "2026-01-01T00:00:00.000Z",
+          total_volume_tao: 999,
+          transfer_count: 1,
+          unique_pairs: 1,
+          pair_count: 1,
+          top_pair_share: null,
+          pairs: [],
+        }),
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        d1Called = true;
+        throw new Error(
+          "D1 must not be queried when Postgres serves the request",
+        );
+      },
+    },
+  };
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfer-pairs?window=7d",
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.total_volume_tao, 999);
+  assert.equal(d1Called, false);
+});
+
+test("GET /api/v1/chain/transfer-pairs: flag=postgres falls back to D1 when DATA_API fails", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return {
+          bind: () => ({ all: () => Promise.resolve({ results: [] }) }),
+        };
+      },
+    },
+  };
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfer-pairs?window=7d",
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.total_volume_tao, 0);
 });
 
 test("GET /api/v1/chain/fees scopes every extrinsics query by call_module", async () => {

--- a/tests/chain-axon-removals.test.mjs
+++ b/tests/chain-axon-removals.test.mjs
@@ -308,6 +308,58 @@ describe("GET /api/v1/chain/axon-removals", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...axonRemovalsEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...axonRemovalsEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(
       req("?window=90d"),

--- a/tests/chain-deregistrations.test.mjs
+++ b/tests/chain-deregistrations.test.mjs
@@ -308,6 +308,58 @@ describe("GET /api/v1/chain/deregistrations", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...deregistrationsEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...deregistrationsEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(
       req("?window=90d"),

--- a/tests/chain-prometheus.test.mjs
+++ b/tests/chain-prometheus.test.mjs
@@ -301,6 +301,58 @@ describe("GET /api/v1/chain/prometheus", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...prometheusEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...prometheusEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(
       req("?window=90d"),

--- a/tests/chain-registrations.test.mjs
+++ b/tests/chain-registrations.test.mjs
@@ -308,6 +308,58 @@ describe("GET /api/v1/chain/registrations", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...registrationsEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...registrationsEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(
       req("?window=90d"),

--- a/tests/chain-serving.test.mjs
+++ b/tests/chain-serving.test.mjs
@@ -301,6 +301,58 @@ describe("GET /api/v1/chain/serving", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...servingEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...servingEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(req("?window=90d"), servingEnv(cold), {});
     assert.equal(res.status, 400);

--- a/tests/chain-stake-flow.test.mjs
+++ b/tests/chain-stake-flow.test.mjs
@@ -379,6 +379,58 @@ describe("GET /api/v1/chain/stake-flow", () => {
     assert.equal(body.data.net_flow_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...stakeFlowEnv([]),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            net_flow_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...stakeFlowEnv(ROWS),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(req("?window=90d"), stakeFlowEnv([]), {});
     assert.equal(res.status, 400);

--- a/tests/chain-stake-moves.test.mjs
+++ b/tests/chain-stake-moves.test.mjs
@@ -301,6 +301,58 @@ describe("GET /api/v1/chain/stake-moves", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...stakeMovesEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...stakeMovesEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(
       req("?window=90d"),

--- a/tests/chain-stake-transfers.test.mjs
+++ b/tests/chain-stake-transfers.test.mjs
@@ -310,6 +310,58 @@ describe("GET /api/v1/chain/stake-transfers", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...stakeTransfersEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {},
+            intensity_distribution: null,
+            subnets: [{ netuid: 42 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...stakeTransfersEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(
       req("?window=90d"),

--- a/tests/chain-weight-setters.test.mjs
+++ b/tests/chain-weight-setters.test.mjs
@@ -330,6 +330,56 @@ describe("GET /api/v1/chain/weights/setters", () => {
     assert.deepEqual(body.data.setters, []);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...eventsEnv([], null),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            setter_count: 99,
+            setters: [{ hotkey: "5Pg", weight_sets: 1 }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.setter_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...eventsEnv(LEADER_ROWS, TOTALS),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.setter_count, 2);
+  });
+
   const WEIGHT_SETTERS_CSV_HEADER =
     "hotkey,uid,weight_sets,share,first_set_at,last_set_at";
 

--- a/tests/chain-weights.test.mjs
+++ b/tests/chain-weights.test.mjs
@@ -386,6 +386,69 @@ describe("GET /api/v1/chain/weights", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
+  // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
+  // table this handler already reads, no new flag) -- tryPostgresTier's own
+  // fallback contract is unit-tested in workers/postgres-tier.mjs's own
+  // tests, so these two just prove the wiring: a Postgres hit is served
+  // as-is with D1 never queried, and a Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...weightsEnv(cold),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            subnet_count: 99,
+            network: {
+              distinct_setters: 1,
+              weight_sets: 1,
+              sets_per_setter: 1,
+            },
+            intensity_distribution: null,
+            subnets: [
+              {
+                netuid: 42,
+                distinct_setters: 1,
+                weight_sets: 1,
+                sets_per_setter: 1,
+              },
+            ],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...weightsEnv(warm),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 3);
+  });
+
   test("rejects an unsupported window with 400", async () => {
     const res = await handleRequest(req("?window=90d"), weightsEnv(cold), {});
     assert.equal(res.status, 400);

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3797,3 +3797,359 @@ test("GET /api/v1/subnets/:netuid/identity-history?limit=1 emits a next_cursor w
   const body = await res.json();
   expect(body.next_cursor).not.toBeNull();
 });
+
+// #4832 Tier 2: the 12 chain-wide account_events analytics routes
+// (mirroring src/chain-*.mjs's D1 loaders). These reuse the ALREADY-flipped
+// METAGRAPH_ACCOUNT_EVENTS_SOURCE flag (no new table/secret), so entities.mjs
+// -- err, analytics.mjs's -- own tryPostgresTier wiring is tested at the
+// handler layer (tests/chain-*.test.mjs); these exercise the actual SQL/
+// shaping in workers/data-api.mjs itself, including the cold-store guard
+// branch each "network + subnet" route shares.
+
+test("GET /api/v1/chain/weights: warm store runs both the network + subnet queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ weight_sets: 3, distinct_setters: 2, newest_observed: "1780000000000" }],
+    [{ netuid: 1, weight_sets: 3, distinct_setters: 2 }],
+  ];
+  const res = await req("/api/v1/chain/weights?window=7d&limit=5");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/weights: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [], // empty network row -- networkRows[0] ?? null falls back to null
+  ];
+  const res = await req("/api/v1/chain/weights");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/weights/setters: runs the leaderboard + totals queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [
+      {
+        hotkey: "5Pg",
+        uid: null,
+        weight_sets: 2,
+        first_set: "1",
+        last_set: "2",
+      },
+    ],
+    [{ weight_sets: 2, distinct_setters: 1, newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/chain/weights/setters?window=30d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.setter_count).toBe(1);
+});
+
+test("GET /api/v1/chain/weights/setters: an empty totals row falls back to null", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+    [],
+  ];
+  const res = await req("/api/v1/chain/weights/setters");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.setter_count).toBe(0);
+});
+
+test("GET /api/v1/chain/serving: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_servers: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, announcements: 1, distinct_servers: 1 }],
+  ];
+  const res = await req("/api/v1/chain/serving");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/serving: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/serving");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/prometheus: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_exporters: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, announcements: 1, distinct_exporters: 1 }],
+  ];
+  const res = await req("/api/v1/chain/prometheus");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/prometheus: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/prometheus");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/axon-removals: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_removers: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, removals: 1, distinct_removers: 1 }],
+  ];
+  const res = await req("/api/v1/chain/axon-removals");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/axon-removals: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/axon-removals");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/registrations: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_registrants: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, registrations: 1, distinct_registrants: 1 }],
+  ];
+  const res = await req("/api/v1/chain/registrations");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/registrations: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/registrations");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/deregistrations: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_deregistered_hotkeys: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, deregistrations: 1, distinct_deregistered_hotkeys: 1 }],
+  ];
+  const res = await req("/api/v1/chain/deregistrations");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/deregistrations: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/deregistrations");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/stake-moves: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_movers: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, movements: 1, distinct_movers: 1 }],
+  ];
+  const res = await req("/api/v1/chain/stake-moves");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/stake-moves: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/stake-moves");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/stake-transfers: warm store runs both queries", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [{ distinct_senders: 1, newest_observed: "1780000000000" }],
+    [{ netuid: 1, transfers: 1, distinct_senders: 1 }],
+  ];
+  const res = await req("/api/v1/chain/stake-transfers");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/stake-transfers: cold store skips the subnet query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+  ];
+  const res = await req("/api/v1/chain/stake-transfers");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(0);
+});
+
+test("GET /api/v1/chain/stake-flow: a single GROUP BY netuid, event_kind query", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [
+      {
+        netuid: 1,
+        event_kind: "StakeAdded",
+        total_tao: 10,
+        event_count: 2,
+        last_observed: "1780000000000",
+      },
+      {
+        netuid: 1,
+        event_kind: "StakeRemoved",
+        total_tao: 4,
+        event_count: 1,
+        last_observed: "1780000000000",
+      },
+    ],
+  ];
+  const res = await req("/api/v1/chain/stake-flow?window=30d&limit=10");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.subnet_count).toBe(1);
+});
+
+test("GET /api/v1/chain/transfers: totals + senders + receivers", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [
+      {
+        transfer_count: 3,
+        total_volume_tao: 100,
+        unique_senders: 2,
+        unique_receivers: 2,
+        newest_observed: "1780000000000",
+      },
+    ],
+    [{ address: "5Sender", volume_tao: 80, transfer_count: 2 }],
+    [{ address: "5Receiver", volume_tao: 60, transfer_count: 1 }],
+  ];
+  const res = await req("/api/v1/chain/transfers?window=7d&limit=5");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.total_volume_tao).toBe(100);
+  expect(body.top_senders[0].address).toBe("5Sender");
+});
+
+test("GET /api/v1/chain/transfers: a cold store's empty totals row falls back to null", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [],
+    [],
+    [],
+  ];
+  const res = await req("/api/v1/chain/transfers");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.total_volume_tao).toBe(0);
+});
+
+test("GET /api/v1/chain/transfer-pairs: default (volume) sort", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [
+      {
+        transfer_count: 3,
+        total_volume_tao: 100,
+        unique_pairs: 1,
+        top_pair_volume_tao: 80,
+        newest_observed: "1780000000000",
+      },
+    ],
+    // `orderBy` is itself built via a bare `sql\`...\`` fragment (not
+    // awaited on its own) before being interpolated into the pairRows
+    // query below -- the mock's sql() shifts a queue slot per call
+    // regardless, so this dummy slot stands in for that construction.
+    [],
+    [
+      {
+        from_address: "5Sa",
+        to_address: "5Rx",
+        volume_tao: 80,
+        transfer_count: 2,
+        last_block: "100",
+        last_observed_at: "1780000000000",
+      },
+    ],
+  ];
+  const res = await req("/api/v1/chain/transfer-pairs?window=7d&limit=5");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.sort).toBe("volume");
+  expect(body.pairs[0].from).toBe("5Sa");
+  expect(queryText()).toContain("volume_tao DESC, transfer_count DESC");
+});
+
+test("GET /api/v1/chain/transfer-pairs?sort=count uses the count ordering", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [
+      {
+        transfer_count: 3,
+        total_volume_tao: 100,
+        unique_pairs: 1,
+        top_pair_volume_tao: 80,
+        newest_observed: "1780000000000",
+      },
+    ],
+    [], // the `orderBy` fragment construction -- see the comment above
+    [],
+  ];
+  const res = await req("/api/v1/chain/transfer-pairs?sort=count");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.sort).toBe("count");
+  expect(queryText()).toContain("transfer_count DESC, volume_tao DESC");
+});
+
+test("GET /api/v1/chain/transfer-pairs: an empty totals row falls back to null", async () => {
+  mockQueue.current = [
+    [], // consumed by the session-scoped `SET statement_timeout` call
+    [], // empty totals row -- totalsRows[0] ?? null falls back to null
+    [], // the `orderBy` fragment construction
+    [],
+  ];
+  const res = await req("/api/v1/chain/transfer-pairs");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.total_volume_tao).toBe(0);
+});

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -215,6 +215,50 @@ import {
   buildCounterpartyRelationship,
   COUNTERPARTIES_SCAN_CAP,
 } from "../src/counterparties.mjs";
+import { ANALYTICS_WINDOWS, DEFAULT_ANALYTICS_WINDOW } from "./config.mjs";
+import {
+  buildChainWeights,
+  CHAIN_WEIGHTS_LIMIT_DEFAULT,
+} from "../src/chain-weights.mjs";
+import {
+  buildChainWeightSetters,
+  CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+  CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+} from "../src/chain-weight-setters.mjs";
+import {
+  buildChainServing,
+  CHAIN_SERVING_LIMIT_DEFAULT,
+} from "../src/chain-serving.mjs";
+import {
+  buildChainPrometheus,
+  CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+} from "../src/chain-prometheus.mjs";
+import {
+  buildChainAxonRemovals,
+  CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+} from "../src/chain-axon-removals.mjs";
+import {
+  buildChainRegistrations,
+  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+} from "../src/chain-registrations.mjs";
+import {
+  buildChainDeregistrations,
+  CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+} from "../src/chain-deregistrations.mjs";
+import {
+  buildChainStakeMoves,
+  CHAIN_STAKE_MOVES_LIMIT_DEFAULT,
+} from "../src/chain-stake-moves.mjs";
+import {
+  buildChainStakeTransfers,
+  CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT,
+} from "../src/chain-stake-transfers.mjs";
+import {
+  buildChainStakeFlow,
+  CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+} from "../src/chain-stake-flow.mjs";
+import { buildChainTransfers } from "../src/chain-transfers.mjs";
+import { buildChainTransferPairs } from "../src/chain-transfer-pairs.mjs";
 import {
   SUBNET_HYPERPARAMS_INSERT_COLUMNS,
   formatSubnetHyperparams,
@@ -259,6 +303,17 @@ function windowCutoff(url, windows, defaultLabel) {
 function windowLabelFor(url, windows, defaultLabel) {
   const label = url.searchParams.get("window") || defaultLabel;
   return Object.hasOwn(windows, label) ? label : defaultLabel;
+}
+
+// A ?limit= value for the /chain/* network-wide analytics routes (#4832
+// Tier 2): by the time tryPostgresTier reaches this route, the D1-side
+// handler's own parseLimitParam has ALREADY validated it (absent ->
+// defaultLimit, present -> a clean positive integer <= its maxLimit) -- a
+// malformed limit 400s before ever reaching here, so this only needs to
+// replicate parseLimitParam's success path, not re-validate.
+function chainLimit(url, defaultLimit) {
+  const raw = url.searchParams.get("limit");
+  return raw === null ? defaultLimit : Number(raw);
 }
 
 // Resolve a ?window= label to a YYYY-MM-DD cutoff date for a neuron_daily
@@ -2408,6 +2463,482 @@ export default {
                 SUBNET_WEIGHT_SETTERS_WINDOWS,
                 DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
               ),
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/weights (#4832 Tier 2): network-wide WeightsSet
+        // leaderboard + rollup, mirroring src/chain-weights.mjs's
+        // loadChainWeights. window/limit are resolved from the shared
+        // ANALYTICS_WINDOWS/DEFAULT_ANALYTICS_WINDOW (workers/config.mjs) --
+        // the same set every chain-* module's own WINDOWS constant
+        // duplicates -- and chainLimit (below) replicates parseLimitParam's
+        // success path since the D1-side handler has already validated a
+        // malformed limit into a 400 before tryPostgresTier is ever reached.
+        const chainWeights = url.pathname.match(/^\/api\/v1\/chain\/weights$/);
+        if (chainWeights) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(*) AS weight_sets,
+                 COUNT(DISTINCT CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                                      WHEN uid IS NOT NULL AND netuid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) AS distinct_setters,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS weight_sets,
+                   COUNT(DISTINCT CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                                        WHEN uid IS NOT NULL AND netuid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) AS distinct_setters
+            FROM account_events WHERE event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid`;
+          }
+          return json(
+            buildChainWeights(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_WEIGHTS_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/weights/setters (#4832 Tier 2): network-wide
+        // weight-setter leaderboard, mirroring
+        // src/chain-weight-setters.mjs's loadChainWeightSetters. The
+        // setter-identity CASE expression here omits chain-weights' extra
+        // `AND netuid IS NOT NULL` guard -- matches SETTER_IDENTITY in
+        // chain-weight-setters.mjs exactly, not chain-weights.mjs's own.
+        const chainWeightSetters = url.pathname.match(
+          /^\/api\/v1\/chain\/weights\/setters$/,
+        );
+        if (chainWeightSetters) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT MAX(hotkey) AS hotkey, MAX(uid) AS uid, COUNT(*) AS weight_sets,
+                 MIN(observed_at) AS first_set, MAX(observed_at) AS last_set
+          FROM account_events WHERE event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}
+            AND (CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                      WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) IS NOT NULL
+          GROUP BY CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                        WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END
+          ORDER BY weight_sets DESC, last_set DESC LIMIT ${CHAIN_WEIGHT_SETTERS_LIMIT_MAX}`;
+          const totalsRows = await sql`
+          SELECT COUNT(*) AS weight_sets,
+                 COUNT(DISTINCT CASE WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
+                                      WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid END) AS distinct_setters,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${WEIGHTS_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          return json(
+            buildChainWeightSetters(rows, totalsRows[0] ?? null, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT),
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/serving (#4832 Tier 2): network-wide AxonServed
+        // announcement leaderboard, mirroring src/chain-serving.mjs's
+        // loadChainServing.
+        const chainServing = url.pathname.match(/^\/api\/v1\/chain\/serving$/);
+        if (chainServing) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT hotkey) AS distinct_servers, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${SERVING_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS announcements, COUNT(DISTINCT hotkey) AS distinct_servers
+            FROM account_events WHERE event_kind = ${SERVING_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY announcements DESC, netuid ASC`;
+          }
+          return json(
+            buildChainServing(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_SERVING_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/prometheus (#4832 Tier 2): network-wide
+        // PrometheusServed announcement leaderboard, mirroring
+        // src/chain-prometheus.mjs's loadChainPrometheus.
+        const chainPrometheus = url.pathname.match(
+          /^\/api\/v1\/chain\/prometheus$/,
+        );
+        if (chainPrometheus) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT hotkey) AS distinct_exporters, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${PROMETHEUS_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS announcements, COUNT(DISTINCT hotkey) AS distinct_exporters
+            FROM account_events WHERE event_kind = ${PROMETHEUS_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY announcements DESC, netuid ASC`;
+          }
+          return json(
+            buildChainPrometheus(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_PROMETHEUS_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/axon-removals (#4832 Tier 2): network-wide
+        // AxonInfoRemoved leaderboard, mirroring
+        // src/chain-axon-removals.mjs's loadChainAxonRemovals.
+        const chainAxonRemovals = url.pathname.match(
+          /^\/api\/v1\/chain\/axon-removals$/,
+        );
+        if (chainAxonRemovals) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT hotkey) AS distinct_removers, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${AXON_REMOVAL_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS removals, COUNT(DISTINCT hotkey) AS distinct_removers
+            FROM account_events WHERE event_kind = ${AXON_REMOVAL_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY removals DESC, netuid ASC`;
+          }
+          return json(
+            buildChainAxonRemovals(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_AXON_REMOVALS_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/registrations (#4832 Tier 2): network-wide
+        // NeuronRegistered leaderboard, mirroring
+        // src/chain-registrations.mjs's loadChainRegistrations.
+        const chainRegistrations = url.pathname.match(
+          /^\/api\/v1\/chain\/registrations$/,
+        );
+        if (chainRegistrations) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT hotkey) AS distinct_registrants, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${REGISTRATION_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS registrations, COUNT(DISTINCT hotkey) AS distinct_registrants
+            FROM account_events WHERE event_kind = ${REGISTRATION_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY registrations DESC, netuid ASC`;
+          }
+          return json(
+            buildChainRegistrations(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_REGISTRATIONS_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/deregistrations (#4832 Tier 2): network-wide
+        // NeuronDeregistered leaderboard, mirroring
+        // src/chain-deregistrations.mjs's loadChainDeregistrations.
+        const chainDeregistrations = url.pathname.match(
+          /^\/api\/v1\/chain\/deregistrations$/,
+        );
+        if (chainDeregistrations) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT hotkey) AS distinct_deregistered_hotkeys, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${DEREGISTRATION_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS deregistrations, COUNT(DISTINCT hotkey) AS distinct_deregistered_hotkeys
+            FROM account_events WHERE event_kind = ${DEREGISTRATION_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY deregistrations DESC, netuid ASC`;
+          }
+          return json(
+            buildChainDeregistrations(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/stake-moves (#4832 Tier 2): network-wide
+        // StakeMoved leaderboard, mirroring src/chain-stake-moves.mjs's
+        // loadChainStakeMoves. Distinct by the "coldkey" column (a stake
+        // move is initiated by the owning account, not a specific hotkey).
+        const chainStakeMoves = url.pathname.match(
+          /^\/api\/v1\/chain\/stake-moves$/,
+        );
+        if (chainStakeMoves) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT "coldkey") AS distinct_movers, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS movements, COUNT(DISTINCT "coldkey") AS distinct_movers
+            FROM account_events WHERE event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY movements DESC, netuid ASC`;
+          }
+          return json(
+            buildChainStakeMoves(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_STAKE_MOVES_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/stake-transfers (#4832 Tier 2): network-wide
+        // StakeTransferred leaderboard, mirroring
+        // src/chain-stake-transfers.mjs's loadChainStakeTransfers.
+        // Distinct by the "coldkey" column -- a stake transfer moves stake
+        // between owning accounts.
+        const chainStakeTransfers = url.pathname.match(
+          /^\/api\/v1\/chain\/stake-transfers$/,
+        );
+        if (chainStakeTransfers) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const networkRows = await sql`
+          SELECT COUNT(DISTINCT "coldkey") AS distinct_senders, MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}`;
+          const networkDistinct = networkRows[0] ?? null;
+          let subnetRows = [];
+          if (networkDistinct?.newest_observed != null) {
+            subnetRows = await sql`
+            SELECT netuid, COUNT(*) AS transfers, COUNT(DISTINCT "coldkey") AS distinct_senders
+            FROM account_events WHERE event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff} GROUP BY netuid
+            ORDER BY transfers DESC, netuid ASC`;
+          }
+          return json(
+            buildChainStakeTransfers(subnetRows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT),
+              networkDistinct,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/stake-flow (#4832 Tier 2): network-wide
+        // cross-subnet capital flow (StakeAdded - StakeRemoved), mirroring
+        // src/chain-stake-flow.mjs's loadChainStakeFlow. A single
+        // GROUP BY netuid, event_kind query, no cold-store guard branch --
+        // matches the D1 loader exactly.
+        const chainStakeFlow = url.pathname.match(
+          /^\/api\/v1\/chain\/stake-flow$/,
+        );
+        if (chainStakeFlow) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao,
+                 COUNT(*) AS event_count, MAX(observed_at) AS last_observed
+          FROM account_events
+          WHERE event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND}) AND observed_at >= ${cutoff}
+          GROUP BY netuid, event_kind`;
+          return json(
+            buildChainStakeFlow(rows, {
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              limit: chainLimit(url, CHAIN_STAKE_FLOW_LIMIT_DEFAULT),
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/transfers (#4832 Tier 2): network-wide native-TAO
+        // transfer scorecard (totals + top senders/receivers), mirroring
+        // src/chain-transfers.mjs's loadChainTransfers. "Transfer" mirrors
+        // that module's own private TRANSFER_KIND constant (not exported, so
+        // inlined here). observedAt: the D1 path sources this from a KV
+        // cron-freshness marker (readHealthMetaKv) that this Worker has no
+        // binding for -- since this route queries Postgres live, the
+        // queried rows' own MAX(observed_at) is a more accurate freshness
+        // signal for what was actually just read, so that's used instead.
+        const chainTransfers = url.pathname.match(
+          /^\/api\/v1\/chain\/transfers$/,
+        );
+        if (chainTransfers) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const limit = chainLimit(url, 25);
+          const totalsRows = await sql`
+          SELECT COUNT(*) AS transfer_count, COALESCE(SUM(amount_tao), 0) AS total_volume_tao,
+                 COUNT(DISTINCT hotkey) AS unique_senders, COUNT(DISTINCT "coldkey") AS unique_receivers,
+                 MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff}`;
+          const senders = await sql`
+          SELECT hotkey AS address, SUM(amount_tao) AS volume_tao, COUNT(*) AS transfer_count
+          FROM account_events WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff} AND hotkey IS NOT NULL
+          GROUP BY hotkey ORDER BY volume_tao DESC, hotkey ASC LIMIT ${limit}`;
+          const receivers = await sql`
+          SELECT "coldkey" AS address, SUM(amount_tao) AS volume_tao, COUNT(*) AS transfer_count
+          FROM account_events WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff} AND "coldkey" IS NOT NULL
+          GROUP BY "coldkey" ORDER BY volume_tao DESC, "coldkey" ASC LIMIT ${limit}`;
+          return json(
+            buildChainTransfers({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              observedAt: latestObservedIso(totalsRows, "newest_observed"),
+              totals: totalsRows[0] ?? null,
+              senders,
+              receivers,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/transfer-pairs (#4832 Tier 2): network-wide
+        // sender->receiver corridor leaderboard, mirroring
+        // src/chain-transfer-pairs.mjs's loadChainTransferPairs -- the
+        // PAIR_FILTER predicate (event_kind/window/non-null/non-empty/
+        // non-self/non-negative-amount) is inlined below since it's a
+        // private, unexported constant there. observedAt: see chainTransfers
+        // above for why this sources from the queried rows, not KV.
+        const chainTransferPairs = url.pathname.match(
+          /^\/api\/v1\/chain\/transfer-pairs$/,
+        );
+        if (chainTransferPairs) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const limit = chainLimit(url, 25);
+          const sort = url.searchParams.get("sort") || "volume";
+          const totalsRows = await sql`
+          WITH pair_totals AS (
+            SELECT hotkey, coldkey, SUM(amount_tao) AS volume_tao, COUNT(*) AS transfer_count,
+                   MAX(observed_at) AS last_observed
+            FROM account_events
+            WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff} AND hotkey IS NOT NULL AND "coldkey" IS NOT NULL
+              AND hotkey <> '' AND "coldkey" <> '' AND hotkey <> "coldkey" AND amount_tao IS NOT NULL AND amount_tao >= 0
+            GROUP BY hotkey, "coldkey"
+          )
+          SELECT COALESCE(SUM(transfer_count), 0) AS transfer_count,
+                 COALESCE(SUM(volume_tao), 0) AS total_volume_tao,
+                 COUNT(*) AS unique_pairs,
+                 COALESCE(MAX(volume_tao), 0) AS top_pair_volume_tao,
+                 MAX(last_observed) AS newest_observed
+          FROM pair_totals`;
+          const orderBy =
+            sort === "count"
+              ? sql`transfer_count DESC, volume_tao DESC, hotkey ASC, "coldkey" ASC`
+              : sql`volume_tao DESC, transfer_count DESC, hotkey ASC, "coldkey" ASC`;
+          const pairRows = await sql`
+          SELECT hotkey AS from_address, "coldkey" AS to_address, SUM(amount_tao) AS volume_tao,
+                 COUNT(*) AS transfer_count, MAX(block_number) AS last_block, MAX(observed_at) AS last_observed_at
+          FROM account_events
+          WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff} AND hotkey IS NOT NULL AND "coldkey" IS NOT NULL
+            AND hotkey <> '' AND "coldkey" <> '' AND hotkey <> "coldkey" AND amount_tao IS NOT NULL AND amount_tao >= 0
+          GROUP BY hotkey, "coldkey" ORDER BY ${orderBy} LIMIT ${limit}`;
+          return json(
+            buildChainTransferPairs({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              sort,
+              observedAt: latestObservedIso(totalsRows, "newest_observed"),
+              totals: totalsRows[0] ?? null,
+              pairs: pairRows,
             }),
           );
         }

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -42,6 +42,7 @@ import {
   publishedAt,
 } from "../responses.mjs";
 import { d1TimeoutMs, withTimeout } from "../storage.mjs";
+import { tryPostgresTier } from "../postgres-tier.mjs";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.mjs";
 import {
   formatGlobalIncidents,
@@ -1126,12 +1127,18 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
     "chain-transfers",
     async () => {
       const meta = await readHealthMetaKv(env);
-      const data = await loadChainTransfers(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        observedAt: meta?.last_run_at || null,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainTransfers(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          observedAt: meta?.last_run_at || null,
+          limit,
+        }));
       return envelopeResponse(
         cacheRequest,
         {
@@ -1186,13 +1193,19 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
     "chain-transfer-pairs",
     async () => {
       const meta = await readHealthMetaKv(env);
-      const data = await loadChainTransferPairs(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        observedAt: meta?.last_run_at || null,
-        limit,
-        sort,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainTransferPairs(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          observedAt: meta?.last_run_at || null,
+          limit,
+          sort,
+        }));
       // CSV exports the row-shaped top corridors; the totals + top_pair_share
       // rollup stay JSON-only (mirrors chain-stake-flow / chain-weights).
       if (csv) {
@@ -1252,11 +1265,17 @@ export async function handleChainStakeFlow(request, env, url, ctx = {}) {
     env,
     "chain-stake-flow",
     async () => {
-      const data = await loadChainStakeFlow(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainStakeFlow(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // net_flow_distribution stay JSON-only (mirrors chain-fees' top_fee_payers).
       if (csv) {
@@ -1315,11 +1334,17 @@ export async function handleChainWeights(request, env, url, ctx = {}) {
     env,
     "chain-weights",
     async () => {
-      const data = await loadChainWeights(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainWeights(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-stake-flow).
       if (csv) {
@@ -1380,11 +1405,17 @@ export async function handleChainWeightSetters(request, env, url, ctx = {}) {
     env,
     "chain-weight-setters",
     async () => {
-      const data = await loadChainWeightSetters(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainWeightSetters(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       if (csv) {
         return csvResponse(
           data.setters,
@@ -1441,11 +1472,17 @@ export async function handleChainServing(request, env, url, ctx = {}) {
     env,
     "chain-serving",
     async () => {
-      const data = await loadChainServing(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainServing(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-weights).
       if (csv) {
@@ -1504,11 +1541,17 @@ export async function handleChainPrometheus(request, env, url, ctx = {}) {
     env,
     "chain-prometheus",
     async () => {
-      const data = await loadChainPrometheus(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainPrometheus(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
       if (csv) {
@@ -1568,11 +1611,17 @@ export async function handleChainAxonRemovals(request, env, url, ctx = {}) {
     env,
     "chain-axon-removals",
     async () => {
-      const data = await loadChainAxonRemovals(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainAxonRemovals(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
       if (csv) {
@@ -1631,11 +1680,17 @@ export async function handleChainRegistrations(request, env, url, ctx = {}) {
     env,
     "chain-registrations",
     async () => {
-      const data = await loadChainRegistrations(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainRegistrations(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
       if (csv) {
@@ -1695,11 +1750,17 @@ export async function handleChainDeregistrations(request, env, url, ctx = {}) {
     env,
     "chain-deregistrations",
     async () => {
-      const data = await loadChainDeregistrations(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainDeregistrations(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-registrations).
       if (csv) {
@@ -1759,11 +1820,17 @@ export async function handleChainStakeMoves(request, env, url, ctx = {}) {
     env,
     "chain-stake-moves",
     async () => {
-      const data = await loadChainStakeMoves(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainStakeMoves(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-registrations).
       if (csv) {
@@ -1823,11 +1890,17 @@ export async function handleChainStakeTransfers(request, env, url, ctx = {}) {
     env,
     "chain-stake-transfers",
     async () => {
-      const data = await loadChainStakeTransfers(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        limit,
-      });
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        )) ??
+        (await loadChainStakeTransfers(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          limit,
+        }));
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-stake-moves).
       if (csv) {


### PR DESCRIPTION
## Summary

Tier 2 of the #4832 D1-completeness sweep. Twelve chain-wide (network-level, not per-subnet/per-account) analytics routes were still reading D1 even though the `account_events` table they query has been Postgres-resident and serving-flipped since Tier 1b:

- `/api/v1/chain/weights`, `/chain/weights/setters`
- `/chain/serving`, `/chain/prometheus`, `/chain/axon-removals`
- `/chain/registrations`, `/chain/deregistrations`
- `/chain/stake-moves`, `/chain/stake-transfers`, `/chain/stake-flow`
- `/chain/transfers`, `/chain/transfer-pairs`

Each route's Postgres SQL is a line-for-line translation of its existing D1 loader (`src/chain-*.mjs`), reusing the exact same pure `buildChainX` shaping functions so the response contract is unchanged. Wired via `tryPostgresTier` inside each `withEdgeCache` callback, reusing `METAGRAPH_ACCOUNT_EVENTS_SOURCE` (already flipped to `"postgres"` in production) — no new flag, no new secret, no new schema.

`observedAt` for `/chain/transfers` and `/chain/transfer-pairs` is derived from the queried rows' own `MAX(observed_at)` rather than the D1 path's KV cron-freshness marker, since this Worker has no KV binding and a live query's own freshness is arguably more accurate anyway (documented in code).

Added `idx_ae_kind_observed (event_kind, observed_at)` to `account_events` and applied it live — these are the first queries filtering by `event_kind` with no `netuid` scope; the existing `(netuid, event_kind, ...)` composite index doesn't help without a netuid filter. TimescaleDB rejects `CREATE INDEX CONCURRENTLY` on hypertables, so this was a plain (brief-lock) `CREATE INDEX IF NOT EXISTS`.

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` / `npm run validate` all clean
- `npx vitest run` — 7545/7545 tests passing across 262 files (12 new/modified test files: `tests/data-api.test.mjs` + 11 `tests/chain-*.test.mjs`)
- `npm run test:coverage` + patch-diff isolation against `origin/main` for `workers/data-api.mjs` and `workers/request-handlers/analytics.mjs` — zero uncovered added lines/branches
- Live: index build confirmed applied (`\d account_events` shows `idx_ae_kind_observed`)