### PR TITLE
fix(data-api): strip NUL bytes from subnet identity sync

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3722,6 +3722,32 @@ test("subnet-identity-sync appends to subnet_identity_history when the hash chan
   expect(queryText()).toMatch(/INSERT INTO subnet_identity_history\b/);
 });
 
+test("subnet-identity-sync strips embedded NUL bytes before inserting Postgres TEXT", async () => {
+  const res = await postSubnetIdentity(
+    [
+      subnetIdentityProfile({
+        symbol: "MI\u0000AO",
+        native_identity: {
+          ...subnetIdentityProfile().native_identity,
+          subnet_name: "Miao\u0000 Subnet",
+          description: "An example\u0000 subnet operator.",
+        },
+      }),
+    ],
+    { secret: SUBNET_IDENTITY_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const insert = sqlCalls.find((c) =>
+    /INSERT INTO subnet_identity_history\b/.test(c.text),
+  );
+  expect(
+    insert.values.some((v) => typeof v === "string" && v.includes("\u0000")),
+  ).toBe(false);
+  expect(insert.values).toContain("MIAO");
+  expect(insert.values).toContain("Miao Subnet");
+  expect(insert.values).toContain("An example subnet operator.");
+});
+
 test("subnet-identity-sync skips the history append when the hash is unchanged", async () => {
   const profile = subnetIdentityProfile();
   const snapshot = identitySnapshotFromProfile(profile);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1332,6 +1332,15 @@ const SUBNET_IDENTITY_SYNC_TOKEN_HEADER = "x-subnet-identity-sync-token";
 const SUBNET_IDENTITY_SYNC_MAX_BODY_BYTES = 5_000_000;
 const SUBNET_IDENTITY_SYNC_MAX_ROWS = 2_000;
 
+function sanitizeSubnetIdentitySyncSnapshot(snapshot) {
+  if (!snapshot) return snapshot;
+  const out = {};
+  for (const [key, value] of Object.entries(snapshot)) {
+    out[key] = stripNullBytes(value);
+  }
+  return out;
+}
+
 async function handleSubnetIdentitySync(request, env) {
   if (!env.SUBNET_IDENTITY_SYNC_SECRET) {
     return writeJson(
@@ -1418,7 +1427,9 @@ async function handleSubnetIdentitySync(request, env) {
       const changedRows = [];
       for (const profile of profiles) {
         if (!Number.isInteger(profile?.netuid)) continue;
-        const snapshot = identitySnapshotFromProfile(profile);
+        const snapshot = sanitizeSubnetIdentitySyncSnapshot(
+          identitySnapshotFromProfile(profile),
+        );
         if (!snapshot) continue;
         const hash = await subnetIdentityHash(snapshot);
         if (latestByNetuid.get(profile.netuid) === hash) continue;


### PR DESCRIPTION
### Motivation
- PostgreSQL `TEXT` rejects embedded U+0000 bytes, and the subnet identity Postgres mirror was bulk-inserting attacker-controlled on-chain text without stripping NULs, which can abort the INSERT and leave the Postgres mirror stale.
- The sibling account-identity sync already strips NULs; the subnet-identity path omitted that mitigation and needed parity to avoid Postgres failures.

### Description
- Add `sanitizeSubnetIdentitySyncSnapshot(snapshot)` to strip embedded NUL bytes from every snapshot field using the existing `stripNullBytes` helper. 
- Use `sanitizeSubnetIdentitySyncSnapshot(identitySnapshotFromProfile(profile))` when building `changedRows` in `handleSubnetIdentitySync` so values are cleaned before hashing and insertion. 
- Add a regression test `subnet-identity-sync strips embedded NUL bytes before inserting Postgres TEXT` to `tests/data-api.test.mjs` that verifies `subnet_name`, `symbol`, and `description` NULs are removed before the `INSERT` values are bound.

### Testing
- Ran the focused test file with `npm test -- tests/data-api.test.mjs` and the suite passed (318 tests passed). 
- Ran `npm run lint` and `npm run format:check`, both succeeded. 
- Ran `git diff --check` to validate workspace hygiene with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5232cc7d20832ca92798c72cc68df0)