### PR TITLE
feat(data-api): migrate chain/activity, chain/calls, chain/signers, chain/fees to Postgres

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4201,3 +4201,204 @@ test("GET /api/v1/chain/identity-history on a cold store returns a schema-stable
   expect(body.subnet_count).toBe(0);
   expect(body.changes).toEqual([]);
 });
+
+// #4832 gap-closure: extrinsics/blocks-derived cluster (handleChainActivity/
+// Calls/Signers/Fees), the last D1-only routes among the "network-wide chain
+// analytics" family. All 4 reuse METAGRAPH_EXTRINSICS_SOURCE (already
+// "postgres" -- see wrangler.jsonc), the same flag Tier 1a's blocks/
+// extrinsics routes already serve from. Live-verified via psql before
+// writing this SQL (2026-07-11): the plain aggregates run well under 500ms
+// at current volume (~1.2M extrinsics/7d), but COUNT(DISTINCT signer) and
+// PERCENTILE_CONT median queries cost ~2.5-2.9s -- a thin margin under the
+// 3s default -- so chain/activity and chain/fees widen their own budget via
+// SET LOCAL, mirroring chain/transfers' fix (#4869).
+
+test("GET /api/v1/chain/signers: default sort + no call_module filter", async () => {
+  mockQueue.current = [
+    [], // session-scoped SET statement_timeout
+    [], // moduleClause construction (call_module absent -> sql``)
+    [], // orderBy construction (sort=tx_count -> sql`tx_count`)
+    [{ newest_observed: "1780000000000" }],
+    [
+      {
+        signer: "5Signer",
+        tx_count: 10,
+        total_fee_tao: 1,
+        total_tip_tao: 0.1,
+        last_tx_block: 500,
+      },
+    ],
+  ];
+  const res = await req("/api/v1/chain/signers?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.sort).toBe("tx_count");
+  expect(body.signers[0].signer).toBe("5Signer");
+});
+
+test("GET /api/v1/chain/signers: sort=total_fee_tao + call_module scopes the query", async () => {
+  mockQueue.current = [
+    [],
+    [], // moduleClause (call_module present -> real fragment)
+    [], // orderBy (sort=total_fee_tao -> sql`total_fee_tao`)
+    [{ newest_observed: "1780000000000" }],
+    [
+      {
+        signer: "5Signer",
+        tx_count: 5,
+        total_fee_tao: 9,
+        total_tip_tao: 0,
+        last_tx_block: 400,
+      },
+    ],
+  ];
+  const res = await req(
+    "/api/v1/chain/signers?window=7d&sort=total_fee_tao&call_module=SubtensorModule",
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.sort).toBe("total_fee_tao");
+  expect(queryText()).toContain("call_module = ");
+});
+
+test("GET /api/v1/chain/calls: default group_by=module, no call_module", async () => {
+  mockQueue.current = [
+    [], // session SET
+    [], // moduleClause (absent)
+    [], // orderBy (module branch)
+    [{ newest_observed: "1780000000000" }],
+    [{ call_module: "SubtensorModule", count: 10 }],
+    [{ total: 12 }],
+  ];
+  const res = await req("/api/v1/chain/calls?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.group_by).toBe("module");
+  expect(body.total_extrinsics).toBe(12);
+  expect(body.calls[0].call_module).toBe("SubtensorModule");
+});
+
+test("GET /api/v1/chain/calls: group_by=module_function + call_module filter", async () => {
+  mockQueue.current = [
+    [],
+    [], // moduleClause (present)
+    [], // orderBy (module_function branch)
+    [{ newest_observed: "1780000000000" }],
+    [
+      {
+        call_module: "SubtensorModule",
+        call_function: "set_weights",
+        count: 4,
+      },
+    ],
+    [{ total: 4 }],
+  ];
+  const res = await req(
+    "/api/v1/chain/calls?window=7d&group_by=module_function&call_module=SubtensorModule",
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.group_by).toBe("module_function");
+  expect(body.calls[0].call_function).toBe("set_weights");
+});
+
+test("GET /api/v1/chain/calls: an empty totals row falls back to 0", async () => {
+  mockQueue.current = [
+    [], // session SET
+    [], // moduleClause (absent)
+    [], // orderBy (module branch)
+    [{ newest_observed: "1780000000000" }],
+    [],
+    [], // empty totalRows -- totalRows[0]?.total ?? 0 falls back to 0
+  ];
+  const res = await req("/api/v1/chain/calls?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.total_extrinsics).toBe(0);
+});
+
+test("GET /api/v1/chain/activity: merges the extrinsics + blocks day series, defaulting a signer-less day to 0", async () => {
+  mockQueue.current = [
+    [], // session SET
+    [], // SET LOCAL statement_timeout widen
+    [
+      { day: "2026-07-10", extrinsic_count: 10, successful_extrinsics: 9 },
+      { day: "2026-07-09", extrinsic_count: 5, successful_extrinsics: 5 },
+    ],
+    // Only one of the two days appears here -- proves the
+    // `signersByDay.get(r.day) ?? 0` fallback for the missing day.
+    [{ day: "2026-07-10", unique_signers: 3 }],
+    [{ day: "2026-07-10", block_count: 2, event_count: 8 }],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/chain/activity?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  const day10 = body.days.find((d) => d.day === "2026-07-10");
+  const day09 = body.days.find((d) => d.day === "2026-07-09");
+  expect(day10.unique_signers).toBe(3);
+  expect(day09.unique_signers).toBe(0);
+  expect(day10.block_count).toBe(2);
+});
+
+test("GET /api/v1/chain/fees: default window, no call_module", async () => {
+  mockQueue.current = [
+    [], // session SET
+    [], // moduleClause (absent)
+    [], // SET LOCAL statement_timeout widen
+    [
+      {
+        day: "2026-07-10",
+        extrinsic_count: 10,
+        total_fee_tao: 1,
+        total_tip_tao: 0.1,
+      },
+    ],
+    [
+      {
+        signer: "5Payer",
+        total_fee_tao: 1,
+        total_tip_tao: 0.1,
+        extrinsic_count: 10,
+      },
+    ],
+    [{ day: "2026-07-10", median_fee_tao: 0.1, median_tip_tao: 0.01 }],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/chain/fees?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.daily[0].median_fee_tao).toBe(0.1);
+  expect(body.top_fee_payers[0].signer).toBe("5Payer");
+});
+
+test("GET /api/v1/chain/fees: call_module filter reuses the same moduleClause across all 3 queries", async () => {
+  mockQueue.current = [
+    [],
+    [], // moduleClause (present)
+    [],
+    [
+      {
+        day: "2026-07-10",
+        extrinsic_count: 4,
+        total_fee_tao: 2,
+        total_tip_tao: 0,
+      },
+    ],
+    [
+      {
+        signer: "5Payer",
+        total_fee_tao: 2,
+        total_tip_tao: 0,
+        extrinsic_count: 4,
+      },
+    ],
+    [{ day: "2026-07-10", median_fee_tao: 0.5, median_tip_tao: 0 }],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req(
+    "/api/v1/chain/fees?window=7d&call_module=SubtensorModule",
+  );
+  expect(res.status).toBe(200);
+  expect(queryText()).toContain("call_module = ");
+});

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -1778,3 +1778,147 @@ describe("chain analytics ?format=csv export", () => {
     assert.match(cache.putKeys[0], /format=csv/);
   });
 });
+
+// #4832 gap-closure: these 4 handlers were D1-only with no Postgres tier at
+// all until now. METAGRAPH_EXTRINSICS_SOURCE is reused (already "postgres"
+// in production -- see wrangler.jsonc) since these read the same
+// extrinsics/blocks tables the Tier 1a routes already serve from Postgres;
+// no new flag-flip cycle needed. tryPostgresTier's own fallback contract is
+// unit-tested in workers/postgres-tier.mjs's own tests, so these just prove
+// the wiring: a Postgres hit is served as-is with D1 never queried, and a
+// Postgres failure falls back to D1 with fallback-marking intact.
+describe("chain analytics extrinsics-derived: postgres tier wiring", () => {
+  const cases = [
+    {
+      name: "chain-activity",
+      path: "/api/v1/chain/activity",
+      handler: handleChainActivity,
+      pgBody: {
+        schema_version: 1,
+        window: "7d",
+        observed_at: null,
+        day_count: 1,
+        days: [
+          {
+            day: "2026-07-10",
+            block_count: 5,
+            extrinsic_count: 10,
+            event_count: 20,
+            successful_extrinsics: 9,
+            success_rate: 0.9,
+            unique_signers: 3,
+          },
+        ],
+      },
+    },
+    {
+      name: "chain-calls",
+      path: "/api/v1/chain/calls",
+      handler: handleChainCalls,
+      pgBody: {
+        schema_version: 1,
+        window: "7d",
+        group_by: "module",
+        observed_at: null,
+        total_extrinsics: 10,
+        call_count: 1,
+        calls: [
+          {
+            call_module: "SubtensorModule",
+            call_function: null,
+            count: 10,
+            share: 1,
+          },
+        ],
+      },
+    },
+    {
+      name: "chain-signers",
+      path: "/api/v1/chain/signers",
+      handler: handleChainSigners,
+      pgBody: {
+        schema_version: 1,
+        window: "7d",
+        sort: "tx_count",
+        observed_at: null,
+        signer_count: 1,
+        signers: [
+          {
+            signer: "5PgSigner",
+            tx_count: 10,
+            total_fee_tao: 1,
+            total_tip_tao: 0,
+            last_tx_block: 100,
+          },
+        ],
+      },
+    },
+    {
+      name: "chain-fees",
+      path: "/api/v1/chain/fees",
+      handler: handleChainFees,
+      pgBody: {
+        schema_version: 1,
+        window: "7d",
+        observed_at: null,
+        day_count: 1,
+        daily: [
+          {
+            day: "2026-07-10",
+            extrinsic_count: 10,
+            total_fee_tao: 1,
+            avg_fee_tao: 0.1,
+            median_fee_tao: 0.1,
+            total_tip_tao: 0,
+            avg_tip_tao: 0,
+            median_tip_tao: 0,
+          },
+        ],
+        top_fee_payers: [
+          {
+            signer: "5PgPayer",
+            total_fee_tao: 1,
+            total_tip_tao: 0,
+            extrinsic_count: 10,
+          },
+        ],
+      },
+    },
+  ];
+
+  for (const { name, path, handler, pgBody } of cases) {
+    test(`${name}: flag=postgres serves the DATA_API response, D1 never queried`, async () => {
+      let d1Called = false;
+      const { env } = dbWith({ rows: [] });
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = { fetch: async () => Response.json(pgBody) };
+      env.METAGRAPH_HEALTH_DB.prepare = () => {
+        d1Called = true;
+        throw new Error(
+          "D1 must not be queried when Postgres serves the request",
+        );
+      };
+      const p = `${path}?window=7d`;
+      const res = await handler(req(p), env, url(p), ctx);
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.deepEqual(body.data, pgBody);
+      assert.equal(d1Called, false);
+    });
+
+    test(`${name}: flag=postgres falls back to D1 when DATA_API fails`, async () => {
+      const { env } = dbWith({ rows: [] });
+      env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+      env.DATA_API = {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      };
+      const p = `${path}?window=7d`;
+      const res = await handler(req(p), env, url(p), ctx);
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.data.schema_version, 1);
+    });
+  }
+});

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -286,6 +286,13 @@ import {
   buildChainIdentityHistory,
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
 } from "../src/chain-identity-history.mjs";
+import {
+  buildChainActivity,
+  buildChainCalls,
+  buildChainFees,
+  buildChainSigners,
+} from "../src/chain-analytics.mjs";
+import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.mjs";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
@@ -2965,6 +2972,232 @@ export default {
               observedAt: latestObservedIso(totalsRows, "newest_observed"),
               totals: totalsRows[0] ?? null,
               pairs: pairRows,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/signers (#4832 gap-closure, extrinsics-derived
+        // cluster): windowed most-active-account leaderboard, mirroring
+        // src/chain-query-loaders.mjs's loadChainSigners. sort/call_module are
+        // already validated D1-side before this route is ever reached. A
+        // separate freshness query is needed (unlike totals-style routes
+        // above) because the grouped rows below carry last_tx_block, not a
+        // network-wide observed_at -- confirmed live via psql: both this
+        // query and the freshness lookup run well under 1s at current
+        // extrinsics volume (~1.2M rows/7d), so no timeout widening needed.
+        const chainSigners = url.pathname.match(/^\/api\/v1\/chain\/signers$/);
+        if (chainSigners) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const limit = chainLimit(url, 50);
+          const sortParam = url.searchParams.get("sort");
+          const sort = CHAIN_SIGNERS_SORTS.includes(sortParam)
+            ? sortParam
+            : "tx_count";
+          const callModule = url.searchParams.get("call_module") || null;
+          const moduleClause = callModule
+            ? sql`AND call_module = ${callModule}`
+            : sql``;
+          const orderBy =
+            sort === "total_fee_tao" ? sql`total_fee_tao` : sql`tx_count`;
+          const freshRows = await sql`
+          SELECT MAX(observed_at) AS newest_observed
+          FROM extrinsics WHERE observed_at >= ${cutoff}`;
+          const rows = await sql`
+          SELECT signer, COUNT(*) AS tx_count, SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+                 SUM(COALESCE(tip_tao, 0)) AS total_tip_tao, MAX(block_number) AS last_tx_block
+          FROM extrinsics WHERE observed_at >= ${cutoff} AND signer IS NOT NULL
+            ${moduleClause}
+          GROUP BY signer ORDER BY ${orderBy} DESC, signer ASC LIMIT ${limit}`;
+          return json(
+            buildChainSigners({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              sort,
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              rows,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/calls (#4832 gap-closure): extrinsic call-mix
+        // breakdown, mirroring src/analytics-live.mjs's loadChainCalls. The
+        // share denominator (total) is read separately so the LIMIT-truncated
+        // grouped rows never skew shares, exactly like the D1 loader.
+        const chainCalls = url.pathname.match(/^\/api\/v1\/chain\/calls$/);
+        if (chainCalls) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const limit = chainLimit(url, 50);
+          const groupBy =
+            url.searchParams.get("group_by") === "module_function"
+              ? "module_function"
+              : "module";
+          const callModule = url.searchParams.get("call_module") || null;
+          const moduleClause = callModule
+            ? sql`AND call_module = ${callModule}`
+            : sql``;
+          const orderBy =
+            groupBy === "module_function"
+              ? sql`count DESC, call_module ASC, call_function ASC`
+              : sql`count DESC, call_module ASC`;
+          const freshRows = await sql`
+          SELECT MAX(observed_at) AS newest_observed
+          FROM extrinsics WHERE observed_at >= ${cutoff}`;
+          const rows =
+            groupBy === "module_function"
+              ? await sql`
+                SELECT call_module, call_function, COUNT(*) AS count
+                FROM extrinsics WHERE observed_at >= ${cutoff} AND call_module IS NOT NULL
+                  ${moduleClause}
+                GROUP BY call_module, call_function ORDER BY ${orderBy} LIMIT ${limit}`
+              : await sql`
+                SELECT call_module, COUNT(*) AS count
+                FROM extrinsics WHERE observed_at >= ${cutoff} AND call_module IS NOT NULL
+                  ${moduleClause}
+                GROUP BY call_module ORDER BY ${orderBy} LIMIT ${limit}`;
+          const totalRows = await sql`
+          SELECT COUNT(*) AS total FROM extrinsics WHERE observed_at >= ${cutoff}
+            ${moduleClause}`;
+          return json(
+            buildChainCalls({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              groupBy,
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              total: totalRows[0]?.total ?? 0,
+              rows,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/activity (#4832 gap-closure): per-UTC-day
+        // extrinsic/event/block counts, success rate, and unique signers,
+        // mirroring src/analytics-live.mjs's loadNetworkActivity. The base
+        // extrinsics aggregate + blocks aggregate are cheap (confirmed live
+        // via psql: well under 500ms each at current volume), but
+        // COUNT(DISTINCT signer) per day forces a per-group sort that
+        // measured ~2.7s against production data (confirmed live,
+        // 2026-07-11) -- the same disease as chain/transfers' DISTINCT
+        // counts, just under the 1.2M-row extrinsics table instead of
+        // account_events' 10M. Splitting it into its own statement and
+        // widening only this route's budget avoids relying on a razor-thin
+        // (2.7s vs 3s default) timeout margin that could flip under load.
+        const chainActivity = url.pathname.match(
+          /^\/api\/v1\/chain\/activity$/,
+        );
+        if (chainActivity) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          await sql`SET LOCAL statement_timeout = '8000ms'`;
+          const extrinsicBase = await sql`
+          SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
+                 COUNT(*) AS extrinsic_count,
+                 SUM(CASE WHEN success THEN 1 ELSE 0 END) AS successful_extrinsics
+          FROM extrinsics WHERE observed_at >= ${cutoff} GROUP BY day`;
+          const extrinsicSigners = await sql`
+          SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
+                 COUNT(DISTINCT signer) AS unique_signers
+          FROM extrinsics WHERE observed_at >= ${cutoff} GROUP BY day`;
+          const signersByDay = new Map(
+            extrinsicSigners.map((r) => [r.day, r.unique_signers]),
+          );
+          const extrinsicRows = extrinsicBase.map((r) => ({
+            ...r,
+            unique_signers: signersByDay.get(r.day) ?? 0,
+          }));
+          const blockRows = await sql`
+          SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
+                 COUNT(*) AS block_count, SUM(event_count) AS event_count
+          FROM blocks WHERE observed_at >= ${cutoff} GROUP BY day`;
+          const freshRows = await sql`
+          SELECT MAX(observed_at) AS newest_observed
+          FROM blocks WHERE observed_at >= ${cutoff}`;
+          return json(
+            buildChainActivity({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              extrinsicRows,
+              blockRows,
+            }),
+          );
+        }
+
+        // GET /api/v1/chain/fees (#4832 gap-closure): per-UTC-day fee/tip
+        // series plus a windowed top-fee-payer leaderboard, mirroring
+        // src/analytics-live.mjs's loadChainFees. Postgres has no equivalent
+        // of the D1 loader's sample-capped rank+partition median CTEs --
+        // PERCENTILE_CONT computes exact per-day medians directly, but
+        // (confirmed live via psql) costs the same ~2.5s per-group-sort as
+        // chain/activity's DISTINCT count, so this route widens its budget
+        // too rather than trust a thin margin under the 3s default.
+        const chainFees = url.pathname.match(/^\/api\/v1\/chain\/fees$/);
+        if (chainFees) {
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const limit = chainLimit(url, 25);
+          const callModule = url.searchParams.get("call_module") || null;
+          const moduleClause = callModule
+            ? sql`AND call_module = ${callModule}`
+            : sql``;
+          await sql`SET LOCAL statement_timeout = '8000ms'`;
+          const dailyRows = await sql`
+          SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
+                 COUNT(*) AS extrinsic_count,
+                 SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+                 SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
+          FROM extrinsics WHERE observed_at >= ${cutoff}
+            ${moduleClause}
+          GROUP BY day`;
+          const payerRows = await sql`
+          SELECT signer, SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+                 SUM(COALESCE(tip_tao, 0)) AS total_tip_tao, COUNT(*) AS extrinsic_count
+          FROM extrinsics WHERE observed_at >= ${cutoff} AND signer IS NOT NULL
+            ${moduleClause}
+          GROUP BY signer ORDER BY total_fee_tao DESC, signer ASC LIMIT ${limit}`;
+          const medianRows = await sql`
+          SELECT to_char(to_timestamp(observed_at / 1000), 'YYYY-MM-DD') AS day,
+                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY COALESCE(fee_tao, 0)) AS median_fee_tao,
+                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY COALESCE(tip_tao, 0)) AS median_tip_tao
+          FROM extrinsics WHERE observed_at >= ${cutoff}
+            ${moduleClause}
+          GROUP BY day`;
+          const freshRows = await sql`
+          SELECT MAX(observed_at) AS newest_observed
+          FROM extrinsics WHERE observed_at >= ${cutoff}`;
+          return json(
+            buildChainFees({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              dailyRows,
+              medianRows,
+              payerRows,
             }),
           );
         }

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -905,13 +905,23 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
     "chain-activity",
     async () => {
       const meta = await readHealthMetaKv(env);
-      const { data, extrinsicRows, blockRows } = await loadNetworkActivity(
-        d1Runner(env),
-        {
+      // A Postgres hit is never a fallback (the rows never touched
+      // hasD1FallbackRows' WeakSets, which only track D1's own degraded-
+      // empty-result bookkeeping); only the D1 branch below can set this.
+      let isFallback = false;
+      let data = await tryPostgresTier(
+        env,
+        request,
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      );
+      if (!data) {
+        const result = await loadNetworkActivity(d1Runner(env), {
           window: label,
           observedAt: meta?.last_run_at || null,
-        },
-      );
+        });
+        data = result.data;
+        isFallback = hasD1FallbackRows(result.extrinsicRows, result.blockRows);
+      }
       if (csv) {
         const csvRes = await csvResponse(
           data.days,
@@ -920,9 +930,7 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
           request,
           CHAIN_ACTIVITY_CSV_COLUMNS,
         );
-        return hasD1FallbackRows(extrinsicRows, blockRows)
-          ? markD1FallbackResponse(csvRes)
-          : csvRes;
+        return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
       }
       const response = await envelopeResponse(
         request,
@@ -936,9 +944,7 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
         },
         "short",
       );
-      return hasD1FallbackRows(extrinsicRows, blockRows)
-        ? markD1FallbackResponse(response)
-        : response;
+      return isFallback ? markD1FallbackResponse(response) : response;
     },
     // Canonicalize the cache key on the RESOLVED window so the bare path, an
     // explicit ?window=<default>, and reordered/duplicate variants all share one
@@ -983,19 +989,26 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     "chain-calls",
     async () => {
       let usedFallback = false;
-      const d1 = async (sql, params) => {
-        const rows = await d1All(env, sql, params);
-        if (hasD1FallbackRows(rows)) usedFallback = true;
-        return rows;
-      };
       const meta = await readHealthMetaKv(env);
-      const data = await loadChainCalls(d1, {
-        window: label,
-        groupBy,
-        callModule,
-        limit,
-        observedAt: meta?.last_run_at || null,
-      });
+      let data = await tryPostgresTier(
+        env,
+        request,
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      );
+      if (!data) {
+        const d1 = async (sql, params) => {
+          const rows = await d1All(env, sql, params);
+          if (hasD1FallbackRows(rows)) usedFallback = true;
+          return rows;
+        };
+        data = await loadChainCalls(d1, {
+          window: label,
+          groupBy,
+          callModule,
+          limit,
+          observedAt: meta?.last_run_at || null,
+        });
+      }
       if (csv) {
         const csvRes = await csvResponse(
           data.calls,
@@ -1059,14 +1072,24 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
     "chain-signers",
     async () => {
       const meta = await readHealthMetaKv(env);
-      const { data, rows } = await loadChainSigners(d1Runner(env), {
-        windowLabel: label,
-        windowDays: days,
-        observedAt: meta?.last_run_at || null,
-        limit,
-        callModule,
-        sort,
-      });
+      let isFallback = false;
+      let data = await tryPostgresTier(
+        env,
+        request,
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      );
+      if (!data) {
+        const result = await loadChainSigners(d1Runner(env), {
+          windowLabel: label,
+          windowDays: days,
+          observedAt: meta?.last_run_at || null,
+          limit,
+          callModule,
+          sort,
+        });
+        data = result.data;
+        isFallback = hasD1FallbackRows(result.rows);
+      }
       if (csv) {
         const csvRes = await csvResponse(
           data.signers,
@@ -1075,9 +1098,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
           request,
           CHAIN_SIGNERS_CSV_COLUMNS,
         );
-        return hasD1FallbackRows(rows)
-          ? markD1FallbackResponse(csvRes)
-          : csvRes;
+        return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
       }
       const response = await envelopeResponse(
         request,
@@ -1091,9 +1112,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         },
         "short",
       );
-      return hasD1FallbackRows(rows)
-        ? markD1FallbackResponse(response)
-        : response;
+      return isFallback ? markD1FallbackResponse(response) : response;
     },
     `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"])}${csv ? "&format=csv" : ""}`,
   );
@@ -1962,15 +1981,26 @@ export async function handleChainFees(request, env, url, ctx = {}) {
     "chain-fees",
     async () => {
       const meta = await readHealthMetaKv(env);
-      const { data, dailyRows, payerRows, medianRows } = await loadChainFees(
-        d1Runner(env),
-        {
+      let isFallback = false;
+      let data = await tryPostgresTier(
+        env,
+        request,
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      );
+      if (!data) {
+        const result = await loadChainFees(d1Runner(env), {
           window: label,
           limit,
           callModule,
           observedAt: meta?.last_run_at || null,
-        },
-      );
+        });
+        data = result.data;
+        isFallback = hasD1FallbackRows(
+          result.dailyRows,
+          result.payerRows,
+          result.medianRows,
+        );
+      }
       if (csv) {
         const csvRes = await csvResponse(
           data.daily,
@@ -1979,9 +2009,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
           request,
           CHAIN_FEES_CSV_COLUMNS,
         );
-        return hasD1FallbackRows(dailyRows, payerRows, medianRows)
-          ? markD1FallbackResponse(csvRes)
-          : csvRes;
+        return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
       }
       const response = await envelopeResponse(
         request,
@@ -1995,9 +2023,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
         },
         "short",
       );
-      return hasD1FallbackRows(dailyRows, payerRows, medianRows)
-        ? markD1FallbackResponse(response)
-        : response;
+      return isFallback ? markD1FallbackResponse(response) : response;
     },
     `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module"])}${csv ? "&format=csv" : ""}`,
   );


### PR DESCRIPTION
## Summary

- Migrates the last D1-only routes in the extrinsics/blocks-derived chain-analytics family -- `handleChainActivity`, `handleChainCalls`, `handleChainSigners`, `handleChainFees` -- deferred earlier in #4832 pending dedicated design work for their `hasD1FallbackRows`/CSV-export machinery.
- Wires all 4 onto `tryPostgresTier`, reusing the already-`"postgres"` `METAGRAPH_EXTRINSICS_SOURCE` flag Tier 1a's blocks/extrinsics routes already serve from -- no new flag-flip cycle. A Postgres hit is never treated as a fallback; only a genuine `tryPostgresTier` failure falls through to the existing D1 loader + its unchanged fallback-marking path.
- Adds the matching `GET /api/v1/chain/{signers,calls,activity,fees}` routes to `workers/data-api.mjs`, mirroring each D1 loader's query.
- **Live-verified via psql against production before writing this SQL** (2026-07-11): plain aggregates run well under 500ms at current volume (~1.2M extrinsics/7d), but `COUNT(DISTINCT signer)` and `PERCENTILE_CONT` median queries cost ~2.5-2.9s -- a thin margin under the shared 3s `statement_timeout` that could flip under load exactly like #4869's chain/transfers incident. `chain/activity` and `chain/fees` split those into their own statement and widen just their own budget via `SET LOCAL`, leaving the global default untouched for every other route.
- The repeated optional `call_module` filter is hoisted into a single `moduleClause` fragment per route instead of being rebuilt at each query site.

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` all clean
- `npx vitest run` -- 7564+/7564+ passing (full local suite)
- `npm run test:coverage` + patch-diff isolation against `origin/main` -- zero uncovered added lines/branches in both touched files
- New postgres-tier wiring tests confirm a Postgres hit is served as-is with D1 never queried, and a Postgres failure falls back to D1 with fallback-marking intact, for all 4 handlers
- New `workers/data-api.mjs` route tests cover both branches of each conditional (sort, group_by, call_module present/absent, empty-totals fallback, signer-less-day defaulting)