### PR TITLE
feat(ui): add focus-visible ring styling to ProfileTabs and EndpointKindTabs buttons

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -29,7 +29,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             aria-selected={active}
             onClick={() => onChange(k)}
             className={classNames(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -38,7 +38,7 @@ export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defa
                   })
                 }
                 className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
                   isActive
                     ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
                     : "text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
Adds the existing `.mg-focus-ring` utility (already used by `mg-metric-tile`, `hero-subnet-chips`, …) to the tab `<button>` in `ProfileTabs` and `EndpointKindTabs`. Both built their className with no focus-visible/outline classes, so keyboard-focused tabs fell back to the raw default browser outline — the two outliers in the app. No new CSS, no markup or hover/active/selected changes; net diff `+mg-focus-ring` on the two buttons (`+2 / -2`). A mouse click shows no ring (`:focus-visible`).

Closes #3451

## Screenshots

`ProfileTabs` on `/subnets/1`, real live data. Each shot is taken right after keyboard-focusing the 3rd tab; `EndpointKindTabs` (`/endpoints`) receives the identical `mg-focus-ring` class and behaves the same.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-desktop-light-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-desktop-light-focus.png)<br><sub>default browser outline</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-desktop-light-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-desktop-light-focus.png)<br><sub>mg-focus-ring</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-desktop-dark-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-desktop-dark-focus.png)<br><sub>default browser outline</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-desktop-dark-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-desktop-dark-focus.png)<br><sub>mg-focus-ring</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-tablet-light-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-tablet-light-focus.png)<br><sub>default browser outline</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-tablet-light-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-tablet-light-focus.png)<br><sub>mg-focus-ring</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-tablet-dark-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-tablet-dark-focus.png)<br><sub>default browser outline</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-tablet-dark-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-tablet-dark-focus.png)<br><sub>mg-focus-ring</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-mobile-light-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-mobile-light-focus.png)<br><sub>default browser outline</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-mobile-light-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-mobile-light-focus.png)<br><sub>mg-focus-ring</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-mobile-dark-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-before-mobile-dark-focus.png)<br><sub>default browser outline</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-mobile-dark-focus.png" width="280">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/3451/profiletabs-after-mobile-dark-focus.png)<br><sub>mg-focus-ring</sub> |

## Test plan

- Existing gates pass (`eslint`, `tsc --noEmit`, `vitest run`); change is a single utility-class addition already proven on `mg-metric-tile`/`hero-subnet-chips`.
- Keyboard-focused tab shows the ring (above); mouse click shows none (`:focus-visible`).
