### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap subnet-api surface

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 31,
-  "name": "Recall",
-  "slug": "recall",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,17 +6,7 @@
     "rag",
     "retrieval"
   ],
-  "source_repo": null,
-  "website_url": null,
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN31 Recall. Public chain/directory sources show the subnet renamed from Halftime to Recall. Backprop currently describes a RAG/retrieval subnet, but no official live website, source repository, API, OpenAPI schema, or docs site is verified.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Public chain/directory sources show a recent Halftime to Recall identity change.",
       "The historical candlestao.com reference currently times out to simple probes and is not promoted.",
@@ -32,7 +17,42 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
-  "surfaces": []
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "Recall",
+  "netuid": 31,
+  "notes": "Reviewed overlay for SN31 Recall. Public chain/directory sources show the subnet renamed from Halftime to Recall. Backprop currently describes a RAG/retrieval subnet, but no official live website, source repository, API, OpenAPI schema, or docs site is verified.",
+  "schema_version": 1,
+  "slug": "recall",
+  "source_repo": null,
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Recall TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning machine-readable JSON for SN31 on-chain subnet state, SubnetIdentitiesV3 metadata (subnetName \"rec4ll\", description: decentralized retrieval-augmented generation — miners serve embedding/vector-search/LLM inference, validators evaluate retrieval accuracy and answer quality), economics, and dTAO market fields. Recall exposes no verified first-party website, repository, or API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/31-recall"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ],
+  "website_url": null
 }


### PR DESCRIPTION
Closes #4032

## What
SN31 Recall (`registry/subnets/recall.json`) currently has zero registered surfaces — the maintainer's reviewed overlay confirms no official website, source repository, API, OpenAPI schema, or docs site is verified for this subnet. TaoMarketCap's public developer API independently indexes on-chain subnet state for every netuid regardless of whether the subnet team publishes anything themselves, and this is already the established pattern used for other zero-first-party-presence subnets in this registry (e.g. Academia SN109, Endure Network SN30).

## Proof it's real
- `GET https://api.taomarketcap.com/public/v1/subnets/31` resolves (301 → `.../31/`) and returns live JSON: `subnetName: "rec4ll"`, a description matching Recall's known RAG/retrieval-augmented-generation positioning ("Miners serve embedding models, vector search, and LLM inference. Validators independently evaluate retrieval accuracy..."), plus on-chain economics/hyperparameters and dTAO market fields — cross-referencing correctly to netuid 31.
- `source_urls` cite TaoMarketCap's own public developer documentation plus `https://backprop.finance/dtao/subnets/31-recall`, an independent public page that also identifies this netuid as Recall/RAG, corroborating it's genuinely SN31's data, not a misattributed netuid.

## Classification note
An earlier, unrelated PR for a different subnet was closed because this same TaoMarketCap `/public/v1/subnets/{netuid}` endpoint was misclassified as `kind: "data-artifact"` when the reviewer flagged it should be `kind: "subnet-api"` (a live, parameterized, callable REST endpoint — not a static dataset). This PR uses `kind: "subnet-api"` from the start, matching that correction and the convention already used for the Academia/Endure Network entries.

## Changes
- **`registry/subnets/recall.json`** — appends exactly one surface to the (previously empty) `surfaces[]` array via `npm run surface:add`: `id: "sn-31-taomarketcap-subnet-api"`, `kind: "subnet-api"`, `authority: "community"`, `review.state: "community-submitted"`, `auth_required: false`, `public_safe: true`. No other field in the file is touched.

## Acceptance criteria
- [x] Exactly one file changed: `registry/subnets/recall.json`
- [x] `url` resolves and returns real, live SN31 data
- [x] `source_urls` independently corroborate it's genuinely SN31's data
- [x] `authority: "community"`, `review.state: "community-submitted"`
- [x] `auth_required: false`, `public_safe: true`
- [x] No secrets, no private/localhost URLs

## Testing
- `npm run validate:surface -- registry/subnets/recall.json`: "Surface validation passed: 1 surface(s) across 1 subnet file(s)."
- `npm run scan:public-safety`: "Public-safety scan passed."
