### PR TITLE
fix(data-api): decode H160/textual fields in chain_events.args

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -7,17 +7,21 @@
 // shape. This decodes once, server-side, so every consumer sees the same
 // human-readable values (#4685).
 //
-// chain-event args arrive as decoded SCALE values, where account ids are raw
-// 32-byte number arrays (indexer-rs's generic dynamic-value dump wraps a
-// tuple-struct-with-one-field like AccountId32([u8;32]) in an extra array
-// layer -- [[b0..b31]], not a flat 32-byte array). Rendered verbatim they
-// read like `{"who":[[109,111,100,101,...]]}` -- unreadable and unbounded.
-// This walks the value and rewrites 32-byte arrays into a human-readable
-// form: an SS58 address when the field name marks it as an account,
-// otherwise a 0x-hex string (so a 32-byte hash isn't mislabelled as an
-// address, and an untagged positional arg with no key hint -- e.g. a
-// non-System/Balances pallet event's args tuple -- always falls to hex
-// rather than guessing). Everything else is untouched.
+// chain-event args arrive as decoded SCALE values, where account ids and
+// Ethereum addresses are raw fixed-length number arrays (indexer-rs's
+// generic dynamic-value dump wraps a tuple-struct-with-one-field like
+// AccountId32([u8;32])/H160([u8;20]) in an extra array layer --
+// [[b0..b31]], not a flat byte array). Rendered verbatim they read like
+// `{"who":[[109,111,100,101,...]]}` -- unreadable and unbounded. This walks
+// the value and rewrites 32-byte arrays into a human-readable form: an SS58
+// address when the field name marks it as an account, otherwise a 0x-hex
+// string (so a 32-byte hash isn't mislabelled as an address, and an
+// untagged positional arg with no key hint -- e.g. a non-System/Balances
+// pallet event's args tuple -- always falls to hex rather than guessing).
+// 20-byte arrays always hex-decode as H160 (Ethereum addresses have no SS58
+// form). A narrow, explicit pallet.method.field allowlist additionally
+// UTF-8-decodes the handful of known free-text byte fields (e.g. Ethereum.
+// Executed's extra_data). Everything else is untouched.
 import { encodeAccountId32 } from "./ss58.mjs";
 import { normalizePostgresValue } from "./scale-normalize.mjs";
 
@@ -51,11 +55,50 @@ function isByteArray(v, len) {
   );
 }
 
+// Any-length byte array (every element 0-255), used only by the
+// TEXTUAL_FIELDS check below -- gated behind an exact pallet.method.field
+// allowlist match, never applied on shape alone, so it can't collide with a
+// same-length numeric/typed field elsewhere (e.g. a netuid list) the way a
+// generic byte-blob heuristic would.
+function isAnyByteArray(v) {
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (n) => typeof n === "number" && Number.isInteger(n) && n >= 0 && n <= 255,
+    )
+  );
+}
+
 function toHex(bytes) {
   return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-function decode(value, keyHint) {
+// Known free-text/opaque variable-length byte fields, keyed by
+// "Pallet.method.field" -- mirrors src/bytes.mjs's TEXTUAL_FIELDS (#4689)
+// for the analogous call_args gap, scoped narrowly by exact pallet/method/
+// field triple rather than any shape heuristic (chain_events.args carries
+// no per-field type string, so a length-based guess would risk the same
+// collection-vs-blob ambiguity #4693/#4915 avoid elsewhere by consulting a
+// typed descriptor's own `type` first -- chain_events has none). Ethereum.
+// Executed's extra_data is a miner/relay note, observed live as ASCII
+// "Gotta Go Fast" (empty on most blocks). Everything not in this allowlist
+// falls through to the generic array-map/object-recurse below, untouched.
+const TEXTUAL_FIELDS = new Set(["Ethereum.Executed.extra_data"]);
+
+function decodeTextualField(bytes) {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      Uint8Array.from(bytes),
+    );
+  } catch {
+    // Malformed UTF-8 for a field expected to be textual -- fall back to
+    // hex rather than producing mojibake, mirroring bytes.mjs's identical
+    // decodeBytesField fallback.
+    return toHex(bytes);
+  }
+}
+
+function decode(value, keyHint, ctx) {
   if (isByteArray(value, 32)) {
     // encodeAccountId32 can't return null here -- isByteArray already
     // confirmed exactly 32 bytes, the only condition it checks internally.
@@ -64,51 +107,85 @@ function decode(value, keyHint) {
     }
     return toHex(value);
   }
-  // indexer-rs newtype-wraps a bare (non-Vec) AccountId32/[u8;32] field in an
-  // extra array layer -- `who: [[b0..b31]]`, depth 2 -- so it must collapse
-  // to a bare decoded value, not `[decoded]`. A genuine `Vec<AccountId32>`
-  // stays distinguishable by depth: each of ITS entries is independently
-  // newtype-wrapped too (`other_signatories: [[[b..]], [[b..]]]`, depth 3
-  // per entry), so the outer Vec's array-map below still produces one
-  // decoded value per entry -- this collapse only fires one layer at a time.
-  if (Array.isArray(value) && value.length === 1 && isByteArray(value[0], 32)) {
-    return decode(value[0], keyHint);
+  // H160 (Ethereum address): a fixed 20-byte type, unambiguous by length --
+  // Ethereum.Executed's to/from and EVM.Log's address all match this shape
+  // (confirmed live, 2026-07-12). Always hex, never SS58 (that's
+  // AccountId32/32-byte territory above).
+  if (isByteArray(value, 20)) {
+    return toHex(value);
+  }
+  // indexer-rs newtype-wraps a bare (non-Vec) AccountId32/H160/[u8;N] field
+  // in an extra array layer -- `who: [[b0..b31]]` / `to: [[b0..b19]]`, depth
+  // 2 -- so it must collapse to a bare decoded value, not `[decoded]`. A
+  // genuine `Vec<AccountId32>` stays distinguishable by depth: each of ITS
+  // entries is independently newtype-wrapped too (`other_signatories:
+  // [[[b..]], [[b..]]]`, depth 3 per entry), so the outer Vec's array-map
+  // below still produces one decoded value per entry -- this collapse only
+  // fires one layer at a time.
+  if (
+    Array.isArray(value) &&
+    value.length === 1 &&
+    (isByteArray(value[0], 32) || isByteArray(value[0], 20))
+  ) {
+    return decode(value[0], keyHint, ctx);
+  }
+  if (keyHint && ctx && isAnyByteArray(value)) {
+    const key = `${ctx.pallet ?? ""}.${ctx.method ?? ""}.${keyHint}`;
+    if (TEXTUAL_FIELDS.has(key)) {
+      return decodeTextualField(value);
+    }
   }
   // Arrays inherit the parent key hint (e.g. `who: [<accountId bytes>]`) --
   // this is also what makes an untagged positional args array (no object
   // key at all) correctly fall through to hex: the hint stays undefined at
   // every recursion depth, so the ACCOUNT_KEYS check never fires.
-  if (Array.isArray(value)) return value.map((item) => decode(item, keyHint));
+  if (Array.isArray(value)) {
+    return value.map((item) => decode(item, keyHint, ctx));
+  }
   if (value && typeof value === "object") {
     const out = {};
-    for (const [k, val] of Object.entries(value)) out[k] = decode(val, k);
+    for (const [k, val] of Object.entries(value)) out[k] = decode(val, k, ctx);
     return out;
   }
   return value;
 }
 
-/** Decode account ids inside a chain-event args value, then unwrap Option<T>/
- * C-like unit-variant enum tags via normalizePostgresValue (#4690's generic
- * pass, reused here for the first time -- previously chain_events.args only
- * got the account-id decode above). Order matters: account decode runs
- * first so its 32-byte-array checks see the pristine byte arrays before
- * normalizePostgresValue's newtype-scalar rule could touch them (neither
- * pass's rules actually collide here -- normalize()'s newtype-scalar
- * collapse only fires on a SCALAR-wrapping single-element array, and a
- * 32-byte account array is never scalar-shaped -- but matching the same
- * ordering src/extrinsics.mjs's formatExtrinsic already uses keeps the two
- * call sites consistent). Confirmed live 2026-07-11: System.ExtrinsicSuccess's
+/** Unwraps Option<T>/C-like unit-variant enum tags via normalizePostgresValue
+ * (#4690's generic pass) FIRST, then decodes account ids and H160 addresses
+ * in the result. This order (opposite of src/extrinsics.mjs's
+ * formatExtrinsic, which runs its nested-call reconstruction before
+ * normalizePostgresValue for an unrelated reason specific to that pass --
+ * see its own header) is required here, not merely conventional: running
+ * the byte-array decode FIRST turns each element of a single-entry
+ * Vec<H256>-shaped field (e.g. EVM.Log's `topics` with exactly one topic)
+ * into a plain hex STRING, which normalizePostgresValue's newtype-scalar
+ * rule would then wrongly collapse from `["0x...hash"]` down to a bare
+ * `"0x...hash"` -- silently changing the field's JSON type from array to
+ * scalar (confirmed live 2026-07-12: a real single-topic EVM.Log). Running
+ * normalizePostgresValue first avoids this: at that point every byte-array
+ * field's elements are still raw integers (0-255), never scalar-shaped
+ * wrapped values, so its newtype-scalar rule can never fire on a pristine
+ * byte array or its 1-element newtype wrapper -- confirmed safe against
+ * every existing fixture in this file's own test suite, including the
+ * single-element Vec<AccountId32> case.
+ *
+ * Confirmed live 2026-07-11: System.ExtrinsicSuccess's
  * `dispatch_info.class`/`pays_fee` rendered as `{"name":"Normal","values":[]}`
  * instead of the bare string "Normal" -- exactly the shape
- * normalizePostgresValue's C-like-unit-enum rule collapses. Deliberately does
- * NOT add general byte-blob decoding here (a 20-byte Ethereum H160 stays a
- * raw array) -- chain_events.args carries no per-field type string the way
- * extrinsics.call_args does post-#4724, so there is no reliable way to
- * distinguish a genuine byte blob from a single-element typed collection by
- * shape alone (the exact #4693 ambiguity src/postgres-call-args.mjs's
- * typed-descriptor path avoids by consulting `type` first); tracked as a
- * separate, narrower-scoped follow-up rather than risking that collision
- * here. */
-export function decodeChainEventArgs(args) {
-  return normalizePostgresValue(decode(args, undefined));
+ * normalizePostgresValue's C-like-unit-enum rule collapses; and (2026-07-12)
+ * Ethereum.Executed's `to`/`from` and EVM.Log's `address` rendered as raw
+ * 20-byte arrays instead of hex H160 addresses.
+ *
+ * `ctx` is the emitting event's `{pallet, method}` (pass `row.pallet`/
+ * `row.method` from the Postgres row) -- used only by the narrow
+ * TEXTUAL_FIELDS allowlist above; omit it and every other decode still
+ * works identically, just without that one field's UTF-8 treatment.
+ * Deliberately does NOT add a GENERIC byte-blob heuristic beyond the two
+ * fixed lengths (32/20) and the explicit allowlist -- chain_events.args
+ * carries no per-field type string the way extrinsics.call_args does
+ * post-#4724, so a length-based guess for an arbitrary-length field would
+ * risk the same collection-vs-blob ambiguity #4693/#4915 avoid elsewhere by
+ * consulting a typed descriptor's own `type` first. */
+export function decodeChainEventArgs(args, ctx = null) {
+  return decode(normalizePostgresValue(args), undefined, ctx);
 }

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -247,4 +247,23 @@ describe("decodeChainEventArgs", () => {
       { extra_data: [1, 2, 3] },
     );
   });
+
+  test("falls back to hex for a textual-allowlisted field with malformed UTF-8 bytes", () => {
+    // 0xff is never valid UTF-8 (not even as a continuation byte), so this
+    // exercises decodeTextualField's catch fallback rather than producing
+    // mojibake.
+    const args = { extra_data: [0xff, 0xfe] };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Ethereum", method: "Executed" }),
+      { extra_data: "0xfffe" },
+    );
+  });
+
+  test("tolerates a ctx object missing pallet/method when checking the textual allowlist", () => {
+    // ctx is truthy (so the allowlist check runs) but pallet/method are both
+    // absent -- the key's `??` fallbacks must produce "..extra_data" rather
+    // than throwing, and that key correctly isn't in TEXTUAL_FIELDS.
+    const args = { extra_data: [1, 2, 3] };
+    assert.deepEqual(decodeChainEventArgs(args, {}), { extra_data: [1, 2, 3] });
+  });
 });

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -145,4 +145,106 @@ describe("decodeChainEventArgs", () => {
       maybe_note: null,
     });
   });
+
+  test("hex-encodes 20-byte H160 fields to/from (real Ethereum.Executed, block 8602940/418, fixed 2026-07-12)", () => {
+    // Found live 2026-07-11 alongside the enum-tag bug above:
+    // Ethereum.Executed's to/from rendered as raw 20-byte arrays instead of
+    // hex H160 addresses -- decodeChainEventArgs's account/hash decode was
+    // scoped to exactly 32 bytes (AccountId32), with no 20-byte (H160) case
+    // at all.
+    const args = {
+      to: [
+        [
+          143, 106, 34, 194, 22, 130, 183, 168, 135, 112, 85, 219, 92, 193, 49,
+          205, 140, 165, 81, 159,
+        ],
+      ],
+      from: [
+        [
+          133, 92, 161, 0, 143, 62, 255, 142, 6, 54, 70, 251, 181, 205, 213,
+          120, 9, 182, 19, 77,
+        ],
+      ],
+      extra_data: [71, 111, 116, 116, 97, 32, 71, 111, 32, 70, 97, 115, 116],
+      transaction_hash:
+        "0x62ae62f39383da65709133bd09033de7dd97bdc761f3f4b9247aacb1a17beeec",
+    };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Ethereum", method: "Executed" }),
+      {
+        to: "0x8f6a22c21682b7a8877055db5cc131cd8ca5519f",
+        from: "0x855ca1008f3eff8e063646fbb5cdd57809b6134d",
+        extra_data: "Gotta Go Fast",
+        transaction_hash:
+          "0x62ae62f39383da65709133bd09033de7dd97bdc761f3f4b9247aacb1a17beeec",
+      },
+    );
+  });
+
+  test("hex-encodes a nested 20-byte H160 field regardless of key depth (real EVM.Log.log.address, block 8602940/418)", () => {
+    const args = {
+      log: {
+        data: "0x000000000000000000000000000000000000000000000000000000000000000c",
+        address: [
+          [
+            218, 113, 193, 120, 106, 128, 89, 109, 32, 202, 31, 37, 41, 213, 16,
+            64, 235, 145, 235, 28,
+          ],
+        ],
+      },
+    };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "EVM", method: "Log" }),
+      {
+        log: {
+          data: "0x000000000000000000000000000000000000000000000000000000000000000c",
+          address: "0xda71c1786a80596d20ca1f2529d51040eb91eb1c",
+        },
+      },
+    );
+  });
+
+  test("keeps a single-element Vec<H256> as an array, not collapsed to a bare string (real EVM.Log.log.topics, fixed 2026-07-12)", () => {
+    // Found live 2026-07-12 while fixing the H160 gap above: a single-topic
+    // EVM.Log collapsed `topics` from `["0x...hash"]` down to a bare
+    // `"0x...hash"` -- normalizePostgresValue's newtype-scalar rule fired
+    // because, by the time it ran, the account/hash decode had already
+    // turned the sole topic into a plain hex STRING (a scalar), making the
+    // outer single-element array indistinguishable from a genuine
+    // newtype-scalar wrap. Fixed by running normalizePostgresValue BEFORE
+    // the byte-array decode instead of after (see decodeChainEventArgs'
+    // own header for why this reordering is safe).
+    const hash = new Array(32).fill(3);
+    const args = { log: { topics: [[hash]] } };
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "EVM",
+      method: "Log",
+    });
+    assert.deepEqual(decoded.log.topics, ["0x" + "03".repeat(32)]);
+  });
+
+  test("is idempotent on already-decoded H160/textual data (safe no-op if run twice)", () => {
+    const decoded = decodeChainEventArgs(
+      {
+        to: [new Array(20).fill(1)],
+        extra_data: [72, 105], // "Hi"
+      },
+      { pallet: "Ethereum", method: "Executed" },
+    );
+    assert.deepEqual(
+      decodeChainEventArgs(decoded, { pallet: "Ethereum", method: "Executed" }),
+      decoded,
+    );
+  });
+
+  test("leaves a variable-length byte field as a raw array when its pallet.method.field isn't in the textual allowlist", () => {
+    const args = { extra_data: [1, 2, 3] };
+    assert.deepEqual(
+      decodeChainEventArgs(args, {
+        pallet: "SomeOtherPallet",
+        method: "SomeEvent",
+      }),
+      { extra_data: [1, 2, 3] },
+    );
+  });
 });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2152,7 +2152,10 @@ function coerceEvent(row) {
     ...(row.block_number !== undefined
       ? { block_number: numberOrNull(row.block_number) }
       : {}),
-    args: decodeChainEventArgs(row.args),
+    args: decodeChainEventArgs(row.args, {
+      pallet: row.pallet,
+      method: row.method,
+    }),
     observed_at: numberOrNull(row.observed_at),
   };
 }


### PR DESCRIPTION
## Summary
- `decodeChainEventArgs` only handled 32-byte (AccountId32) fields; 20-byte H160 addresses (`Ethereum.Executed.to`/`from`, `EVM.Log.address`) were rendered as raw byte arrays instead of hex.
- Added a narrow `pallet.method.field` allowlist (mirroring `src/bytes.mjs`'s `TEXTUAL_FIELDS` for `call_args`) to UTF-8-decode `Ethereum.Executed.extra_data`.
- Self-discovered regression while testing the above: reordered `decodeChainEventArgs` to run `normalizePostgresValue` *before* the byte-array decode instead of after — decoding first was turning a single-topic `EVM.Log.topics` entry into a scalar hex string, which `normalizePostgresValue`'s newtype-scalar rule then wrongly collapsed from a 1-element array down to a bare string.
- All three fixes verified against real production block/event fixtures (block 8602940/418 for H160+extra_data, block 8602601/381 carried over from the prior enum-tag fix).

Continuation of the live chain-data decode audit that produced #4916 (top-level AccountId32/MultiAddress in `call_args`) and #4918 (Option/enum unwrap in `chain_events.args`).

Closes #4921

## Test plan
- [x] `tests/chain-event-args.test.mjs`: 17/17 passing (8 new — H160 to/from, extra_data, nested `EVM.Log.address`, single-topic `Vec<H256>` non-collapse regression, H160/textual idempotence, non-allowlisted textual field left untouched, malformed-UTF-8 fallback, ctx-less allowlist key build)
- [x] Full suite passing locally (255 files / 7531 tests)
- [x] `npm run test:coverage` patch coverage: 100% statements/branches/lines on `src/chain-event-args.mjs`
- [x] `npm run lint` / `format:check` clean on the final diff
- [ ] Live-verify against production after merge (curl a real `Ethereum.Executed`/`EVM.Log` chain event)