### PR TITLE
fix(subnet-identity): log recordSubnetIdentityChanges D1 failures

### DIFF
--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -251,7 +251,15 @@ export async function recordSubnetIdentityChanges(
   let latestByNetuid;
   try {
     latestByNetuid = await latestIdentityHashes(database);
-  } catch {
+  } catch (error) {
+    // #4832 gap-closure follow-up: a swallowed D1 error here (prod schema
+    // drift, a locked/unavailable DB) dark-served the identity-history
+    // write for an unknown stretch before anyone noticed -- same failure
+    // class d1All was hardened against, see that fix's own comment.
+    console.error(
+      "[recordSubnetIdentityChanges]",
+      String(error?.message ?? error),
+    );
     return { recorded: false, reason: "read_failed" };
   }
   const blockNumber = await latestBlockNumber(database);
@@ -291,7 +299,11 @@ export async function recordSubnetIdentityChanges(
   try {
     await runStatementBatches(database, statements);
     return { recorded: true, rows: statements.length };
-  } catch {
+  } catch (error) {
+    console.error(
+      "[recordSubnetIdentityChanges]",
+      String(error?.message ?? error),
+    );
     return { recorded: false, reason: "write_failed" };
   }
 }

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -681,6 +681,64 @@ describe("recordSubnetIdentityChanges", () => {
     );
   });
 
+  test("logs a non-Error read failure via the error fallback", async () => {
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return this;
+          },
+          all: async () => {
+            throw "boom";
+          },
+        };
+      },
+    };
+    assert.deepEqual(
+      await recordSubnetIdentityChanges(
+        {},
+        {
+          profiles: [{ netuid: 7, native_identity: { subnet_name: "X" } }],
+          db,
+        },
+      ),
+      { recorded: false, reason: "read_failed" },
+    );
+  });
+
+  test("logs a non-Error write failure via the error fallback", async () => {
+    const db = {
+      prepare(sql) {
+        return {
+          bind() {
+            return this;
+          },
+          all: async () => {
+            if (/FROM blocks/.test(sql)) {
+              return { results: [{ block_number: 123 }] };
+            }
+            return { results: [] };
+          },
+        };
+      },
+      batch: async () => {
+        throw "boom";
+      },
+    };
+    assert.deepEqual(
+      await recordSubnetIdentityChanges(
+        {},
+        {
+          profiles: [
+            { netuid: 7, native_identity: { subnet_name: "Changed" } },
+          ],
+          db,
+        },
+      ),
+      { recorded: false, reason: "write_failed" },
+    );
+  });
+
   test("tolerates a missing blocks table when resolving block_number", async () => {
     const binds = [];
     const db = {


### PR DESCRIPTION
## Summary
- `recordSubnetIdentityChanges` (`src/subnet-identity-history.mjs`) swallowed both its read-hash-lookup and its write-batch D1 errors with bare `catch {}` blocks -- no `console.error`, unlike `d1All`'s already-hardened equivalent (task #130 from this same #4832 gap-closure sweep, whose own comment states: "a swallowed... error here... dark-served the uptime tier for days before anyone noticed").
- Adds a `console.error("[recordSubnetIdentityChanges]", ...)` call to both catch blocks before returning the existing `{recorded: false, reason: "read_failed" | "write_failed"}` shape -- behavior is otherwise unchanged, this only makes an existing silent failure mode visible in Cloudflare Logpush/`wrangler tail`.
- Completes task #163 of the #4832 D1-completeness sweep.

## Test plan
- [x] `npx eslint` + `npx prettier --check` on both changed files
- [x] `npx vitest run tests/subnet-identity-history.test.mjs`: 67/67 passing (added 2 tests exercising the `error?.message ?? error` fallback branch with a non-`Error` thrown value, matching the existing `read_failed`/`write_failed` test pairs)
- [x] `npx vitest run` (full suite): 7631/7631 passing
- [x] `npm run test:coverage` + patch-coverage isolation: 100% of added lines/branches covered
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `git diff --check`