### PR TITLE
feat(data-api): migrate chain/identity-history to Postgres, backfill schema.sql indexes

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -104,6 +104,13 @@ CREATE INDEX IF NOT EXISTS idx_ae_netuid_kind ON account_events (netuid, event_k
 -- Applied live via a plain (non-concurrent) CREATE INDEX -- TimescaleDB
 -- hypertables reject CREATE INDEX CONCURRENTLY.
 CREATE INDEX IF NOT EXISTS idx_ae_kind_observed ON account_events (event_kind, observed_at DESC);
+-- #4869: fast-follow on #4832 Tier 2 -- /chain/transfers is the one route among
+-- the 12 that hits the highest-volume event_kind ('Transfer', ~10M rows/7d);
+-- these cover its per-hotkey/per-coldkey GROUP BY + COUNT(DISTINCT ...) scans
+-- (idx_ae_kind_observed above only covers the network-wide totals scan).
+-- INCLUDE (amount_tao) makes the GROUP BY ... SUM(amount_tao) queries index-only.
+CREATE INDEX IF NOT EXISTS idx_ae_kind_hotkey_observed ON account_events (event_kind, hotkey, observed_at DESC) INCLUDE (amount_tao);
+CREATE INDEX IF NOT EXISTS idx_ae_kind_coldkey_observed ON account_events (event_kind, coldkey, observed_at DESC) INCLUDE (amount_tao);
 
 -- Generic all-events tier (audit gap: only ~8 kinds of 2 pallets decoded today).
 -- Stores EVERY decoded event; the curated account_events stays the fast path.

--- a/tests/chain-identity-history.test.mjs
+++ b/tests/chain-identity-history.test.mjs
@@ -315,6 +315,58 @@ describe("GET /api/v1/chain/identity-history", () => {
     const body = await res.json();
     assert.equal(body.data.count, 1);
   });
+
+  // #4832 gap-closure: METAGRAPH_SUBNET_IDENTITY_SOURCE reused (same
+  // subnet_identity_history table this route already reads, no new flag) --
+  // tryPostgresTier's own fallback contract is unit-tested in
+  // workers/postgres-tier.mjs's own tests, so these two just prove the
+  // wiring: a Postgres hit is served as-is with D1 never queried, and a
+  // Postgres failure falls back to D1.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      ...identityEnv([]),
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            count: 1,
+            subnet_count: 1,
+            changes: [{ netuid: 99, subnet_name: "PgSubnet" }],
+          }),
+      },
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleRequest(req(), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.count, 1);
+    assert.equal(body.data.changes[0].netuid, 99);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      ...identityEnv([change({ id: 1, netuid: 7, subnet_name: "Alpha" })]),
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await handleRequest(req(), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.count, 1);
+    assert.equal(body.data.changes[0].subnet_name, "Alpha");
+  });
 });
 
 describe("chain/identity-history edge cache", () => {

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4163,3 +4163,41 @@ test("GET /api/v1/chain/transfer-pairs: an empty totals row falls back to null",
   const body = await res.json();
   expect(body.total_volume_tao).toBe(0);
 });
+
+// #4832 gap-closure: chain-wide identity-change feed, mirroring
+// src/chain-identity-history.mjs's loadChainIdentityHistory -- no netuid
+// filter, single query, reusing METAGRAPH_SUBNET_IDENTITY_SOURCE (same
+// table as the per-subnet identity-history route already tested above).
+test("GET /api/v1/chain/identity-history returns the network-wide feed", async () => {
+  mockRows.current = [
+    {
+      id: "10",
+      netuid: 7,
+      block_number: "100",
+      observed_at: "1780000000000",
+      subnet_name: "Alpha",
+      symbol: "α",
+      description: "old",
+      github_repo: null,
+      subnet_url: null,
+      discord: null,
+      logo_url: null,
+      identity_hash: "abc",
+    },
+  ];
+  const res = await req("/api/v1/chain/identity-history?limit=10");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.count).toBe(1);
+  expect(body.changes[0].netuid).toBe(7);
+});
+
+test("GET /api/v1/chain/identity-history on a cold store returns a schema-stable empty feed", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/chain/identity-history");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.count).toBe(0);
+  expect(body.subnet_count).toBe(0);
+  expect(body.changes).toEqual([]);
+});

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -282,6 +282,10 @@ import {
   identityHash as subnetIdentityHash,
   buildSubnetIdentityHistory,
 } from "../src/subnet-identity-history.mjs";
+import {
+  buildChainIdentityHistory,
+  CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+} from "../src/chain-identity-history.mjs";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
@@ -3725,6 +3729,23 @@ export default {
               nextCursor,
             }),
           );
+        }
+
+        // GET /api/v1/chain/identity-history?limit= (#4832 gap-closure):
+        // network-wide identity-change feed across EVERY subnet, mirroring
+        // src/chain-identity-history.mjs's loadChainIdentityHistory -- no
+        // netuid filter, unlike the per-subnet route above.
+        const chainIdentityHistory = url.pathname.match(
+          /^\/api\/v1\/chain\/identity-history$/,
+        );
+        if (chainIdentityHistory) {
+          const limit = chainLimit(url, CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT);
+          const rows = await sql`
+          SELECT id, netuid, block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash
+          FROM subnet_identity_history
+          ORDER BY block_number DESC, netuid ASC, id DESC
+          LIMIT ${limit}`;
+          return json(buildChainIdentityHistory(rows, { limit }));
         }
 
         // GET /api/v1/accounts/:ss58/portfolio (#4832 Tier 2): one wallet's

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1252,7 +1252,9 @@ export async function handleChainIdentityHistory(request, env, url) {
     maxLimit: CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   });
   if (limitError) return analyticsQueryError(limitError);
-  const data = await loadChainIdentityHistory(d1Runner(env), { limit });
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_SUBNET_IDENTITY_SOURCE")) ??
+    (await loadChainIdentityHistory(d1Runner(env), { limit }));
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- Wires `handleChainIdentityHistory` onto Postgres via the already-flipped `METAGRAPH_SUBNET_IDENTITY_SOURCE` flag (same table this route already reads via `subnet_identity_history` -- no new flag-flip cycle needed).
- Adds `GET /api/v1/chain/identity-history` to `workers/data-api.mjs`: the network-wide identity-change feed (no `netuid` filter), mirroring `src/chain-identity-history.mjs`'s `loadChainIdentityHistory` and the existing per-subnet route.
- Backfills `deploy/postgres/schema.sql` with `idx_ae_kind_hotkey_observed` and `idx_ae_kind_coldkey_observed` -- applied live via psql during #4869's chain/transfers timeout fix but never committed to the schema file. Verified against the live `pg_indexes` definitions on the indexer host so the file now matches production exactly.

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` all clean
- `npx vitest run` -- 7549/7549 tests passing
- `npm run test:coverage` + patch-diff isolation against `origin/main` -- zero uncovered added lines/branches in both touched files
- `tests/chain-identity-history.test.mjs`'s new postgres-tier wiring tests confirm a Postgres hit is served as-is with D1 never queried, and a Postgres failure falls back to D1