### PR TITLE
fix(mcp): wire identity-history MCP tools through the Postgres tier

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -979,6 +979,38 @@ function mcpExtrinsicDetailRequest(ref) {
   return new Request(`https://d/api/v1/extrinsics/${encodeURIComponent(ref)}`);
 }
 
+// Synthetic GET /api/v1/subnets/{netuid}/identity-history{...} request,
+// forwarded UNCHANGED to DATA_API via tryPostgresTier -- mirrors REST's
+// handleSubnetIdentityHistory, which parses the identical limit/offset/cursor
+// query-string shape (workers/data-api.mjs's subnetIdentityHistory route),
+// same METAGRAPH_SUBNET_IDENTITY_SOURCE flag, so get_subnet_identity_history
+// and GET /api/v1/subnets/{netuid}/identity-history never diverge on which
+// tier answered.
+function mcpSubnetIdentityHistoryRequest(netuid, { limit, offset, cursor }) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
+  if (cursor) params.set("cursor", cursor);
+  const qs = params.toString();
+  return new Request(
+    `https://d/api/v1/subnets/${encodeURIComponent(netuid)}/identity-history${qs ? `?${qs}` : ""}`,
+  );
+}
+
+// Synthetic GET /api/v1/chain/identity-history{...} request, same contract as
+// mcpSubnetIdentityHistoryRequest above but for the network-wide feed --
+// mirrors REST's handleChainIdentityHistory (also gated on
+// METAGRAPH_SUBNET_IDENTITY_SOURCE, the one flag covering both the per-subnet
+// and network-wide subnet_identity_history reads).
+function mcpChainIdentityHistoryRequest({ limit }) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  const qs = params.toString();
+  return new Request(
+    `https://d/api/v1/chain/identity-history${qs ? `?${qs}` : ""}`,
+  );
+}
+
 // One subnet's economics: live KV tier (KV-primary), else the committed R2
 // snapshot — the precedence /api/v1/economics uses. A missing row → economics:null.
 async function loadSubnetEconomics(ctx, netuid) {
@@ -1182,16 +1214,28 @@ async function loadSubnetHistory(ctx, netuid, { label, days }) {
   return buildSubnetHistory(rows, netuid, { window: label });
 }
 
+// Mirrors REST's handleSubnetIdentityHistory: try Postgres first, fall back
+// to D1 on any failure -- same tryPostgresTier contract, same
+// METAGRAPH_SUBNET_IDENTITY_SOURCE flag as the REST route (#4832), so this
+// tool and GET /api/v1/subnets/{netuid}/identity-history never diverge on
+// which tier answered.
 async function loadSubnetIdentityHistoryTool(
   ctx,
   netuid,
   { limit, offset, cursor },
 ) {
-  return loadSubnetIdentityHistory(mcpD1Runner(ctx), netuid, {
-    limit,
-    offset,
-    cursor,
-  });
+  return (
+    (await tryPostgresTier(
+      ctx.env,
+      mcpSubnetIdentityHistoryRequest(netuid, { limit, offset, cursor }),
+      "METAGRAPH_SUBNET_IDENTITY_SOURCE",
+    )) ??
+    (await loadSubnetIdentityHistory(mcpD1Runner(ctx), netuid, {
+      limit,
+      offset,
+      cursor,
+    }))
+  );
 }
 
 // One UID's per-day time series — mirrors handleNeuronHistory: neuron_daily rows
@@ -2542,9 +2586,21 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(args, ctx) {
-      return loadChainIdentityHistory(mcpD1Runner(ctx), {
-        limit: args?.limit,
-      });
+      // Mirrors REST's handleChainIdentityHistory: try Postgres first, fall
+      // back to D1 on any failure -- same tryPostgresTier contract, same
+      // METAGRAPH_SUBNET_IDENTITY_SOURCE flag as the REST route (#4832), so
+      // this tool and GET /api/v1/chain/identity-history never diverge on
+      // which tier answered.
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpChainIdentityHistoryRequest({ limit: args?.limit }),
+          "METAGRAPH_SUBNET_IDENTITY_SOURCE",
+        )) ??
+        (await loadChainIdentityHistory(mcpD1Runner(ctx), {
+          limit: args?.limit,
+        }))
+      );
     },
   },
   {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -9081,6 +9081,149 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.changes[1].netuid, 7);
   });
 
+  // #4832 gap-closure: get_chain_identity_history mirrors REST's
+  // handleChainIdentityHistory tier-selection exactly (same
+  // METAGRAPH_SUBNET_IDENTITY_SOURCE flag, same tryPostgresTier fallback
+  // contract) -- see the equivalent "flag=postgres" tests for
+  // handleSubnetIdentityHistory in tests/request-handlers-entities.test.mjs.
+  describe("get_chain_identity_history D1 -> Postgres serving cutover", () => {
+    function identityHistoryD1(rows, capture = []) {
+      return {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                all() {
+                  if (sql.includes("FROM subnet_identity_history")) {
+                    return Promise.resolve({ results: rows });
+                  }
+                  return Promise.resolve({ results: [] });
+                },
+              };
+            },
+          };
+        },
+      };
+    }
+    const ALPHA_ROW = {
+      id: 1,
+      netuid: 7,
+      block_number: 100,
+      observed_at: 1_600_000_000_000,
+      subnet_name: "Alpha",
+      symbol: "α",
+      description: null,
+      github_repo: null,
+      subnet_url: null,
+      discord: null,
+      logo_url: null,
+      identity_hash: "h1",
+    };
+
+    test("flag=postgres uses Postgres data, D1 never queried", async () => {
+      const capture = [];
+      const env = {
+        METAGRAPH_HEALTH_DB: identityHistoryD1([], capture),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async () =>
+            Response.json({
+              schema_version: 1,
+              count: 1,
+              subnet_count: 1,
+              changes: [{ netuid: 99, subnet_name: "pg-only" }],
+            }),
+        },
+      };
+      const res = await callTool("get_chain_identity_history", {}, { env });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.changes[0].subnet_name, "pg-only");
+      assert.deepEqual(capture, []);
+    });
+
+    test("flag=postgres falls back to D1 on failure", async () => {
+      const capture = [];
+      const env = {
+        METAGRAPH_HEALTH_DB: identityHistoryD1([ALPHA_ROW], capture),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async () => {
+            throw new Error("boom");
+          },
+        },
+      };
+      const res = await callTool("get_chain_identity_history", {}, { env });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.changes[0].subnet_name, "Alpha");
+      assert.ok(capture.length > 0, "D1 must actually be queried on fallback");
+    });
+
+    test("flag absent uses D1 even when DATA_API is bound (zero regression, unflipped)", async () => {
+      const capture = [];
+      const env = {
+        METAGRAPH_HEALTH_DB: identityHistoryD1([ALPHA_ROW], capture),
+        DATA_API: {
+          fetch: async () =>
+            Response.json({
+              schema_version: 1,
+              count: 0,
+              subnet_count: 0,
+              changes: [],
+            }),
+        },
+      };
+      const res = await callTool("get_chain_identity_history", {}, { env });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.changes[0].subnet_name, "Alpha");
+      assert.ok(capture.length > 0, "D1 must actually be queried");
+    });
+
+    test("flag=postgres forwards limit as a REST-equivalent query param", async () => {
+      let seenUrl;
+      const env = {
+        METAGRAPH_HEALTH_DB: identityHistoryD1([]),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (request) => {
+            seenUrl = new URL(request.url);
+            return Response.json({
+              schema_version: 1,
+              count: 0,
+              subnet_count: 0,
+              changes: [],
+            });
+          },
+        },
+      };
+      await callTool("get_chain_identity_history", { limit: 25 }, { env });
+      assert.equal(seenUrl.pathname, "/api/v1/chain/identity-history");
+      assert.equal(seenUrl.searchParams.get("limit"), "25");
+    });
+
+    test("flag=postgres omits the limit param when not supplied", async () => {
+      let seenUrl;
+      const env = {
+        METAGRAPH_HEALTH_DB: identityHistoryD1([]),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (request) => {
+            seenUrl = new URL(request.url);
+            return Response.json({
+              schema_version: 1,
+              count: 0,
+              subnet_count: 0,
+              changes: [],
+            });
+          },
+        },
+      };
+      await callTool("get_chain_identity_history", {}, { env });
+      assert.equal(seenUrl.pathname, "/api/v1/chain/identity-history");
+      assert.equal(seenUrl.searchParams.has("limit"), false);
+    });
+  });
+
   test("get_chain_yield returns schema-stable null blocks on cold D1", async () => {
     const res = await callTool("get_chain_yield", {});
     const out = res.body.result.structuredContent;
@@ -13524,6 +13667,153 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     assert.equal(out.entry_count, 1);
     assert.equal(out.entries[0].subnet_name, "MIAO");
     assert.equal(out.limit, 10);
+  });
+
+  // #4832 gap-closure: get_subnet_identity_history mirrors REST's
+  // handleSubnetIdentityHistory tier-selection exactly (same
+  // METAGRAPH_SUBNET_IDENTITY_SOURCE flag, same tryPostgresTier fallback
+  // contract) -- see the equivalent "flag=postgres" tests for
+  // handleSubnetIdentityHistory in tests/request-handlers-entities.test.mjs,
+  // which this block mirrors. Also mirrors list_extrinsics/get_extrinsic's own
+  // "D1 -> Postgres serving cutover (#4694)" block in the block-explorer
+  // describe above.
+  describe("get_subnet_identity_history D1 -> Postgres serving cutover", () => {
+    const MIAO_ROW = {
+      id: 2,
+      block_number: 100,
+      observed_at: 1_700_000_000_000,
+      subnet_name: "MIAO",
+      symbol: "α",
+      description: "sound AI",
+      github_repo: null,
+      subnet_url: null,
+      discord: null,
+      logo_url: null,
+      identity_hash: "hash-1",
+    };
+
+    test("flag=postgres uses Postgres data, D1 never queried", async () => {
+      const capture = [];
+      const env = {
+        ...parityD1({ identityHistory: [] }, capture),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async () =>
+            Response.json({
+              schema_version: 1,
+              netuid: 86,
+              entry_count: 1,
+              limit: null,
+              offset: null,
+              next_cursor: null,
+              entries: [{ identity_hash: "pg-hash" }],
+            }),
+        },
+      };
+      const res = await callTool(
+        "get_subnet_identity_history",
+        { netuid: 86 },
+        { env },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.entries[0].identity_hash, "pg-hash");
+      assert.deepEqual(capture, []);
+    });
+
+    test("flag=postgres falls back to D1 on failure", async () => {
+      const env = {
+        ...parityD1({ identityHistory: [MIAO_ROW] }),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async () => {
+            throw new Error("boom");
+          },
+        },
+      };
+      const res = await callTool(
+        "get_subnet_identity_history",
+        { netuid: 86 },
+        { env },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.entries[0].identity_hash, "hash-1");
+    });
+
+    test("flag absent uses D1 even when DATA_API is bound (zero regression, unflipped)", async () => {
+      const capture = [];
+      const env = {
+        ...parityD1({ identityHistory: [MIAO_ROW] }, capture),
+        DATA_API: {
+          fetch: async () =>
+            Response.json({
+              schema_version: 1,
+              netuid: 86,
+              entry_count: 0,
+              entries: [],
+            }),
+        },
+      };
+      const res = await callTool(
+        "get_subnet_identity_history",
+        { netuid: 86 },
+        { env },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.entries[0].identity_hash, "hash-1");
+      assert.ok(capture.length > 0, "D1 must actually be queried");
+    });
+
+    test("flag=postgres forwards netuid + limit/offset/cursor as a REST-equivalent request", async () => {
+      let seenUrl;
+      const env = {
+        ...parityD1({ identityHistory: [] }),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (request) => {
+            seenUrl = new URL(request.url);
+            return Response.json({
+              schema_version: 1,
+              netuid: 86,
+              entry_count: 0,
+              entries: [],
+            });
+          },
+        },
+      };
+      await callTool(
+        "get_subnet_identity_history",
+        { netuid: 86, limit: 10, offset: 5, cursor: "abc" },
+        { env },
+      );
+      assert.equal(seenUrl.pathname, "/api/v1/subnets/86/identity-history");
+      assert.equal(seenUrl.searchParams.get("limit"), "10");
+      assert.equal(seenUrl.searchParams.get("offset"), "5");
+      assert.equal(seenUrl.searchParams.get("cursor"), "abc");
+    });
+
+    test("flag=postgres omits pagination params when not supplied", async () => {
+      let seenUrl;
+      const env = {
+        ...parityD1({ identityHistory: [] }),
+        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (request) => {
+            seenUrl = new URL(request.url);
+            return Response.json({
+              schema_version: 1,
+              netuid: 86,
+              entry_count: 0,
+              entries: [],
+            });
+          },
+        },
+      };
+      await callTool("get_subnet_identity_history", { netuid: 86 }, { env });
+      assert.equal(seenUrl.pathname, "/api/v1/subnets/86/identity-history");
+      assert.equal(seenUrl.searchParams.has("limit"), false);
+      assert.equal(seenUrl.searchParams.has("offset"), false);
+      assert.equal(seenUrl.searchParams.has("cursor"), false);
+    });
   });
 
   test("get_neuron_history returns one UID's per-day series", async () => {


### PR DESCRIPTION
## Summary

`get_subnet_identity_history` and `get_chain_identity_history` in
`src/mcp-server.mjs` read D1 directly via `mcpD1Runner(ctx)`, completely
unguarded by `tryPostgresTier` -- unlike the sibling `get_extrinsics`/
`get_extrinsic` MCP tools in the same file, and unlike their own REST
mirrors (`handleSubnetIdentityHistory`/`handleChainIdentityHistory` in
`workers/request-handlers/entities.mjs`), which already try Postgres first
via `tryPostgresTier(env, request, "METAGRAPH_SUBNET_IDENTITY_SOURCE")`.

**This was a live divergence, not just a future risk.**
`METAGRAPH_SUBNET_IDENTITY_SOURCE` is already `"postgres"` in
`wrangler.jsonc`, so REST is Postgres-served today while these two MCP tools
were silently still reading D1. Confirmed live before this fix, both
querying netuid 1's identity history:

- REST `GET /api/v1/subnets/1/identity-history` (Postgres): `block_number:
  8596770`, `observed_at: "2026-07-11T08:04:07.388Z"`
- MCP `get_subnet_identity_history` (D1, pre-fix): `block_number: null`,
  `observed_at: "2026-07-11T18:00:52.378Z"`

Same identity row, different tier, different (and staler/incomplete) data
returned to an agent calling the tool vs. calling the REST endpoint.

## What changed

- `src/mcp-server.mjs`: added `mcpSubnetIdentityHistoryRequest(netuid,
  {limit, offset, cursor})` and `mcpChainIdentityHistoryRequest({limit})`,
  synthetic-`Request` builders following the exact pattern
  `mcpExtrinsicsListRequest`/`mcpExtrinsicDetailRequest` already use for
  `get_extrinsics`/`get_extrinsic`. `loadSubnetIdentityHistoryTool` and the
  `get_chain_identity_history` handler now call `tryPostgresTier(ctx.env,
  <synthetic request>, "METAGRAPH_SUBNET_IDENTITY_SOURCE")` first, falling
  back to the existing `loadSubnetIdentityHistory`/`loadChainIdentityHistory`
  D1 path on any failure -- the same `?? d1Fallback()` contract, the same
  flag the REST routes use, so these two tools and their REST mirrors can
  never diverge on which tier answered again.
- `tests/mcp-server.test.mjs`: added a `D1 -> Postgres serving cutover`
  describe block for each tool (mirroring the existing one for
  `list_extrinsics`/`get_extrinsic`), covering: Postgres success (D1 never
  queried), Postgres failure (falls back to D1), flag absent (D1 used even
  with `DATA_API` bound -- zero regression while unflipped), and the
  synthetic request's path/query-param shape (netuid in the path,
  limit/offset/cursor forwarded for the per-subnet tool, limit for the
  network-wide feed).

No schema/contract changes, so no regeneration was needed.

## Test plan

- [x] `npx vitest run` (full repo, after `npm run build`) -- 256 files /
      7563 tests pass
- [x] New regression tests: 13 new tests across the two `D1 -> Postgres
      serving cutover` describe blocks, all passing
- [x] `npx vitest run tests/mcp-server.test.mjs --coverage
      --coverage.include=src/mcp-server.mjs` -- every changed line/branch in
      this diff is covered; all uncovered lines in the report are
      pre-existing and outside this diff
- [x] `npm run lint` -- clean
- [x] `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs` --
      clean
- [x] `npm run validate` -- clean
- [x] `git diff --check` -- clean
- [x] Live-verified the pre-fix divergence against the deployed MCP server
      (`https://api.metagraph.sh/mcp`, `get_subnet_identity_history`/
      `get_chain_identity_history`) vs. the REST endpoints, as shown above