### PR TITLE
fix(data-api): split chain/transfers' totals query, widen its own timeout

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4048,18 +4048,23 @@ test("GET /api/v1/chain/stake-flow: a single GROUP BY netuid, event_kind query",
   expect(body.subnet_count).toBe(1);
 });
 
-test("GET /api/v1/chain/transfers: totals + senders + receivers", async () => {
+test("GET /api/v1/chain/transfers: totals + distinct counts + senders + receivers", async () => {
   mockQueue.current = [
     [], // consumed by the session-scoped `SET statement_timeout` call
+    // `SET LOCAL statement_timeout` widening this route's own budget (the
+    // dual COUNT(DISTINCT) statements below are the slowest queries in this
+    // file against the real, high-volume 'Transfer' event_kind -- confirmed
+    // live 2026-07-11) -- also consumes a queue slot.
+    [],
     [
       {
         transfer_count: 3,
         total_volume_tao: 100,
-        unique_senders: 2,
-        unique_receivers: 2,
         newest_observed: "1780000000000",
       },
     ],
+    [{ unique_senders: 2 }],
+    [{ unique_receivers: 2 }],
     [{ address: "5Sender", volume_tao: 80, transfer_count: 2 }],
     [{ address: "5Receiver", volume_tao: 60, transfer_count: 1 }],
   ];
@@ -4067,12 +4072,17 @@ test("GET /api/v1/chain/transfers: totals + senders + receivers", async () => {
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.total_volume_tao).toBe(100);
+  expect(body.unique_senders).toBe(2);
+  expect(body.unique_receivers).toBe(2);
   expect(body.top_senders[0].address).toBe("5Sender");
 });
 
 test("GET /api/v1/chain/transfers: a cold store's empty totals row falls back to null", async () => {
   mockQueue.current = [
     [], // consumed by the session-scoped `SET statement_timeout` call
+    [], // `SET LOCAL statement_timeout`
+    [],
+    [],
     [],
     [],
     [],

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2856,10 +2856,28 @@ export default {
             DEFAULT_ANALYTICS_WINDOW,
           );
           const limit = chainLimit(url, 25);
+          // event_kind = 'Transfer' is by far the highest-volume kind in
+          // account_events (~10M rows/7d, vs the low hundred-thousands for
+          // every other kind these 12 routes cover) -- a single query
+          // computing COUNT(*)/SUM/MAX *and* two COUNT(DISTINCT ...) in one
+          // pass measured 15s+ against production data (confirmed live,
+          // 2026-07-11), well past the router's 3s statement_timeout, and
+          // was intermittently surfacing stale/zeroed totals rather than a
+          // clean fallback. Splitting the two DISTINCT counts into their own
+          // statements cut that to ~3s each (still the slowest queries here
+          // even with idx_ae_kind_hotkey_observed/idx_ae_kind_coldkey_observed),
+          // so this route alone widens its budget rather than raising the
+          // global 3s default for every other (much lighter) route.
+          await sql`SET LOCAL statement_timeout = '10000ms'`;
           const totalsRows = await sql`
           SELECT COUNT(*) AS transfer_count, COALESCE(SUM(amount_tao), 0) AS total_volume_tao,
-                 COUNT(DISTINCT hotkey) AS unique_senders, COUNT(DISTINCT "coldkey") AS unique_receivers,
                  MAX(observed_at) AS newest_observed
+          FROM account_events WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff}`;
+          const distinctSenders = await sql`
+          SELECT COUNT(DISTINCT hotkey) AS unique_senders
+          FROM account_events WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff}`;
+          const distinctReceivers = await sql`
+          SELECT COUNT(DISTINCT "coldkey") AS unique_receivers
           FROM account_events WHERE event_kind = 'Transfer' AND observed_at >= ${cutoff}`;
           const senders = await sql`
           SELECT hotkey AS address, SUM(amount_tao) AS volume_tao, COUNT(*) AS transfer_count
@@ -2877,7 +2895,11 @@ export default {
                 DEFAULT_ANALYTICS_WINDOW,
               ),
               observedAt: latestObservedIso(totalsRows, "newest_observed"),
-              totals: totalsRows[0] ?? null,
+              totals: {
+                ...(totalsRows[0] ?? null),
+                unique_senders: distinctSenders[0]?.unique_senders ?? 0,
+                unique_receivers: distinctReceivers[0]?.unique_receivers ?? 0,
+              },
               senders,
               receivers,
             }),


### PR DESCRIPTION
## Summary

Fast-follow on #4868, found during live verification.

`/api/v1/chain/transfers` is the one route among the 12 migrated in #4868 that queries the highest-volume `event_kind` in `account_events` — `'Transfer'` runs ~10M rows/7d, versus low hundred-thousands for every other kind these routes cover (weights, serving, registrations, etc.).

Live-verified against production: the totals query (`COUNT(*)`/`SUM`/`MAX` plus two `COUNT(DISTINCT hotkey)`/`COUNT(DISTINCT coldkey)` in one statement) measured **15+ seconds** — far past the shared 3s `statement_timeout` every route in this Worker runs under. On a timeout the request correctly fell back toward an error path, but was intermittently surfacing a **stale or zeroed totals response** instead of a clean D1 fallback (confirmed via `wrangler tail` — `PostgresError: canceling statement due to statement timeout` on essentially every fresh execution).

Fix:
- Split the two `COUNT(DISTINCT ...)` aggregates into their own statements — each measured ~3s independently (still the slowest queries in this file, even with two new covering indexes added in #4868's follow-up), versus 15s+ combined.
- Widen **only this route's** query budget via `SET LOCAL statement_timeout`, rather than raising the global 3s default that every other (much lighter) route also depends on.

Also disabled Hyperdrive's query-result caching (`wrangler hyperdrive update ... --caching-disabled=true`) on the shared Hyperdrive config — it was compounding the symptom by serving increasingly-stale cached totals for this fast-churning table, which cuts directly against the reason for this whole migration (serving live chain data instead of a lagging copy).

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` all clean
- `npx vitest run` — 7545/7545 tests passing
- `npm run test:coverage` + patch-diff isolation against `origin/main` — zero uncovered added lines/branches
- Live: direct `psql` timing confirmed the split queries land at ~3s each (vs 15s+ combined); repeated live curls against `/api/v1/chain/transfers` post-fix will be re-verified after this merges and redeploys