### PR TITLE
feat(health): add best-effort Postgres mirror to the health-check prober

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -508,6 +508,7 @@ export async function runHealthProber(env, ctx, overrides = {}) {
 
   const d1Persist = await persistToD1(db, probed, runAt);
   await persistToKv(kv, probed, runAt);
+  await syncHealthChecksToPostgres(env, probed);
 
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
   for (const row of probed) counts[normalizeProbeStatus(row.status)] += 1;
@@ -688,6 +689,42 @@ async function persistToKv(kv, probed, runAt) {
     kv.put(KV_HEALTH_RPC_POOL, JSON.stringify(rpcPool)),
     kv.put(KV_HEALTH_META, JSON.stringify(meta)),
   ]);
+}
+
+// #4832 gap-closure: best-effort Postgres mirror of the D1 write above --
+// never awaited-and-thrown into the caller, mirroring
+// syncSubnetIdentityToPostgres's own header comment (subnet-identity-history.mjs)
+// for why this is a direct service-binding call rather than routing through
+// the public proxy layer. D1+KV remain the sole authoritative write target;
+// a Postgres failure here never affects live serving.
+export async function syncHealthChecksToPostgres(env, probed) {
+  if (!env?.DATA_API || !env?.HEALTH_CHECKS_SYNC_SECRET) {
+    return { synced: false, reason: "unavailable" };
+  }
+  if (!Array.isArray(probed) || probed.length === 0) {
+    return { synced: false, reason: "no_rows" };
+  }
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/health-checks-sync",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-health-checks-sync-token": env.HEALTH_CHECKS_SYNC_SECRET,
+          },
+          body: JSON.stringify({ probed }),
+        },
+      ),
+    );
+    if (!upstream.ok) {
+      return { synced: false, reason: `status_${upstream.status}` };
+    }
+    return { synced: true };
+  } catch {
+    return { synced: false, reason: "fetch_failed" };
+  }
 }
 
 // UTC day bounds for a given epoch-ms instant: { date: "YYYY-MM-DD", start, end }.

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -62,6 +62,11 @@ const accountIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
 // grouping alone.
 const subnetIdentitySyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
+// State for the health-checks-sync write route's tests only (#4832
+// gap-closure). No hash-diff / latest-lookup query -- unlike the identity
+// sync routes, this one just bulk-inserts + upserts the same probed batch
+// D1/KV already received, so there's nothing to prime beyond the failure hook.
+const healthChecksSyncFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -130,6 +135,12 @@ vi.mock("postgres", () => ({
       ) {
         return Promise.reject(subnetIdentitySyncFailure.error);
       }
+      if (
+        healthChecksSyncFailure.error &&
+        /INSERT INTO surface_checks\b/.test(text)
+      ) {
+        return Promise.reject(healthChecksSyncFailure.error);
+      }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
       }
@@ -182,6 +193,7 @@ const ROLLUP_SYNC_SECRET = "test-rollup-sync-secret";
 const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
 const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
 const SUBNET_IDENTITY_SYNC_SECRET = "test-subnet-identity-sync-secret";
+const HEALTH_CHECKS_SYNC_SECRET = "test-health-checks-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
@@ -189,6 +201,7 @@ const env = {
   SUBNET_HYPERPARAMS_SYNC_SECRET,
   ACCOUNT_IDENTITY_SYNC_SECRET,
   SUBNET_IDENTITY_SYNC_SECRET,
+  HEALTH_CHECKS_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -208,6 +221,7 @@ beforeEach(() => {
   accountIdentityLatestHashes.current = [];
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
+  healthChecksSyncFailure.error = null;
   mockRows.current = [
     {
       block_number: "123",
@@ -3741,6 +3755,184 @@ test("subnet-identity-sync maps a DB failure to a clean 502 instead of throwing"
   const res = await postSubnetIdentity([subnetIdentityProfile()], {
     secret: SUBNET_IDENTITY_SYNC_SECRET,
   });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+// #4832 gap-closure: health-checks-sync -- best-effort Postgres mirror of
+// src/health-prober.mjs's D1+KV write, called from the main Worker's own
+// 15-minute cron (syncHealthChecksToPostgres), not an external workflow.
+function probedRow(overrides = {}) {
+  return {
+    surface_id: "sn-1-example-api",
+    surface_key: "srf-abc123",
+    netuid: 1,
+    kind: "subnet-api",
+    provider: "example",
+    url: "https://example.com/api",
+    status: "ok",
+    classification: "healthy",
+    latency_ms: 120,
+    status_code: 200,
+    checked_at_ms: 1780000000000,
+    last_ok_ms: 1780000000000,
+    consecutive_failures: 0,
+    ...overrides,
+  };
+}
+
+function postHealthChecks(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-health-checks-sync-token"] = secret;
+  return req("/api/v1/internal/health-checks-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? { probed: [] }),
+  });
+}
+
+test("health-checks-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postHealthChecks(
+    { probed: [probedRow()] },
+    { secret: "wrong" },
+  );
+  expect(wrong.status).toBe(401);
+  const missing = await postHealthChecks({ probed: [probedRow()] });
+  expect(missing.status).toBe(401);
+});
+
+test("health-checks-sync is disabled (503) when HEALTH_CHECKS_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/health-checks-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-health-checks-sync-token": HEALTH_CHECKS_SYNC_SECRET,
+      },
+      body: JSON.stringify({ probed: [probedRow()] }),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("health-checks-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/health-checks-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-health-checks-sync-token": HEALTH_CHECKS_SYNC_SECRET,
+      },
+      body: JSON.stringify({ probed: [probedRow()] }),
+    }),
+    { HEALTH_CHECKS_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("health-checks-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postHealthChecks(null, {
+    secret: HEALTH_CHECKS_SYNC_SECRET,
+    raw: '{"probed":[' + "1".repeat(2_000_000) + "]}",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("health-checks-sync rejects malformed JSON (400)", async () => {
+  const res = await postHealthChecks(null, {
+    secret: HEALTH_CHECKS_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("health-checks-sync rejects a body without a probed array (400)", async () => {
+  const res = await postHealthChecks(
+    { not: "the right shape" },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("health-checks-sync rejects more than the row cap (413)", async () => {
+  const many = Array.from({ length: 2_001 }, () => probedRow());
+  const res = await postHealthChecks(
+    { probed: many },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(413);
+});
+
+test("health-checks-sync on an empty probed array is a clean no-op (200)", async () => {
+  const res = await postHealthChecks(
+    { probed: [] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, checks_written: 0, status_written: 0 });
+});
+
+test("health-checks-sync silently skips a row missing a required field, no error", async () => {
+  const res = await postHealthChecks(
+    { probed: [probedRow({ netuid: "not-a-number" })] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, checks_written: 0, status_written: 0 });
+});
+
+test("health-checks-sync bulk-inserts surface_checks and upserts surface_status", async () => {
+  const res = await postHealthChecks(
+    { probed: [probedRow(), probedRow({ surface_id: "sn-2-other-api" })] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({
+    ok: true,
+    checks_written: 2,
+    status_written: 2,
+  });
+  expect(queryText()).toMatch(/INSERT INTO surface_checks\b/);
+  expect(queryText()).toMatch(
+    /INSERT INTO surface_status\b[\s\S]*ON CONFLICT \(surface_id\) DO UPDATE/,
+  );
+});
+
+test("health-checks-sync defaults every optional field to null/0 when absent", async () => {
+  const minimal = {
+    surface_id: "sn-3-minimal",
+    netuid: 3,
+    kind: "subnet-api",
+    status: "failed",
+    checked_at_ms: 1780000000000,
+    // surface_key, classification, latency_ms, status_code, url, provider,
+    // last_ok_ms, consecutive_failures all intentionally absent.
+  };
+  const res = await postHealthChecks(
+    { probed: [minimal] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, checks_written: 1, status_written: 1 });
+  const statusInsert = sqlCalls.find((c) =>
+    /INSERT INTO surface_status\b/.test(c.text),
+  );
+  expect(statusInsert.values).toContain(0); // consecutive_failures default
+});
+
+test("health-checks-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  healthChecksSyncFailure.error = new Error("connection reset");
+  const res = await postHealthChecks(
+    { probed: [probedRow()] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
   expect(res.status).toBe(502);
   expect((await res.json()).error).toBe("write failed");
 });

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -11,6 +11,7 @@ import {
   runD1StatementBatches,
   D1_STATEMENTS_PER_BATCH,
   runHealthProber,
+  syncHealthChecksToPostgres,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
 } from "../src/health-prober.mjs";
@@ -1442,6 +1443,155 @@ describe("persistToD1 via runHealthProber", () => {
     assert.equal(db.calls.batches.length, 2);
     assert.equal(db.calls.batches[0].length, D1_STATEMENTS_PER_BATCH);
     assert.equal(db.calls.batches[1].length, 10);
+  });
+});
+
+// #4832 gap-closure: syncHealthChecksToPostgres is a private helper (unlike
+// syncSubnetIdentityToPostgres, which lives in its own module and is tested
+// directly in tests/subnet-identity-history.test.mjs) -- exercised the same
+// way persistToD1/persistToKv above are, indirectly through runHealthProber.
+// D1+KV remain the authoritative write target throughout; these tests only
+// prove the Postgres mirror attempt fires (or safely no-ops) without ever
+// affecting runHealthProber's own `ok`/`d1_persisted` result.
+describe("syncHealthChecksToPostgres", () => {
+  // runHealthProber never calls this with an empty array (it short-circuits
+  // on zero operational surfaces before ever reaching persist/sync), so this
+  // guard is only reachable via a direct call, unlike the other tests below.
+  test("returns no_rows for an empty or non-array probed batch", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("{}") },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    assert.deepEqual(await syncHealthChecksToPostgres(env, []), {
+      synced: false,
+      reason: "no_rows",
+    });
+    assert.deepEqual(await syncHealthChecksToPostgres(env, undefined), {
+      synced: false,
+      reason: "no_rows",
+    });
+  });
+});
+
+describe("syncHealthChecksToPostgres via runHealthProber", () => {
+  test("no-ops (no DATA_API call) when DATA_API is not bound", async () => {
+    let called = false;
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(called, false);
+  });
+
+  test("no-ops (no DATA_API call) when HEALTH_CHECKS_SYNC_SECRET is not configured", async () => {
+    let called = false;
+    const result = await runHealthProber(
+      {
+        DATA_API: { fetch: async () => ((called = true), new Response("{}")) },
+      },
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(called, false);
+  });
+
+  test("posts the probed batch to health-checks-sync with the token header", async () => {
+    let request;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          request = req;
+          return new Response("{}", { status: 200 });
+        },
+      },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    const result = await runHealthProber(
+      env,
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.ok(request);
+    assert.equal(request.method, "POST");
+    assert.equal(
+      request.headers.get("x-health-checks-sync-token"),
+      "test-secret",
+    );
+    const body = await request.json();
+    assert.ok(Array.isArray(body.probed));
+    assert.equal(body.probed.length, SURFACES.length);
+  });
+
+  test("a DATA_API failure never affects runHealthProber's own result", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    const result = await runHealthProber(
+      env,
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.d1_persisted, true);
+  });
+
+  test("a non-2xx DATA_API response never affects runHealthProber's own result", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => new Response("nope", { status: 502 }),
+      },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    const result = await runHealthProber(
+      env,
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
   });
 });
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1460,6 +1460,186 @@ async function handleSubnetIdentitySync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/health-checks-sync (#4832 gap-closure) --------
+//
+// Best-effort Postgres mirror of the D1+KV probe write in
+// src/health-prober.mjs's runHealthProber -- same "own hourly/15-min cron,
+// direct env.DATA_API.fetch() service-binding call" shape as
+// subnet-identity-sync above, not an external GitHub Actions workflow. D1+KV
+// stay the sole authoritative write target (live serving reads them
+// unchanged); this route only mirrors the SAME probed batch into
+// surface_checks/surface_status so the Postgres tier can eventually take
+// over the read side. surface_status uses ON CONFLICT (surface_id) only
+// (not D1's dual surface_key/surface_id conflict targets -- Postgres allows
+// one conflict target per INSERT): a surface rename mid-migration can
+// briefly fail this route's UPSERT on the surface_key unique index rather
+// than silently duplicate a row, which is an acceptable degrade for a
+// mirror that isn't yet the read source of truth.
+const HEALTH_CHECKS_SYNC_TOKEN_HEADER = "x-health-checks-sync-token";
+// One probe run today is ~150-200 surfaces; generous headroom.
+const HEALTH_CHECKS_SYNC_MAX_BODY_BYTES = 2_000_000;
+const HEALTH_CHECKS_SYNC_MAX_ROWS = 2_000;
+
+async function handleHealthChecksSync(request, env) {
+  if (!env.HEALTH_CHECKS_SYNC_SECRET) {
+    return writeJson(
+      { error: "health-checks sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(HEALTH_CHECKS_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.HEALTH_CHECKS_SYNC_SECRET)) {
+    return writeJson(
+      { error: `provide a valid ${HEALTH_CHECKS_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > HEALTH_CHECKS_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${HEALTH_CHECKS_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const probed = Array.isArray(parsed?.probed) ? parsed.probed : null;
+  if (!probed) {
+    return writeJson({ error: "body must be {probed:[...]}" }, 400);
+  }
+  if (probed.length > HEALTH_CHECKS_SYNC_MAX_ROWS) {
+    return writeJson(
+      {
+        error: `at most ${HEALTH_CHECKS_SYNC_MAX_ROWS} probed rows per request`,
+      },
+      413,
+    );
+  }
+  if (!probed.length) {
+    return writeJson({ ok: true, checks_written: 0, status_written: 0 });
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  const validRows = probed.filter(
+    (row) =>
+      row &&
+      typeof row.surface_id === "string" &&
+      row.surface_id.length > 0 &&
+      Number.isInteger(row.netuid) &&
+      typeof row.kind === "string" &&
+      typeof row.status === "string" &&
+      Number.isFinite(row.checked_at_ms),
+  );
+  if (!validRows.length) {
+    return writeJson({ ok: true, checks_written: 0, status_written: 0 });
+  }
+
+  const checkRows = validRows.map((row) => ({
+    surface_id: row.surface_id,
+    surface_key: row.surface_key ?? null,
+    netuid: row.netuid,
+    kind: row.kind,
+    status: row.status,
+    classification: row.classification ?? null,
+    latency_ms: Number.isFinite(row.latency_ms) ? row.latency_ms : null,
+    status_code: Number.isInteger(row.status_code) ? row.status_code : null,
+    ok: row.status === "ok",
+    checked_at: row.checked_at_ms,
+  }));
+  const statusRows = validRows.map((row) => ({
+    surface_id: row.surface_id,
+    surface_key: row.surface_key ?? null,
+    netuid: row.netuid,
+    kind: row.kind,
+    url: row.url ?? null,
+    provider: row.provider ?? null,
+    status: row.status,
+    classification: row.classification ?? null,
+    latency_ms: Number.isFinite(row.latency_ms) ? row.latency_ms : null,
+    status_code: Number.isInteger(row.status_code) ? row.status_code : null,
+    last_checked: row.checked_at_ms,
+    last_ok: Number.isFinite(row.last_ok_ms) ? row.last_ok_ms : null,
+    consecutive_failures: Number.isInteger(row.consecutive_failures)
+      ? row.consecutive_failures
+      : 0,
+    updated_at: row.checked_at_ms,
+  }));
+
+  try {
+    return await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '10000ms'`;
+      await sql`
+        INSERT INTO surface_checks ${sql(
+          checkRows,
+          "surface_id",
+          "surface_key",
+          "netuid",
+          "kind",
+          "status",
+          "classification",
+          "latency_ms",
+          "status_code",
+          "ok",
+          "checked_at",
+        )}
+        ON CONFLICT (surface_id, checked_at) DO NOTHING`;
+      await sql`
+        INSERT INTO surface_status ${sql(
+          statusRows,
+          "surface_id",
+          "surface_key",
+          "netuid",
+          "kind",
+          "url",
+          "provider",
+          "status",
+          "classification",
+          "latency_ms",
+          "status_code",
+          "last_checked",
+          "last_ok",
+          "consecutive_failures",
+          "updated_at",
+        )}
+        ON CONFLICT (surface_id) DO UPDATE SET
+          surface_key = excluded.surface_key,
+          netuid = excluded.netuid,
+          kind = excluded.kind,
+          url = excluded.url,
+          provider = excluded.provider,
+          status = excluded.status,
+          classification = excluded.classification,
+          latency_ms = excluded.latency_ms,
+          status_code = excluded.status_code,
+          last_checked = excluded.last_checked,
+          last_ok = excluded.last_ok,
+          consecutive_failures = excluded.consecutive_failures,
+          updated_at = excluded.updated_at`;
+      return writeJson({
+        ok: true,
+        checks_written: checkRows.length,
+        status_written: statusRows.length,
+      });
+    });
+  } catch (err) {
+    console.error("data-api health-checks-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -1602,6 +1782,12 @@ export default {
       url.pathname === "/api/v1/internal/subnet-identity-sync"
     ) {
       return handleSubnetIdentitySync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/health-checks-sync"
+    ) {
+      return handleHealthChecksSync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -4,10 +4,14 @@
   // main Worker's bundle budget. Reached only via the main Worker's DATA_API service
   // binding (no public routes of its own). Deploy: wrangler deploy -c wrangler.data.jsonc
   //
-  // Also owns the one write route into this same Postgres instance (#4771,
-  // POST /api/v1/internal/neurons-sync -- see workers/data-api.mjs's
-  // handleNeuronsSync) -- requires its own secret, set via:
-  //   wrangler secret put NEURONS_SYNC_SECRET -c wrangler.data.jsonc
+  // Also owns every write route into this same Postgres instance (#4771's
+  // neurons-sync, subnet-hyperparams-sync, account-identity-sync,
+  // subnet-identity-sync, health-checks-sync -- see workers/data-api.mjs's
+  // handle*Sync functions) -- each requires its own secret, set via:
+  //   wrangler secret put <NAME>_SYNC_SECRET -c wrangler.data.jsonc
+  // (and, for the ones called from the main Worker's own cron rather than an
+  // external GitHub Actions workflow, the SAME secret value on the main
+  // Worker too -- see wrangler.jsonc.)
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "metagraphed-data-api",
   "main": "workers/data-api.mjs",


### PR DESCRIPTION
## Summary

The write-path half of the health-tracking Postgres migration (#4832), following the schema-first PR (#4880).

- Adds `POST /api/v1/internal/health-checks-sync` (`workers/data-api.mjs`, `handleHealthChecksSync`) -- bulk-inserts the probed batch into `surface_checks` and upserts `surface_status`.
- Calls it from `src/health-prober.mjs`'s `runHealthProber` via a new `syncHealthChecksToPostgres` helper, mirroring `syncSubnetIdentityToPostgres`'s exact isolation pattern: best-effort, try/catch-wrapped, never awaited-and-thrown, called via a direct `env.DATA_API` service-binding fetch rather than the public proxy layer since this fires from the main Worker's own 15-minute cron.
- **D1+KV remain the sole authoritative write target** -- live serving is completely unaffected by this change; a Postgres failure here is silently swallowed exactly like a D1 batch failure already is.
- `surface_status` upserts on `ON CONFLICT (surface_id)` only (Postgres allows one conflict target per INSERT, unlike D1's dual `surface_key`/`surface_id` targets) -- a mid-migration surface rename can briefly fail the UPSERT on the `surface_key` unique index rather than silently duplicate a row, an acceptable degrade for a mirror that isn't yet the read source of truth.
- Provisioned `HEALTH_CHECKS_SYNC_SECRET` on both Workers (main + data-api) via `wrangler secret put`, matching every other sync route's secret pattern.
- Also fixes `wrangler.data.jsonc`'s header comment, stale since before the other 4 sync routes were added (it still said "the one write route").

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` all clean
- `npx vitest run` -- 7583/7583 passing (full local suite)
- `npm run test:coverage` + patch-diff isolation against `origin/main` -- zero uncovered added lines/branches in both touched files
- New tests cover: auth (missing/wrong token, unprovisioned secret), validation (byte cap, malformed JSON, row cap, missing-field skip), the bulk insert/upsert happy path, optional-field defaulting, DB-failure-to-502 mapping, and (via `runHealthProber`) that a Postgres failure never affects the prober's own `ok`/`d1_persisted` result