### PR TITLE
fix(data-api): order broad extrinsics/chain-events feeds by observed_at

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11771,7 +11771,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11966,7 +11966,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "next_before": 1,
-                     *         "next_cursor": "example"
+                     *         "next_cursor": "100.123.4"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -3767,13 +3767,13 @@ export interface components {
             method: string | null;
             pallet: string | null;
         };
-        /** @description Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs. */
+        /** @description Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless observed_at.block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs. */
         ChainEventsFeedArtifact: {
             count: number;
             events: components["schemas"]["ChainEvent"][];
             /** @description Legacy block_number-only cursor for the next page. Prefer next_cursor to avoid skipping same-block events. */
             next_before?: number | null;
-            /** @description Lossless block_number.event_index cursor for the next page. Both parts are non-negative safe integers; pass it back as ?cursor=. */
+            /** @description Lossless observed_at.block_number.event_index cursor for the next page. All parts are non-negative safe integers; pass it back as ?cursor=. */
             next_cursor?: string | null;
         } & {
             [key: string]: unknown;
@@ -11966,7 +11966,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "next_before": 1,
-                     *         "next_cursor": "123.4"
+                     *         "next_cursor": "example"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27077,7 +27077,7 @@
                       }
                     ],
                     "next_before": 1,
-                    "next_cursor": "example"
+                    "next_cursor": "100.123.4"
                   },
                   "meta": {
                     "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4596,7 +4596,7 @@
       },
       "ChainEventsFeedArtifact": {
         "additionalProperties": true,
-        "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
+        "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless observed_at.block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
         "properties": {
           "count": {
             "minimum": 0,
@@ -4616,9 +4616,9 @@
             ]
           },
           "next_cursor": {
-            "description": "Lossless block_number.event_index cursor for the next page. Both parts are non-negative safe integers; pass it back as ?cursor=.",
-            "maxLength": 33,
-            "pattern": "^\\d+\\.\\d+$",
+            "description": "Lossless observed_at.block_number.event_index cursor for the next page. All parts are non-negative safe integers; pass it back as ?cursor=.",
+            "maxLength": 50,
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
             "type": [
               "string",
               "null"
@@ -27077,7 +27077,7 @@
                       }
                     ],
                     "next_before": 1,
-                    "next_cursor": "123.4"
+                    "next_cursor": "example"
                   },
                   "meta": {
                     "artifact_path": "example",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11966,7 +11966,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "next_before": 1,
-                     *         "next_cursor": "example"
+                     *         "next_cursor": "100.123.4"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3767,13 +3767,13 @@ export interface components {
             method: string | null;
             pallet: string | null;
         };
-        /** @description Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs. */
+        /** @description Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless observed_at.block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs. */
         ChainEventsFeedArtifact: {
             count: number;
             events: components["schemas"]["ChainEvent"][];
             /** @description Legacy block_number-only cursor for the next page. Prefer next_cursor to avoid skipping same-block events. */
             next_before?: number | null;
-            /** @description Lossless block_number.event_index cursor for the next page. Both parts are non-negative safe integers; pass it back as ?cursor=. */
+            /** @description Lossless observed_at.block_number.event_index cursor for the next page. All parts are non-negative safe integers; pass it back as ?cursor=. */
             next_cursor?: string | null;
         } & {
             [key: string]: unknown;
@@ -11966,7 +11966,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "next_before": 1,
-                     *         "next_cursor": "123.4"
+                     *         "next_cursor": "example"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4582,7 +4582,7 @@
       },
       "ChainEventsFeedArtifact": {
         "additionalProperties": true,
-        "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
+        "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless observed_at.block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
         "properties": {
           "count": {
             "minimum": 0,
@@ -4602,9 +4602,9 @@
             ]
           },
           "next_cursor": {
-            "description": "Lossless block_number.event_index cursor for the next page. Both parts are non-negative safe integers; pass it back as ?cursor=.",
-            "maxLength": 33,
-            "pattern": "^\\d+\\.\\d+$",
+            "description": "Lossless observed_at.block_number.event_index cursor for the next page. All parts are non-negative safe integers; pass it back as ?cursor=.",
+            "maxLength": 50,
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
             "type": [
               "string",
               "null"

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -4950,7 +4950,7 @@
       "ChainEventsFeedArtifact": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
+        "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events. Optional ?pallet / ?method narrow by event id (method requires pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless observed_at.block_number.event_index keyset cursor (exclusive), while ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). next_cursor is the cursor for the next page (null when the page was not full); next_before is retained for legacy callers. Empty (count:0, events:[]) before the all-events backfill runs.",
         "required": ["count", "events"],
         "properties": {
           "count": { "type": "integer", "minimum": 0 },
@@ -4960,9 +4960,9 @@
           },
           "next_cursor": {
             "type": ["string", "null"],
-            "pattern": "^\\d+\\.\\d+$",
-            "maxLength": 33,
-            "description": "Lossless block_number.event_index cursor for the next page. Both parts are non-negative safe integers; pass it back as ?cursor=."
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
+            "maxLength": 50,
+            "description": "Lossless observed_at.block_number.event_index cursor for the next page. All parts are non-negative safe integers; pass it back as ?cursor=."
           },
           "events": {
             "type": "array",

--- a/scripts/fetch-subnet-hyperparams.py
+++ b/scripts/fetch-subnet-hyperparams.py
@@ -111,7 +111,18 @@ def main():
 
     # Reuse the bulk metagraph call purely to discover the active netuid set —
     # the same pattern fetch-native-subnets.py already uses for the same reason
-    # (get_subnet_hyperparameters itself has no bulk/all-subnets variant).
+    # (get_subnet_hyperparameters itself has no bulk/all-subnets variant). Also
+    # reuse its per-info `.block` (the metagraph snapshot's chain height) as
+    # this run's block_number: `get_subnet_hyperparameters()` itself carries no
+    # block field, and the previous `getattr(s.substrate, "block_number", 0)`
+    # always silently fell back to 0 because SubstrateInterface has no
+    # `block_number` attribute (it's a method, `get_block_number()`) — live-
+    # verified 2026-07-12, every hyperparameters row served in production had
+    # block_number:0. One shared value for the whole run, matching
+    # fetch-metagraph-native.py's `int(getattr(info, "block", 0) or 0)`
+    # convention, rather than a fresh get_block_number() call per netuid
+    # (~129 extra RPC round-trips returning a slightly different block each
+    # time as the loop runs).
     infos = s.metagraphs.get_all_metagraphs_info(all_mechanisms=True)
     netuids = sorted(
         {
@@ -120,6 +131,7 @@ def main():
             if int(getattr(info, "mechid", 0) or 0) == 0
         }
     )
+    block_number = int(getattr(infos[0], "block", 0) or 0) if infos else 0
 
     captured_at = int(time.time() * 1000)
     rows = []
@@ -141,7 +153,6 @@ def main():
         if hp is None:
             errors.append(f"netuid={netuid}: empty hyperparameters response")
             continue
-        block_number = int(getattr(s.substrate, "block_number", 0) or 0)
         rows.append(
             {
                 "netuid": netuid,

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -14,6 +14,7 @@ const OPTIONAL_DEPTH = 3;
 const MAX_DEPTH = 8;
 const ISO = "2026-06-01T00:00:00.000Z";
 const CURSOR2 = "123.4";
+const CURSOR3 = "100.123.4";
 const HEX64 = "a3f1".repeat(16); // 64 hex chars, matches ^[a-f0-9]{64}$
 const SAMPLE_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 const SAMPLE_COUNTERPARTY_SS58 =
@@ -32,6 +33,8 @@ function valueForPattern(pattern, name = "") {
       return "2026-06-01";
     case "^\\d+\\.\\d+$":
       return CURSOR2;
+    case "^\\d+\\.\\d+\\.\\d+$":
+      return CURSOR3;
     case "^[a-z0-9][a-z0-9-]*$":
       return "example-subnet";
     case "^/metagraph/":

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -437,7 +437,7 @@ test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)
   const body = await res.json();
   expect(body.count).toBe(1);
   expect(body.next_before).toBe(123); // rows.length === limit → cursor is the last row
-  expect(body.next_cursor).toBe("123.0"); // lossless block_number.event_index cursor
+  expect(body.next_cursor).toBe("100.123.0"); // lossless observed_at.block_number.event_index cursor
   // BIGINT columns are coerced from postgres.js strings to numbers (D1-route parity).
   expect(body.events[0].block_number).toBe(123);
   expect(typeof body.events[0].block_number).toBe("number");
@@ -445,15 +445,19 @@ test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)
   expect(typeof body.events[0].observed_at).toBe("number");
 });
 
-test("chain-events cursor seeks by block_number and event_index", async () => {
-  const res = await req("/api/v1/chain-events?limit=1&cursor=123.4&before=500");
+test("chain-events cursor seeks by observed_at, block_number and event_index", async () => {
+  const res = await req(
+    "/api/v1/chain-events?limit=1&cursor=50.123.4&before=500",
+  );
   expect(res.status).toBe(200);
-  expect(queryText()).toContain("AND (block_number, event_index) < (?, ?)");
+  expect(queryText()).toContain(
+    "AND (observed_at, block_number, event_index) < (?, ?, ?)",
+  );
   expect(queryText()).not.toContain("AND block_number <");
   const cursorCall = sqlCalls.find((call) =>
-    call.text.includes("(block_number, event_index) <"),
+    call.text.includes("(observed_at, block_number, event_index) <"),
   );
-  expect(cursorCall.values).toEqual([123, 4]);
+  expect(cursorCall.values).toEqual([50, 123, 4]);
 });
 
 test("limit is clamped and defaults safely", async () => {
@@ -867,9 +871,9 @@ test("GET /api/v1/extrinsics ignores a malformed call_hash instead of erroring",
 
 test("GET /api/v1/extrinsics uses a composite cursor seek instead of OFFSET", async () => {
   mockRows.current = [EXTRINSIC_ROW];
-  await req("/api/v1/extrinsics?cursor=8586300.2");
+  await req("/api/v1/extrinsics?cursor=1783600000000.8586300.2");
   const text = queryText();
-  expect(text).toContain("AND (block_number, extrinsic_index) <");
+  expect(text).toContain("AND (observed_at, block_number, extrinsic_index) <");
   expect(text).not.toContain("OFFSET");
 });
 
@@ -1125,7 +1129,7 @@ test("GET /api/v1/governance/config-changes filters to call_module='AdminUtils'"
 test("GET /api/v1/sudo applies block/block_start/block_end/from/to filters and a cursor seek", async () => {
   mockRows.current = [];
   await req(
-    "/api/v1/sudo?block=1&block_start=1&block_end=2&from=1&to=2&cursor=8586300.2",
+    "/api/v1/sudo?block=1&block_start=1&block_end=2&from=1&to=2&cursor=1783600000000.8586300.2",
   );
   const text = queryText();
   expect(text).toContain("AND block_number =");
@@ -1133,7 +1137,7 @@ test("GET /api/v1/sudo applies block/block_start/block_end/from/to filters and a
   expect(text).toContain("AND block_number <=");
   expect(text).toContain("AND observed_at >=");
   expect(text).toContain("AND observed_at <=");
-  expect(text).toContain("AND (block_number, extrinsic_index) <");
+  expect(text).toContain("AND (observed_at, block_number, extrinsic_index) <");
   expect(text).not.toContain("OFFSET");
 });
 
@@ -1151,7 +1155,7 @@ test("GET /api/v1/sudo returns a next_cursor when the page is full", async () =>
   mockRows.current = [{ ...EXTRINSIC_ROW, call_module: "Sudo" }];
   const res = await req("/api/v1/sudo?limit=1");
   const body = await res.json();
-  expect(body.next_cursor).toBe("8586300.2");
+  expect(body.next_cursor).toBe("1783600000000.8586300.2");
 });
 
 test("GET /api/v1/runtime returns the spec-version transition timeline", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2446,14 +2446,32 @@ export default {
         // GET /api/v1/extrinsics — the recent-extrinsic feed, mirroring
         // src/extrinsics.mjs's loadExtrinsics filter set exactly (signer,
         // call_module, call_function, call_hash, success, block, block_start/
-        // block_end, from/to, cursor). Index selection is left to Postgres'
-        // planner (schema.sql's idx_extrinsics_signer_block / idx_extrinsics_call
-        // cover the same access patterns D1's INDEXED BY hints targeted) --
-        // Postgres has no INDEXED BY equivalent.
+        // block_end, from/to, cursor). Ordered by observed_at (not
+        // block_number) because `extrinsics` is a TimescaleDB hypertable
+        // partitioned on observed_at (see timescaledb_information.dimensions):
+        // an unfiltered/broad `ORDER BY block_number DESC` forces a
+        // Parallel Append + Sort across every chunk (including decompressing
+        // historical compressed chunks) since block_number carries no chunk-
+        // exclusion information, which measured 6+ seconds live against
+        // production on 2026-07-12 -- past this route's 3000ms
+        // statement_timeout, tripping tryPostgresTier's D1 fallback into the
+        // now-fully-dropped D1 extrinsics table (#4772), which silently
+        // resolves to an empty-but-200 response. `ORDER BY observed_at DESC,
+        // block_number DESC, extrinsic_index DESC` lets ChunkAppend prune to
+        // just the live head chunk (confirmed live: same queries dropped to
+        // 0.5-75ms). observed_at is the genuine on-chain block timestamp
+        // (verified against block #1: 2023-03-20, not an ingestion clock), so
+        // this produces the identical "most recent first" ordering as
+        // block_number DESC -- block production is strictly monotonic with
+        // wall-clock time -- with block_number/extrinsic_index only breaking
+        // ties among the (rare) extrinsics that share one block's timestamp.
+        // The cursor is now a 3-tuple to match; decodeCursor's arity check
+        // makes an old 2-part cursor a clean "ignored, no next-page" miss
+        // rather than a crash.
         if (url.pathname === "/api/v1/extrinsics") {
           const limit = clampBlockLimit(url.searchParams.get("limit"));
           const offset = clampOffset(url.searchParams.get("offset"));
-          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 3);
           const block = nonNegativeIntegerParam(url.searchParams, "block");
           const signer = url.searchParams.get("signer") || null;
           const callModule = url.searchParams.get("call_module") || null;
@@ -2492,13 +2510,14 @@ export default {
             ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
             ${from != null ? sql`AND observed_at >= ${from}` : sql``}
             ${to != null ? sql`AND observed_at <= ${to}` : sql``}
-            ${cursor ? sql`AND (block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
-          ORDER BY block_number DESC, extrinsic_index DESC
+            ${cursor ? sql`AND (observed_at, block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
+          ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC
           LIMIT ${limit}
           ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
           const last = rows.length === limit ? rows[rows.length - 1] : null;
           const nextCursor = last
             ? encodeCursor([
+                numberOrNull(last.observed_at),
                 numberOrNull(last.block_number),
                 numberOrNull(last.extrinsic_index),
               ])
@@ -2511,6 +2530,8 @@ export default {
         // fixed rather than caller-supplied (mirroring src/extrinsics.mjs's
         // loadExtrinsics({callModule: "Sudo"|"AdminUtils", ...}) call sites in
         // entities.mjs) -- so neither accepts ?signer=/?call_module=/?call_hash=.
+        // Ordered by observed_at for the same chunk-exclusion reason as
+        // /api/v1/extrinsics above (identical hypertable, identical cursor shape).
         const SUDO_GOVERNANCE_ROUTES = {
           "/api/v1/sudo": "Sudo",
           "/api/v1/governance/config-changes": "AdminUtils",
@@ -2519,7 +2540,7 @@ export default {
           const callModule = SUDO_GOVERNANCE_ROUTES[url.pathname];
           const limit = clampBlockLimit(url.searchParams.get("limit"));
           const offset = clampOffset(url.searchParams.get("offset"));
-          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 3);
           const block = nonNegativeIntegerParam(url.searchParams, "block");
           const callFunction = url.searchParams.get("call_function") || null;
           const successRaw = url.searchParams.get("success");
@@ -2550,13 +2571,14 @@ export default {
             ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
             ${from != null ? sql`AND observed_at >= ${from}` : sql``}
             ${to != null ? sql`AND observed_at <= ${to}` : sql``}
-            ${cursor ? sql`AND (block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]})` : sql``}
-          ORDER BY block_number DESC, extrinsic_index DESC
+            ${cursor ? sql`AND (observed_at, block_number, extrinsic_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
+          ORDER BY observed_at DESC, block_number DESC, extrinsic_index DESC
           LIMIT ${limit}
           ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
           const last = rows.length === limit ? rows[rows.length - 1] : null;
           const nextCursor = last
             ? encodeCursor([
+                numberOrNull(last.observed_at),
                 numberOrNull(last.block_number),
                 numberOrNull(last.extrinsic_index),
               ])
@@ -4862,7 +4884,15 @@ export default {
             blockN != null
               ? nonNegativeIntegerParam(url.searchParams, "extrinsic")
               : null;
-          const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
+          // 3-tuple cursor (observed_at, block_number, event_index) for the
+          // same reason as /api/v1/extrinsics above: chain_events is a
+          // TimescaleDB hypertable partitioned on observed_at, so ordering
+          // (and seeking) by observed_at first lets ChunkAppend prune to the
+          // live head chunk instead of a full cross-chunk sort. The legacy
+          // `before` (block_number) cursor still does a plain inequality —
+          // correct (block_number and observed_at are monotonic together)
+          // even though it can't get the same single-chunk shortcut.
+          const cursor = decodeCursor(url.searchParams.get("cursor"), 3);
           const beforeBn = cursor
             ? null
             : nonNegativeIntegerParam(url.searchParams, "before"); // legacy block_number cursor
@@ -4883,19 +4913,23 @@ export default {
             ${extrN != null ? sql`AND extrinsic_index = ${extrN}` : sql``}
             ${
               cursor
-                ? sql`AND (block_number, event_index) < (${cursor[0]}, ${cursor[1]})`
+                ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})`
                 : beforeBn != null
                   ? sql`AND block_number < ${beforeBn}`
                   : sql``
             }
             ${pallet ? sql`AND pallet = ${pallet}` : sql``}
             ${method ? sql`AND method = ${method}` : sql``}
-          ORDER BY block_number DESC, event_index DESC
+          ORDER BY observed_at DESC, block_number DESC, event_index DESC
           LIMIT ${limit}`;
           const last = rows.length === limit ? rows[rows.length - 1] : null;
           const nextBlock = last ? numberOrNull(last.block_number) : null;
           const nextCursor = last
-            ? encodeCursor([nextBlock, numberOrNull(last.event_index)])
+            ? encodeCursor([
+                numberOrNull(last.observed_at),
+                nextBlock,
+                numberOrNull(last.event_index),
+              ])
             : null;
           return json({
             count: rows.length,


### PR DESCRIPTION
## Summary

- `GET /api/v1/extrinsics` was silently returning an empty feed (HTTP 200, `extrinsic_count:0`, `generated_at:null`) for the unfiltered/default view and for broad filters (`success=true`, `call_module=SubtensorModule`) — confirmed in production during a live-wiring verification sweep. Narrow filters (a specific block, `success=false`, a specific signer) worked correctly, which pointed at a query-shape problem rather than a data or decode problem.
- Root cause: `extrinsics`/`chain_events` are TimescaleDB hypertables partitioned on `observed_at`, but the recent-feed queries ordered by `block_number DESC, extrinsic_index DESC` — a column with zero chunk-exclusion value for the planner. `EXPLAIN ANALYZE` against production showed a full cross-chunk `Parallel Append` + `Sort`, decompressing 15 historical compressed chunks, taking 6041ms — well past this route's 3000ms `statement_timeout`. `tryPostgresTier` treats any non-2xx as "fall back to D1"; D1's `extrinsics` table was fully dropped in the 2026-07-11 chain-data retirement (#4772), so the fallback silently resolved to an empty-but-200 response instead of surfacing an error anywhere.
- Fix: reorder the recent-feed queries (`/api/v1/extrinsics`, `/api/v1/sudo`, `/api/v1/governance/config-changes`, `/api/v1/chain-events`) to `ORDER BY observed_at DESC, block_number DESC, ...`, which lets TimescaleDB's `ChunkAppend` prune straight to the live head chunk. Confirmed live against production Postgres: the identical queries dropped from 6041ms to 0.5–75ms. `observed_at` is the genuine on-chain block timestamp (verified against block #1 → 2023-03-20, not an ingestion clock), so ordering by it produces the exact same "most recent first" semantics as `block_number DESC` — block production is strictly monotonic with wall-clock time. Cursors for the affected routes are now 3-tuples `(observed_at, block_number, position)`; an old 2-part cursor just decodes to `null` (cursor ignored, page restarts) rather than erroring — no live callers depend on cursor stability across this change.
- Also fixes `scripts/fetch-subnet-hyperparams.py`: every hyperparameters row served in production had `block_number:0` because `getattr(s.substrate, "block_number", 0)` silently fell back to the default — `SubstrateInterface` has no `block_number` attribute (it's the method `get_block_number()`). Now reuses the metagraph snapshot's own per-info `.block` field (already fetched in the same run, zero extra RPC calls), matching `fetch-metagraph-native.py`'s existing convention. Verified live: 129/129 subnets now report the real chain height (~8605812) instead of 0.

## Test plan

- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm test` — 256/256 files, 7579/7579 tests green (full suite, twice)
- [x] `npm run validate` / `validate:contract-drift` / `validate:schemas` / `validate:api` / `validate:openapi` all green
- [x] Live-verified the root cause and the fix directly against production Postgres via `EXPLAIN (ANALYZE, BUFFERS, TIMING)` (SSH to the indexer box) — before: 6041ms unfiltered scan; after: 36–75ms for unfiltered, `success=true`, and `call_module=SubtensorModule` cases
- [x] Live-ran the fixed `fetch-subnet-hyperparams.py` end-to-end against production `finney` (bittensor 10.4.0, the CI-pinned version) — 129/129 subnets, all with a real non-zero `block_number`
- [x] Updated + added regression tests in `tests/data-api.test.mjs` for the new 3-tuple cursor shape on all four affected routes
- [x] Schema contract updated (`ChainEventsFeedArtifact.next_cursor` pattern/length/description) and regenerated (`npm run build` → `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts`, `schemas/api-components.schema.json`)