### PR TITLE
feat(ui-kit): add CI guardrail against app-logic imports

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -377,7 +377,14 @@ SDK` commit, so a hand-bump here is redundant at best and a conflicting version 
   commit the resulting `dist/index.js`/`index.cjs`/`index.css` in the same PR** — the `ui` CI job's
   "Build packages/ui-kit (drift check)" step rebuilds fresh and fails loudly (`git diff --exit-code`)
   if the committed copy doesn't match, same as the `packages/client` drift check above. The job also
-  runs a dedicated `npm run typecheck --workspace=packages/ui-kit` step ("Typecheck packages/ui-kit").
+  runs dedicated `npm run typecheck --workspace=packages/ui-kit` ("Typecheck packages/ui-kit") and
+  `npm test --workspace=packages/ui-kit` ("Test packages/ui-kit") steps. **A separate "Lint
+  packages/ui-kit (app-logic import guardrail)" step (#4865) enforces that the package stays a real,
+  standalone library** — `packages/ui-kit/eslint.config.js`'s `no-restricted-imports` rule fails on
+  any import of `@tanstack/react-router`, `@tanstack/react-query`, or anything resolving into
+  `apps/ui/**`. If a component genuinely needs routing/data, accept it as a prop from the caller
+  instead of reaching for app infrastructure — that's the exact regression this package's extraction
+  exists to prevent.
 - **`packages/contract` is a types-only npm workspace (#3067) holding the OpenAPI-derived contract
   types** — `openapi-typescript`'s output (`scripts/generate-types.mjs`/`validate-types.mjs`/
   `validate-contract-drift.mjs` all write/check `packages/contract/index.d.ts` now, no longer

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -723,6 +723,14 @@ jobs:
         if: env.RUN_UI_VALIDATION == 'true'
         run: npm test --workspace=packages/ui-kit
 
+      # Enforces the #4867 epic's core invariant: packages/ui-kit stays a
+      # real, standalone library. no-restricted-imports (packages/ui-kit/
+      # eslint.config.js) fails on @tanstack/react-router,
+      # @tanstack/react-query, or any import resolving into apps/ui/**.
+      - name: Lint packages/ui-kit (app-logic import guardrail)
+        if: env.RUN_UI_VALIDATION == 'true'
+        run: npm run lint --workspace=packages/ui-kit
+
       - name: Lint (ESLint + Prettier)
         if: env.RUN_UI_VALIDATION == 'true'
         run: npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui

--- a/package-lock.json
+++ b/package-lock.json
@@ -1560,9 +1560,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1572,7 +1572,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -11804,12 +11804,19 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "eslint": "^9.39.4",
+        "eslint-plugin-prettier": "^5.5.6",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "globals": "^15.15.0",
+        "prettier": "^3.9.4",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
+        "typescript-eslint": "^8.62.1",
         "vitest": "^3.2.6"
       },
       "engines": {
@@ -11818,6 +11825,84 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "packages/ui-kit/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/ui-kit/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/ui-kit/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/ui-kit/node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "packages/ui-kit/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/ui-kit/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "packages/ui-kit/node_modules/@vitest/expect": {
@@ -11935,6 +12020,41 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "packages/ui-kit/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/ui-kit/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ui-kit/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "packages/ui-kit/node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -11950,6 +12070,134 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/ui-kit/node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui-kit/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ui-kit/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ui-kit/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ui-kit/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ui-kit/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "packages/ui-kit/node_modules/std-env": {

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -8,9 +8,21 @@ Why this package exists: [#4867](https://github.com/JSONbored/metagraphed/issues
 
 ## Status
 
-Scaffold only ([#4860](https://github.com/JSONbored/metagraphed/issues/4860)) — no real
-components have migrated yet. `PlaceholderCard` exists only to prove the build pipeline (JS +
-`.d.ts` + CSS extraction) works end to end; it's removed once the first real component lands.
+Design tokens, the shadcn-style `components/ui/*` primitives, the cross-cutting visual-language
+components, and the chart primitives have all migrated
+([#4861](https://github.com/JSONbored/metagraphed/issues/4861)-[#4864](https://github.com/JSONbored/metagraphed/issues/4864)).
+`apps/ui` consumes everything from `@jsonbored/ui-kit`.
+
+## Boundary rule: no app-specific imports
+
+This package must stay a real, standalone, dependency-free library — the moment a component here
+imports something app-specific, the extraction has silently regressed back into the exact problem
+this package exists to fix. `eslint.config.js`'s `no-restricted-imports` rule enforces this in CI:
+importing `@tanstack/react-router`, `@tanstack/react-query`, or anything resolving into
+`apps/ui/**` fails the build. If a component genuinely needs routing/data, accept it as a prop
+from the caller instead. If it needs a small pure helper that also lives in `apps/ui` (date
+formatting, a `cn()`-style className joiner, etc.), duplicate the specific pieces needed rather
+than importing across the package boundary — see `src/lib/format.ts` for the established pattern.
 
 ## Build
 

--- a/packages/ui-kit/eslint.config.js
+++ b/packages/ui-kit/eslint.config.js
@@ -1,0 +1,54 @@
+import js from "@eslint/js";
+import eslintPluginPrettier from "eslint-plugin-prettier/recommended";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  { ignores: ["dist"] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      // The whole point of packages/ui-kit is that it's a real, standalone,
+      // dependency-free library (#4867). These two packages are apps/ui's
+      // routing/data-fetching infrastructure -- if a component here needs
+      // either, accept the data/navigation as a prop from the caller
+      // instead (see packages/ui-kit/README.md).
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@tanstack/react-router",
+              message:
+                "packages/ui-kit must stay app-agnostic -- accept navigation/URLs as props instead of importing router infrastructure.",
+            },
+            {
+              name: "@tanstack/react-query",
+              message:
+                "packages/ui-kit must stay app-agnostic -- accept fetched data as props instead of importing query infrastructure.",
+            },
+          ],
+          patterns: [
+            {
+              group: ["**/apps/ui/**", "**/apps/ui"],
+              message:
+                "packages/ui-kit must never import from apps/ui -- that's the app-context leak this package exists to prevent. Duplicate the needed pure logic into packages/ui-kit instead (see src/lib/format.ts for the established pattern).",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  eslintPluginPrettier,
+);

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -34,7 +34,8 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --dts-resolve --clean --treeshake",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.15",
@@ -54,12 +55,19 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "eslint": "^9.39.4",
+    "eslint-plugin-prettier": "^5.5.6",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^15.15.0",
+    "prettier": "^3.9.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.62.1",
     "vitest": "^3.2.6"
   }
 }


### PR DESCRIPTION
## Summary

Closes #4865 (part of the `packages/ui-kit` extraction epic, #4867).

The entire point of `packages/ui-kit` is that it's a real, standalone, dependency-free library — the moment a component inside it imports something app-specific (`@tanstack/react-router`, `@tanstack/react-query`, an `apps/ui`-local file), the extraction has silently regressed back into the exact problem this epic exists to fix. Nothing in #4862/#4863/#4864 structurally prevented that from creeping back in over time. This adds the enforced boundary.

## What this adds

- **`packages/ui-kit/eslint.config.js`** — a dedicated flat-config ESLint setup for the package (mirrors `apps/ui/eslint.config.js`'s shape: `@eslint/js` + `typescript-eslint` + `eslint-plugin-react-hooks` + `eslint-plugin-prettier`). Its `no-restricted-imports` rule fails on:
  - `@tanstack/react-router` (exact package match)
  - `@tanstack/react-query` (exact package match)
  - any import resolving into `apps/ui/**` (pattern match — catches relative-path escapes too, e.g. `../../../apps/ui/...`)

  Each violation gets an actionable message pointing at the fix (accept as a prop instead of importing app infrastructure).
- **CI wiring**: a new "Lint packages/ui-kit (app-logic import guardrail)" step in `validate.yml`, alongside the existing typecheck/test/build-drift steps for the package — a violation fails the PR the same way any other lint error does, no separate opt-in.
- **Docs**: `packages/ui-kit/README.md` now states the boundary rule in plain language (also fixed its stale "scaffold only" status left over from #4860, and removed the reference to `PlaceholderCard`, which #4862 already deleted — found while updating the file for this PR). The metagraphed skill's `reference.md` also documents the new CI step.

## Confirmed the rule actually fires

Per the issue's explicit requirement — didn't just trust the config compiles. Added a temporary file with all three violation types:

```tsx
import { Link } from "@tanstack/react-router";
import { useQuery } from "@tanstack/react-query";
import { formatNumber } from "../../../../apps/ui/src/lib/metagraphed/format";
```

Ran `npm run lint --workspace=packages/ui-kit` — all three errored correctly with their custom messages. Removed the file, confirmed clean again.

## Validation

- [x] `npm run lint --workspace=packages/ui-kit` — clean against the existing (real) codebase, confirming #4862-#4864 never actually introduced a violation
- [x] Guardrail fire-test as described above (added violation → 3 errors → removed → clean)
- [x] `npm run typecheck --workspace=packages/ui-kit` — clean
- [x] `npm run build --workspace=packages/ui-kit` — clean
- [x] `npm test --workspace=packages/ui-kit` — 9/9 files, 52/52 tests passing
- [x] `npm run typecheck --workspace=apps/ui` — clean (untouched by this PR, sanity-checked anyway)
- [x] `npx prettier --check` on all touched files — clean
- [x] Confirmed the root-level `eslint.config.mjs` doesn't conflict — it only ever covered `.mjs` files repo-wide (never `.ts`/`.tsx`, not even for `packages/client`), so `packages/ui-kit`'s new config is purely additive, no double-linting or config clash

No visual changes — this PR touches only tooling config, CI workflow, and docs, not `apps/ui` component code.