### PR TITLE
fix(ui): wrap Validators/miners KPI eyebrow instead of truncating on mobile (#3936)

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/stat-tile.tsx
+++ b/apps/ui/src/components/metagraphed/charts/stat-tile.tsx
@@ -10,6 +10,13 @@ interface Props {
   chart?: ReactNode;
   tone?: "default" | "accent" | "ok" | "warn" | "down";
   className?: string;
+  /**
+   * Allow the eyebrow label to wrap to a second line instead of truncating.
+   * Opt-in (#3936) for tiles whose label is too long to fit on one line in a
+   * narrow grid column (e.g. "Validators / miners"); defaults to the single-line
+   * truncate behavior every other caller relies on.
+   */
+  wrapEyebrow?: boolean;
 }
 
 /**
@@ -24,6 +31,7 @@ export function StatTile({
   chart,
   tone = "default",
   className,
+  wrapEyebrow = false,
 }: Props) {
   return (
     <div
@@ -55,7 +63,12 @@ export function StatTile({
         />
       ) : null}
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate">
+        <div
+          className={classNames(
+            "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+            wrapEyebrow ? "text-balance" : "truncate",
+          )}
+        >
           {eyebrow}
         </div>
         <div className="mt-1 flex min-w-0 items-baseline gap-1.5">

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -102,6 +102,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
           eyebrow="Validators / miners"
           value={`${y.validator_count ?? "—"} / ${y.miner_count ?? "—"}`}
           hint={`${y.neuron_count ?? neurons.length} UIDs`}
+          wrapEyebrow
         />
       </div>
 


### PR DESCRIPTION
## Summary

In the Yield tab's KPI row, the "Validators / miners" `StatTile` truncated its eyebrow label mid-word (`"VALIDATORS /…"`) at narrow grid-column widths, while its shorter-labeled siblings ("Subnet yield", "Median yield") rendered in full — leaving that tile looking broken relative to the row.

The tiles share the `StatTile` component, whose eyebrow is `truncate` (single-line) by design — correct for every other short-label caller. This adds an **opt-in `wrapEyebrow` prop** (default `false` = unchanged truncate behavior) that lets a long label wrap (`text-balance`) instead of truncating, and enables it only on the "Validators / miners" tile.

## Change

- 2 files, +15/−1: `charts/stat-tile.tsx` (new opt-in `wrapEyebrow` prop) + `yield-panel.tsx` (pass `wrapEyebrow` on the one long-label tile).
- Every other `StatTile` caller is unchanged (prop defaults to the existing truncate). The other two tiles in the row are untouched (issue non-goal); values/data unchanged.

## Verification (behavioral, in-browser)

At the narrow-column widths where the bug occurs (grid-cols-2, ~400–640px), measured `scrollWidth > clientWidth` on the eyebrow:
- **Before:** `truncated = true` (label cut to "VALIDATORS /…")
- **After:** `truncated = false`, eyebrow wraps to two lines showing the full "Validators / miners"
- Siblings and single-column phone layout (<400px, already full-width) unaffected.

## Screenshots

Yield KPI row. The **Mobile** rows are captured at 430px (grid-cols-2 — the width where the third tile truncated). **Before:** "VALIDATORS / MI…"; **After:** full label. Desktop/tablet (wider, no truncation) render identically.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

```
npm run lint --workspace=apps/ui        # 0 errors
npm run typecheck --workspace=apps/ui   # clean
npm test --workspace=apps/ui            # 717 passed
npm run test:e2e --workspace=apps/ui    # 24 passed (responsive-overflow)
```

Closes #3936
