### PR TITLE
feat(ui): wire Download CSV into the account detail events/extrinsics/transfers feeds

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -33,6 +33,7 @@ import { PageHero } from "@/components/metagraphed/page-hero";
 import { ShareButton } from "@/components/metagraphed/share-button";
 import { SectionAnchor } from "@/components/metagraphed/section-anchor";
 import { SelectFilter } from "@/components/metagraphed/table-controls";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { StatTile } from "@/components/metagraphed/charts/stat-tile";
 import { BarMini } from "@/components/metagraphed/charts/bar-mini";
@@ -61,6 +62,7 @@ import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import type {
@@ -336,6 +338,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
 
       <AccountExtrinsicsSection
+        ss58={ss58}
         rows={signedExtrinsics}
         isPending={extrinsicsResult.isPending}
         isError={extrinsicsResult.isError}
@@ -453,12 +456,14 @@ function AccountFeedSectionSkeleton({
 }
 
 function AccountExtrinsicsSection({
+  ss58,
   rows,
   isPending,
   isError,
   error,
   onRetry,
 }: {
+  ss58: string;
   rows: Extrinsic[];
   isPending?: boolean;
   isError?: boolean;
@@ -498,13 +503,19 @@ function AccountExtrinsicsSection({
     );
   }
   if (phase === "empty") return null;
+  const extrinsicsCsvUrl = buildUrl(`/api/v1/accounts/${ss58PathSegment(ss58)}/extrinsics`);
   return (
     <SectionAnchor
       id="extrinsics"
       title="Signed extrinsics"
       subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
       tone="accent"
-      right={<SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>}
+      right={
+        <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
+          <SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>
+          <DownloadCsvButton url={extrinsicsCsvUrl} />
+        </div>
+      }
     >
       <DataPanel>
         <table className="w-full text-left text-sm">
@@ -620,13 +631,19 @@ function AccountTransfersSection({
     );
   }
   if (phase === "empty") return null;
+  const transfersCsvUrl = buildUrl(`/api/v1/accounts/${ss58PathSegment(ss58)}/transfers`);
   return (
     <SectionAnchor
       id="transfers"
       title="Transfers"
       subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
       tone="accent"
-      right={<SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>}
+      right={
+        <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
+          <SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>
+          <DownloadCsvButton url={transfersCsvUrl} />
+        </div>
+      }
     >
       <DataPanel>
         <table className="w-full text-left text-sm">
@@ -1949,6 +1966,11 @@ function AccountEventsSection({
   const params: { limit: number; offset: number; kind?: string } = { limit, offset };
   if (search.ev_kind) params.kind = search.ev_kind;
 
+  // Export the full filtered feed (kind only) — not the current page window.
+  const eventsCsvUrl = buildUrl(`/api/v1/accounts/${ss58PathSegment(ss58)}/events`, {
+    kind: search.ev_kind,
+  });
+
   const result = useQuery(accountEventsQuery(ss58, params));
   const page = result.data?.data;
   const events = page?.events ?? [];
@@ -2003,14 +2025,17 @@ function AccountEventsSection({
       subtitle="Full first-party event feed for this account, newest first — filter by kind, page through history."
       tone="accent"
       right={
-        kindOptions.length > 0 ? (
-          <SelectFilter
-            label="Kind"
-            value={search.ev_kind ?? ""}
-            onChange={(v) => setSearch({ ev_kind: v || undefined, ev_offset: undefined })}
-            options={kindOptions.map((k) => ({ value: k.kind, label: k.kind }))}
-          />
-        ) : undefined
+        <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
+          {kindOptions.length > 0 ? (
+            <SelectFilter
+              label="Kind"
+              value={search.ev_kind ?? ""}
+              onChange={(v) => setSearch({ ev_kind: v || undefined, ev_offset: undefined })}
+              options={kindOptions.map((k) => ({ value: k.kind, label: k.kind }))}
+            />
+          ) : null}
+          <DownloadCsvButton url={eventsCsvUrl} />
+        </div>
       }
     >
       {events.length > 0 ? (


### PR DESCRIPTION
## Summary

The account detail page renders three chain-direct feeds — **Chain events**, **Signed extrinsics**, and **Transfers** — but none offered an export affordance, even though all three backing routes already accept `?format=csv`. This wires a **Download CSV** control into each of the three section headers so a visitor can export exactly what a feed shows.

Closes #3407.

## What changed

- Placed `DownloadCsvButton` (the shared component from #3402, already used on seven other routes) in the header `right` slot of `AccountEventsSection`, `AccountExtrinsicsSection`, and `AccountTransfersSection`.
- Each button's URL is built with `buildUrl(...)` against that feed's own route (`/events`, `/extrinsics`, `/transfers`), mirroring the existing account query paths via `ss58PathSegment` — no hand-built query strings, no hardcoded origin.
- The **Chain events** export reflects the active `ev_kind` filter (and omits `kind` when no filter is set), so the CSV matches the on-screen rows.
- Threaded `ss58` into `AccountExtrinsicsSection` (the other two sections already received it).
- Header controls stack on mobile (`flex-col` → `sm:flex-row`) so the added button never crowds the section title on narrow viewports.

No changes to `queries.ts`, `client.ts`, or any `workers/` file — the `?format=csv` support already ships and is out of scope.

## Scope / non-goals

- Only `apps/ui/src/routes/accounts.$ss58.tsx` is touched (one file, +35 / −10).
- The shared `DownloadCsvButton` is consumed as-is, not reimplemented.
- No CSV export added to any other page, and the account summary/history/subnets sections are untouched.

## Tests

No new unit test: this is presentational wiring that composes already-tested helpers (`buildUrl`, `ss58PathSegment`) and the already-tested `DownloadCsvButton` (`download-csv-button.test.ts` covers the `format=csv` URL logic). The `apps/ui` vitest suite runs in a node environment with no render harness, so — like the seven existing `DownloadCsvButton` wirings — there is no component-render test to add.

## Gates

`typecheck` ✓ · `lint` ✓ (0 errors) · `format:check` ✓ · `test` ✓ (717 passed) · `build` ✓

## Screenshots

Captured on account `5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3`, with the three feeds fixtured to a few rows each for a stable before/after. The only difference is the new **Download CSV** control in each feed header (on the Chain events feed it sits beside the existing Kind filter).

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-before-desktop-light.png) | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-before-desktop-dark.png) | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-before-tablet-light.png) | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-before-tablet-dark.png) | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-before-mobile-light.png) | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-before-mobile-dark.png) | ![](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/account-csv-after-mobile-dark.png) |
