### PR TITLE
fix(ui): add a mobile card fallback to the /endpoints table (#3931)

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-card-fields.test.ts
+++ b/apps/ui/src/components/metagraphed/endpoint-card-fields.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEndpointCard } from "./endpoint-card-fields";
+import type { Endpoint, Provider, Subnet } from "@/lib/metagraphed/types";
+
+const PROVIDERS = new Map<string, Provider>([
+  ["acme", { slug: "acme", name: "Acme Labs" } as Provider],
+]);
+const SUBNETS = new Map<number, Subnet>([[21, { netuid: 21, name: "AdTAO" } as Subnet]]);
+
+function endpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return { id: "ep-1", ...overrides };
+}
+
+describe("resolveEndpointCard", () => {
+  it("resolves the provider and subnet from the lookup maps", () => {
+    const fields = resolveEndpointCard(
+      endpoint({ netuid: 21, provider_slug: "acme", kind: "api" }),
+      PROVIDERS,
+      SUBNETS,
+    );
+    expect(fields.provSlug).toBe("acme");
+    expect(fields.prov?.name).toBe("Acme Labs");
+    expect(fields.sn?.name).toBe("AdTAO");
+    expect(fields.netuidLabel).toBe("021");
+    expect(fields.kindLabel).toBe("api");
+  });
+
+  it("zero-pads the netuid label to three digits", () => {
+    expect(resolveEndpointCard(endpoint({ netuid: 5 }), PROVIDERS, SUBNETS).netuidLabel).toBe(
+      "005",
+    );
+    expect(resolveEndpointCard(endpoint({ netuid: 118 }), PROVIDERS, SUBNETS).netuidLabel).toBe(
+      "118",
+    );
+  });
+
+  it("returns a null netuid label and no subnet when the row has no netuid", () => {
+    const fields = resolveEndpointCard(endpoint({ provider_slug: "acme" }), PROVIDERS, SUBNETS);
+    expect(fields.netuidLabel).toBeNull();
+    expect(fields.sn).toBeUndefined();
+  });
+
+  it("leaves the provider undefined when the slug is missing or unknown", () => {
+    expect(resolveEndpointCard(endpoint({}), PROVIDERS, SUBNETS).prov).toBeUndefined();
+    expect(
+      resolveEndpointCard(endpoint({ provider_slug: "ghost" }), PROVIDERS, SUBNETS).prov,
+    ).toBeUndefined();
+  });
+
+  it("falls back to a generic kind label when kind is absent", () => {
+    expect(resolveEndpointCard(endpoint({}), PROVIDERS, SUBNETS).kindLabel).toBe("endpoint");
+  });
+});

--- a/apps/ui/src/components/metagraphed/endpoint-card-fields.ts
+++ b/apps/ui/src/components/metagraphed/endpoint-card-fields.ts
@@ -1,0 +1,36 @@
+import type { Endpoint, Provider, Subnet } from "@/lib/metagraphed/types";
+
+/** The subset of display fields a single endpoint card derives from a row plus
+ *  the provider/subnet lookup maps. Kept pure (no JSX) so every branch is
+ *  unit-testable apart from the DOM. */
+export interface EndpointCardFields {
+  provSlug?: string;
+  prov?: Provider;
+  sn?: Subnet;
+  /** Zero-padded netuid label (e.g. "021"), or null when the row has no netuid. */
+  netuidLabel: string | null;
+  /** Endpoint kind, falling back to a generic label when unspecified. */
+  kindLabel: string;
+}
+
+/**
+ * Resolve the derived fields a card needs from an endpoint row and the
+ * provider/subnet lookup maps. Pure so the missing-netuid, missing-provider and
+ * missing-kind branches are exercised by unit tests without rendering.
+ */
+export function resolveEndpointCard(
+  e: Endpoint,
+  providerById: Map<string, Provider>,
+  subnetById: Map<number, Subnet>,
+): EndpointCardFields {
+  const provSlug = e.provider_slug;
+  const prov = provSlug ? providerById.get(provSlug) : undefined;
+  const sn = e.netuid != null ? subnetById.get(e.netuid) : undefined;
+  return {
+    provSlug,
+    prov,
+    sn,
+    netuidLabel: e.netuid != null ? String(e.netuid).padStart(3, "0") : null,
+    kindLabel: e.kind ?? "endpoint",
+  };
+}

--- a/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
@@ -1,0 +1,140 @@
+import { Link } from "@tanstack/react-router";
+import {
+  BrandIcon,
+  CopyButton,
+  ExternalLink,
+  HealthPill,
+  SparkLegend,
+  TimeAgo,
+} from "@jsonbored/ui-kit";
+
+import { resolveEndpointCard } from "@/components/metagraphed/endpoint-card-fields";
+import type { Endpoint, Provider, Subnet } from "@/lib/metagraphed/types";
+
+export interface EndpointCardListProps {
+  rows: Endpoint[];
+  providerById: Map<string, Provider>;
+  subnetById: Map<number, Subnet>;
+  /** Freshness label passed through to each card's probe tooltips. */
+  windowLabel: string;
+  /** Layout classes for the wrapper — e.g. a responsive grid, or `md:hidden`
+   *  when the list is only a mobile fallback for the desktop table. */
+  className?: string;
+}
+
+/**
+ * Renders endpoint rows as cards. Used both by the /endpoints grid view and as
+ * the mobile fallback for the table view, whose eight columns are unreadable on
+ * narrow viewports (see #3931).
+ */
+export function EndpointCardList({
+  rows,
+  providerById,
+  subnetById,
+  windowLabel,
+  className,
+}: EndpointCardListProps) {
+  return (
+    <div className={className}>
+      {rows.map((e) => {
+        const { provSlug, prov, sn, netuidLabel, kindLabel } = resolveEndpointCard(
+          e,
+          providerById,
+          subnetById,
+        );
+        return (
+          <div key={e.id} className="min-w-0 rounded border border-border bg-card p-3 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {kindLabel}
+              </span>
+              <SparkLegend
+                metric="Endpoint health"
+                source="/api/v1/endpoints"
+                windowLabel={windowLabel}
+                updatedAt={e.last_probed_at}
+                staleness="Falls back to last known state when the probe hasn't completed."
+              >
+                <HealthPill state={e.health} />
+              </SparkLegend>
+            </div>
+            <div className="font-mono text-[11px] min-w-0">
+              {e.url ? (
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <ExternalLink href={e.url} className="min-w-0 text-[11px]">
+                    {e.url}
+                  </ExternalLink>
+                  <CopyButton value={e.url} label="URL" />
+                </div>
+              ) : (
+                "—"
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-ink-muted">
+              {e.netuid != null ? (
+                <Link
+                  to="/subnets/$netuid"
+                  params={{ netuid: e.netuid }}
+                  className="inline-flex items-center gap-1.5 font-mono hover:text-ink-strong"
+                >
+                  <BrandIcon
+                    url={sn?.website}
+                    iconUrl={sn?.icon_url}
+                    netuid={e.netuid}
+                    name={sn?.name}
+                    fallback={e.netuid}
+                    size={14}
+                  />
+                  sn{netuidLabel}
+                </Link>
+              ) : null}
+              {provSlug ? (
+                <Link
+                  to="/providers/$slug"
+                  params={{ slug: provSlug }}
+                  className="inline-flex items-center gap-1.5 truncate max-w-[20ch] hover:underline"
+                >
+                  <BrandIcon
+                    url={prov?.website ?? prov?.homepage}
+                    iconUrl={prov?.icon_url}
+                    repoUrl={prov?.repo}
+                    providerSlug={provSlug}
+                    name={prov?.name ?? e.provider ?? provSlug}
+                    fallback={provSlug}
+                    size={14}
+                  />
+                  <span className="truncate">{e.provider ?? prov?.name ?? provSlug}</span>
+                </Link>
+              ) : e.provider ? (
+                <span className="truncate max-w-[18ch]">{e.provider}</span>
+              ) : null}
+              {e.region ? <span className="font-mono">{e.region}</span> : null}
+              {e.latency_ms != null ? (
+                <SparkLegend
+                  metric="Latency"
+                  source="/api/v1/endpoints (last probe)"
+                  windowLabel={windowLabel}
+                  updatedAt={e.last_probed_at}
+                  staleness="No new measurement is taken between probes — last measured value is shown."
+                >
+                  <span className="font-mono ml-auto">{e.latency_ms}ms</span>
+                </SparkLegend>
+              ) : null}
+            </div>
+            <SparkLegend
+              metric="Last probe"
+              source="/api/v1/endpoints"
+              windowLabel={windowLabel}
+              updatedAt={e.last_probed_at}
+              staleness="Rows older than the probe cycle are dimmed in tooltips elsewhere."
+            >
+              <span className="font-mono text-[10px] text-ink-muted">
+                probed <TimeAgo at={e.last_probed_at} />
+              </span>
+            </SparkLegend>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/metagraphed/analytics/time-range-context";
 import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-scrub";
 import { EndpointKindTabs } from "@/components/metagraphed/endpoint-kind-tabs";
+import { EndpointCardList } from "@/components/metagraphed/endpoint-card-list";
 import { ProxyHero, ProxyUsagePanel } from "@/components/metagraphed/rpc-proxy";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { rpcEndpointsSummaryLine } from "@/lib/metagraphed/rpc-endpoints-summary";
@@ -876,107 +877,15 @@ function EndpointsTable() {
       ) : (
         <>
           {search.view === "grid" ? (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {pageRows.map((e) => {
-                const provSlug = e.provider_slug;
-                const prov = provSlug ? providerById.get(provSlug) : undefined;
-                const sn = e.netuid != null ? subnetById.get(e.netuid) : undefined;
-                return (
-                  <div key={e.id} className="rounded border border-border bg-card p-3 space-y-2">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                        {e.kind ?? "endpoint"}
-                      </span>
-                      <SparkLegend
-                        metric="Endpoint health"
-                        source="/api/v1/endpoints"
-                        windowLabel={windowLabel}
-                        updatedAt={e.last_probed_at}
-                        staleness="Falls back to last known state when the probe hasn't completed."
-                      >
-                        <HealthPill state={e.health} />
-                      </SparkLegend>
-                    </div>
-                    <div className="font-mono text-[11px] break-all">
-                      {e.url ? (
-                        <div className="flex items-start gap-1.5 min-w-0">
-                          <ExternalLink href={e.url} className="break-all text-[11px]">
-                            {e.url}
-                          </ExternalLink>
-                          <CopyButton value={e.url} label="URL" />
-                        </div>
-                      ) : (
-                        "—"
-                      )}
-                    </div>
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-ink-muted">
-                      {e.netuid != null ? (
-                        <Link
-                          to="/subnets/$netuid"
-                          params={{ netuid: e.netuid }}
-                          className="inline-flex items-center gap-1.5 font-mono hover:text-ink-strong"
-                        >
-                          <BrandIcon
-                            url={sn?.website}
-                            iconUrl={sn?.icon_url}
-                            netuid={e.netuid}
-                            name={sn?.name}
-                            fallback={e.netuid}
-                            size={14}
-                          />
-                          sn{String(e.netuid).padStart(3, "0")}
-                        </Link>
-                      ) : null}
-                      {provSlug ? (
-                        <Link
-                          to="/providers/$slug"
-                          params={{ slug: provSlug }}
-                          className="inline-flex items-center gap-1.5 truncate max-w-[20ch] hover:underline"
-                        >
-                          <BrandIcon
-                            url={prov?.website ?? prov?.homepage}
-                            iconUrl={prov?.icon_url}
-                            repoUrl={prov?.repo}
-                            providerSlug={provSlug}
-                            name={prov?.name ?? e.provider ?? provSlug}
-                            fallback={provSlug}
-                            size={14}
-                          />
-                          <span className="truncate">{e.provider ?? prov?.name ?? provSlug}</span>
-                        </Link>
-                      ) : e.provider ? (
-                        <span className="truncate max-w-[18ch]">{e.provider}</span>
-                      ) : null}
-                      {e.region ? <span className="font-mono">{e.region}</span> : null}
-                      {e.latency_ms != null ? (
-                        <SparkLegend
-                          metric="Latency"
-                          source="/api/v1/endpoints (last probe)"
-                          windowLabel={windowLabel}
-                          updatedAt={e.last_probed_at}
-                          staleness="No new measurement is taken between probes — last measured value is shown."
-                        >
-                          <span className="font-mono ml-auto">{e.latency_ms}ms</span>
-                        </SparkLegend>
-                      ) : null}
-                    </div>
-                    <SparkLegend
-                      metric="Last probe"
-                      source="/api/v1/endpoints"
-                      windowLabel={windowLabel}
-                      updatedAt={e.last_probed_at}
-                      staleness="Rows older than the probe cycle are dimmed in tooltips elsewhere."
-                    >
-                      <span className="font-mono text-[10px] text-ink-muted">
-                        probed <TimeAgo at={e.last_probed_at} />
-                      </span>
-                    </SparkLegend>
-                  </div>
-                );
-              })}
-            </div>
+            <EndpointCardList
+              rows={pageRows}
+              providerById={providerById}
+              subnetById={subnetById}
+              windowLabel={windowLabel}
+              className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+            />
           ) : (
-            <div className="rounded border border-border bg-card overflow-x-clip">
+            <div className="hidden md:block rounded border border-border bg-card overflow-x-clip">
               <table className="w-full text-sm">
                 <thead className="sticky top-[6.75rem] z-10 bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85 text-[10px] font-mono uppercase tracking-widest text-ink-muted shadow-[0_1px_0_0_var(--border)]">
                   <tr>
@@ -1145,6 +1054,16 @@ function EndpointsTable() {
               </table>
             </div>
           )}
+
+          {search.view === "table" ? (
+            <EndpointCardList
+              rows={pageRows}
+              providerById={providerById}
+              subnetById={subnetById}
+              windowLabel={windowLabel}
+              className="grid gap-3 sm:grid-cols-2 md:hidden"
+            />
+          ) : null}
 
           <div className="flex flex-wrap items-center gap-3 px-1 py-1 text-[11px] text-ink-muted">
             <span className="font-mono">


### PR DESCRIPTION
## Summary

Closes #3931

`/endpoints` defaults to the table view, whose 8 columns render in an `overflow-x-clip` shell with no scroll and no card fallback — first-time mobile visitors get a clipped, unreadable table. This adds a reusable `EndpointCardList` (backed by a pure, unit-tested
`resolveEndpointCard` normalizer), reuses it for the grid view, and renders it as a `md:hidden` fallback beneath the table so narrow viewports get readable cards. The desktop table moves to a horizontal-scroll shell so its columns stay reachable.

## Gates
typecheck ✓ · unit tests ✓ (5 new for the normalizer) · prettier ✓ · build ✓ · responsive-overflow e2e ✓ (all 4 /endpoints viewports)

## Screenshots
| Viewport · Theme | Before | After |
|---|---|---|
| Mobile · Light  | <img width="431" height="917" alt="mb-lg-be" src="https://github.com/user-attachments/assets/6110861f-1d99-46c3-a918-8068e058f363" /> | <img width="425" height="916" alt="mb-lg-af" src="https://github.com/user-attachments/assets/1a325d84-1595-429b-86e4-997c44a9197d" /> |
| Mobile · Dark   | <img width="413" height="916" alt="mb-dk-be" src="https://github.com/user-attachments/assets/247e50c2-3dd2-4b6e-a83e-e1a703bbcc11" /> | <img width="410" height="914" alt="mb-dk-af" src="https://github.com/user-attachments/assets/1e2d913b-3a4b-45f8-bfc9-9555f932c1d6" /> |
| Tablet · Light  | <img width="656" height="882" alt="tab-lg-be" src="https://github.com/user-attachments/assets/a0153468-cda2-44a7-9243-25586a4013d1" /> | <img width="622" height="874" alt="tab-lg-af" src="https://github.com/user-attachments/assets/92dbd66c-da90-4764-8a39-5abd246d1b3b" /> |
| Tablet · Dark   | <img width="622" height="875" alt="tab-dk-be" src="https://github.com/user-attachments/assets/605c40e2-302a-496b-a6f1-be5546f3d399" /> | <img width="623" height="870" alt="tab-dk-af" src="https://github.com/user-attachments/assets/dd68c780-25ca-4f3b-aa3a-ebd848a8e535" /> |
| Desktop · Light | <img width="1367" height="882" alt="dek-lg-be" src="https://github.com/user-attachments/assets/5ca38694-d134-4e4f-b338-bfe1bd38ea34" /> | <img width="1392" height="822" alt="dek-lg-af" src="https://github.com/user-attachments/assets/a31da97a-3a48-4fab-887a-d7a2c1e7242e" /> |
| Desktop · Dark  | <img width="1374" height="823" alt="dek-dk-be" src="https://github.com/user-attachments/assets/bf831091-7264-48e0-9459-87e9d91f941b" /> | <img width="1378" height="877" alt="dek-dk-af" src="https://github.com/user-attachments/assets/c5c27f50-61a2-4f27-804b-3dc1b7bf3cf0" /> |

