### PR TITLE
fix(data-api): unwrap Option<T>/enum tags in chain_events.args

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -19,6 +19,7 @@
 // non-System/Balances pallet event's args tuple -- always falls to hex
 // rather than guessing). Everything else is untouched.
 import { encodeAccountId32 } from "./ss58.mjs";
+import { normalizePostgresValue } from "./scale-normalize.mjs";
 
 const ACCOUNT_KEYS = new Set([
   "who",
@@ -86,7 +87,28 @@ function decode(value, keyHint) {
   return value;
 }
 
-/** Decode account ids inside a chain-event args value (leaves everything else as-is). */
+/** Decode account ids inside a chain-event args value, then unwrap Option<T>/
+ * C-like unit-variant enum tags via normalizePostgresValue (#4690's generic
+ * pass, reused here for the first time -- previously chain_events.args only
+ * got the account-id decode above). Order matters: account decode runs
+ * first so its 32-byte-array checks see the pristine byte arrays before
+ * normalizePostgresValue's newtype-scalar rule could touch them (neither
+ * pass's rules actually collide here -- normalize()'s newtype-scalar
+ * collapse only fires on a SCALAR-wrapping single-element array, and a
+ * 32-byte account array is never scalar-shaped -- but matching the same
+ * ordering src/extrinsics.mjs's formatExtrinsic already uses keeps the two
+ * call sites consistent). Confirmed live 2026-07-11: System.ExtrinsicSuccess's
+ * `dispatch_info.class`/`pays_fee` rendered as `{"name":"Normal","values":[]}`
+ * instead of the bare string "Normal" -- exactly the shape
+ * normalizePostgresValue's C-like-unit-enum rule collapses. Deliberately does
+ * NOT add general byte-blob decoding here (a 20-byte Ethereum H160 stays a
+ * raw array) -- chain_events.args carries no per-field type string the way
+ * extrinsics.call_args does post-#4724, so there is no reliable way to
+ * distinguish a genuine byte blob from a single-element typed collection by
+ * shape alone (the exact #4693 ambiguity src/postgres-call-args.mjs's
+ * typed-descriptor path avoids by consulting `type` first); tracked as a
+ * separate, narrower-scoped follow-up rather than risking that collision
+ * here. */
 export function decodeChainEventArgs(args) {
-  return decode(args, undefined);
+  return normalizePostgresValue(decode(args, undefined));
 }

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -108,4 +108,41 @@ describe("decodeChainEventArgs", () => {
     assert.equal(decodeChainEventArgs(42), 42);
     assert.equal(decodeChainEventArgs("x"), "x");
   });
+
+  test("unwraps a C-like unit-variant enum tag to its bare name (real System.ExtrinsicSuccess.dispatch_info, block 8602601/381, fixed 2026-07-12)", () => {
+    // Found live 2026-07-11: dispatch_info.class/pays_fee rendered as
+    // {"name":"Normal","values":[]} / {"name":"No","values":[]} instead of
+    // the bare strings D1 always produced -- decodeChainEventArgs only ran
+    // the account-id decode above, never normalizePostgresValue's C-like
+    // unit-enum rule (#4690), despite every other consumer of that rule
+    // (extrinsics.call_args) already getting it.
+    const args = {
+      dispatch_info: {
+        class: { name: "Normal", values: [] },
+        weight: { ref_time: 1012718000, proof_size: 11869 },
+        pays_fee: { name: "No", values: [] },
+      },
+    };
+    assert.deepEqual(decodeChainEventArgs(args), {
+      dispatch_info: {
+        class: "Normal",
+        weight: { ref_time: 1012718000, proof_size: 11869 },
+        pays_fee: "No",
+      },
+    });
+  });
+
+  test("unwraps an Option<T> Some/None pair alongside an account-keyed field in the same event", () => {
+    const bytes = new Array(32).fill(9);
+    const args = {
+      who: [bytes],
+      maybe_amount: { name: "Some", values: [42] },
+      maybe_note: { name: "None", values: [] },
+    };
+    assert.deepEqual(decodeChainEventArgs(args), {
+      who: "5CGYyLcrWUfBDKExbvRjDQinEoCZWQmD6SjaXBLhny6A2wjE",
+      maybe_amount: 42,
+      maybe_note: null,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `decodeChainEventArgs` only ever decoded 32-byte AccountId32 arrays to SS58 — it never ran the generic Option<T>/C-like-unit-enum unwrap (`normalizePostgresValue`, #4690) that `extrinsics.call_args` already gets.
- Confirmed live: a `System.ExtrinsicSuccess` row's `dispatch_info.class`/`dispatch_info.pays_fee` rendered as `{"name":"Normal","values":[]}` / `{"name":"No","values":[]}` instead of the bare strings D1 always produced — affecting every `chain_events` row through both REST (`/api/v1/chain-events` and friends) and the three MCP tools (`list_chain_events`, `get_block_chain_events`, `get_extrinsic_chain_events`) that share `coerceEvent`.
- `decodeChainEventArgs` now composes `normalizePostgresValue` after its existing account-id decode.
- Deliberately does **not** add general byte-blob decoding (an Ethereum H160 in `Ethereum.Executed`'s `to`/`from` still renders as a raw array) — `chain_events.args` carries no per-field type string the way `extrinsics.call_args` does post-#4724, so there's no reliable way to distinguish a genuine byte blob from a single-element typed collection by shape alone. Tracked as a separate, narrower follow-up, not bundled here.

Closes #4917

## Test plan

- [x] `npx vitest run` — 255 files / 7524 tests passing
- [x] New regression tests: the live-confirmed `dispatch_info` fixture, and an Option<T> Some/None pair alongside an account-keyed field
- [x] `npm run lint` / `npx prettier --check` — clean
- [x] `git diff --check` — clean
- [x] `npm run test:coverage` — `src/chain-event-args.mjs` at 100% lines/branches
- [x] `npm run scan:public-safety` / `npm run validate` — clean