### PR TITLE
fix(data-api): wrap Postgres counterparty drilldowns

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -2744,7 +2744,17 @@ test("GET /api/v1/accounts/:ss58/counterparties?counterparty= returns the relati
   );
   expect(res.status).toBe(200);
   const body = await res.json();
-  expect(body.counterparty).toBe("5Cold");
+  expect(body.counterparty_count).toBe(1);
+  expect(body.counterparties[0]).toMatchObject({
+    address: "5Cold",
+    sent_tao: 2,
+    received_tao: 0,
+    net_tao: -2,
+    transfer_count: 1,
+    last_block: 100,
+  });
+  expect(body.relationship.counterparty).toBe("5Cold");
+  expect(body.relationship.transfer_count).toBe(1);
   expect(queryText()).toContain("(hotkey = ");
 });
 

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -2758,6 +2758,18 @@ test("GET /api/v1/accounts/:ss58/counterparties?counterparty= returns the relati
   expect(queryText()).toContain("(hotkey = ");
 });
 
+test("GET /api/v1/accounts/:ss58/counterparties?counterparty= with no matching transfers returns an empty counterparties array", async () => {
+  mockRows.current = [];
+  const res = await req(
+    `/api/v1/accounts/${SS58}/counterparties?counterparty=5Cold`,
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.counterparty_count).toBe(0);
+  expect(body.counterparties).toEqual([]);
+  expect(body.relationship.transfer_count).toBe(0);
+});
+
 // #4832 gap-closure: POST /api/v1/internal/rollup-account-events-daily -- the
 // account_events_daily write path account_events itself lacked (indexer-rs
 // writes account_events continuously, but nothing rolled it into the daily

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -7544,6 +7544,61 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
+  test("handleAccountCounterparties: flag=postgres accepts relationship drilldown envelope", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          counterparty_count: 1,
+          transfers_scanned: 1,
+          scan_capped: false,
+          total_sent_tao: 4.2,
+          total_received_tao: 0,
+          counterparties: [
+            {
+              address: COUNTERPARTY,
+              sent_tao: 4.2,
+              received_tao: 0,
+              net_tao: -4.2,
+              transfer_count: 1,
+              last_block: BLOCK_NUM,
+            },
+          ],
+          relationship: {
+            schema_version: 1,
+            ss58: SS58,
+            counterparty: COUNTERPARTY,
+            transfer_count: 1,
+            transfers_scanned: 1,
+            scan_capped: false,
+            total_sent_tao: 4.2,
+            total_received_tao: 0,
+            net_tao: -4.2,
+            first_seen_at: new Date(OBSERVED_AT).toISOString(),
+            last_seen_at: new Date(OBSERVED_AT).toISOString(),
+            first_block: BLOCK_NUM,
+            last_block: BLOCK_NUM,
+            transfers: [],
+          },
+        }),
+    };
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
+        ),
+      ),
+    );
+    assert.equal(body.data.relationship.counterparty, COUNTERPARTY);
+    assert.deepEqual(captures.sql, []);
+  });
+
   test("handleAccountCounterparties: flag=postgres falls back to D1 on failure", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -4827,11 +4827,36 @@ export default {
             WHERE event_kind = 'Transfer'
               AND ((hotkey = ${ss58} AND coldkey = ${counterparty}) OR (hotkey = ${counterparty} AND coldkey = ${ss58}))
             ORDER BY block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP}`;
-            return json(
-              buildCounterpartyRelationship(rows, ss58, counterparty, {
-                limit,
-              }),
+            const relationship = buildCounterpartyRelationship(
+              rows,
+              ss58,
+              counterparty,
+              { limit },
             );
+            const counterparties =
+              relationship.transfer_count === 0
+                ? []
+                : [
+                    {
+                      address: counterparty,
+                      sent_tao: relationship.total_sent_tao,
+                      received_tao: relationship.total_received_tao,
+                      net_tao: relationship.net_tao,
+                      transfer_count: relationship.transfer_count,
+                      last_block: relationship.last_block,
+                    },
+                  ];
+            return json({
+              schema_version: 1,
+              ss58,
+              counterparty_count: counterparties.length,
+              transfers_scanned: relationship.transfers_scanned,
+              scan_capped: relationship.scan_capped,
+              total_sent_tao: relationship.total_sent_tao,
+              total_received_tao: relationship.total_received_tao,
+              counterparties,
+              relationship,
+            });
           }
           const rows = await sql`
           SELECT hotkey, coldkey, amount_tao, block_number, event_index


### PR DESCRIPTION
### Motivation

- The Postgres branch for the account counterparty drilldown returned a top-level `relationship` object, while the public handler expects the D1 loader's envelope with a nested `relationship` property, causing a TypeError and a 500 for public unauthenticated requests when Postgres is enabled.

### Description

- Normalize the Postgres counterparty drilldown response in `workers/data-api.mjs` to the D1-compatible envelope including `counterparties` and the nested `relationship` object so `data.relationship.last_seen_at` is safe to dereference.
- Preserve the existing behaviour for the non-drilldown (leaderboard) branch that returns `buildCounterparties` unchanged.
- Update `tests/data-api.test.mjs` to assert the wrapped counterparty drilldown envelope shape and expected fields.
- Add a regression test in `tests/request-handlers-entities.test.mjs` to verify the public handler accepts a Postgres-sourced relationship envelope and does not fall back to D1.

### Testing

- Ran the focused unit tests with `npx vitest run tests/data-api.test.mjs tests/request-handlers-entities.test.mjs --testNamePattern "counterparties|handleAccountCounterparties"`, which completed successfully with the relevant tests passing.
- Ran `npm run format:check` (`prettier --check`) which reported no style issues.
- Verified `git diff --check` reported no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e5a947dc832cb0deb822339729e7)