### PR TITLE
fix(ui): restore sort-order label and fix spacing gap on /blocks

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -105,7 +105,7 @@ function BlocksPage() {
         </Suspense>
       </QueryErrorBoundary>
       <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-28 w-full mb-8" />}>
+        <Suspense fallback={<Skeleton className="h-28 w-full mb-6" />}>
           <BlockProductionHeader />
         </Suspense>
       </QueryErrorBoundary>
@@ -165,7 +165,7 @@ function BlockProductionHeader() {
   const nakamoto = summary.author_concentration?.nakamoto_coefficient;
   const nakamotoStatTone = nakamotoTone(nakamoto);
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-6">
       <StatTile
         icon={Timer}
         eyebrow="Inter-block time"
@@ -270,6 +270,7 @@ function BlocksTable() {
         inputMode="numeric"
         className="min-w-[120px] max-w-[140px] flex-none"
       />
+      <span className="ml-auto font-mono text-[11px] text-ink-muted">Newest first</span>
       <PageSizeSelect
         value={search.limit}
         onChange={(n) => setSearch({ limit: n, offset: 0 })}


### PR DESCRIPTION
## Summary

PR #3699 added six filter inputs to the `/blocks` controls row but introduced two regressions:

1. **Sort-order label removed** — the "Newest first" indicator that was visible to the left of the per-page dropdown no longer appears anywhere on the page.
2. **Spacing gap** — the section margin below the block-production stats grid (`mb-8`) is larger than the equivalent spacing used on the sibling `/extrinsics` page (`mb-6`), creating a visually disproportionate gap above the filter bar.

Changes (one file, 3 lines):
- Re-add `"Newest first"` as a right-aligned label in the controls row (`ml-auto` before `<PageSizeSelect>`), restoring the sort-order indicator in its original position
- Reduce `BlockProductionHeader` bottom margin `mb-8` → `mb-6` (and the matching Suspense skeleton) to match the `/extrinsics` page spacing convention

Closes #3988

## Gates

| Check | Result |
|-------|--------|
| typecheck | ✓ |
| unit tests | ✓ (670 passing) |
| prettier | ✓ |
| build | ✓ |

## Screenshots

The "before" represents the current state (sort label missing, larger gap). The "after" shows both regressions corrected.

> ⚠️ Screenshots were captured against the local dev server (no live API data), so the block list and stat tiles show skeleton/loading state. The layout change — label presence and spacing — is visible in the controls row.

| Viewport | Before (label missing, larger gap) | After (label restored, tighter spacing) |
|----------|------------------------------------|-----------------------------------------|
| Mobile · Light | *(see issue #3988 screenshots)* | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3988/.screenshots/3988/after-blocks-mobile-light.png) |
| Mobile · Dark | *(see issue #3988 screenshots)* | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3988/.screenshots/3988/after-blocks-mobile-dark.png) |
| Tablet · Light | *(see issue #3988 screenshots)* | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3988/.screenshots/3988/after-blocks-tablet-light.png) |
| Tablet · Dark | *(see issue #3988 screenshots)* | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3988/.screenshots/3988/after-blocks-tablet-dark.png) |
| Desktop · Light | *(see issue #3988 screenshots)* | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3988/.screenshots/3988/after-blocks-desktop-light.png) |
| Desktop · Dark | *(see issue #3988 screenshots)* | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/screenshots-3988/.screenshots/3988/after-blocks-desktop-dark.png) |