### PR TITLE
feat(ui): add focus-visible ring styling to ProfileTabs and EndpointKindTabs buttons

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -29,7 +29,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             aria-selected={active}
             onClick={() => onChange(k)}
             className={classNames(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -38,7 +38,7 @@ export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defa
                   })
                 }
                 className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
                   isActive
                     ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
                     : "text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
## What & why

`ProfileTabs` and `EndpointKindTabs` built their tab `<button>` className via `classNames(...)` with **no** focus-visible/outline classes, so keyboard-focused tabs fell back to the raw default browser outline — the two outliers versus the rest of the app, which applies the existing `.mg-focus-ring` utility (`styles.css`, already used by `mg-metric-tile`, `hero-subnet-chips`, …).

This wires that **same existing** utility onto both tab buttons: a keyboard-focused tab shows the design-system ring; a mouse click shows no ring (`:focus-visible`).

- No new CSS (`.mg-focus-ring` already exists), no markup restructuring, no change to hover/active/selected styling.
- Net diff: `+mg-focus-ring` on the two tab buttons (`+2 / -2`).

## Before / after — keyboard-focused tab (all viewports × themes)

### ProfileTabs — subnet detail (`/subnets/{netuid}`)

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-desktop-light-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-desktop-light-focus.png" width="340"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-desktop-dark-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-desktop-dark-focus.png" width="340"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-tablet-light-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-tablet-light-focus.png" width="340"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-tablet-dark-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-tablet-dark-focus.png" width="340"> |
| Mobile · Light | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-mobile-light-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-mobile-light-focus.png" width="340"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-mobile-dark-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-mobile-dark-focus.png" width="340"> |

### EndpointKindTabs — endpoints page (`/endpoints`)

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-before-desktop-light-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-after-desktop-light-focus.png" width="340"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-before-desktop-dark-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-after-desktop-dark-focus.png" width="340"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-before-tablet-light-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-after-tablet-light-focus.png" width="340"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-before-tablet-dark-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-after-tablet-dark-focus.png" width="340"> |
| Mobile · Light | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-before-mobile-light-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-after-mobile-light-focus.png" width="340"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-before-mobile-dark-focus.png" width="340"> | <img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/kindtabs-after-mobile-dark-focus.png" width="340"> |

The focused (3rd) tab is shown in each pair. Delta: raw default browser outline → the rounded `.mg-focus-ring` matching the rest of the app.

Closes #3451
