### PR TITLE
fix(data-api): enforce limit validation for /chain/identity-history and disable workers.dev for data worker

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4536,6 +4536,18 @@ test("GET /api/v1/chain/identity-history returns the network-wide feed", async (
   expect(body.changes[0].netuid).toBe(7);
 });
 
+test("GET /api/v1/chain/identity-history rejects oversized direct data-worker limits", async () => {
+  const res = await req("/api/v1/chain/identity-history?limit=1000000000");
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({
+    error: {
+      parameter: "limit",
+      message: "limit must be an integer between 1 and 200.",
+    },
+  });
+  expect(queryText()).not.toMatch(/FROM subnet_identity_history/);
+});
+
 test("GET /api/v1/chain/identity-history on a cold store returns a schema-stable empty feed", async () => {
   mockRows.current = [];
   const res = await req("/api/v1/chain/identity-history");

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -285,6 +285,7 @@ import {
 import {
   buildChainIdentityHistory,
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+  CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
 } from "../src/chain-identity-history.mjs";
 import {
   buildChainActivity,
@@ -317,14 +318,17 @@ function windowLabelFor(url, windows, defaultLabel) {
 }
 
 // A ?limit= value for the /chain/* network-wide analytics routes (#4832
-// Tier 2): by the time tryPostgresTier reaches this route, the D1-side
-// handler's own parseLimitParam has ALREADY validated it (absent ->
-// defaultLimit, present -> a clean positive integer <= its maxLimit) -- a
-// malformed limit 400s before ever reaching here, so this only needs to
-// replicate parseLimitParam's success path, not re-validate.
+// Tier 2). Most callers arrive via tryPostgresTier after the D1-side handler
+// has already validated the route-specific bounds, so this mirrors
+// parseLimitParam's success path. Direct data-worker routes that are reachable
+// before the main Worker must still call parseLimitParam themselves below.
 function chainLimit(url, defaultLimit) {
   const raw = url.searchParams.get("limit");
   return raw === null ? defaultLimit : Number(raw);
+}
+
+function queryError(error) {
+  return json({ error }, 400);
 }
 
 // Resolve a ?window= label to a YYYY-MM-DD cutoff date for a neuron_daily
@@ -367,6 +371,7 @@ import {
   DAY_PATTERN,
   clampLimit as clampRequestLimit,
   clampOffset as clampRequestOffset,
+  parseLimitParam,
 } from "./request-params.mjs";
 import {
   buildSubnetMetagraph,
@@ -4304,7 +4309,11 @@ export default {
           /^\/api\/v1\/chain\/identity-history$/,
         );
         if (chainIdentityHistory) {
-          const limit = chainLimit(url, CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT);
+          const { limit, error } = parseLimitParam(url, {
+            defaultLimit: CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
+            maxLimit: CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
+          });
+          if (error) return queryError(error);
           const rows = await sql`
           SELECT id, netuid, block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash
           FROM subnet_identity_history

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -15,6 +15,11 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "metagraphed-data-api",
   "main": "workers/data-api.mjs",
+  // Reached only through the main Worker's DATA_API service binding. Wrangler
+  // defaults workers.dev to enabled when a Worker has no public routes, so keep
+  // both public and preview URLs disabled for this private data tier.
+  "workers_dev": false,
+  "preview_urls": false,
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
   // Smart placement: run the Worker close to the Hyperdrive origin (self-hosted indexer


### PR DESCRIPTION
### Motivation
- A direct data-worker route for `GET /api/v1/chain/identity-history` trusted validation performed by the main Worker and could be invoked via Wrangler preview/workers.dev, allowing unauthenticated callers to bind an oversized `LIMIT` into Postgres and amplify cost/availability.
- Defensive-in-depth requires the data Worker to validate `limit` itself and the worker config must explicitly disable public preview URLs so the private tier cannot be reached directly.

### Description
- Validate the `limit` inside the data Worker by calling `parseLimitParam(...)` with the same `default`/`max` pair used by the main handler, and return a 400 JSON error when invalid instead of binding an attacker-supplied value into `LIMIT` (`workers/data-api.mjs`).
- Import `CHAIN_IDENTITY_HISTORY_LIMIT_MAX` and `parseLimitParam`, add a small `queryError` helper, and update the `chainLimit` comment to document the defensive expectation (`workers/data-api.mjs`).
- Explicitly disable preview/public exposure for the data Worker by setting `"workers_dev": false` and `"preview_urls": false` in `wrangler.data.jsonc` to avoid Wrangler defaulting to an exposed workers.dev URL.
- Add a regression test that requests `/api/v1/chain/identity-history?limit=1000000000` and asserts a `400` response and that no identity-history SQL query was executed (`tests/data-api.test.mjs`).

### Testing
- Ran the focused data-worker test file with `npm test -- tests/data-api.test.mjs` and all tests in that file passed: `327 passed` (including the new regression test). 
- Ran `npm run lint -- --max-warnings=0` and `npm run format:check`, both succeeded. 
- A prior attempt using the unsupported `--runInBand` flag with `vitest` failed due to the flag being invalid, so the suite was run without that flag and passed. 
- Verified `git diff --check` had no issues before finalizing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5234787dd4832c987940dfa72871e0)