### PR TITLE
feat(health): add Postgres tier for subnet_snapshots (trajectory + economics trends)

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -220,6 +220,39 @@ CREATE INDEX IF NOT EXISTS idx_account_position_daily_netuid_date
 CREATE INDEX IF NOT EXISTS idx_account_position_daily_date
   ON account_position_daily (snapshot_date);
 
+-- Daily structural + economics snapshot per subnet (#4832 gap-closure;
+-- mirrors D1 migrations/0002_analytics.sql + 0008_economics_history.sql).
+-- Low-volume (~129 rows/day, one per active subnet) -- plain table, not a
+-- hypertable, matching account_position_daily/subnet_hyperparams above.
+-- Written from src/health-prober.mjs's writeSubnetSnapshot, the SAME
+-- function that already calls syncSubnetIdentityToPostgres -- an in-Worker-
+-- cron direct env.DATA_API.fetch() service-binding call, not an external
+-- GitHub Actions workflow (see that function's own header comment for why).
+-- total_stake_tao/alpha_price_tao/emission_share are NUMERIC (not REAL),
+-- matching subnet_hyperparams' TAO-precision rationale above.
+CREATE TABLE IF NOT EXISTS subnet_snapshots (
+  netuid             INTEGER NOT NULL,
+  snapshot_date      DATE NOT NULL,
+  completeness_score INTEGER,
+  surface_count      INTEGER,
+  endpoint_count     INTEGER,
+  monitored_count    INTEGER,
+  candidate_count    INTEGER,
+  captured_at        BIGINT NOT NULL,
+  validator_count    INTEGER,
+  miner_count        INTEGER,
+  total_stake_tao    NUMERIC,
+  alpha_price_tao    NUMERIC,
+  emission_share     NUMERIC,
+  PRIMARY KEY (netuid, snapshot_date)
+);
+CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date
+  ON subnet_snapshots (snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_netuid_date
+  ON subnet_snapshots (netuid, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date_netuid
+  ON subnet_snapshots (snapshot_date, netuid);
+
 -- Subnet hyperparameters, latest-only (#4832 gap-closure; mirrors D1
 -- migrations/0036_subnet_hyperparams.sql). One row per netuid, upserted by
 -- the refresh-subnet-hyperparams workflow's direct POST to data-api.mjs.

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -893,6 +893,67 @@ export async function pruneHealthHistory(env, overrides = {}) {
   }
 }
 
+// #4832 gap-closure: mirror writeSubnetSnapshot's D1 upsert into Postgres via
+// the DATA_API service binding, called directly from writeSubnetSnapshot
+// below -- same "in-Worker hourly cron, direct env.DATA_API.fetch() service-
+// binding call, not an external GitHub Actions workflow" shape as
+// syncSubnetIdentityToPostgres (src/subnet-identity-history.mjs), which this
+// same function already calls. Best-effort: never throws, and a failure here
+// must never block the D1 write above (the primary contract).
+export async function syncSubnetSnapshotToPostgres(
+  env,
+  { profiles, economicsByNetuid, date, capturedAt } = {},
+) {
+  if (!env?.DATA_API || !env?.SUBNET_SNAPSHOT_SYNC_SECRET) {
+    return { synced: false, reason: "unavailable" };
+  }
+  if (!Array.isArray(profiles) || profiles.length === 0) {
+    return { synced: false, reason: "no_profiles" };
+  }
+  const rows = profiles
+    .filter((profile) => Number.isInteger(profile.netuid))
+    .map((profile) => {
+      const econ = economicsByNetuid?.get(profile.netuid) || {};
+      return {
+        netuid: profile.netuid,
+        snapshot_date: date,
+        completeness_score: profile.completeness_score ?? null,
+        surface_count: profile.surface_count ?? null,
+        endpoint_count: profile.endpoint_count ?? null,
+        monitored_count: profile.monitored_endpoint_count ?? null,
+        candidate_count: profile.candidate_count ?? null,
+        validator_count: econ.validator_count ?? null,
+        miner_count: econ.miner_count ?? null,
+        total_stake_tao: econ.total_stake_tao ?? null,
+        alpha_price_tao: econ.alpha_price_tao ?? null,
+        emission_share: econ.emission_share ?? null,
+        captured_at: capturedAt,
+      };
+    });
+  if (!rows.length) return { synced: false, reason: "no_rows" };
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/subnet-snapshot-sync",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-subnet-snapshot-sync-token": env.SUBNET_SNAPSHOT_SYNC_SECRET,
+          },
+          body: JSON.stringify(rows),
+        },
+      ),
+    );
+    if (!upstream.ok) {
+      return { synced: false, reason: `status_${upstream.status}` };
+    }
+    return { synced: true, rows: rows.length };
+  } catch {
+    return { synced: false, reason: "fetch_failed" };
+  }
+}
+
 // Daily growth snapshot (AI-4). Captures each subnet's structural maturity into
 // subnet_snapshots, keyed on (netuid, UTC date). Fired from the hourly cron;
 // ON CONFLICT DO NOTHING makes repeated fires within a day idempotent (the first
@@ -940,6 +1001,16 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
   );
 
   const date = new Date(capturedAt).toISOString().slice(0, 10);
+  // #4832 gap-closure: best-effort Postgres mirror of the D1 upsert below --
+  // never awaited-and-thrown into the caller, see syncSubnetSnapshotToPostgres's
+  // own header comment for why this is a direct service-binding call rather
+  // than routing through the public proxy layer.
+  await syncSubnetSnapshotToPostgres(env, {
+    profiles,
+    economicsByNetuid,
+    date,
+    capturedAt,
+  });
   // The structural columns + captured_at are owned by the first same-day fire.
   // The economics columns can arrive late (economics.json is pure chain state
   // with no committed-asset fallback, unlike profiles.json), so DO NOTHING

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -8,7 +8,10 @@ import {
   loadSubnetTrajectory,
   LEADERBOARD_BOARDS,
 } from "../src/health-serving.mjs";
-import { writeSubnetSnapshot } from "../src/health-prober.mjs";
+import {
+  syncSubnetSnapshotToPostgres,
+  writeSubnetSnapshot,
+} from "../src/health-prober.mjs";
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -1002,6 +1005,159 @@ describe("writeSubnetSnapshot", () => {
     for (const col of ["completeness_score", "surface_count", "captured_at"]) {
       assert.doesNotMatch(captured, new RegExp(`${col}\\s*=`));
     }
+  });
+});
+
+// #4832 gap-closure: mirrors src/subnet-identity-history.mjs's
+// syncSubnetIdentityToPostgres tests -- same shape, own dedicated secret
+// (SUBNET_SNAPSHOT_SYNC_SECRET) and own internal route.
+describe("syncSubnetSnapshotToPostgres", () => {
+  const profiles = [{ netuid: 8, completeness_score: 90 }];
+  const economicsByNetuid = new Map([[8, { validator_count: 5 }]]);
+  const opts = {
+    profiles,
+    economicsByNetuid,
+    date: "2026-06-10",
+    capturedAt: 1,
+  };
+
+  test("returns unavailable when DATA_API is not bound", async () => {
+    const result = await syncSubnetSnapshotToPostgres(
+      { SUBNET_SNAPSHOT_SYNC_SECRET: "shh" },
+      opts,
+    );
+    assert.deepEqual(result, { synced: false, reason: "unavailable" });
+  });
+
+  test("returns unavailable when the secret is not configured", async () => {
+    const result = await syncSubnetSnapshotToPostgres(
+      { DATA_API: { fetch: async () => new Response("{}", { status: 200 }) } },
+      opts,
+    );
+    assert.deepEqual(result, { synced: false, reason: "unavailable" });
+  });
+
+  test("returns no_profiles for an empty or missing profiles array", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("{}", { status: 200 }) },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    assert.deepEqual(
+      await syncSubnetSnapshotToPostgres(env, { ...opts, profiles: [] }),
+      { synced: false, reason: "no_profiles" },
+    );
+    assert.deepEqual(await syncSubnetSnapshotToPostgres(env, {}), {
+      synced: false,
+      reason: "no_profiles",
+    });
+  });
+
+  test("returns no_rows when every profile lacks an integer netuid", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("{}", { status: 200 }) },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetSnapshotToPostgres(env, {
+      ...opts,
+      profiles: [{ netuid: null }],
+    });
+    assert.deepEqual(result, { synced: false, reason: "no_rows" });
+  });
+
+  test("POSTs one row per profile with the token header and reports synced:true on 200", async () => {
+    let receivedToken;
+    let receivedPath;
+    let receivedBody;
+    const env = {
+      DATA_API: {
+        fetch: async (request) => {
+          receivedToken = request.headers.get("x-subnet-snapshot-sync-token");
+          receivedPath = new URL(request.url).pathname;
+          receivedBody = await request.json();
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        },
+      },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetSnapshotToPostgres(env, opts);
+    assert.deepEqual(result, { synced: true, rows: 1 });
+    assert.equal(receivedToken, "shh");
+    assert.equal(receivedPath, "/api/v1/internal/subnet-snapshot-sync");
+    assert.deepEqual(receivedBody, [
+      {
+        netuid: 8,
+        snapshot_date: "2026-06-10",
+        completeness_score: 90,
+        surface_count: null,
+        endpoint_count: null,
+        monitored_count: null,
+        candidate_count: null,
+        validator_count: 5,
+        miner_count: null,
+        total_stake_tao: null,
+        alpha_price_tao: null,
+        emission_share: null,
+        captured_at: 1,
+      },
+    ]);
+  });
+
+  test("reports the upstream status when the response is not ok, never throws", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("{}", { status: 502 }) },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetSnapshotToPostgres(env, opts);
+    assert.deepEqual(result, { synced: false, reason: "status_502" });
+  });
+
+  test("reports fetch_failed and never throws when the binding call rejects", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("network down");
+        },
+      },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetSnapshotToPostgres(env, opts);
+    assert.deepEqual(result, { synced: false, reason: "fetch_failed" });
+  });
+
+  test("defaults every optional field to null when absent, without an economics map", async () => {
+    let receivedBody;
+    const env = {
+      DATA_API: {
+        fetch: async (request) => {
+          receivedBody = await request.json();
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        },
+      },
+      SUBNET_SNAPSHOT_SYNC_SECRET: "shh",
+    };
+    const result = await syncSubnetSnapshotToPostgres(env, {
+      profiles: [{ netuid: 9 }],
+      date: "2026-06-10",
+      capturedAt: 1,
+    });
+    assert.deepEqual(result, { synced: true, rows: 1 });
+    assert.deepEqual(receivedBody, [
+      {
+        netuid: 9,
+        snapshot_date: "2026-06-10",
+        completeness_score: null,
+        surface_count: null,
+        endpoint_count: null,
+        monitored_count: null,
+        candidate_count: null,
+        validator_count: null,
+        miner_count: null,
+        total_stake_tao: null,
+        alpha_price_tao: null,
+        emission_share: null,
+        captured_at: 1,
+      },
+    ]);
   });
 });
 

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -68,6 +68,7 @@ const subnetIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
 // D1/KV already received, so there's nothing to prime beyond the failure hook.
 const healthChecksSyncFailure = vi.hoisted(() => ({ error: null }));
 const healthUptimeRollupSyncFailure = vi.hoisted(() => ({ error: null }));
+const subnetSnapshotSyncFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -129,6 +130,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO account_identity\b/.test(text)
       ) {
         return Promise.reject(accountIdentitySyncFailure.error);
+      }
+      if (
+        subnetSnapshotSyncFailure.error &&
+        /INSERT INTO subnet_snapshots\b/.test(text)
+      ) {
+        return Promise.reject(subnetSnapshotSyncFailure.error);
       }
       if (
         subnetIdentitySyncFailure.error &&
@@ -201,6 +208,7 @@ const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
 const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
 const SUBNET_IDENTITY_SYNC_SECRET = "test-subnet-identity-sync-secret";
 const HEALTH_CHECKS_SYNC_SECRET = "test-health-checks-sync-secret";
+const SUBNET_SNAPSHOT_SYNC_SECRET = "test-subnet-snapshot-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
@@ -209,6 +217,7 @@ const env = {
   ACCOUNT_IDENTITY_SYNC_SECRET,
   SUBNET_IDENTITY_SYNC_SECRET,
   HEALTH_CHECKS_SYNC_SECRET,
+  SUBNET_SNAPSHOT_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -229,6 +238,7 @@ beforeEach(() => {
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
   healthChecksSyncFailure.error = null;
+  subnetSnapshotSyncFailure.error = null;
   healthUptimeRollupSyncFailure.error = null;
   mockRows.current = [
     {
@@ -5021,4 +5031,215 @@ test("GET /api/v1/internal/subnet-identity-aliases: no netuids returns rows:[] w
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.rows).toEqual([]);
+});
+
+test("GET /api/v1/subnets/:netuid/trajectory: formats daily snapshot rows", async () => {
+  mockRows.current = [
+    {
+      snapshot_date: "2026-06-01",
+      completeness_score: 90,
+      surface_count: 5,
+      endpoint_count: 5,
+      validator_count: 8,
+      miner_count: 60,
+      total_stake_tao: 90,
+      alpha_price_tao: 0.01,
+      emission_share: 0.02,
+    },
+  ];
+  const res = await req("/api/v1/subnets/7/trajectory");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.netuid).toBe(7);
+  expect(body.points[0].date).toBe("2026-06-01");
+  expect(body.points[0].completeness_score).toBe(90);
+});
+
+test("GET /api/v1/economics/trends: aggregates daily rows network-wide", async () => {
+  mockRows.current = [
+    {
+      snapshot_date: "2026-06-01",
+      total_stake_tao: 300,
+      alpha_price_tao: 0.02,
+      validator_count: 8,
+      miner_count: 50,
+      emission_share: 0.04,
+    },
+  ];
+  const res = await req("/api/v1/economics/trends?window=30d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("30d");
+  expect(body.day_count).toBe(1);
+  expect(body.days[0].snapshot_date).toBe("2026-06-01");
+});
+
+test("GET /api/v1/economics/trends: unrecognized window degrades to all", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/economics/trends?window=bogus");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("all");
+});
+
+function snapshotRow(overrides = {}) {
+  return {
+    netuid: 7,
+    snapshot_date: "2026-06-01",
+    completeness_score: 90,
+    surface_count: 5,
+    endpoint_count: 5,
+    monitored_count: 5,
+    candidate_count: 1,
+    validator_count: 8,
+    miner_count: 60,
+    total_stake_tao: 90,
+    alpha_price_tao: 0.01,
+    emission_share: 0.02,
+    captured_at: 1780000000000,
+    ...overrides,
+  };
+}
+
+function postSubnetSnapshot(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-subnet-snapshot-sync-token"] = secret;
+  return req("/api/v1/internal/subnet-snapshot-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? []),
+  });
+}
+
+test("subnet-snapshot-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postSubnetSnapshot([snapshotRow()], { secret: "wrong" });
+  expect(wrong.status).toBe(401);
+  const missing = await postSubnetSnapshot([snapshotRow()]);
+  expect(missing.status).toBe(401);
+});
+
+test("subnet-snapshot-sync is disabled (503) when SUBNET_SNAPSHOT_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/subnet-snapshot-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-subnet-snapshot-sync-token": SUBNET_SNAPSHOT_SYNC_SECRET,
+      },
+      body: JSON.stringify([snapshotRow()]),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("subnet-snapshot-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/subnet-snapshot-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-subnet-snapshot-sync-token": SUBNET_SNAPSHOT_SYNC_SECRET,
+      },
+      body: JSON.stringify([snapshotRow()]),
+    }),
+    { SUBNET_SNAPSHOT_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("subnet-snapshot-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postSubnetSnapshot(null, {
+    secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+    raw: "[" + "1".repeat(2_000_000) + "]",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("subnet-snapshot-sync rejects malformed JSON (400)", async () => {
+  const res = await postSubnetSnapshot(null, {
+    secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("subnet-snapshot-sync rejects a body that isn't an array (400)", async () => {
+  const res = await postSubnetSnapshot(
+    { not: "an array" },
+    { secret: SUBNET_SNAPSHOT_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("subnet-snapshot-sync rejects more than the row cap (413)", async () => {
+  const many = Array.from({ length: 2_001 }, (_, i) =>
+    snapshotRow({ netuid: i }),
+  );
+  const res = await postSubnetSnapshot(many, {
+    secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+  });
+  expect(res.status).toBe(413);
+});
+
+test("subnet-snapshot-sync on an empty array is a clean no-op (200)", async () => {
+  const res = await postSubnetSnapshot([], {
+    secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, rows_written: 0 });
+});
+
+test("subnet-snapshot-sync silently skips a row missing a required field, no error", async () => {
+  const res = await postSubnetSnapshot(
+    [snapshotRow({ netuid: "not-a-number" })],
+    {
+      secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+    },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, rows_written: 0 });
+});
+
+test("subnet-snapshot-sync upserts subnet_snapshots with the COALESCE-on-economics-columns SET clause", async () => {
+  const res = await postSubnetSnapshot(
+    [snapshotRow(), snapshotRow({ netuid: 8, snapshot_date: "2026-06-02" })],
+    { secret: SUBNET_SNAPSHOT_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, rows_written: 2 });
+  expect(queryText()).toMatch(/INSERT INTO subnet_snapshots\b/);
+  expect(queryText()).toMatch(
+    /ON CONFLICT \(netuid, snapshot_date\) DO UPDATE SET/,
+  );
+  expect(queryText()).toMatch(
+    /validator_count = COALESCE\(subnet_snapshots\.validator_count, excluded\.validator_count\)/,
+  );
+});
+
+test("subnet-snapshot-sync defaults every optional field to null when absent", async () => {
+  const minimal = {
+    netuid: 3,
+    snapshot_date: "2026-06-01",
+    captured_at: 1780000000000,
+  };
+  const res = await postSubnetSnapshot([minimal], {
+    secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, rows_written: 1 });
+});
+
+test("subnet-snapshot-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  subnetSnapshotSyncFailure.error = new Error("connection reset");
+  const res = await postSubnetSnapshot([snapshotRow()], {
+    secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
 });

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -276,6 +276,60 @@ describe("handleTrajectory", () => {
     const body = await res.json();
     assert.equal(body.data.point_count, 1);
   });
+
+  // #4832 gap-closure: METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is a NEW flag,
+  // deliberately left unset in wrangler.jsonc (no historical backfill --
+  // see handleTrajectory's own header comment) -- these tests only prove
+  // the wiring, not a live flip.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = d1Env();
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    env.METAGRAPH_SUBNET_SNAPSHOTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          netuid: NETUID,
+          points: [],
+          point_count: 0,
+        }),
+    };
+    const res = await handleTrajectory(
+      req(`/api/v1/subnets/${NETUID}/trajectory`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/trajectory`),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = d1Env();
+    env.METAGRAPH_SUBNET_SNAPSHOTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const res = await handleTrajectory(
+      req(`/api/v1/subnets/${NETUID}/trajectory`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/trajectory`),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body.data.points, []);
+  });
 });
 
 describe("handleEconomicsTrends", () => {
@@ -484,6 +538,51 @@ describe("handleEconomicsTrends", () => {
     assert.match(res.headers.get("content-type"), /application\/json/);
     const body = await res.json();
     assert.equal(body.data.day_count, 1);
+  });
+
+  // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same table
+  // and same deliberately-unflipped rationale as handleTrajectory above.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = d1Env();
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error(
+        "D1 must not be queried when Postgres serves the request",
+      );
+    };
+    env.METAGRAPH_SUBNET_SNAPSHOTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({ schema_version: 1, day_count: 0, days: [] }),
+    };
+    const res = await handleEconomicsTrends(
+      req("/api/v1/economics/trends"),
+      env,
+      url("/api/v1/economics/trends"),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.day_count, 0);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = d1Env();
+    env.METAGRAPH_SUBNET_SNAPSHOTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    const res = await handleEconomicsTrends(
+      req("/api/v1/economics/trends"),
+      env,
+      url("/api/v1/economics/trends"),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body.data.days, []);
   });
 });
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -232,9 +232,15 @@ import {
   formatIncidents,
   formatGlobalIncidents,
   formatUptime,
+  formatTrajectory,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.mjs";
+import {
+  buildEconomicsTrends,
+  parseHistoryWindow,
+} from "../src/neuron-history.mjs";
+import { ECONOMICS_TRENDS_ROW_CAP } from "../src/economics-trends.mjs";
 import {
   buildChainWeights,
   CHAIN_WEIGHTS_LIMIT_DEFAULT,
@@ -1799,6 +1805,160 @@ async function handleHealthUptimeRollupSync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/subnet-snapshot-sync (#4832 gap-closure) ------
+//
+// Best-effort Postgres mirror of writeSubnetSnapshot's D1 upsert
+// (src/health-prober.mjs) -- same "own hourly cron, direct
+// env.DATA_API.fetch() service-binding call" shape as subnet-identity-sync
+// above, not an external GitHub Actions workflow. Rows arrive precomputed
+// (one per active subnet, already joined against economics.json), mirroring
+// health-checks-sync's shape rather than subnet-identity-sync's own
+// diff-and-append shape. ON CONFLICT (netuid, snapshot_date) DO UPDATE
+// mirrors D1's COALESCE-on-economics-columns semantics exactly: structural
+// columns + captured_at are owned by the day's first fire, economics
+// columns can backfill across the day's later fires but a later NULL can
+// never wipe an earlier fire's good value.
+const SUBNET_SNAPSHOT_SYNC_TOKEN_HEADER = "x-subnet-snapshot-sync-token";
+// ~129 subnets/day; generous headroom, matching the other sync routes.
+const SUBNET_SNAPSHOT_SYNC_MAX_BODY_BYTES = 2_000_000;
+const SUBNET_SNAPSHOT_SYNC_MAX_ROWS = 2_000;
+
+async function handleSubnetSnapshotSync(request, env) {
+  if (!env.SUBNET_SNAPSHOT_SYNC_SECRET) {
+    return writeJson(
+      { error: "subnet-snapshot sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(SUBNET_SNAPSHOT_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.SUBNET_SNAPSHOT_SYNC_SECRET)
+  ) {
+    return writeJson(
+      { error: `provide a valid ${SUBNET_SNAPSHOT_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > SUBNET_SNAPSHOT_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${SUBNET_SNAPSHOT_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const rows = Array.isArray(parsed) ? parsed : null;
+  if (!rows) {
+    return writeJson(
+      { error: "body must be a JSON array of subnet snapshot rows" },
+      400,
+    );
+  }
+  if (rows.length > SUBNET_SNAPSHOT_SYNC_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${SUBNET_SNAPSHOT_SYNC_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!rows.length) {
+    return writeJson({ ok: true, rows_written: 0 });
+  }
+
+  const validRows = rows.filter(
+    (row) =>
+      row &&
+      Number.isInteger(row.netuid) &&
+      typeof row.snapshot_date === "string" &&
+      Number.isFinite(row.captured_at),
+  );
+  if (!validRows.length) {
+    return writeJson({ ok: true, rows_written: 0 });
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  const snapshotRows = validRows.map((row) => ({
+    netuid: row.netuid,
+    snapshot_date: row.snapshot_date,
+    completeness_score: Number.isFinite(row.completeness_score)
+      ? row.completeness_score
+      : null,
+    surface_count: Number.isFinite(row.surface_count)
+      ? row.surface_count
+      : null,
+    endpoint_count: Number.isFinite(row.endpoint_count)
+      ? row.endpoint_count
+      : null,
+    monitored_count: Number.isFinite(row.monitored_count)
+      ? row.monitored_count
+      : null,
+    candidate_count: Number.isFinite(row.candidate_count)
+      ? row.candidate_count
+      : null,
+    validator_count: Number.isFinite(row.validator_count)
+      ? row.validator_count
+      : null,
+    miner_count: Number.isFinite(row.miner_count) ? row.miner_count : null,
+    total_stake_tao: Number.isFinite(row.total_stake_tao)
+      ? row.total_stake_tao
+      : null,
+    alpha_price_tao: Number.isFinite(row.alpha_price_tao)
+      ? row.alpha_price_tao
+      : null,
+    emission_share: Number.isFinite(row.emission_share)
+      ? row.emission_share
+      : null,
+    captured_at: row.captured_at,
+  }));
+
+  try {
+    return await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '10000ms'`;
+      await sql`
+        INSERT INTO subnet_snapshots ${sql(
+          snapshotRows,
+          "netuid",
+          "snapshot_date",
+          "completeness_score",
+          "surface_count",
+          "endpoint_count",
+          "monitored_count",
+          "candidate_count",
+          "validator_count",
+          "miner_count",
+          "total_stake_tao",
+          "alpha_price_tao",
+          "emission_share",
+          "captured_at",
+        )}
+        ON CONFLICT (netuid, snapshot_date) DO UPDATE SET
+          validator_count = COALESCE(subnet_snapshots.validator_count, excluded.validator_count),
+          miner_count = COALESCE(subnet_snapshots.miner_count, excluded.miner_count),
+          total_stake_tao = COALESCE(subnet_snapshots.total_stake_tao, excluded.total_stake_tao),
+          alpha_price_tao = COALESCE(subnet_snapshots.alpha_price_tao, excluded.alpha_price_tao),
+          emission_share = COALESCE(subnet_snapshots.emission_share, excluded.emission_share)`;
+      return writeJson({ ok: true, rows_written: snapshotRows.length });
+    });
+  } catch (err) {
+    console.error("data-api subnet-snapshot-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -1953,6 +2113,12 @@ export default {
       url.pathname === "/api/v1/internal/health-uptime-rollup-sync"
     ) {
       return handleHealthUptimeRollupSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/subnet-snapshot-sync"
+    ) {
+      return handleSubnetSnapshotSync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
@@ -3964,6 +4130,62 @@ export default {
             netuids,
           );
           return json({ rows });
+        }
+
+        // GET /api/v1/subnets/:netuid/trajectory (#4832 gap-closure): weekly
+        // structural + economics trajectory from the daily snapshot, mirroring
+        // workers/request-handlers/analytics-routes.mjs's handleTrajectory.
+        // format=csv is handled entirely D1-side (csvResponse never reaches
+        // tryPostgresTier's own request-forward for this route -- see that
+        // handler); this route only ever needs to return JSON.
+        const subnetTrajectory = url.pathname.match(
+          /^\/api\/v1\/subnets\/(\d+)\/trajectory$/,
+        );
+        if (subnetTrajectory) {
+          const netuid = Number(subnetTrajectory[1]);
+          const rows = await sql`
+          SELECT snapshot_date::text AS snapshot_date, completeness_score,
+                 surface_count, endpoint_count, validator_count, miner_count,
+                 total_stake_tao, alpha_price_tao, emission_share
+          FROM subnet_snapshots
+          WHERE netuid = ${netuid}
+          ORDER BY snapshot_date DESC
+          LIMIT 400`;
+          return json(formatTrajectory({ netuid, rows }));
+        }
+
+        // GET /api/v1/economics/trends?window= (#4832 gap-closure):
+        // network-wide daily economics time series, mirroring
+        // workers/request-handlers/analytics-routes.mjs's handleEconomicsTrends
+        // via src/economics-trends.mjs's loadEconomicsTrends. A malformed
+        // window degrades to "all" (no cutoff) rather than erroring -- the
+        // D1-side handler already rejects it before ever reaching this route
+        // in the real request path, same convention as the uptime route's
+        // windowParam above.
+        if (url.pathname === "/api/v1/economics/trends") {
+          const windowParam = url.searchParams.get("window");
+          const parsedWindow = parseHistoryWindow(windowParam);
+          const windowDays = parsedWindow.error ? null : parsedWindow.days;
+          const windowLabel = parsedWindow.error ? "all" : parsedWindow.label;
+          const cutoff =
+            windowDays != null
+              ? new Date(Date.now() - windowDays * ANALYTICS_DAY_MS)
+                  .toISOString()
+                  .slice(0, 10)
+              : null;
+          const rows = await sql`
+          SELECT snapshot_date::text AS snapshot_date, total_stake_tao,
+                 alpha_price_tao, validator_count, miner_count, emission_share
+          FROM subnet_snapshots
+          ${cutoff ? sql`WHERE snapshot_date >= ${cutoff}::date` : sql``}
+          ORDER BY snapshot_date DESC
+          LIMIT ${ECONOMICS_TRENDS_ROW_CAP}`;
+          return json(
+            buildEconomicsTrends(rows, {
+              window: windowLabel,
+              capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP,
+            }),
+          );
         }
 
         // GET /api/v1/accounts/:ss58/stake-flow

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -125,28 +125,43 @@ export async function handleTrajectory(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
-  const rows = await d1All(
+  // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE (deliberately
+  // unflipped -- subnet_snapshots has no historical backfill, only started
+  // accumulating from writeSubnetSnapshot's dual-write landing, same
+  // rationale as METAGRAPH_HEALTH_SOURCE's own header comment). A Postgres
+  // hit never reaches d1All, so it can never be marked a fallback.
+  let isFallback = false;
+  let data = await tryPostgresTier(
     env,
-    `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
-            validator_count, miner_count, total_stake_tao, alpha_price_tao,
-            emission_share
-     FROM subnet_snapshots
-     WHERE netuid = ?
-     ORDER BY snapshot_date DESC
-     LIMIT 400`,
-    [netuid],
+    request,
+    "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
   );
-  const data = formatTrajectory({ netuid, rows });
+  if (!data) {
+    const rows = await d1All(
+      env,
+      `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
+              validator_count, miner_count, total_stake_tao, alpha_price_tao,
+              emission_share
+       FROM subnet_snapshots
+       WHERE netuid = ?
+       ORDER BY snapshot_date DESC
+       LIMIT 400`,
+      [netuid],
+    );
+    data = formatTrajectory({ netuid, rows });
+    isFallback = hasD1FallbackRows(rows);
+  }
   if (csvRequested(url, request)) {
-    return csvResponse(
+    const csvRes = csvResponse(
       data.points,
       `subnet-${netuid}-trajectory`,
       "short",
       request,
       TRAJECTORY_CSV_COLUMNS,
     );
+    return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
   }
-  return envelopeWithD1Fallback(
+  const response = await envelopeResponse(
     request,
     {
       data,
@@ -157,8 +172,8 @@ export async function handleTrajectory(request, env, netuid, url) {
       ),
     },
     "short",
-    [rows],
   );
+  return isFallback ? markD1FallbackResponse(response) : response;
 }
 
 // Network-wide economics time series (#1307): aggregate the per-subnet daily
@@ -176,28 +191,41 @@ export async function handleEconomicsTrends(request, env, url) {
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  const { data, rows } = await loadEconomicsTrends(
-    (sql, params) => d1All(env, sql, params),
-    { windowLabel: label, windowDays: days },
+  // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same table
+  // and same deliberately-unflipped rationale as handleTrajectory above.
+  let isFallback = false;
+  let data = await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
   );
+  if (!data) {
+    const loaded = await loadEconomicsTrends(
+      (sql, params) => d1All(env, sql, params),
+      { windowLabel: label, windowDays: days },
+    );
+    data = loaded.data;
+    isFallback = hasD1FallbackRows(loaded.rows);
+  }
   if (csvRequested(url, request)) {
-    return csvResponse(
+    const csvRes = csvResponse(
       data.days,
       "economics-trends",
       "short",
       request,
       ECONOMICS_TRENDS_CSV_COLUMNS,
     );
+    return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
   }
-  return envelopeWithD1Fallback(
+  const response = await envelopeResponse(
     request,
     {
       data,
       meta: await analyticsMeta(env, "/metagraph/economics/trends.json", null),
     },
     "short",
-    [rows],
   );
+  return isFallback ? markD1FallbackResponse(response) : response;
 }
 
 // Long-term daily uptime history for one subnet's operational surfaces.

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -6,8 +6,9 @@
   //
   // Also owns every write route into this same Postgres instance (#4771's
   // neurons-sync, subnet-hyperparams-sync, account-identity-sync,
-  // subnet-identity-sync, health-checks-sync -- see workers/data-api.mjs's
-  // handle*Sync functions) -- each requires its own secret, set via:
+  // subnet-identity-sync, health-checks-sync, health-uptime-rollup-sync,
+  // subnet-snapshot-sync -- see workers/data-api.mjs's handle*Sync
+  // functions) -- each requires its own secret, set via:
   //   wrangler secret put <NAME>_SYNC_SECRET -c wrangler.data.jsonc
   // (and, for the ones called from the main Worker's own cron rather than an
   // external GitHub Actions workflow, the SAME secret value on the main


### PR DESCRIPTION
## Summary
- Adds `subnet_snapshots` to `deploy/postgres/schema.sql` (plain table, not a hypertable -- low-volume, ~129 rows/day) and applies it live to production Postgres.
- Adds `syncSubnetSnapshotToPostgres` (`src/health-prober.mjs`), a best-effort Postgres mirror called from `writeSubnetSnapshot` -- the same hourly-cron function that already calls `syncSubnetIdentityToPostgres` for the sibling `subnet_identity_history` table. Same in-Worker-cron/direct-service-binding shape, no external GitHub Actions workflow.
- Adds the write route (`POST /api/v1/internal/subnet-snapshot-sync`, `handleSubnetSnapshotSync` in `workers/data-api.mjs`), gated by a new `SUBNET_SNAPSHOT_SYNC_SECRET` (provisioned on both Workers). `ON CONFLICT (netuid, snapshot_date) DO UPDATE` mirrors D1's COALESCE-on-economics-columns semantics exactly.
- Adds Postgres-backed `GET /api/v1/subnets/:netuid/trajectory` and `GET /api/v1/economics/trends` routes in `workers/data-api.mjs`, wired via `tryPostgresTier` into `handleTrajectory`/`handleEconomicsTrends` (`workers/request-handlers/analytics-routes.mjs`) behind a new `METAGRAPH_SUBNET_SNAPSHOTS_SOURCE` flag -- deliberately left unset in `wrangler.jsonc` pending a real accumulated history window (no backfill exists), same rationale as `METAGRAPH_HEALTH_SOURCE`.
- **Deliberately out of scope for this PR**: `handleLeaderboards`' `growthSamples` sub-query (one of five parallel inputs, harder to isolate cleanly) and the two MCP-side duplicate D1 loaders (`loadSubnetTrajectory` in `src/health-serving.mjs`, `loadRegistryLeaderboards` in `src/analytics-live.mjs`) still read D1 directly. Flagging as a narrower follow-up rather than widening this change.

## Test plan
- [x] `npx eslint` + `npx prettier --check` on all 8 changed files
- [x] `npx vitest run tests/data-api.test.mjs tests/analytics.test.mjs tests/request-handlers-analytics-routes.test.mjs`
- [x] `npx vitest run` (full suite): 7663/7663 passing
- [x] `npm run test:coverage` + patch-coverage isolation: 100% of added lines/branches covered across all 4 changed source files
- [x] `npm run scan:public-safety`
- [x] `npm run validate`
- [x] `git diff --check`
- [x] Live-verified the trajectory/economics-trends SQL via `psql` against production (index scans, sub-ms) and applied the schema DDL live
- [x] Provisioned `SUBNET_SNAPSHOT_SYNC_SECRET` on both Workers with a matching value