### PR TITLE
fix(ui): make the sparkline hover-tooltip keyboard-operable

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3190,6 +3190,20 @@ function Sparkline({
     const idx = Math.round(x / rect.width * (pts.length - 1));
     setHover(idx);
   }
+  function onKeyDown(e) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(pts.length - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? pts.length) - 1));
+    }
+  }
+  function onFocus() {
+    if (!canTooltip) return;
+    setHover((prev) => prev ?? 0);
+  }
   const hoverPoint = hover != null ? coords[hover] : null;
   const hoverValue = hover != null ? pts[hover] : null;
   const hoverLabel = hover != null ? points?.[hover]?.t : void 0;
@@ -3202,6 +3216,11 @@ function Sparkline({
       style: { width: "100%", maxWidth: width, height },
       onPointerMove: onMove,
       onPointerLeave: () => setHover(null),
+      onKeyDown,
+      onFocus,
+      onBlur: () => setHover(null),
+      tabIndex: canTooltip ? 0 : void 0,
+      "aria-label": canTooltip ? `${ariaLabel ?? "Sparkline chart"}, use arrow keys to step through values` : void 0,
       children: [
         /* @__PURE__ */ jsxRuntime.jsxs(
           "svg",
@@ -3263,7 +3282,8 @@ function Sparkline({
             role: "tooltip",
             children: tooltipText
           }
-        ) : null
+        ) : null,
+        /* @__PURE__ */ jsxRuntime.jsx("span", { "aria-live": "polite", className: "sr-only", children: tooltipText })
       ]
     }
   );

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3161,6 +3161,20 @@ function Sparkline({
     const idx = Math.round(x / rect.width * (pts.length - 1));
     setHover(idx);
   }
+  function onKeyDown(e) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(pts.length - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? pts.length) - 1));
+    }
+  }
+  function onFocus() {
+    if (!canTooltip) return;
+    setHover((prev) => prev ?? 0);
+  }
   const hoverPoint = hover != null ? coords[hover] : null;
   const hoverValue = hover != null ? pts[hover] : null;
   const hoverLabel = hover != null ? points?.[hover]?.t : void 0;
@@ -3173,6 +3187,11 @@ function Sparkline({
       style: { width: "100%", maxWidth: width, height },
       onPointerMove: onMove,
       onPointerLeave: () => setHover(null),
+      onKeyDown,
+      onFocus,
+      onBlur: () => setHover(null),
+      tabIndex: canTooltip ? 0 : void 0,
+      "aria-label": canTooltip ? `${ariaLabel ?? "Sparkline chart"}, use arrow keys to step through values` : void 0,
       children: [
         /* @__PURE__ */ jsxs(
           "svg",
@@ -3234,7 +3253,8 @@ function Sparkline({
             role: "tooltip",
             children: tooltipText
           }
-        ) : null
+        ) : null,
+        /* @__PURE__ */ jsx("span", { "aria-live": "polite", className: "sr-only", children: tooltipText })
       ]
     }
   );

--- a/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
@@ -140,7 +140,11 @@ export function Sparkline({
       onFocus={onFocus}
       onBlur={() => setHover(null)}
       tabIndex={canTooltip ? 0 : undefined}
-      aria-label={canTooltip ? `${ariaLabel ?? "Sparkline chart"}, use arrow keys to step through values` : undefined}
+      aria-label={
+        canTooltip
+          ? `${ariaLabel ?? "Sparkline chart"}, use arrow keys to step through values`
+          : undefined
+      }
     >
       <svg
         width="100%"

--- a/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
@@ -1,6 +1,7 @@
 import {
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 
@@ -104,6 +105,22 @@ export function Sparkline({
     setHover(idx);
   }
 
+  function onKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(pts.length - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? pts.length) - 1));
+    }
+  }
+
+  function onFocus() {
+    if (!canTooltip) return;
+    setHover((prev) => prev ?? 0);
+  }
+
   const hoverPoint = hover != null ? coords[hover] : null;
   const hoverValue = hover != null ? pts[hover] : null;
   const hoverLabel = hover != null ? points?.[hover]?.t : undefined;
@@ -119,6 +136,11 @@ export function Sparkline({
       style={{ width: "100%", maxWidth: width, height }}
       onPointerMove={onMove}
       onPointerLeave={() => setHover(null)}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      onBlur={() => setHover(null)}
+      tabIndex={canTooltip ? 0 : undefined}
+      aria-label={canTooltip ? `${ariaLabel ?? "Sparkline chart"}, use arrow keys to step through values` : undefined}
     >
       <svg
         width="100%"
@@ -170,6 +192,9 @@ export function Sparkline({
           {tooltipText}
         </div>
       ) : null}
+      <span aria-live="polite" className="sr-only">
+        {tooltipText}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
Closes #3954

## What
The shared `Sparkline` component (now `packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx`, migrated there from `apps/ui/src/components/metagraphed/charts/sparkline.tsx` since this issue was filed) drove its per-point value/date tooltip purely from `onPointerMove`/`onPointerLeave`. There was no `tabIndex`, `onFocus`, or `onKeyDown` handling, so keyboard-only and screen-reader users got only the single static `aria-label` summary on the `<svg>` and never the point-by-point detail mouse users see on hover. This component is reused broadly (`concentration-panel.tsx`, `subnet-history-chart.tsx`, `neuron-history-chart.tsx`, and more).

## Changes
- **`packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx`**:
  - The wrapping `<div>` now gets `tabIndex={0}` whenever `canTooltip` is true (same gate the pointer-hover path already uses: `interactive && pts.length > 1`).
  - `onKeyDown` handles `ArrowRight`/`ArrowLeft` to step the same `hover` index state the pointer path already drives — so the existing tooltip/dot/guide-line rendering just works for keyboard focus too, with zero duplicated rendering logic.
  - `onFocus` seeds `hover` to `0` (first point) so keyboard users get immediate feedback on focus, matching the "step through points" requirement; `onBlur` clears it, mirroring `onPointerLeave`.
  - Added an `aria-live="polite"` visually-hidden (`sr-only`) span mirroring the same `tooltipText` used by the visual tooltip, so screen readers announce each point's value/date as the user arrows through — the issue's suggested mechanism.
  - The wrapper's `aria-label` (only set when `canTooltip`) now reads `"{ariaLabel ?? "Sparkline chart"}, use arrow keys to step through values"` — falling back to a generic label for the several real consumers (e.g. `subnet-history-chart.tsx`) that don't pass an explicit `ariaLabel` prop, so the focusable element never ships without an accessible name.
  - `packages/ui-kit/dist/index.js` / `dist/index.cjs` are regenerated (`npm run build --workspace=packages/ui-kit`) and committed alongside, per this package's own `.gitignore` convention — `apps/ui` consumes it as a live workspace link, not a rebuilt-at-deploy artifact.

## Verification across real consumers
Verified interactively (Playwright) against two independent real consumers, not just in isolation:
- **`concentration-panel.tsx`**'s reward-drift `DriftRow` chart (Rewards tab, `/subnets/$netuid`): focusing the chart announces the first point's value via the `aria-live` region; stepping `ArrowRight` through a real 32-point series correctly advances the announced/tooltip value once the underlying data changes (confirmed the value holds flat across a flat data segment, then updates exactly where the real series changes) — proving the index-stepping logic tracks real data, not just re-rendering a static string.
- **`subnet-history-chart.tsx`**'s per-metric trend rows (Overview tab): confirmed a second, independently-rendered `Sparkline` instance (different `ariaLabel`) is likewise focusable and keyboard-steppable.
- Confirmed `Tab` from a focused sparkline moves to the next natural focusable element with no trapping, and mouse-hover behavior (`onPointerMove`/`onPointerLeave`) is untouched — same code paths, now also driven by keyboard.

## On screenshots
This is a purely interaction-only fix — the sparkline's at-rest (unfocused, non-hovered) rendering is pixel-identical before and after; the only behavior change is what happens when a keyboard user focuses/steps through it, which a static image can't show. Per the repo's screenshot-contract guidance, skipping the static viewport×theme matrix for this reason and providing only the required animated evidence below.

### Keyboard interaction (animated)

| Target | Before | After |
| --- | --- | --- |
| Reward-drift sparkline, `/subnets/19?tab=metagraph` (Rewards) | [before-sparkline-kbd.webm](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-sparkline-keyboard-3954/before-sparkline-kbd.webm) | [after-sparkline-kbd.webm](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-sparkline-keyboard-3954/after-sparkline-kbd.webm) |

(GitHub doesn't inline-render `.webm` from a `raw.githubusercontent.com` link in a PR body — click through to view. Before: repeatedly pressing Tab near the chart never reaches or steps through it — only the static SVG summary exists. After: focusing the chart directly and pressing `ArrowRight` repeatedly visibly moves the guide-line/dot and updates the tooltip through the real series.)

## Acceptance criteria
- [x] `sparkline.tsx` appears in the diff
- [x] A keyboard-only user can focus the sparkline and step through points via arrow keys, with each point's value/date exposed to assistive tech (`aria-live`) as they do
- [x] Mouse-hover behavior is completely unchanged
- [x] Verified across two real consumers (`concentration-panel.tsx` and `subnet-history-chart.tsx`), not just in isolation
- [x] Includes a before/after screen recording demonstrating keyboard-driven point stepping

## Testing
- `npm run build --workspace=packages/ui-kit` + `npm run typecheck --workspace=packages/ui-kit`: clean.
- `npx eslint` on the changed source file: clean aside from pre-existing CRLF noise unrelated to this change.
- Diff is 3 files (source + 2 regenerated dist bundles), no visual-rendering change at rest.
