### PR TITLE
feat(data-api): backfill D1 subnet_snapshots history into Postgres

### DIFF
--- a/scripts/backfill-subnet-snapshots-postgres.mjs
+++ b/scripts/backfill-subnet-snapshots-postgres.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// One-time D1 -> Postgres BACKFILL for `subnet_snapshots` (D1-to-Postgres
+// retirement effort, sibling to #4772's chain-data retirement). D1 has been
+// the PRIMARY store for this table since AI-4 (src/health-prober.mjs's
+// writeSubnetSnapshot, fired every hour): 47k+ rows back to 2025-06-23.
+// Postgres only started receiving rows via syncSubnetSnapshotToPostgres's
+// best-effort dual-write mirror once #4832 landed
+// (workers/data-api.mjs's handleSubnetSnapshotSync), so it is missing over a
+// year of history D1 already has -- exactly why METAGRAPH_SUBNET_SNAPSHOTS_SOURCE
+// stays deliberately unflipped in wrangler.jsonc (see
+// workers/request-handlers/analytics-routes.mjs's own header comment):
+// flipping serving to Postgres before this backfill runs would truncate every
+// trajectory/economics-trends chart down to the dual-write's short tail.
+//
+// This is a pure COPY, not a decode operation -- D1's values are already
+// correct/final. The script pages the full D1 table (ordered by the table's
+// implicit SQLite `rowid`, which is dense/gapless on this table, so paging
+// never needs an expensive OFFSET re-scan) and emits ONE .sql file of batched
+// `INSERT ... ON CONFLICT (netuid, snapshot_date) DO UPDATE SET <col> =
+// excluded.<col>` statements wrapped in a single transaction. D1 is treated
+// as authoritative on conflict, so re-applying this export always converges
+// Postgres to match D1 exactly -- including for the ~258-row dual-write
+// overlap window Postgres already had before the first run.
+//
+// There is no network path from this machine (or CI) directly to Postgres --
+// it's reachable only via Hyperdrive from a deployed Worker, or via SSH to
+// the indexer box. This script therefore only PAGES D1 and WRITES the .sql
+// file; applying it is a separate, manual step (see below). Both steps are
+// idempotent and safe to re-run: every row upserts on the table's real
+// (netuid, snapshot_date) primary key, so re-running never duplicates
+// anything, and a re-run after D1 has accrued more rows just picks up the
+// delta.
+//
+// Usage:
+//   node scripts/backfill-subnet-snapshots-postgres.mjs [--out <path>]
+//     [--d1-database <name>] [--page-size <n>] [--rows-per-statement <n>]
+//
+// Apply the generated file against the indexer box's Postgres (never run
+// migrations directly on prod -- copy in, then execute):
+//   scp <out> indexeradmin@meta-indexer-01-us-lax1:/tmp/subnet-snapshots-backfill.sql
+//   ssh indexeradmin@meta-indexer-01-us-lax1 \
+//     "sudo docker cp /tmp/subnet-snapshots-backfill.sql metagraphed-indexer-postgres-1:/tmp/x.sql && \
+//      sudo docker exec metagraphed-indexer-postgres-1 psql -U metagraphed -d metagraphed \
+//        -v ON_ERROR_STOP=1 -f /tmp/x.sql"
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./lib.mjs";
+
+// Column order matches Postgres's `subnet_snapshots` exactly (verified via
+// `psql -c '\d subnet_snapshots'` against the live indexer instance), which
+// in turn matches D1's own column order 1:1 -- this backfill was built
+// specifically because the two schemas already agree, so no field mapping/
+// renaming is needed, only a straight copy.
+const COLUMNS = [
+  "netuid",
+  "snapshot_date",
+  "completeness_score",
+  "surface_count",
+  "endpoint_count",
+  "monitored_count",
+  "candidate_count",
+  "captured_at",
+  "validator_count",
+  "miner_count",
+  "total_stake_tao",
+  "alpha_price_tao",
+  "emission_share",
+];
+const INTEGER_COLUMNS = new Set([
+  "netuid",
+  "completeness_score",
+  "surface_count",
+  "endpoint_count",
+  "monitored_count",
+  "candidate_count",
+  "captured_at",
+  "validator_count",
+  "miner_count",
+]);
+const REAL_COLUMNS = new Set([
+  "total_stake_tao",
+  "alpha_price_tao",
+  "emission_share",
+]);
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const UPDATE_COLUMNS = COLUMNS.filter(
+  (column) => column !== "netuid" && column !== "snapshot_date",
+);
+
+export function parseArgs(argv) {
+  const out = {
+    out: path.join(repoRoot, "dist/subnet-snapshots-backfill.sql"),
+    database: "metagraphed-health",
+    pageSize: 3000,
+    rowsPerStatement: 1000,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out") out.out = argv[++i];
+    else if (arg === "--d1-database") out.database = argv[++i];
+    else if (arg === "--page-size") out.pageSize = Number(argv[++i]);
+    else if (arg === "--rows-per-statement")
+      out.rowsPerStatement = Number(argv[++i]);
+    else throw new Error(`unrecognized argument: ${arg}`);
+  }
+  if (
+    !Number.isInteger(out.pageSize) ||
+    out.pageSize <= 0 ||
+    out.pageSize > 5000
+  ) {
+    throw new Error("--page-size must be an integer in (0, 5000]");
+  }
+  if (!Number.isInteger(out.rowsPerStatement) || out.rowsPerStatement <= 0) {
+    throw new Error("--rows-per-statement must be a positive integer");
+  }
+  return out;
+}
+
+// One page of `wrangler d1 execute --remote --json`, ordered by rowid so
+// paging is a cheap indexed `WHERE rowid > ?` rather than an ever-more-costly
+// `OFFSET`. `runner` is injection-only (tests stub it); production always
+// uses the real `spawnSync` default below.
+export function fetchPage(database, afterRowid, pageSize, runner = spawnSync) {
+  const sql =
+    `SELECT rowid, ${COLUMNS.join(", ")} FROM subnet_snapshots ` +
+    `WHERE rowid > ${afterRowid} ORDER BY rowid LIMIT ${pageSize}`;
+  const result = runner(
+    "npx",
+    [
+      "wrangler",
+      "d1",
+      "execute",
+      database,
+      "--remote",
+      "--json",
+      "--command",
+      sql,
+    ],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `wrangler d1 execute failed (exit ${result.status}): ${result.stderr || result.stdout || "no output"}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      `wrangler d1 output was not valid JSON: ${String(result.stdout).slice(0, 500)}`,
+    );
+  }
+  const rows = parsed?.[0]?.results;
+  if (!Array.isArray(rows)) {
+    throw new Error(
+      `unexpected wrangler d1 output shape: ${String(result.stdout).slice(0, 500)}`,
+    );
+  }
+  return rows;
+}
+
+export function sqlLiteral(column, value) {
+  if (value === null || value === undefined) return "NULL";
+  if (column === "snapshot_date") {
+    if (typeof value !== "string" || !DATE_RE.test(value)) {
+      throw new Error(
+        `row has invalid snapshot_date: ${JSON.stringify(value)}`,
+      );
+    }
+    return `'${value}'`;
+  }
+  if (INTEGER_COLUMNS.has(column)) {
+    if (!Number.isInteger(value)) {
+      throw new Error(
+        `row has non-integer ${column}: ${JSON.stringify(value)}`,
+      );
+    }
+    return String(value);
+  }
+  if (REAL_COLUMNS.has(column)) {
+    if (!Number.isFinite(value)) {
+      throw new Error(`row has non-finite ${column}: ${JSON.stringify(value)}`);
+    }
+    return String(value);
+  }
+  throw new Error(`unrecognized column: ${column}`);
+}
+
+export function rowTuple(row) {
+  return `(${COLUMNS.map((column) => sqlLiteral(column, row[column])).join(", ")})`;
+}
+
+export function chunkRows(array, size) {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export function insertStatement(rows) {
+  const values = rows.map(rowTuple).join(",\n  ");
+  const setClause = UPDATE_COLUMNS.map(
+    (column) => `${column} = excluded.${column}`,
+  ).join(",\n    ");
+  return (
+    `INSERT INTO subnet_snapshots (${COLUMNS.join(", ")}) VALUES\n  ${values}\n` +
+    `ON CONFLICT (netuid, snapshot_date) DO UPDATE SET\n    ${setClause};`
+  );
+}
+
+export function buildBackfillSql(allRows, rowsPerStatement) {
+  const statements = chunkRows(allRows, rowsPerStatement).map(insertStatement);
+  return (
+    `-- Generated by scripts/backfill-subnet-snapshots-postgres.mjs -- ` +
+    `${allRows.length} rows, ${statements.length} statements.\n` +
+    `-- Apply with: psql -v ON_ERROR_STOP=1 -f <this file>\n` +
+    `BEGIN;\n\n${statements.join("\n\n")}\n\nCOMMIT;\n`
+  );
+}
+
+export async function fetchAllRows(database, pageSize, runner = spawnSync) {
+  const allRows = [];
+  let afterRowid = 0;
+  for (;;) {
+    const page = fetchPage(database, afterRowid, pageSize, runner);
+    if (!page.length) break;
+    allRows.push(...page);
+    afterRowid = page[page.length - 1].rowid;
+    console.log(
+      `  fetched ${allRows.length} rows so far (last rowid ${afterRowid})...`,
+    );
+    if (page.length < pageSize) break;
+  }
+  return allRows;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `Paging D1 database "${args.database}" (subnet_snapshots), page size ${args.pageSize}...`,
+  );
+
+  const allRows = await fetchAllRows(args.database, args.pageSize);
+  if (!allRows.length) {
+    throw new Error(
+      "D1 returned zero rows for subnet_snapshots -- refusing to write an empty backfill",
+    );
+  }
+
+  const sql = buildBackfillSql(allRows, args.rowsPerStatement);
+  await fs.mkdir(path.dirname(args.out), { recursive: true });
+  await fs.writeFile(args.out, sql, "utf8");
+  const statementCount = chunkRows(allRows, args.rowsPerStatement).length;
+  console.log(
+    `Wrote ${allRows.length} rows (${statementCount} statements) to ${args.out}`,
+  );
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) ===
+    path.resolve(new URL(import.meta.url).pathname);
+if (isMain) {
+  await main();
+}

--- a/tests/backfill-subnet-snapshots-postgres.test.mjs
+++ b/tests/backfill-subnet-snapshots-postgres.test.mjs
@@ -1,0 +1,287 @@
+// Unit tests for scripts/backfill-subnet-snapshots-postgres.mjs's pure
+// helpers (SQL-literal encoding, statement batching, arg parsing, and the D1
+// paging loop with an injected subprocess runner). Not part of the codecov
+// coverage.include scope (see vitest.config.mjs's own comment on why only a
+// named subset of scripts/ is instrumented) -- these tests exist for
+// correctness confidence before running the script against production, the
+// same convention tests/registry-sync-client.test.mjs already follows for
+// scripts/backfill-registry-postgres.mjs's sibling helpers.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  buildBackfillSql,
+  chunkRows,
+  fetchAllRows,
+  fetchPage,
+  insertStatement,
+  parseArgs,
+  rowTuple,
+  sqlLiteral,
+} from "../scripts/backfill-subnet-snapshots-postgres.mjs";
+
+const SAMPLE_ROW = {
+  rowid: 1,
+  netuid: 43,
+  snapshot_date: "2025-06-23",
+  completeness_score: 80,
+  surface_count: 3,
+  endpoint_count: 2,
+  monitored_count: 1,
+  candidate_count: 0,
+  captured_at: 1750643200000,
+  validator_count: 64,
+  miner_count: 192,
+  total_stake_tao: 123.456,
+  alpha_price_tao: 0.789,
+  emission_share: 0.0123,
+};
+
+test("parseArgs returns defaults with no arguments", () => {
+  const args = parseArgs([]);
+  assert.equal(args.database, "metagraphed-health");
+  assert.equal(args.pageSize, 3000);
+  assert.equal(args.rowsPerStatement, 1000);
+  assert.ok(args.out.endsWith("dist/subnet-snapshots-backfill.sql"));
+});
+
+test("parseArgs honors overrides", () => {
+  const args = parseArgs([
+    "--out",
+    "/tmp/x.sql",
+    "--d1-database",
+    "some-db",
+    "--page-size",
+    "500",
+    "--rows-per-statement",
+    "200",
+  ]);
+  assert.deepEqual(args, {
+    out: "/tmp/x.sql",
+    database: "some-db",
+    pageSize: 500,
+    rowsPerStatement: 200,
+  });
+});
+
+test("parseArgs rejects an unrecognized flag", () => {
+  assert.throws(() => parseArgs(["--bogus"]), /unrecognized argument/);
+});
+
+test("parseArgs rejects an out-of-range page size", () => {
+  assert.throws(
+    () => parseArgs(["--page-size", "0"]),
+    /--page-size must be an integer/,
+  );
+  assert.throws(
+    () => parseArgs(["--page-size", "5001"]),
+    /--page-size must be an integer/,
+  );
+  assert.throws(
+    () => parseArgs(["--page-size", "abc"]),
+    /--page-size must be an integer/,
+  );
+});
+
+test("parseArgs rejects a non-positive rows-per-statement", () => {
+  assert.throws(
+    () => parseArgs(["--rows-per-statement", "0"]),
+    /--rows-per-statement must be a positive integer/,
+  );
+});
+
+test("sqlLiteral renders NULL for null/undefined", () => {
+  assert.equal(sqlLiteral("miner_count", null), "NULL");
+  assert.equal(sqlLiteral("miner_count", undefined), "NULL");
+});
+
+test("sqlLiteral quotes a valid snapshot_date", () => {
+  assert.equal(sqlLiteral("snapshot_date", "2025-06-23"), "'2025-06-23'");
+});
+
+test("sqlLiteral rejects a malformed snapshot_date", () => {
+  assert.throws(
+    () => sqlLiteral("snapshot_date", "06/23/2025"),
+    /invalid snapshot_date/,
+  );
+  assert.throws(
+    () => sqlLiteral("snapshot_date", 20250623),
+    /invalid snapshot_date/,
+  );
+});
+
+test("sqlLiteral renders integer columns verbatim and rejects non-integers", () => {
+  assert.equal(sqlLiteral("netuid", 43), "43");
+  assert.equal(sqlLiteral("captured_at", 1750643200000), "1750643200000");
+  assert.throws(() => sqlLiteral("netuid", 43.5), /non-integer netuid/);
+  assert.throws(() => sqlLiteral("netuid", "43"), /non-integer netuid/);
+});
+
+test("sqlLiteral renders real columns and rejects non-finite values", () => {
+  assert.equal(sqlLiteral("alpha_price_tao", 0.789), "0.789");
+  assert.equal(sqlLiteral("total_stake_tao", 100), "100");
+  assert.throws(
+    () => sqlLiteral("alpha_price_tao", NaN),
+    /non-finite alpha_price_tao/,
+  );
+  assert.throws(
+    () => sqlLiteral("alpha_price_tao", Infinity),
+    /non-finite alpha_price_tao/,
+  );
+});
+
+test("sqlLiteral rejects an unrecognized column", () => {
+  assert.throws(
+    () => sqlLiteral("not_a_real_column", 1),
+    /unrecognized column/,
+  );
+});
+
+test("rowTuple renders every column in declared order", () => {
+  const tuple = rowTuple(SAMPLE_ROW);
+  assert.equal(
+    tuple,
+    "(43, '2025-06-23', 80, 3, 2, 1, 0, 1750643200000, 64, 192, 123.456, 0.789, 0.0123)",
+  );
+});
+
+test("rowTuple carries NULLs through for missing economics columns", () => {
+  const tuple = rowTuple({
+    ...SAMPLE_ROW,
+    validator_count: null,
+    miner_count: null,
+    total_stake_tao: null,
+    alpha_price_tao: null,
+    emission_share: null,
+  });
+  assert.match(tuple, /NULL, NULL, NULL, NULL, NULL\)$/);
+});
+
+test("chunkRows splits into fixed-size chunks with a final remainder", () => {
+  const rows = Array.from({ length: 7 }, (_, i) => i);
+  assert.deepEqual(chunkRows(rows, 3), [[0, 1, 2], [3, 4, 5], [6]]);
+});
+
+test("chunkRows returns an empty array for empty input", () => {
+  assert.deepEqual(chunkRows([], 100), []);
+});
+
+test("insertStatement emits an upsert that overwrites every non-key column", () => {
+  const statement = insertStatement([SAMPLE_ROW]);
+  assert.match(statement, /^INSERT INTO subnet_snapshots \(/);
+  assert.match(
+    statement,
+    /ON CONFLICT \(netuid, snapshot_date\) DO UPDATE SET/,
+  );
+  // Every column except the two PK columns must appear in the SET clause,
+  // as a straight excluded.<col> overwrite (D1 is authoritative on conflict).
+  for (const column of [
+    "completeness_score",
+    "surface_count",
+    "endpoint_count",
+    "monitored_count",
+    "candidate_count",
+    "captured_at",
+    "validator_count",
+    "miner_count",
+    "total_stake_tao",
+    "alpha_price_tao",
+    "emission_share",
+  ]) {
+    assert.match(
+      statement,
+      new RegExp(`${column} = excluded\\.${column}`),
+      `expected SET clause to overwrite ${column}`,
+    );
+  }
+  assert.doesNotMatch(statement, /netuid = excluded\.netuid/);
+  assert.doesNotMatch(statement, /snapshot_date = excluded\.snapshot_date/);
+  assert.ok(statement.trim().endsWith(";"));
+});
+
+test("buildBackfillSql wraps batched statements in a single transaction", () => {
+  const rows = Array.from({ length: 5 }, (_, i) => ({
+    ...SAMPLE_ROW,
+    netuid: i,
+  }));
+  const sql = buildBackfillSql(rows, 2);
+  assert.match(
+    sql,
+    /^-- Generated by scripts\/backfill-subnet-snapshots-postgres\.mjs -- 5 rows, 3 statements\./,
+  );
+  assert.match(sql, /^BEGIN;/m);
+  assert.match(sql, /\nCOMMIT;\n$/);
+  // 5 rows at 2/statement -> 3 INSERT statements.
+  assert.equal((sql.match(/^INSERT INTO subnet_snapshots/gm) || []).length, 3);
+});
+
+function stubRunner(pages) {
+  let call = 0;
+  return () => {
+    const page = pages[call] ?? [];
+    call += 1;
+    return { status: 0, stdout: JSON.stringify([{ results: page }]) };
+  };
+}
+
+test("fetchPage parses a successful wrangler --json response", () => {
+  const runner = stubRunner([[SAMPLE_ROW]]);
+  const rows = fetchPage("metagraphed-health", 0, 3000, runner);
+  assert.deepEqual(rows, [SAMPLE_ROW]);
+});
+
+test("fetchPage throws when the wrangler subprocess exits non-zero", () => {
+  const runner = () => ({ status: 1, stdout: "", stderr: "boom" });
+  assert.throws(
+    () => fetchPage("metagraphed-health", 0, 3000, runner),
+    /wrangler d1 execute failed.*boom/s,
+  );
+});
+
+test("fetchPage throws on non-JSON stdout", () => {
+  const runner = () => ({ status: 0, stdout: "not json" });
+  assert.throws(
+    () => fetchPage("metagraphed-health", 0, 3000, runner),
+    /not valid JSON/,
+  );
+});
+
+test("fetchPage throws on an unexpected JSON shape", () => {
+  const runner = () => ({ status: 0, stdout: JSON.stringify([{}]) });
+  assert.throws(
+    () => fetchPage("metagraphed-health", 0, 3000, runner),
+    /unexpected wrangler d1 output shape/,
+  );
+});
+
+test("fetchAllRows pages until a short page ends the loop", async () => {
+  const page1 = Array.from({ length: 3 }, (_, i) => ({
+    ...SAMPLE_ROW,
+    rowid: i + 1,
+    netuid: i,
+  }));
+  const page2 = [{ ...SAMPLE_ROW, rowid: 4, netuid: 99 }]; // shorter than pageSize -> stop
+  const runner = stubRunner([page1, page2]);
+  const rows = await fetchAllRows("metagraphed-health", 3, runner);
+  assert.equal(rows.length, 4);
+  assert.deepEqual(
+    rows.map((r) => r.rowid),
+    [1, 2, 3, 4],
+  );
+});
+
+test("fetchAllRows stops immediately on an empty first page", async () => {
+  const runner = stubRunner([[]]);
+  const rows = await fetchAllRows("metagraphed-health", 100, runner);
+  assert.deepEqual(rows, []);
+});
+
+test("fetchAllRows stops on an exact-pageSize page followed by empty", async () => {
+  const page1 = Array.from({ length: 2 }, (_, i) => ({
+    ...SAMPLE_ROW,
+    rowid: i + 1,
+    netuid: i,
+  }));
+  const runner = stubRunner([page1, []]);
+  const rows = await fetchAllRows("metagraphed-health", 2, runner);
+  assert.equal(rows.length, 2);
+});


### PR DESCRIPTION
## Summary

- Backfills Postgres's `subnet_snapshots` with D1's full history (47,666 rows, 2025-06-23 to
  2026-07-12) so `METAGRAPH_SUBNET_SNAPSHOTS_SOURCE` can eventually be flipped without truncating
  every trajectory/economics-trends chart down to the short dual-write tail Postgres started with.
- **Already run once against production** — this is not just a script drop. Postgres now matches
  D1 exactly: same row count, same `MIN(snapshot_date)`, and 5 random `(netuid, snapshot_date)`
  pairs spot-checked field-for-field.

## What Changed

- `scripts/backfill-subnet-snapshots-postgres.mjs` (new): pages the full D1 `subnet_snapshots`
  table via `wrangler d1 execute --remote --json`, ordered by the table's dense/gapless implicit
  `rowid` (cheap indexed paging, no `OFFSET` re-scan cost), and emits one `.sql` file of batched
  `INSERT ... ON CONFLICT (netuid, snapshot_date) DO UPDATE SET <col> = excluded.<col>` statements
  wrapped in a single transaction. There's no network path from this machine (or CI) directly to
  Postgres — only via Hyperdrive from a deployed Worker, or via SSH to the indexer box — so the
  script only pages D1 and writes the file; applying it is the documented manual
  `scp` → `docker cp` → `psql -v ON_ERROR_STOP=1 -f` step (same pattern as other one-time
  indexer-box operations). D1 is treated as authoritative on conflict (this is a pure copy, not a
  decode operation — D1's values are already correct/final), so re-running is always safe and
  idempotent, including for the ~258-row dual-write overlap window Postgres already had.
- `tests/backfill-subnet-snapshots-postgres.test.mjs` (new): unit tests for the script's pure
  helpers (SQL-literal encoding + validation, row-tuple/statement/transaction building, arg
  parsing, and the D1 paging loop against an injected subprocess runner). Not part of the
  `codecov/patch` scope (`vitest.config.mjs`'s `coverage.include` only instruments a named subset
  of `scripts/`, and this file isn't one of them) — these exist for correctness confidence before
  running the script against production, the same convention `tests/registry-sync-client.test.mjs`
  already follows for `scripts/backfill-registry-postgres.mjs`'s sibling helpers.

## Verification (production, post-run)

```
D1:       count=47666  min_date=2025-06-23  max_date=2026-07-12
Postgres: count=47666  min_date=2025-06-23  max_date=2026-07-12
```

5 random `(netuid, snapshot_date)` pairs — `(64, 2026-02-06)`, `(18, 2025-09-22)`,
`(109, 2025-08-12)`, `(71, 2026-06-07)`, `(25, 2026-01-21)` — match D1 field-for-field in Postgres
(all columns, including `NULL`s). Also spot-checked `(netuid=1, 2026-07-12)`, inside the
pre-existing dual-write overlap window, to confirm the `DO UPDATE` overwrite behaved correctly
there too — matches exactly, including populated economics columns.

## Follow-up (explicitly out of scope here)

`METAGRAPH_SUBNET_SNAPSHOTS_SOURCE` stays unflipped in `wrangler.jsonc` — flipping serving to
Postgres is a separate, deliberate config change once this backfill has been running clean in
production for a while (per the existing header comment in
`workers/request-handlers/analytics-routes.mjs`). Not done in this PR.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state —
      the committed script contains no secrets (it doesn't need any; it only shells out to
      `wrangler d1 execute` and writes a local file).
- [x] Generated artifacts were produced by repo scripts, not hand-edited — N/A, no generated
      artifacts touched.
- [x] R2-only/high-churn detail artifacts are not committed — N/A.
- [x] Public API/OpenAPI/schema changes are intentional and documented — N/A, no contract change.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (scoped to the two changed files; `main` isn't fully prettier-clean)
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` (full suite: 256 files / 7,555 tests, all passing)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Refs #4832 (the dual-write that created Postgres's `subnet_snapshots` mirror, closed).
