### PR TITLE
feat(ui): scaffold packages/ui-kit as a real buildable library package

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -447,9 +447,11 @@ your PR adds a new API call on one of the checked routes (`/`, `/subnets/1`,
 CI also gzip-measures the initial client JS for a cold `/` visit against a budget (currently ~300 KB,
 `.github/workflows/validate.yml`'s "Bundle size budget" step) — keep new dependencies/imports lean; if
 a real feature legitimately grows it, raise the budget deliberately in the same PR. If your PR also
-touches `packages/client`, CI rebuilds it fresh and diffs against the committed
-`packages/client/dist` — run `npm run build --workspace=packages/client` and commit the result if you
-changed `packages/client/src`.
+touches `packages/client` or `packages/ui-kit`, CI rebuilds each fresh and diffs against its committed
+`dist` (`packages/client/dist` / `packages/ui-kit/dist`) — run `npm run build --workspace=packages/client`
+(or `--workspace=packages/ui-kit`) and commit the result if you changed `packages/client/src` (or
+`packages/ui-kit/src`). `packages/ui-kit` also gets its own `npm run typecheck --workspace=packages/ui-kit`
+step in the `ui` CI job.
 
 ### Phase C4 — Commit + PR
 
@@ -505,7 +507,8 @@ confidence — this is a deliberate exception to the normal one-shot autonomous 
       missing/malformed table is an automatic close.
 - [ ] `lint` + `format:check` + `typecheck` + `test` + `test:e2e` + `build` all green
       (`--workspace=apps/ui`); bundle size still under budget.
-- [ ] If `packages/client/src` changed: rebuilt and committed `packages/client/dist`.
+- [ ] If `packages/client/src` or `packages/ui-kit/src` changed: rebuilt and committed the respective
+      `dist` (`packages/client/dist` / `packages/ui-kit/dist`).
 - [ ] Conventional Commit (no AI attribution); `Closes #<issue>` — required, referencing an issue that's still open.
 
 If every box is checked, the PR has the best chance of a one-shot approve-and-merge. If any box can't

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -108,12 +108,15 @@ discover -s tests` (the `[test]` extra pulls in httpx so the async cases run). N
   `npm run test:e2e:update-baseline --workspace=apps/ui` after a real fix or an accepted new layout),
   build, and bundle-size-budget for `apps/ui` (the TanStack Start/Vite frontend, folded into this
   repo as an npm workspace — #3062), plus a `packages/client/dist` drift check (rebuild fresh,
-  `git diff --exit-code` against the committed runtime bundle — #3066/#3294). Gated on
-  `run_ui_validation` (`^apps/ui/` **or** `^packages/client/` in the diff — the latter is required,
-  not optional: it's the only place that verifies committed `packages/client/dist/index.js`/`index.cjs`
-  still match a fresh build, so a `packages/client`-only PR must also trip this job or
-  stale/tampered committed runtime code could merge unverified) via the same per-step guard pattern
-  `checks` uses for its docs fast lane — never a job-level skip. Entirely independent of the
+  `git diff --exit-code` against the committed runtime bundle — #3066/#3294) and, the same way, a
+  `packages/ui-kit/dist` drift check plus its own `npm run typecheck --workspace=packages/ui-kit`
+  step (`packages/ui-kit` is the design-system component library extracted from `apps/ui` — issue
+  #4867's epic). Gated on `run_ui_validation` (`^apps/ui/` **or** `^packages/client/` **or**
+  `^packages/ui-kit/` in the diff — `packages/client` and `packages/ui-kit` are both required, not
+  optional: each is the only place that verifies its own committed `dist/index.js`/`index.cjs` still
+  matches a fresh build, so a `packages/client`- or `packages/ui-kit`-only PR must also trip this
+  job or stale/tampered committed runtime code could merge unverified) via the same per-step guard
+  pattern `checks` uses for its docs fast lane — never a job-level skip. Entirely independent of the
   backend's own lint/test/build; a backend-only PR touching neither directory doesn't build or
   install `apps/ui`'s tree at all, and vice versa. Not part of the Gittensory contributor gate —
   both `apps/ui/**` and `packages/**` are `blockedPaths` entries in `.gittensory.yml`, maintainer-only.
@@ -364,6 +367,17 @@ SDK` commit, so a hand-bump here is redundant at best and a conflicting version 
   Deliberately NOT a package.json "prepare" script even for the drift-check purpose: that would
   auto-run on every `npm install`/`ci` repo-wide, which a security scan already flagged once as
   unnecessary install-time code execution (#3066 review).
+- **`packages/ui-kit` is an internal design-system component library extracted from `apps/ui`
+  (issue #4867's epic), following the identical committed-dist pattern as `packages/client` above:**
+  `dist/index.js`, `dist/index.cjs`, and `dist/index.css` are committed — the same `.gitignore`
+  exception, same reasoning (`apps/ui` consumes it as a live workspace link, and Cloudflare Workers
+  Builds must never depend on rebuilding a sibling workspace package) — while
+  `dist/index.d.ts`/`dist/index.d.cts` stay gitignored, built fresh by CI/local dev only. **After
+  editing `packages/ui-kit/src/*`, you must run `npm run build --workspace=packages/ui-kit` and
+  commit the resulting `dist/index.js`/`index.cjs`/`index.css` in the same PR** — the `ui` CI job's
+  "Build packages/ui-kit (drift check)" step rebuilds fresh and fails loudly (`git diff --exit-code`)
+  if the committed copy doesn't match, same as the `packages/client` drift check above. The job also
+  runs a dedicated `npm run typecheck --workspace=packages/ui-kit` step ("Typecheck packages/ui-kit").
 - **`packages/contract` is a types-only npm workspace (#3067) holding the OpenAPI-derived contract
   types** — `openapi-typescript`'s output (`scripts/generate-types.mjs`/`validate-types.mjs`/
   `validate-contract-drift.mjs` all write/check `packages/contract/index.d.ts` now, no longer

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -170,7 +170,7 @@ jobs:
           else
             echo "run_migrations_validation=false" >> "$GITHUB_OUTPUT"
           fi
-          if grep -qE '^apps/ui/|^packages/client/|^packages/contract/' changed-files.txt; then
+          if grep -qE '^apps/ui/|^packages/client/|^packages/contract/|^packages/ui-kit/' changed-files.txt; then
             echo "run_ui_validation=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_ui_validation=false" >> "$GITHUB_OUTPUT"
@@ -700,6 +700,24 @@ jobs:
             echo "::error::packages/client/dist is stale -- run 'npm run build --workspace=packages/client' and commit the result."
             exit 1
           fi
+
+      # Same drift-check shape as packages/client above, same reason:
+      # packages/ui-kit/dist/{index.js,index.cjs,index.css} are committed
+      # (see packages/ui-kit/.gitignore) so apps/ui's Cloudflare Workers
+      # Builds deploy never depends on rebuilding a sibling workspace
+      # package first (#4860).
+      - name: Build packages/ui-kit (drift check)
+        if: env.RUN_UI_VALIDATION == 'true'
+        run: |
+          npm run build --workspace=packages/ui-kit
+          if ! git diff --exit-code -- packages/ui-kit/dist; then
+            echo "::error::packages/ui-kit/dist is stale -- run 'npm run build --workspace=packages/ui-kit' and commit the result."
+            exit 1
+          fi
+
+      - name: Typecheck packages/ui-kit
+        if: env.RUN_UI_VALIDATION == 'true'
+        run: npm run typecheck --workspace=packages/ui-kit
 
       - name: Lint (ESLint + Prettier)
         if: env.RUN_UI_VALIDATION == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "apps/ui",
         "packages/client",
-        "packages/contract"
+        "packages/contract",
+        "packages/ui-kit"
       ],
       "dependencies": {
         "@noble/hashes": "^2.2.0",
@@ -2375,6 +2376,10 @@
     },
     "node_modules/@jsonbored/metagraphed": {
       "resolved": "packages/client",
+      "link": true
+    },
+    "node_modules/@jsonbored/ui-kit": {
+      "resolved": "packages/ui-kit",
       "link": true
     },
     "node_modules/@lovable.dev/vite-plugin-dev-server-bridge": {
@@ -11788,6 +11793,26 @@
     "packages/contract": {
       "name": "metagraphed-contract",
       "version": "0.0.0"
+    },
+    "packages/ui-kit": {
+      "name": "@jsonbored/ui-kit",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "workspaces": [
     "apps/ui",
     "packages/client",
-    "packages/contract"
+    "packages/contract",
+    "packages/ui-kit"
   ],
   "scripts": {
     "validate": "node scripts/validate.mjs",

--- a/packages/ui-kit/.gitignore
+++ b/packages/ui-kit/.gitignore
@@ -1,0 +1,19 @@
+node_modules
+
+# dist/index.js + dist/index.cjs + dist/index.css (the RUNTIME bundle only,
+# exported publicly as "./styles.css" -- see package.json's "exports") ARE
+# committed here -- same exception as packages/client/.gitignore, same
+# reason: once apps/ui depends on this package (starting with the migration
+# issues, #4862+), it consumes it as a live workspace link, and Cloudflare
+# Workers Builds' production deploy of apps/ui must never depend on
+# rebuilding a sibling workspace package first. The .d.ts/.d.cts type
+# declarations stay gitignored -- built fresh by CI/local dev only, not
+# needed at runtime (vite build transpiles via esbuild, which strips types
+# without resolving them), and they're the part of this package's output
+# that grows with every new component added.
+!dist
+!dist/index.js
+!dist/index.cjs
+!dist/index.css
+dist/index.d.ts
+dist/index.d.cts

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -1,0 +1,24 @@
+# @jsonbored/ui-kit
+
+Internal design-system component library for `apps/ui` — extracted into a real, buildable
+package instead of living directly inside the app's `src/`. Not published to npm; consumed by
+`apps/ui` as an npm workspace link.
+
+Why this package exists: [#4867](https://github.com/JSONbored/metagraphed/issues/4867).
+
+## Status
+
+Scaffold only ([#4860](https://github.com/JSONbored/metagraphed/issues/4860)) — no real
+components have migrated yet. `PlaceholderCard` exists only to prove the build pipeline (JS +
+`.d.ts` + CSS extraction) works end to end; it's removed once the first real component lands.
+
+## Build
+
+```sh
+npm run build --workspace=packages/ui-kit
+```
+
+Emits `dist/index.js` (ESM), `dist/index.cjs` (CJS), `dist/index.d.ts` (types), and
+`dist/index.css` (extracted CSS, exported publicly as `@jsonbored/ui-kit/styles.css`) via
+`tsup`. `dist/index.{js,cjs,css}` are committed (see `.gitignore`'s comment for why);
+`.d.ts`/`.d.cts` are built fresh, not committed.

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+var jsxRuntime = require('react/jsx-runtime');
+
+// src/PlaceholderCard.tsx
+function PlaceholderCard({ label }) {
+  return /* @__PURE__ */ jsxRuntime.jsx("div", { className: "ui-kit-placeholder-card", children: label });
+}
+
+exports.PlaceholderCard = PlaceholderCard;

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -1,0 +1,4 @@
+/* src/styles.css */
+.ui-kit-placeholder-card {
+  display: block;
+}

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,0 +1,8 @@
+import { jsx } from 'react/jsx-runtime';
+
+// src/PlaceholderCard.tsx
+function PlaceholderCard({ label }) {
+  return /* @__PURE__ */ jsx("div", { className: "ui-kit-placeholder-card", children: label });
+}
+
+export { PlaceholderCard };

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@jsonbored/ui-kit",
+  "version": "0.0.1",
+  "description": "Internal design-system component library for apps/ui — extracted so it's a real, buildable package a design-system sync tool (or any consumer) can import, not just app-internal source.",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JSONbored/metagraphed.git",
+    "directory": "packages/ui-kit"
+  },
+  "engines": {
+    "node": ">=18.20.8"
+  },
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./styles.css": "./dist/index.css"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --dts-resolve --clean --treeshake",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/ui-kit/src/PlaceholderCard.tsx
+++ b/packages/ui-kit/src/PlaceholderCard.tsx
@@ -1,0 +1,12 @@
+/**
+ * Proves the build pipeline end-to-end (JS + .d.ts + CSS extraction) before
+ * any real component migrates. Delete once the first real component lands
+ * (#4862) -- this only exists to validate the scaffold in #4860.
+ */
+export interface PlaceholderCardProps {
+  label: string;
+}
+
+export function PlaceholderCard({ label }: PlaceholderCardProps) {
+  return <div className="ui-kit-placeholder-card">{label}</div>;
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,0 +1,3 @@
+import "./styles.css";
+
+export { PlaceholderCard, type PlaceholderCardProps } from "./PlaceholderCard";

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -1,0 +1,6 @@
+/* Placeholder -- proves tsup extracts a real dist/styles.css from an
+   imported stylesheet. Replaced with the real extracted design tokens
+   in #4861. */
+.ui-kit-placeholder-card {
+  display: block;
+}

--- a/packages/ui-kit/tsconfig.json
+++ b/packages/ui-kit/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Closes #4860 — the second step of the `packages/ui-kit` epic (#4867), after the audit in #4874/#4859. Scaffolds `packages/ui-kit` as a real, independently buildable npm workspace package, empty except for a placeholder that proves the pipeline works. No real components migrate in this PR.

## What Changed

- New workspace: `packages/ui-kit/` — `package.json` (`main`/`module`/`types`/`exports` mirroring `packages/client`'s shape, `private: true`, React 19 as a peer dep), `tsconfig.json` (same base as `packages/client`'s plus `jsx: react-jsx`), `.gitignore`.
- `src/PlaceholderCard.tsx` + `src/styles.css` + `src/index.ts` — minimal, deleted once the first real component migrates (#4862).
- Root `package.json` workspaces array: added `packages/ui-kit`.
- `.github/workflows/validate.yml`: `packages/ui-kit` added to the `run_ui_validation` trigger path-filter; new "Build packages/ui-kit (drift check)" and "Typecheck packages/ui-kit" steps, mirroring the existing `packages/client` pattern.
- `.claude/skills/metagraphed/{SKILL.md,reference.md}` updated to document the new workspace and CI steps (the contributor-flow skill).

## Design notes

- **CSS output naming**: tsup names the extracted stylesheet after the entry file (`dist/index.css`, not a custom `styles.css`) — I initially assumed otherwise and caught it by actually running the build rather than trusting the plan. The public subpath export is still named `@jsonbored/ui-kit/styles.css` (a clean consumer-facing name), it just maps to the real `dist/index.css` file.
- **Committed dist**: `dist/index.js`/`index.cjs`/`index.css` are committed (gitignore exception), `dist/index.d.ts`/`.d.cts` are not — identical pattern and reasoning to `packages/client` (Cloudflare Workers Builds must never depend on rebuilding a sibling workspace package mid-deploy).

## Validation

- [x] `npm run build --workspace=packages/ui-kit` — clean (ESM/CJS/`.d.ts`/CSS all emit correctly)
- [x] `npm run typecheck --workspace=packages/ui-kit` — clean
- [x] Smoke-tested both `dist/index.js` (ESM `import()`) and `dist/index.cjs` (`require()`) resolve and export `PlaceholderCard` correctly
- [x] `npm run typecheck --workspace=apps/ui` — still clean with the new workspace present
- [x] `npm run build --workspace=apps/ui` (full production build, same env vars CI uses) — still clean
- [x] `npx prettier --check` on all new files — clean

No visual change (nothing in `apps/ui` imports from this package yet), so this doesn't fall under the visual-change review rule — but flagging since it does touch CI wiring.