### PR TITLE
fix(data-api): Ethereum.transact/EVM.withdraw call_args decoders are a 100% no-op

### DIFF
--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -164,32 +164,73 @@ function decodeEip1559Payload(payload) {
   return out;
 }
 
-/** Ethereum.transact's call_args: decodes the `transaction` field's nested
- * EIP1559 payload (U256s, action's H160, signature's hash bytes) into D1's
- * `{transaction: {EIP1559: {...}}}` shape. No-op (returns callArgs
- * unchanged) when `transaction` isn't Postgres's enum-tree shape -- D1's own
- * `[{name,type,value}]` descriptor array has no `.transaction` property at
- * all (arrays don't have named keys), so this never fires on a D1 row. */
-export function decodeEthereumTransactArgs(callArgs) {
-  if (!callArgs || typeof callArgs !== "object" || Array.isArray(callArgs)) {
-    return callArgs;
+// #4692's original design assumed call_args reaches this point as a flat
+// {fieldName: value} object -- D1's shape was documented as the ONLY
+// exception, an array of {name,type,value} descriptors with "no .transaction
+// property at all (arrays don't have named keys)". That assumption was
+// wrong: confirmed live 2026-07-12, EVERY extrinsic's call_args -- D1 is
+// fully retired (#4772), so this is genuine indexer-rs/Postgres output, not
+// a legacy D1 artifact -- is served as this exact descriptor-array shape
+// (e.g. Ethereum.transact's sole argument arrives as
+// `[{name:"transaction",type:"TransactionV3",value:{...}}]`), which is WHY
+// every decoder below was silently a 100% no-op in production despite being
+// individually well-tested against hand-constructed flat-object fixtures.
+// decodePostgresCallArgs (walk(), src/postgres-call-args.mjs) already
+// decodes AccountId32/byte-blob fields INSIDE each descriptor's `.value`
+// without flattening the outer array -- by design, since the descriptor
+// array is the real, final served shape for every call type, not something
+// meant to be unwrapped away. findCallArg/withCallArg below locate and
+// replace a named argument within that array (or, defensively, a flat
+// object, since nothing else in this file distinguishes the two and a past
+// design intended to support both).
+function findCallArg(callArgs, fieldName) {
+  if (Array.isArray(callArgs)) {
+    const descriptor = callArgs.find(
+      (d) => d && typeof d === "object" && d.name === fieldName,
+    );
+    return descriptor ? descriptor.value : undefined;
   }
-  const tx = callArgs.transaction;
-  if (!isEnumTreeNode(tx) || tx.values.length !== 1) return callArgs;
-  return {
-    ...callArgs,
-    transaction: decodeTupleVariantEnum(tx, decodeEip1559Payload),
-  };
+  if (callArgs && typeof callArgs === "object") {
+    return callArgs[fieldName];
+  }
+  return undefined;
 }
 
-/** EVM.withdraw's call_args: decodes `address` (H160) to hex. Same D1
- * no-op guarantee as above (a D1 descriptor array has no `.address` key). */
-export function decodeEvmWithdrawArgs(callArgs) {
-  if (!callArgs || typeof callArgs !== "object" || Array.isArray(callArgs)) {
-    return callArgs;
+// Only ever called after findCallArg has already returned a defined value
+// for the same (callArgs, fieldName) pair, which requires callArgs to
+// already be an array or an object (see findCallArg above) -- no third
+// fallback needed.
+function withCallArg(callArgs, fieldName, newValue) {
+  if (Array.isArray(callArgs)) {
+    return callArgs.map((d) =>
+      d && typeof d === "object" && d.name === fieldName
+        ? { ...d, value: newValue }
+        : d,
+    );
   }
-  if (!("address" in callArgs)) return callArgs;
-  return { ...callArgs, address: decodeH160Bytes(callArgs.address) };
+  return { ...callArgs, [fieldName]: newValue };
+}
+
+/** Ethereum.transact's call_args: decodes the `transaction` field's nested
+ * EIP1559 payload (U256s, action's H160, signature's hash bytes). Returns
+ * callArgs unchanged (same shape, `transaction` untouched) when the field
+ * isn't found or isn't Postgres's enum-tree shape. */
+export function decodeEthereumTransactArgs(callArgs) {
+  const tx = findCallArg(callArgs, "transaction");
+  if (!isEnumTreeNode(tx) || tx.values.length !== 1) return callArgs;
+  return withCallArg(
+    callArgs,
+    "transaction",
+    decodeTupleVariantEnum(tx, decodeEip1559Payload),
+  );
+}
+
+/** EVM.withdraw's call_args: decodes `address` (H160) to hex. Returns
+ * callArgs unchanged when the field isn't found. */
+export function decodeEvmWithdrawArgs(callArgs) {
+  const address = findCallArg(callArgs, "address");
+  if (address === undefined) return callArgs;
+  return withCallArg(callArgs, "address", decodeH160Bytes(address));
 }
 
 // {name:"Sr25519", values:[bytes]} -> {Sr25519: "0x..."}. Gated on the
@@ -213,24 +254,44 @@ function decodeSr25519SignatureValue(value) {
   return bytes ? { Sr25519: bytesToHex(bytes) } : value;
 }
 
-// Recursively finds every key literally named "signature" and decodes it if
-// (and only if) its value matches the Sr25519 shape above -- scoped to
-// LimitOrders.execute_batched_orders/Drand.write_pulse specifically (via the
-// dispatch table below), not applied to every call's args. A plain
-// recursive walk rather than a fixed-depth lookup because the two calls
-// place `signature` at different depths: Drand.write_pulse has it as a
-// direct top-level field, LimitOrders.execute_batched_orders has it nested
-// inside each entry of its (Vec-wrapped) `orders` array -- both confirmed
-// against real production data.
+// A "signature"/"randomness"-named field that ISN'T enum-wrapped -- confirmed
+// live 2026-07-12: Drand.write_pulse's per-pulse `signature`/`randomness`
+// (round-based VRF output, not a MultiSignature) are bare 32-byte newtype-
+// wrapped arrays, unlike LimitOrders.execute_batched_orders' per-order
+// `signature`, which genuinely IS a Signature::Sr25519 enum variant. Tries
+// the enum shape first so LimitOrders keeps its richer {Sr25519:"0x..."}
+// output; falls back to plain hex (the same generic hash-like treatment
+// decodeHash32Bytes already gives EIP1559's r/s) when the enum shape doesn't
+// match, rather than leaving a bare hash-like field raw.
+function decodeSignatureLikeField(value) {
+  const enumDecoded = decodeSr25519SignatureValue(value);
+  return enumDecoded === value ? decodeHash32Bytes(value) : enumDecoded;
+}
+
+// Recursively finds every key literally named "signature"/"randomness"
+// (decodeSignatureLikeField -- enum-wrapped or bare 32 bytes, either way) or
+// "public" (decodeSr25519SignatureValue -- Drand.write_pulse's
+// MultiSigner::Sr25519 pubkey, the same enum shape as a Signature::Sr25519
+// payload) -- scoped to LimitOrders.execute_batched_orders/Drand.write_pulse
+// specifically (via the dispatch table below), not applied to every call's
+// args. A plain recursive walk rather than a fixed-depth lookup because the
+// two calls place these fields at different depths: Drand.write_pulse has
+// `public`/`pulses[].signature`/`pulses[].randomness`, LimitOrders.
+// execute_batched_orders has `signature` nested inside each entry of its
+// (Vec-wrapped) `orders` array -- all confirmed against real production
+// data.
 function walkForSignatureFields(value) {
   if (Array.isArray(value)) return value.map(walkForSignatureFields);
   if (value && typeof value === "object") {
     const out = {};
     for (const [key, val] of Object.entries(value)) {
-      out[key] =
-        key === "signature"
-          ? decodeSr25519SignatureValue(val)
-          : walkForSignatureFields(val);
+      if (key === "signature" || key === "randomness") {
+        out[key] = decodeSignatureLikeField(val);
+      } else if (key === "public") {
+        out[key] = decodeSr25519SignatureValue(val);
+      } else {
+        out[key] = walkForSignatureFields(val);
+      }
     }
     return out;
   }
@@ -238,10 +299,10 @@ function walkForSignatureFields(value) {
 }
 
 /** LimitOrders.execute_batched_orders / Drand.write_pulse call_args: decodes
- * any `signature` field matching the Sr25519 shape, at whatever depth it
- * occurs. A no-op on D1's own already-decoded {"Sr25519": "0x..."} shape
- * (isEnumTreeNode requires a "values" array key, which a single-key shorthand
- * object doesn't have). */
+ * every `signature`/`randomness`/`public` field matching the shapes above, at
+ * whatever depth they occur. A no-op on an already-decoded shape (a bare hex
+ * string or a single-key `{Sr25519: "..."}` shorthand doesn't match either
+ * decoder's own shape check). */
 export function decodeSignatureFieldArgs(callArgs) {
   return walkForSignatureFields(callArgs);
 }

--- a/tests/indexer-rs-ethereum-decode.test.mjs
+++ b/tests/indexer-rs-ethereum-decode.test.mjs
@@ -206,14 +206,41 @@ describe("decodeEthereumTransactArgs (real production fixture, block 8587453/9)"
     });
   });
 
-  test("is a no-op on D1's own call_args shape (an array of {name,type,value} descriptors has no .transaction property)", () => {
-    const d1Shape = [
-      { name: "transaction", type: "Transaction", value: { EIP1559: {} } },
+  test("decodes the real production call_args shape -- an array of {name,type,value} descriptors, confirmed live 2026-07-12 (block 8604176/7)", () => {
+    // This is what genuine indexer-rs/Postgres output actually looks like for
+    // EVERY extrinsic (D1 is fully retired, #4772) -- decodeEthereumTransactArgs
+    // previously assumed this shape meant "not Postgres's data, skip", making
+    // it a 100% no-op in production. The `transaction` field lives inside a
+    // {name,type,value} descriptor, not a flat top-level key.
+    const descriptorShape = [
+      {
+        name: "transaction",
+        type: "TransactionV3",
+        value: raw.transaction,
+      },
     ];
-    assert.deepEqual(decodeEthereumTransactArgs(d1Shape), d1Shape);
+    const out = decodeEthereumTransactArgs(descriptorShape);
+    assert.equal(Array.isArray(out), true);
+    assert.equal(out[0].name, "transaction");
+    assert.equal(out[0].type, "TransactionV3");
+    assert.deepEqual(out[0].value.EIP1559.action, {
+      Call: "0x7e4c9cc4b96eeb035aa16f1a73df55252dc7055c",
+    });
+    assert.equal(out[0].value.EIP1559.nonce, "69392");
+    // Sibling descriptors (if any) pass through untouched.
+    const withSibling = [
+      { name: "unrelated", type: "u32", value: 42 },
+      descriptorShape[0],
+    ];
+    const outWithSibling = decodeEthereumTransactArgs(withSibling);
+    assert.deepEqual(outWithSibling[0], {
+      name: "unrelated",
+      type: "u32",
+      value: 42,
+    });
   });
 
-  test("is a no-op when transaction is missing or already D1-shaped", () => {
+  test("is a no-op when transaction is missing from either shape, or the descriptor array has no matching entry", () => {
     assert.deepEqual(decodeEthereumTransactArgs({}), {});
     assert.deepEqual(
       decodeEthereumTransactArgs({ transaction: { EIP1559: {} } }),
@@ -222,6 +249,8 @@ describe("decodeEthereumTransactArgs (real production fixture, block 8587453/9)"
       },
     );
     assert.equal(decodeEthereumTransactArgs(null), null);
+    const noMatch = [{ name: "other_field", type: "u32", value: 1 }];
+    assert.deepEqual(decodeEthereumTransactArgs(noMatch), noMatch);
   });
 
   test("passes a non-object EIP1559 payload through unchanged (malformed/defensive case)", () => {
@@ -304,10 +333,35 @@ describe("decodeEvmWithdrawArgs (real production fixture, block 8573895/15)", ()
     });
   });
 
-  test("is a no-op when address is absent or already D1-shaped", () => {
+  test("is a no-op when address is absent, and leaves an already-hex address untouched", () => {
     assert.deepEqual(decodeEvmWithdrawArgs({ value: 1 }), { value: 1 });
-    const d1Shape = [{ name: "address", type: "H160", value: "0x..." }];
-    assert.deepEqual(decodeEvmWithdrawArgs(d1Shape), d1Shape);
+    const alreadyHex = [{ name: "address", type: "H160", value: "0x..." }];
+    assert.deepEqual(decodeEvmWithdrawArgs(alreadyHex), alreadyHex);
+    const noMatch = [{ name: "value", type: "u128", value: 1 }];
+    assert.deepEqual(decodeEvmWithdrawArgs(noMatch), noMatch);
+  });
+
+  test("decodes the real production call_args shape -- an array of {name,type,value} descriptors", () => {
+    const descriptorShape = [
+      { name: "value", type: "u128", value: 67756440 },
+      {
+        name: "address",
+        type: "H160",
+        value: [
+          [
+            211, 47, 118, 124, 7, 153, 44, 49, 231, 209, 195, 129, 20, 9, 75,
+            146, 116, 40, 240, 71,
+          ],
+        ],
+      },
+    ];
+    const out = decodeEvmWithdrawArgs(descriptorShape);
+    assert.deepEqual(out[0], { name: "value", type: "u128", value: 67756440 });
+    assert.deepEqual(out[1], {
+      name: "address",
+      type: "H160",
+      value: "0xd32f767c07992c31e7d1c38114094b927428f047",
+    });
   });
 });
 
@@ -366,10 +420,9 @@ describe("decodeSignatureFieldArgs", () => {
         ],
       },
       pulses_payload: {
-        // A DIFFERENT field that happens to also be Sr25519-shaped (a
-        // MultiSigner public key, not a MultiSignature) -- deliberately left
-        // untouched, confirming decodeSignatureFieldArgs only targets keys
-        // literally named "signature", not any Sr25519-shaped value anywhere.
+        // A DIFFERENT field that also uses the Sr25519 shape (a MultiSigner
+        // public key, not a MultiSignature) -- decoded the same way, since
+        // "public" is now a matched key alongside "signature"/"randomness".
         public: { name: "Sr25519", values: [[1, 2, 3, 4]] },
       },
     };
@@ -379,9 +432,44 @@ describe("decodeSignatureFieldArgs", () => {
         "0x84b9970dc4354e6298a3ed7bca069992d8601d93b80e0c7794c5c555fb2d727ea02301c2881babd215069cc6cc7faab9765135d7da3680d845068ef918a55d8d",
     });
     assert.deepEqual(out.pulses_payload.public, {
-      name: "Sr25519",
-      values: [[1, 2, 3, 4]],
+      Sr25519: "0x01020304",
     });
+  });
+
+  test("decodes Drand.write_pulse's per-pulse signature/randomness -- bare 32-byte arrays, NOT Sr25519-enum-wrapped (real production fixture, block 8604176)", () => {
+    const raw = {
+      pulses_payload: {
+        pulses: [
+          {
+            round: 30347496,
+            signature: [
+              [
+                146, 56, 3, 31, 123, 237, 132, 59, 123, 234, 164, 93, 97, 46,
+                156, 91, 23, 39, 177, 160, 170, 10, 92, 222, 197, 83, 161, 45,
+                20, 120, 163, 1,
+              ],
+            ],
+            randomness: [
+              [
+                240, 33, 67, 144, 32, 232, 205, 35, 16, 13, 65, 216, 92, 171,
+                251, 103, 72, 7, 98, 149, 253, 169, 154, 217, 2, 11, 177, 42,
+                234, 132, 67, 65,
+              ],
+            ],
+          },
+        ],
+      },
+    };
+    const out = decode("Drand", "write_pulse", raw);
+    assert.equal(
+      out.pulses_payload.pulses[0].signature,
+      "0x9238031f7bed843b7beaa45d612e9c5b1727b1a0aa0a5cdec553a12d1478a301",
+    );
+    assert.equal(
+      out.pulses_payload.pulses[0].randomness,
+      "0xf021439020e8cd23100d41d85cabfb6748076295fda99ad9020bb12aea844341",
+    );
+    assert.equal(out.pulses_payload.pulses[0].round, 30347496);
   });
 
   test("is a no-op on D1's own already-decoded {Sr25519: hex} shorthand", () => {


### PR DESCRIPTION
## Summary
- `decodeEthereumTransactArgs`/`decodeEvmWithdrawArgs` guarded on `Array.isArray(callArgs)` and bailed immediately, on the documented (and wrong) assumption that Postgres always serves a flat `{transaction:{...}}` object and the array-of-descriptors shape was D1-only. Confirmed live: D1's `extrinsics` table no longer exists (#4772), and **every** extrinsic's call_args is genuinely served as `[{name,type,value}]` — making both decoders a 100% no-op in production. Affects all 13,743 `Ethereum.transact` rows.
- `findCallArg`/`withCallArg` locate and replace a named argument within the real descriptor-array shape (flat-object still supported too, harmless to keep). Both decoders rewritten on top of these — same decode logic as before, just correctly locating the target field.
- From the same sweep: `Drand.write_pulse`'s `public` field uses the same Sr25519-enum shape as `signature` but wasn't matched; its per-pulse `signature`/`randomness` are bare 32-byte arrays (not enum-wrapped, unlike `LimitOrders`' genuinely-enum-wrapped `signature`). `walkForSignatureFields` now matches `public` too, and `signature`/`randomness` try enum-unwrap first, falling back to plain hex.

Closes #4932

Continuation of the live chain-data decode audit that produced #4916, #4918, #4920, #4927, and #4930.

## Test plan
- [x] `tests/indexer-rs-ethereum-decode.test.mjs`: 32/32 passing (rewrote the two tests that asserted the descriptor-array shape was a no-op — now assert correct decoding — plus new tests for the array-shape path, the `public` field, and the bare-32-byte `signature`/`randomness` fallback)
- [x] `tests/extrinsics.test.mjs`: 58/58 passing (consumer of this module, unaffected)
- [x] Full suite passing locally (255 files / 7533 tests)
- [x] `npm run lint` / `format:check` clean on the final diff
- [x] 100% statement/branch/line coverage on `src/indexer-rs-ethereum-decode.mjs`
- [ ] Live-verify against production after merge (re-curl a real `Ethereum.transact`/`Drand.write_pulse` extrinsic)