### PR TITLE
feat(health): wire handleCompare's health dimension to the Postgres tier

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4986,3 +4986,20 @@ test("GET /api/v1/subnets/:netuid/uptime: unrecognized window falls back to 90d"
   const body = await res.json();
   expect(body.window).toBe("90d");
 });
+
+test("GET /api/v1/internal/compare-health: aggregates surface_status by netuid", async () => {
+  mockRows.current = [
+    { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 120 },
+  ];
+  const res = await req("/api/v1/internal/compare-health?netuids=7,64");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.rows).toEqual(mockRows.current);
+});
+
+test("GET /api/v1/internal/compare-health: no netuids returns rows:[] without querying", async () => {
+  const res = await req("/api/v1/internal/compare-health");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.rows).toEqual([]);
+});

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -790,6 +790,74 @@ describe("handleCompare", () => {
     );
     assert.deepEqual(body.data.requested_netuids, [1, 7]);
   });
+
+  // #4832 gap-closure: handleCompare has no single D1 route to forward, so
+  // its health dimension synthesizes its own /api/v1/internal/compare-health
+  // request rather than reusing tryPostgresTier's usual "forward the caller's
+  // request unchanged" contract -- these tests prove that wiring in
+  // isolation (D1 called or not), same reused METAGRAPH_HEALTH_SOURCE flag
+  // as handleUptime above.
+  test("health dimension: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = createLocalArtifactEnv();
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          rows: [
+            { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 120 },
+          ],
+        }),
+    };
+    env.METAGRAPH_HEALTH_DB = {
+      prepare() {
+        d1Called = true;
+        throw new Error(
+          "D1 must not be queried when Postgres serves the request",
+        );
+      },
+    };
+    const body = await json(
+      await handleCompare(
+        req("/api/v1/compare"),
+        env,
+        url("/api/v1/compare?netuids=7&dimensions=health"),
+      ),
+    );
+    assert.equal(body.data.subnets[0].netuid, 7);
+    assert.equal(d1Called, false);
+  });
+
+  test("health dimension: flag=postgres falls back to D1 when DATA_API fails", async () => {
+    let d1Called = false;
+    const env = createLocalArtifactEnv();
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const baseEnv = d1Env({
+      "FROM surface_status": [
+        { netuid: 7, surface_count: 5, ok_count: 4, avg_latency_ms: 90 },
+      ],
+    });
+    env.METAGRAPH_HEALTH_DB = {
+      prepare(sqlText) {
+        d1Called = true;
+        return baseEnv.METAGRAPH_HEALTH_DB.prepare(sqlText);
+      },
+    };
+    const body = await json(
+      await handleCompare(
+        req("/api/v1/compare"),
+        env,
+        url("/api/v1/compare?netuids=7&dimensions=health"),
+      ),
+    );
+    assert.equal(body.data.subnets[0].netuid, 7);
+    assert.equal(d1Called, true);
+  });
 });
 
 describe("composeCompareData", () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -3919,9 +3919,9 @@ export default {
             .join(", ");
           const rows = await sql.unsafe(
             `SELECT netuid,
-                    COUNT(*) AS surface_count,
-                    SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
-                    ROUND(AVG(CASE WHEN status = 'ok' AND latency_ms IS NOT NULL THEN latency_ms END)) AS avg_latency_ms
+                    COUNT(*)::int AS surface_count,
+                    SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END)::int AS ok_count,
+                    ROUND(AVG(CASE WHEN status = 'ok' AND latency_ms IS NOT NULL THEN latency_ms END))::int AS avg_latency_ms
              FROM surface_status
              WHERE netuid IN (${placeholders})
              GROUP BY netuid`,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -3890,6 +3890,46 @@ export default {
           );
         }
 
+        // GET /api/v1/internal/compare-health?netuids=1,7,19 (#4832 gap-closure
+        // follow-up): the health-dimension slice handleCompare embeds inline
+        // (workers/request-handlers/analytics-routes.mjs) rather than a
+        // standalone D1 route, so there's no client request to forward
+        // unchanged -- handleCompare synthesizes this request itself once its
+        // own netuids/dimensions validation has already run, same "internal"
+        // trust boundary as the write-side sync routes above, minus the
+        // secret header since a read has no mutation to gate. Reuses
+        // METAGRAPH_HEALTH_SOURCE (surface_status, same table the compare
+        // dimension reads from D1). netuids is a plain scalar list (never a
+        // bound JS array) via sql.unsafe -- see the neurons-sync prune
+        // query's comment above for why an ANY($1)/array bind breaks under
+        // this Worker's Hyperdrive fetch_types:false setting.
+        if (url.pathname === "/api/v1/internal/compare-health") {
+          const netuidsRaw = url.searchParams.get("netuids");
+          // "".split(",") is [""] and Number("") is 0, so an empty/missing
+          // param must short-circuit before split -- not fall through to a
+          // spurious IN (0).
+          const netuids = netuidsRaw
+            ? netuidsRaw.split(",").map(Number).filter(Number.isInteger)
+            : [];
+          if (netuids.length === 0) {
+            return json({ rows: [] });
+          }
+          const placeholders = netuids
+            .map((_, i) => `$${i + 1}::int`)
+            .join(", ");
+          const rows = await sql.unsafe(
+            `SELECT netuid,
+                    COUNT(*) AS surface_count,
+                    SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+                    ROUND(AVG(CASE WHEN status = 'ok' AND latency_ms IS NOT NULL THEN latency_ms END)) AS avg_latency_ms
+             FROM surface_status
+             WHERE netuid IN (${placeholders})
+             GROUP BY netuid`,
+            netuids,
+          );
+          return json({ rows });
+        }
+
         // GET /api/v1/accounts/:ss58/stake-flow
         const acctStakeFlow = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/stake-flow$/,

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -682,10 +682,26 @@ export async function handleCompare(request, env, url) {
   }
 
   const { subnetMeta, mostComplete } = await leaderboardProfilesProjection(env);
-  const [economicsRows, healthRows] = await Promise.all([
-    dimensions.includes("economics") ? resolveEconomicsRows(env) : null,
-    dimensions.includes("health")
-      ? d1All(
+  // The health dimension is the only one of the three backed by a table with
+  // a Postgres mirror (surface_status, #4832 gap-closure) -- structure/
+  // economics stay D1-only. handleCompare has no clean 1:1 D1 route to
+  // forward, so it synthesizes its own internal request the same way a
+  // syncXToPostgres write helper builds one, rather than forwarding the
+  // caller's netuids=/dimensions= request unchanged (tryPostgresTier's usual
+  // contract).
+  let healthIsFallback = false;
+  const healthPromise = dimensions.includes("health")
+    ? (async () => {
+        const pgUrl = new URL(request.url);
+        pgUrl.pathname = "/api/v1/internal/compare-health";
+        pgUrl.search = `?netuids=${requestedNetuids.join(",")}`;
+        const pgData = await tryPostgresTier(
+          env,
+          new Request(pgUrl),
+          "METAGRAPH_HEALTH_SOURCE",
+        );
+        if (pgData) return pgData.rows;
+        const rows = await d1All(
           env,
           `SELECT netuid,
                 COUNT(*) AS surface_count,
@@ -695,8 +711,14 @@ export async function handleCompare(request, env, url) {
          WHERE netuid IN (${requestedNetuids.map(() => "?").join(", ")})
          GROUP BY netuid`,
           requestedNetuids,
-        )
-      : null,
+        );
+        healthIsFallback = hasD1FallbackRows(rows);
+        return rows;
+      })()
+    : null;
+  const [economicsRows, healthRows] = await Promise.all([
+    dimensions.includes("economics") ? resolveEconomicsRows(env) : null,
+    healthPromise,
   ]);
 
   const meta = await readHealthMetaKv(env);
@@ -709,7 +731,7 @@ export async function handleCompare(request, env, url) {
     healthRows,
     observedAt: meta?.last_run_at ?? null,
   });
-  return envelopeWithD1Fallback(
+  const response = await envelopeResponse(
     request,
     {
       data,
@@ -722,6 +744,6 @@ export async function handleCompare(request, env, url) {
       },
     },
     "standard",
-    [healthRows],
   );
+  return healthIsFallback ? markD1FallbackResponse(response) : response;
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/internal/compare-health?netuids=...` to `workers/data-api.mjs`: `handleCompare` has no single D1 route to forward (it embeds a `surface_status` query inline alongside two unrelated dimensions), so it synthesizes its own internal request rather than reusing `tryPostgresTier`'s usual "forward the caller's request unchanged" contract -- mirrors how a write-side `syncXToPostgres` helper builds its own request.
- Wires `handleCompare` (`workers/request-handlers/analytics-routes.mjs`) to call that route via `tryPostgresTier`, reusing the existing `METAGRAPH_HEALTH_SOURCE` flag (same deliberately-unflipped-pending-history rationale as #4887/#4889).
- Uses explicit `IN ($1::int, $2::int, ...)` scalar positional binds via `sql.unsafe` for the netuid list, not a bound JS array -- the neurons-sync prune query's existing comment documents that `ANY($1)`/array binds break under this Worker's Hyperdrive `fetch_types:false` setting.
- Completes the #4832 gap-closure health-tracking cluster (`handleUptime` + `handleCompare` were the last two D1-only health handlers; #4889 shipped `handleUptime`).

## Test plan
- [x] `npx eslint` + `npx prettier --check` on all 4 changed files
- [x] `npx vitest run tests/data-api.test.mjs tests/request-handlers-analytics-routes.test.mjs`
- [x] `npx vitest run` (full suite): 7629/7629 passing
- [x] `npm run test:coverage` + patch-coverage isolation: 100% of added lines/branches covered in both `workers/data-api.mjs` and `workers/request-handlers/analytics-routes.mjs`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `git diff --check`
- [x] Live-verified the underlying `surface_status` netuid-scoped aggregate query via `psql` against production (index scan, sub-ms)