### PR TITLE
fix(ui): wire the /surfaces public_safe/auth/rate_limited filter shortcuts (#3975)

### DIFF
--- a/apps/ui/src/lib/metagraphed/surface-filters.test.ts
+++ b/apps/ui/src/lib/metagraphed/surface-filters.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesSurfaceFilters, surfacesSearchSchema } from "./surface-filters";
+import type { Surface } from "./types";
+
+/** A fully-defaulted search, so each test overrides only the field under test. */
+function search(overrides: Record<string, unknown> = {}) {
+  return surfacesSearchSchema.parse(overrides);
+}
+
+function surface(overrides: Partial<Surface> = {}): Surface {
+  return { id: "srf-1", name: "Example API", kind: "api", ...overrides };
+}
+
+describe("surfacesSearchSchema", () => {
+  it("defaults the three shortcut params to empty strings", () => {
+    const s = search();
+    expect(s.public_safe).toBe("");
+    expect(s.auth).toBe("");
+    expect(s.rate_limited).toBe("");
+  });
+
+  it("parses the mega-menu shortcut values", () => {
+    const s = search({ public_safe: "1", auth: "required", rate_limited: "1" });
+    expect(s.public_safe).toBe("1");
+    expect(s.auth).toBe("required");
+    expect(s.rate_limited).toBe("1");
+  });
+});
+
+describe("matchesSurfaceFilters", () => {
+  it("passes every row when no filter is set", () => {
+    expect(matchesSurfaceFilters(surface(), search())).toBe(true);
+  });
+
+  it("filters by kind, provider, and netuid", () => {
+    const s = surface({ kind: "docs", provider_slug: "acme", netuid: 21 });
+    expect(matchesSurfaceFilters(s, search({ kind: "docs" }))).toBe(true);
+    expect(matchesSurfaceFilters(s, search({ kind: "api" }))).toBe(false);
+    expect(matchesSurfaceFilters(s, search({ provider: "acme" }))).toBe(true);
+    expect(matchesSurfaceFilters(s, search({ provider: "other" }))).toBe(false);
+    expect(matchesSurfaceFilters(s, search({ netuid: "21" }))).toBe(true);
+    expect(matchesSurfaceFilters(s, search({ netuid: "22" }))).toBe(false);
+  });
+
+  it("public_safe=1 keeps only public-safe surfaces", () => {
+    expect(
+      matchesSurfaceFilters(surface({ public_safe: true }), search({ public_safe: "1" })),
+    ).toBe(true);
+    expect(
+      matchesSurfaceFilters(surface({ public_safe: false }), search({ public_safe: "1" })),
+    ).toBe(false);
+  });
+
+  it("auth=required keeps only auth-gated surfaces; auth=none keeps only open ones", () => {
+    expect(
+      matchesSurfaceFilters(surface({ auth_required: true }), search({ auth: "required" })),
+    ).toBe(true);
+    expect(
+      matchesSurfaceFilters(surface({ auth_required: false }), search({ auth: "required" })),
+    ).toBe(false);
+    expect(matchesSurfaceFilters(surface({ auth_required: false }), search({ auth: "none" }))).toBe(
+      true,
+    );
+    expect(matchesSurfaceFilters(surface({ auth_required: true }), search({ auth: "none" }))).toBe(
+      false,
+    );
+  });
+
+  it("rate_limited=1 keeps only surfaces that document a rate limit", () => {
+    expect(
+      matchesSurfaceFilters(
+        surface({ rate_limit_notes: "100 req/min" }),
+        search({ rate_limited: "1" }),
+      ),
+    ).toBe(true);
+    expect(
+      matchesSurfaceFilters(surface({ rate_limit_notes: null }), search({ rate_limited: "1" })),
+    ).toBe(false);
+    expect(matchesSurfaceFilters(surface({}), search({ rate_limited: "1" }))).toBe(false);
+  });
+
+  it("combines the query with a shortcut filter", () => {
+    const s = surface({ name: "Public docs", public_safe: true });
+    expect(matchesSurfaceFilters(s, search({ q: "docs", public_safe: "1" }))).toBe(true);
+    expect(matchesSurfaceFilters(s, search({ q: "nomatch", public_safe: "1" }))).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/surface-filters.ts
+++ b/apps/ui/src/lib/metagraphed/surface-filters.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { fallback } from "@tanstack/zod-adapter";
+
+import { tableSearchSchema, matchesQuery } from "@/lib/metagraphed/url-state";
+import type { Surface } from "@/lib/metagraphed/types";
+
+/**
+ * /surfaces extends the shared table-state schema with three public-interface
+ * filter shortcuts that the nav mega-menu links to (`?public_safe=1`,
+ * `?auth=required`, `?rate_limited=1`). They live here — not on the shared
+ * `tableSearchSchema` — so the sibling /subnets route's schema stays lean.
+ */
+export const surfacesSearchSchema = tableSearchSchema.extend({
+  public_safe: fallback(z.string(), "").default(""),
+  auth: fallback(z.string(), "").default(""),
+  rate_limited: fallback(z.string(), "").default(""),
+});
+
+export type SurfacesSearch = z.infer<typeof surfacesSearchSchema>;
+
+/**
+ * Whether a surface row passes the active /surfaces filters. Kept pure so every
+ * branch — including the `public_safe` / `auth` / `rate_limited` shortcuts wired
+ * for #3975, which previously rendered the unfiltered list — is unit-tested
+ * without rendering. Rate-limited surfaces are those that document a limit via
+ * the per-row `rate_limit_notes` field.
+ */
+export function matchesSurfaceFilters(s: Surface, search: SurfacesSearch): boolean {
+  if (!matchesQuery([s.name, s.url, s.provider, s.provider_slug, s.netuid], search.q)) return false;
+  if (search.kind && s.kind !== search.kind) return false;
+  if (search.provider && (s.provider_slug ?? s.provider) !== search.provider) return false;
+  if (search.netuid && String(s.netuid) !== search.netuid) return false;
+  if (search.public_safe && !s.public_safe) return false;
+  if (search.auth === "required" && !s.auth_required) return false;
+  if (search.auth === "none" && s.auth_required) return false;
+  if (search.rate_limited && !s.rate_limit_notes) return false;
+  return true;
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -226,6 +226,8 @@ export interface Surface {
   provider_slug?: string;
   auth_required?: boolean;
   public_safe?: boolean;
+  /** Free-text note describing a rate limit, when the surface documents one. */
+  rate_limit_notes?: string | null;
   verified?: boolean;
   schema_url?: string;
   curation_level?: CurationLevel;

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -38,11 +38,12 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { surfacesInfiniteQuery, providersQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { matchesQuery, sortBy, tableSearchSchema } from "@/lib/metagraphed/url-state";
+import { sortBy } from "@/lib/metagraphed/url-state";
+import { surfacesSearchSchema, matchesSurfaceFilters } from "@/lib/metagraphed/surface-filters";
 import type { Surface, Provider, Subnet } from "@/lib/metagraphed/types";
 
 export const Route = createFileRoute("/surfaces")({
-  validateSearch: tableSearchSchema,
+  validateSearch: surfacesSearchSchema,
   head: () => ({
     meta: [
       { title: "Surfaces — Metagraphed" },
@@ -71,6 +72,9 @@ function SurfacesPage() {
     !!search.kind ||
     !!search.provider ||
     !!search.netuid ||
+    !!search.public_safe ||
+    !!search.auth ||
+    !!search.rate_limited ||
     !!search.cursor;
   const onReset = () =>
     navigate({
@@ -223,14 +227,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
         }) as never,
     });
 
-  const filtered = all.filter((s) => {
-    if (!matchesQuery([s.name, s.url, s.provider, s.provider_slug, s.netuid], search.q))
-      return false;
-    if (search.kind && s.kind !== search.kind) return false;
-    if (search.provider && (s.provider_slug ?? s.provider) !== search.provider) return false;
-    if (search.netuid && String(s.netuid) !== search.netuid) return false;
-    return true;
-  });
+  const filtered = all.filter((s) => matchesSurfaceFilters(s, search));
   const rows = sortBy(
     filtered,
     search.sort,
@@ -267,7 +264,15 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
     </>
   );
 
-  const filtersActive = !!(search.q || search.kind || search.provider || search.netuid);
+  const filtersActive = !!(
+    search.q ||
+    search.kind ||
+    search.provider ||
+    search.netuid ||
+    search.public_safe ||
+    search.auth ||
+    search.rate_limited
+  );
 
   const emptyNode = (
     <RegistryEmpty
@@ -285,7 +290,16 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
           ? [
               {
                 label: "Reset filters",
-                onClick: () => setSearch({ q: "", kind: "", provider: "", netuid: "" }),
+                onClick: () =>
+                  setSearch({
+                    q: "",
+                    kind: "",
+                    provider: "",
+                    netuid: "",
+                    public_safe: "",
+                    auth: "",
+                    rate_limited: "",
+                  }),
                 primary: true,
               },
               { label: "Open API", href: "/api/v1/surfaces", external: true },


### PR DESCRIPTION
## Summary

Closes #3975

The nav mega-menu links to `/surfaces?public_safe=1`, `?auth=required`, and `?rate_limited=1`, but `surfaces.tsx` validated against the shared `tableSearchSchema` (no such params) and its predicate never read them — so all three shortcuts silently rendered the *unfiltered* list.

This adds a surfaces-local `surfacesSearchSchema` (extends the shared schema, so the sibling /subnets schema stays lean) and moves the row predicate into a pure, unit-tested `matchesSurfaceFilters`: `public_safe`→`s.public_safe`, `auth`→`s.auth_required` (required/none), `rate_limited`→ the per-row `rate_limit_notes`. Reset + active-filter indicator now cover them too.

## Gates
typecheck ✓ · unit tests ✓ (8 new: every filter branch) · prettier ✓ · build ✓ · responsive-overflow e2e ✓

## Screenshots
Shown on `?auth=required` (the demonstrable case: **188 → 2 rows**). All 3 filters are covered by the 8 unit tests.

| Viewport · Theme | Before | After |
|---|---|---|
| Mobile · Light  | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-mobile-light.png)<br><sub>filter ignored — full list</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-mobile-light.png)<br><sub>2 auth-gated surfaces</sub> |
| Mobile · Dark   | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-mobile-dark.png)<br><sub>filter ignored — full list</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-mobile-dark.png)<br><sub>2 auth-gated surfaces</sub> |
| Tablet · Light  | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-tablet-light.png)<br><sub>filter ignored — full list</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-tablet-light.png)<br><sub>2 auth-gated surfaces</sub> |
| Tablet · Dark   | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-tablet-dark.png)<br><sub>filter ignored — full list</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-tablet-dark.png)<br><sub>2 auth-gated surfaces</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-desktop-light.png)<br><sub>filter ignored — full list</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-desktop-light.png)<br><sub>2 of 1598</sub> |
| Desktop · Dark  | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-before-desktop-dark.png)<br><sub>filter ignored — full list</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/surfaces-after-desktop-dark.png)<br><sub>2 of 1598</sub> |
