### PR TITLE
feat(health): add Postgres tier for rpc_proxy_events (RPC usage analytics)

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -532,6 +532,34 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_surface_uptime_daily_key_day_unique
 CREATE INDEX IF NOT EXISTS idx_surface_uptime_daily_day_netuid
   ON surface_uptime_daily (day, netuid);
 
+-- RPC reverse-proxy usage telemetry (#4832 gap-closure; mirrors D1
+-- migrations/0004_rpc_proxy_usage.sql + 0010_perf_indexes.sql). Written
+-- best-effort per proxied request (workers/request-handlers/rpc-proxy.mjs's
+-- recordRpcUsage), not a cron/workflow batch like every other #4832 table --
+-- confirmed live 2026-07-11 the real volume is trivial (69 rows over ~25
+-- days), so this stays a plain table like subnet_hyperparams/
+-- subnet_snapshots above rather than a hypertable; revisit if traffic grows.
+-- Same 30-day pruning window as surface_checks (src/health-prober.mjs's
+-- pruneHealthHistory).
+CREATE TABLE IF NOT EXISTS rpc_proxy_events (
+  id          BIGSERIAL PRIMARY KEY,
+  observed_at BIGINT NOT NULL,
+  network     TEXT NOT NULL,
+  endpoint_id TEXT,
+  provider    TEXT,
+  ok          BOOLEAN NOT NULL,
+  status      INTEGER,
+  attempts    INTEGER,
+  latency_ms  INTEGER,
+  cache       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_observed
+  ON rpc_proxy_events (observed_at);
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_network_observed
+  ON rpc_proxy_events (network, observed_at);
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_observed_endpoint
+  ON rpc_proxy_events (observed_at, endpoint_id);
+
 -- ---------------------------------------------------------------------------
 -- Indexer coordination
 -- ---------------------------------------------------------------------------

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -69,6 +69,7 @@ const subnetIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
 const healthChecksSyncFailure = vi.hoisted(() => ({ error: null }));
 const healthUptimeRollupSyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetSnapshotSyncFailure = vi.hoisted(() => ({ error: null }));
+const rpcUsageSyncFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -136,6 +137,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO subnet_snapshots\b/.test(text)
       ) {
         return Promise.reject(subnetSnapshotSyncFailure.error);
+      }
+      if (
+        rpcUsageSyncFailure.error &&
+        /INSERT INTO rpc_proxy_events\b/.test(text)
+      ) {
+        return Promise.reject(rpcUsageSyncFailure.error);
       }
       if (
         subnetIdentitySyncFailure.error &&
@@ -209,6 +216,7 @@ const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
 const SUBNET_IDENTITY_SYNC_SECRET = "test-subnet-identity-sync-secret";
 const HEALTH_CHECKS_SYNC_SECRET = "test-health-checks-sync-secret";
 const SUBNET_SNAPSHOT_SYNC_SECRET = "test-subnet-snapshot-sync-secret";
+const RPC_USAGE_SYNC_SECRET = "test-rpc-usage-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
@@ -218,6 +226,7 @@ const env = {
   SUBNET_IDENTITY_SYNC_SECRET,
   HEALTH_CHECKS_SYNC_SECRET,
   SUBNET_SNAPSHOT_SYNC_SECRET,
+  RPC_USAGE_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -240,6 +249,7 @@ beforeEach(() => {
   healthChecksSyncFailure.error = null;
   subnetSnapshotSyncFailure.error = null;
   healthUptimeRollupSyncFailure.error = null;
+  rpcUsageSyncFailure.error = null;
   mockRows.current = [
     {
       block_number: "123",
@@ -5252,6 +5262,205 @@ test("subnet-snapshot-sync maps a DB failure to a clean 502 instead of throwing"
   subnetSnapshotSyncFailure.error = new Error("connection reset");
   const res = await postSubnetSnapshot([snapshotRow()], {
     secret: SUBNET_SNAPSHOT_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
+});
+
+test("GET /api/v1/rpc/usage: formats the 6 parallel queries via formatRpcUsage", async () => {
+  // Queue order MUST match the route's Promise.all array: totals, latency,
+  // endpoints, networks, buckets, freshRows -- each is a separate top-level
+  // sql`` call, constructed eagerly (before Promise.all resolves anything),
+  // so mockQueue.current is consumed in that same left-to-right order. The
+  // leading [] is the router's own `SET statement_timeout` query.
+  mockQueue.current = [
+    [], // SET statement_timeout
+    [
+      {
+        total: 100,
+        ok_count: 95,
+        failover_count: 5,
+        cache_hits: 20,
+        avg_latency_ms: "150",
+      },
+    ],
+    [{ p50: "120", p95: "400" }],
+    [
+      {
+        endpoint_id: "fx",
+        provider: "onfinality",
+        requests: 100,
+        ok_count: 95,
+        avg_latency_ms: "140",
+      },
+    ],
+    [{ network: "finney", requests: 100, ok_count: 95 }],
+    [{ ts: 1_718_323_200_000, requests: 100, errors: 5, avg_latency_ms: 150 }],
+    [{ newest_observed: 1_718_323_200_000 }],
+  ];
+  const res = await req("/api/v1/rpc/usage?window=30d");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("30d");
+  expect(body.source).toBe("rpc-proxy");
+  expect(body.summary.total_requests).toBe(100);
+  expect(body.summary.error_requests).toBe(5);
+  expect(body.summary.latency_ms.p50).toBe(120);
+  expect(body.endpoints[0].endpoint_id).toBe("fx");
+  expect(body.networks[0].network).toBe("finney");
+  expect(body.buckets[0].ts).toBe(1_718_323_200_000);
+  expect(body.observed_at).toBe(new Date(1_718_323_200_000).toISOString());
+});
+
+test("GET /api/v1/rpc/usage: unrecognized window falls back to the 7d default", async () => {
+  mockQueue.current = [[], [], [], [], [], [], []]; // SET + 6 route queries
+  const res = await req("/api/v1/rpc/usage?window=bogus");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window).toBe("7d");
+  expect(body.summary.total_requests).toBe(0);
+});
+
+function rpcUsageEvent(overrides = {}) {
+  return {
+    observed_at: 1_718_323_200_000,
+    network: "finney",
+    endpoint_id: "fx",
+    provider: "onfinality",
+    ok: true,
+    status: 200,
+    attempts: 1,
+    latency_ms: 140,
+    cache: "miss",
+    ...overrides,
+  };
+}
+
+function postRpcUsageEvent(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-rpc-usage-sync-token"] = secret;
+  return req("/api/v1/internal/rpc-usage-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? rpcUsageEvent()),
+  });
+}
+
+test("rpc-usage-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postRpcUsageEvent(rpcUsageEvent(), { secret: "wrong" });
+  expect(wrong.status).toBe(401);
+  const missing = await postRpcUsageEvent(rpcUsageEvent());
+  expect(missing.status).toBe(401);
+});
+
+test("rpc-usage-sync is disabled (503) when RPC_USAGE_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/rpc-usage-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-rpc-usage-sync-token": RPC_USAGE_SYNC_SECRET,
+      },
+      body: JSON.stringify(rpcUsageEvent()),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("rpc-usage-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/rpc-usage-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-rpc-usage-sync-token": RPC_USAGE_SYNC_SECRET,
+      },
+      body: JSON.stringify(rpcUsageEvent()),
+    }),
+    { RPC_USAGE_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("rpc-usage-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postRpcUsageEvent(null, {
+    secret: RPC_USAGE_SYNC_SECRET,
+    raw: `{"network":"${"a".repeat(4_000)}"}`,
+  });
+  expect(res.status).toBe(413);
+});
+
+test("rpc-usage-sync rejects malformed JSON (400)", async () => {
+  const res = await postRpcUsageEvent(null, {
+    secret: RPC_USAGE_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("rpc-usage-sync rejects an event missing required fields (400)", async () => {
+  const res = await postRpcUsageEvent(
+    { observed_at: 1_718_323_200_000 },
+    { secret: RPC_USAGE_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("rpc-usage-sync rejects a JSON array body (400)", async () => {
+  const res = await postRpcUsageEvent([rpcUsageEvent()], {
+    secret: RPC_USAGE_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("rpc-usage-sync inserts a single row and defaults optional fields to null", async () => {
+  const res = await postRpcUsageEvent(
+    { observed_at: 1_718_323_200_000, network: "finney", ok: false },
+    { secret: RPC_USAGE_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true });
+  expect(queryText()).toMatch(/INSERT INTO rpc_proxy_events\b/);
+  const call = sqlCalls.at(-1);
+  expect(call.values).toEqual([
+    1_718_323_200_000,
+    "finney",
+    null,
+    null,
+    false,
+    null,
+    null,
+    null,
+    null,
+  ]);
+});
+
+test("rpc-usage-sync inserts a fully-populated row", async () => {
+  const res = await postRpcUsageEvent(rpcUsageEvent(), {
+    secret: RPC_USAGE_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const call = sqlCalls.at(-1);
+  expect(call.values).toEqual([
+    1_718_323_200_000,
+    "finney",
+    "fx",
+    "onfinality",
+    true,
+    200,
+    1,
+    140,
+    "miss",
+  ]);
+});
+
+test("rpc-usage-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  rpcUsageSyncFailure.error = new Error("connection reset");
+  const res = await postRpcUsageEvent(rpcUsageEvent(), {
+    secret: RPC_USAGE_SYNC_SECRET,
   });
   expect(res.status).toBe(502);
 });

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
@@ -431,6 +431,131 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
   });
 });
 
+// #4832 gap-closure: syncRpcUsageEventToPostgres (the Pattern-C per-request
+// Postgres mirror recordRpcUsage fires before its D1 write) is unexported, so
+// these drive it the same way the telemetry test above drives recordRpcUsage
+// itself -- through a guaranteed-502 handleRpcProxyRequest call (both
+// upstreams throw) that deterministically reaches the served-event write.
+describe("syncRpcUsageEventToPostgres wiring (#4832 gap-closure)", () => {
+  const rpcPost = (body) =>
+    req("/rpc/v1/finney", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "203.0.113.20",
+      },
+      body: JSON.stringify(body),
+    });
+
+  function dataApiCapture() {
+    const calls = [];
+    return {
+      calls,
+      fetch: async (request) => {
+        calls.push(request);
+        return Response.json({ ok: true });
+      },
+    };
+  }
+
+  const failBothUpstreams = () =>
+    scriptedFetch(
+      () => {
+        throw new Error("net");
+      },
+      () => {
+        throw new Error("net");
+      },
+    );
+
+  test("posts a mirrored event to DATA_API when the sync secret is configured", async () => {
+    const db = captureDb();
+    const dataApi = dataApiCapture();
+    let waited = null;
+    const ctx = {
+      waitUntil: (p) => {
+        waited = p;
+      },
+    };
+    const original = globalThis.fetch;
+    globalThis.fetch = failBothUpstreams();
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
+        rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
+          METAGRAPH_HEALTH_DB: db,
+          DATA_API: dataApi,
+          RPC_USAGE_SYNC_SECRET: "test-secret",
+        }),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      await errorJson(res, 502);
+      assert.equal(dataApi.calls.length, 1);
+      const sent = dataApi.calls[0];
+      assert.equal(
+        sent.url,
+        "https://api.metagraph.sh/api/v1/internal/rpc-usage-sync",
+      );
+      assert.equal(sent.method, "POST");
+      assert.equal(sent.headers.get("x-rpc-usage-sync-token"), "test-secret");
+      const body = await sent.json();
+      assert.equal(body.network, "finney");
+      assert.equal(body.ok, false);
+      assert.equal(body.attempts, 2);
+      // ctx.waitUntil actually received the fire-and-forget promise.
+      assert.ok(waited);
+      await waited;
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("skips the Postgres mirror when RPC_USAGE_SYNC_SECRET is not configured", async () => {
+    const db = captureDb();
+    const dataApi = dataApiCapture();
+    const ctx = { waitUntil: () => {} };
+    const original = globalThis.fetch;
+    globalThis.fetch = failBothUpstreams();
+    try {
+      await handleRpcProxyRequest(
+        rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
+        rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
+          METAGRAPH_HEALTH_DB: db,
+          DATA_API: dataApi,
+        }),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(dataApi.calls.length, 0);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("skips the Postgres mirror when ctx.waitUntil is not a function", async () => {
+    const db = captureDb();
+    const dataApi = dataApiCapture();
+    const original = globalThis.fetch;
+    globalThis.fetch = failBothUpstreams();
+    try {
+      await handleRpcProxyRequest(
+        rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
+        rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
+          METAGRAPH_HEALTH_DB: db,
+          DATA_API: dataApi,
+          RPC_USAGE_SYNC_SECRET: "test-secret",
+        }),
+        url("/rpc/v1/finney"),
+        {},
+      );
+      assert.equal(dataApi.calls.length, 0);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
 describe("state-query methods (#4344/9.2)", () => {
   const rpcPost = (body) =>
     req("/rpc/v1/finney", {

--- a/tests/request-handlers-rpc-proxy.test.mjs
+++ b/tests/request-handlers-rpc-proxy.test.mjs
@@ -197,6 +197,62 @@ describe("handleRpcUsage", () => {
     assert.equal(body.data.networks[0].network, "finney");
     assert.equal(body.data.buckets.length, 1);
   });
+
+  // #4832 gap-closure: METAGRAPH_RPC_USAGE_SOURCE is a NEW flag, deliberately
+  // left unset in wrangler.jsonc (no historical backfill -- see
+  // handleRpcUsage's own header comment) -- these tests only prove the
+  // wiring, not a live flip.
+  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
+    let d1Called = false;
+    const env = {
+      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "7d",
+            source: "rpc-proxy",
+            summary: { total_requests: 42 },
+            endpoints: [],
+            networks: [],
+            buckets: [],
+          }),
+      },
+      get METAGRAPH_HEALTH_DB() {
+        d1Called = true;
+        throw new Error("D1 must not be queried when Postgres serves");
+      },
+    };
+    const body = await json(
+      await handleRpcUsage(
+        req("/api/v1/rpc/usage"),
+        env,
+        url("/api/v1/rpc/usage"),
+      ),
+    );
+    assert.equal(body.data.summary.total_requests, 42);
+    assert.equal(d1Called, false);
+  });
+
+  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+    const env = {
+      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const body = await json(
+      await handleRpcUsage(
+        req("/api/v1/rpc/usage"),
+        env,
+        url("/api/v1/rpc/usage"),
+      ),
+    );
+    assert.equal(body.data.source, "rpc-proxy");
+    assert.equal(body.data.summary.total_requests, 0);
+  });
 });
 
 describe("handleSurfaceVerify", () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -224,6 +224,7 @@ import {
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   UPTIME_WINDOWS,
   MAX_UPTIME_ROWS,
+  RPC_USAGE_BUCKETS,
 } from "./config.mjs";
 import {
   formatBulkTrends,
@@ -233,6 +234,7 @@ import {
   formatGlobalIncidents,
   formatUptime,
   formatTrajectory,
+  formatRpcUsage,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../src/health-serving.mjs";
@@ -1964,6 +1966,90 @@ async function handleSubnetSnapshotSync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/rpc-usage-sync (#4832 gap-closure) ------------
+//
+// Best-effort Postgres mirror of recordRpcUsage's D1 insert
+// (workers/request-handlers/rpc-proxy.mjs's syncRpcUsageEventToPostgres) --
+// Pattern C, unlike every sync route above: one fire-and-forget POST per
+// live proxied RPC request under the caller's own ctx.waitUntil, not a
+// cron/workflow batch. Justified only after confirming live production
+// volume is trivial (69 rows / ~25 days, wrangler d1 execute 2026-07-11) --
+// batching would be premature for traffic this low. One event per request,
+// not an array, matching the caller's one-row-per-call shape.
+const RPC_USAGE_SYNC_TOKEN_HEADER = "x-rpc-usage-sync-token";
+// A single event object is a few hundred bytes; generous headroom.
+const RPC_USAGE_SYNC_MAX_BODY_BYTES = 4_000;
+
+async function handleRpcUsageEventSync(request, env) {
+  if (!env.RPC_USAGE_SYNC_SECRET) {
+    return writeJson(
+      { error: "rpc-usage sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(RPC_USAGE_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.RPC_USAGE_SYNC_SECRET)) {
+    return writeJson(
+      { error: `provide a valid ${RPC_USAGE_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > RPC_USAGE_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${RPC_USAGE_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let event;
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  if (
+    !event ||
+    typeof event !== "object" ||
+    Array.isArray(event) ||
+    !Number.isFinite(event.observed_at) ||
+    typeof event.network !== "string" ||
+    !event.network
+  ) {
+    return writeJson({ error: "malformed rpc usage event" }, 400);
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    await sql`
+      INSERT INTO rpc_proxy_events
+        (observed_at, network, endpoint_id, provider, ok, status, attempts, latency_ms, cache)
+      VALUES (
+        ${event.observed_at},
+        ${event.network},
+        ${typeof event.endpoint_id === "string" ? event.endpoint_id : null},
+        ${typeof event.provider === "string" ? event.provider : null},
+        ${Boolean(event.ok)},
+        ${Number.isFinite(event.status) ? event.status : null},
+        ${Number.isFinite(event.attempts) ? event.attempts : null},
+        ${Number.isFinite(event.latency_ms) ? event.latency_ms : null},
+        ${typeof event.cache === "string" ? event.cache : null}
+      )`;
+    return writeJson({ ok: true });
+  } catch (err) {
+    console.error("data-api rpc-usage-sync write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -2124,6 +2210,12 @@ export default {
       url.pathname === "/api/v1/internal/subnet-snapshot-sync"
     ) {
       return handleSubnetSnapshotSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/rpc-usage-sync"
+    ) {
+      return handleRpcUsageEventSync(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);
@@ -4189,6 +4281,101 @@ export default {
             buildEconomicsTrends(rows, {
               window: windowLabel,
               capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP,
+            }),
+          );
+        }
+
+        // GET /api/v1/rpc/usage?window= (#4832 gap-closure): RPC
+        // reverse-proxy usage analytics -- request volume, latency p50/p95,
+        // failover + error rate, cache-hit rate, per-endpoint/network
+        // breakdown, and bounded time buckets. Mirrors
+        // src/rpc-usage-loader.mjs's loadRpcUsage exactly (same 5 parallel
+        // queries feeding formatRpcUsage): the D1 rank-CTE p50/p95 becomes
+        // PERCENTILE_CONT (live-verified via psql 2026-07-11, same
+        // precedent as the health-trends/percentiles routes above), and D1's
+        // `ok = 1` becomes the bare BOOLEAN column. window is already
+        // validated by handleRpcUsage before tryPostgresTier ever forwards
+        // this request, so an unrecognized label just falls back to the
+        // default here (same convention as windowCutoff/windowLabelFor
+        // everywhere else in this file).
+        if (url.pathname === "/api/v1/rpc/usage") {
+          const windowLabel = windowLabelFor(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const cutoff = windowCutoff(
+            url,
+            ANALYTICS_WINDOWS,
+            DEFAULT_ANALYTICS_WINDOW,
+          );
+          const bucketConfig = RPC_USAGE_BUCKETS[windowLabel];
+          const [
+            totalsRows,
+            latencyRows,
+            endpointRows,
+            networkRows,
+            bucketRows,
+            freshRows,
+          ] = await Promise.all([
+            sql`
+            SELECT COUNT(*)::int AS total,
+                   SUM(CASE WHEN ok THEN 1 ELSE 0 END)::int AS ok_count,
+                   SUM(CASE WHEN attempts > 1 THEN 1 ELSE 0 END)::int AS failover_count,
+                   SUM(CASE WHEN cache = 'hit' THEN 1 ELSE 0 END)::int AS cache_hits,
+                   AVG(latency_ms) AS avg_latency_ms
+            FROM rpc_proxy_events
+            WHERE observed_at >= ${cutoff}`,
+            sql`
+            SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY latency_ms) AS p50,
+                   PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms) AS p95
+            FROM rpc_proxy_events
+            WHERE observed_at >= ${cutoff} AND latency_ms IS NOT NULL`,
+            sql`
+            SELECT endpoint_id, provider,
+                   COUNT(*)::int AS requests,
+                   SUM(CASE WHEN ok THEN 1 ELSE 0 END)::int AS ok_count,
+                   AVG(latency_ms) AS avg_latency_ms
+            FROM rpc_proxy_events
+            WHERE observed_at >= ${cutoff} AND endpoint_id IS NOT NULL
+            GROUP BY endpoint_id, provider
+            ORDER BY requests DESC, endpoint_id ASC, provider ASC
+            LIMIT 50`,
+            sql`
+            SELECT network,
+                   COUNT(*)::int AS requests,
+                   SUM(CASE WHEN ok THEN 1 ELSE 0 END)::int AS ok_count
+            FROM rpc_proxy_events
+            WHERE observed_at >= ${cutoff}
+            GROUP BY network
+            ORDER BY requests DESC, network ASC`,
+            sql`
+            SELECT ts, requests, errors, avg_latency_ms FROM (
+              SELECT (observed_at / ${bucketConfig.bucketMs}::bigint)::bigint * ${bucketConfig.bucketMs}::bigint AS ts,
+                     COUNT(*)::int AS requests,
+                     SUM(CASE WHEN ok THEN 0 ELSE 1 END)::int AS errors,
+                     AVG(latency_ms) AS avg_latency_ms
+              FROM rpc_proxy_events
+              WHERE observed_at >= ${cutoff}
+              GROUP BY ts
+              ORDER BY ts DESC
+              LIMIT ${bucketConfig.maxBuckets}
+            ) sub
+            ORDER BY ts ASC`,
+            sql`
+            SELECT MAX(observed_at) AS newest_observed
+            FROM rpc_proxy_events WHERE observed_at >= ${cutoff}`,
+          ]);
+          return json(
+            formatRpcUsage({
+              window: windowLabel,
+              observedAt: latestObservedIso(freshRows, "newest_observed"),
+              totals: totalsRows[0],
+              latency: latencyRows[0],
+              endpointRows,
+              networkRows,
+              bucketRows,
+              bucketGranularity: bucketConfig.granularity,
             }),
           );
         }

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -52,6 +52,7 @@ import {
 import { ipv6EmbeddedIpv4 } from "../../src/ip-safety.mjs";
 import { overlayRpcPoolEligibility } from "../../src/health-serving.mjs";
 import { loadRpcUsage } from "../../src/rpc-usage-loader.mjs";
+import { tryPostgresTier } from "../postgres-tier.mjs";
 import {
   DENIED_RPC_PREFIXES,
   JSON_CONTENT_TYPE,
@@ -108,12 +109,36 @@ export async function readRpcPoolArtifact(env, now = Date.now()) {
   return poolArtifact;
 }
 
+// #4832 gap-closure: best-effort Postgres mirror of a single rpc_proxy_events
+// row, called alongside the D1 write below. Unlike every other #4832 sync
+// route (all cron/workflow batch writes), this fires once per live proxied
+// request -- confirmed live 2026-07-11 the real volume is trivial (69 rows
+// over ~25 days), so a plain per-request env.DATA_API.fetch() under the
+// SAME ctx.waitUntil is safe; revisit if traffic grows enough to warrant
+// batching. Never throws, never adds latency to the proxied call.
+function syncRpcUsageEventToPostgres(env, ctx, event) {
+  if (!env?.DATA_API || !env?.RPC_USAGE_SYNC_SECRET) return;
+  if (typeof ctx?.waitUntil !== "function") return;
+  const send = env.DATA_API.fetch(
+    new Request("https://api.metagraph.sh/api/v1/internal/rpc-usage-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-rpc-usage-sync-token": env.RPC_USAGE_SYNC_SECRET,
+      },
+      body: JSON.stringify(event),
+    }),
+  ).catch(() => {});
+  ctx.waitUntil(send);
+}
+
 // Best-effort, async usage telemetry for the RPC proxy (B3). A telemetry write
 // must never add latency to, or fail, a proxied call — so it runs under
 // ctx.waitUntil and swallows every error (notably "no such table" before the
 // 0004 migration is applied). When the binding/ctx is absent (tests, local dev)
 // it is a no-op. The proxy degrades to "no analytics", never to "broken".
 function recordRpcUsage(env, ctx, event) {
+  syncRpcUsageEventToPostgres(env, ctx, event);
   const db = env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare || typeof ctx?.waitUntil !== "function") return;
   try {
@@ -150,10 +175,17 @@ export async function handleRpcUsage(request, env, url) {
   const { label, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
   const meta = await readHealthMetaKv(env);
-  const data = await loadRpcUsage(d1Runner(env), {
-    window: label,
-    observedAt: meta?.last_run_at || null,
-  });
+  // #4832 gap-closure: reuses tryPostgresTier's usual "forward the caller's
+  // request unchanged" contract (a clean 1:1 route, unlike handleCompare's
+  // embedded-helper shape). METAGRAPH_RPC_USAGE_SOURCE is deliberately
+  // unflipped in wrangler.jsonc -- no historical backfill exists, same
+  // rationale as METAGRAPH_HEALTH_SOURCE/METAGRAPH_SUBNET_SNAPSHOTS_SOURCE.
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_RPC_USAGE_SOURCE")) ??
+    (await loadRpcUsage(d1Runner(env), {
+      window: label,
+      observedAt: meta?.last_run_at || null,
+    }));
   return envelopeResponse(
     request,
     {

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -7,8 +7,8 @@
   // Also owns every write route into this same Postgres instance (#4771's
   // neurons-sync, subnet-hyperparams-sync, account-identity-sync,
   // subnet-identity-sync, health-checks-sync, health-uptime-rollup-sync,
-  // subnet-snapshot-sync -- see workers/data-api.mjs's handle*Sync
-  // functions) -- each requires its own secret, set via:
+  // subnet-snapshot-sync, rpc-usage-sync -- see workers/data-api.mjs's
+  // handle*Sync functions) -- each requires its own secret, set via:
   //   wrangler secret put <NAME>_SYNC_SECRET -c wrangler.data.jsonc
   // (and, for the ones called from the main Worker's own cron rather than an
   // external GitHub Actions workflow, the SAME secret value on the main


### PR DESCRIPTION
## Summary

- Completes the #4832 gap-closure sweep: `rpc_proxy_events`/`handleRpcUsage` was the last remaining D1-only health/analytics handler cluster.
- Adds the `rpc_proxy_events` schema (plain table + 3 indexes) to `deploy/postgres/schema.sql`, applied live to production Postgres and verified via `EXPLAIN` for all 5 read queries.
- Adds a per-request fire-and-forget Postgres write mirror (`syncRpcUsageEventToPostgres`, called from `recordRpcUsage` alongside the existing D1 write) — a new "Pattern C" shape, unlike every other #4832 sync route (all cron/GitHub-Actions-workflow batch writes). Justified by live-verified production volume: 69 rows over ~25 days (`wrangler d1 execute ... SELECT COUNT(*)...`), so per-request writes and a plain (non-hypertable) table are safe without batching.
- Adds `POST /api/v1/internal/rpc-usage-sync` (single-event write route, token-gated) and `GET /api/v1/rpc/usage` (5 parallel queries mirroring `src/rpc-usage-loader.mjs`'s `loadRpcUsage` exactly) to `workers/data-api.mjs`. The D1 rank-CTE p50/p95 becomes `PERCENTILE_CONT`, aggregates get explicit `::int` casts (per the bigint/numeric string-serialization convention from PR #4892's review), and D1's `ok = 1` becomes the bare Postgres `BOOLEAN` column.
- Wires `handleRpcUsage` (`workers/request-handlers/rpc-proxy.mjs`) to `tryPostgresTier(env, request, "METAGRAPH_RPC_USAGE_SOURCE")`, falling back to the existing D1 path unchanged.
- `METAGRAPH_RPC_USAGE_SOURCE` is deliberately left **unset** in `wrangler.jsonc`/`wrangler.data.jsonc` — no historical backfill exists yet, same rationale as `METAGRAPH_HEALTH_SOURCE`/`METAGRAPH_SUBNET_SNAPSHOTS_SOURCE`. Flipping it is a manual follow-up once real production history accumulates, not part of this PR.
- `RPC_USAGE_SYNC_SECRET` provisioned on both `metagraphed` and `metagraphed-data-api` Workers (matching value, `wrangler secret put` / `wrangler versions secret put`).
- **Deferred, not addressed in this PR**: the MCP `get_rpc_usage` tool (`src/mcp-server.mjs`) still reads D1 directly via `mcpD1Runner`. Wiring it to the same Postgres tier is straightforward follow-up but was left out to keep this PR focused on the REST surface, matching the precedent set by PR #4903 deferring `handleLeaderboards`' growth-samples sub-query and the MCP-side duplicate loaders.

## Test plan

- `npx vitest run` — full suite, 7684/7684 passing (262 files).
- New tests: `syncRpcUsageEventToPostgres` branch coverage (3 tests covering the guard conditions) + `handleRpcUsage` postgres-tier wiring (2 tests) in the rpc-proxy test files; 15 new `data-api.test.mjs` tests covering the read route (6-query aggregation, window fallback) and the write route (401/503×2/413/400×3/502/success paths).
- `npm run test:coverage` (unsharded) + a patch-coverage isolation pass against `coverage/lcov.info` — 100% of added lines/branches covered in both `workers/data-api.mjs` and `workers/request-handlers/rpc-proxy.mjs`.
- `npm run lint`, `npx prettier --check` on all touched files, `git diff --check`, `npm run scan:public-safety`, `npm run validate` — all clean.
- Live-verified all 5 read-route SQL queries (totals, latency percentiles, endpoint/network breakdowns, time-bucketed series) via `EXPLAIN` against production Postgres, using the real applied indexes.
- Live-applied the `rpc_proxy_events` schema (table + 3 indexes) to production Postgres via psql; confirmed successful creation.