### PR TITLE
feat(health): wire handleUptime to the Postgres tier

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4956,6 +4956,21 @@ test("GET /api/v1/subnets/:netuid/uptime: min_samples adds a HAVING clause", asy
   expect(body.surfaces).toEqual([]);
 });
 
+test("GET /api/v1/subnets/:netuid/uptime: malformed min_samples degrades to no filter instead of NaN", async () => {
+  mockQueue.current = [
+    [],
+    [], // havingClause construction (min_samples unparseable -> sql``, same as absent)
+    [],
+    [{ newest_observed: null }],
+  ];
+  const res = await req("/api/v1/subnets/7/uptime?min_samples=abc");
+  expect(res.status).toBe(200);
+  const boundValues = sqlCalls.flatMap((call) => call.values);
+  expect(
+    boundValues.some((v) => typeof v === "number" && Number.isNaN(v)),
+  ).toBe(false);
+});
+
 test("GET /api/v1/subnets/:netuid/uptime on a cold store returns surfaces:[]", async () => {
   mockQueue.current = [[], [], [], []];
   const res = await req("/api/v1/subnets/7/uptime");

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4912,3 +4912,62 @@ test("GET /api/v1/incidents on a cold store returns a schema-stable empty ledger
   expect(body.summary.incident_count).toBe(0);
   expect(body.surfaces).toEqual([]);
 });
+
+test("GET /api/v1/subnets/:netuid/uptime: aggregates surface_uptime_daily by day", async () => {
+  mockQueue.current = [
+    [], // session-scoped SET statement_timeout
+    [], // havingClause construction (min_samples absent -> sql``)
+    [
+      {
+        surface_id: "sn-7-api",
+        surface_key: "sn-7-api",
+        day: "2026-06-01",
+        samples: 10,
+        ok_count: 9,
+        uptime_ratio: 0.9,
+        latency_samples: 10,
+        avg_latency_ms: 120,
+        p50: 100,
+        p95: 200,
+        p99: 250,
+        status: "degraded",
+      },
+    ],
+    [{ newest_observed: "1780000600000" }],
+  ];
+  const res = await req("/api/v1/subnets/7/uptime?window=1y");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("1y");
+  expect(body.surfaces[0].surface_id).toBe("sn-7-api");
+  expect(body.surfaces[0].days[0].uptime_ratio).toBe(0.9);
+});
+
+test("GET /api/v1/subnets/:netuid/uptime: min_samples adds a HAVING clause", async () => {
+  mockQueue.current = [
+    [],
+    [], // havingClause construction (min_samples present -> real fragment)
+    [],
+    [{ newest_observed: null }],
+  ];
+  const res = await req("/api/v1/subnets/7/uptime?min_samples=5");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces).toEqual([]);
+});
+
+test("GET /api/v1/subnets/:netuid/uptime on a cold store returns surfaces:[]", async () => {
+  mockQueue.current = [[], [], [], []];
+  const res = await req("/api/v1/subnets/7/uptime");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.surfaces).toEqual([]);
+});
+
+test("GET /api/v1/subnets/:netuid/uptime: unrecognized window falls back to 90d", async () => {
+  mockQueue.current = [[], [], [], []];
+  const res = await req("/api/v1/subnets/7/uptime?window=bogus");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("90d");
+});

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -550,6 +550,57 @@ describe("handleUptime", () => {
     assert.equal(body.data.surfaces[0].surface_id, "sn-7-acme-subnet-api");
     assert.equal(body.data.surfaces[0].days[0].uptime_ratio, 0.9);
   });
+
+  // #4832 gap-closure: METAGRAPH_HEALTH_SOURCE is a NEW flag, deliberately
+  // left unset in wrangler.jsonc (see handleBulkHealthTrends' own header
+  // comment in analytics.mjs) -- these tests only prove the wiring, not a
+  // live flip.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = d1Env();
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ netuid: NETUID, window: "90d", surfaces: [] }),
+    };
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    const body = await json(
+      await handleUptime(
+        req(`/api/v1/subnets/${NETUID}/uptime`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/uptime`),
+      ),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.deepEqual(body.data.surfaces, []);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = d1Env();
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const body = await json(
+      await handleUptime(
+        req(`/api/v1/subnets/${NETUID}/uptime`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/uptime`),
+      ),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.deepEqual(body.data.surfaces, []);
+  });
 });
 
 describe("handleLeaderboards", () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -3831,9 +3831,18 @@ export default {
           const cutoff = new Date(Date.now() - days * ANALYTICS_DAY_MS)
             .toISOString()
             .slice(0, 10);
+          // A malformed min_samples ("abc", "-1", "1.5") degrades to "no
+          // filter" rather than sending NaN/an invalid value to Postgres --
+          // same graceful-fallback treatment as windowParam above, not a
+          // hard validation error (the D1-side handleUptime already rejects
+          // it before ever reaching this route in the real request path).
           const minSamplesRaw = url.searchParams.get("min_samples");
-          const minSamples =
+          const minSamplesParsed =
             minSamplesRaw === null ? null : Number(minSamplesRaw);
+          const minSamples =
+            Number.isInteger(minSamplesParsed) && minSamplesParsed >= 0
+              ? minSamplesParsed
+              : null;
           const havingClause =
             minSamples !== null
               ? sql`HAVING SUM(samples) >= ${minSamples}`

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -222,6 +222,8 @@ import {
   MAX_BULK_TREND_ROWS,
   MAX_INCIDENT_ROWS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+  UPTIME_WINDOWS,
+  MAX_UPTIME_ROWS,
 } from "./config.mjs";
 import {
   formatBulkTrends,
@@ -229,6 +231,7 @@ import {
   formatPercentiles,
   formatIncidents,
   formatGlobalIncidents,
+  formatUptime,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.mjs";
@@ -3806,6 +3809,74 @@ export default {
               observedAt: latestObservedIso(freshRows, "newest_observed"),
               incidentRows,
               maxIncidents: MAX_INCIDENT_ROWS,
+            }),
+          );
+        }
+
+        // GET /api/v1/subnets/:netuid/uptime?window=&min_samples= (#4832
+        // gap-closure follow-up): durable 90d/1y availability history from
+        // the daily rollup, mirroring workers/request-handlers/
+        // analytics-routes.mjs's handleUptime. Reuses METAGRAPH_HEALTH_SOURCE
+        // (same table already covered by the bulk-trends route above), a
+        // simple GROUP BY + optional HAVING with no window functions.
+        const subnetUptime = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/uptime$/,
+        );
+        if (subnetUptime) {
+          const netuid = Number(subnetUptime[1]);
+          const windowParam = url.searchParams.get("window") || "90d";
+          const days = Object.hasOwn(UPTIME_WINDOWS, windowParam)
+            ? UPTIME_WINDOWS[windowParam]
+            : UPTIME_WINDOWS["90d"];
+          const cutoff = new Date(Date.now() - days * ANALYTICS_DAY_MS)
+            .toISOString()
+            .slice(0, 10);
+          const minSamplesRaw = url.searchParams.get("min_samples");
+          const minSamples =
+            minSamplesRaw === null ? null : Number(minSamplesRaw);
+          const havingClause =
+            minSamples !== null
+              ? sql`HAVING SUM(samples) >= ${minSamples}`
+              : sql``;
+          const rows = await sql`
+          SELECT MAX(surface_id) AS surface_id,
+                 COALESCE(surface_key, surface_id) AS surface_key,
+                 day::text AS day,
+                 SUM(samples) AS samples,
+                 SUM(ok_count) AS ok_count,
+                 CASE WHEN SUM(samples) > 0 THEN ROUND(SUM(ok_count)::numeric / SUM(samples), 4) ELSE NULL END AS uptime_ratio,
+                 SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END) AS latency_samples,
+                 CASE WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END) > 0
+                   THEN ROUND(SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * COALESCE(latency_samples, samples) ELSE 0 END)::numeric
+                        / SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END))::int
+                   ELSE NULL END AS avg_latency_ms,
+                 MAX(p50_latency_ms) AS p50,
+                 MAX(p95_latency_ms) AS p95,
+                 MAX(p99_latency_ms) AS p99,
+                 CASE
+                   WHEN SUM(samples) = 0 THEN 'unknown'
+                   WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
+                   WHEN SUM(ok_count) = 0 THEN 'failed'
+                   ELSE 'degraded'
+                 END AS status
+          FROM surface_uptime_daily
+          WHERE netuid = ${netuid} AND day >= ${cutoff}::date
+          GROUP BY COALESCE(surface_key, surface_id), day
+          ${havingClause}
+          ORDER BY day DESC
+          LIMIT ${MAX_UPTIME_ROWS}`;
+          const freshRows = await sql`
+          SELECT MAX(updated_at) AS newest_observed
+          FROM surface_uptime_daily WHERE netuid = ${netuid} AND day >= ${cutoff}::date`;
+          return json(
+            formatUptime({
+              netuid,
+              window: Object.hasOwn(UPTIME_WINDOWS, windowParam)
+                ? windowParam
+                : "90d",
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              rows,
+              now: new Date().toISOString(),
             }),
           );
         }

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -9,6 +9,7 @@
 // injected once at module-init so this file never imports api.mjs back.
 
 import { DAY_MS, MAX_UPTIME_ROWS, UPTIME_WINDOWS } from "../config.mjs";
+import { tryPostgresTier } from "../postgres-tier.mjs";
 import { csvRequested, csvResponse } from "../csv.mjs";
 import { errorResponse } from "../http.mjs";
 import { readArtifact } from "../storage.mjs";
@@ -222,45 +223,54 @@ export async function handleUptime(request, env, netuid, url) {
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);
-  const rows = await d1All(
-    env,
-    `SELECT MAX(surface_id) AS surface_id,
-            COALESCE(surface_key, surface_id) AS surface_key,
-            day,
-            SUM(samples) AS samples,
-            SUM(ok_count) AS ok_count,
-            CASE
-              WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
-              ELSE NULL
-            END AS uptime_ratio,
-            ${dailyLatencyColumns({ roundedAvg: true })},
-            MAX(p50_latency_ms) AS p50,
-            MAX(p95_latency_ms) AS p95,
-            MAX(p99_latency_ms) AS p99,
-            CASE
-              WHEN SUM(samples) = 0 THEN 'unknown'
-              WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
-              WHEN SUM(ok_count) = 0 THEN 'failed'
-              ELSE 'degraded'
-            END AS status
-     FROM surface_uptime_daily
-     WHERE netuid = ? AND day >= ?
-     GROUP BY COALESCE(surface_key, surface_id), day
-     ${minSamples.value !== null ? "HAVING SUM(samples) >= ?\n     " : ""}ORDER BY day DESC
-     LIMIT ?`,
-    minSamples.value !== null
-      ? [netuid, cutoff, minSamples.value, MAX_UPTIME_ROWS]
-      : [netuid, cutoff, MAX_UPTIME_ROWS],
-  );
-  const healthMeta = await readHealthMetaKv(env);
-  const data = formatUptime({
-    netuid,
-    window: windowParam,
-    observedAt: healthMeta?.last_run_at || null,
-    rows,
-    now: new Date().toISOString(),
-  });
-  return envelopeWithD1Fallback(
+  // #4832 gap-closure follow-up: reuses METAGRAPH_HEALTH_SOURCE (same table
+  // as the bulk-trends/trends/percentiles/incidents routes in analytics.mjs,
+  // deliberately unflipped pending Postgres accumulating a real history
+  // window -- see handleBulkHealthTrends' own header comment there).
+  let isFallback = false;
+  let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
+  if (!data) {
+    const rows = await d1All(
+      env,
+      `SELECT MAX(surface_id) AS surface_id,
+              COALESCE(surface_key, surface_id) AS surface_key,
+              day,
+              SUM(samples) AS samples,
+              SUM(ok_count) AS ok_count,
+              CASE
+                WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
+                ELSE NULL
+              END AS uptime_ratio,
+              ${dailyLatencyColumns({ roundedAvg: true })},
+              MAX(p50_latency_ms) AS p50,
+              MAX(p95_latency_ms) AS p95,
+              MAX(p99_latency_ms) AS p99,
+              CASE
+                WHEN SUM(samples) = 0 THEN 'unknown'
+                WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
+                WHEN SUM(ok_count) = 0 THEN 'failed'
+                ELSE 'degraded'
+              END AS status
+       FROM surface_uptime_daily
+       WHERE netuid = ? AND day >= ?
+       GROUP BY COALESCE(surface_key, surface_id), day
+       ${minSamples.value !== null ? "HAVING SUM(samples) >= ?\n       " : ""}ORDER BY day DESC
+       LIMIT ?`,
+      minSamples.value !== null
+        ? [netuid, cutoff, minSamples.value, MAX_UPTIME_ROWS]
+        : [netuid, cutoff, MAX_UPTIME_ROWS],
+    );
+    const healthMeta = await readHealthMetaKv(env);
+    data = formatUptime({
+      netuid,
+      window: windowParam,
+      observedAt: healthMeta?.last_run_at || null,
+      rows,
+      now: new Date().toISOString(),
+    });
+    isFallback = hasD1FallbackRows(rows);
+  }
+  const response = await envelopeResponse(
     request,
     {
       data,
@@ -271,8 +281,8 @@ export async function handleUptime(request, env, netuid, url) {
       ),
     },
     "short",
-    [rows],
   );
+  return isFallback ? markD1FallbackResponse(response) : response;
 }
 
 // Normalises the uptime URL so that a bare ?-free request and an explicit


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/subnets/:netuid/uptime` to `workers/data-api.mjs` (the Postgres worker), mirroring `handleUptime`'s D1 query against `surface_uptime_daily`.
- Wires `handleUptime` (`workers/request-handlers/analytics-routes.mjs`) to `tryPostgresTier`, reusing the existing `METAGRAPH_HEALTH_SOURCE` flag introduced for the sibling health-tracking routes (#4887) rather than a new one — same table, same deliberately-unflipped-pending-history rationale.
- Continues the #4832 D1-completeness sweep; `handleCompare` remains the one outstanding handler in this cluster (deferred — needs a synthesized-internal-request pattern rather than a straight request-forward).

## Test plan
- [x] `npx eslint` + `npx prettier --check` on all 4 changed files
- [x] `npx vitest run tests/data-api.test.mjs tests/request-handlers-analytics-routes.test.mjs`
- [x] `npx vitest run` (full suite): 7624/7624 passing
- [x] `npm run test:coverage` + patch-coverage isolation: 100% of added lines/branches covered in both `workers/data-api.mjs` and `workers/request-handlers/analytics-routes.mjs`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `git diff --check`
- [x] Live-verified the new SQL fragment via `psql` against production `surface_uptime_daily`