### PR TITLE
fix(data-api): close 10 chain-decode gaps found by a full 150-item ground-truth audit

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -61,6 +61,19 @@ const ACCOUNT_KEYS = new Set([
   "delegator",
   "new_hotkey",
   "old_hotkey",
+  // Added 2026-07-12 from a full 150-item ground-truth audit against live
+  // served output (all 82 chain_events + 68 extrinsics pallet.method/
+  // module.function combinations): multisig/approving (Multisig.NewMultisig/
+  // MultisigApproval/MultisigExecuted) and sender (System.Remarked) are all
+  // confirmed-live 32-byte AccountId32 fields missed by the prior sweep.
+  // "caller" (Contracts.Called) is the account payload of a
+  // MultiAddress::Signed(AccountId32) unwrapped via ENUM_PAYLOAD_FIELDS below
+  // -- must be here too, since the unwrapped payload is decoded with THIS
+  // key's own hint, not a synthetic one.
+  "multisig",
+  "approving",
+  "sender",
+  "caller",
 ]);
 
 function isByteArray(v, len) {
@@ -206,34 +219,40 @@ function decode(value, keyHint, ctx) {
     return value.map((item) => decode(item, keyHint, ctx));
   }
   if (value && typeof value === "object") {
-    const out = {};
-    for (const [k, val] of Object.entries(value)) out[k] = decode(val, k, ctx);
     // Field-specific enum-tag collapse (see ENUM_PAYLOAD_FIELDS above) --
-    // only after `out` has been fully decoded, so "unit-or-passthrough" sees
-    // the REAL payload shape (an untouched empty array for a unit `()`, or
-    // whatever a genuine Err(DispatchError) decoded to).
+    // checked against the RAW (not-yet-decoded) shape and BEFORE the generic
+    // recursion below, so the unwrapped payload can be decoded with the
+    // OUTER field's own keyHint (e.g. "caller") instead of the enum
+    // wrapper's own "values" key. Decoding generically first and unwrapping
+    // `out.values[0]` afterwards (the previous approach) silently lost the
+    // outer keyHint across the unwrap -- confirmed live 2026-07-12:
+    // Contracts.Called.caller (MultiAddress::Signed(AccountId32)) rendered
+    // as raw hex instead of SS58 because by the time its account bytes were
+    // reached, decode() had already recursed with keyHint="values", not
+    // "caller", so the ACCOUNT_KEYS check never fired.
     if (
       keyHint &&
       ctx &&
-      Object.keys(out).length === 2 &&
-      typeof out.name === "string" &&
-      Array.isArray(out.values) &&
-      out.values.length === 1
+      typeof value.name === "string" &&
+      Array.isArray(value.values) &&
+      value.values.length === 1
     ) {
       const strategy = ENUM_PAYLOAD_FIELDS.get(
         `${ctx.pallet ?? ""}.${ctx.method ?? ""}.${keyHint}`,
       );
       if (strategy === "unwrap") {
-        return out.values[0];
+        return decode(value.values[0], keyHint, ctx);
       }
-      if (
-        strategy === "unit-or-passthrough" &&
-        Array.isArray(out.values[0]) &&
-        out.values[0].length === 0
-      ) {
-        return out.name;
+      if (strategy === "unit-or-passthrough") {
+        const decodedPayload = decode(value.values[0], keyHint, ctx);
+        if (Array.isArray(decodedPayload) && decodedPayload.length === 0) {
+          return value.name;
+        }
+        return { name: value.name, values: [decodedPayload] };
       }
     }
+    const out = {};
+    for (const [k, val] of Object.entries(value)) out[k] = decode(val, k, ctx);
     return out;
   }
   return value;

--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -243,6 +243,23 @@ export function decodeEvmWithdrawArgs(callArgs) {
   return withCallArg(callArgs, "address", decodeH160Bytes(address));
 }
 
+/** DynamicFee.note_min_gas_price_target's call_args: decodes `target` (U256,
+ * the same 4-limb little-endian encoding as Ethereum.transact's nonce/value/
+ * gas_limit) to an exact decimal string. Returns callArgs unchanged when the
+ * field isn't found. Found live 2026-07-12: this call type wasn't in
+ * DECODERS at all, so `target` fell into the generic non-collection
+ * byte-blob branch elsewhere in the pipeline (postgres-call-args.mjs),
+ * which misinterprets the 4 raw u64 limbs as individual bytes and
+ * hex-encodes them directly -- silently WRONG (not just undecoded) whenever
+ * a limb is small enough to look like a valid byte value, e.g. limbs
+ * [1,0,0,0] (the real target value 1) rendered as hex "0x01000000"
+ * (16,777,216) instead of decimal "1". */
+export function decodeDynamicFeeArgs(callArgs) {
+  const target = findCallArg(callArgs, "target");
+  if (target === undefined) return callArgs;
+  return withCallArg(callArgs, "target", decodeU256Limbs(target));
+}
+
 // {name:"Sr25519", values:[bytes]} -> {Sr25519: "0x..."}. Gated on the
 // variant name specifically (not "any tuple-variant enum found under a key
 // named signature") since MultiSignature has other variants (Ed25519,
@@ -275,7 +292,19 @@ function decodeSr25519SignatureValue(value) {
 // match, rather than leaving a bare hash-like field raw.
 function decodeSignatureLikeField(value) {
   const enumDecoded = decodeSr25519SignatureValue(value);
-  return enumDecoded === value ? decodeHash32Bytes(value) : enumDecoded;
+  if (enumDecoded !== value) return enumDecoded;
+  // Fallback for a bare (non-enum-wrapped) hash-like byte array. Length-
+  // agnostic, unlike decodeHash32Bytes's other uses in this file (EIP1559's
+  // signature.r/s, always exactly 32 bytes for ECDSA) -- confirmed live
+  // 2026-07-12: Drand.write_pulse's per-pulse `signature` is a 48-byte
+  // BLS12-381 G1 point (its `randomness` sibling happens to be 32 bytes, so
+  // it coincidentally passed decodeHash32Bytes's strict length check while
+  // `signature` silently stayed raw). This function is only ever reached for
+  // a field literally named "signature"/"randomness" within the narrow
+  // Drand/LimitOrders call types this module dispatches to, so any byte-blob
+  // shape here is safe to hex-encode regardless of exact length.
+  const bytes = unwrapByteArray(value);
+  return bytes && bytes.length > 0 ? bytesToHex(bytes) : value;
 }
 
 // Recursively finds every key literally named "signature"/"randomness"
@@ -290,9 +319,46 @@ function decodeSignatureLikeField(value) {
 // execute_batched_orders has `signature` nested inside each entry of its
 // (Vec-wrapped) `orders` array -- all confirmed against real production
 // data.
+// True for D1/indexer-rs's typed call_args field descriptor {name,type,value}
+// (duplicated 3-line shape check, matching this codebase's own established
+// pattern of not cross-importing such a check between sibling decode modules
+// -- see postgres-call-args.mjs's identical isTypedFieldDescriptor and its
+// header comment for the rationale).
+function isTypedFieldDescriptor(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 3 &&
+    typeof value.name === "string" &&
+    typeof value.type === "string" &&
+    "value" in value
+  );
+}
+
 function walkForSignatureFields(value) {
   if (Array.isArray(value)) return value.map(walkForSignatureFields);
   if (value && typeof value === "object") {
+    // A typed-descriptor node carries its field name as the VALUE of its own
+    // "name" property, not as a literal object key the generic loop below
+    // can match against "signature"/"randomness"/"public" -- confirmed live
+    // 2026-07-12: Drand.write_pulse's TOP-LEVEL `signature`
+    // (Option<MultiSignature>, arrives as {name:"signature",
+    // type:"Option<MultiSignature>", value:{...}}) stayed completely raw
+    // because this function only ever recursed generically into `.value`,
+    // never recognizing the descriptor itself as the signature field (unlike
+    // the per-pulse `signature`/`randomness`/`public` fields nested deeper,
+    // which arrive as genuine struct fields with real object keys and
+    // already matched correctly).
+    if (isTypedFieldDescriptor(value)) {
+      if (value.name === "signature" || value.name === "randomness") {
+        return { ...value, value: decodeSignatureLikeField(value.value) };
+      }
+      if (value.name === "public") {
+        return { ...value, value: decodeSr25519SignatureValue(value.value) };
+      }
+      return { ...value, value: walkForSignatureFields(value.value) };
+    }
     const out = {};
     for (const [key, val] of Object.entries(value)) {
       if (key === "signature" || key === "randomness") {
@@ -322,6 +388,7 @@ const DECODERS = {
   "EVM.withdraw": decodeEvmWithdrawArgs,
   "LimitOrders.execute_batched_orders": decodeSignatureFieldArgs,
   "Drand.write_pulse": decodeSignatureFieldArgs,
+  "DynamicFee.note_min_gas_price_target": decodeDynamicFeeArgs,
 };
 
 /** Dispatches to the right decoder for (callModule, callFunction), or

--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -151,6 +151,33 @@ function isStructVariantEnum(value) {
   );
 }
 
+// Narrow allowlist for Vec<(_, AccountId32)>-shaped typed-descriptor fields
+// whose account slot is nested inside each tuple element, keyed by
+// "call_module.call_function.field_name" -> the account's 0-based tuple
+// index. A raw tuple element carries no field name of its own (unlike a
+// named struct field), so neither isAccountId32Type (needs the OUTER
+// descriptor's own `type` string, which describes the whole Vec<(...)>, not
+// each tuple slot) nor the ACCOUNT_KEYS name-guess (the only keyHint
+// available this deep is the OUTER field's own name -- "children" here --
+// which isn't itself account-shaped, unlike other_signatories above) can
+// catch this. Confirmed live 2026-07-12: SubtensorModule.set_children's
+// `children` (Vec<(u64, AccountId32)>, the child's own proportion + account)
+// left its per-child AccountId32 (tuple index 1) as a raw byte array.
+const TUPLE_ACCOUNT_FIELDS = new Map([
+  ["SubtensorModule.set_children.children", 1],
+]);
+
+function decodeTupleAccountField(items, accountIndex) {
+  return items.map((tuple) => {
+    if (!Array.isArray(tuple) || accountIndex >= tuple.length) return tuple;
+    const decoded = normalizeAccountId32Field(tuple[accountIndex]);
+    if (decoded == null) return tuple;
+    const out = tuple.slice();
+    out[accountIndex] = decoded;
+    return out;
+  });
+}
+
 function decodeRootClaimTypeValue(value) {
   if (!isStructVariantEnum(value)) return value;
   const out = { name: value.name, values: { ...value.values } };
@@ -204,6 +231,19 @@ const ACCOUNT_KEYS = new Set([
   "real",
   "signer",
   "fee_recipient",
+  // Added 2026-07-12 from a full 150-item ground-truth audit against live
+  // served output. Multisig.approve_as_multi/as_multi's other_signatories
+  // (type "Vec<AccountId32>") isn't an AccountId32/MultiAddress type itself
+  // (isAccountId32Type doesn't match a collection type), so it falls through
+  // to the generic recursive walk with keyHint="other_signatories" -- that
+  // whole-array keyHint fails normalizeAccountId32Field once (it's an array
+  // of accounts, not one), but the SAME keyHint then propagates unchanged
+  // into the per-element recursion, where each individual (newtype-wrapped)
+  // account now matches this name and decodes correctly. "signatories"
+  // added defensively for the same field under an alternate name, unseen
+  // live so far but equally plausible for a future runtime/pallet version.
+  "other_signatories",
+  "signatories",
 ]);
 
 function isAccountField(keyHint) {
@@ -374,7 +414,34 @@ function walk(value, keyHint, nestedCall, topCall) {
         value: decodeRootClaimTypeValue(value.value),
       };
     }
-    if (!isCollectionType(value.type)) {
+    if (isCollectionType(value.type)) {
+      const tupleCtx = nestedCall ?? topCall;
+      const tupleKey = `${tupleCtx?.call_module ?? ""}.${tupleCtx?.call_function ?? ""}.${value.name}`;
+      const accountIndex = TUPLE_ACCOUNT_FIELDS.get(tupleKey);
+      if (accountIndex != null && Array.isArray(value.value)) {
+        return {
+          name: value.name,
+          type: value.type,
+          value: decodeTupleAccountField(value.value, accountIndex),
+        };
+      }
+    }
+    // U256 excluded from the generic byte-blob-unwrap attempt below: its
+    // 4-limb little-endian u64 array ([[limb0..limb3]]) is shape-identical
+    // to a genuine 1-4-byte blob whenever every limb happens to be small
+    // (0-255) -- the same #4693/#4915 collection-vs-blob ambiguity class,
+    // just for U256 instead of a BTreeSet. Confirmed live 2026-07-12:
+    // DynamicFee.note_min_gas_price_target's `target` (real value 1, raw
+    // limbs [1,0,0,0]) was silently misinterpreted as 4 raw bytes and
+    // hex-encoded to "0x01000000" (16,777,216) -- actively WRONG, not just
+    // undecoded -- before decodeEthereumEvmCallArgs (indexer-rs-ethereum-
+    // decode.mjs, which runs AFTER this module and knows the real 4-limb
+    // encoding) ever got a chance to correctly decode it via decodeU256Limbs.
+    // Every OTHER U256 field (Ethereum.transact's nonce/value/gas_limit/...)
+    // already survived this unscathed only because those arrive nested
+    // inside the `transaction` descriptor's untyped struct body, never
+    // themselves a separate top-level typed descriptor the way `target` is.
+    if (!isCollectionType(value.type) && value.type !== "U256") {
       const bytes = unwrapByteArray(value.value);
       if (bytes && bytes.length > 0) {
         const ctx = nestedCall ?? topCall;

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -376,7 +376,16 @@ describe("decodeChainEventArgs", () => {
     );
   });
 
-  test("unwraps MultiAddress::Signed(AccountId32) to the bare decoded account (real Contracts.Called.caller, block 8604327/354)", () => {
+  test("unwraps MultiAddress::Signed(AccountId32) to an SS58 address, not raw hex (real Contracts.Called.caller, block 8605283/615, fixed 2026-07-12)", () => {
+    // Found live 2026-07-12 during a 150-item ground-truth audit: caller
+    // rendered as raw hex instead of SS58 despite the ENUM_PAYLOAD_FIELDS
+    // "unwrap" entry existing for exactly this field -- decode() built the
+    // enum wrapper's `out` object generically first (recursing into `values`
+    // with keyHint="values", not the outer "caller"), so by the time
+    // out.values[0] was unwrapped its account bytes had already been
+    // hex-encoded under the wrong hint. Fixed by checking ENUM_PAYLOAD_FIELDS
+    // against the RAW node before generic recursion, so the unwrap can
+    // re-decode the payload under the OUTER field's own keyHint.
     const args = {
       caller: {
         name: "Signed",
@@ -399,7 +408,75 @@ describe("decodeChainEventArgs", () => {
     });
     assert.equal(
       decoded.caller,
-      "0x0ca198fb49b4d7b66203f3aede3386e5f46ec65fdc59e5b6ed602bfc5940a770",
+      "5CMGSFvP5A2UAunRzjaZHx5BDBYmYBm8nQNdW25uZNqX5sEi",
+    );
+  });
+
+  test("decodes multisig/approving to SS58 (real Multisig.MultisigApproval, block 4632809/18, fixed 2026-07-12)", () => {
+    // Found live 2026-07-12: both fields rendered as raw hex -- missing from
+    // ACCOUNT_KEYS entirely (call_hash correctly staying hex, since it's a
+    // hash, not an account).
+    const args = {
+      multisig: [
+        [
+          186, 213, 47, 1, 241, 147, 62, 158, 248, 121, 160, 10, 7, 238, 71, 27,
+          165, 167, 203, 221, 13, 96, 69, 222, 78, 252, 141, 157, 111, 214, 82,
+          36,
+        ],
+      ],
+      approving: [
+        [
+          208, 169, 201, 121, 190, 117, 20, 237, 200, 43, 143, 65, 208, 150, 33,
+          47, 141, 90, 42, 172, 206, 45, 223, 232, 122, 127, 142, 209, 217, 224,
+          110, 85,
+        ],
+      ],
+      call_hash: [
+        6, 171, 78, 162, 128, 230, 11, 75, 28, 70, 147, 177, 247, 165, 165, 113,
+        145, 156, 233, 147, 172, 84, 72, 55, 227, 80, 81, 46, 4, 157, 139, 63,
+      ],
+      timepoint: { index: 7, height: 4632808 },
+    };
+    assert.deepEqual(
+      decodeChainEventArgs(args, {
+        pallet: "Multisig",
+        method: "MultisigApproval",
+      }),
+      {
+        multisig: "5GHg6KMXajvZPAbLEK2eKDrWz8r15d7ymShTW8hMfZLiPHgs",
+        approving: "5GnJFiFL1X6nGUHQ2Sd3eVNRYeYwbkBDNRYdvgSeEJB5g6xV",
+        call_hash:
+          "0x06ab4ea280e60b4b1c4693b1f7a5a571919ce993ac544837e350512e049d8b3f",
+        timepoint: { index: 7, height: 4632808 },
+      },
+    );
+  });
+
+  test("decodes sender to SS58, hash stays hex (real System.Remarked, block 8605284/559, fixed 2026-07-12)", () => {
+    // Found live 2026-07-12: sender rendered as raw hex -- missing from
+    // ACCOUNT_KEYS (hash correctly stayed hex, it's a hash, not an account).
+    const args = {
+      hash: [
+        [
+          191, 202, 247, 136, 103, 241, 66, 244, 111, 216, 15, 11, 170, 32, 109,
+          126, 227, 240, 204, 114, 93, 72, 26, 39, 98, 154, 215, 132, 194, 90,
+          117, 155,
+        ],
+      ],
+      sender: [
+        [
+          196, 86, 57, 143, 56, 117, 132, 48, 77, 60, 250, 101, 214, 119, 121,
+          140, 120, 53, 162, 127, 186, 101, 145, 121, 101, 95, 105, 169, 164, 6,
+          148, 48,
+        ],
+      ],
+    };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "System", method: "Remarked" }),
+      {
+        hash: "0xbfcaf78867f142f46fd80f0baa206d7ee3f0cc725d481a27629ad784c25a759b",
+        sender: "5GW8reAHZEeVReXHq6QaDTQA82seeTME5BPKMEvRckmk4fgQ",
+      },
     );
   });
 

--- a/tests/indexer-rs-ethereum-decode.test.mjs
+++ b/tests/indexer-rs-ethereum-decode.test.mjs
@@ -544,6 +544,144 @@ describe("decodeSignatureFieldArgs", () => {
     const raw = { signature: { name: "Sr25519", values: [{ not: "bytes" }] } };
     assert.deepEqual(decodeSignatureFieldArgs(raw), raw);
   });
+
+  test("decodes the TOP-LEVEL signature against the real descriptor-array call_args shape (fixed 2026-07-12, real production fixture, block 8605291/5)", () => {
+    // Found live 2026-07-12: unlike the flat-object fixture above, real
+    // call_args is a descriptor ARRAY -- the top-level `signature` field
+    // arrives as {name:"signature", type:"Option<MultiSignature>",
+    // value:{...}}, not a literal object key named "signature". The generic
+    // key-matching loop in walkForSignatureFields never recognized this
+    // descriptor as representing the signature field, so it stayed
+    // completely raw despite the identical-looking flat-object test above
+    // passing the whole time.
+    const raw = [
+      {
+        name: "pulses_payload",
+        type: "PulsesPayload<MultiSigner, u32>",
+        value: {
+          public: {
+            name: "Sr25519",
+            values: [
+              [
+                214, 13, 49, 183, 157, 175, 40, 221, 225, 104, 187, 249, 129,
+                82, 106, 18, 60, 124, 104, 159, 226, 111, 192, 13, 146, 73, 7,
+                64, 62, 212, 0, 35,
+              ],
+            ],
+          },
+          pulses: [
+            {
+              round: 30351957,
+              signature: [
+                [
+                  164, 69, 3, 150, 91, 10, 102, 28, 75, 20, 154, 78, 140, 231,
+                  52, 248, 186, 241, 43, 219, 170, 160, 94, 167, 131, 145, 168,
+                  8, 60, 53, 199, 90, 102, 43, 128, 110, 128, 171, 178, 230,
+                  161, 207, 175, 47, 85, 234, 50, 49,
+                ],
+              ],
+              randomness: [
+                [
+                  65, 86, 219, 252, 253, 21, 250, 126, 87, 222, 32, 237, 220,
+                  176, 74, 199, 12, 172, 25, 41, 209, 180, 142, 181, 250, 118,
+                  118, 124, 117, 98, 212, 59,
+                ],
+              ],
+            },
+          ],
+          block_number: 8605290,
+        },
+      },
+      {
+        name: "signature",
+        type: "Option<MultiSignature>",
+        value: {
+          name: "Some",
+          values: [
+            {
+              name: "Sr25519",
+              values: [
+                [
+                  70, 3, 96, 108, 107, 125, 0, 151, 142, 139, 67, 132, 42, 212,
+                  154, 58, 9, 217, 244, 135, 155, 223, 51, 110, 122, 166, 243,
+                  18, 60, 210, 229, 116, 68, 26, 55, 64, 190, 27, 217, 154, 208,
+                  79, 92, 189, 16, 68, 17, 139, 197, 43, 236, 81, 7, 123, 245,
+                  223, 24, 14, 84, 54, 33, 240, 46, 135,
+                ],
+              ],
+            },
+          ],
+        },
+      },
+    ];
+    const out = decode("Drand", "write_pulse", raw);
+    const signatureField = out.find((f) => f.name === "signature");
+    assert.deepEqual(signatureField.value, {
+      Sr25519:
+        "0x4603606c6b7d00978e8b43842ad49a3a09d9f4879bdf336e7aa6f3123cd2e574441a3740be1bd99ad04f5cbd1044118bc52bec51077bf5df180e543621f02e87",
+    });
+    // pulses[0].signature is a 48-byte BLS12-381 G1 point (NOT 32 bytes like
+    // its randomness sibling) -- decodeHash32Bytes' hardcoded length===32
+    // check silently left it raw before this fix, while randomness (32
+    // bytes) coincidentally already worked.
+    const pulsesField = out.find((f) => f.name === "pulses_payload");
+    const pulse = pulsesField.value.pulses[0];
+    assert.equal(
+      pulse.signature,
+      "0xa44503965b0a661c4b149a4e8ce734f8baf12bdbaaa05ea78391a8083c35c75a662b806e80abb2e6a1cfaf2f55ea3231",
+    );
+    assert.equal(
+      pulse.randomness,
+      "0x4156dbfcfd15fa7e57de20eddcb04ac70cac1929d1b48eb5fa76767c7562d43b",
+    );
+    assert.deepEqual(pulsesField.value.public, {
+      Sr25519:
+        "0xd60d31b79daf28dde168bbf981526a123c7c689fe26fc00d924907403ed40023",
+    });
+  });
+
+  test("decodes a top-level typed-descriptor field literally named 'public' the same way (defensive -- not confirmed live at the top level, but the same descriptor-recognition branch as signature/randomness)", () => {
+    const raw = [
+      {
+        name: "public",
+        type: "MultiSigner",
+        value: { name: "Sr25519", values: [[1, 2, 3, 4]] },
+      },
+    ];
+    const out = decode("Drand", "write_pulse", raw);
+    assert.deepEqual(out.find((f) => f.name === "public").value, {
+      Sr25519: "0x01020304",
+    });
+  });
+});
+
+describe("decodeDynamicFeeArgs (fixed 2026-07-12: DynamicFee.note_min_gas_price_target wasn't in DECODERS at all)", () => {
+  test("decodes target (U256) to an exact decimal string, not raw hex (real production fixture, block 4633999/1)", () => {
+    // Found live 2026-07-12: `target` (real value 1, raw 4-limb array
+    // [1,0,0,0]) was actively WRONG in served output -- "0x01000000"
+    // (16,777,216) -- because this call type was missing from DECODERS
+    // entirely, AND (a deeper bug in the shared pipeline) postgres-call-
+    // args.mjs's typed-descriptor branch eagerly byte-blob-hex-encoded any
+    // top-level U256-typed field before this module ever got a chance to
+    // run, whenever every limb happened to look like a valid byte (0-255).
+    const raw = [{ name: "target", type: "U256", value: [[1, 0, 0, 0]] }];
+    const out = decode("DynamicFee", "note_min_gas_price_target", raw);
+    assert.equal(out.find((f) => f.name === "target").value, "1");
+  });
+
+  test("decodes a target whose limb exceeds 255 correctly too (would have stayed completely raw, not just wrong, under the old byte-blob path)", () => {
+    const raw = [
+      { name: "target", type: "U256", value: [[20000000000, 0, 0, 0]] },
+    ];
+    const out = decode("DynamicFee", "note_min_gas_price_target", raw);
+    assert.equal(out.find((f) => f.name === "target").value, "20000000000");
+  });
+
+  test("is a no-op when target isn't found (defensive)", () => {
+    const raw = [{ name: "unrelated", type: "u32", value: 1 }];
+    const out = decode("DynamicFee", "note_min_gas_price_target", raw);
+    assert.deepEqual(out, raw);
+  });
 });
 
 describe("decodeEthereumEvmCallArgs dispatch", () => {

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -803,6 +803,157 @@ describe("decodePostgresCallArgs", () => {
     });
   });
 
+  describe("Multisig.approve_as_multi/as_multi other_signatories (fixed 2026-07-12: Vec<AccountId32> stayed raw byte arrays)", () => {
+    test("decodes each entry of other_signatories to SS58 (real production fixture, block 4632809/7)", () => {
+      const raw = [
+        { name: "threshold", type: "u16", value: 2 },
+        {
+          name: "other_signatories",
+          type: "Vec<AccountId32>",
+          value: [
+            [
+              [
+                52, 255, 249, 238, 218, 121, 67, 90, 186, 146, 46, 183, 175, 6,
+                146, 64, 101, 217, 169, 111, 81, 96, 147, 188, 104, 1, 0, 156,
+                67, 23, 174, 86,
+              ],
+            ],
+            [
+              [
+                162, 215, 243, 37, 1, 85, 128, 30, 191, 174, 156, 92, 192, 213,
+                34, 164, 121, 217, 17, 4, 153, 99, 4, 9, 190, 0, 74, 91, 83,
+                131, 140, 52,
+              ],
+            ],
+          ],
+        },
+        {
+          name: "maybe_timepoint",
+          type: "Option<Timepoint<u32>>",
+          value: { name: "Some", values: [{ index: 7, height: 4632808 }] },
+        },
+        {
+          name: "call_hash",
+          type: "[u8; 32]",
+          value: [
+            6, 171, 78, 162, 128, 230, 11, 75, 28, 70, 147, 177, 247, 165, 165,
+            113, 145, 156, 233, 147, 172, 84, 72, 55, 227, 80, 81, 46, 4, 157,
+            139, 63,
+          ],
+        },
+        {
+          name: "max_weight",
+          type: "Weight",
+          value: { ref_time: 0, proof_size: 0 },
+        },
+      ];
+      const out = decodePostgresCallArgs(raw, {
+        call_module: "Multisig",
+        call_function: "approve_as_multi",
+      });
+      const field = out.find((f) => f.name === "other_signatories");
+      assert.deepEqual(field.value, [
+        "5DGCPTWzKXExX2HTNsZpQNzmgWxbTZtBxqwP9ezpk882g98d",
+        "5FkDmKc49rqCgCf4xsfuAcWE1qUui4vhTibMSC6LouFCi8US",
+      ]);
+      // call_hash is a hash, not an account -- must stay hex.
+      const hashField = out.find((f) => f.name === "call_hash");
+      assert.equal(
+        normalizePostgresValue(hashField).value,
+        "0x06ab4ea280e60b4b1c4693b1f7a5a571919ce993ac544837e350512e049d8b3f",
+      );
+    });
+  });
+
+  describe("SubtensorModule.set_children children tuple-nested AccountId32 (fixed 2026-07-12: the child's own account stayed a raw byte array)", () => {
+    test("decodes each child tuple's AccountId32 slot to SS58 (real production fixture, block 8605286/512)", () => {
+      const raw = [
+        {
+          name: "hotkey",
+          type: "AccountId32",
+          value: [
+            [
+              56, 190, 186, 205, 170, 242, 100, 142, 182, 91, 198, 146, 215,
+              237, 72, 58, 84, 32, 140, 109, 76, 95, 243, 46, 207, 113, 61, 19,
+              59, 170, 128, 17,
+            ],
+          ],
+        },
+        { name: "netuid", type: "u16", value: 80 },
+        {
+          name: "children",
+          type: "Vec<(u64, AccountId32)>",
+          value: [
+            [
+              // Number(...) rather than a raw literal: 18446744073709551615
+              // (u64::MAX) already exceeds Number.MAX_SAFE_INTEGER, so a
+              // literal of this exact value trips eslint's
+              // no-loss-of-precision rule even though the rounding itself is
+              // the deliberately-accepted, already-tested behavior below.
+              Number("18446744073709551615"),
+              [
+                [
+                  238, 231, 18, 242, 2, 200, 120, 232, 18, 157, 79, 64, 75, 233,
+                  32, 237, 213, 155, 154, 95, 243, 100, 213, 231, 94, 249, 193,
+                  31, 21, 125, 234, 98,
+                ],
+              ],
+            ],
+          ],
+        },
+      ];
+      const out = decodePostgresCallArgs(raw, {
+        call_module: "SubtensorModule",
+        call_function: "set_children",
+      });
+      const field = out.find((f) => f.name === "children");
+      assert.equal(field.value.length, 1);
+      // proportion (tuple[0]) is untouched -- a separately accepted
+      // float64-rounding precision invariant (#4693), not this fix's
+      // concern (the raw u64::MAX literal itself already rounds on arrival,
+      // matching tests/extrinsics.test.mjs:306's identical assertion).
+      assert.equal(field.value[0][0], 18446744073709552000);
+      assert.equal(
+        field.value[0][1],
+        "5HTwtytUfeUhK4p8NRCGppjUZrhJ5ckoRHeVWEQafg2N1Zo6",
+      );
+    });
+
+    test("leaves a different call's Vec<(u64, AccountId32)>-shaped field untouched (narrow allowlist, not a generic tuple rule)", () => {
+      const raw = [
+        {
+          name: "children",
+          type: "Vec<(u64, AccountId32)>",
+          value: [[1, [[9, 9, 9]]]],
+        },
+      ];
+      const out = decodePostgresCallArgs(raw, {
+        call_module: "SomeOtherModule",
+        call_function: "some_other_function",
+      });
+      assert.deepEqual(out[0].value, [[1, [[9, 9, 9]]]]);
+    });
+
+    test("tolerates malformed/short tuple entries in children without throwing (defensive)", () => {
+      const raw = [
+        {
+          name: "children",
+          type: "Vec<(u64, AccountId32)>",
+          value: [
+            [1], // too short -- no account slot at all
+            "not-a-tuple", // not even an array
+            [2, [[9, 9, 9]]], // an array, but not a real 32-byte account
+          ],
+        },
+      ];
+      const out = decodePostgresCallArgs(raw, {
+        call_module: "SubtensorModule",
+        call_function: "set_children",
+      });
+      assert.deepEqual(out[0].value, [[1], "not-a-tuple", [2, [[9, 9, 9]]]]);
+    });
+  });
+
   describe("RawN identity-data variant family (fixed 2026-07-12: Commitments.set_commitment's info.fields[].RawN never decoded, nestedCall-gated heuristic never fires for a non-call struct field)", () => {
     test("UTF-8-decodes a Raw20 payload (real production fixture, block 8604175/9)", () => {
       const raw = [


### PR DESCRIPTION
## Summary

Ran a systematic audit comparing every distinct `chain_events` (82) and `extrinsics` (68) pallet/method or module/function type currently in production against live served API output. Found and fixed 10 confirmed bugs, each independently verified by running the actual decode functions against real fixture data through the full `formatExtrinsic`-equivalent pipeline.

**`src/chain-event-args.mjs`**
- `multisig`/`approving`/`sender` missing from `ACCOUNT_KEYS` (`Multisig.NewMultisig`/`MultisigApproval`/`MultisigExecuted`, `System.Remarked`) -- rendered raw hex instead of SS58.
- `Contracts.Called.caller`'s `MultiAddress::Signed(AccountId32)` unwrap lost the outer field's `keyHint` across the enum-tag collapse -- rendered hex instead of SS58 despite an explicit `ENUM_PAYLOAD_FIELDS` entry existing specifically for this field.

**`src/postgres-call-args.mjs`**
- `Multisig.approve_as_multi`/`as_multi`'s `other_signatories` (`Vec<AccountId32>`) missing from the `ACCOUNT_KEYS` fallback -- rendered as raw nested byte arrays.
- `SubtensorModule.set_children`'s `children` (`Vec<(u64, AccountId32)>`) left its per-child account raw -- a tuple element carries no field name of its own, so neither the typed-descriptor nor name-based account decode could reach it. Added a narrow `TUPLE_ACCOUNT_FIELDS` allowlist for this specific field.
- The typed-descriptor byte-blob-unwrap attempt ran **unconditionally** (unlike its `nestedCall`-scoped sibling a few lines down), eagerly corrupting any top-level `U256`-typed field into wrong hex whenever every limb happened to look byte-sized (0-255) -- this is what let the `DynamicFee` bug below actually corrupt data, not just leave it undecoded.

**`src/indexer-rs-ethereum-decode.mjs`**
- `Drand.write_pulse`'s top-level `signature` (`Option<MultiSignature>`) was never recognized -- `walkForSignatureFields` only matched literal object keys, not a typed descriptor's own `name` property.
- `pulses[].signature` (a 48-byte BLS12-381 G1 point, vs. its 32-byte `randomness` sibling) failed `decodeHash32Bytes`' hardcoded `length === 32` check and stayed raw.
- `DynamicFee.note_min_gas_price_target` wasn't in `DECODERS` at all, so its `target` (`U256`) fell into the now-fixed byte-blob-unwrap bug above and rendered an **actively wrong** value -- limbs `[1,0,0,0]` served as hex `"0x01000000"` (16,777,216) instead of decimal `"1"`.

## Testing

- [x] All fixes verified against real production data through the full `formatExtrinsic`/`decodeChainEventArgs` pipeline (not just the individual decode functions in isolation) -- exact block/extrinsic-index citations in each new test's description.
- [x] `npx vitest run` -- 256 files / 7579 tests passing, zero regressions.
- [x] 100% statement/branch/line coverage on all three touched source files (verified via targeted `--coverage.include`).
- [x] `npm run lint` -- clean.
- [x] `npx prettier --check` on all touched files -- clean.

No linked issue -- this audit was scoped and executed inline this session, not tracked as a separate pre-filed issue.