### PR TITLE
fix(ui): scope the incident strip as a network-wide notice

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -75,6 +75,7 @@ export function IncidentStrip() {
           )}
         />
         <span className="font-mono text-[10px] uppercase tracking-widest shrink-0">
+          <span className="text-ink-muted">Network · </span>
           {isDown ? "Incident" : "Degraded"}
         </span>
         <span className="min-w-0 flex-1 truncate">


### PR DESCRIPTION
## Summary

On a subnet detail page (`/subnets/$netuid`) the incident strip renders directly above the subnet's own masthead and led with just `DEGRADED` / `INCIDENT`. Because the top active incident can belong to a **different** subnet (e.g. SN0 while you're viewing SN1/Apex), a user could misread it as the currently-viewed subnet's own health — there was no text establishing that it's a network-wide operational notice.

## Change

One file: `apps/ui/src/components/metagraphed/incident-strip.tsx`.

- Prefix the strip's eyebrow with a muted `Network · ` scope label, so it reads **NETWORK · DEGRADED** (or **NETWORK · INCIDENT**).
- Text-only; no logic, query, or layout change. The affected-subnet link (`SN{netuid}`), `+N more`, View, and dismiss controls are unchanged.

Closes #3951

## Screenshots

Incident strip on `/subnets/1` (Apex) with a live active incident, three viewports × both themes. Theme forced via `localStorage.setItem("mg-theme", …)`. **Before** = `upstream/main`; **After** = this branch (same active incident, directly comparable).

> **Where to look:** the eyebrow. *Before:* `⚠ DEGRADED · SN0 +16 more` — reads as if SN1 (the page you're on) is degraded. *After:* `⚠ NETWORK · DEGRADED · SN0 +16 more` — clearly a network-wide notice about another subnet.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3951-assets/3951/after-mobile-dark.png) |

## Validation

- `tsc --noEmit` clean; `prettier --check` clean.
- Verified live (built + served, Playwright on `/subnets/1`): eyebrow renders `NETWORK · DEGRADED` in both themes; no change to the incident message, affected-subnet link, or controls.