### PR TITLE
fix(data-api): preserve u64/u128 precision reading Postgres json/jsonb

### DIFF
--- a/src/postgres-json-parse.mjs
+++ b/src/postgres-json-parse.mjs
@@ -5,11 +5,17 @@
 // cjs/src/types.js, OIDs 114/3802) is a bare `JSON.parse(x)`, which silently
 // rounds any integer literal beyond Number.MAX_SAFE_INTEGER (2^53-1) to the
 // nearest representable float64 -- "18446744073709551615" becomes the JS
-// number 18446744073709552000, a DIFFERENT value, before any application
-// code (src/chain-event-args.mjs, src/postgres-call-args.mjs, ...) ever sees
-// it. Confirmed live 2026-07-12 in three chain_events.args fields
+// number 18446744073709552000, a DIFFERENT value, before src/chain-event-
+// args.mjs (or anything else reading a jsonb column through this client)
+// ever sees it. Confirmed live 2026-07-12 in three chain_events.args fields
 // (SubtensorModule.DifficultySet/SetChildren/SetChildrenScheduled) carrying
-// u64 sentinel/fixed-point values in this range.
+// u64 sentinel/fixed-point values in this range. Does NOT apply to
+// extrinsics.call_args -- that column is queried with an explicit `::text`
+// cast (workers/data-api.mjs) specifically so src/extrinsics.mjs's own,
+// separately-gated big-int handling (src/big-int-safe-json.mjs, scoped only
+// to Ethereum/EVM call types) runs instead; after the cast the wire type is
+// `text`, not `json`/`jsonb`, so this module's parser is never invoked for
+// it.
 //
 // Fix: pre-process the raw JSON text before handing it to JSON.parse,
 // quoting any bare (unquoted) integer literal that exceeds the safe-integer
@@ -43,8 +49,8 @@ function quoteUnsafeIntegers(text) {
  * integer literals beyond Number.MAX_SAFE_INTEGER by returning them as
  * strings instead of numbers -- everything else parses identically to the
  * native JSON.parse. Intended for the `postgres` client's json/jsonb type
- * parser (OIDs 114/3802) so every reader downstream (decodeChainEventArgs,
- * decodePostgresCallArgs, ...) already sees the exact value with no
+ * parser (OIDs 114/3802) so every reader of a genuine json/jsonb column
+ * (decodeChainEventArgs, ...) already sees the exact value with no
  * additional per-call-site handling required. */
 export function parseJsonPreservingBigIntegers(text) {
   return JSON.parse(quoteUnsafeIntegers(text));

--- a/src/postgres-json-parse.mjs
+++ b/src/postgres-json-parse.mjs
@@ -1,0 +1,51 @@
+// Postgres's json/jsonb columns store numeric literals with full precision
+// (confirmed live: `args::text` for a real SubtensorModule.DifficultySet row
+// reads the exact digit string "18446744073709551615", u64::MAX) -- but the
+// `postgres` npm client's built-in json/jsonb parser (node_modules/postgres/
+// cjs/src/types.js, OIDs 114/3802) is a bare `JSON.parse(x)`, which silently
+// rounds any integer literal beyond Number.MAX_SAFE_INTEGER (2^53-1) to the
+// nearest representable float64 -- "18446744073709551615" becomes the JS
+// number 18446744073709552000, a DIFFERENT value, before any application
+// code (src/chain-event-args.mjs, src/postgres-call-args.mjs, ...) ever sees
+// it. Confirmed live 2026-07-12 in three chain_events.args fields
+// (SubtensorModule.DifficultySet/SetChildren/SetChildrenScheduled) carrying
+// u64 sentinel/fixed-point values in this range.
+//
+// Fix: pre-process the raw JSON text before handing it to JSON.parse,
+// quoting any bare (unquoted) integer literal that exceeds the safe-integer
+// range so it round-trips as an exact string instead of a lossy number --
+// the same convention large-integer chain/financial APIs commonly use (e.g.
+// a u64 stays a string, not a number, past 2^53). Quoted string CONTENTS
+// (including one that happens to look like a long digit run, e.g. an SS58
+// address or a hex hash) are matched and passed through unchanged by the
+// same regex, never touched by the integer branch.
+const JSON_TOKEN_RE = /"(?:[^"\\]|\\.)*"|-?\d+(\.\d+)?([eE][+-]?\d+)?/g;
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = -MAX_SAFE;
+
+function quoteUnsafeIntegers(text) {
+  return text.replace(JSON_TOKEN_RE, (match, decimalPart, exponentPart) => {
+    // A quoted string always starts with '"' -- the alternation above can
+    // only otherwise match a bare number, so this check alone distinguishes
+    // the two branches without needing a separate capture group.
+    if (match.charCodeAt(0) === 34) return match;
+    // A literal with a fractional or exponent part isn't the u64/u128
+    // sentinel-integer shape this fix targets -- float precision loss for
+    // those is a different, unobserved concern; leave them exactly as
+    // JSON.parse would have handled them.
+    if (decimalPart || exponentPart) return match;
+    const big = BigInt(match);
+    return big > MAX_SAFE || big < MIN_SAFE ? `"${match}"` : match;
+  });
+}
+
+/** Drop-in replacement for `JSON.parse` that preserves exact precision for
+ * integer literals beyond Number.MAX_SAFE_INTEGER by returning them as
+ * strings instead of numbers -- everything else parses identically to the
+ * native JSON.parse. Intended for the `postgres` client's json/jsonb type
+ * parser (OIDs 114/3802) so every reader downstream (decodeChainEventArgs,
+ * decodePostgresCallArgs, ...) already sees the exact value with no
+ * additional per-call-site handling required. */
+export function parseJsonPreservingBigIntegers(text) {
+  return JSON.parse(quoteUnsafeIntegers(text));
+}

--- a/tests/postgres-json-parse.test.mjs
+++ b/tests/postgres-json-parse.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { parseJsonPreservingBigIntegers } from "../src/postgres-json-parse.mjs";
+
+describe("parseJsonPreservingBigIntegers", () => {
+  test("parses ordinary JSON identically to JSON.parse", () => {
+    const text = JSON.stringify({
+      a: 1,
+      b: "two",
+      c: [3, 4, 5],
+      d: null,
+      e: true,
+      f: -42,
+      g: { nested: "object" },
+    });
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), JSON.parse(text));
+  });
+
+  test("preserves a u64::MAX integer as an exact string (real SubtensorModule.DifficultySet, block 4132551/0)", () => {
+    const text = "[13, 18446744073709551615]";
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), [
+      13,
+      "18446744073709551615",
+    ]);
+  });
+
+  test("preserves a large negative integer as an exact string", () => {
+    const text = "[-18446744073709551615]";
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), [
+      "-18446744073709551615",
+    ]);
+  });
+
+  test("leaves an integer at exactly Number.MAX_SAFE_INTEGER as a number", () => {
+    const text = `[${Number.MAX_SAFE_INTEGER}]`;
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), [
+      Number.MAX_SAFE_INTEGER,
+    ]);
+    assert.equal(typeof parseJsonPreservingBigIntegers(text)[0], "number");
+  });
+
+  test("converts an integer one past Number.MAX_SAFE_INTEGER to a string", () => {
+    const text = `[${Number.MAX_SAFE_INTEGER}0]`; // 90071992547409910
+    const [value] = parseJsonPreservingBigIntegers(text);
+    assert.equal(typeof value, "string");
+    assert.equal(value, "90071992547409910");
+  });
+
+  test("does not touch a digit run inside a quoted string, even a hostile one matching the same length/shape as a real u64::MAX field", () => {
+    const text = JSON.stringify({
+      account: "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i",
+      note: "contains18446744073709551615digits",
+      hash: "0x18446744073709551615aabbccddee",
+    });
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), JSON.parse(text));
+  });
+
+  test("leaves fractional and exponential numbers untouched even when they exceed safe-integer magnitude", () => {
+    const text = "[1.5e21, 3.14159, -2.5e-10]";
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), JSON.parse(text));
+  });
+
+  test("handles big integers nested deep inside objects and arrays (real SubtensorModule.SetChildren shape, block 8603683/133)", () => {
+    const text =
+      '{"parent":"5F...","children":[[[9042069731475589000,"5G..."],[6776677281062051000,"5H..."]]]}';
+    const parsed = parseJsonPreservingBigIntegers(text);
+    assert.deepEqual(parsed, {
+      parent: "5F...",
+      children: [
+        [
+          ["9042069731475589000", "5G..."],
+          ["6776677281062051000", "5H..."],
+        ],
+      ],
+    });
+  });
+
+  test("round-trips an escaped quote inside a string without breaking token boundaries", () => {
+    const text = String.raw`{"note": "she said \"hi\" then 18446744073709551615 things happened"}`;
+    assert.deepEqual(parseJsonPreservingBigIntegers(text), {
+      note: 'she said "hi" then 18446744073709551615 things happened',
+    });
+  });
+});

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2238,9 +2238,14 @@ export default {
     // real u64 values (SubtensorModule.DifficultySet/SetChildren/
     // SetChildrenScheduled) beyond Number.MAX_SAFE_INTEGER. See
     // src/postgres-json-parse.mjs's own header for why this must happen at
-    // the client boundary, not in decodeChainEventArgs/decodePostgresCallArgs
-    // -- by the time either of those run, a lossy default parse has already
-    // destroyed the original value with no way to recover it downstream.
+    // the client boundary, not in decodeChainEventArgs -- by the time that
+    // runs, a lossy default parse has already destroyed the original value
+    // with no way to recover it downstream. Does NOT touch extrinsics'
+    // call_args -- that column is queried with an explicit `::text` cast
+    // (see the "extrinsics' call_args is cast to text" comment below) so its
+    // own, separately-gated big-int handling in src/extrinsics.mjs runs
+    // instead; after the cast the wire type is `text` (OID 25), which this
+    // override never sees.
     const sql = postgres(env.HYPERDRIVE.connectionString, {
       max: 5,
       prepare: false,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -20,6 +20,7 @@
 // per-request client and response headers (a write ack must never carry the
 // read routes' `cache-control: public, max-age=10`).
 import postgres from "postgres";
+import { parseJsonPreservingBigIntegers } from "../src/postgres-json-parse.mjs";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
 import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
 import {
@@ -2229,11 +2230,30 @@ export default {
     // `prepare: false` + `fetch_types: false` are the Hyperdrive-recommended settings:
     // they avoid per-connection type-introspection round-trips and prepared-statement
     // state that don't survive the pooler. max:5 keeps us within the origin limit.
+    //
+    // `types` overrides postgres.js's default json/jsonb parser (OIDs 114/3802,
+    // a bare `JSON.parse`) with one that preserves u64/u128-range integer
+    // literals as exact strings instead of silently rounding them to the
+    // nearest float64 -- confirmed live 2026-07-12: chain_events.args carries
+    // real u64 values (SubtensorModule.DifficultySet/SetChildren/
+    // SetChildrenScheduled) beyond Number.MAX_SAFE_INTEGER. See
+    // src/postgres-json-parse.mjs's own header for why this must happen at
+    // the client boundary, not in decodeChainEventArgs/decodePostgresCallArgs
+    // -- by the time either of those run, a lossy default parse has already
+    // destroyed the original value with no way to recover it downstream.
     const sql = postgres(env.HYPERDRIVE.connectionString, {
       max: 5,
       prepare: false,
       fetch_types: false,
       idle_timeout: 10,
+      types: {
+        bigIntSafeJson: {
+          to: 114,
+          from: [114, 3802],
+          serialize: (x) => JSON.stringify(x),
+          parse: (x) => parseJsonPreservingBigIntegers(x),
+        },
+      },
     });
 
     try {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2255,8 +2255,8 @@ export default {
         bigIntSafeJson: {
           to: 114,
           from: [114, 3802],
-          serialize: (x) => JSON.stringify(x),
-          parse: (x) => parseJsonPreservingBigIntegers(x),
+          serialize: JSON.stringify,
+          parse: parseJsonPreservingBigIntegers,
         },
       },
     });


### PR DESCRIPTION
## Summary
- postgres.js's default json/jsonb column parser (OIDs 114/3802) is a bare `JSON.parse`, which silently rounds any integer literal beyond `Number.MAX_SAFE_INTEGER` to the nearest float64.
- Postgres itself preserves the exact digit string in the jsonb column — confirmed live via `args::text` for a real `SubtensorModule.DifficultySet` row (`18446744073709551615`, u64::MAX) — the corruption happens purely in the JS client's parse step, before `decodeChainEventArgs` (or anything else) ever sees the value.
- Registers a custom parser on the read-tier `postgres()` client (`workers/data-api.mjs`) that quotes any out-of-range bare integer literal before `JSON.parse` runs, so it round-trips as an exact string. Quoted string contents (including ones containing long digit runs) are matched and passed through unchanged by the same regex.
- Scope correction from an earlier draft of this PR: this fixes `chain_events.args` (a genuine `jsonb` column read with no cast, so postgres.js's default parser — now this one — runs automatically). It does **not** touch `extrinsics.call_args` — that column is deliberately queried with an explicit `::text` cast specifically so `src/extrinsics.mjs`'s own `parseJsonPreservingBigInts`/`JSON.parse` gate (scoped to only the 4 Ethereum/EVM call types, per `src/indexer-rs-ethereum-decode.mjs`'s header) can run instead; after the cast, the wire type is `text` (OID 25), which my `types` override never touches. No conflict, but also no effect there — any `call_args` precision gap is a separate, pre-existing, already-partially-addressed concern tracked separately.

Closes #4927

Continuation of the live chain-data decode audit that produced #4916, #4918, and #4920.

## Test plan
- [x] `tests/postgres-json-parse.test.mjs`: 9/9 passing (ordinary JSON parity, real u64::MAX preservation, negative big integers, safe/unsafe boundary, adversarial digit-run-inside-a-string cases, fractional/exponential passthrough, nested big integers, escaped-quote string boundaries)
- [x] Full suite passing locally (256 files / 7551 tests; one unrelated heavy build test flaked under full-suite resource contention, passes clean in isolation)
- [x] `npm run lint` / `format:check` clean on the final diff
- [x] 100% statement/branch/line coverage on both touched source files
- [ ] Live-verify against production after merge (re-curl the DifficultySet/SetChildren/SetChildrenScheduled fixtures)