### PR TITLE
fix(ui): wrap Validators/miners KPI eyebrow instead of truncating on mobile (#3936)

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -104,6 +104,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
           eyebrow="Validators / miners"
           value={`${y.validator_count ?? "—"} / ${y.miner_count ?? "—"}`}
           hint={`${y.neuron_count ?? neurons.length} UIDs`}
+          wrapEyebrow
         />
       </div>
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3275,7 +3275,8 @@ function StatTile({
   hint,
   chart,
   tone = "default",
-  className
+  className,
+  wrapEyebrow = false
 }) {
   return /* @__PURE__ */ jsxRuntime.jsxs(
     "div",
@@ -3301,7 +3302,16 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate", children: eyebrow }),
+          /* @__PURE__ */ jsxRuntime.jsx(
+            "div",
+            {
+              className: classNames(
+                "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+                wrapEyebrow ? "text-balance" : "truncate"
+              ),
+              children: eyebrow
+            }
+          ),
           /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 flex min-w-0 items-baseline gap-1.5", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
             hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 font-mono text-[10px] text-ink-muted truncate", children: hint }) : null

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3246,7 +3246,8 @@ function StatTile({
   hint,
   chart,
   tone = "default",
-  className
+  className,
+  wrapEyebrow = false
 }) {
   return /* @__PURE__ */ jsxs(
     "div",
@@ -3272,7 +3273,16 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate", children: eyebrow }),
+          /* @__PURE__ */ jsx(
+            "div",
+            {
+              className: classNames(
+                "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+                wrapEyebrow ? "text-balance" : "truncate"
+              ),
+              children: eyebrow
+            }
+          ),
           /* @__PURE__ */ jsxs("div", { className: "mt-1 flex min-w-0 items-baseline gap-1.5", children: [
             /* @__PURE__ */ jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
             hint ? /* @__PURE__ */ jsx("span", { className: "min-w-0 font-mono text-[10px] text-ink-muted truncate", children: hint }) : null

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -10,6 +10,13 @@ interface Props {
   chart?: ReactNode;
   tone?: "default" | "accent" | "ok" | "warn" | "down";
   className?: string;
+  /**
+   * Allow the eyebrow label to wrap to a second line instead of truncating.
+   * Opt-in (#3936) for tiles whose label is too long to fit on one line in a
+   * narrow grid column (e.g. "Validators / miners"); defaults to the single-line
+   * truncate behavior every other caller relies on.
+   */
+  wrapEyebrow?: boolean;
 }
 
 /**
@@ -24,6 +31,7 @@ export function StatTile({
   chart,
   tone = "default",
   className,
+  wrapEyebrow = false,
 }: Props) {
   return (
     <div
@@ -55,7 +63,12 @@ export function StatTile({
         />
       ) : null}
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate">
+        <div
+          className={classNames(
+            "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+            wrapEyebrow ? "text-balance" : "truncate",
+          )}
+        >
           {eyebrow}
         </div>
         <div className="mt-1 flex min-w-0 items-baseline gap-1.5">


### PR DESCRIPTION
> Resubmit of #4891 — auto-closed for a stale-base conflict (StatTile moved to `packages/ui-kit` in #4890), **not** a quality issue (the gate said readiness 100/100, no blockers, CI green). Rebased onto current main: the fix now lives in the ui-kit StatTile, and `packages/ui-kit/dist` is rebuilt + committed so the dist-drift check passes.

## Summary

In the Yield tab's KPI row, the "Validators / miners" `StatTile` truncated its eyebrow label mid-word (`"VALIDATORS /…"`) at narrow grid-column widths (~400–640px), while its shorter-labeled siblings ("Subnet yield", "Median yield") rendered in full — leaving that tile looking broken relative to the row.

Adds an **opt-in `wrapEyebrow` prop** to the shared `StatTile` (default `false` = unchanged `truncate`) that lets a long label wrap (`text-balance`), and enables it only on the "Validators / miners" tile.

## Change

- `packages/ui-kit/.../charts/stat-tile.tsx` — new opt-in `wrapEyebrow` prop (+ rebuilt `packages/ui-kit/dist`).
- `apps/ui/.../yield-panel.tsx` — pass `wrapEyebrow` on the one long-label tile.
- Every other `StatTile` caller unchanged (prop defaults to truncate); the other two tiles untouched; values/data unchanged.

## Verification (behavioral, in-browser)

At the narrow-column widths where the bug occurs, measured `scrollWidth > clientWidth` on the eyebrow: **before** `truncated=true` ("VALIDATORS /…"), **after** `truncated=false` (full "Validators / miners" wraps to two lines). Sibling tiles and the single-column phone layout are unaffected.

## Screenshots

Yield KPI row. **Mobile** rows captured at 430px (grid-cols-2 — the width where the third tile truncated). **Before:** "VALIDATORS / MI…"; **After:** full label. Wider viewports (no truncation) render identically.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3936/mobile-dark-after.png)<br><sub>after</sub> |

## Validation

```
npm run build --workspace=packages/ui-kit   # dist rebuilt + committed (drift check passes)
npm run typecheck --workspace=apps/ui       # 0 errors
npm run lint --workspace=apps/ui            # 0 errors
npm test --workspace=apps/ui                # 665 passed
npm run test:e2e --workspace=apps/ui        # 24 passed
```

Closes #3936
