### PR TITLE
fix(data-api): decode top-level AccountId32/MultiAddress call_args fields

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -138,7 +138,10 @@ export function formatExtrinsic(row) {
           row.call_module,
           row.call_function,
           normalizePostgresValue(
-            decodePostgresCallArgs(parseCallArgs(row.call_args)),
+            decodePostgresCallArgs(parseCallArgs(row.call_args), {
+              call_module: row.call_module,
+              call_function: row.call_function,
+            }),
           ),
         ),
       );

--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -26,12 +26,59 @@ import { isEnumTreeNode } from "./scale-normalize.mjs";
 import { normalizeAccountId32Field } from "./ss58.mjs";
 import { unwrapByteArray, decodeBytesField } from "./bytes.mjs";
 
-// Field names decoded to SS58 within a reconstructed nested call's own args
-// (#4691's scope -- top-level call_args fields of the same type are a
-// separate, not-yet-covered gap, tracked on #4669). Mirrors
-// src/chain-event-args.mjs's ACCOUNT_KEYS (the analogous chain_events.args
-// decode, #4685) plus two additions specific to call_args' richer field
-// vocabulary: "real" (Proxy.proxy's acting-account arg, extrinsics.ts:117-129)
+// True when `value` is D1/indexer-rs's typed call_args field descriptor
+// `{name, type, value}` -- duplicated from scale-normalize.mjs's identical
+// check (not imported: that module deliberately treats AccountId32/byte-blob
+// decoding as a sibling concern it never touches, so importing its type
+// predicate here would be the only coupling between the two modules for a
+// three-line shape test). Distinguished from isEnumTreeNode's `{name,
+// values}` (2 keys, plural) by key count/name.
+function isTypedFieldDescriptor(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 3 &&
+    keys.includes("name") &&
+    keys.includes("type") &&
+    keys.includes("value") &&
+    typeof value.name === "string" &&
+    typeof value.type === "string"
+  );
+}
+
+// True when a descriptor's own `type` string names an AccountId32 field
+// directly, or a MultiAddress generic wrapping one (MultiAddress<AccountId32,
+// ...>, Balances/Proxy/Contracts dest-style fields) -- the two concrete type
+// strings indexer-rs's type_name() produces for values D1/substrate-interface
+// already rendered as a bare SS58 string. normalizeAccountId32Field already
+// unwraps both the bare newtype shape and the MultiAddress::Id wrapper, so a
+// single call handles either type here.
+function isAccountId32Type(type) {
+  return type === "AccountId32" || type.startsWith("MultiAddress<");
+}
+
+// Duplicated from scale-normalize.mjs's identical COLLECTION_TYPE_RE/
+// isCollectionType (not imported, same "one shared shape-test, not a real
+// coupling" rationale as isTypedFieldDescriptor above) -- a collection-typed
+// field's single-element `value` must never be attempted as a byte-blob
+// here: it's shape-identical to a genuine 1-byte blob, and this ambiguity
+// is deliberately resolved later, by decodeBTreeSetFields' narrow per-field
+// allowlist (#4693), not by guessing from `type` + element count alone.
+const COLLECTION_TYPE_RE =
+  /(?:Vec|BoundedVec|WeakBoundedVec|BTreeSet|BoundedBTreeSet|BTreeMap|BoundedBTreeMap)</;
+function isCollectionType(type) {
+  return COLLECTION_TYPE_RE.test(type);
+}
+
+// Fallback name-guessing for an account field with NO type info of its own
+// (a reconstructed nested call's args, which lose their per-field `type`
+// string once repackaged, or a struct field nested inside an untyped
+// `value`) -- a field carrying its own `type: "AccountId32"`/`"MultiAddress<...>"`
+// is decoded via isAccountId32Type above instead, which doesn't need to
+// guess. Mirrors src/chain-event-args.mjs's ACCOUNT_KEYS (the analogous
+// chain_events.args decode, #4685) plus two additions specific to
+// call_args' richer field vocabulary: "real" (Proxy.proxy's acting-account
+// arg, extrinsics.ts:117-129)
 // and the hotkey/coldkey SUFFIX rule below -- chain_events field names are
 // short single words ("who", "from"), but SubtensorModule call_args commonly
 // use compound names ("destination_coldkey", "origin_coldkey") that an
@@ -108,49 +155,104 @@ function tryReconstructNestedCall(value) {
   };
 }
 
-// Recursive walk: reconstructs nested calls at any depth, and -- only within
-// an already-reconstructed call's own call_args (per #4691's scope) --
-// decodes AccountId32/MultiAddress fields to SS58 and byte-blob fields to
-// hex/text. `enclosingCall` is null at the top level (so call_args' own
-// top-level fields are deliberately left untouched) and becomes
-// `{callModule, callFunction}` for the NEAREST enclosing reconstructed call
-// once we've descended into one, so decodeBytesField's callModule/
-// callFunction-keyed textual-field lookup always uses the innermost call,
-// not the outer extrinsic's own call_module/call_function.
-function walk(value, keyHint, enclosingCall) {
+// Recursive walk: reconstructs nested calls at any depth, and decodes
+// AccountId32/MultiAddress fields to SS58 and byte-blob fields to hex/text
+// EVERYWHERE -- both at the top level of an extrinsic's own call_args and
+// within an already-reconstructed nested call's args. `call` starts as the
+// OUTER extrinsic's own {call_module, call_function} (threaded in from
+// decodePostgresCallArgs' second argument) and is replaced with the NEAREST
+// enclosing reconstructed call's own module/function once we descend into
+// one, so decodeBytesField's callModule/callFunction-keyed textual-field
+// lookup always matches the call that actually owns the field, not some
+// outer ancestor.
+//
+// A typed descriptor (`{name, type, value}`, D1/indexer-rs's per-field
+// shape) is decoded using its OWN declared `type` when it names an
+// AccountId32/MultiAddress -- more reliable than the ACCOUNT_KEYS
+// name-guessing heuristic below, which exists only for account fields with
+// no type info of their own (an already-reconstructed nested call's args,
+// which lose their per-field `type` string once repackaged, or a struct
+// field nested inside an untyped `value`).
+//
+// Two DISTINCT call contexts are threaded through: `nestedCall` is null at
+// the top level and becomes {call_module, call_function} only once we've
+// descended into a reconstructed nested call -- it gates the GENERIC
+// (untyped-shape) byte-blob heuristic below exactly as it always did,
+// because a bare untyped array's "single-element collection vs. 1-byte
+// blob" ambiguity (#4724) is only resolved later, by decodeBTreeSetFields'
+// narrow per-field allowlist -- attempting it here for every untyped
+// top-level array would silently corrupt a genuine single-element
+// collection (confirmed against a real fixture: SubtensorModule.claim_root's
+// `subnets: [[104]]`, #4693). `topCall` is the OUTER extrinsic's own
+// {call_module, call_function} (from decodePostgresCallArgs' second
+// argument) -- used ONLY within a typed descriptor whose `type` already
+// rules out both AccountId32/MultiAddress and a collection generic, where
+// the ambiguity above cannot occur (a declared non-collection scalar/hash/
+// bytes type is unambiguously safe to byte-decode regardless of nesting).
+function walk(value, keyHint, nestedCall, topCall) {
   const nested = tryReconstructNestedCall(value);
   if (nested) {
-    const call = {
+    const nextCall = {
       call_module: nested.call_module,
       call_function: nested.call_function,
     };
     return {
-      ...call,
-      call_args: walk(nested.call_args, undefined, call),
+      ...nextCall,
+      call_args: walk(nested.call_args, undefined, nextCall, topCall),
     };
   }
-  if (enclosingCall && isAccountField(keyHint)) {
+  if (isTypedFieldDescriptor(value)) {
+    if (isAccountId32Type(value.type)) {
+      return {
+        name: value.name,
+        type: value.type,
+        value: normalizeAccountId32Field(value.value) ?? value.value,
+      };
+    }
+    if (!isCollectionType(value.type)) {
+      const bytes = unwrapByteArray(value.value);
+      if (bytes && bytes.length > 0) {
+        const ctx = nestedCall ?? topCall;
+        return {
+          name: value.name,
+          type: value.type,
+          value: decodeBytesField(
+            ctx?.call_module,
+            ctx?.call_function,
+            value.name,
+            bytes,
+          ),
+        };
+      }
+    }
+    return {
+      name: value.name,
+      type: value.type,
+      value: walk(value.value, value.name, nestedCall, topCall),
+    };
+  }
+  if (isAccountField(keyHint)) {
     const ss58 = normalizeAccountId32Field(value);
     if (ss58) return ss58;
   }
-  if (enclosingCall) {
+  if (nestedCall) {
     const bytes = unwrapByteArray(value);
     if (bytes && bytes.length > 0) {
       return decodeBytesField(
-        enclosingCall.call_module,
-        enclosingCall.call_function,
+        nestedCall.call_module,
+        nestedCall.call_function,
         keyHint ?? "",
         bytes,
       );
     }
   }
   if (Array.isArray(value)) {
-    return value.map((item) => walk(item, keyHint, enclosingCall));
+    return value.map((item) => walk(item, keyHint, nestedCall, topCall));
   }
   if (value && typeof value === "object") {
     const out = {};
     for (const [key, val] of Object.entries(value)) {
-      out[key] = walk(val, key, enclosingCall);
+      out[key] = walk(val, key, nestedCall, topCall);
     }
     return out;
   }
@@ -162,17 +264,28 @@ function walk(value, keyHint, enclosingCall) {
  * (Proxy.proxy wrapping one call, Utility.batch wrapping an array of calls,
  * Multisig.as_multi/Sudo.sudo/Utility.batch_all composing three deep --
  * all confirmed against real production data), and decodes AccountId32/
- * MultiAddress/byte-blob fields within each reconstructed call's own args.
- * Deliberately does NOT attempt to synthesize a nested call's own
- * `call_hash` (Multisig.as_multi's permanent, accepted gap -- indexer-rs's
- * dynamic-value dump has no equivalent of fetch-events.py's Python-side
- * re-encode-and-hash step; the reconstructed object simply has no
- * `call_hash` key, same as extrinsics.ts's normalizeIndexerRsCall). A no-op
- * on D1's own call_args shape (an array of {name,type,value} descriptors --
- * "value" singular is never mistaken for "values" plural) and on a
- * call_args tree with no nested calls at all -- safe to apply
- * unconditionally regardless of which tier produced the row, same contract
- * as normalizePostgresValue (#4690). */
-export function decodePostgresCallArgs(value) {
-  return walk(value, undefined, null);
+ * MultiAddress/byte-blob fields to SS58/hex EVERYWHERE -- both at the
+ * top level of the extrinsic's own call_args and within each reconstructed
+ * nested call's args (fixed 2026-07-12: the top-level case was previously
+ * left undecoded -- confirmed live, e.g. SubtensorModule.add_stake's
+ * top-level `hotkey` field served as a raw `[[b0..b31]]` array instead of an
+ * SS58 string, and Balances.transfer_keep_alive's top-level `dest`
+ * (MultiAddress<AccountId32, ()>) likewise -- a gap this repo's own
+ * `#4669`-era comments explicitly flagged as "not yet covered" and which
+ * turned out to affect the vast majority of real extrinsics, since almost
+ * every SubtensorModule/Balances call carries a top-level account field).
+ * `topCall` is the OUTER extrinsic's own {call_module, call_function}
+ * (pass row.call_module/row.call_function; used only for
+ * decodeBytesField's textual-field lookup on a top-level byte-blob field
+ * like System.remark's `remark`, harmless to omit otherwise). Deliberately
+ * does NOT attempt to synthesize a nested call's own `call_hash`
+ * (Multisig.as_multi's permanent, accepted gap -- indexer-rs's dynamic-value
+ * dump has no equivalent of fetch-events.py's Python-side re-encode-and-hash
+ * step; the reconstructed object simply has no `call_hash` key, same as
+ * extrinsics.ts's normalizeIndexerRsCall). A no-op on D1's own call_args
+ * shape historically (D1 is retired, #4772) and on a call_args tree with no
+ * nested calls or account/byte fields at all -- safe to apply
+ * unconditionally, same contract as normalizePostgresValue (#4690). */
+export function decodePostgresCallArgs(value, topCall = null) {
+  return walk(value, undefined, null, topCall);
 }

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -72,7 +72,7 @@ describe("decodePostgresCallArgs", () => {
       assert.equal(decode(raw).call.call_args.commit, "0x0102ff00");
     });
 
-    test("Proxy.proxy's own top-level fields (real, force_proxy_type) are NOT decoded -- out of #4691's scope, only fields WITHIN a reconstructed call are", () => {
+    test("Proxy.proxy's own top-level fields (real, force_proxy_type) are BOTH decoded -- real via the ACCOUNT_KEYS name heuristic, fixed 2026-07-12 alongside the top-level AccountId32/MultiAddress typed-descriptor fix", () => {
       const raw = {
         call: {
           name: "SubtensorModule",
@@ -96,21 +96,17 @@ describe("decodePostgresCallArgs", () => {
       // force_proxy_type IS unwrapped -- that's normalizePostgresValue's
       // Option<T> rule (#4690), unaffected by #4691's narrower scope.
       assert.equal(out.force_proxy_type, null);
-      // real stays the raw MultiAddress::Id shape -- neither pass touches a
-      // top-level field of this type today (documented gap, tracked on
-      // #4669 as the next piece after this issue).
-      assert.deepEqual(out.real, {
-        name: "Id",
-        values: [
-          [
-            [
-              88, 174, 247, 177, 239, 180, 72, 6, 254, 20, 198, 197, 141, 12,
-              30, 182, 52, 165, 159, 210, 81, 63, 12, 237, 111, 45, 16, 224, 86,
-              154, 244, 13,
-            ],
-          ],
-        ],
-      });
+      // real: a MultiAddress::Id-wrapped AccountId32, previously left raw
+      // because the ACCOUNT_KEYS name heuristic was gated behind an
+      // enclosing reconstructed call -- a top-level field never had one.
+      // Now decoded regardless of nesting (2026-07-12): the untyped
+      // enum-tree shape carries no `type` string to consult, so this relies
+      // on "real" being an unambiguous account-field name, same as any
+      // other ACCOUNT_KEYS entry.
+      assert.equal(
+        out.real,
+        "5E4z3h9yVhmQyCFWNbY9BPpwhx4xFiPwq3eeqmBgVF6KULde",
+      );
     });
 
     test("Utility.batch wrapping 8 SubtensorModule.transfer_stake calls, each independently reconstructed and decoded (block 8587171/21)", () => {
@@ -307,6 +303,126 @@ describe("decodePostgresCallArgs", () => {
     });
   });
 
+  describe("top-level typed-descriptor AccountId32/MultiAddress fields (fixed 2026-07-12)", () => {
+    // Found live 2026-07-11 during a full data-pipeline audit: an extrinsic's
+    // OWN top-level call_args (the {name,type,value} descriptor array
+    // indexer-rs's #4724 typed JSON produces) never ran through ANY
+    // AccountId32/MultiAddress decode -- only fields inside a reconstructed
+    // NESTED call did (#4691's scope). Confirmed against real production
+    // API responses before this fix: GET /api/v1/extrinsics?call_module=
+    // SubtensorModule&call_function=add_stake served block 8602480/21's
+    // `hotkey` field as a raw [[b0..b31]] array instead of an SS58 string,
+    // and GET /api/v1/extrinsics/0xf4a09042...c86be (Balances.
+    // transfer_keep_alive, block 8602605/18) served `dest`
+    // (MultiAddress<AccountId32, ()>) the same way. This affected almost
+    // every SubtensorModule/Balances extrinsic, since a top-level account
+    // field is the common case, not the exception.
+    test("SubtensorModule.add_stake's top-level hotkey (real, block 8602480/21)", () => {
+      const out = decode([
+        {
+          name: "hotkey",
+          type: "AccountId32",
+          value: [
+            [
+              82, 234, 56, 192, 220, 185, 225, 113, 153, 236, 163, 61, 27, 214,
+              91, 165, 227, 249, 82, 146, 53, 250, 51, 138, 121, 207, 28, 250,
+              180, 216, 123, 127,
+            ],
+          ],
+        },
+        { name: "netuid", type: "u16", value: 117 },
+        { name: "amount_staked", type: "u64", value: 741700000 },
+      ]);
+      assert.equal(
+        out[0].value,
+        "5DwRMxJG2KxxMXF9qqfc1NowJWKnY46QJHNf5R4CG9RozmGE",
+      );
+      // Sibling non-account typed fields are untouched by this fix.
+      assert.equal(out[1].value, 117);
+      assert.equal(out[2].value, 741700000);
+    });
+
+    test("Balances.transfer_keep_alive's top-level dest, a MultiAddress<AccountId32, ()> (real, block 8602605/18)", () => {
+      const out = decode([
+        {
+          name: "dest",
+          type: "MultiAddress<AccountId32, ()>",
+          value: {
+            name: "Id",
+            values: [
+              [
+                [
+                  180, 56, 69, 59, 155, 20, 102, 39, 96, 253, 195, 62, 155, 114,
+                  113, 244, 236, 219, 6, 167, 180, 153, 46, 209, 55, 105, 249,
+                  113, 25, 165, 243, 113,
+                ],
+              ],
+            ],
+          },
+        },
+        { name: "value", type: "Compact<u64>", value: 30000000 },
+      ]);
+      assert.equal(
+        out[0].value,
+        "5G91C6t2GywqvaBJmWRrmtmyFauai8pSDtyg6qA9X3Gw1uGF",
+      );
+    });
+
+    test("a typed collection field (BTreeSet<NetUid>) is never mistaken for a byte blob at the top level", () => {
+      // Guards the #4693 ambiguity this fix must not reopen: a
+      // collection-typed descriptor's value stays an array at ANY element
+      // count, even though a single netuid is shape-identical to a 1-byte
+      // blob (isCollectionType's job, mirroring scale-normalize.mjs's
+      // COLLECTION_TYPE_RE, applied before any byte-blob decode attempt).
+      const out = decode([
+        { name: "subnets", type: "BTreeSet<NetUid>", value: [104] },
+      ]);
+      assert.deepEqual(out[0].value, [104]);
+    });
+
+    test("SubtensorModule.commit_weights' top-level commit_hash, an H256 (real, block 8602444/9)", () => {
+      // A non-account, non-collection typed byte-blob field: `type` rules
+      // out both AccountId32/MultiAddress (isAccountId32Type) and a
+      // collection generic (isCollectionType), so the byte-blob decode is
+      // unambiguously safe regardless of nesting -- exercises the
+      // topCall-only (no enclosing reconstructed call) branch of the
+      // typed-descriptor byte-blob path.
+      const out = decode([
+        { name: "netuid", type: "u16", value: 10 },
+        {
+          name: "commit_hash",
+          type: "H256",
+          value: [
+            [
+              213, 57, 183, 176, 61, 250, 160, 19, 224, 152, 214, 79, 109, 80,
+              105, 202, 162, 172, 175, 227, 217, 16, 133, 137, 40, 249, 62, 29,
+              84, 71, 29, 149,
+            ],
+          ],
+        },
+      ]);
+      assert.equal(
+        out[1].value,
+        "0xd539b7b03dfaa013e098d64f6d5069caa2acafe3d910858928f93e1d54471d95",
+      );
+    });
+
+    test("a typed AccountId32 descriptor whose value isn't a decodable shape falls through unchanged, not to null", () => {
+      // normalizeAccountId32Field returns null for a malformed value (here, a
+      // 3-byte array -- neither a flat 32-byte AccountId32 nor a newtype/
+      // MultiAddress wrap around one); the `?? value.value` fallback must
+      // preserve the original raw value rather than silently nulling out a
+      // field the caller can still inspect.
+      const malformed = {
+        name: "hotkey",
+        type: "AccountId32",
+        value: [1, 2, 3],
+      };
+      const out = decodePostgresCallArgs([malformed]);
+      assert.deepEqual(out[0].value, [1, 2, 3]);
+    });
+  });
+
   describe("Sudo.sudo_unchecked_weight (synthetic -- 0 confirmed occurrences in the retention window; code path still exercised)", () => {
     test("reconstructs like any other single-nested call", () => {
       const raw = {
@@ -500,13 +616,13 @@ describe("decodePostgresCallArgs", () => {
       assert.deepEqual(decodePostgresCallArgs({}), {});
     });
 
-    test("a bare 32-byte AccountId32 array outside any reconstructed call is left untouched (top-level scope boundary)", () => {
+    test("a bare 32-byte AccountId32 array outside any reconstructed call now decodes via the ACCOUNT_KEYS name heuristic (fixed 2026-07-12; the old top-level scope boundary)", () => {
       const bytes = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
         21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
       ];
       assert.deepEqual(decodePostgresCallArgs({ who: [bytes] }), {
-        who: [bytes],
+        who: "5C62W7ELLAAfjCQeBU3me9ykaYomD8XTg2B9Hk6ki6Cm3v58",
       });
     });
   });


### PR DESCRIPTION
## Summary

- An extrinsic's own top-level `call_args` never ran through AccountId32/MultiAddress decode — only fields inside a reconstructed nested call did (#4691's scope). Since a top-level account field (hotkey/coldkey/dest) is the common case for SubtensorModule/Balances extrinsics, not the exception, this served raw nested byte arrays instead of SS58 for the vast majority of extrinsics, via both the REST `/api/v1/extrinsics*` routes and the MCP tools that share `formatExtrinsic`.
- Confirmed live before the fix: `SubtensorModule.add_stake` (block 8602480/21) served `hotkey` as `[[82,234,...]]`; `Balances.transfer_keep_alive` (block 8602605/18) served `dest` (`MultiAddress<AccountId32, ()>`) the same way. Cross-checked against the same extrinsic's `StakeAdded` account_event, which correctly showed the SS58 value — proving indexer-rs itself decodes correctly, only the `call_args` serving path was broken.
- `decodePostgresCallArgs` now recognizes the `{name, type, value}` typed-descriptor shape and decodes `value` via its own declared `type` (AccountId32/MultiAddress) regardless of nesting depth. The existing ACCOUNT_KEYS name-heuristic is also un-gated (fixes the same bug for untyped/legacy-shape rows). The generic untyped byte-blob heuristic stays nested-call-gated to avoid reopening the #4693 single-element-collection-vs-1-byte-blob ambiguity for an untyped top-level array.

Closes #4915

## Test plan

- [x] `npx vitest run` — 255 files / 7522 tests passing
- [x] New regression tests from live-confirmed fixtures: `add_stake`'s top-level `hotkey`, `transfer_keep_alive`'s top-level `dest` (`MultiAddress<AccountId32, ()>`), a `commit_weights` H256 `commit_hash` (non-collection byte-blob type), a `BTreeSet<NetUid>` collision guard, and a malformed-value fallback — each independently verified against `src/ss58.mjs`/`src/bytes.mjs` directly
- [x] `npm run lint` / `npx prettier --check` — clean
- [x] `git diff --check` — clean
- [x] `npm run test:coverage` — `src/postgres-call-args.mjs` at 100% lines/branches; `src/extrinsics.mjs`'s 3-line diff fully covered by the existing suite
- [x] `npm run scan:public-safety` / `npm run validate` — clean