### PR TITLE
fix(data-api): close remaining chain_events.args decode gaps

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -21,7 +21,12 @@
 // 20-byte arrays always hex-decode as H160 (Ethereum addresses have no SS58
 // form). A narrow, explicit pallet.method.field allowlist additionally
 // UTF-8-decodes the handful of known free-text byte fields (e.g. Ethereum.
-// Executed's extra_data). Everything else is untouched.
+// Executed's extra_data), hex-decodes a few known opaque byte-blob fields
+// (e.g. EVM.Log's log data) regardless of length, and collapses a handful of
+// known {name,values} enum-tag nodes once their payload is fully decoded
+// (e.g. a MultiAddress::Signed(AccountId32) tag once the account itself is
+// hex, or a Result<(),E>::Ok(()) down to bare "Ok"). Everything else is
+// untouched.
 import { encodeAccountId32 } from "./ss58.mjs";
 import { normalizePostgresValue } from "./scale-normalize.mjs";
 
@@ -43,6 +48,19 @@ const ACCOUNT_KEYS = new Set([
   "target",
   "validator",
   "address",
+  // Added 2026-07-12 from a live sweep of every chain_events.args pallet.method
+  // combination: real/proxy/delegatee/delegator (Proxy.RealPaysFeeSet/
+  // Announced/ProxyAdded/ProxyRemoved) and new_hotkey/old_hotkey
+  // (SubtensorModule.HotkeySwappedOnSubnet) are all confirmed-live 32-byte
+  // AccountId32 fields that stayed raw hex only because their exact key name
+  // wasn't in this set yet -- same root cause/fix shape as the original
+  // allowlist, not a new mechanism.
+  "real",
+  "proxy",
+  "delegatee",
+  "delegator",
+  "new_hotkey",
+  "old_hotkey",
 ]);
 
 function isByteArray(v, len) {
@@ -84,6 +102,48 @@ function toHex(bytes) {
 // "Gotta Go Fast" (empty on most blocks). Everything not in this allowlist
 // falls through to the generic array-map/object-recurse below, untouched.
 const TEXTUAL_FIELDS = new Set(["Ethereum.Executed.extra_data"]);
+
+// Known opaque variable-length byte-blob fields, same narrow allowlist
+// discipline as TEXTUAL_FIELDS (and for the same reason -- no per-field type
+// string to consult) but decoded as 0x-hex instead of UTF-8: EVM log data and
+// contract-emitted data are raw binary payloads (typically ABI-encoded
+// parameters), not intended text. Confirmed live 2026-07-12: both fields
+// already happened to render as hex on the rare occasion they were exactly
+// 32 bytes (isByteArray(value,32) below catches that length coincidentally),
+// but stayed a raw, unbounded number array at every other length (64/96/128/
+// 224/320/352 bytes all observed live) -- this closes the gap uniformly.
+const HEX_BLOB_FIELDS = new Set([
+  "EVM.Log.data",
+  "Contracts.ContractEmitted.data",
+]);
+
+// Known {name, values:[payload]} enum-tree nodes (indexer-rs's generic shape
+// for any enum variant carrying data, left otherwise untouched by
+// normalizePostgresValue -- see its own module header) worth a further,
+// field-specific collapse once `payload` has been fully decoded below. Keyed
+// "Pallet.method.field" like the two allowlists above, for the identical
+// narrow-allowlist-over-shape-heuristic reason: a generic "collapse any
+// single-payload enum tag" rule would risk erasing a genuinely meaningful
+// tag/payload pair this codebase hasn't seen yet, so this only ever fires
+// for a name explicitly confirmed live below.
+//
+// - "unwrap": drop the tag, keep only the (now-decoded) payload --
+//   Contracts.Called.caller is MultiAddress::Signed(AccountId32); the
+//   "Signed" tag carries no information once the account itself is hex, and
+//   MultiAddress has no OTHER variant this pallet's caller ever takes.
+// - "unit-or-passthrough": if the decoded payload is SCALE's `()` unit
+//   (an empty array -- decode()'s own array-map leaves a genuine empty array
+//   untouched, so this is unambiguous), collapse to the bare variant name
+//   the same way normalizePostgresValue already does for a zero-payload
+//   C-like unit enum (Proxy.ProxyExecuted.result / Sudo.Sudid.sudo_result are
+//   both Result<(), DispatchError> -- Ok(()) becomes bare "Ok"). Otherwise
+//   (a real Err(DispatchError) payload) the tag+payload are left exactly as
+//   decoded -- the error detail is meaningful and must not be discarded.
+const ENUM_PAYLOAD_FIELDS = new Map([
+  ["Contracts.Called.caller", "unwrap"],
+  ["Proxy.ProxyExecuted.result", "unit-or-passthrough"],
+  ["Sudo.Sudid.sudo_result", "unit-or-passthrough"],
+]);
 
 function decodeTextualField(bytes) {
   try {
@@ -134,6 +194,9 @@ function decode(value, keyHint, ctx) {
     if (TEXTUAL_FIELDS.has(key)) {
       return decodeTextualField(value);
     }
+    if (HEX_BLOB_FIELDS.has(key)) {
+      return toHex(value);
+    }
   }
   // Arrays inherit the parent key hint (e.g. `who: [<accountId bytes>]`) --
   // this is also what makes an untagged positional args array (no object
@@ -145,6 +208,32 @@ function decode(value, keyHint, ctx) {
   if (value && typeof value === "object") {
     const out = {};
     for (const [k, val] of Object.entries(value)) out[k] = decode(val, k, ctx);
+    // Field-specific enum-tag collapse (see ENUM_PAYLOAD_FIELDS above) --
+    // only after `out` has been fully decoded, so "unit-or-passthrough" sees
+    // the REAL payload shape (an untouched empty array for a unit `()`, or
+    // whatever a genuine Err(DispatchError) decoded to).
+    if (
+      keyHint &&
+      ctx &&
+      Object.keys(out).length === 2 &&
+      typeof out.name === "string" &&
+      Array.isArray(out.values) &&
+      out.values.length === 1
+    ) {
+      const strategy = ENUM_PAYLOAD_FIELDS.get(
+        `${ctx.pallet ?? ""}.${ctx.method ?? ""}.${keyHint}`,
+      );
+      if (strategy === "unwrap") {
+        return out.values[0];
+      }
+      if (
+        strategy === "unit-or-passthrough" &&
+        Array.isArray(out.values[0]) &&
+        out.values[0].length === 0
+      ) {
+        return out.name;
+      }
+    }
     return out;
   }
   return value;
@@ -174,18 +263,27 @@ function decode(value, keyHint, ctx) {
  * instead of the bare string "Normal" -- exactly the shape
  * normalizePostgresValue's C-like-unit-enum rule collapses; and (2026-07-12)
  * Ethereum.Executed's `to`/`from` and EVM.Log's `address` rendered as raw
- * 20-byte arrays instead of hex H160 addresses.
+ * 20-byte arrays instead of hex H160 addresses. A broader live sweep across
+ * all 75 distinct chain_events pallet.method combinations (also 2026-07-12)
+ * additionally found: several more AccountId32 fields missing from
+ * ACCOUNT_KEYS by key-name only (real/proxy/delegatee/delegator/new_hotkey/
+ * old_hotkey); EVM.Log.data/Contracts.ContractEmitted.data staying raw byte
+ * arrays at every length except the one where they coincidentally matched
+ * the 32-byte special case (HEX_BLOB_FIELDS); and three {name,values} enum
+ * nodes worth a field-specific collapse once decoded (ENUM_PAYLOAD_FIELDS).
  *
  * `ctx` is the emitting event's `{pallet, method}` (pass `row.pallet`/
  * `row.method` from the Postgres row) -- used only by the narrow
- * TEXTUAL_FIELDS allowlist above; omit it and every other decode still
- * works identically, just without that one field's UTF-8 treatment.
- * Deliberately does NOT add a GENERIC byte-blob heuristic beyond the two
- * fixed lengths (32/20) and the explicit allowlist -- chain_events.args
- * carries no per-field type string the way extrinsics.call_args does
- * post-#4724, so a length-based guess for an arbitrary-length field would
- * risk the same collection-vs-blob ambiguity #4693/#4915 avoid elsewhere by
- * consulting a typed descriptor's own `type` first. */
+ * TEXTUAL_FIELDS/HEX_BLOB_FIELDS/ENUM_PAYLOAD_FIELDS allowlists above; omit
+ * it and every other decode still works identically, just without those
+ * fields' extra treatment.
+ * Deliberately does NOT add a GENERIC byte-blob or enum-collapse heuristic
+ * beyond the two fixed byte-array lengths (32/20) and the explicit
+ * allowlists -- chain_events.args carries no per-field type string the way
+ * extrinsics.call_args does post-#4724, so a length- or shape-based guess
+ * for an arbitrary field would risk the same collection-vs-blob ambiguity
+ * #4693/#4915 avoid elsewhere by consulting a typed descriptor's own `type`
+ * first. */
 export function decodeChainEventArgs(args, ctx = null) {
   return decode(normalizePostgresValue(args), undefined, ctx);
 }

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -266,4 +266,196 @@ describe("decodeChainEventArgs", () => {
     const args = { extra_data: [1, 2, 3] };
     assert.deepEqual(decodeChainEventArgs(args, {}), { extra_data: [1, 2, 3] });
   });
+
+  test("decodes the expanded ACCOUNT_KEYS entries to SS58 (real Proxy.RealPaysFeeSet, block 8602853/169)", () => {
+    const args = {
+      real: [
+        [
+          110, 166, 14, 55, 47, 227, 14, 161, 235, 124, 205, 108, 34, 72, 103,
+          213, 183, 86, 243, 33, 182, 132, 58, 138, 179, 161, 214, 5, 245, 217,
+          13, 56,
+        ],
+      ],
+      delegate: [
+        [
+          230, 177, 94, 10, 88, 222, 149, 217, 176, 218, 228, 3, 237, 17, 117,
+          251, 19, 70, 95, 132, 123, 114, 171, 235, 189, 66, 130, 2, 183, 175,
+          143, 88,
+        ],
+      ],
+      pays_fee: true,
+    };
+    assert.deepEqual(decodeChainEventArgs(args), {
+      real: "5EZnTF4puVufyK8HQvtw41gVrxe1GsfDMBtLSeNw5jQXocrp",
+      delegate: "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i",
+      pays_fee: true,
+    });
+  });
+
+  test("decodes new_hotkey/old_hotkey to SS58 alongside coldkey (real SubtensorModule.HotkeySwappedOnSubnet, block 8604030/450)", () => {
+    const args = {
+      netuid: 15,
+      coldkey: [
+        [
+          144, 158, 68, 79, 84, 143, 61, 208, 20, 43, 118, 26, 39, 96, 148, 122,
+          168, 30, 111, 246, 84, 111, 21, 202, 65, 235, 176, 84, 214, 32, 171,
+          91,
+        ],
+      ],
+      new_hotkey: [
+        [
+          228, 83, 193, 133, 106, 220, 127, 200, 235, 67, 95, 159, 89, 171, 150,
+          18, 90, 19, 131, 225, 161, 7, 15, 132, 128, 133, 147, 204, 144, 163,
+          135, 27,
+        ],
+      ],
+      old_hotkey: [
+        [
+          130, 205, 192, 119, 145, 18, 5, 151, 137, 1, 185, 235, 182, 204, 47,
+          122, 81, 6, 91, 207, 22, 229, 133, 239, 30, 171, 204, 195, 118, 169,
+          31, 6,
+        ],
+      ],
+    };
+    const decoded = decodeChainEventArgs(args);
+    assert.equal(
+      decoded.new_hotkey,
+      "5HE5eye8JdfMFe8Q1z7HosfwebqFUNUnyvmLZ1WWYtircSWe",
+    );
+    assert.equal(
+      decoded.old_hotkey,
+      "5F2DCjvQ5VruGJF2cjHfYou7SW6mVKBgpLjHFr6bF1SgAQWr",
+    );
+    assert.equal(decoded.netuid, 15);
+  });
+
+  test("hex-encodes an arbitrary-length EVM.Log.data byte blob regardless of length (real, block 8604282/307, 96 bytes)", () => {
+    const args = {
+      log: {
+        data: new Array(96).fill(0).map((_, i) => (i * 7) % 256),
+        address: [new Array(20).fill(1)],
+        topics: [],
+      },
+    };
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "EVM",
+      method: "Log",
+    });
+    assert.equal(typeof decoded.log.data, "string");
+    assert.match(decoded.log.data, /^0x[0-9a-f]{192}$/);
+  });
+
+  test("hex-encodes Contracts.ContractEmitted.data at a length that never coincidentally hits the 32-byte special case (real, block 8604169/872, 41 bytes)", () => {
+    const args = {
+      caller: [new Array(32).fill(2)],
+      contract:
+        "0xc94098c05c1e036d1901f16112166ceaf185f83c33eec1a2ee353caeb721ec43",
+      data: [
+        206, 2, 0, 0, 0, 0, 8, 80, 95, 223, 85, 98, 11, 0, 0, 0, 0, 0, 0, 0, 96,
+        81, 155, 233, 204, 157, 239, 94, 11, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 1,
+      ],
+    };
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "Contracts",
+      method: "ContractEmitted",
+    });
+    assert.equal(
+      decoded.data,
+      "0xce020000000008505fdf55620b0000000000000060519be9cc9def5e0b000000000000000200000001",
+    );
+  });
+
+  test("leaves a byte blob raw when its pallet.method.field isn't in HEX_BLOB_FIELDS (no false-positive on shape alone)", () => {
+    const args = { data: [1, 2, 3, 4, 5] };
+    assert.deepEqual(
+      decodeChainEventArgs(args, {
+        pallet: "SomeOtherPallet",
+        method: "SomeEvent",
+      }),
+      { data: [1, 2, 3, 4, 5] },
+    );
+  });
+
+  test("unwraps MultiAddress::Signed(AccountId32) to the bare decoded account (real Contracts.Called.caller, block 8604327/354)", () => {
+    const args = {
+      caller: {
+        name: "Signed",
+        values: [
+          [
+            [
+              12, 161, 152, 251, 73, 180, 215, 182, 98, 3, 243, 174, 222, 51,
+              134, 229, 244, 110, 198, 95, 220, 89, 229, 182, 237, 96, 43, 252,
+              89, 64, 167, 112,
+            ],
+          ],
+        ],
+      },
+      contract:
+        "0xc94098c05c1e036d1901f16112166ceaf185f83c33eec1a2ee353caeb721ec43",
+    };
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "Contracts",
+      method: "Called",
+    });
+    assert.equal(
+      decoded.caller,
+      "0x0ca198fb49b4d7b66203f3aede3386e5f46ec65fdc59e5b6ed602bfc5940a770",
+    );
+  });
+
+  test('collapses Result<(),DispatchError>::Ok(()) to bare "Ok" (real Proxy.ProxyExecuted.result, block 8604336/424)', () => {
+    const args = { result: { name: "Ok", values: [[]] } };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Proxy", method: "ProxyExecuted" }),
+      { result: "Ok" },
+    );
+  });
+
+  test("collapses Sudo.Sudid.sudo_result's Ok(()) the same way (real, block 231589/3)", () => {
+    const args = { sudo_result: { name: "Ok", values: [[]] } };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Sudo", method: "Sudid" }),
+      { sudo_result: "Ok" },
+    );
+  });
+
+  test("preserves an Err(DispatchError) payload untouched -- only an empty-unit Ok(()) collapses", () => {
+    const args = {
+      result: {
+        name: "Err",
+        values: [
+          { name: "Module", values: [{ index: 7, error: [31, 0, 0, 0] }] },
+        ],
+      },
+    };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Proxy", method: "ProxyExecuted" }),
+      {
+        result: {
+          name: "Err",
+          values: [
+            { name: "Module", values: [{ index: 7, error: [31, 0, 0, 0] }] },
+          ],
+        },
+      },
+    );
+  });
+
+  test("does not collapse an enum-tag node for a field outside ENUM_PAYLOAD_FIELDS", () => {
+    const args = { outcome: { name: "Ok", values: [[]] } };
+    assert.deepEqual(
+      decodeChainEventArgs(args, {
+        pallet: "SomeOtherPallet",
+        method: "SomeEvent",
+      }),
+      { outcome: { name: "Ok", values: [[]] } },
+    );
+  });
+
+  test("tolerates a ctx object missing pallet/method when checking the enum-payload allowlist", () => {
+    const args = { result: { name: "Ok", values: [[]] } };
+    assert.deepEqual(decodeChainEventArgs(args, {}), {
+      result: { name: "Ok", values: [[]] },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Expands `ACCOUNT_KEYS` with six confirmed 32-byte AccountId32 field names (real/proxy/delegatee/delegator/new_hotkey/old_hotkey) found missing in a broad live sweep.
- Adds `HEX_BLOB_FIELDS` (narrow pallet.method.field allowlist, mirrors `TEXTUAL_FIELDS`): hex-encodes `EVM.Log.data`/`Contracts.ContractEmitted.data` regardless of length.
- Adds `ENUM_PAYLOAD_FIELDS` (narrow allowlist, two strategies): `"unwrap"` for `Contracts.Called.caller` (MultiAddress::Signed), `"unit-or-passthrough"` for `Proxy.ProxyExecuted.result`/`Sudo.Sudid.sudo_result` (Result<(),E>::Ok(()) → bare "Ok", but a real Err(...) payload stays untouched).

Closes #4930

Continuation of the live chain-data decode audit that produced #4916, #4918, #4920, and #4927 (the last a sibling PR, #4928, fixing a related-but-architecturally-distinct u64 precision bug found in the same sweep).

## Test plan
- [x] `tests/chain-event-args.test.mjs`: 28/28 passing (10 new — expanded ACCOUNT_KEYS, byte-blob hex at multiple lengths incl. a false-positive-avoidance case, enum unwrap/collapse for all three fields, an Err(...) preservation case, and a not-in-allowlist non-collapse case)
- [x] Full suite passing locally (256 files / 7551 tests; one unrelated heavy build test flaked under full-suite resource contention, passes clean in isolation)
- [x] `npm run lint` / `format:check` clean on the final diff
- [x] 100% statement/branch/line coverage on `src/chain-event-args.mjs`
- [ ] Live-verify against production after merge