### PR TITLE
feat(health): flip rpc_proxy_events serving to Postgres

### DIFF
--- a/tests/request-handlers-rpc-proxy.test.mjs
+++ b/tests/request-handlers-rpc-proxy.test.mjs
@@ -198,10 +198,10 @@ describe("handleRpcUsage", () => {
     assert.equal(body.data.buckets.length, 1);
   });
 
-  // #4832 gap-closure: METAGRAPH_RPC_USAGE_SOURCE is a NEW flag, deliberately
-  // left unset in wrangler.jsonc (no historical backfill -- see
-  // handleRpcUsage's own header comment) -- these tests only prove the
-  // wiring, not a live flip.
+  // #4832 gap-closure: METAGRAPH_RPC_USAGE_SOURCE is flipped to "postgres" in
+  // wrangler.jsonc (after a one-time historical backfill -- see its inline
+  // comment) -- these tests prove the wiring, independent of that live flag
+  // value.
   test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
     let d1Called = false;
     const env = {

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -177,9 +177,13 @@ export async function handleRpcUsage(request, env, url) {
   const meta = await readHealthMetaKv(env);
   // #4832 gap-closure: reuses tryPostgresTier's usual "forward the caller's
   // request unchanged" contract (a clean 1:1 route, unlike handleCompare's
-  // embedded-helper shape). METAGRAPH_RPC_USAGE_SOURCE is deliberately
-  // unflipped in wrangler.jsonc -- no historical backfill exists, same
-  // rationale as METAGRAPH_HEALTH_SOURCE/METAGRAPH_SUBNET_SNAPSHOTS_SOURCE.
+  // embedded-helper shape). METAGRAPH_RPC_USAGE_SOURCE flipped to "postgres"
+  // in wrangler.jsonc 2026-07-12 after a one-time historical backfill closed
+  // the gap (see wrangler.jsonc's inline comment for the verification
+  // details) -- unlike METAGRAPH_HEALTH_SOURCE/METAGRAPH_SUBNET_SNAPSHOTS_SOURCE,
+  // this table's reads are always window-bounded (7d/30d) and both stores
+  // only ever hold that same rolling slice, so there was no long-tail
+  // history a backfill could leave behind.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_RPC_USAGE_SOURCE")) ??
     (await loadRpcUsage(d1Runner(env), {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -247,6 +247,22 @@
     // a single-flag revert -- though note D1's fallback is currently a no-op
     // for reads (empty) until that bug is fixed.
     "METAGRAPH_SUBNET_IDENTITY_SOURCE": "postgres",
+    // rpc_proxy_events (#4832 gap-closure follow-up): FLIPPED to "postgres"
+    // 2026-07-12, after a one-time historical backfill closed the only gap --
+    // D1 had 70 rows (wrangler d1 execute, confirmed the same day), Postgres
+    // had 1 (the newest, already mirrored live by
+    // workers/request-handlers/rpc-proxy.mjs's syncRpcUsageEventToPostgres,
+    // matched via an exact observed_at tie); the other 69 were inserted
+    // directly into Postgres and verified row-for-row against D1 afterward
+    // (count, min/max observed_at, and a 5-row spot-check including the
+    // null-endpoint/cache-hit and 503-failure shapes). No historical-window
+    // regression risk here (unlike subnet_snapshots): handleRpcUsage's own
+    // ANALYTICS_WINDOWS caps every query at 7d/30d, and both D1 (via the
+    // hourly pruneHealthHistory) and Postgres only ever hold this same
+    // rolling 30-day slice, so there is no long-tail history to lose by
+    // switching the read tier. tryPostgresTier still falls back to D1 on any
+    // failure, so this remains a single-flag revert.
+    "METAGRAPH_RPC_USAGE_SOURCE": "postgres",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
   // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the


### PR DESCRIPTION
## Summary

Backfills D1's historical `rpc_proxy_events` rows into Postgres and flips
`METAGRAPH_RPC_USAGE_SOURCE` to `"postgres"`, closing the last remaining gap
from the #4832 D1-completeness sweep (following #4906, which built the
Postgres tier's read/write paths but deliberately left the flag unset
pending this backfill).

**Backfill performed before this flip:**

1. Pulled all rows from D1 via `wrangler d1 execute metagraphed-health --remote`: 70 total, `observed_at` spanning 2026-06-15 through 2026-07-12.
2. Queried production Postgres: 1 row present, with `observed_at` exactly matching D1's newest row — confirming it was already captured by the live per-request mirror (`syncRpcUsageEventToPostgres`, shipped in #4906).
3. Inserted the other 69 (historical, pre-dating that live sync) directly into Postgres via `psql`, matching `deploy/postgres/schema.sql`'s exact column set (`ok` as `BOOLEAN`, nullable `endpoint_id`/`provider`/`status`/`attempts`/`latency_ms`).
4. Verified: Postgres row count now matches D1 exactly (70/70), same `min`/`max observed_at`, plus a 5-row spot-check by `observed_at` covering the normal-success, cache-hit, and 503-failure row shapes — all fields matched D1 field-for-field.

**Why this flip carries no historical-window regression risk** (unlike `subnet_snapshots`, per `bcf7de09`'s prior caution): confirmed by reading `workers/request-handlers/rpc-proxy.mjs` and `src/rpc-usage-loader.mjs` — `handleRpcUsage` only ever queries `observed_at >= now - {7,30}d` (`ANALYTICS_WINDOWS`), and both stores already only retain that same rolling 30-day slice (D1 via the hourly `pruneHealthHistory` prune, Postgres by construction — it only ever received live writes going forward). There's no long-tail history either store could be missing.

`tryPostgresTier` still falls back to D1 on any failure, so this remains a single-flag revert.

Refs #4832

## Test plan

- `npm run lint` clean
- `npx prettier --check wrangler.jsonc workers/request-handlers/rpc-proxy.mjs tests/request-handlers-rpc-proxy.test.mjs` clean
- `npm run build && npx vitest run` — 255 files / 7531 tests passing
- `npm run validate` clean
- `npx wrangler deploy --dry-run` confirms `wrangler.jsonc` parses and `METAGRAPH_RPC_USAGE_SOURCE` resolves to `"postgres"`
- Live: `psql` confirms Postgres `rpc_proxy_events` row count (70) and min/max `observed_at` now match D1 exactly, plus a 5-row spot-check