### PR TITLE
fix(ui): keep the account address copy icon inside the viewport at mobile (#3944)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -199,8 +199,12 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
               Cross-subnet registrations, first-party chain events, and daily activity rollups for
               one Bittensor account.
             </p>
-            <div className="max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
-              <CopyableCode value={ss58} truncate={false} />
+            {/* #3944: keep the box shrink-to-content on wide viewports but cap it
+                at the parent width so the long ss58 can't push its trailing copy
+                icon past the right edge at mobile — the address truncates inside
+                the capped box while the icon stays fully visible/tappable. */}
+            <div className="w-fit max-w-full rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+              <CopyableCode value={ss58} truncate={false} className="max-w-full" />
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary

Closes #3944

On `/accounts/$ss58` the address box wrapped the full ss58 in a `max-w-fit` box around an `inline-flex` `CopyableCode` — both of which size to content. At 375px the long address grew the box past the right viewport edge and clipped the trailing copy icon (the page's primary tap target). This caps the box at the parent width while keeping it shrink-to-content on wider viewports
(`w-fit max-w-full`) and caps the code button too, so the address truncates inside the box and the copy icon stays fully visible and tappable.

## Changes

- `routes/accounts.$ss58.tsx` — the address-box wrapper is now `w-fit max-w-full`  (shrink-to-content, capped at the parent) and the `CopyableCode` is passed  `className="max-w-full"` so its code truncates and the copy icon (already  `shrink-0`) stays inside the viewport.

## Screenshots

Account address box on `/accounts/<ss58>` at fixed viewports (Playwright, no devtools). The fix is mobile-gated: at **375px** the before lets the box grow to the full ss58 with the copy icon jammed against the right edge, while the after
caps the box so the address truncates and the copy icon stays fully visible/tappable. At tablet/desktop the box is compact either way — those pairs confirm no regression.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3944/after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `tsc --noEmit` ✓ · `prettier --check` (3.9.4) ✓ · `eslint` (0 errors) ✓
- `vitest run` — 670/670 pass ✓ · `build` ✓
- One file changed; `/accounts/*` isn't an e2e-checked route, so no HAR re-record


