### PR TITLE
fix(ui): make activity-heatmap day cells keyboard-focusable

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -116,7 +116,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
         <div
           className="grid gap-[3px]"
           style={{ gridTemplateColumns: `repeat(${weeks}, minmax(0, 1fr))` }}
-          role="img"
+          role="group"
           aria-label={`Registry activity heatmap for the last ${weeks} weeks`}
         >
           {columns.map((col, ci) => (
@@ -124,8 +124,9 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
               {col.map((c) => (
                 <Tooltip key={c.key} delayDuration={120}>
                   <TooltipTrigger asChild>
-                    <div
-                      className="aspect-square rounded-[2px] border border-border/40"
+                    <button
+                      type="button"
+                      className="aspect-square rounded-[2px] border border-border/40 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                       style={{ background: tone(c.score, maxScore) }}
                       aria-label={`${c.key}: ${c.probes} probes, ${c.incidents} incidents`}
                     />


### PR DESCRIPTION
Closes #3955

## What
`activity-heatmap.tsx`'s day cells were bare `<div>`s wrapped in a Radix `TooltipTrigger asChild`, with `onPointerMove`/`onPointerLeave`-driven hover as the only way to reveal the per-day probe/incident tooltip. There was no `tabIndex`/focus handling, so keyboard-only and screen-reader users got only the parent grid's single static `aria-label` summary and never the per-day detail mouse users see on hover.

## Building on a prior, correctly-reviewed attempt
An earlier PR (#4652) took the straightforward fix — swap the `<div>` for a `<button>` — and was reviewed favorably (readiness 95/100, no blockers) before being closed. That review flagged a real, unaddressed wrinkle: the day cells sit inside a parent `<div role="img" aria-label="Registry activity heatmap...">`. `role="img"` tells assistive tech the element is a single atomic graphic with no interactive descendants — most screen readers flatten/hide a `role="img"` subtree, so nesting real `<button>`s inside it would restore keyboard *tab* focus but likely still fail to expose them to screen-reader users navigating by AT, defeating part of the point.

This PR fixes both pieces:
1. Each day cell (`activity-heatmap.tsx:127`) becomes a `<button type="button">`, keeping the same className/style/`aria-label`, plus a `focus-visible:ring-1 focus-visible:ring-ring` ring consistent with other focusable tiles in this codebase (e.g. `stat-with-spark.tsx`). Since Radix's `TooltipTrigger asChild` already wires its child's focus/blur to open/close the tooltip, this alone makes the existing tooltip reveal on keyboard focus — no new tooltip logic needed.
2. The parent grid (`activity-heatmap.tsx:116-120`) changes from `role="img"` to `role="group"` with the same `aria-label`. `group` is a container role that does not flatten or hide interactive descendants, so it keeps a labeled-region summary for the grid as a whole while letting each day cell be independently focusable and exposed to assistive tech — resolving the exact nested-interactive-in-atomic-image conflict the prior PR's review identified, rather than leaving it unaddressed.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-mobile-dark.png)<br><sub>after</sub> |

At rest the heatmap is pixel-identical before/after (confirmed above) — Tailwind's base reset already neutralizes native `<button>` default styling, so no visual regression from the div→button swap.

### Keyboard interaction (animated)

| Target | Before | After |
| --- | --- | --- |
| Day-cell focus + tooltip reveal, `/subnets/1` | [before-heatmap-kbd.webm](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/before-heatmap-kbd.webm) | [after-heatmap-kbd.webm](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-activity-heatmap-kbd-3955/after-heatmap-kbd.webm) |

(GitHub doesn't inline-render `.webm` from a `raw.githubusercontent.com` link — click through to view. Before: repeatedly pressing Tab near the grid never lands on or reveals a day cell's tooltip. After: Tab reaches the first cell directly, and the Radix tooltip opens on focus exactly as it does on hover; continuing to Tab moves cleanly through subsequent cells.)

## Verification
- Focus lands on a day-cell `<button>` (confirmed via `document.activeElement`), and the Radix `TooltipContent` becomes `visible` with real per-day text (e.g. `"2026-04-19", "0 probes"`) — no separate tooltip-reveal code needed, since `TooltipTrigger asChild` already wires this.
- Confirmed no ancestor of a day-cell button carries `role="img"` anymore (walked the DOM tree in-browser) — the exact nested-interactive-in-atomic-image conflict the prior PR's review flagged is resolved.
- Tab from the first cell lands on the second cell — clean sequential order, no trapping.

## Acceptance criteria
- [x] `activity-heatmap.tsx` appears in the diff
- [x] Keyboard focus reaches each day cell and reveals the same per-day tooltip mouse hover does
- [x] No invalid nested-interactive/atomic-image ARIA conflict — `role="img"` replaced with `role="group"` on the parent, which doesn't hide interactive descendants
- [x] Mouse-hover behavior unchanged; at-rest visual rendering unchanged (screenshots above)
- [x] Full 3-viewport × 2-theme before/after matrix, plus animated evidence for the focus-triggered tooltip reveal

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx prettier --check` and `npx eslint` on the changed file: clean aside from pre-existing CRLF noise unrelated to this change.
- Diff is 4 insertions / 3 deletions in a single file.
