### PR TITLE
fix(ui): persist 7d/30d window toggle in URL on /status and /endpoints

### DIFF
--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Zap, GitBranch, Database, ShieldCheck, Gauge, ArrowUpDown } from "lucide-react";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { useNetwork } from "@/hooks/use-api-base";
@@ -155,7 +155,8 @@ function UsageStat({
 }
 
 export function ProxyUsagePanel() {
-  const [window, setWindow] = useState<"7d" | "30d">("7d");
+  const { proxy_window: window } = useSearch({ from: "/endpoints" });
+  const navigate = useNavigate({ from: "/endpoints" });
   const { data } = useSuspenseQuery(rpcUsageQuery(window));
   const usage = data.data as RpcUsage;
   const s = usage.summary;
@@ -179,7 +180,7 @@ export function ProxyUsagePanel() {
             <button
               key={w}
               type="button"
-              onClick={() => setWindow(w)}
+              onClick={() => navigate({ search: (prev) => ({ ...prev, proxy_window: w }) })}
               className={classNames(
                 "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
                 window === w ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -84,6 +84,7 @@ const endpointsSearchSchema = z.object({
   page: fallback(z.number().int().min(1), 1).default(1),
   pageSize: fallback(z.number().int().min(10).max(200), 25).default(25),
   view: fallback(z.enum(["table", "grid"]), "table").default("table"),
+  proxy_window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
 });
 
 type EndpointsSearch = z.infer<typeof endpointsSearchSchema>;

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -66,6 +66,7 @@ const statusSearchSchema = z.object({
   status: fallback(z.string(), "").default(""),
   sort: fallback(z.enum(SURFACE_SORT_FIELDS), "status").default("status"),
   order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
 });
 
 export const Route = createFileRoute("/status")({
@@ -324,7 +325,8 @@ function Kpi({
 
 /** Global, cross-subnet incident ledger from /api/v1/incidents (7d / 30d window). */
 function RecentIncidents() {
-  const [window, setWindow] = useState<IncidentWindow>("7d");
+  const { window } = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
   const [showAll, setShowAll] = useState(false);
   const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
@@ -380,7 +382,7 @@ function RecentIncidents() {
               key={w}
               type="button"
               onClick={() => {
-                setWindow(w);
+                navigate({ search: (prev) => ({ ...prev, window: w }) });
                 setShowAll(false);
               }}
               className={classNames(


### PR DESCRIPTION
## Summary

- The 7d/30d window toggle in `RecentIncidents` (`status.tsx`) used plain `useState` — the selected window reset on every reload, couldn't be shared or bookmarked.
- Same issue in `ProxyUsagePanel` (`rpc-proxy.tsx`) on `/endpoints`.
- Fix: wire both to the same URL-backed pattern `/explorer` already uses (`explorerSearchSchema` → `Route.useSearch()` + `navigate`).

Changes:
- **`apps/ui/src/routes/status.tsx`** — add `window` to `statusSearchSchema`; `RecentIncidents` reads `Route.useSearch().window` and writes `navigate({ search: (prev) => ({ ...prev, window: w }) })`
- **`apps/ui/src/routes/endpoints.tsx`** — add `proxy_window` to `endpointsSearchSchema`
- **`apps/ui/src/components/metagraphed/rpc-proxy.tsx`** — replace `useState` with `useSearch({ from: '/endpoints' })` + `useNavigate`, matching the pattern already used in `status-diagnostics.tsx`

Closes #3976

## Gates

| Check | Result |
|-------|--------|
| typecheck | ✓ |
| unit tests | ✓ (670 passing) |
| prettier | ✓ |
| build | ✓ |

## Screenshots

The key behavioral difference is the URL: **before**, toggling to 30d left the URL unchanged (`/status`); **after**, it updates to `/status?window=30d` so the window survives reload and sharing.

### /status — RecentIncidents panel

| Viewport | Before (7d, no URL param) | After (30d, URL: `?window=30d`) |
|----------|---------------------------|-----------------------------------|
| Mobile · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-status-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-status-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-status-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-status-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-status-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-status-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-status-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-status-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-status-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-status-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-status-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-status-desktop-dark.png) |

### /endpoints — ProxyUsagePanel

| Viewport | Before (7d, no URL param) | After (30d, URL: `?proxy_window=30d`) |
|----------|---------------------------|------------------------------------------|
| Mobile · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-endpoints-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-endpoints-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-endpoints-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-endpoints-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-endpoints-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-endpoints-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-endpoints-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-endpoints-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-endpoints-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-endpoints-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/before-endpoints-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3976/.screenshots/3976/after-endpoints-desktop-dark.png) |