### PR TITLE
fix(ui): URL-back the 7d/30d window toggle on /status and /endpoints

### DIFF
--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useSearch, useNavigate } from "@tanstack/react-router";
 import { Zap, GitBranch, Database, ShieldCheck, Gauge, ArrowUpDown } from "lucide-react";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { useNetwork } from "@/hooks/use-api-base";
@@ -156,7 +156,11 @@ function UsageStat({
 }
 
 export function ProxyUsagePanel() {
-  const [window, setWindow] = useState<"7d" | "30d">("7d");
+  // #3976: URL-back the 7d/30d window (was local state) so it survives reload
+  // and is shareable, matching /explorer. Lives on the /endpoints route search.
+  const search = useSearch({ from: "/endpoints" });
+  const navigate = useNavigate({ from: "/endpoints" });
+  const window = search.window;
   const { data } = useSuspenseQuery(rpcUsageQuery(window));
   const usage = data.data as RpcUsage;
   const s = usage.summary;
@@ -180,7 +184,7 @@ export function ProxyUsagePanel() {
             <button
               key={w}
               type="button"
-              onClick={() => setWindow(w)}
+              onClick={() => navigate({ search: (prev) => ({ ...prev, window: w }) })}
               className={classNames(
                 "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
                 window === w ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -80,6 +80,9 @@ const endpointsSearchSchema = z.object({
   page: fallback(z.number().int().min(1), 1).default(1),
   pageSize: fallback(z.number().int().min(10).max(200), 25).default(25),
   view: fallback(z.enum(["table", "grid"]), "table").default("table"),
+  // #3976: the ProxyUsagePanel 7d/30d window, URL-backed so it survives reload
+  // and is shareable — matching how /explorer already persists its window.
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
 });
 
 type EndpointsSearch = z.infer<typeof endpointsSearchSchema>;

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -63,6 +63,9 @@ const statusSearchSchema = z.object({
   status: fallback(z.string(), "").default(""),
   sort: fallback(z.enum(SURFACE_SORT_FIELDS), "status").default("status"),
   order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+  // #3976: the RecentIncidents 7d/30d window, URL-backed so it survives reload
+  // and is shareable — matching how /explorer already persists its window.
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
 });
 
 export const Route = createFileRoute("/status")({
@@ -321,7 +324,9 @@ function Kpi({
 
 /** Global, cross-subnet incident ledger from /api/v1/incidents (7d / 30d window). */
 function RecentIncidents() {
-  const [window, setWindow] = useState<IncidentWindow>("7d");
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const window = search.window;
   const [showAll, setShowAll] = useState(false);
   const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
@@ -377,7 +382,7 @@ function RecentIncidents() {
               key={w}
               type="button"
               onClick={() => {
-                setWindow(w);
+                navigate({ search: (prev) => ({ ...prev, window: w }) });
                 setShowAll(false);
               }}
               className={classNames(


### PR DESCRIPTION
## Summary
The 7d/30d window toggle is URL-backed on `/explorer`, but `status.tsx`'s `RecentIncidents` and `rpc-proxy.tsx`'s `ProxyUsagePanel` (rendered on `/endpoints`) each kept their own local `useState`, so the selected window reset to 7d on every reload or share and was invisible to back/forward navigation. A shared 30d `/status` or `/endpoints` link couldn't preserve the window the way an `/explorer` link does.

## Change
- `apps/ui/src/routes/status.tsx` — add `window` to the route search schema; `RecentIncidents` reads/writes it via `useSearch`/`useNavigate`.
- `apps/ui/src/routes/endpoints.tsx` — add `window` to the route search schema.
- `apps/ui/src/components/metagraphed/rpc-proxy.tsx` — `ProxyUsagePanel` reads/writes the `/endpoints` `window` param instead of local state.
- Matches `/explorer`'s existing shareable window. No data or visual-layout change; the toggle just persists.

Three files, `apps/ui` only. `tsc`, `eslint`, `prettier` clean.

Closes #3976

## Screenshots
Shared link `/status?window=30d` — **before** ignores it (toggle falls back to **7D**); **after** restores it (toggle shows **30D**). Same URL in every cell; theme forced via `localStorage`.

| Viewport · Theme | Before (7D — dropped) | After (30D — restored) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-mobile-dark.png) |