### PR TITLE
fix(data-api): decode Ethereum.transact's Legacy variant gas_price

### DIFF
--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -110,7 +110,7 @@ export function decodeH160Bytes(value) {
 
 // A 32-byte hash-like value (Ethereum's ECDSA signature r/s components) --
 // same generic byte-blob-to-hex treatment, just gated on length 32 instead
-// of 20. Not exported: only meaningful composed inside decodeEip1559Payload
+// of 20. Not exported: only meaningful composed inside decodeEthereumTransactionPayload
 // below, unlike decodeH160Bytes which Requirement 3 names as its own
 // reusable unit.
 function decodeHash32Bytes(value) {
@@ -133,17 +133,27 @@ const U256_FIELDS = [
   "gas_limit",
   "max_fee_per_gas",
   "max_priority_fee_per_gas",
+  // Added 2026-07-12, found live-verifying #4933: TransactionV3::Legacy
+  // (confirmed live alongside EIP1559 -- both are the only two variants
+  // observed so far) uses a single `gas_price` U256 instead of the dual
+  // max_fee_per_gas/max_priority_fee_per_gas fee-market fields -- it stayed
+  // raw because it wasn't in this list, the same shape gap as every other
+  // field here, just missed because the initial fix's fixture happened to
+  // be an EIP1559 transaction.
+  "gas_price",
 ];
 
-// Ethereum.transact's `transaction` field's inner EIP1559 struct: the 5 U256
-// fields above, `action` (a nested TransactionAction::Call tuple-variant
+// Ethereum.transact's `transaction` field's inner payload struct (shared by
+// every TransactionV3 variant -- EIP1559 and Legacy confirmed live): the
+// U256 fields above, `action` (a nested TransactionAction::Call tuple-variant
 // wrapping an H160), and `signature.r`/`signature.s` (32-byte hash-like
-// values, NOT wrapped in an enum -- EIP1559's own ECDSA signature is a plain
-// struct, unrelated to the Signature::Sr25519 enum family below).
-// `chain_id`/`odd_y_parity`/`access_list` need no decode (already plain
-// scalars/empty arrays either tier). `input` is deliberately left untouched
-// -- its own mojibake bug is D1's, out of scope here (bytes.mjs's own header).
-function decodeEip1559Payload(payload) {
+// values, NOT wrapped in an enum -- the ECDSA signature is a plain struct,
+// unrelated to the Signature::Sr25519 enum family below). `chain_id`/
+// `odd_y_parity`/`access_list`/Legacy's `signature.v` need no decode
+// (already plain scalars/empty arrays either tier). `input` is deliberately
+// left untouched -- its own mojibake bug is D1's, out of scope here
+// (bytes.mjs's own header).
+function decodeEthereumTransactionPayload(payload) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return payload;
   }
@@ -221,7 +231,7 @@ export function decodeEthereumTransactArgs(callArgs) {
   return withCallArg(
     callArgs,
     "transaction",
-    decodeTupleVariantEnum(tx, decodeEip1559Payload),
+    decodeTupleVariantEnum(tx, decodeEthereumTransactionPayload),
   );
 }
 

--- a/tests/indexer-rs-ethereum-decode.test.mjs
+++ b/tests/indexer-rs-ethereum-decode.test.mjs
@@ -206,6 +206,64 @@ describe("decodeEthereumTransactArgs (real production fixture, block 8587453/9)"
     });
   });
 
+  test("decodes a Legacy transaction's gas_price (real production fixture, block 8604625/17, fixed 2026-07-12)", () => {
+    // Found live while verifying #4933: TransactionV3::Legacy uses a single
+    // gas_price U256 instead of EIP1559's dual max_fee_per_gas/
+    // max_priority_fee_per_gas fee-market fields -- U256_FIELDS didn't list
+    // it, so it stayed a raw 4-limb array while every other field decoded
+    // correctly.
+    const legacyRaw = {
+      transaction: {
+        name: "Legacy",
+        values: [
+          {
+            input: [172, 30, 93, 191],
+            nonce: [[1555, 0, 0, 0]],
+            value: [[0, 0, 0, 0]],
+            action: {
+              name: "Call",
+              values: [
+                [
+                  [
+                    45, 121, 248, 109, 83, 187, 141, 203, 154, 206, 22, 32, 10,
+                    219, 1, 78, 247, 227, 135, 61,
+                  ],
+                ],
+              ],
+            },
+            gas_limit: [[150000, 0, 0, 0]],
+            gas_price: [[10000000000, 0, 0, 0]],
+            signature: {
+              r: [
+                [
+                  179, 97, 128, 16, 14, 209, 76, 209, 215, 88, 24, 117, 168,
+                  130, 228, 240, 229, 86, 14, 29, 46, 159, 224, 129, 224, 52,
+                  248, 68, 179, 224, 104, 131,
+                ],
+              ],
+              s: [
+                [
+                  112, 178, 135, 59, 14, 137, 89, 93, 207, 134, 232, 100, 105,
+                  242, 238, 120, 85, 182, 108, 100, 7, 46, 79, 120, 5, 229, 105,
+                  144, 92, 91, 166, 198,
+                ],
+              ],
+              v: 1963,
+            },
+          },
+        ],
+      },
+    };
+    const out = decode("Ethereum", "transact", legacyRaw);
+    assert.equal(out.transaction.Legacy.gas_price, "10000000000");
+    assert.equal(out.transaction.Legacy.nonce, "1555");
+    assert.equal(
+      out.transaction.Legacy.action.Call,
+      "0x2d79f86d53bb8dcb9ace16200adb014ef7e3873d",
+    );
+    assert.equal(out.transaction.Legacy.signature.v, 1963);
+  });
+
   test("decodes the real production call_args shape -- an array of {name,type,value} descriptors, confirmed live 2026-07-12 (block 8604176/7)", () => {
     // This is what genuine indexer-rs/Postgres output actually looks like for
     // EVERY extrinsic (D1 is fully retired, #4772) -- decodeEthereumTransactArgs


### PR DESCRIPTION
## Summary
- `TransactionV3::Legacy` (confirmed live alongside `EIP1559` — the only two variants observed so far) uses a single `gas_price` U256 field instead of EIP1559's dual `max_fee_per_gas`/`max_priority_fee_per_gas`. `U256_FIELDS` didn't list it, so it stayed a raw 4-limb array while every other field on the same transaction decoded correctly.
- Renames `decodeEip1559Payload` → `decodeEthereumTransactionPayload` (its only two references) since it's shared by every `TransactionV3` variant — naming cleanup, no behavior change.

Closes #4939

Continuation of the live chain-data decode audit; found while live-verifying #4933 against production after merge.

## Test plan
- [x] `tests/indexer-rs-ethereum-decode.test.mjs`: 33/33 passing (1 new, real production `Legacy` fixture, block 8604625/17)
- [x] Full suite passing locally (256 files / 7545 tests)
- [x] `npm run lint` / `format:check` clean on the final diff
- [x] 100% statement/branch/line coverage on `src/indexer-rs-ethereum-decode.mjs`
- [x] Live-verified the underlying gap against production before writing the fix (block 8604625/17)
- [ ] Live-verify the fix itself after merge