### PR TITLE
feat(registry): add SN62 Ridges public data artifact via TaoMarketCap

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "id": "sn-62-taomarketcap-data-artifact",
+      "name": "Ridges subnet-state snapshot (via TaoMarketCap)",
+      "kind": "data-artifact",
+      "url": "https://api.taomarketcap.com/public/v1/subnets/62",
+      "provider": "taomarketcap",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/ridgesai/ridges"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "notes": "Public no-auth GET https://api.taomarketcap.com/public/v1/subnets/62 from the TaoMarketCap developer API — a machine-readable JSON snapshot of SN62's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields (verified live: HTTP 200, netuid 62). A standing third-party subnet-state data artifact for Ridges; the same universal TaoMarketCap subnet feed already registered for other subnets."
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

Appends **exactly one** `data-artifact` surface (`sn-62-taomarketcap-data-artifact`) to `registry/subnets/ridges.json` (SN62, Ridges). Strictly append-only — no reordering of existing top-level fields or surfaces; the diff is `+19 / -0`, the new object only.

## Surface

- **Netuid:** 62
- **Kind:** `data-artifact`
- **Public URL:** https://api.taomarketcap.com/public/v1/subnets/62
- **Source URLs:**
  - https://api.taomarketcap.com/developer/documentation/
  - https://github.com/ridgesai/ridges
- **Provider slug:** `taomarketcap`

The TaoMarketCap developer API exposes a public no-auth `GET /public/v1/subnets/{netuid}` snapshot returning machine-readable JSON for on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — verified live for netuid 62. Registered as a standing subnet-state data artifact for SN62.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/ridges.json` — passed
- [x] `git diff` is append-only (`+19 / -0`) — no existing content reordered
- [x] Verified `https://api.taomarketcap.com/public/v1/subnets/62` returns HTTP 200 with valid JSON (`netuid: 62`)
- [x] Confirmed no existing registry surface `url` uses this endpoint

Closes #4069
