### PR TITLE
feat(health): add Postgres read routes for the last D1-only health handlers

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4746,3 +4746,169 @@ test("GET /api/v1/chain/fees: call_module filter reuses the same moduleClause ac
   expect(res.status).toBe(200);
   expect(queryText()).toContain("call_module = ");
 });
+
+// #4832 gap-closure: health-tracking read routes. All 5 read from
+// surface_checks/surface_uptime_daily -- populated by the health-checks-sync
+// / health-uptime-rollup-sync write routes -- and are gated behind the
+// deliberately-unflipped METAGRAPH_HEALTH_SOURCE flag (see
+// handleBulkHealthTrends' own header comment in
+// workers/request-handlers/analytics.mjs), so these tests only prove the
+// SQL/routing wiring, matching every other route's test style regardless.
+
+test("GET /api/v1/health/trends: aggregates surface_uptime_daily into 7d/30d windows", async () => {
+  mockQueue.current = [
+    [], // session-scoped SET statement_timeout
+    [
+      {
+        netuid: 7,
+        date: "2026-07-10",
+        total: 100,
+        ok_count: 98,
+        latency_samples: 96,
+        avg_latency_ms: 120,
+      },
+    ],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/health/trends");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.windows["7d"].subnets[0].netuid).toBe(7);
+});
+
+test("GET /api/v1/health/trends on a cold store returns a schema-stable empty matrix", async () => {
+  mockQueue.current = [[], [], []];
+  const res = await req("/api/v1/health/trends");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.windows["7d"].subnet_count).toBe(0);
+});
+
+test("GET /api/v1/subnets/:netuid/health/trends: merges the 7d+30d PERCENTILE_CONT windows", async () => {
+  mockQueue.current = [
+    [],
+    [
+      {
+        surface_id: "sn-7-api",
+        total: 10,
+        ok_count: 9,
+        latency_samples: 9,
+        avg_latency_ms: 100,
+        p50: 90,
+        p95: 150,
+        p99: 180,
+      },
+    ],
+    [
+      {
+        surface_id: "sn-7-api",
+        total: 40,
+        ok_count: 38,
+        latency_samples: 38,
+        avg_latency_ms: 105,
+        p50: 92,
+        p95: 155,
+        p99: 190,
+      },
+    ],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/subnets/7/health/trends");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.netuid).toBe(7);
+  expect(body.windows["7d"].surfaces[0].surface_id).toBe("sn-7-api");
+  expect(body.windows["30d"].surfaces[0].samples).toBe(40);
+});
+
+test("GET /api/v1/subnets/:netuid/health/percentiles: p50/p95/p99 via PERCENTILE_CONT", async () => {
+  mockQueue.current = [
+    [],
+    [
+      {
+        surface_id: "sn-7-api",
+        latency_samples: 20,
+        avg_latency_ms: 110,
+        min_latency_ms: 40,
+        max_latency_ms: 300,
+        p50: 100,
+        p95: 200,
+        p99: 280,
+      },
+    ],
+    [{ newest_observed: "1780000000000" }],
+  ];
+  const res = await req("/api/v1/subnets/7/health/percentiles?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces[0].latency_ms.p99).toBe(280);
+});
+
+test("GET /api/v1/subnets/:netuid/health/percentiles on a cold store returns surfaces:[]", async () => {
+  mockQueue.current = [[], [], []];
+  const res = await req("/api/v1/subnets/7/health/percentiles");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces).toEqual([]);
+});
+
+test("GET /api/v1/subnets/:netuid/health/incidents: SLA rollup + gap-island incidents", async () => {
+  mockQueue.current = [
+    [],
+    [{ surface_id: "sn-7-api", total: 100, ok_count: 92 }],
+    [
+      {
+        surface_id: "sn-7-api",
+        surface_key: "sn-7-api",
+        started_at: "1780000000000",
+        ended_at: "1780000600000",
+        failed_samples: 3,
+      },
+    ],
+    [{ newest_observed: "1780000600000" }],
+  ];
+  const res = await req("/api/v1/subnets/7/health/incidents?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces[0].incident_count).toBe(1);
+  expect(body.surfaces[0].incidents[0].failed_samples).toBe(3);
+});
+
+test("GET /api/v1/subnets/:netuid/health/incidents on a cold store returns surfaces:[]", async () => {
+  mockQueue.current = [[], [], [], []];
+  const res = await req("/api/v1/subnets/7/health/incidents");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces).toEqual([]);
+});
+
+test("GET /api/v1/incidents: global gap-island ledger across every subnet", async () => {
+  mockQueue.current = [
+    [],
+    [
+      {
+        netuid: 7,
+        surface_id: "sn-7-api",
+        surface_key: "sn-7-api",
+        started_at: "1780000000000",
+        ended_at: "1780000600000",
+        failed_samples: 2,
+      },
+    ],
+    [{ newest_observed: "1780000600000" }],
+  ];
+  const res = await req("/api/v1/incidents?window=7d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces[0].netuid).toBe(7);
+  expect(body.summary.incident_count).toBe(1);
+});
+
+test("GET /api/v1/incidents on a cold store returns a schema-stable empty ledger", async () => {
+  mockQueue.current = [[], [], []];
+  const res = await req("/api/v1/incidents");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.summary.incident_count).toBe(0);
+  expect(body.surfaces).toEqual([]);
+});

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -1922,3 +1922,201 @@ describe("chain analytics extrinsics-derived: postgres tier wiring", () => {
     });
   }
 });
+
+// #4832 gap-closure: METAGRAPH_HEALTH_SOURCE is a NEW flag, deliberately
+// left unset in wrangler.jsonc (see handleBulkHealthTrends' own header
+// comment) -- these tests only prove the wiring, not a live flip.
+describe("health analytics: postgres tier wiring", () => {
+  test("handleBulkHealthTrends: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, windows: { "7d": {}, "30d": {} } }),
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const res = await handleBulkHealthTrends(
+      req("/api/v1/health/trends"),
+      env,
+      url("/api/v1/health/trends"),
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+    assert.equal(d1Called, false);
+  });
+
+  test("handleBulkHealthTrends: flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const p = "/api/v1/health/trends";
+    const res = await handleBulkHealthTrends(req(p), env, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+  });
+
+  test("handleHealthTrends: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, netuid: NETUID, windows: {} }),
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const p = `/api/v1/subnets/${NETUID}/health/trends`;
+    const res = await handleHealthTrends(req(p), env, NETUID, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(d1Called, false);
+  });
+
+  test("handleHealthTrends: flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const p = `/api/v1/subnets/${NETUID}/health/trends`;
+    const res = await handleHealthTrends(req(p), env, NETUID, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+  });
+
+  test("handleHealthPercentiles: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, netuid: NETUID, surfaces: [] }),
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const p = `/api/v1/subnets/${NETUID}/health/percentiles?window=7d`;
+    const res = await handleHealthPercentiles(req(p), env, NETUID, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(d1Called, false);
+  });
+
+  test("handleHealthPercentiles: flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const p = `/api/v1/subnets/${NETUID}/health/percentiles?window=7d`;
+    const res = await handleHealthPercentiles(req(p), env, NETUID, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+  });
+
+  test("handleHealthIncidents: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, netuid: NETUID, surfaces: [] }),
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const p = `/api/v1/subnets/${NETUID}/health/incidents?window=7d`;
+    const res = await handleHealthIncidents(req(p), env, NETUID, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(d1Called, false);
+  });
+
+  test("handleHealthIncidents: flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const p = `/api/v1/subnets/${NETUID}/health/incidents?window=7d`;
+    const res = await handleHealthIncidents(req(p), env, NETUID, url(p), ctx);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+  });
+
+  test("handleGlobalIncidents: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          summary: { incident_count: 0 },
+          surfaces: [],
+        }),
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const p = "/api/v1/incidents?window=7d";
+    const res = await handleGlobalIncidents(req(p), env, url(p));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+    assert.equal(d1Called, false);
+  });
+
+  test("handleGlobalIncidents: flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const p = "/api/v1/incidents?window=7d";
+    const res = await handleGlobalIncidents(req(p), env, url(p));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.schema_version, 1);
+  });
+});

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -215,7 +215,23 @@ import {
   buildCounterpartyRelationship,
   COUNTERPARTIES_SCAN_CAP,
 } from "../src/counterparties.mjs";
-import { ANALYTICS_WINDOWS, DEFAULT_ANALYTICS_WINDOW } from "./config.mjs";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+  HEALTH_TREND_WINDOWS,
+  MAX_BULK_TREND_ROWS,
+  MAX_INCIDENT_ROWS,
+  MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+} from "./config.mjs";
+import {
+  formatBulkTrends,
+  formatTrends,
+  formatPercentiles,
+  formatIncidents,
+  formatGlobalIncidents,
+  INCIDENT_GAP_MS,
+  MIN_INCIDENT_SAMPLES,
+} from "../src/health-serving.mjs";
 import {
   buildChainWeights,
   CHAIN_WEIGHTS_LIMIT_DEFAULT,
@@ -3530,6 +3546,266 @@ export default {
               dailyRows,
               medianRows,
               payerRows,
+            }),
+          );
+        }
+
+        // GET /api/v1/health/trends (#4832 gap-closure): all-subnet 7d/30d
+        // daily uptime + latency matrix from the daily rollup, mirroring
+        // src/bulk-health-trends.mjs's loadBulkHealthTrends. Reads
+        // surface_uptime_daily -- populated by the health-uptime-rollup-sync
+        // write route (#4885), not surface_checks -- so this route stays
+        // cheap regardless of the raw window's size.
+        const bulkHealthTrends = url.pathname.match(
+          /^\/api\/v1\/health\/trends$/,
+        );
+        if (bulkHealthTrends) {
+          const now = Date.now();
+          const maxWindowDays = Math.max(
+            ...Object.values(HEALTH_TREND_WINDOWS),
+          );
+          const cutoffDay = new Date(now - maxWindowDays * ANALYTICS_DAY_MS)
+            .toISOString()
+            .slice(0, 10);
+          const rows = await sql`
+          SELECT netuid, day::text AS date, SUM(samples) AS total, SUM(ok_count) AS ok_count,
+                 SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END) AS latency_samples,
+                 CASE WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END) > 0
+                   THEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * COALESCE(latency_samples, samples) ELSE 0 END)::float8
+                        / SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END)
+                   ELSE NULL END AS avg_latency_ms
+          FROM surface_uptime_daily WHERE day >= ${cutoffDay}::date
+          GROUP BY netuid, day ORDER BY netuid, day LIMIT ${MAX_BULK_TREND_ROWS}`;
+          const freshRows = await sql`
+          SELECT MAX(updated_at) AS newest_observed
+          FROM surface_uptime_daily WHERE day >= ${cutoffDay}::date`;
+          const windows = {};
+          for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
+            const windowCutoff = new Date(now - days * ANALYTICS_DAY_MS)
+              .toISOString()
+              .slice(0, 10);
+            windows[label] = rows.filter(
+              (row) => String(row.date) >= windowCutoff,
+            );
+          }
+          return json(
+            formatBulkTrends({
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              windows,
+              windowDays: HEALTH_TREND_WINDOWS,
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/health/trends (#4832 gap-closure):
+        // per-subnet 7d/30d uptime + latency trends from the raw
+        // surface_checks window, mirroring src/analytics-live.mjs's
+        // loadSubnetHealthTrends. `ok` is BOOLEAN here (D1's `ok = 1`
+        // becomes a bare `ok`); the SQLite rank-based p50/p95/p99 pick
+        // (src/health-sql.mjs's latencyStatColumns) becomes PERCENTILE_CONT
+        // -- live-verified via psql (2026-07-11) at sub-millisecond cost
+        // against current production volume (~350 rows across 117 surfaces,
+        // 30 min of the 15-min cron so far).
+        const subnetHealthTrends = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/health\/trends$/,
+        );
+        if (subnetHealthTrends) {
+          const netuid = Number(subnetHealthTrends[1]);
+          const now = Date.now();
+          const windows = {};
+          for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
+            const cutoff = now - days * ANALYTICS_DAY_MS;
+            windows[label] = await sql`
+            SELECT MAX(surface_id) AS surface_id,
+                   COUNT(*) AS total,
+                   SUM(CASE WHEN ok THEN 1 ELSE 0 END) AS ok_count,
+                   COUNT(*) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS latency_samples,
+                   AVG(latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS avg_latency_ms,
+                   PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p50,
+                   PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p95,
+                   PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p99
+            FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${cutoff}
+            GROUP BY COALESCE(surface_key, surface_id)`;
+          }
+          const freshRows = await sql`
+          SELECT MAX(checked_at) AS newest_observed
+          FROM surface_checks WHERE netuid = ${netuid}`;
+          return json(
+            formatTrends({
+              netuid,
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              windows,
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/health/percentiles?window= (#4832
+        // gap-closure): p50/p95/p99 + avg/min/max latency per surface,
+        // mirroring src/analytics-live.mjs's loadSubnetPercentiles.
+        const subnetHealthPercentiles = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/health\/percentiles$/,
+        );
+        if (subnetHealthPercentiles) {
+          const netuid = Number(subnetHealthPercentiles[1]);
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const rows = await sql`
+          SELECT MAX(surface_id) AS surface_id,
+                 COUNT(*) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS latency_samples,
+                 AVG(latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS avg_latency_ms,
+                 MIN(latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS min_latency_ms,
+                 MAX(latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS max_latency_ms,
+                 PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p50,
+                 PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p95,
+                 PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY latency_ms) FILTER (WHERE ok AND latency_ms IS NOT NULL) AS p99
+          FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${cutoff}
+          GROUP BY COALESCE(surface_key, surface_id)
+          HAVING COUNT(*) FILTER (WHERE ok AND latency_ms IS NOT NULL) > 0`;
+          const freshRows = await sql`
+          SELECT MAX(checked_at) AS newest_observed
+          FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${cutoff}`;
+          return json(
+            formatPercentiles({
+              netuid,
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              rows,
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/health/incidents?window= (#4832
+        // gap-closure): per-surface SLA + reconstructed downtime incidents,
+        // mirroring src/analytics-live.mjs's loadSubnetIncidents. The
+        // gap-island grouping (LAG/window functions) is syntactically
+        // near-identical between SQLite and Postgres -- live-verified via
+        // psql (2026-07-11) -- the only real adaptation is `ok` being
+        // BOOLEAN here (`ok = 1`/`ok = 0` become bare `ok`/`NOT ok`).
+        const subnetHealthIncidents = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/health\/incidents$/,
+        );
+        if (subnetHealthIncidents) {
+          const netuid = Number(subnetHealthIncidents[1]);
+          const since = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const slaRows = await sql`
+          SELECT MAX(surface_id) AS surface_id,
+                 COUNT(*) AS total,
+                 SUM(CASE WHEN ok THEN 1 ELSE 0 END) AS ok_count
+          FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${since}
+          GROUP BY COALESCE(surface_key, surface_id)`;
+          const incidentRows = await sql`
+          WITH checks AS (
+            SELECT COALESCE(surface_key, surface_id) AS surface_key,
+                   surface_id, checked_at, ok,
+                   checked_at - LAG(checked_at)
+                     OVER (PARTITION BY COALESCE(surface_key, surface_id) ORDER BY checked_at) AS gap
+            FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${since}
+          ),
+          grouped AS (
+            SELECT surface_key, surface_id, checked_at, ok,
+                   SUM(CASE WHEN ok OR gap IS NULL OR gap > ${INCIDENT_GAP_MS} THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
+            FROM checks
+          ),
+          incidents AS (
+            SELECT MAX(surface_id) AS surface_id, surface_key,
+                   MIN(checked_at) AS started_at, MAX(checked_at) AS ended_at,
+                   COUNT(*) AS failed_samples
+            FROM grouped WHERE NOT ok
+            GROUP BY surface_key, grp
+            HAVING COUNT(*) >= ${MIN_INCIDENT_SAMPLES}
+          )
+          SELECT surface_id, surface_key, started_at, ended_at, failed_samples
+          FROM (
+            SELECT surface_id, surface_key, started_at, ended_at, failed_samples,
+                   ROW_NUMBER() OVER (PARTITION BY surface_key ORDER BY started_at) AS rn
+            FROM incidents
+          ) ranked
+          WHERE rn <= ${MAX_INCIDENT_ROWS}
+          ORDER BY surface_id, started_at`;
+          const freshRows = await sql`
+          SELECT MAX(checked_at) AS newest_observed
+          FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${since}`;
+          return json(
+            formatIncidents({
+              netuid,
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              slaRows,
+              incidentRows,
+              maxIncidents: MAX_INCIDENT_ROWS,
+            }),
+          );
+        }
+
+        // GET /api/v1/incidents?window= (#4832 gap-closure): global,
+        // cross-subnet incident ledger -- the same gap-island grouping as
+        // the per-subnet route above but with no netuid filter, grouped by
+        // (netuid, surface_key) and capped to the newest
+        // MAX_GLOBAL_INCIDENT_SOURCE_ROWS checks, mirroring
+        // GLOBAL_INCIDENTS_SQL in workers/request-handlers/analytics.mjs.
+        const globalIncidents = url.pathname.match(/^\/api\/v1\/incidents$/);
+        if (globalIncidents) {
+          const since = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const incidentRows = await sql`
+          WITH recent_checks AS (
+            SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key,
+                   surface_id, checked_at, ok
+            FROM surface_checks WHERE checked_at >= ${since}
+            ORDER BY checked_at DESC LIMIT ${MAX_GLOBAL_INCIDENT_SOURCE_ROWS}
+          ),
+          checks AS (
+            SELECT netuid, surface_key, surface_id, checked_at, ok,
+                   checked_at - LAG(checked_at)
+                     OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS gap
+            FROM recent_checks
+          ),
+          grouped AS (
+            SELECT netuid, surface_key, surface_id, checked_at, ok,
+                   SUM(CASE WHEN ok OR gap IS NULL OR gap > ${INCIDENT_GAP_MS} THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
+            FROM checks
+          )
+          SELECT netuid, MAX(surface_id) AS surface_id, surface_key,
+                 MIN(checked_at) AS started_at, MAX(checked_at) AS ended_at,
+                 COUNT(*) AS failed_samples
+          FROM grouped WHERE NOT ok
+          GROUP BY netuid, surface_key, grp
+          HAVING COUNT(*) >= ${MIN_INCIDENT_SAMPLES}
+          ORDER BY started_at DESC
+          LIMIT ${MAX_INCIDENT_ROWS}`;
+          const freshRows = await sql`
+          SELECT MAX(checked_at) AS newest_observed
+          FROM surface_checks WHERE checked_at >= ${since}`;
+          return json(
+            formatGlobalIncidents({
+              window: windowLabelFor(
+                url,
+                ANALYTICS_WINDOWS,
+                DEFAULT_ANALYTICS_WINDOW,
+              ),
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              incidentRows,
+              maxIncidents: MAX_INCIDENT_ROWS,
             }),
           );
         }

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -477,9 +477,25 @@ export async function handleBulkHealthTrends(
 
   return withEdgeCache(request, ctx, env, "bulk-trends", async () => {
     const meta = await readHealthMetaKv(env);
-    const { data, rows } = await loadBulkHealthTrends(d1Runner(env), {
-      observedAt: meta?.last_run_at || null,
-    });
+    // #4832 gap-closure: METAGRAPH_HEALTH_SOURCE is a NEW flag (unlike every
+    // other tier's tryPostgresTier wiring this session, which reused an
+    // already-flipped flag on an already-backfilled table) -- surface_checks/
+    // surface_uptime_daily only started accumulating from the dual-write
+    // landing (#4881/#4885), with no historical backfill. Left unset in
+    // wrangler.jsonc deliberately: an empty/short Postgres window is still a
+    // valid 200 response, so tryPostgresTier's error-only fallback can't
+    // detect "technically fine but missing D1's history" the way it detects
+    // a hard failure. Flip only once Postgres has accumulated a real 30-day
+    // window.
+    let isFallback = false;
+    let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
+    if (!data) {
+      const result = await loadBulkHealthTrends(d1Runner(env), {
+        observedAt: meta?.last_run_at || null,
+      });
+      data = result.data;
+      isFallback = hasD1FallbackRows(result.rows);
+    }
     const response = await envelopeResponse(
       request,
       {
@@ -495,9 +511,7 @@ export async function handleBulkHealthTrends(
       },
       "short",
     );
-    return hasD1FallbackRows(rows)
-      ? markD1FallbackResponse(response)
-      : response;
+    return isFallback ? markD1FallbackResponse(response) : response;
   });
 }
 
@@ -513,21 +527,27 @@ export async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
   return withEdgeCache(request, ctx, env, "trends", async () => {
-    // Read through the shared d1All (rather than handing the loader the bare
-    // db) so a failure is still logged + marked as a D1 fallback (the
-    // dark-serve log contract) — usedFallback tracks it across the loader's
-    // parallel per-window reads since the formatted result no longer exposes
-    // the raw row arrays hasD1FallbackRows used to check.
+    // See handleBulkHealthTrends' own comment: METAGRAPH_HEALTH_SOURCE is a
+    // new, deliberately-unflipped flag pending Postgres accumulating a real
+    // history window.
     let usedFallback = false;
-    const d1 = async (sql, params) => {
-      const rows = await d1All(env, sql, params);
-      if (hasD1FallbackRows(rows)) usedFallback = true;
-      return rows;
-    };
-    const meta = await readHealthMetaKv(env);
-    const data = await loadSubnetHealthTrends(d1, netuid, {
-      observedAt: meta?.last_run_at || null,
-    });
+    let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
+    if (!data) {
+      // Read through the shared d1All (rather than handing the loader the bare
+      // db) so a failure is still logged + marked as a D1 fallback (the
+      // dark-serve log contract) — usedFallback tracks it across the loader's
+      // parallel per-window reads since the formatted result no longer exposes
+      // the raw row arrays hasD1FallbackRows used to check.
+      const d1 = async (sql, params) => {
+        const rows = await d1All(env, sql, params);
+        if (hasD1FallbackRows(rows)) usedFallback = true;
+        return rows;
+      };
+      const meta = await readHealthMetaKv(env);
+      data = await loadSubnetHealthTrends(d1, netuid, {
+        observedAt: meta?.last_run_at || null,
+      });
+    }
     const response = await envelopeResponse(
       request,
       {
@@ -565,20 +585,25 @@ export async function handleHealthPercentiles(
     env,
     "percentiles",
     async () => {
-      // Wrap d1All so a failure is still logged + marked as a D1 fallback (the
-      // dark-serve contract), since the formatted result no longer exposes the
-      // raw rows hasD1FallbackRows used to check (mirrors handleHealthTrends).
+      // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
       let usedFallback = false;
-      const d1 = async (sql, params) => {
-        const rows = await d1All(env, sql, params);
-        if (hasD1FallbackRows(rows)) usedFallback = true;
-        return rows;
-      };
-      const meta = await readHealthMetaKv(env);
-      const data = await loadSubnetPercentiles(d1, netuid, {
-        window: label,
-        observedAt: meta?.last_run_at || null,
-      });
+      let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
+      if (!data) {
+        // Wrap d1All so a failure is still logged + marked as a D1 fallback
+        // (the dark-serve contract), since the formatted result no longer
+        // exposes the raw rows hasD1FallbackRows used to check (mirrors
+        // handleHealthTrends).
+        const d1 = async (sql, params) => {
+          const rows = await d1All(env, sql, params);
+          if (hasD1FallbackRows(rows)) usedFallback = true;
+          return rows;
+        };
+        const meta = await readHealthMetaKv(env);
+        data = await loadSubnetPercentiles(d1, netuid, {
+          window: label,
+          observedAt: meta?.last_run_at || null,
+        });
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -613,21 +638,25 @@ export async function handleHealthIncidents(
     env,
     "incidents",
     async () => {
-      // Wrap d1All so a failure in either read is still logged + marked as a D1
-      // fallback (the dark-serve contract), since the formatted result no longer
-      // exposes the raw row arrays hasD1FallbackRows used to check (mirrors
-      // handleHealthTrends / handleHealthPercentiles).
+      // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
       let usedFallback = false;
-      const d1 = async (sql, params) => {
-        const rows = await d1All(env, sql, params);
-        if (hasD1FallbackRows(rows)) usedFallback = true;
-        return rows;
-      };
-      const meta = await readHealthMetaKv(env);
-      const data = await loadSubnetIncidents(d1, netuid, {
-        window: label,
-        observedAt: meta?.last_run_at || null,
-      });
+      let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
+      if (!data) {
+        // Wrap d1All so a failure in either read is still logged + marked
+        // as a D1 fallback (the dark-serve contract), since the formatted
+        // result no longer exposes the raw row arrays hasD1FallbackRows
+        // used to check (mirrors handleHealthTrends / handleHealthPercentiles).
+        const d1 = async (sql, params) => {
+          const rows = await d1All(env, sql, params);
+          if (hasD1FallbackRows(rows)) usedFallback = true;
+          return rows;
+        };
+        const meta = await readHealthMetaKv(env);
+        data = await loadSubnetIncidents(d1, netuid, {
+          window: label,
+          observedAt: meta?.last_run_at || null,
+        });
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -726,10 +755,16 @@ export async function handleGlobalIncidents(request, env, url) {
   if (error) {
     return analyticsQueryError(error);
   }
-  const { data, incidentRows } = await loadGlobalIncidentsLedger(env, {
-    label,
-    days,
-  });
+  // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE. Only
+  // this REST handler is wired -- loadGlobalIncidentsLedger's other caller
+  // (a content feed, workers/api.mjs) stays D1-only, out of scope here.
+  let isFallback = false;
+  let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
+  if (!data) {
+    const result = await loadGlobalIncidentsLedger(env, { label, days });
+    data = result.data;
+    isFallback = hasD1FallbackRows(result.incidentRows);
+  }
   const response = await envelopeResponse(
     request,
     {
@@ -742,9 +777,7 @@ export async function handleGlobalIncidents(request, env, url) {
     },
     "short",
   );
-  return hasD1FallbackRows(incidentRows)
-    ? markD1FallbackResponse(response)
-    : response;
+  return isFallback ? markD1FallbackResponse(response) : response;
 }
 
 // Explicit CSV column order for the chain-analytics ?format=csv exports (#2532).


### PR DESCRIPTION
## Summary

The read side of the health-tracking Postgres migration (#4832) -- the final piece of the #4832 sweep.

- Wires `handleBulkHealthTrends`, `handleHealthTrends`, `handleHealthPercentiles`, `handleHealthIncidents`, and `handleGlobalIncidents` onto `tryPostgresTier`, and adds the matching `GET /api/v1/health/trends`, `/api/v1/subnets/:netuid/health/{trends,percentiles,incidents}`, and `/api/v1/incidents` routes to `workers/data-api.mjs`.
- The SQLite rank-based percentile pick (`src/health-sql.mjs`'s `rankedChecksCte`/`latencyStatColumns`) becomes `PERCENTILE_CONT ... FILTER (WHERE ...)`; the gap-island incident grouping (`LAG`/window functions) is syntactically near-identical between SQLite and Postgres -- the only real adaptation is `ok` being BOOLEAN here instead of D1's INTEGER 0/1.
- **Every query was live-verified via psql against production** before writing this code (2026-07-11) -- both for correctness (against real `surface_checks` rows written by #4881's dual-write) and for the `PERCENTILE_CONT` + `FILTER` combination executing cleanly.

### On the flag

Uses a **new** flag, `METAGRAPH_HEALTH_SOURCE`, **deliberately left unset** in `wrangler.jsonc`. Unlike every other tier's read migration this session (which reused an already-flipped flag on an already-backfilled table), `surface_checks`/`surface_uptime_daily` only started accumulating from the dual-write PRs (#4881/#4885) landing tonight -- there's no historical backfill. An empty or short Postgres window is still a valid 200 response, so `tryPostgresTier`'s error-only fallback can't detect "technically fine but missing D1's history" the way it detects a hard failure. Flipping the flag now would silently serve incomplete health data where D1 currently has real history. **The flag should be flipped once Postgres has accumulated a genuine 30-day window** -- a manual follow-up, not part of this PR.

`handleGlobalIncidents`' `loadGlobalIncidentsLedger` has a second caller (a content feed in `workers/api.mjs`) that stays D1-only, out of scope here -- only the REST handler itself is wired.

Refs #4832

## Test plan

- `npm run lint` / `npx prettier --check` / `npm run scan:public-safety` all clean
- `npx vitest run` -- 7618/7618 passing (full local suite)
- `npm run test:coverage` + patch-diff isolation against `origin/main` -- zero uncovered added lines/branches in both touched files
- New postgres-tier wiring tests (10) confirm a Postgres hit is served as-is with D1 never queried, and a Postgres failure falls back to D1, for all 5 handlers
- New `workers/data-api.mjs` route tests (10) cover the happy path and cold-store (schema-stable empty payload) for all 5 routes, including asserting the `PERCENTILE_CONT` window-function output flows through to the formatted response