### PR TITLE
fix(ui): keep TreemapMini tail tiles legible under skewed distributions

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/treemap-mini.tsx
@@ -25,10 +25,16 @@ interface Rect {
 
 const sum = (ns: number[]) => ns.reduce((a, b) => a + b, 0);
 
-// A tile only shows its value readout when it is large enough to fit one without
-// clipping — width/height are percentages of the map box.
-const MIN_TILE_W_FOR_VALUE = 12;
-const MIN_TILE_H_FOR_VALUE = 14;
+// A tile only shows its readouts when it is large enough to fit them without
+// clipping — width/height are percentages of the map box. The label needs less
+// room than the label+value pair; below the label threshold a squashed tail tile
+// (common when one validator dominates the stake) shows nothing inline — its
+// name/value/share stay on the title tooltip — rather than clipping to a bare
+// "#" or stacking its value on top of its own label (#3937).
+const MIN_TILE_W_FOR_LABEL = 11;
+const MIN_TILE_H_FOR_LABEL = 13;
+const MIN_TILE_W_FOR_VALUE = 13;
+const MIN_TILE_H_FOR_VALUE = 22;
 
 /** Worst (largest) aspect ratio in a row laid along `side`. */
 function worstRatio(areas: number[], side: number): number {
@@ -147,9 +153,11 @@ export function TreemapMini({ data, className, formatValue = String, ariaLabel }
             className="flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5"
             style={{ background: t.color ?? "var(--accent)" }}
           >
-            <span className="truncate font-mono text-[10px] font-medium leading-none text-accent-foreground">
-              {t.label}
-            </span>
+            {t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? (
+              <span className="truncate font-mono text-[10px] font-medium leading-none text-accent-foreground">
+                {t.label}
+              </span>
+            ) : null}
             {t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? (
               <span className="truncate font-mono text-[9px] leading-none text-accent-foreground/80">
                 {formatValue(t.value)}


### PR DESCRIPTION
## Summary

`TreemapMini` (`charts/treemap-mini.tsx`, the stake-dominance treemap) size-gated only the **value** readout — the **label** was always rendered. When one validator dominates a subnet's stake (the common Bittensor case, not an edge case), the tail tiles squarify to near-zero height/width, so their label clips to a bare `"#"` or — for a tile just above the value threshold but still too short — the value stacks directly on top of the label, overlapping into illegible text and clipping the tile border.

This gates the **label** by tile size too, and raises the value's height threshold so a label+value pair only renders when there's vertical room for both. Below the label threshold a squashed tail tile now shows **nothing inline** — its name, value, and share stay on the tile's `title` tooltip (already present) — rather than rendering garbled text. Larger tiles are unchanged. It follows the exact size-gating idiom already in this file (the existing `MIN_TILE_*_FOR_VALUE` check), just extended to the label.

## What changed

- `apps/ui/src/components/metagraphed/charts/treemap-mini.tsx`:
  - added `MIN_TILE_W_FOR_LABEL` / `MIN_TILE_H_FOR_LABEL` (11 / 13) and wrapped the label span in that size check;
  - raised `MIN_TILE_H_FOR_VALUE` 14 → 22 (and `MIN_TILE_W_FOR_VALUE` 12 → 13) so the value only shows with room for both lines.
  - No change to `squarify`, tile positioning, colors, or the tooltip — purely which readouts render at which tile size.

## Screenshots

Captured on `/subnets/64?tab=validators` (the "Stake dominance" treemap), real live data (SN64's naturally skewed validator stake reproduces the squashed tail tiles). Fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes forced via `localStorage.setItem("mg-theme", …)`, `deviceScaleFactor: 1`.

The defect scales with squashing, so it is clearest on **Mobile** (before: tile `"#46"`'s value overlaps its label into illegible text, and the smallest tail tiles show clipped `"#"` fragments → after: `"#46"` renders a clean label, and sub-threshold tiles show a clean colored rect with the data on hover). Tablet/Desktop have a larger map so fewer tiles squash, but the same gating cleans the smallest slivers there too.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-tablet-dark.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-mobile-light.png)<br><sub>before — "#46" value overlaps its label</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-mobile-light.png)<br><sub>after — clean label; data on hover</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-before-mobile-dark.png)<br><sub>before — overlapping/clipped tail tiles</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/screenshots/sn3937-after-mobile-dark.png)<br><sub>after — clean tiles</sub> |

## Validation

- `tsc --noEmit` — clean (after building `packages/client`, as CI does)
- `eslint` — 0 errors on the changed file
- `prettier --check` — clean
- `vitest run` — full suite, 717 tests pass
- `git diff` touches only `treemap-mini.tsx`; no squarify/positioning/tooltip change, only which readouts render at which tile size.

Closes #3937
