### PR TITLE
fix(ui): keep the account address box copy icon inside the mobile viewport

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -197,8 +197,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
               Cross-subnet registrations, first-party chain events, and daily activity rollups for
               one Bittensor account.
             </p>
-            <div className="max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
-              <CopyableCode value={ss58} truncate={false} />
+            <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+              <CopyableCode value={ss58} truncate={false} className="max-w-full" />
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary

On `/accounts/$ss58` at mobile width, the account address box rendered the full untruncated ss58 inside an `inline-flex` `CopyableCode` button that had no width cap. The button overflowed its `max-w-fit` container (measured button right edge **383px at a 375px viewport**, container `overflow-x: visible`), pushing the trailing copy-to-clipboard icon off the right edge — the primary identifier control on the page was clipped and not fully tappable.

## Change

One file: `apps/ui/src/routes/accounts.$ss58.tsx` (the hero address box only).

- Container: `max-w-fit` → `max-w-full sm:max-w-fit` — caps the box at the viewport on mobile while preserving the desktop "hug the address" look at `sm+`.
- Button: pass `className="max-w-full"` to `CopyableCode` so the inline-flex button clamps to its container; the ss58 (already `truncate` on mobile) then ellipsizes and the `shrink-0` copy icon stays fully inside the viewport.

Measured after: button right edge **346px** (was 383px) at 375px. No query/logic change; desktop and tablet rendering are unchanged.

Closes #3944

## Screenshots

Address box on `/accounts/5F4tQyWrhf…`, three viewports × both themes. Theme forced via `localStorage.setItem("mg-theme", …)`. **Before** = `upstream/main`; **After** = this branch.

> **Where to look:** at **mobile (375px)**, *before* the ss58 runs to the edge and the copy icon is entirely off-screen; *after* it truncates with an ellipsis and the copy icon is fully visible with right padding. Desktop/tablet are unchanged (the address fits at those widths) and are included to show no regression.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3944-assets/3944/after-mobile-dark.png) |

## Validation

- `tsc --noEmit` clean; `prettier --check` clean; `eslint` no new errors.
- Verified live (built + served, Playwright at 375px): copy button right edge 383px → 346px, icon fully within viewport.