### PR TITLE
fix(ui): flag the incident strip's scope when it reports a different subnet (#3951)

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -57,6 +57,19 @@ export function IncidentStrip() {
   const more = active.length - 1;
   const isDown = (top.state ?? "").toLowerCase() === "down";
 
+  // The strip surfaces the network's single top active incident, which often
+  // concerns a different subnet than the one currently being viewed. When its
+  // subject differs from the current /subnets/<n> page, label the scope
+  // explicitly so the banner isn't misread as this subnet's own status (#3951).
+  const currentSubnet = pathname.match(/^\/subnets\/(\d+)(?:\/|$)/)?.[1] ?? null;
+  const concernsOtherEntity =
+    currentSubnet != null && (top.netuid == null || String(top.netuid) !== currentSubnet);
+  const scopeLabel = concernsOtherEntity
+    ? top.netuid != null
+      ? "Other subnet"
+      : "Network-wide"
+    : null;
+
   return (
     <div
       role="alert"
@@ -77,6 +90,11 @@ export function IncidentStrip() {
         <span className="font-mono text-[10px] uppercase tracking-widest shrink-0">
           {isDown ? "Incident" : "Degraded"}
         </span>
+        {scopeLabel ? (
+          <span className="shrink-0 rounded-sm border border-ink/20 bg-ink/5 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-widest text-ink-muted">
+            {scopeLabel}
+          </span>
+        ) : null}
         <span className="min-w-0 flex-1 truncate">
           {top.message ?? `Endpoint ${top.endpoint_id ?? top.id} reported ${top.state ?? "issue"}.`}
           {top.netuid != null ? (


### PR DESCRIPTION
## Summary

Closes #3951

The global incident strip surfaces the network's single top active incident on every `/subnets` and `/endpoints` route, but on a subnet detail page it gave no signal when that incident concerned a *different* subnet — so "Degraded … SN10"
rendering directly above SN1's masthead read as SN1's own status (#3951).

This derives the current subnet from the path and, when the incident's subject differs (another subnet, or a non-subnet network-wide notice), renders an explicit scope chip ("Other subnet" / "Network-wide") next to the severity label, so the banner can't be misread as the current page's health.

## Changes
- `components/metagraphed/incident-strip.tsx` — compute `concernsOtherEntity`   from the current `/subnets/<n>` path vs. the incident's `netuid`, and render a  scope chip when they differ.

## Screenshots

Incident strip on `/subnets/1` while the active incident concerns SN10 (mocked
for a deterministic capture). The only change is the **"Other subnet"** scope
chip after the "Degraded" label — captured at fixed viewports via Playwright.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951/after-mobile-dark.png)<br><sub>after</sub> |


## Validation
- `tsc --noEmit` ✓ · `prettier --check` (3.9.4) ✓ · `eslint` (0 errors) ✓
- `vitest run` — 665/665 pass ✓ · `build` ✓
- No new API call (uses the existing incidents query) → no HAR re-record
