### PR TITLE
feat(health): wire loadPreviouslyKnownAs to the Postgres tier

### DIFF
--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -342,24 +342,14 @@ export async function loadPreviouslyKnownAs(d1, netuid, currentName) {
   return derivePreviouslyKnownAs(rows, currentName);
 }
 
-export async function loadPreviouslyKnownAsForNetuids(d1, entries) {
-  const items = entries || [];
-  const netuids = items
-    .map((entry) => entry?.netuid)
-    .filter((netuid) => Number.isInteger(netuid));
-  if (!netuids.length) return new Map();
-  const placeholders = netuids.map(() => "?").join(", ");
-  const rows = await d1(
-    `SELECT netuid, subnet_name, MAX(observed_at) AS observed_at
-     FROM subnet_identity_history
-     WHERE netuid IN (${placeholders})
-       AND subnet_name IS NOT NULL AND TRIM(subnet_name) != ''
-     GROUP BY netuid, subnet_name
-     ORDER BY netuid, observed_at DESC`,
-    netuids,
-  );
+// Groups already-fetched (netuid, subnet_name, observed_at) rows by netuid and
+// derives each subnet's alias list — split out of loadPreviouslyKnownAsForNetuids
+// so a Postgres-tier caller (workers/api.mjs) can reuse the exact same grouping
+// instead of duplicating it, the same way the single-netuid derivePreviouslyKnownAs
+// above is shared by both storage tiers.
+export function deriveNetuidGroupedAliases(rows, entries) {
   const currentByNetuid = new Map(
-    items
+    (entries || [])
       .filter((entry) => Number.isInteger(entry?.netuid))
       .map((entry) => [entry.netuid, entry.native_name ?? entry.name ?? null]),
   );
@@ -380,4 +370,23 @@ export async function loadPreviouslyKnownAsForNetuids(d1, entries) {
     if (names.length) out.set(netuid, names);
   }
   return out;
+}
+
+export async function loadPreviouslyKnownAsForNetuids(d1, entries) {
+  const items = entries || [];
+  const netuids = items
+    .map((entry) => entry?.netuid)
+    .filter((netuid) => Number.isInteger(netuid));
+  if (!netuids.length) return new Map();
+  const placeholders = netuids.map(() => "?").join(", ");
+  const rows = await d1(
+    `SELECT netuid, subnet_name, MAX(observed_at) AS observed_at
+     FROM subnet_identity_history
+     WHERE netuid IN (${placeholders})
+       AND subnet_name IS NOT NULL AND TRIM(subnet_name) != ''
+     GROUP BY netuid, subnet_name
+     ORDER BY netuid, observed_at DESC`,
+    netuids,
+  );
+  return deriveNetuidGroupedAliases(rows, items);
 }

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -5003,3 +5003,22 @@ test("GET /api/v1/internal/compare-health: no netuids returns rows:[] without qu
   const body = await res.json();
   expect(body.rows).toEqual([]);
 });
+
+test("GET /api/v1/internal/subnet-identity-aliases: aggregates subnet_name by netuid", async () => {
+  mockRows.current = [
+    { netuid: 7, subnet_name: "Old Allways", observed_at: 2 },
+  ];
+  const res = await req(
+    "/api/v1/internal/subnet-identity-aliases?netuids=7,64",
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.rows).toEqual(mockRows.current);
+});
+
+test("GET /api/v1/internal/subnet-identity-aliases: no netuids returns rows:[] without querying", async () => {
+  const res = await req("/api/v1/internal/subnet-identity-aliases");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.rows).toEqual([]);
+});

--- a/tests/subnet-identity-history-api.test.mjs
+++ b/tests/subnet-identity-history-api.test.mjs
@@ -177,3 +177,96 @@ test("GET /agent-catalog/{netuid} overlays previously_known_as on the detail ent
   const body = await res.json();
   assert.deepEqual(body.data.previously_known_as, ["Old Allways"]);
 });
+
+// #4832 gap-closure: loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids are
+// D1-fetch helpers embedded in these overlay call sites (no standalone route),
+// so tryPostgresTier can't forward the caller's own request -- api.mjs
+// synthesizes an internal request instead. These tests prove that wiring,
+// reusing METAGRAPH_SUBNET_IDENTITY_SOURCE (already flipped in production).
+// Only the alias query itself must be skipped when Postgres serves it -- the
+// same request also runs the unrelated live-health overlay (surface_status),
+// which stays D1-backed here since only METAGRAPH_SUBNET_IDENTITY_SOURCE is
+// flipped in these tests.
+function identityAliasesMustNotBeQueried() {
+  let called = false;
+  return {
+    get called() {
+      return called;
+    },
+    db: {
+      prepare(sql) {
+        if (/subnet_identity_history/.test(sql)) {
+          called = true;
+          throw new Error(
+            "D1 must not be queried when Postgres serves the request",
+          );
+        }
+        return {
+          bind: () => ({
+            async all() {
+              return { results: [] };
+            },
+          }),
+        };
+      },
+    },
+  };
+}
+
+test("GET /agent-catalog/{netuid}: flag=postgres serves the DATA_API response, D1 never queried", async () => {
+  const tracker = identityAliasesMustNotBeQueried();
+  const env = createLocalArtifactEnv({
+    METAGRAPH_HEALTH_DB: tracker.db,
+    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          rows: [{ netuid: 7, subnet_name: "Old Allways", observed_at: 2 }],
+        }),
+    },
+  });
+  const res = await handleRequest(req("/api/v1/agent-catalog/7"), env, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.data.previously_known_as, ["Old Allways"]);
+  assert.equal(tracker.called, false);
+});
+
+test("GET /agent-catalog/{netuid}: flag=postgres falls back to D1 when DATA_API fails", async () => {
+  const env = createLocalArtifactEnv({
+    ...identityHistoryEnv([
+      { netuid: 7, subnet_name: "Old Allways", observed_at: 2 },
+    ]),
+    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    },
+  });
+  const res = await handleRequest(req("/api/v1/agent-catalog/7"), env, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.data.previously_known_as, ["Old Allways"]);
+});
+
+test("GET /agent-catalog: flag=postgres serves the bulk DATA_API response, D1 never queried", async () => {
+  const tracker = identityAliasesMustNotBeQueried();
+  const env = createLocalArtifactEnv({
+    METAGRAPH_HEALTH_DB: tracker.db,
+    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          rows: [{ netuid: 7, subnet_name: "Old Allways", observed_at: 2 }],
+        }),
+    },
+  });
+  const res = await handleRequest(req("/api/v1/agent-catalog"), env, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const subnet = body.data.subnets.find((entry) => entry.netuid === 7);
+  assert.ok(subnet);
+  assert.deepEqual(subnet.previously_known_as, ["Old Allways"]);
+  assert.equal(tracker.called, false);
+});

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   buildSubnetIdentityHistory,
+  deriveNetuidGroupedAliases,
   derivePreviouslyKnownAs,
   formatIdentityHistoryEntry,
   identityHash,
@@ -1012,6 +1013,35 @@ describe("loadPreviouslyKnownAsForNetuids", () => {
       [{ netuid: 86, name: "Current" }],
     );
     assert.deepEqual(map.get(86), ["System   [scrubbed] ."]);
+  });
+});
+
+// #4832 gap-closure: deriveNetuidGroupedAliases is the row-grouping half
+// extracted out of loadPreviouslyKnownAsForNetuids so workers/api.mjs's
+// Postgres-tier wrapper can reuse it directly on rows it fetched itself.
+describe("deriveNetuidGroupedAliases", () => {
+  test("returns an empty map when entries are null", () => {
+    const map = deriveNetuidGroupedAliases(
+      [{ netuid: 7, subnet_name: "Old7", observed_at: 1 }],
+      null,
+    );
+    // No current-name context, so the alias is kept unfiltered.
+    assert.deepEqual(map.get(7), ["Old7"]);
+  });
+
+  test("groups rows by netuid, matching loadPreviouslyKnownAsForNetuids", () => {
+    const map = deriveNetuidGroupedAliases(
+      [
+        { netuid: 86, subnet_name: "MIAO", observed_at: 2 },
+        { netuid: 7, subnet_name: "Old7", observed_at: 1 },
+      ],
+      [
+        { netuid: 86, name: "⚒" },
+        { netuid: 7, name: "Current" },
+      ],
+    );
+    assert.deepEqual(map.get(86), ["MIAO"]);
+    assert.deepEqual(map.get(7), ["Old7"]);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -252,10 +252,13 @@ import {
   resolveLiveHealth,
 } from "../src/health-serving.mjs";
 import {
+  deriveNetuidGroupedAliases,
+  derivePreviouslyKnownAs,
   loadPreviouslyKnownAs,
   loadPreviouslyKnownAsForNetuids,
   overlayPreviouslyKnownAs,
 } from "../src/subnet-identity-history.mjs";
+import { tryPostgresTier } from "./postgres-tier.mjs";
 import {
   rollupNeuronDaily,
   archiveNeuronDaily,
@@ -3372,6 +3375,46 @@ async function lookupSubnetNetuid(
   return Number.isInteger(netuid) ? netuid : null;
 }
 
+// loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids (src/subnet-identity-
+// history.mjs) are D1-fetch helpers embedded in 3 overlay call sites below
+// rather than standalone routes, so there is no single client request for
+// tryPostgresTier to forward unchanged -- these two wrappers synthesize their
+// own internal /api/v1/internal/subnet-identity-aliases request instead,
+// mirroring composeCompareData's health-dimension wiring (#4832 gap-closure).
+// Reuses METAGRAPH_SUBNET_IDENTITY_SOURCE, already flipped to postgres for
+// /identity-history. derivePreviouslyKnownAs/deriveNetuidGroupedAliases run
+// identically over rows regardless of which tier served them.
+async function loadPreviouslyKnownAsTiered(env, netuid, currentName) {
+  const pgUrl = new URL(
+    "https://data-api.internal/api/v1/internal/subnet-identity-aliases",
+  );
+  pgUrl.searchParams.set("netuids", String(netuid));
+  const pgData = await tryPostgresTier(
+    env,
+    new Request(pgUrl),
+    "METAGRAPH_SUBNET_IDENTITY_SOURCE",
+  );
+  if (pgData) return derivePreviouslyKnownAs(pgData.rows, currentName);
+  return loadPreviouslyKnownAs(d1Runner(env), netuid, currentName);
+}
+
+async function loadPreviouslyKnownAsForNetuidsTiered(env, entries) {
+  const netuids = entries
+    .map((entry) => entry?.netuid)
+    .filter((netuid) => Number.isInteger(netuid));
+  const pgUrl = new URL(
+    "https://data-api.internal/api/v1/internal/subnet-identity-aliases",
+  );
+  pgUrl.searchParams.set("netuids", netuids.join(","));
+  const pgData = await tryPostgresTier(
+    env,
+    new Request(pgUrl),
+    "METAGRAPH_SUBNET_IDENTITY_SOURCE",
+  );
+  if (pgData) return deriveNetuidGroupedAliases(pgData.rows, entries);
+  return loadPreviouslyKnownAsForNetuids(d1Runner(env), entries);
+}
+
 async function handleApiRequest(
   request,
   env,
@@ -3546,8 +3589,8 @@ async function handleApiRequest(
       baseData.subnet && typeof baseData.subnet === "object"
         ? baseData.subnet
         : baseData;
-    const aliasNames = await loadPreviouslyKnownAs(
-      d1Runner(env),
+    const aliasNames = await loadPreviouslyKnownAsTiered(
+      env,
       Number(matched.params.netuid),
       aliasTarget.native_name ?? aliasTarget.name,
     );
@@ -3568,8 +3611,8 @@ async function handleApiRequest(
     baseData &&
     typeof baseData === "object"
   ) {
-    const aliasNames = await loadPreviouslyKnownAs(
-      d1Runner(env),
+    const aliasNames = await loadPreviouslyKnownAsTiered(
+      env,
       Number(matched.params.netuid),
       baseData.name,
     );
@@ -3580,8 +3623,8 @@ async function handleApiRequest(
     matched.id === "agent-catalog" &&
     baseData?.subnets?.length
   ) {
-    const aliasMap = await loadPreviouslyKnownAsForNetuids(
-      d1Runner(env),
+    const aliasMap = await loadPreviouslyKnownAsForNetuidsTiered(
+      env,
       baseData.subnets,
     );
     baseData = {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -3930,6 +3930,42 @@ export default {
           return json({ rows });
         }
 
+        // GET /api/v1/internal/subnet-identity-aliases?netuids=1,7,19 (#4832
+        // gap-closure follow-up): src/subnet-identity-history.mjs's
+        // loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids are D1-fetch
+        // helpers embedded in 3 workers/api.mjs call sites (overlay logic,
+        // not standalone routes), so -- same rationale as
+        // /api/v1/internal/compare-health -- there is no single client
+        // request to forward; api.mjs synthesizes this request itself.
+        // Reuses METAGRAPH_SUBNET_IDENTITY_SOURCE (same table already
+        // covered by /identity-history, and already flipped to postgres).
+        // Returns raw grouped rows; derivePreviouslyKnownAs/
+        // deriveNetuidGroupedAliases run identically over D1 or Postgres
+        // rows, so the current-name exclusion logic lives in exactly one
+        // place regardless of which tier served the query.
+        if (url.pathname === "/api/v1/internal/subnet-identity-aliases") {
+          const netuidsRaw = url.searchParams.get("netuids");
+          const netuids = netuidsRaw
+            ? netuidsRaw.split(",").map(Number).filter(Number.isInteger)
+            : [];
+          if (netuids.length === 0) {
+            return json({ rows: [] });
+          }
+          const placeholders = netuids
+            .map((_, i) => `$${i + 1}::int`)
+            .join(", ");
+          const rows = await sql.unsafe(
+            `SELECT netuid, subnet_name, MAX(observed_at) AS observed_at
+             FROM subnet_identity_history
+             WHERE netuid IN (${placeholders})
+               AND subnet_name IS NOT NULL AND TRIM(subnet_name) != ''
+             GROUP BY netuid, subnet_name
+             ORDER BY netuid, observed_at DESC`,
+            netuids,
+          );
+          return json({ rows });
+        }
+
         // GET /api/v1/accounts/:ss58/stake-flow
         const acctStakeFlow = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/stake-flow$/,


### PR DESCRIPTION
## Summary
- `loadPreviouslyKnownAs`/`loadPreviouslyKnownAsForNetuids` (`src/subnet-identity-history.mjs`) are D1-fetch helpers embedded in 3 `workers/api.mjs` overlay call sites (subnet-detail, agent-catalog-subnet, agent-catalog bulk) rather than standalone routes, so `tryPostgresTier` can't forward the caller's own request. Two new tiered wrappers (`loadPreviouslyKnownAsTiered`, `loadPreviouslyKnownAsForNetuidsTiered`) synthesize an internal `/api/v1/internal/subnet-identity-aliases` request instead, mirroring #4892's `handleCompare` health-dimension wiring.
- Adds `GET /api/v1/internal/subnet-identity-aliases?netuids=...` to `workers/data-api.mjs`, reusing `METAGRAPH_SUBNET_IDENTITY_SOURCE` (already flipped to postgres in production, covering `/identity-history`).
- Extracts `deriveNetuidGroupedAliases` out of `loadPreviouslyKnownAsForNetuids` so the netuid-grouping logic is shared by both storage tiers instead of duplicated -- the Postgres-tier wrapper reuses it directly on rows it fetched itself.
- Completes task #172 of the #4832 D1-completeness sweep.

## Test plan
- [x] `npx eslint` + `npx prettier --check` on all 6 changed files
- [x] `npx vitest run tests/data-api.test.mjs tests/subnet-identity-history-api.test.mjs tests/subnet-identity-history.test.mjs`
- [x] `npx vitest run` (full suite): 7636/7636 passing
- [x] `npm run test:coverage` + patch-coverage isolation: 100% of added lines/branches covered in `workers/api.mjs`, `workers/data-api.mjs`, and `src/subnet-identity-history.mjs`
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `git diff --check`
- [x] Live-verified the underlying `subnet_identity_history` netuid-scoped aggregate query via `psql` against production (index scan, sub-ms)