### PR TITLE
fix(ui): remove misleading full-row click affordance from the neuron table

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -174,20 +174,15 @@ export function NeuronTable({
                   key={n.uid}
                   className={classNames(
                     "mg-row-hover border-t border-border/60",
-                    onSelect && "cursor-pointer",
                     active && "bg-accent-surface",
                   )}
-                  onClick={onSelect ? () => onSelect(n.uid) : undefined}
                 >
                   <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
                     {onSelect ? (
                       <button
                         type="button"
-                        className="hover:text-accent hover:underline"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSelect(n.uid);
-                        }}
+                        className="underline decoration-border underline-offset-2 hover:text-accent hover:decoration-accent"
+                        onClick={() => onSelect(n.uid)}
                       >
                         {n.uid}
                       </button>
@@ -202,7 +197,6 @@ export function NeuronTable({
                           to="/validators/$hotkey"
                           params={{ hotkey: n.hotkey }}
                           className="text-ink-muted hover:text-ink hover:underline"
-                          onClick={(e) => e.stopPropagation()}
                           title={n.hotkey}
                         >
                           {shortHash(n.hotkey) ?? n.hotkey}
@@ -212,7 +206,6 @@ export function NeuronTable({
                           to="/accounts/$ss58"
                           params={{ ss58: n.hotkey }}
                           className="text-ink-muted hover:text-ink hover:underline"
-                          onClick={(e) => e.stopPropagation()}
                           title={n.hotkey}
                         >
                           {shortHash(n.hotkey) ?? n.hotkey}


### PR DESCRIPTION
Closes #3952

## What
In `neuron-table.tsx`, every `<tr>` in the metagraph/validator table had an `onClick` handler plus a `cursor-pointer` class covering the whole row, implying the entire row drills into a per-UID snapshot. In reality only the small nested UID `<button>` was ever keyboard-reachable — a keyboard or screen-reader user relying on the row's visual full-row affordance had no way to trigger it except by specifically finding that one small button. Mouse users could click anywhere in the row; keyboard users effectively could not.

## Why option (b), not (a)
The issue's own deliverable offered two paths: (a) make the `<tr>` itself keyboard-operable (`role="button"` + `tabIndex` + `onKeyDown`), or (b) drop the row-level affordance and make the existing nested button the sole, honestly-signposted entry point — with (a) preferred *only if it can be done without invalid nested-interactive markup*. The row already contains a nested `<button>` (UID) **and** a nested `<Link>` (hotkey) — giving the `<tr>` an interactive role/tabIndex on top of those would nest two more interactive elements inside another interactive element, which is invalid ARIA structure regardless of `stopPropagation` bookkeeping. So this PR takes (b).

## Changes
- **`apps/ui/src/components/metagraphed/neuron-table.tsx`**: removed the row's `onClick` and conditional `cursor-pointer` class — the row itself no longer claims to be clickable. The UID `<button>` (already the real, keyboard-focusable entry point) now gets a persistent `underline` (not just on `:hover`) so it visually reads as the click target independent of row hover, instead of implying the whole row is one. Also removed the two now-dead `onClick={(e) => e.stopPropagation()}` handlers on the hotkey `<Link>`s, which only existed to stop the row's own (now-removed) click handler from double-firing.

## Verification
- **No invalid nested-interactive markup**: confirmed via Playwright that the `<tr>` has no `role` or `tabindex` attribute at all (checked directly against the DOM, not just visually).
- **Keyboard operability preserved**: the UID button is a native `<button>`, so it's unconditionally part of the tab order. Verified: focusing it and pressing `Enter` fires `onSelect` and updates the URL to `?uid=<n>`, and `Tab` from it moves cleanly to the next natural focusable element in the row (the hotkey link) — no focus trapping or double-activation.
- **Recordings** (before/after) below show: hovering a non-interactive cell (Stake), then tabbing to and activating the UID button via keyboard.

| | Recording |
| --- | --- |
| Before | [<video src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-kbd-3952/before-neuron-row-kbd.webm" width="420"></video>](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-kbd-3952/before-neuron-row-kbd.webm) |
| After | [<video src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-kbd-3952/after-neuron-row-kbd.webm" width="420"></video>](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-kbd-3952/after-neuron-row-kbd.webm) |

(GitHub doesn't inline-render `<video>` in PR bodies from a raw.githubusercontent.com URL — click through to view; a static frame is also attached: [neuron-kbd-test.png](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-kbd-3952/neuron-kbd-test.png) showing the focus ring on the UID button after a direct `.focus()` + `Tab`-order check.)

## Acceptance criteria
- [x] `neuron-table.tsx` appears in the diff
- [x] A keyboard-only user can reach and activate the row's drill-in action via Tab + Enter, without needing to specifically target a *misleadingly-implied* full-row affordance — the sole entry point (the UID button) is now honestly the only thing that looks and behaves like a click target
- [x] No invalid nested-interactive-element ARIA structure introduced — verified via the DOM (`role`/`tabindex` both absent on the row)
- [x] Mouse-click behavior on the UID button is unchanged; the row's other cells no longer falsely suggest clickability
- [x] Includes before/after screen recordings demonstrating keyboard interaction, not just static screenshots

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx eslint` on the changed file: clean aside from pre-existing CRLF noise unrelated to this change.
- Diff is 2 insertions / 9 deletions in a single file.
