### PR TITLE
fix(data-api): close remaining call_args decode gaps

### DIFF
--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -24,7 +24,8 @@
 // order this depends on.
 import { isEnumTreeNode } from "./scale-normalize.mjs";
 import { normalizeAccountId32Field } from "./ss58.mjs";
-import { unwrapByteArray, decodeBytesField } from "./bytes.mjs";
+import { unwrapByteArray, decodeBytesField, bytesToHex } from "./bytes.mjs";
+import { BTREESET_FIELDS } from "./postgres-collection-normalize.mjs";
 
 // True when `value` is D1/indexer-rs's typed call_args field descriptor
 // `{name, type, value}` -- duplicated from scale-normalize.mjs's identical
@@ -70,6 +71,100 @@ function isCollectionType(type) {
   return COLLECTION_TYPE_RE.test(type);
 }
 
+// A collection type specifically parameterized over `u8` (Vec<u8>,
+// BoundedVec<u8,_>, WeakBoundedVec<u8,_>, optionally Option<...>-wrapped) is
+// semantically a byte blob, not a "collection of typed things" -- unlike
+// every OTHER collection type isCollectionType exists to protect (e.g.
+// Vec<AccountId32>, BTreeSet<NetUid>), individually walking each element of
+// a byte blob is meaningless; it needs the same hex/text treatment as any
+// other opaque byte field. Confirmed live 2026-07-12:
+// MevShield.submit_encrypted's `ciphertext` ("BoundedVec<u8, _>") and
+// announce_next_key's `enc_key` ("Option<BoundedVec<u8, _>>") both stayed
+// raw, undecoded byte arrays -- isCollectionType's (correct, for every
+// OTHER case) broad match excluded them from the byte-blob branch below,
+// with nothing narrower to catch this specific case instead.
+const BYTE_BLOB_COLLECTION_RE =
+  /(?:Vec|BoundedVec|WeakBoundedVec)<\s*u8\s*[,>]/;
+function isByteBlobCollectionType(type) {
+  return BYTE_BLOB_COLLECTION_RE.test(type);
+}
+
+// Decodes a byte-blob-typed descriptor's value, which may either be a bare
+// (possibly newtype-wrapped) byte array (BoundedVec<u8,_>) or an Option-
+// wrapped one (Option<BoundedVec<u8,_>> -- confirmed live: announce_next_key's
+// enc_key arrives as {name:"Some"/"None", values:[...]} at this point in the
+// pipeline, since decodePostgresCallArgs runs BEFORE normalizePostgresValue's
+// Option<T> unwrap). Returns `value` unchanged if neither shape matches
+// (defensive; not expected for a real byte-blob-typed field).
+function decodeByteBlobTypedValue(value, ctx, fieldName) {
+  const bytes = unwrapByteArray(value);
+  if (bytes && bytes.length > 0) {
+    return decodeBytesField(
+      ctx?.call_module,
+      ctx?.call_function,
+      fieldName,
+      bytes,
+    );
+  }
+  if (isEnumTreeNode(value)) {
+    if (value.name === "None" && value.values.length === 0) return null;
+    if (value.name === "Some" && value.values.length === 1) {
+      const inner = unwrapByteArray(value.values[0]);
+      if (inner && inner.length > 0) {
+        return decodeBytesField(
+          ctx?.call_module,
+          ctx?.call_function,
+          fieldName,
+          inner,
+        );
+      }
+    }
+  }
+  return value;
+}
+
+// SubtensorModule.set_root_claim_type's `new_root_claim_type` is a
+// STRUCT-variant enum (RootClaimTypeEnum::KeepSubnets{subnets:
+// BTreeSet<NetUid>}), unlike every OTHER enum shape this file/
+// scale-normalize.mjs handles (all TUPLE-variant, `values` an ARRAY) --
+// confirmed live 2026-07-12: its raw shape is {name:"KeepSubnets",
+// values:{subnets:[[u16,...]]}}, `values` a plain OBJECT. isEnumTreeNode's
+// own Array.isArray(values) check correctly does NOT recognize this as an
+// enum-tree node at all, so neither this file's own enum handling nor
+// normalizePostgresValue's ever touches the struct-variant's OWN inner
+// fields -- `subnets` keeps its extra BTreeSet newtype-wrap layer
+// ([[82,97]] instead of [82,97]) with nothing to unwrap it, the same
+// #4693 ambiguity BTREESET_FIELDS resolves for claim_root's OWN top-level
+// `subnets`, just one struct-field layer deeper. Only one struct-variant
+// enum type is confirmed live so far; scoped narrowly to it (by its
+// declared `type` string) rather than a generic "any struct-variant enum"
+// rule, matching this file's established narrow-allowlist discipline.
+function isStructVariantEnum(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof value.name === "string" &&
+    value.values &&
+    typeof value.values === "object" &&
+    !Array.isArray(value.values)
+  );
+}
+
+function decodeRootClaimTypeValue(value) {
+  if (!isStructVariantEnum(value)) return value;
+  const out = { name: value.name, values: { ...value.values } };
+  const { subnets } = out.values;
+  if (
+    Array.isArray(subnets) &&
+    subnets.length === 1 &&
+    Array.isArray(subnets[0])
+  ) {
+    out.values.subnets = subnets[0];
+  }
+  return out;
+}
+
 // Fallback name-guessing for an account field with NO type info of its own
 // (a reconstructed nested call's args, which lose their per-field `type`
 // string once repackaged, or a struct field nested inside an untyped
@@ -96,6 +191,10 @@ const ACCOUNT_KEYS = new Set([
   "dest",
   "destination",
   "source",
+  // Added 2026-07-12 from a live sweep of call_args -- LimitOrders.
+  // execute_batched_orders' per-order signer/fee_recipient are confirmed
+  // 32-byte AccountId32 fields (same length/shape as the sibling `hotkey`
+  // field in the same order struct, which was already correctly decoded).
   "delegate",
   "nominator",
   "owner",
@@ -103,6 +202,8 @@ const ACCOUNT_KEYS = new Set([
   "validator",
   "address",
   "real",
+  "signer",
+  "fee_recipient",
 ]);
 
 function isAccountField(keyHint) {
@@ -155,6 +256,52 @@ function tryReconstructNestedCall(value) {
   };
 }
 
+// Substrate's identity-pallet-style Data::RawN(BoundedVec<u8,N>) variant
+// family (RawN for N=0..128) -- confirmed live 2026-07-12:
+// Commitments.set_commitment's info.fields[].RawN payload is genuinely
+// human-readable free text (a URL, in the confirmed fixture), matching the
+// pallet's own purpose for this enum family (short user-supplied metadata
+// -- "Raw" here is Substrate's own name for exactly this: raw text data),
+// unlike the narrow byte-blob-vs-text ambiguity TEXTUAL_FIELDS/
+// isByteBlobCollectionType exist to resolve elsewhere in this file. This
+// deeply-nested struct field is never reached by the nestedCall-gated
+// generic byte-blob heuristic below (Commitments.set_commitment is the
+// OUTER call, not itself nested inside a reconstructed RuntimeCall) or by
+// isTypedFieldDescriptor (a RawN node has no `type` string -- it's a bare
+// enum-tree node, one level below "info"'s own typed descriptor, which
+// isCollectionType correctly leaves generically recursed since
+// "CommitmentInfo<_>" is neither AccountId32/MultiAddress nor a
+// Vec/BoundedVec/etc collection). Checked unconditionally (not gated by
+// keyHint or nestedCall) since the RawN tag name itself is unambiguous --
+// unlike a bare byte array, no OTHER shape in this codebase's confirmed
+// data legitimately produces a 2-key {name,values} node named "RawN".
+const RAW_DATA_VARIANT_RE = /^Raw\d+$/;
+
+function isRawDataVariant(value) {
+  return (
+    isEnumTreeNode(value) &&
+    RAW_DATA_VARIANT_RE.test(value.name) &&
+    value.values.length === 1
+  );
+}
+
+function decodeRawDataValue(value) {
+  const bytes = unwrapByteArray(value.values[0]);
+  if (!bytes) return value;
+  try {
+    return {
+      [value.name]: new TextDecoder("utf-8", { fatal: true }).decode(
+        Uint8Array.from(bytes),
+      ),
+    };
+  } catch {
+    // Malformed UTF-8 for a field expected to be textual -- fall back to
+    // hex rather than producing mojibake, mirroring decodeBytesField's
+    // identical fallback (src/bytes.mjs).
+    return { [value.name]: bytesToHex(bytes) };
+  }
+}
+
 // Recursive walk: reconstructs nested calls at any depth, and decodes
 // AccountId32/MultiAddress fields to SS58 and byte-blob fields to hex/text
 // EVERYWHERE -- both at the top level of an extrinsic's own call_args and
@@ -201,12 +348,30 @@ function walk(value, keyHint, nestedCall, topCall) {
       call_args: walk(nested.call_args, undefined, nextCall, topCall),
     };
   }
+  if (isRawDataVariant(value)) {
+    return decodeRawDataValue(value);
+  }
   if (isTypedFieldDescriptor(value)) {
     if (isAccountId32Type(value.type)) {
       return {
         name: value.name,
         type: value.type,
         value: normalizeAccountId32Field(value.value) ?? value.value,
+      };
+    }
+    if (isByteBlobCollectionType(value.type)) {
+      const ctx = nestedCall ?? topCall;
+      return {
+        name: value.name,
+        type: value.type,
+        value: decodeByteBlobTypedValue(value.value, ctx, value.name),
+      };
+    }
+    if (value.type === "RootClaimTypeEnum") {
+      return {
+        name: value.name,
+        type: value.type,
+        value: decodeRootClaimTypeValue(value.value),
       };
     }
     if (!isCollectionType(value.type)) {
@@ -235,7 +400,23 @@ function walk(value, keyHint, nestedCall, topCall) {
     const ss58 = normalizeAccountId32Field(value);
     if (ss58) return ss58;
   }
-  if (nestedCall) {
+  // BTREESET_FIELDS-allowlisted fields (postgres-collection-normalize.mjs)
+  // are excluded from the generic byte-blob heuristic below -- confirmed
+  // live 2026-07-12: a nested SubtensorModule.claim_root's `subnets` (inside
+  // Utility.batch) is shape-identical to a genuine byte blob (a handful of
+  // small integers), and without this exclusion unwrapByteArray/
+  // decodeBytesField would hex-encode it into an opaque, actively WRONG
+  // string (`[1,2,3,4,5]` -> "0x0102030405") before decodeBTreeSetFields
+  // ever gets a chance to correctly unwrap the genuine collection -- this
+  // module runs first in formatExtrinsic's pipeline, so leaving the field
+  // untouched here is the only way that later pass can still see the real
+  // array.
+  const isNestedBTreeSetField =
+    nestedCall &&
+    BTREESET_FIELDS.has(
+      `${nestedCall.call_module}.${nestedCall.call_function}.${keyHint ?? ""}`,
+    );
+  if (nestedCall && !isNestedBTreeSetField) {
     const bytes = unwrapByteArray(value);
     if (bytes && bytes.length > 0) {
       return decodeBytesField(

--- a/src/postgres-collection-normalize.mjs
+++ b/src/postgres-collection-normalize.mjs
@@ -29,7 +29,16 @@
 // exactly what this module then unwraps to [104,71,9]), but running after
 // keeps the two passes' responsibilities cleanly separated: generic
 // Option/enum/scalar shapes first, named-field collection shapes second.
-const BTREESET_FIELDS = new Set(["SubtensorModule.claim_root.subnets"]);
+//
+// Exported (not just used internally) because src/postgres-call-args.mjs's
+// walk() also needs it: confirmed live 2026-07-12, a NESTED claim_root call
+// (inside Utility.batch) has its `subnets` field corrupted from an array
+// into an opaque hex STRING by walk()'s own generic nestedCall byte-blob
+// heuristic -- the exact #4724 collection-vs-blob ambiguity this module's
+// header already describes, except walk() runs BEFORE this module ever gets
+// a chance to unwrap the (by-then-already-destroyed) field. walk() checks
+// this same set to skip that heuristic for an allowlisted field instead.
+export const BTREESET_FIELDS = new Set(["SubtensorModule.claim_root.subnets"]);
 
 function unwrapBTreeSetLayer(value) {
   return Array.isArray(value) && value.length === 1 && Array.isArray(value[0])
@@ -37,21 +46,95 @@ function unwrapBTreeSetLayer(value) {
     : value;
 }
 
+// True for postgres-call-args.mjs's tryReconstructNestedCall output --
+// {call_module, call_function, call_args} -- so walk() below can switch to
+// that nested call's own module/function when descending into its args,
+// the same context-tracking pattern postgres-call-args.mjs's own walk()
+// uses for AccountId32/byte-blob decoding.
+function isReconstructedCall(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof value.call_module === "string" &&
+    typeof value.call_function === "string" &&
+    "call_args" in value
+  );
+}
+
+// True for a typed field descriptor ({name, type, value}) -- the shape
+// EVERY extrinsic's own top-level call_args is genuinely served as
+// (confirmed live 2026-07-12; D1's `[{name,type,value}]` shape was never
+// D1-only -- see src/indexer-rs-ethereum-decode.mjs's header for the same
+// correction). A nested call's own call_args, by contrast, arrives as a
+// flat {fieldName: value} object with no per-field type string (confirmed
+// live: a nested claim_root's call_args is `{"subnets": ...}`, not an array
+// of descriptors) -- walk() below handles both shapes, since the field name
+// that matters for the BTREESET_FIELDS lookup is the descriptor's own
+// `.name` in one case and the plain object key in the other.
+function isTypedFieldDescriptor(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof value.name === "string" &&
+    typeof value.type === "string" &&
+    Object.keys(value).length === 3 &&
+    "value" in value
+  );
+}
+
+function walk(value, call) {
+  if (isReconstructedCall(value)) {
+    return {
+      ...value,
+      call_args: walk(value.call_args, {
+        call_module: value.call_module,
+        call_function: value.call_function,
+      }),
+    };
+  }
+  if (isTypedFieldDescriptor(value)) {
+    let inner = walk(value.value, call);
+    if (
+      call &&
+      BTREESET_FIELDS.has(
+        `${call.call_module}.${call.call_function}.${value.name}`,
+      )
+    ) {
+      inner = unwrapBTreeSetLayer(inner);
+    }
+    return { ...value, value: inner };
+  }
+  if (Array.isArray(value)) return value.map((item) => walk(item, call));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      let processed = walk(val, call);
+      if (
+        call &&
+        BTREESET_FIELDS.has(`${call.call_module}.${call.call_function}.${key}`)
+      ) {
+        processed = unwrapBTreeSetLayer(processed);
+      }
+      out[key] = processed;
+    }
+    return out;
+  }
+  return value;
+}
+
 /** Unwraps BTreeSet-typed fields in callArgs for the small set of
- * (callModule, callFunction, fieldName) triples confirmed to need it. A
+ * (callModule, callFunction, fieldName) triples confirmed to need it, at any
+ * nesting depth (a top-level field, or one inside a reconstructed nested
+ * RuntimeCall -- e.g. Utility.batch wrapping SubtensorModule.claim_root). A
  * no-op (returns callArgs unchanged, or with only the confirmed fields
  * touched) for every other call -- safe to apply unconditionally in
  * formatExtrinsic regardless of which tier produced the row, same contract
  * as normalizePostgresValue (#4690) and decodePostgresCallArgs (#4691). */
 export function decodeBTreeSetFields(callModule, callFunction, callArgs) {
-  if (!callArgs || typeof callArgs !== "object" || Array.isArray(callArgs)) {
-    return callArgs;
-  }
-  const out = { ...callArgs };
-  for (const key of Object.keys(callArgs)) {
-    if (BTREESET_FIELDS.has(`${callModule}.${callFunction}.${key}`)) {
-      out[key] = unwrapBTreeSetLayer(callArgs[key]);
-    }
-  }
-  return out;
+  return walk(callArgs, {
+    call_module: callModule,
+    call_function: callFunction,
+  });
 }

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -239,6 +239,39 @@ test("formatExtrinsic unwraps a single-element BTreeSet (real SubtensorModule.cl
   assert.deepEqual(out.call_args.subnets, [104]);
 });
 
+test("formatExtrinsic correctly unwraps a BTreeSet nested inside Utility.batch, through the FULL real pipeline (real production fixture, block 8604111/11, fixed 2026-07-12)", () => {
+  // Before this fix, a nested claim_root's `subnets` was corrupted into an
+  // opaque hex string ("0x0102030405") by postgres-call-args.mjs's generic
+  // nested-call byte-blob heuristic, running before decodeBTreeSetFields
+  // ever got a chance to see the real array -- confirmed live via direct
+  // Postgres query for this exact block/extrinsic.
+  const callArgsText = JSON.stringify([
+    {
+      name: "calls",
+      type: "Vec<RuntimeCall>",
+      value: [
+        {
+          name: "SubtensorModule",
+          values: [
+            { name: "claim_root", values: { subnets: [[1, 2, 3, 4, 5]] } },
+          ],
+        },
+      ],
+    },
+  ]);
+  const out = formatExtrinsic({
+    block_number: 8604111,
+    extrinsic_index: 11,
+    call_module: "Utility",
+    call_function: "batch",
+    call_args: callArgsText,
+  });
+  const nestedCall = out.call_args[0].value[0];
+  assert.equal(nestedCall.call_module, "SubtensorModule");
+  assert.equal(nestedCall.call_function, "claim_root");
+  assert.deepEqual(nestedCall.call_args.subnets, [1, 2, 3, 4, 5]);
+});
+
 test("formatExtrinsic pins SubtensorModule.register's PoW nonce precision as an accepted, tested invariant (real block 8556317/20, #4693) -- Postgres's exact literal converges on the same value D1 already serves, not a regression to fix here", () => {
   // nonce is a BARE u64 scalar in the real Postgres row (confirmed via
   // direct query -- not newtype-wrapped like most other fields), and

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -626,4 +626,297 @@ describe("decodePostgresCallArgs", () => {
       });
     });
   });
+
+  describe("BTREESET_FIELDS exclusion (fixed 2026-07-12: a nested claim_root's subnets was being corrupted into an opaque hex string)", () => {
+    test("leaves a nested SubtensorModule.claim_root's subnets untouched -- NOT hex-encoded by the generic byte-blob heuristic (real production fixture, block 8604111/11, Utility.batch)", () => {
+      // Real raw shape confirmed via direct Postgres query: the pallet/
+      // function enum-tree BEFORE reconstruction, one level down from
+      // Utility.batch's own `calls` field.
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [
+            { name: "claim_root", values: { subnets: [[1, 2, 3, 4, 5]] } },
+          ],
+        },
+      };
+      const out = decodePostgresCallArgs(raw);
+      // Without the exclusion, unwrapByteArray/decodeBytesField would have
+      // hex-encoded this into "0x0102030405" -- the array must survive
+      // intact so decodeBTreeSetFields (postgres-collection-normalize.mjs)
+      // can still correctly unwrap it afterward.
+      assert.deepEqual(out.call.call_args.subnets, [[1, 2, 3, 4, 5]]);
+    });
+
+    test("still hex-encodes a genuine byte-blob field with a different name inside the SAME nested call (the exclusion is scoped to the exact allowlisted field, not the whole call)", () => {
+      const raw = {
+        call: {
+          name: "SubtensorModule",
+          values: [
+            {
+              name: "claim_root",
+              values: {
+                subnets: [[1, 2, 3, 4, 5]],
+                some_other_blob: [6, 7, 8],
+              },
+            },
+          ],
+        },
+      };
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out.call.call_args.subnets, [[1, 2, 3, 4, 5]]);
+      assert.equal(out.call.call_args.some_other_blob, "0x060708");
+    });
+
+    test("still hex-encodes a same-named field on a DIFFERENT nested call type -- scoped to (call_module, call_function, field), not field name alone", () => {
+      const raw = {
+        call: {
+          name: "SomeOtherModule",
+          values: [{ name: "some_function", values: { subnets: [1, 2, 3] } }],
+        },
+      };
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out.call.call_args.subnets, "0x010203");
+    });
+  });
+
+  describe("Vec<u8>/BoundedVec<u8> byte-blob-typed collections (fixed 2026-07-12: MevShield's ciphertext/enc_key were never hex-decoded, miscategorized as a generic collection)", () => {
+    test("hex-encodes a bare BoundedVec<u8,_> field (real MevShield.submit_encrypted.ciphertext, block 8543969/7)", () => {
+      const raw = [
+        {
+          name: "ciphertext",
+          type: "BoundedVec<u8, _>",
+          value: [[88, 203, 173, 120, 143]],
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out[0].value, "0x58cbad788f");
+    });
+
+    test("hex-encodes an Option<BoundedVec<u8,_>>::Some field (real MevShield.announce_next_key.enc_key, block 8543971/1)", () => {
+      const raw = [
+        {
+          name: "enc_key",
+          type: "Option<BoundedVec<u8, _>>",
+          value: { name: "Some", values: [[[32, 103, 199, 46, 69]]] },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out[0].value, "0x2067c72e45");
+    });
+
+    test("decodes an Option<BoundedVec<u8,_>>::None field to null", () => {
+      const raw = [
+        {
+          name: "enc_key",
+          type: "Option<BoundedVec<u8, _>>",
+          value: { name: "None", values: [] },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out[0].value, null);
+    });
+
+    test("leaves a genuine (non-u8) collection type untouched, still deferred to the generic array-recurse below", () => {
+      const raw = [
+        { name: "signers", type: "Vec<AccountId32>", value: [1, 2, 3] },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out[0].value, [1, 2, 3]);
+    });
+
+    test("is a no-op when the value matches neither the bare-array nor the Option-wrapped shape (malformed/defensive case)", () => {
+      const raw = [
+        { name: "ciphertext", type: "BoundedVec<u8, _>", value: 42 },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out[0].value, 42);
+    });
+
+    test("is a no-op on a Some-wrapped value whose payload isn't a byte array (malformed/defensive case)", () => {
+      const raw = [
+        {
+          name: "enc_key",
+          type: "Option<BoundedVec<u8, _>>",
+          value: { name: "Some", values: [{ not: "bytes" }] },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out[0].value, {
+        name: "Some",
+        values: [{ not: "bytes" }],
+      });
+    });
+
+    test("is a no-op on a malformed Some variant carrying more than one value (defensive case)", () => {
+      const raw = [
+        {
+          name: "enc_key",
+          type: "Option<BoundedVec<u8, _>>",
+          value: {
+            name: "Some",
+            values: [
+              [1, 2],
+              [3, 4],
+            ],
+          },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out[0].value, {
+        name: "Some",
+        values: [
+          [1, 2],
+          [3, 4],
+        ],
+      });
+    });
+  });
+
+  describe("LimitOrders signer/fee_recipient (fixed 2026-07-12: ACCOUNT_KEYS was missing these two)", () => {
+    test("decodes signer and fee_recipient to SS58 inside a nested order struct (real production fixture, block 8587347/16)", () => {
+      const signerBytes = new Array(32).fill(3);
+      const raw = {
+        orders: [
+          [
+            {
+              order: {
+                name: "V1",
+                values: [
+                  {
+                    signer: [signerBytes],
+                    fee_recipient: [signerBytes],
+                    hotkey: [new Array(32).fill(4)],
+                  },
+                ],
+              },
+            },
+          ],
+        ],
+      };
+      const out = decodePostgresCallArgs(raw);
+      const decoded = out.orders[0][0].order.values[0];
+      assert.equal(typeof decoded.signer, "string");
+      assert.ok(decoded.signer.startsWith("5"));
+      assert.equal(decoded.signer, decoded.fee_recipient);
+      assert.notEqual(decoded.signer, decoded.hotkey);
+    });
+  });
+
+  describe("RawN identity-data variant family (fixed 2026-07-12: Commitments.set_commitment's info.fields[].RawN never decoded, nestedCall-gated heuristic never fires for a non-call struct field)", () => {
+    test("UTF-8-decodes a Raw20 payload (real production fixture, block 8604175/9)", () => {
+      const raw = [
+        { name: "netuid", type: "u16", value: 89 },
+        {
+          name: "info",
+          type: "CommitmentInfo<_>",
+          value: {
+            fields: [
+              [
+                {
+                  name: "Raw20",
+                  values: [
+                    [
+                      50, 59, 98, 59, 66, 84, 67, 44, 49, 46, 48, 49, 61, 48,
+                      46, 49, 48, 52, 58, 49,
+                    ],
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out[1].value.fields[0][0], {
+        Raw20: "2;b;BTC,1.01=0.104:1",
+      });
+    });
+
+    test("falls back to hex for malformed UTF-8 in a RawN payload", () => {
+      const raw = { name: "Raw2", values: [[0xff, 0xfe]] };
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out, { Raw2: "0xfffe" });
+    });
+
+    test("is a no-op for a RawN-shaped node whose payload isn't a byte array", () => {
+      const raw = { name: "Raw2", values: [{ not: "bytes" }] };
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out, raw);
+    });
+
+    test("does not misfire on an unrelated 2-key {name,values} node whose name doesn't match RawN", () => {
+      const raw = { name: "NotRaw", values: [[1, 2]] };
+      const out = decodePostgresCallArgs(raw);
+      // NotRaw isn't RawN, so this falls through to the generic recursive
+      // walk instead -- the byte array is untouched since there's no
+      // nestedCall/typed-descriptor context here to trigger a byte-decode.
+      assert.deepEqual(out, { name: "NotRaw", values: [[1, 2]] });
+    });
+  });
+
+  describe("SubtensorModule.set_root_claim_type's struct-variant enum (fixed 2026-07-12: subnets kept an extra BTreeSet newtype-wrap layer)", () => {
+    test("unwraps the extra layer on RootClaimTypeEnum::KeepSubnets.subnets (real production fixture)", () => {
+      const raw = [
+        {
+          name: "new_root_claim_type",
+          type: "RootClaimTypeEnum",
+          value: { name: "KeepSubnets", values: { subnets: [[82, 97]] } },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.deepEqual(out[0].value, {
+        name: "KeepSubnets",
+        values: { subnets: [82, 97] },
+      });
+    });
+
+    test("leaves a sibling field on the same struct-variant untouched", () => {
+      const raw = [
+        {
+          name: "new_root_claim_type",
+          type: "RootClaimTypeEnum",
+          value: {
+            name: "KeepSubnets",
+            values: { subnets: [[82, 97]], note: "unrelated" },
+          },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out[0].value.values.note, "unrelated");
+    });
+
+    test("is a no-op when subnets is already unwrapped or absent", () => {
+      const alreadyUnwrapped = [
+        {
+          name: "new_root_claim_type",
+          type: "RootClaimTypeEnum",
+          value: { name: "KeepSubnets", values: { subnets: [82, 97] } },
+        },
+      ];
+      assert.deepEqual(
+        decodePostgresCallArgs(alreadyUnwrapped)[0].value.values.subnets,
+        [82, 97],
+      );
+      const noSubnets = [
+        {
+          name: "new_root_claim_type",
+          type: "RootClaimTypeEnum",
+          value: { name: "Unrestricted", values: {} },
+        },
+      ];
+      assert.deepEqual(decodePostgresCallArgs(noSubnets)[0].value, {
+        name: "Unrestricted",
+        values: {},
+      });
+    });
+
+    test("is a no-op on a non-struct-variant value for this type (defensive)", () => {
+      const raw = [
+        { name: "new_root_claim_type", type: "RootClaimTypeEnum", value: 42 },
+      ];
+      const out = decodePostgresCallArgs(raw);
+      assert.equal(out[0].value, 42);
+    });
+  });
 });

--- a/tests/postgres-collection-normalize.test.mjs
+++ b/tests/postgres-collection-normalize.test.mjs
@@ -53,14 +53,72 @@ describe("decodeBTreeSetFields", () => {
     assert.deepEqual(out.other_field, [[104, 71]]);
   });
 
-  test("is a no-op on D1's own call_args shape (an array of {name,type,value} descriptors, not an object)", () => {
-    const d1Shape = [
+  test("is a no-op on an already-correctly-shaped typed-descriptor array (the real top-level call_args shape, confirmed live 2026-07-12)", () => {
+    const descriptorShape = [
       { name: "subnets", type: "BTreeSet<NetUid>", value: [104, 71] },
     ];
     assert.deepEqual(
-      decodeBTreeSetFields("SubtensorModule", "claim_root", d1Shape),
-      d1Shape,
+      decodeBTreeSetFields("SubtensorModule", "claim_root", descriptorShape),
+      descriptorShape,
     );
+  });
+
+  test("unwraps a still-double-wrapped typed-descriptor value (real top-level call_args shape, block 8604385/23)", () => {
+    // Unlike normalizePostgresValue's OWN typed-descriptor handling (which
+    // already strips this layer when it can see the sibling `type` string),
+    // this proves decodeBTreeSetFields' independent unwrap also does the
+    // right thing if it ever received the raw, still-wrapped shape directly
+    // (e.g. if called without normalizePostgresValue having run first).
+    const descriptorShape = [
+      { name: "subnets", type: "BTreeSet<u16>", value: [[84]] },
+    ];
+    const out = decodeBTreeSetFields(
+      "SubtensorModule",
+      "claim_root",
+      descriptorShape,
+    );
+    assert.deepEqual(out[0].value, [84]);
+  });
+
+  test("unwraps a BTreeSet field nested inside a Utility.batch-wrapped call (real production fixture, block 8604111/11)", () => {
+    // The raw shape indexer-rs actually serves for a nested claim_root call
+    // -- confirmed live via direct Postgres query -- is the pallet/function
+    // enum-tree BEFORE reconstruction: {name:"SubtensorModule",
+    // values:[{name:"claim_root", values:{subnets:[[1,2,3,4,5]]}}]}, one
+    // level down from Utility.batch's own `calls` typed descriptor. This
+    // test starts from the shape AFTER decodePostgresCallArgs has already
+    // reconstructed that into {call_module,call_function,call_args} --
+    // src/postgres-call-args.test.mjs and tests/extrinsics.test.mjs cover
+    // the reconstruction step (and its own BTREESET_FIELDS exclusion fix)
+    // itself; this test is scoped to decodeBTreeSetFields' own recursive
+    // unwrap.
+    const reconstructed = [
+      {
+        name: "calls",
+        type: "Vec<RuntimeCall>",
+        value: [
+          {
+            call_module: "SubtensorModule",
+            call_function: "claim_root",
+            call_args: { subnets: [[1, 2, 3, 4, 5]] },
+          },
+        ],
+      },
+    ];
+    const out = decode("Utility", "batch", reconstructed);
+    assert.deepEqual(out[0].value[0].call_args.subnets, [1, 2, 3, 4, 5]);
+  });
+
+  test("leaves a non-allowlisted field inside a nested call untouched", () => {
+    const reconstructed = [
+      {
+        call_module: "SubtensorModule",
+        call_function: "add_stake",
+        call_args: { amount: [[1, 2, 3]] },
+      },
+    ];
+    const out = decode("Utility", "batch", reconstructed);
+    assert.deepEqual(out[0].call_args.amount, [[1, 2, 3]]);
   });
 
   test("is a no-op on null/undefined/scalar call_args", () => {


### PR DESCRIPTION
## Summary
Most severe first: a nested `SubtensorModule.claim_root` call (inside `Utility.batch`) had its `subnets` field corrupted from an array into an opaque hex string — **actively wrong data**, not just undecoded. `postgres-call-args.mjs`'s generic nested-call byte-blob heuristic ran before `decodeBTreeSetFields` ever got a chance to see the real array. Fixed by excluding `BTREESET_FIELDS`-allowlisted fields from that heuristic, and rewriting `decodeBTreeSetFields` to recurse into reconstructed nested calls using each one's own module/function context.

Four more, independently-rooted gaps from the same sweep:
- `MevShield.submit_encrypted`/`announce_next_key`: `"BoundedVec<u8, _>"`/`"Option<BoundedVec<u8, _>>"` matched `isCollectionType`'s broad regex (correctly, for genuine typed collections) but are semantically byte blobs — `isByteBlobCollectionType`/`decodeByteBlobTypedValue` narrows that case.
- `LimitOrders.execute_batched_orders`' `signer`/`fee_recipient`: confirmed AccountId32 fields missing from `ACCOUNT_KEYS`.
- `Commitments.set_commitment`'s `info.fields[].RawN`: never decoded — the byte-blob heuristic is gated behind `nestedCall` (a *separate reconstructed call*), but `RawN` here is merely deeply nested within `set_commitment`'s own struct fields. `isRawDataVariant`/`decodeRawDataValue` check the tag name directly, unconditionally.
- `SubtensorModule.set_root_claim_type`: a STRUCT-variant enum (`values` an object, not an array) that `isEnumTreeNode` correctly never recognizes as an enum-tree node — `subnets` kept an extra newtype-wrap layer with nothing to unwrap it. `decodeRootClaimTypeValue` is narrowly scoped to this one confirmed type string.

Closes #4936

Continuation of the live chain-data decode audit that produced #4916, #4918, #4920, #4927, #4930, and #4932/#4933.

## Test plan
- [x] `tests/postgres-call-args.test.mjs`: 45/45 passing (16 new)
- [x] `tests/postgres-collection-normalize.test.mjs`: 11/11 passing (5 new)
- [x] `tests/extrinsics.test.mjs`: 59/59 passing (1 new full-pipeline integration test)
- [x] Full suite passing locally (255 files / 7565 tests)
- [x] `npm run lint` / `format:check` clean on the final diff
- [x] 100% statement/branch/line coverage on both touched source files
- [ ] Live-verify against production after merge