### PR TITLE
feat(registry): add SN67 Harnyx live benchmark dashboard surface

### DIFF
--- a/registry/subnets/harnyx.json
+++ b/registry/subnets/harnyx.json
@@ -46,6 +46,25 @@
         "https://github.com/harnyx/harnyx/blob/41771ae6b74fc8b2f14b365745c1292782ed9d3a/packages/commons/src/harnyx_commons/miner_task_benchmark/webwalkerqa/data/versions/2026-05-14-webwalkerqa-test-single-source-easy__correctness-v1/test.json"
       ],
       "url": "https://raw.githubusercontent.com/harnyx/harnyx/41771ae6b74fc8b2f14b365745c1292782ed9d3a/packages/commons/src/harnyx_commons/miner_task_benchmark/webwalkerqa/data/versions/2026-05-14-webwalkerqa-test-single-source-easy__correctness-v1/test.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-67-harnyx-benchmark-dashboard",
+      "kind": "dashboard",
+      "name": "Harnyx live benchmark dashboard",
+      "notes": "Public benchmark dashboard for SN67 Harnyx showing benchmark history and sampled run detail for the subnet's champion/challenger agent evaluations. Declared as the subnet's public benchmark surface in the official harnyx/harnyx repository: the root README links 'Live benchmark: dashboard.harnyx.ai/benchmark' and docs/api/README.md documents it as 'the public surface for inspecting benchmark history and sampled run detail'. Publicly readable, no auth.",
+      "provider": "harnyx",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "pedramhatef"
+      },
+      "source_urls": [
+        "https://github.com/harnyx/harnyx/blob/main/README.md",
+        "https://github.com/harnyx/harnyx/blob/main/docs/api/README.md"
+      ],
+      "url": "https://dashboard.harnyx.ai/benchmark"
     }
   ],
   "source_repo": "https://github.com/harnyx/harnyx",


### PR DESCRIPTION
Part of the surface-enrichment epic #427 (related issue: #4075 — see my comment there on why an OpenAPI surface is not currently submittable for SN67).

Adds `dashboard.harnyx.ai/benchmark` as a `dashboard` surface on `registry/subnets/harnyx.json` (append-only, one file).

**Why it's genuinely SN67's:** the official `harnyx/harnyx` repository declares it twice — the [root README](https://github.com/harnyx/harnyx/blob/main/README.md) links it as 'Live benchmark', and [docs/api/README.md](https://github.com/harnyx/harnyx/blob/main/docs/api/README.md) documents it as 'the public surface for inspecting benchmark history and sampled run detail'.

**Why it's useful:** it is the only public window into the subnet's champion/challenger evaluation history and per-run quality — the page miners are told to use to inspect champion quality before competing.

**Verification:** `surface:add` live check passed (`OK reachable + public-safe`); `validate-surface` passes (3 surfaces in the file); HTTP 200 confirmed no-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)