### PR TITLE
fix(data-api): retire account_position_daily's dead D1 write path (#4910)

### DIFF
--- a/docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md
+++ b/docs/adr/0014-chain-data-infrastructure-and-postgres-cutover.md
@@ -249,7 +249,8 @@ silently drift from each other.
    `EVENTS_LOAD_CRON`, `HEALTH_PRUNE_CRON`, and `NEURON_HISTORY_ROLLUP_CRON` to
    drop only what they retired (`subnet_hyperparams`/`account_identity`
    staging and `account_position_daily`'s rollup/prune are untouched, and stay
-   D1-only pending their own Postgres migration). Every read route already
+   D1-only pending their own Postgres migration — see item 12, which found
+   this premise stale). Every read route already
    falls back through `tryPostgresTier(...) ?? d1Fallback()`, and `d1All`
    degrades a missing-table error to an empty result, so dropping the D1
    tables after this code deploys is provably safe — sequenced as
@@ -295,6 +296,28 @@ NOTHING`, so a backfill re-run would have silently preserved
     `blocks`' existing column-level `DO UPDATE SET` pattern on all four
     tables — a precondition for item 7 to actually be "flawless," not just
     "runs without erroring."
+12. ✅ **`account_position_daily`'s D1 rollup/prune retired + its dead D1
+    read-route fallback removed (2026-07-12).** Item 8 left this tier's D1
+    rollup (`rollupAccountPositionDaily`/`pruneAccountPositionDaily`,
+    formerly `src/account-position-history.mjs`, wired from
+    `NEURON_HISTORY_ROLLUP_CRON`) untouched because it had "no Postgres
+    migration yet" — that premise, and #4910 (filed on the same belief), were
+    both stale: #4839 had already shipped this tier's Postgres write path
+    (`handleNeuronsSync`, same transaction as neurons/neuron_daily) and read
+    route (`tryPostgresTier` + `METAGRAPH_NEURONS_SOURCE`), live-verified in
+    production. Item 8's own D1 write-path retirement had an unannounced side
+    effect on this tier specifically: dropping D1's `neurons` table broke
+    `rollupAccountPositionDaily`'s `FROM neurons` query outright (confirmed
+    live: `wrangler d1 execute` now returns `no such table: neurons`),
+    silently swallowed by its cron `.catch()` every tick since #4908 merged
+    (2026-07-11); D1's `account_position_daily` table has been frozen at that
+    same date ever since. Retired the dead cron wiring (deleted
+    `rollupAccountPositionDaily`/`pruneAccountPositionDaily` outright, same
+    treatment item 8 gave the sibling `rollupNeuronDaily`/`pruneNeuronDaily`)
+    and the read route's `?? d1Fallback()` branch — the one branch of item
+    8's ~40 that's addressed now rather than deferred to #4909, specifically
+    because its D1 source data had gone from merely unwritten to actively
+    erroring, unlike the other ~40 (still tracked, not urgent).
 
 ## Links/resources
 

--- a/src/account-position-history.mjs
+++ b/src/account-position-history.mjs
@@ -1,29 +1,29 @@
 // Per-account daily position HISTORY (block-explorer Tier-1, epic #4329/6.1).
 //
-// The refresh-metagraph cron lands the LATEST per-UID snapshot in `neurons`
-// (overwrite-on-conflict — no history is kept). This daily rollup copies the
-// current snapshot into the append-only `account_position_daily` table, keyed by
-// (account, netuid, snapshot_date) instead of neuron_daily's (netuid, uid,
-// snapshot_date) — giving /accounts/{addr}/portfolio's positions a per-account
-// time-series (the "Alpha Holdings chart") the same way neuron_daily gives
-// per-UID metagraph time-series. Same source table as neuron_daily, so both
-// rollups fire from the SAME cron tick for a consistent snapshot stamp.
+// The refresh-metagraph cron lands the LATEST per-UID snapshot in Postgres's
+// `neurons` (overwrite-on-conflict — no history is kept). The rollup that
+// copies that snapshot into the append-only `account_position_daily` table,
+// keyed by (account, netuid, snapshot_date) instead of neuron_daily's
+// (netuid, uid, snapshot_date), now runs entirely on the Postgres side
+// (workers/data-api.mjs's handleNeuronsSync, #4839) — in the SAME write
+// transaction as the neurons/neuron_daily sync, not from a separate cron.
 // account = hotkey ss58, matching loadAccountPortfolio's own "WHERE hotkey = ?"
-// framing (src/account-portfolio.mjs). Pure + injectable for tests; the Worker
-// runs the D1 I/O.
+// framing (src/account-portfolio.mjs).
 //
-// Known overlap with neuron_daily (#4330's own issue text mandates this new
-// table regardless — flagging the tradeoff here, not silently accepting or
-// re-litigating it): every column this table stores already exists in
-// neuron_daily, which already carries a `hotkey` column and a purpose-built
-// `idx_neuron_daily_hotkey_date` index ("Point-in-time account history: which
-// UID a hotkey held on a date" — migrations/0011_neuron_daily.sql) that could
-// serve most of this same read pattern (`WHERE hotkey = ? ORDER BY
-// snapshot_date`) with no new table. This rollup doubles daily write volume
-// onto the same D1 database that has already hit its capacity limit once
-// (neuron_daily's own 400d->90d retention cut, src/neuron-history.mjs) — worth
-// weighing before #4331's read route builds on top of this table, and before
-// assuming this data couldn't instead be served from neuron_daily directly.
+// This module previously also owned D1's OWN rollup/prune
+// (rollupAccountPositionDaily/pruneAccountPositionDaily, called from
+// workers/api.mjs's NEURON_HISTORY_ROLLUP_CRON) as a parallel write path.
+// That D1 side is retired here: #4908 (#4772, D1 chain-data write-path
+// retirement) dropped D1's `neurons` table entirely, so a `FROM neurons`
+// D1 rollup query can no longer even run — confirmed live via `wrangler d1
+// execute` returning "no such table: neurons", and D1's own
+// account_position_daily table frozen at 2026-07-11 (the day #4908 merged)
+// ever since. #4839 already gave this table a fully independent, live-
+// verified Postgres write + read path, so nothing depends on the D1 side.
+// This module is now READ-PATH ONLY: the shaping/formatting helpers the
+// Postgres-backed handleAccountPositionHistory route
+// (workers/request-handlers/entities.mjs) and workers/data-api.mjs's own
+// Postgres query both share.
 //
 // Known scope limitation: "position"/stake_tao here is a HOTKEY's own
 // registered-neuron stake (for a validator hotkey, the FULL pool delegated to
@@ -37,106 +37,6 @@
 // framing (src/account-portfolio.mjs) — not a new gap, but worth restating
 // here since epic #4329 explicitly frames this as taostats.io's (coldkey-
 // centric) "Alpha Holdings" feature.
-
-// Columns written to account_position_daily by the rollup — the load contract,
-// positionally aligned with NEURONS_SELECT_COLUMNS below.
-const ROLLUP_COLUMNS = [
-  "account",
-  "netuid",
-  "uid",
-  "coldkey",
-  "active",
-  "validator_permit",
-  "rank",
-  "trust",
-  "incentive",
-  "dividends",
-  "stake_tao",
-  "emission_tao",
-  "captured_at",
-];
-
-// The `neurons` columns snapshotted into account_position_daily — mirrors
-// ACCOUNT_PORTFOLIO_READ_COLUMNS (src/account-portfolio.mjs) plus coldkey for
-// ownership display, not the full neuron row (no axon/registered_at_block/
-// is_immunity_period — point-in-time metagraph facts, not portfolio economics).
-const NEURONS_SELECT_COLUMNS =
-  "hotkey AS account, netuid, uid, coldkey, active, validator_permit, rank, " +
-  "trust, incentive, dividends, stake_tao, emission_tao, captured_at";
-
-// Retention window for the simple prune below. Mirrors EVENT_RETENTION_MS's
-// plain-DELETE approach (src/account-events.mjs), not neuron_daily's cold-archive
-// tier — account_position_daily is new and unproven at scale; add archival later
-// if row growth demands it, following neuron_daily's own later evolution (PR-A2)
-// rather than building it preemptively.
-export const ACCOUNT_POSITION_DAILY_RETENTION_DAYS = 90;
-
-function accountPositionDailyRetentionCutoff(now) {
-  return new Date(now - ACCOUNT_POSITION_DAILY_RETENTION_DAYS * 86_400_000)
-    .toISOString()
-    .slice(0, 10);
-}
-
-// Daily rollup: snapshot the current `neurons` table into
-// `account_position_daily` for the captured UTC day. Same atomic INSERT...SELECT
-// shape as rollupNeuronDaily (src/neuron-history.mjs):
-//  - WHERE captured_at = MAX(captured_at): one consistent snapshot stamp, so a
-//    concurrent partial load can't bleed two stamps into a single day.
-//  - AND hotkey IS NOT NULL: `account` is NOT NULL and part of the primary key,
-//    but neurons.hotkey is nullable — an unfiltered SELECT would abort the
-//    WHOLE INSERT (every account/subnet for the day, not just the offending
-//    row) the moment any one neuron row lacked a hotkey.
-//  - snapshot_date = the UTC day of that captured_at, computed in SQL.
-//  - ON CONFLICT(account, netuid, snapshot_date) DO UPDATE: intra-day re-runs
-//    are idempotent (the row reflects the last capture that UTC day).
-// Returns {rolled, rows} for cron observability; the caller .catch-isolates it
-// so a failure never affects the rest of the scheduled run.
-export async function rollupAccountPositionDaily(
-  env,
-  { now = Date.now() } = {},
-) {
-  const db = env?.METAGRAPH_HEALTH_DB;
-  if (!db?.prepare) return { rolled: false, reason: "no-db" };
-  const cols = ROLLUP_COLUMNS.join(", ");
-  const setClause = ROLLUP_COLUMNS.filter(
-    (c) => c !== "account" && c !== "netuid",
-  )
-    .map((c) => `${c} = excluded.${c}`)
-    .concat("updated_at = excluded.updated_at")
-    .join(", ");
-  const sql =
-    `INSERT INTO account_position_daily (${cols}, snapshot_date, updated_at) ` +
-    `SELECT ${NEURONS_SELECT_COLUMNS}, date(captured_at / 1000, 'unixepoch'), ? ` +
-    `FROM neurons WHERE captured_at = (SELECT MAX(captured_at) FROM neurons) ` +
-    `AND hotkey IS NOT NULL ` +
-    `ON CONFLICT(account, netuid, snapshot_date) DO UPDATE SET ${setClause}`;
-  const res = await db.prepare(sql).bind(now).run();
-  return { rolled: true, rows: res?.meta?.changes ?? null };
-}
-
-// Prune rows older than the retention window — a plain DELETE, no cold-archive
-// tier (mirrors pruneAccountEvents, src/account-events.mjs). Returns
-// {pruned, changes} for cron observability. The D1 call is try/caught, but the
-// retention-cutoff computation just above it is NOT — a non-finite `now` would
-// still throw there; every current caller passes now = Date.now(), so that's
-// not reachable today, but this function is not unconditionally exception-free.
-export async function pruneAccountPositionDaily(
-  env,
-  { now = Date.now() } = {},
-) {
-  const db = env?.METAGRAPH_HEALTH_DB;
-  if (!db?.prepare) return { pruned: false, reason: "no-db" };
-  const cutoff = accountPositionDailyRetentionCutoff(now);
-  try {
-    const result = await db
-      .prepare("DELETE FROM account_position_daily WHERE snapshot_date < ?")
-      .bind(cutoff)
-      .run();
-    return { pruned: true, cutoff, changes: result?.meta?.changes ?? null };
-  } catch {
-    return { pruned: false };
-  }
-}
 
 // ---- Read path (block-explorer Tier-1, epic #4329/6.2) --------------------
 // GET /api/v1/accounts/{ss58}/subnets/{netuid}/history — the per-position

--- a/src/accounts-list.mjs
+++ b/src/accounts-list.mjs
@@ -24,8 +24,8 @@
 // or delegated to someone else's validator, and never registered its own
 // hotkey, never appears here. That is the same "hotkey-only" framing
 // loadAccountPortfolio (src/account-portfolio.mjs) and
-// rollupAccountPositionDaily (src/account-position-history.mjs) already carry
-// for this exact reason — not a new gap this route introduces.
+// src/account-position-history.mjs already carry for this exact reason — not
+// a new gap this route introduces.
 
 const RAO_PER_TAO = 1e9;
 

--- a/tests/account-position-history.test.mjs
+++ b/tests/account-position-history.test.mjs
@@ -1,165 +1,27 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
-  rollupAccountPositionDaily,
-  pruneAccountPositionDaily,
-  ACCOUNT_POSITION_DAILY_RETENTION_DAYS,
-  ACCOUNT_POSITION_DAILY_READ_COLUMNS,
   formatAccountPosition,
   buildAccountPositionHistory,
 } from "../src/account-position-history.mjs";
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
 import { NEURON_HISTORY_ROLLUP_CRON } from "../workers/config.mjs";
-import { MAX_HISTORY_POINTS } from "../src/neuron-history.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 const ctx = { waitUntil: (p) => p };
 const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-describe("rollupAccountPositionDaily", () => {
-  test("issues a single INSERT...SELECT with a consistent captured_at snapshot + idempotent upsert", async () => {
-    const captured = {};
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          captured.sql = sql;
-          return {
-            bind(...params) {
-              captured.params = params;
-              return { run: () => Promise.resolve({ meta: { changes: 42 } }) };
-            },
-          };
-        },
-      },
-    };
-    const res = await rollupAccountPositionDaily(env, {
-      now: 1_780_000_000_001,
-    });
-    assert.deepEqual(res, { rolled: true, rows: 42 });
-    // One consistent snapshot stamp (WHERE captured_at = MAX), dated in SQL.
-    assert.match(captured.sql, /INSERT INTO account_position_daily/);
-    assert.match(captured.sql, /hotkey AS account/);
-    assert.match(captured.sql, /SELECT MAX\(captured_at\) FROM neurons/);
-    assert.match(captured.sql, /date\(captured_at \/ 1000, 'unixepoch'\)/);
-    // account is NOT NULL + part of the primary key, but neurons.hotkey is
-    // nullable — an unfiltered SELECT would abort the whole INSERT on any one
-    // null-hotkey row (see the function's own docstring).
-    assert.match(captured.sql, /AND hotkey IS NOT NULL/);
-    // Idempotent intra-day re-run.
-    assert.match(
-      captured.sql,
-      /ON CONFLICT\(account, netuid, snapshot_date\) DO UPDATE/,
-    );
-    assert.deepEqual(captured.params, [1_780_000_000_001]);
-  });
-
-  test("no-ops cleanly without a DB binding (cron isolation)", async () => {
-    assert.deepEqual(await rollupAccountPositionDaily({}), {
-      rolled: false,
-      reason: "no-db",
-    });
-  });
-
-  test("reports rows:null when the run result omits meta.changes", async () => {
+// account_position_daily's D1 rollup/prune (formerly rollupAccountPositionDaily/
+// pruneAccountPositionDaily, src/account-position-history.mjs, wired from this
+// cron) are retired: #4908 dropped D1's `neurons` table entirely, and #4839
+// already gave this table its own independent, live-verified Postgres write +
+// read path. This cron tick now has no remaining work.
+describe("handleScheduled NEURON_HISTORY_ROLLUP_CRON (retired, #4329/6.1)", () => {
+  test("is a pure no-op — never touches D1", async () => {
     const env = {
       METAGRAPH_HEALTH_DB: {
         prepare() {
-          return { bind: () => ({ run: () => Promise.resolve({}) }) };
-        },
-      },
-    };
-    const res = await rollupAccountPositionDaily(env, { now: 1 });
-    assert.equal(res.rolled, true);
-    assert.equal(res.rows, null);
-  });
-});
-
-describe("pruneAccountPositionDaily", () => {
-  test("deletes below the retention cutoff", async () => {
-    let boundCutoff;
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare() {
-          return {
-            bind: (cutoff) => {
-              boundCutoff = cutoff;
-              return { run: async () => ({ meta: { changes: 7 } }) };
-            },
-          };
-        },
-      },
-    };
-    const now = new Date("2026-07-09T00:00:00.000Z").getTime();
-    const res = await pruneAccountPositionDaily(env, { now });
-    assert.equal(res.pruned, true);
-    assert.equal(res.changes, 7);
-    const expectedCutoff = new Date(
-      now - ACCOUNT_POSITION_DAILY_RETENTION_DAYS * 86_400_000,
-    )
-      .toISOString()
-      .slice(0, 10);
-    assert.equal(boundCutoff, expectedCutoff);
-    assert.equal(res.cutoff, expectedCutoff);
-  });
-
-  test("no-ops cleanly without a DB binding", async () => {
-    assert.deepEqual(await pruneAccountPositionDaily({}), {
-      pruned: false,
-      reason: "no-db",
-    });
-  });
-
-  test("reports changes:null when the run result omits meta.changes", async () => {
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare() {
-          return { bind: () => ({ run: () => Promise.resolve({}) }) };
-        },
-      },
-    };
-    const res = await pruneAccountPositionDaily(env, { now: 1 });
-    assert.equal(res.pruned, true);
-    assert.equal(res.changes, null);
-  });
-
-  test("returns pruned:false when D1 throws", async () => {
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare() {
-          return {
-            bind: () => ({
-              run: async () => {
-                throw new Error("d1 down");
-              },
-            }),
-          };
-        },
-      },
-    };
-    const res = await pruneAccountPositionDaily(env, { now: 1 });
-    assert.equal(res.pruned, false);
-  });
-});
-
-describe("handleScheduled rollup cron wiring (#4329/6.1)", () => {
-  test("isolates a rollup failure from the rest of the NEURON_HISTORY_ROLLUP_CRON tick", async () => {
-    // account_position_daily's INSERT throws; every other statement (neuron_daily's
-    // rollup/archive-read/prune) resolves emptily, so the surrounding cron tick
-    // completes and the failure stays isolated to accountPositionRolled.
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind: () => ({
-              run: () => {
-                if (sql.includes("account_position_daily")) {
-                  return Promise.reject(new Error("d1 down"));
-                }
-                return Promise.resolve({ meta: { changes: 0 } });
-              },
-              all: () => Promise.resolve({ results: [] }),
-            }),
-          };
+          throw new Error("D1 must not be queried by a retired cron branch");
         },
       },
     };
@@ -168,37 +30,7 @@ describe("handleScheduled rollup cron wiring (#4329/6.1)", () => {
       env,
       ctx,
     );
-    assert.equal(result.accountPositionRolled.rolled, false);
-  });
-
-  test("rolls up and prunes account_position_daily on the same cron tick", async () => {
-    const calls = [];
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          calls.push(sql);
-          return {
-            bind: () => ({
-              run: () => Promise.resolve({ meta: { changes: 3 } }),
-              all: () => Promise.resolve({ results: [] }),
-            }),
-          };
-        },
-      },
-    };
-    const result = await handleScheduled(
-      { cron: NEURON_HISTORY_ROLLUP_CRON },
-      env,
-      ctx,
-    );
-    assert.equal(result.accountPositionRolled.rolled, true);
-    assert.equal(result.accountPositionPruned.pruned, true);
-    assert.ok(
-      calls.some((sql) => sql.includes("INSERT INTO account_position_daily")),
-    );
-    assert.ok(
-      calls.some((sql) => sql.includes("DELETE FROM account_position_daily")),
-    );
+    assert.deepEqual(result, { ok: true, retired: true });
   });
 });
 
@@ -403,28 +235,42 @@ describe("buildAccountPositionHistory", () => {
   });
 });
 
-// Stub METAGRAPH_HEALTH_DB whose .all() returns the given rows and records the SQL.
-function positionHistoryEnv(rows, captured = {}) {
+// D1 must never be queried by this route anymore — it's Postgres-only
+// (#4839 shipped the write path + this read route; #4910's "no Postgres read
+// route" premise was stale, and D1's own rollup has been permanently broken
+// since #4908 dropped D1's `neurons` table). This stub throws if `prepare()`
+// is ever called, so any regression back to a D1 fallback fails the test
+// loudly instead of silently passing on stale/empty D1 data.
+function positionHistoryEnv(overrides = {}) {
   return {
     ...createLocalArtifactEnv(),
     METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        captured.sql = sql;
-        return {
-          bind(...params) {
-            captured.params = params;
-            return { all: () => Promise.resolve({ results: rows }) };
-          },
-        };
+      prepare() {
+        throw new Error(
+          "D1 must not be queried by the Postgres-only account-position-history route",
+        );
       },
     },
+    ...overrides,
   };
 }
 
+// A Postgres-tier env: METAGRAPH_NEURONS_SOURCE=postgres + a DATA_API stub
+// returning the given account-position-history payload.
+function postgresPositionHistoryEnv(payload) {
+  return positionHistoryEnv({
+    METAGRAPH_NEURONS_SOURCE: "postgres",
+    DATA_API: { fetch: async () => Response.json(payload) },
+  });
+}
+
 describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch", () => {
-  test("returns a 200 series + applies a date cutoff", async () => {
-    const captured = {};
-    const env = positionHistoryEnv([positionRow()], captured);
+  test("Postgres tier: returns the series the DATA_API binding provides", async () => {
+    const env = postgresPositionHistoryEnv(
+      buildAccountPositionHistory([positionRow()], SS58, 7, {
+        window: "7d",
+      }),
+    );
     const res = await handleRequest(
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history?window=7d`,
@@ -437,29 +283,7 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
     assert.equal(body.data.ss58, SS58);
     assert.equal(body.data.netuid, 7);
     assert.equal(body.data.points[0].snapshot_date, "2026-06-20");
-    assert.match(
-      captured.sql,
-      /FROM account_position_daily WHERE account = \? AND netuid = \?/,
-    );
-    assert.match(captured.sql, /snapshot_date >= \?/);
-    assert.deepEqual(captured.params.slice(0, 2), [SS58, 7]);
-    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
     assert.match(res.headers.get("content-type"), /^application\/json/);
-  });
-
-  test("uses ACCOUNT_POSITION_DAILY_READ_COLUMNS in the SELECT list", async () => {
-    const captured = {};
-    await handleRequest(
-      new Request(
-        `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history`,
-      ),
-      positionHistoryEnv([], captured),
-      ctx,
-    );
-    assert.match(
-      captured.sql,
-      new RegExp(`SELECT ${ACCOUNT_POSITION_DAILY_READ_COLUMNS}`),
-    );
   });
 
   test("an unsupported ?window is a 400, never a silent coerce", async () => {
@@ -467,7 +291,7 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history?window=400d`,
       ),
-      positionHistoryEnv([]),
+      positionHistoryEnv(),
       ctx,
     );
     assert.equal(res.status, 400);
@@ -476,25 +300,30 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
     assert.equal(body.meta.parameter, "window");
   });
 
-  test("?window=all omits the cutoff (full history, still bounded by the row cap)", async () => {
-    const captured = {};
-    await handleRequest(
+  test("?window=all is accepted (forwarded to Postgres unchanged, no D1 cutoff logic left)", async () => {
+    const env = postgresPositionHistoryEnv(
+      buildAccountPositionHistory([positionRow()], SS58, 7, {
+        window: "all",
+      }),
+    );
+    const res = await handleRequest(
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history?window=all`,
       ),
-      positionHistoryEnv([positionRow()], captured),
+      env,
       ctx,
     );
-    assert.doesNotMatch(captured.sql, /snapshot_date >= \?/);
-    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.window, "all");
   });
 
-  test("cold/absent store returns 200 with empty points, never 404", async () => {
+  test("Postgres tier unavailable → 200 with empty points, never 404 or a D1 read", async () => {
     const res = await handleRequest(
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history`,
       ),
-      positionHistoryEnv([]),
+      positionHistoryEnv(),
       ctx,
     );
     assert.equal(res.status, 200);
@@ -508,18 +337,23 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history?bogus=1`,
       ),
-      positionHistoryEnv([]),
+      positionHistoryEnv(),
       ctx,
     );
     assert.equal(res.status, 400);
   });
 
-  test("meta.generated_at reflects the newest point's captured_at", async () => {
+  test("meta.generated_at reflects the newest point's captured_at (Postgres tier)", async () => {
+    const env = postgresPositionHistoryEnv(
+      buildAccountPositionHistory([positionRow()], SS58, 7, {
+        window: "30d",
+      }),
+    );
     const res = await handleRequest(
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history`,
       ),
-      positionHistoryEnv([positionRow()]),
+      env,
       ctx,
     );
     const body = await res.json();
@@ -530,12 +364,12 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
     assert.equal(body.meta.source, "metagraph-snapshot");
   });
 
-  test("meta.generated_at is null when the store is cold", async () => {
+  test("meta.generated_at is null when the Postgres tier is unavailable", async () => {
     const res = await handleRequest(
       new Request(
         `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/7/history`,
       ),
-      positionHistoryEnv([]),
+      positionHistoryEnv(),
       ctx,
     );
     const body = await res.json();
@@ -547,7 +381,7 @@ describe("GET /accounts/{ss58}/subnets/{netuid}/history via the Worker dispatch"
       new Request(
         "https://api.metagraph.sh/api/v1/accounts/not-a-valid-address/subnets/7/history",
       ),
-      positionHistoryEnv([]),
+      positionHistoryEnv(),
       ctx,
     );
     assert.equal(res.status, 404);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -8837,7 +8837,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountPositionHistory: flag=postgres falls back to D1 on failure", async () => {
+  // No D1 fallback here (unlike the ~40 branches #4909 tracks separately):
+  // D1's own account_position_daily rollup has been permanently broken since
+  // #4908 dropped D1's `neurons` table, so a Postgres failure degrades to the
+  // same schema-stable empty series a cold store returns, never a D1 read.
+  test("handleAccountPositionHistory: flag=postgres degrades to an empty schema-stable series on failure, D1 never queried", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
     env.DATA_API = {
@@ -8855,7 +8859,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
       ),
     );
     assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
+    assert.deepEqual(body.data.points, []);
+    assert.equal(body.data.point_count, 0);
+    assert.deepEqual(captures.sql, []);
   });
 
   // #4832 gap-closure: handleAccountHistory (account_events_daily, now

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -254,10 +254,6 @@ import {
 } from "../src/subnet-identity-history.mjs";
 import { tryPostgresTier } from "./postgres-tier.mjs";
 import {
-  rollupAccountPositionDaily,
-  pruneAccountPositionDaily,
-} from "../src/account-position-history.mjs";
-import {
   economicsSnapshotUpsertStatements,
   validEconomicsBackfillRows,
 } from "../src/economics-backfill.mjs";
@@ -646,24 +642,26 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
     // cap forcing an archive-then-prune dance, so this cron no longer needs
     // either step.
     //
-    // account_position_daily (#4329/6.1) is untouched — same `neurons` source
-    // and cron tick as the old neuron_daily rollup, but it has no Postgres
-    // serving route yet (still read straight from D1 in entities.mjs), so it is
-    // explicitly out of scope for this retirement.
-    const now = Date.now();
-    // pruneAccountPositionDaily already self-catches its own D1 errors (unlike
-    // rollupAccountPositionDaily, which has no internal try/catch), so it needs
-    // no wrapper .catch() here.
-    const accountPositionRolled = await rollupAccountPositionDaily(env).catch(
-      () => ({ rolled: false }),
-    );
-    const accountPositionPruned = await pruneAccountPositionDaily(env, {
-      now,
-    });
-    return {
-      accountPositionRolled,
-      accountPositionPruned,
-    };
+    // account_position_daily's own rollupAccountPositionDaily/
+    // pruneAccountPositionDaily (src/account-position-history.mjs), previously
+    // called from here, are retired too: #4908 dropped D1's `neurons` table
+    // entirely (confirmed live: `SELECT ... FROM neurons` now errors "no such
+    // table: neurons"), so rollupAccountPositionDaily's `FROM neurons` query
+    // has been throwing -- silently swallowed by its own .catch() -- every
+    // tick since #4908 merged (2026-07-11); D1's account_position_daily table
+    // has been frozen at that same date ever since (confirmed via `wrangler
+    // d1 execute`). #4839 already gave this table its own independent
+    // Postgres write path (handleNeuronsSync, the same transaction as
+    // neurons/neuron_daily) and read route (tryPostgresTier +
+    // METAGRAPH_NEURONS_SOURCE, live in production per wrangler.jsonc), so
+    // nothing depends on the D1 side continuing to run. #4910, which asked
+    // for a Postgres read route believing none existed, was stale -- #4839
+    // already shipped it.
+    //
+    // This cron trigger (47 5 * * *, wrangler.jsonc) has no remaining work;
+    // left wired but inert rather than also retiring the schedule trigger
+    // itself, which is a separate deploy-config decision.
+    return { ok: true, retired: true };
   }
   return runHealthProber(env, ctx);
 }

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -679,12 +679,13 @@ async function handleNeuronsSync(request, env) {
           WHERE neuron_daily.captured_at <= EXCLUDED.captured_at`;
       }
 
-      // Per-account daily position rollup (#4832 gap-closure, mirrors D1's
-      // rollupAccountPositionDaily / src/account-position-history.mjs): the SAME
-      // snapshot as neuron_daily above, re-keyed by (account, netuid,
-      // snapshot_date) with account = hotkey. `hotkey IS NOT NULL` mirrors the D1
-      // rollup's own filter -- account is NOT NULL and part of the primary key,
-      // but a neuron row's hotkey can itself be null.
+      // Per-account daily position rollup (#4832 gap-closure; #4839 gave this
+      // its own Postgres write path in this same transaction, replacing D1's
+      // now-retired rollupAccountPositionDaily / src/account-position-history.mjs):
+      // the SAME snapshot as neuron_daily above, re-keyed by (account, netuid,
+      // snapshot_date) with account = hotkey. `hotkey IS NOT NULL` mirrors that
+      // retired D1 rollup's own filter -- account is NOT NULL and part of the
+      // primary key, but a neuron row's hotkey can itself be null.
       const positionRows = dailyRows
         .filter((row) => row.hotkey != null)
         .map((row) => ({

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -93,10 +93,7 @@ import {
   loadAccountSubnets,
 } from "../../src/account-events.mjs";
 import { loadAccountPortfolio } from "../../src/account-portfolio.mjs";
-import {
-  ACCOUNT_POSITION_DAILY_READ_COLUMNS,
-  buildAccountPositionHistory,
-} from "../../src/account-position-history.mjs";
+import { buildAccountPositionHistory } from "../../src/account-position-history.mjs";
 import { loadAccountIdentity } from "../../src/account-identity.mjs";
 import { loadAccountIdentityHistory } from "../../src/account-identity-history.mjs";
 import {
@@ -3213,12 +3210,17 @@ export async function handleAccountPortfolio(request, env, ss58) {
 // GET /api/v1/accounts/{ss58}/subnets/{netuid}/history?window=7d|30d|90d|1y|all
 // (block-explorer Tier-1, #4329/6.2): one wallet's position on one subnet over
 // time — the "Alpha Holdings chart" — read from the account_position_daily
-// rollup tier (#4330/6.1). Same window/SQL shape as handleNeuronHistory, keyed
-// by (account, netuid) instead of (netuid, uid); source is metagraph-snapshot
-// (rolled from `neurons`), not chain-events, so this uses envelopeResponse +
-// metagraphMeta like the neuron/subnet history routes, not accountEnvelopeResponse.
-// Cold/absent store → 200 with empty points (never 404), matching every sibling
-// history route.
+// rollup tier (#4330/6.1). Source is metagraph-snapshot (rolled from
+// `neurons`), not chain-events, so this uses envelopeResponse + metagraphMeta
+// like the neuron/subnet history routes, not accountEnvelopeResponse.
+// Postgres-only (#4839 shipped its write path + this read route; #4910's "no
+// Postgres read route" premise was stale). No D1 fallback: D1's own
+// account_position_daily rollup (rollupAccountPositionDaily,
+// src/account-position-history.mjs) has been permanently broken since #4908
+// dropped D1's `neurons` table out from under it, so a D1 branch here could
+// only ever serve data frozen at 2026-07-11 — worse than the schema-stable
+// empty response below. Cold/absent store → 200 with empty points (never
+// 404), matching every sibling history route.
 export async function handleAccountPositionHistory(
   request,
   env,
@@ -3228,26 +3230,11 @@ export async function handleAccountPositionHistory(
 ) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return analyticsQueryError(error);
-  const params = [ss58, netuid];
-  let sql = `SELECT ${ACCOUNT_POSITION_DAILY_READ_COLUMNS} FROM account_position_daily WHERE account = ? AND netuid = ?`;
-  if (days != null) {
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    sql += " AND snapshot_date >= ?";
-    params.push(cutoff);
-  }
-  sql += " ORDER BY snapshot_date DESC LIMIT ?";
-  params.push(MAX_HISTORY_POINTS);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildAccountPositionHistory(await d1All(env, sql, params), ss58, netuid, {
-      window: label,
-    });
+    buildAccountPositionHistory([], ss58, netuid, { window: label });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

`account_position_daily` is fully flipped to Postgres already -- #4910's premise
("no Postgres read route") is stale. #4839 shipped this tier's independent
Postgres write path (`handleNeuronsSync`, same transaction as
neurons/neuron_daily) and read route (`tryPostgresTier` +
`METAGRAPH_NEURONS_SOURCE`), and it's confirmed live-serving fresh data today
(`GET /api/v1/accounts/5HbNZ.../subnets/1/history?window=all` returns a
2026-07-12 point). This PR retires the now-permanently-broken D1 write path
that was left running alongside it.

**Diagnosis, confirmed before removing anything:**
- `rollupAccountPositionDaily` (`src/account-position-history.mjs`) does
  `... FROM neurons WHERE captured_at = (SELECT MAX(captured_at) FROM
  neurons)` against D1. #4908 (merged 2026-07-11) retired D1's `neurons`
  table entirely as part of the D1 chain-data write-path retirement.
  Confirmed live via `wrangler d1 execute metagraphed-health --remote
  --command "SELECT ... FROM neurons"` -> `no such table: neurons`.
- The cron wraps this call in `.catch(() => ({ rolled: false }))`, so it has
  been silently no-op-failing every tick since #4908 merged -- never an
  outage, just quietly dead.
- Confirmed the downstream effect: D1's `account_position_daily` table is
  frozen at `2026-07-11` (`SELECT MAX(snapshot_date) FROM
  account_position_daily` via `wrangler d1 execute`), the exact day #4908
  merged. `pruneAccountPositionDaily` still runs fine in isolation (it
  operates on the still-existing `account_position_daily` table), but with
  the rollup permanently broken it only ever deletes rows going forward,
  never replenishes them.

**What changed:**
- `workers/api.mjs`: removed the `rollupAccountPositionDaily`/
  `pruneAccountPositionDaily` cron wiring from `NEURON_HISTORY_ROLLUP_CRON`
  (the neuron_daily rollup/archive/prune this branch used to also run was
  already retired by #4908). The branch is now an explicit no-op -- left
  wired rather than also removing the `47 5 * * *` Cloudflare Cron Trigger
  from `wrangler.jsonc`, since that's a separate deploy-config decision.
- `src/account-position-history.mjs`: deleted `rollupAccountPositionDaily`/
  `pruneAccountPositionDaily` and their D1-only supporting helpers
  (`ROLLUP_COLUMNS`, `NEURONS_SELECT_COLUMNS`,
  `ACCOUNT_POSITION_DAILY_RETENTION_DAYS`,
  `accountPositionDailyRetentionCutoff`) outright -- the same treatment #4908
  gave the sibling `rollupNeuronDaily`/`pruneNeuronDaily` in
  `src/neuron-history.mjs`. The module is now read-path only.
- `workers/request-handlers/entities.mjs`: removed the dead
  `?? d1Fallback()` branch from `handleAccountPositionHistory`'s own read
  route -- ONLY this table's branch, not the ~40 others #4909 tracks
  separately (those still fail closed and aren't urgent; this one's D1
  source data had gone from merely unwritten to actively erroring, so it's
  addressed now). On a Postgres-tier failure the route now degrades to the
  same schema-stable empty series a cold store returns, matching every
  sibling history route's "never 404" contract, instead of reading D1 data
  frozen at 2026-07-11.
- `workers/data-api.mjs`: updated a comment referencing the now-deleted D1
  `rollupAccountPositionDaily` by name.
- `docs/adr/0014-...md`: added sequencing item 12 recording this retirement
  and cross-referenced it from item 8 (which had left this tier out of scope
  under the now-stale "no Postgres migration yet" premise).

## Test plan

- [x] `npm run lint` -- clean
- [x] `npx prettier --check <changed files>` -- clean
- [x] `npx vitest run` (full repo, after `npm run build`) -- 255 files / 7522
      tests pass
- [x] `npx vitest run --coverage` scoped to the touched source files
      (`workers/api.mjs`, `workers/request-handlers/entities.mjs`,
      `workers/data-api.mjs`, `src/account-position-history.mjs`,
      `src/accounts-list.mjs`) -- every uncovered line confirmed pre-existing
      and outside this diff
- [x] `npm run validate` -- clean
- [x] `git diff --check` -- clean
- [x] Live-verified via `wrangler d1 execute` (D1 `neurons` table gone,
      `account_position_daily` frozen at 2026-07-11) and `curl
      https://api.metagraph.sh/api/v1/accounts/.../subnets/1/history` (fresh
      2026-07-12 Postgres-served data)

Closes #4910
