### PR TITLE
feat(health): add Postgres mirror for the daily uptime rollup

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -727,6 +727,46 @@ export async function syncHealthChecksToPostgres(env, probed) {
   }
 }
 
+// #4832 gap-closure: best-effort Postgres mirror of rollupDailyUptime below.
+// Reuses HEALTH_CHECKS_SYNC_SECRET (same conceptual sync boundary as
+// syncHealthChecksToPostgres, not a separate secret) since this fires from
+// the same hourly cron right alongside it. Unlike syncHealthChecksToPostgres
+// -- which ships the already-computed probed batch -- this only ships the
+// UTC day *boundaries*; Postgres computes its own rollup from its own
+// surface_checks (already populated by the sibling sync), using
+// PERCENTILE_CONT for the p50/p95/p99 tail instead of D1/SQLite's
+// rank-based CTE (see src/health-sql.mjs's rankedChecksCte/
+// latencyStatColumns, which this mirrors semantically, not textually).
+export async function syncHealthUptimeRollupToPostgres(env, days, updatedAt) {
+  if (!env?.DATA_API || !env?.HEALTH_CHECKS_SYNC_SECRET) {
+    return { synced: false, reason: "unavailable" };
+  }
+  if (!Array.isArray(days) || days.length === 0) {
+    return { synced: false, reason: "no_days" };
+  }
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/health-uptime-rollup-sync",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-health-checks-sync-token": env.HEALTH_CHECKS_SYNC_SECRET,
+          },
+          body: JSON.stringify({ days, updated_at: updatedAt }),
+        },
+      ),
+    );
+    if (!upstream.ok) {
+      return { synced: false, reason: `status_${upstream.status}` };
+    }
+    return { synced: true };
+  } catch {
+    return { synced: false, reason: "fetch_failed" };
+  }
+}
+
 // UTC day bounds for a given epoch-ms instant: { date: "YYYY-MM-DD", start, end }.
 function utcDayBounds(ms) {
   const d = new Date(ms);
@@ -801,18 +841,27 @@ export async function rollupDailyUptime(env, overrides = {}) {
      ON CONFLICT(surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET${conflictColumns}
      ON CONFLICT(surface_id, day) DO UPDATE SET${conflictColumns}`,
   );
+  let result;
   try {
     await db.batch(
       days.map(({ date, start, end }) => stmt.bind(start, end, date, runAt)),
     );
-    return { rolled: true, days: days.map((d) => d.date) };
+    result = { rolled: true, days: days.map((d) => d.date) };
   } catch (error) {
     // Don't swallow silently: a failing INSERT here (e.g. a missing column from
     // un-applied schema migration) freezes the daily uptime rollup invisibly.
     // Surface the reason so the hourly cron's result is diagnosable.
     console.error("[rollupDailyUptime]", String(error?.message ?? error));
-    return { rolled: false, error: String(error?.message ?? error) };
+    result = { rolled: false, error: String(error?.message ?? error) };
   }
+  // #4832 gap-closure: best-effort Postgres mirror, independent of the D1
+  // outcome above -- Postgres computes its OWN rollup from its own
+  // surface_checks (already populated by syncHealthChecksToPostgres in
+  // runHealthProber), it doesn't need D1's rolled-up rows shipped to it. A
+  // D1 failure here doesn't block attempting the Postgres side, and vice
+  // versa; each store's rollup is independently best-effort.
+  await syncHealthUptimeRollupToPostgres(env, days, runAt);
+  return result;
 }
 
 // Hourly maintenance cron: prune time-series rows older than the retention

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -67,6 +67,7 @@ const subnetIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
 // sync routes, this one just bulk-inserts + upserts the same probed batch
 // D1/KV already received, so there's nothing to prime beyond the failure hook.
 const healthChecksSyncFailure = vi.hoisted(() => ({ error: null }));
+const healthUptimeRollupSyncFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -140,6 +141,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO surface_checks\b/.test(text)
       ) {
         return Promise.reject(healthChecksSyncFailure.error);
+      }
+      if (
+        healthUptimeRollupSyncFailure.error &&
+        /INSERT INTO surface_uptime_daily\b/.test(text)
+      ) {
+        return Promise.reject(healthUptimeRollupSyncFailure.error);
       }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
@@ -222,6 +229,7 @@ beforeEach(() => {
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
   healthChecksSyncFailure.error = null;
+  healthUptimeRollupSyncFailure.error = null;
   mockRows.current = [
     {
       block_number: "123",
@@ -3931,6 +3939,150 @@ test("health-checks-sync maps a DB failure to a clean 502 instead of throwing", 
   healthChecksSyncFailure.error = new Error("connection reset");
   const res = await postHealthChecks(
     { probed: [probedRow()] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+// #4832 gap-closure: health-uptime-rollup-sync -- best-effort Postgres
+// mirror of rollupDailyUptime, reusing HEALTH_CHECKS_SYNC_SECRET (same
+// conceptual sync boundary, not a separate secret). Unlike health-checks-
+// sync, the body carries only UTC day boundaries; Postgres computes its own
+// rollup from its own surface_checks via PERCENTILE_CONT.
+function dayBounds(date, start, end) {
+  return { date, start, end };
+}
+
+function postHealthUptimeRollup(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-health-checks-sync-token"] = secret;
+  return req("/api/v1/internal/health-uptime-rollup-sync", {
+    method: "POST",
+    headers,
+    body:
+      raw !== undefined
+        ? raw
+        : JSON.stringify(body ?? { days: [], updated_at: 1 }),
+  });
+}
+
+test("health-uptime-rollup-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postHealthUptimeRollup(
+    { days: [dayBounds("2026-07-11", 1, 2)], updated_at: 1 },
+    { secret: "wrong" },
+  );
+  expect(wrong.status).toBe(401);
+  const missing = await postHealthUptimeRollup({
+    days: [dayBounds("2026-07-11", 1, 2)],
+    updated_at: 1,
+  });
+  expect(missing.status).toBe(401);
+});
+
+test("health-uptime-rollup-sync is disabled (503) when HEALTH_CHECKS_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/health-uptime-rollup-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-health-checks-sync-token": HEALTH_CHECKS_SYNC_SECRET,
+      },
+      body: JSON.stringify({
+        days: [dayBounds("2026-07-11", 1, 2)],
+        updated_at: 1,
+      }),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("health-uptime-rollup-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/health-uptime-rollup-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-health-checks-sync-token": HEALTH_CHECKS_SYNC_SECRET,
+      },
+      body: JSON.stringify({
+        days: [dayBounds("2026-07-11", 1, 2)],
+        updated_at: 1,
+      }),
+    }),
+    { HEALTH_CHECKS_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("health-uptime-rollup-sync rejects malformed JSON (400)", async () => {
+  const res = await postHealthUptimeRollup(null, {
+    secret: HEALTH_CHECKS_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("health-uptime-rollup-sync rejects a body missing days or updated_at (400)", async () => {
+  const noDays = await postHealthUptimeRollup(
+    { updated_at: 1 },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(noDays.status).toBe(400);
+  const noUpdatedAt = await postHealthUptimeRollup(
+    { days: [dayBounds("2026-07-11", 1, 2)] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(noUpdatedAt.status).toBe(400);
+});
+
+test("health-uptime-rollup-sync rejects more than the day cap (413)", async () => {
+  const many = Array.from({ length: 11 }, (_, i) =>
+    dayBounds(`2026-07-${String(i + 1).padStart(2, "0")}`, i, i + 1),
+  );
+  const res = await postHealthUptimeRollup(
+    { days: many, updated_at: 1 },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(413);
+});
+
+test("health-uptime-rollup-sync silently skips a malformed day entry, no error", async () => {
+  const res = await postHealthUptimeRollup(
+    { days: [{ date: "not-a-date", start: 1, end: 2 }], updated_at: 1 },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, days_rolled: [] });
+});
+
+test("health-uptime-rollup-sync rolls up each valid day via PERCENTILE_CONT", async () => {
+  const res = await postHealthUptimeRollup(
+    {
+      days: [
+        dayBounds("2026-07-11", 1780000000000, 1780086400000),
+        dayBounds("2026-07-10", 1779913600000, 1780000000000),
+      ],
+      updated_at: 1780086400000,
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, days_rolled: ["2026-07-11", "2026-07-10"] });
+  expect(queryText()).toMatch(/INSERT INTO surface_uptime_daily\b/);
+  expect(queryText()).toMatch(/PERCENTILE_CONT\(0\.5\)/);
+  expect(queryText()).toMatch(/ON CONFLICT \(surface_id, day\) DO UPDATE/);
+});
+
+test("health-uptime-rollup-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  healthUptimeRollupSyncFailure.error = new Error("connection reset");
+  const res = await postHealthUptimeRollup(
+    { days: [dayBounds("2026-07-11", 1, 2)], updated_at: 1 },
     { secret: HEALTH_CHECKS_SYNC_SECRET },
   );
   expect(res.status).toBe(502);

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -12,6 +12,7 @@ import {
   D1_STATEMENTS_PER_BATCH,
   runHealthProber,
   syncHealthChecksToPostgres,
+  syncHealthUptimeRollupToPostgres,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
 } from "../src/health-prober.mjs";
@@ -2169,5 +2170,140 @@ describe("rollupDailyUptime (durable daily history)", () => {
       !order.some((o) => o.includes("DELETE FROM surface_checks")),
       "raw surface_checks must not be pruned when rollup fails",
     );
+  });
+});
+
+// #4832 gap-closure: syncHealthUptimeRollupToPostgres, exercised the same
+// way syncHealthChecksToPostgres is above -- indirectly through
+// rollupDailyUptime (private helper) -- proving the Postgres mirror attempt
+// fires (or safely no-ops) without affecting rollupDailyUptime's own
+// `rolled`/`days`/`error` result either way.
+describe("syncHealthUptimeRollupToPostgres", () => {
+  // rollupDailyUptime never calls this with an empty days array (it always
+  // computes exactly [today, yesterday]), so this guard is only reachable
+  // via a direct call, unlike the other tests below.
+  test("returns no_days for an empty or non-array days argument", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("{}") },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    assert.deepEqual(await syncHealthUptimeRollupToPostgres(env, [], 1), {
+      synced: false,
+      reason: "no_days",
+    });
+    assert.deepEqual(
+      await syncHealthUptimeRollupToPostgres(env, undefined, 1),
+      { synced: false, reason: "no_days" },
+    );
+  });
+
+  test("reports the upstream status when the DATA_API response isn't ok", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("nope", { status: 502 }) },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    assert.deepEqual(
+      await syncHealthUptimeRollupToPostgres(
+        env,
+        [{ date: "2026-06-13", start: 1, end: 2 }],
+        1,
+      ),
+      { synced: false, reason: "status_502" },
+    );
+  });
+});
+
+describe("syncHealthUptimeRollupToPostgres via rollupDailyUptime", () => {
+  test("no-ops (no DATA_API call) when DATA_API is not bound", async () => {
+    const result = await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: makeDb() },
+      { now: () => Date.UTC(2026, 5, 13, 10, 0, 0) },
+    );
+    assert.equal(result.rolled, true);
+  });
+
+  test("degrades to { rolled: false, error } when the batch throws a non-Error value", async () => {
+    // Exercises the `error?.message ?? error` fallback branch: a thrown
+    // plain string has no .message, unlike the sibling "d1 unavailable"
+    // Error test above.
+    const db = {
+      prepare: () => ({ bind: () => ({}) }),
+      async batch() {
+        throw "plain string failure";
+      },
+    };
+    const result = await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => Date.UTC(2026, 5, 13, 10, 0, 0) },
+    );
+    assert.deepEqual(result, {
+      rolled: false,
+      error: "plain string failure",
+    });
+  });
+
+  test("posts the UTC day boundaries to health-uptime-rollup-sync with the token header", async () => {
+    let request;
+    const env = {
+      METAGRAPH_HEALTH_DB: makeDb(),
+      DATA_API: {
+        fetch: async (req) => {
+          request = req;
+          return new Response("{}", { status: 200 });
+        },
+      },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    const fixedNow = Date.UTC(2026, 5, 13, 10, 0, 0);
+    const result = await rollupDailyUptime(env, { now: () => fixedNow });
+    assert.equal(result.rolled, true);
+    assert.ok(request);
+    assert.equal(request.method, "POST");
+    assert.equal(
+      request.headers.get("x-health-checks-sync-token"),
+      "test-secret",
+    );
+    const body = await request.json();
+    assert.equal(body.days.length, 2);
+    assert.equal(body.days[0].date, "2026-06-13");
+    assert.equal(body.updated_at, fixedNow);
+  });
+
+  test("a DATA_API failure never affects rollupDailyUptime's own result", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: makeDb(),
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    const result = await rollupDailyUptime(env, {
+      now: () => Date.UTC(2026, 5, 13, 10, 0, 0),
+    });
+    assert.equal(result.rolled, true);
+  });
+
+  test("still attempts the Postgres sync when D1's own rollup fails", async () => {
+    let called = false;
+    const db = {
+      prepare: () => ({ bind: () => ({}) }),
+      async batch() {
+        throw new Error("d1 unavailable");
+      },
+    };
+    const env = {
+      METAGRAPH_HEALTH_DB: db,
+      DATA_API: {
+        fetch: async () => ((called = true), new Response("{}")),
+      },
+      HEALTH_CHECKS_SYNC_SECRET: "test-secret",
+    };
+    const result = await rollupDailyUptime(env, {
+      now: () => Date.UTC(2026, 5, 13, 10, 0, 0),
+    });
+    assert.equal(result.rolled, false);
+    assert.equal(called, true);
   });
 });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1640,6 +1640,146 @@ async function handleHealthChecksSync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/health-uptime-rollup-sync (#4832 gap-closure) --
+//
+// Best-effort Postgres mirror of src/health-prober.mjs's rollupDailyUptime,
+// same shape/isolation as health-checks-sync above (reuses
+// HEALTH_CHECKS_SYNC_SECRET -- see that route's own header comment). Unlike
+// health-checks-sync, the request body carries only UTC day *boundaries*,
+// not precomputed rows -- this route computes the rollup itself from
+// surface_checks (already mirrored here by health-checks-sync), using
+// PERCENTILE_CONT for the p50/p95/p99 tail latency instead of replaying
+// D1/SQLite's rank-based CTE (src/health-sql.mjs's rankedChecksCte/
+// latencyStatColumns) column-for-column.
+const HEALTH_UPTIME_ROLLUP_SYNC_MAX_DAYS = 10;
+
+async function handleHealthUptimeRollupSync(request, env) {
+  if (!env.HEALTH_CHECKS_SYNC_SECRET) {
+    return writeJson(
+      { error: "health-checks sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(HEALTH_CHECKS_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.HEALTH_CHECKS_SYNC_SECRET)) {
+    return writeJson(
+      { error: `provide a valid ${HEALTH_CHECKS_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(await request.text());
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const days = Array.isArray(parsed?.days) ? parsed.days : null;
+  const updatedAt = Number(parsed?.updated_at);
+  if (!days || !Number.isFinite(updatedAt)) {
+    return writeJson(
+      { error: "body must be {days:[{date,start,end}...], updated_at}" },
+      400,
+    );
+  }
+  if (days.length > HEALTH_UPTIME_ROLLUP_SYNC_MAX_DAYS) {
+    return writeJson(
+      {
+        error: `at most ${HEALTH_UPTIME_ROLLUP_SYNC_MAX_DAYS} days per request`,
+      },
+      413,
+    );
+  }
+  const validDays = days.filter(
+    (d) =>
+      d &&
+      typeof d.date === "string" &&
+      /^\d{4}-\d{2}-\d{2}$/.test(d.date) &&
+      Number.isFinite(d.start) &&
+      Number.isFinite(d.end),
+  );
+  if (!validDays.length) {
+    return writeJson({ ok: true, days_rolled: [] });
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    return await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+      for (const { date, start, end } of validDays) {
+        await sql`
+        WITH ranked AS (
+          SELECT
+            surface_id,
+            COALESCE(surface_key, surface_id) AS surface_key,
+            netuid,
+            ok,
+            latency_ms
+          FROM surface_checks
+          WHERE checked_at >= ${start} AND checked_at < ${end}
+        )
+        INSERT INTO surface_uptime_daily
+          (surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
+           latency_samples, avg_latency_ms, p50_latency_ms, p95_latency_ms,
+           p99_latency_ms, status, updated_at)
+        SELECT
+          MAX(surface_id) AS surface_id,
+          surface_key,
+          netuid,
+          ${date}::date AS day,
+          COUNT(*) AS samples,
+          SUM(CASE WHEN ok THEN 1 ELSE 0 END) AS ok_count,
+          CASE
+            WHEN SUM(CASE WHEN ok THEN 1 ELSE 0 END) = COUNT(*) THEN 1.0
+            WHEN ROUND(SUM(CASE WHEN ok THEN 1 ELSE 0 END)::numeric / COUNT(*), 4) >= 1.0 THEN 0.9999
+            ELSE ROUND(SUM(CASE WHEN ok THEN 1 ELSE 0 END)::numeric / COUNT(*), 4)
+          END AS uptime_ratio,
+          COUNT(*) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS latency_samples,
+          ROUND(AVG(latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL))::int AS avg_latency_ms,
+          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p50_latency_ms,
+          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p95_latency_ms,
+          PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p99_latency_ms,
+          CASE
+            WHEN SUM(CASE WHEN ok THEN 1 ELSE 0 END) = COUNT(*) THEN 'ok'
+            WHEN SUM(CASE WHEN ok THEN 1 ELSE 0 END) = 0 THEN 'failed'
+            ELSE 'degraded'
+          END AS status,
+          ${updatedAt} AS updated_at
+        FROM ranked
+        GROUP BY surface_key, netuid
+        ON CONFLICT (surface_id, day) DO UPDATE SET
+          surface_key = excluded.surface_key,
+          netuid = excluded.netuid,
+          samples = excluded.samples,
+          ok_count = excluded.ok_count,
+          uptime_ratio = excluded.uptime_ratio,
+          latency_samples = excluded.latency_samples,
+          avg_latency_ms = excluded.avg_latency_ms,
+          p50_latency_ms = excluded.p50_latency_ms,
+          p95_latency_ms = excluded.p95_latency_ms,
+          p99_latency_ms = excluded.p99_latency_ms,
+          status = excluded.status,
+          updated_at = excluded.updated_at`;
+      }
+      return writeJson({
+        ok: true,
+        days_rolled: validDays.map((d) => d.date),
+      });
+    });
+  } catch (err) {
+    console.error("data-api health-uptime-rollup-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -1788,6 +1928,12 @@ export default {
       url.pathname === "/api/v1/internal/health-checks-sync"
     ) {
       return handleHealthChecksSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/health-uptime-rollup-sync"
+    ) {
+      return handleHealthUptimeRollupSync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);


### PR DESCRIPTION
## Summary

The last write-path piece of the health-tracking Postgres migration (#4832), following #4881's raw-checks dual-write.

- Adds `POST /api/v1/internal/health-uptime-rollup-sync` (`workers/data-api.mjs`, `handleHealthUptimeRollupSync`) and calls it from `src/health-prober.mjs`'s `rollupDailyUptime` via a new `syncHealthUptimeRollupToPostgres` helper.
- Unlike `health-checks-sync`, this route doesn't receive precomputed rows -- it ships only the UTC day boundaries, and **Postgres computes its own rollup directly from its own `surface_checks`** (already populated by the sibling sync), using `PERCENTILE_CONT` for the p50/p95/p99 tail latency instead of replaying D1/SQLite's rank-based CTE (`src/health-sql.mjs`'s `rankedChecksCte`/`latencyStatColumns`) column-for-column.
- **Live-verified** the `PERCENTILE_CONT(...) FILTER (WHERE ...)` syntax executes cleanly against production Postgres before committing to it.
- Reuses `HEALTH_CHECKS_SYNC_SECRET` (same conceptual sync boundary, fires from the same hourly cron right alongside `health-checks-sync`) rather than provisioning a new secret.
- The Postgres sync is attempted independently of D1's own rollup outcome -- Postgres doesn't depend on D1's rolled-up rows, so a D1 failure never blocks attempting the Postgres side and vice versa.

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` all clean
- `npx vitest run` -- 7599/7599 passing (full local suite; one earlier run under heavy background load flaked on 2 unrelated tests, confirmed clean on retry)
- `npm run test:coverage` + patch-diff isolation against `origin/main` -- zero uncovered added lines/branches in both touched files
- New tests cover: auth, validation (malformed JSON, missing fields, day cap, malformed-day skip), the happy-path rollup (asserts `PERCENTILE_CONT` + `ON CONFLICT (surface_id, day)` appear), DB-failure-to-502 mapping, and (via `rollupDailyUptime`) that the Postgres sync fires independently of D1's own success/failure