### PR TITLE
fix(data-api): enforce data-tier rate limit for Postgres-backed /api/v1/chain/fees

### DIFF
--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -1886,6 +1886,41 @@ describe("chain analytics extrinsics-derived: postgres tier wiring", () => {
     },
   ];
 
+  test("chain-fees charges the data-tier limiter before Postgres", async () => {
+    let limiterCalls = 0;
+    let dataApiCalls = 0;
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
+    env.DATA_RATE_LIMITER = {
+      limit: async ({ key }) => {
+        limiterCalls += 1;
+        assert.equal(key, "data:203.0.113.10");
+        return { success: false };
+      },
+    };
+    env.DATA_API = {
+      fetch: async () => {
+        dataApiCalls += 1;
+        return Response.json({});
+      },
+    };
+
+    const res = await handleChainFees(
+      req("/api/v1/chain/fees?window=7d&call_module=Balances", {
+        headers: { "cf-connecting-ip": "203.0.113.10" },
+      }),
+      env,
+      url("/api/v1/chain/fees?window=7d&call_module=Balances"),
+      ctx,
+    );
+
+    const body = await errorJson(res, 429);
+    assert.equal(body.error.code, "data_rate_limited");
+    assert.equal(res.headers.get("retry-after"), "60");
+    assert.equal(limiterCalls, 1);
+    assert.equal(dataApiCalls, 0);
+  });
+
   for (const { name, path, handler, pgBody } of cases) {
     test(`${name}: flag=postgres serves the DATA_API response, D1 never queried`, async () => {
       let d1Called = false;

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -32,6 +32,7 @@ import {
   DAY_MS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
+  resolveClientIp,
 } from "../config.mjs";
 import { parseLimitParam } from "../request-params.mjs";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.mjs";
@@ -199,6 +200,26 @@ export function canonicalHealthWindowCachePath(url) {
   const { label, error } = analyticsWindow(url);
   if (error) return `${url.pathname}${url.search}`;
   return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
+async function dataRateLimitResponse(request, env) {
+  if (!env.DATA_RATE_LIMITER?.limit) return null;
+  const { success } = await env.DATA_RATE_LIMITER.limit({
+    key: `data:${resolveClientIp(request)}`,
+  });
+  if (success) return null;
+  return errorResponse(
+    "data_rate_limited",
+    "Too many data API requests from this client; slow down.",
+    429,
+    {},
+    {
+      "retry-after": "60",
+      "x-ratelimit-limit": "60",
+      "x-ratelimit-policy": "60;w=60",
+      "x-ratelimit-remaining": "0",
+    },
+  );
 }
 
 function analyticsQueryError(error) {
@@ -1982,11 +2003,16 @@ export async function handleChainFees(request, env, url, ctx = {}) {
     async () => {
       const meta = await readHealthMetaKv(env);
       let isFallback = false;
-      let data = await tryPostgresTier(
-        env,
-        request,
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      );
+      let data = null;
+      if (env.METAGRAPH_EXTRINSICS_SOURCE === "postgres" && env.DATA_API) {
+        const limited = await dataRateLimitResponse(request, env);
+        if (limited) return limited;
+        data = await tryPostgresTier(
+          env,
+          request,
+          "METAGRAPH_EXTRINSICS_SOURCE",
+        );
+      }
       if (!data) {
         const result = await loadChainFees(d1Runner(env), {
           window: label,


### PR DESCRIPTION
### Motivation

- The Postgres-backed `/api/v1/chain/fees` path forwarded public requests to the DATA_API without charging the per-client `DATA_RATE_LIMITER`, enabling potential availability/cost amplification via expensive percentile queries.
- Apply the same data-tier rate-limit used by other Postgres-backed routes before reaching the DATA_API while keeping the existing D1 fallback behavior intact.

### Description

- Add a `dataRateLimitResponse` helper that checks `env.DATA_RATE_LIMITER.limit` keyed by `resolveClientIp(request)` and returns a uniform 429 `data_rate_limited` response when denied (`workers/request-handlers/analytics.mjs`).
- Import `resolveClientIp` and wire the helper into the analytics handlers file so it can be reused by Postgres-backed analytics routes (`workers/request-handlers/analytics.mjs`).
- Update `handleChainFees` to invoke the limiter before calling `tryPostgresTier` when `METAGRAPH_EXTRINSICS_SOURCE` is `postgres` and `DATA_API` is present, and preserve the D1 fallback path when Postgres is unavailable or disabled (`workers/request-handlers/analytics.mjs`).
- Add a regression test that asserts a denied limiter returns 429, sets the expected retry headers, charges the limiter once, and prevents the `DATA_API.fetch` from being invoked (`tests/request-handlers-analytics.test.mjs`).

### Testing

- Ran `npx vitest run tests/request-handlers-analytics.test.mjs --reporter=verbose` and the analytics test file passed (all tests in the file succeeded).
- Ran `npm run lint` and `npm run format:check` and both checks completed successfully.
- Ran `git diff --check` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52347897d8832cb39a14fb97c7fe39)