### PR TITLE
fix(data-api): close 4 decode gaps from a fresh ground-truth audit

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -74,6 +74,14 @@ const ACCOUNT_KEYS = new Set([
   "approving",
   "sender",
   "caller",
+  // Added from a follow-up live sweep (2026-07-12): contract (Contracts.
+  // ContractEmitted/Called) and signer (LimitOrders.OrderExecuted) are
+  // confirmed-live 32-byte AccountId32 fields, cross-checked against a
+  // sibling field with the identical raw bytes correctly SS58-encoded in
+  // the same block (Contracts.Called's own "caller", and
+  // LimitOrders.execute_batched_orders' explicitly-typed nested "signer").
+  "contract",
+  "signer",
 ]);
 
 function isByteArray(v, len) {
@@ -157,6 +165,24 @@ const ENUM_PAYLOAD_FIELDS = new Map([
   ["Proxy.ProxyExecuted.result", "unit-or-passthrough"],
   ["Sudo.Sudid.sudo_result", "unit-or-passthrough"],
 ]);
+
+// Known genuine Vec<T>/collection fields that must stay arrays regardless of
+// element count, mirroring TEXTUAL_FIELDS/HEX_BLOB_FIELDS/ENUM_PAYLOAD_FIELDS'
+// narrow-allowlist discipline for the identical reason (chain_events.args
+// has no per-field type string to consult -- see #4724's COLLECTION_TYPE_RE
+// note in scale-normalize.mjs, which explicitly scopes ITS fix to the
+// `{name,type,value}` D1/extrinsics shape only and punts this untyped side
+// to a narrow allowlist here). normalizePostgresValue's generic newtype-
+// scalar rule runs BEFORE decode() ever sees this tree and has no ctx to
+// consult, so a genuine single-element Vec (e.g. Drand.NewPulse's `rounds`
+// on a pulse carrying exactly one round -- the common case at current block
+// heights, confirmed live 2026-07-12: block 8606141 event_index 148 served
+// `"rounds": 30355357` instead of `[30355357]`, while a multi-round pulse a
+// few million blocks earlier correctly stayed an array) has already been
+// collapsed to a bare scalar by the time this file's own decode() runs.
+// Restored below in decode()'s object branch, the one place ctx + the
+// collapsed value are both in scope together.
+const COLLECTION_FIELDS = new Set(["Drand.NewPulse.rounds"]);
 
 function decodeTextualField(bytes) {
   try {
@@ -252,7 +278,17 @@ function decode(value, keyHint, ctx) {
       }
     }
     const out = {};
-    for (const [k, val] of Object.entries(value)) out[k] = decode(val, k, ctx);
+    for (const [k, val] of Object.entries(value)) {
+      // Restore a COLLECTION_FIELDS field's array-ness before recursing --
+      // see that allowlist's own comment for why normalizePostgresValue can
+      // collapse a genuine single-element Vec<T> to a bare scalar upstream.
+      // Never fires on an already-multi-element array (Array.isArray(val)
+      // is already true, so there is nothing to restore).
+      const key = ctx ? `${ctx.pallet ?? ""}.${ctx.method ?? ""}.${k}` : "";
+      const restored =
+        COLLECTION_FIELDS.has(key) && !Array.isArray(val) ? [val] : val;
+      out[k] = decode(restored, k, ctx);
+    }
     return out;
   }
   return value;

--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -467,6 +467,37 @@ function walk(value, keyHint, nestedCall, topCall) {
     const ss58 = normalizeAccountId32Field(value);
     if (ss58) return ss58;
   }
+  // A generic enum-tree node (Option<T>'s Some/None, or any other tagged
+  // union) that isn't a reconstructed nested call, a RawN text variant, or
+  // an account-keyed MultiAddress::Id/AccountId32 wrap (all already handled
+  // above -- this check runs AFTER isAccountField specifically so a real
+  // `dest: {name:"Id", values:[[bytes]]}` MultiAddress field still gets
+  // normalizeAccountId32Field's whole-shape unwrap-and-SS58-encode, not this
+  // generic per-element walk) -- e.g. a nested call's own Option<u64> field,
+  // `limit_price: {name:"Some", values:[0]}`. Must be walked as its OWN
+  // shape (each element of `values` individually) rather than falling
+  // through to the generic object recursion below, which would hand the
+  // WHOLE `values` array to the nestedCall byte-blob heuristic under
+  // keyHint="values" -- confirmed live 2026-07-12: a nested SubtensorModule.
+  // remove_stake_full_limit (inside Utility.batch) with limit_price Some(0)
+  // served `{"name":"Some","values":"0x00"}` instead of the scalar 0,
+  // because `unwrapByteArray([0])` sees a single valid byte value and
+  // decodeBytesField hex-encodes it -- actively WRONG, not just undecoded,
+  // and only for values 0-255 (a genuine Some(32896091) survives unscathed,
+  // since 32896091 fails the byte-array shape check and falls through
+  // untouched). scale-normalize.mjs's normalizePostgresValue (which runs
+  // AFTER this module) still does the actual Some/None/C-enum collapse on
+  // the shape this preserves -- this branch only protects `values`'
+  // elements from the byte-blob heuristic before that later pass gets a
+  // chance to see them.
+  if (isEnumTreeNode(value)) {
+    return {
+      name: value.name,
+      values: value.values.map((item) =>
+        walk(item, keyHint, nestedCall, topCall),
+      ),
+    };
+  }
   // BTREESET_FIELDS-allowlisted fields (postgres-collection-normalize.mjs)
   // are excluded from the generic byte-blob heuristic below -- confirmed
   // live 2026-07-12: a nested SubtensorModule.claim_root's `subnets` (inside

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -535,4 +535,120 @@ describe("decodeChainEventArgs", () => {
       result: { name: "Ok", values: [[]] },
     });
   });
+
+  test("decodes contract (Contracts.ContractEmitted) to SS58, previously missing from ACCOUNT_KEYS (real block 8606116/157)", () => {
+    const args = {
+      contract: [
+        [
+          201, 64, 152, 192, 92, 30, 3, 109, 25, 1, 241, 97, 18, 22, 108, 234,
+          241, 133, 248, 60, 51, 238, 193, 162, 238, 53, 60, 174, 183, 33, 236,
+          67,
+        ],
+      ],
+      data: [],
+    };
+    assert.equal(
+      decodeChainEventArgs(args, {
+        pallet: "Contracts",
+        method: "ContractEmitted",
+      }).contract,
+      "5GcaftCj1psi5489Dp8RiL5UmMsbRMf9XsfNrDMMsfM5hFoB",
+    );
+  });
+
+  test("decodes contract (Contracts.Called) to SS58 alongside caller, previously missing from ACCOUNT_KEYS (real block 8606268/612)", () => {
+    const args = {
+      caller: {
+        name: "Signed",
+        values: [
+          [
+            [
+              202, 232, 71, 249, 210, 189, 168, 73, 116, 18, 3, 108, 59, 153,
+              137, 124, 86, 117, 67, 86, 45, 7, 44, 82, 58, 94, 4, 234, 83, 139,
+              27, 119,
+            ],
+          ],
+        ],
+      },
+      contract: [
+        [
+          201, 64, 152, 192, 92, 30, 3, 109, 25, 1, 241, 97, 18, 22, 108, 234,
+          241, 133, 248, 60, 51, 238, 193, 162, 238, 53, 60, 174, 183, 33, 236,
+          67,
+        ],
+      ],
+    };
+    const out = decodeChainEventArgs(args, {
+      pallet: "Contracts",
+      method: "Called",
+    });
+    assert.equal(
+      out.contract,
+      "5GcaftCj1psi5489Dp8RiL5UmMsbRMf9XsfNrDMMsfM5hFoB",
+    );
+    assert.equal(
+      out.caller,
+      "5GekXoBfig3G9yqnYmD2N7VGruNQwqU2UpeksXDytzHEGduw",
+    );
+  });
+
+  test("decodes signer (LimitOrders.OrderExecuted) to SS58, previously missing from ACCOUNT_KEYS (real block 8605497/410)", () => {
+    const args = {
+      netuid: 97,
+      signer: [
+        [
+          234, 255, 34, 21, 96, 42, 74, 67, 71, 170, 124, 177, 152, 223, 123,
+          243, 9, 253, 62, 44, 230, 106, 211, 253, 170, 40, 153, 130, 79, 78,
+          235, 74,
+        ],
+      ],
+      amount_in: 65802619318,
+    };
+    const out = decodeChainEventArgs(args, {
+      pallet: "LimitOrders",
+      method: "OrderExecuted",
+    });
+    assert.equal(
+      out.signer,
+      "5HNprQFF4MmHNgDFnfQE4XznnNaVTz2qBtufLG4Apq1RUNrf",
+    );
+    assert.equal(out.amount_in, 65802619318);
+  });
+
+  test("Drand.NewPulse's rounds stays an array for a single-round pulse, not collapsed to a bare number (real block 8606141/148)", () => {
+    const args = { rounds: [30355357] };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Drand", method: "NewPulse" }),
+      { rounds: [30355357] },
+    );
+  });
+
+  test("Drand.NewPulse's rounds stays an array for a multi-round pulse (real block 4633999/58, unaffected baseline)", () => {
+    const args = {
+      rounds: [
+        14409684, 14409685, 14409686, 14409687, 14409688, 14409689, 14409690,
+        14409691,
+      ],
+    };
+    assert.deepEqual(
+      decodeChainEventArgs(args, { pallet: "Drand", method: "NewPulse" }),
+      {
+        rounds: [
+          14409684, 14409685, 14409686, 14409687, 14409688, 14409689, 14409690,
+          14409691,
+        ],
+      },
+    );
+  });
+
+  test("a single-element Vec field NOT in COLLECTION_FIELDS still collapses via normalizePostgresValue (baseline, unaffected)", () => {
+    const args = { fee_rate: [0] };
+    assert.deepEqual(
+      decodeChainEventArgs(args, {
+        pallet: "LimitOrders",
+        method: "SomeOtherEvent",
+      }),
+      { fee_rate: 0 },
+    );
+  });
 });

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -680,6 +680,119 @@ describe("decodePostgresCallArgs", () => {
     });
   });
 
+  describe("nested enum-tree nodes (fixed 2026-07-12: a nested Option<u64> Some(0-255) was corrupted into a hex string)", () => {
+    // Real raw shape confirmed via direct Postgres query, block 8606044/13:
+    // a Utility.batch wrapping SubtensorModule.remove_stake_full_limit,
+    // whose limit_price: Option<u64> arrives as this enum-tree node.
+    const rawBatch = (limitPriceValue) => [
+      {
+        name: "calls",
+        type: "Vec<RuntimeCall>",
+        value: [
+          {
+            name: "SubtensorModule",
+            values: [
+              {
+                name: "remove_stake_full_limit",
+                values: {
+                  hotkey: [
+                    [
+                      62, 34, 147, 208, 104, 248, 29, 37, 128, 200, 66, 207,
+                      247, 252, 215, 171, 215, 140, 177, 84, 32, 140, 232, 171,
+                      206, 168, 176, 128, 94, 80, 101, 113,
+                    ],
+                  ],
+                  netuid: 10,
+                  limit_price: limitPriceValue,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    test("a nested Option<u64> Some(0) decodes to the scalar 0, not a corrupted hex string (real block 8606044/13)", () => {
+      const raw = rawBatch({ name: "Some", values: [0] });
+      const out = decode(raw);
+      assert.equal(out[0].value[0].call_args.limit_price, 0);
+    });
+
+    test("a nested Option<u64> Some(<256) decodes correctly for another small value (real block 8602712/8)", () => {
+      // Every value 0-255 is shape-identical to a genuine 1-byte blob, so
+      // this isn't just the 0 case -- confirm a couple more small values.
+      for (const v of [1, 64, 255]) {
+        const raw = rawBatch({ name: "Some", values: [v] });
+        const out = decode(raw);
+        assert.equal(out[0].value[0].call_args.limit_price, v);
+      }
+    });
+
+    test("a nested Option<u64> Some(>255) still decodes correctly (real block 8601736/10, the pre-existing working baseline)", () => {
+      const raw = rawBatch({ name: "Some", values: [32896091] });
+      const out = decode(raw);
+      assert.equal(out[0].value[0].call_args.limit_price, 32896091);
+    });
+
+    test("a nested Option<u64> None decodes to null", () => {
+      const raw = rawBatch({ name: "None", values: [] });
+      const out = decode(raw);
+      assert.equal(out[0].value[0].call_args.limit_price, null);
+    });
+
+    test("a top-level (non-nested) Option<u64> Some(0) is unaffected -- already correct before this fix (real block 8606132/11)", () => {
+      const raw = [
+        {
+          name: "limit_price",
+          type: "Option<u64>",
+          value: { name: "Some", values: [0] },
+        },
+      ];
+      const out = decode(raw);
+      // Top-level typed descriptors don't hit the nestedCall byte-blob
+      // heuristic at all (nestedCall is null there) -- normalizePostgresValue
+      // alone already unwraps Some(0) correctly via its generic pass.
+      assert.equal(out[0].value, 0);
+    });
+
+    test("does not regress MultiAddress::Id decoding inside a nested call -- the same enum-tree shape, but account-keyed (real block 8605925/20's own Balances.transfer_keep_alive dest)", () => {
+      const raw = {
+        name: "calls",
+        type: "Vec<RuntimeCall>",
+        value: [
+          {
+            name: "Balances",
+            values: [
+              {
+                name: "transfer_keep_alive",
+                values: {
+                  dest: {
+                    name: "Id",
+                    values: [
+                      [
+                        [
+                          2, 231, 237, 169, 77, 48, 47, 104, 42, 49, 75, 52,
+                          183, 161, 133, 231, 62, 34, 120, 255, 67, 79, 133, 73,
+                          252, 53, 179, 55, 34, 140, 130, 223,
+                        ],
+                      ],
+                    ],
+                  },
+                  value: 1415000000,
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const out = decode(raw);
+      assert.equal(
+        out.value[0].call_args.dest,
+        "5C8WrFofZBQWdEctJhwticZ2osjL7eVDeHyL5mE6V3AGx1VN",
+      );
+    });
+  });
+
   describe("Vec<u8>/BoundedVec<u8> byte-blob-typed collections (fixed 2026-07-12: MevShield's ciphertext/enc_key were never hex-decoded, miscategorized as a generic collection)", () => {
     test("hex-encodes a bare BoundedVec<u8,_> field (real MevShield.submit_encrypted.ciphertext, block 8543969/7)", () => {
       const raw = [


### PR DESCRIPTION
## Summary

A fresh fan-out audit across all 63 chain_events + 55 extrinsics pallet.method/module.function combinations currently landing in production (verified live against real Postgres rows + api.metagraph.sh, adversarially re-checked before reporting) surfaced 16 candidates. 10 were correctly refuted as this codebase's deliberate, tested "untagged positional args stay hex rather than guessing" design — no per-field type/name info exists to safely resolve those. **These are the 4 real, confirmed gaps.**

- **`chain_events.args`: `contract` (Contracts.ContractEmitted/Called) and `signer` (LimitOrders.OrderExecuted)** were missing from `ACCOUNT_KEYS` despite being *named* fields with an unambiguous AccountId32 shape — `Contracts.Called`'s own sibling `caller` field already correctly SS58-encodes the identical account type in the same event, proving this is an allowlist gap, not a design choice.

- **`chain_events.args`: `Drand.NewPulse`'s `rounds` (`Vec<RoundNumber>`)** silently changed JSON type from array to bare number whenever a pulse happened to carry exactly one round — the common case at current block heights. `scale-normalize.mjs`'s newtype-scalar collapse rule has no per-field type string to consult for `chain_events.args` (unlike D1/extrinsics `call_args` post-#4724), so a genuine single-element `Vec` is indistinguishable by shape alone from a newtype-scalar wrap. Fixed via a narrow `COLLECTION_FIELDS` allowlist restoring array-ness after normalization runs, mirroring `BTREESET_FIELDS`' identical narrow-allowlist discipline for the analogous extrinsics-side ambiguity.

- **`extrinsics.call_args`: a nested `Option<u64>` field** inside a reconstructed call (e.g. `Utility.batch` wrapping `SubtensorModule.remove_stake_full_limit`'s `limit_price`) was corrupted from `Some(0)` into `{"name":"Some","values":"0x00"}` whenever the wrapped value was 0-255 — `postgres-call-args.mjs`'s `walk()` had no dedicated handling for a bare enum-tree node, so its `values` array fell through to the generic nestedCall byte-blob heuristic and got hex-encoded before `normalizePostgresValue`'s later `Option<T>` pass ever got a chance to see it (only values >255 survived, since they fail the byte-array shape check). Fixed by giving `walk()` its own `isEnumTreeNode` branch — positioned **after** the existing `isAccountField` check, so a `MultiAddress::Id`-wrapped account (the identical enum-tree shape) still gets its dedicated, correct whole-shape unwrap first. Caught this ordering mistake myself mid-fix via a real `MultiAddress::Id` regression test before it ever left my machine.

All four fixes were live-verified end-to-end (`decodePostgresCallArgs` → `normalizePostgresValue` / `decodeChainEventArgs` chains) against real production block/event/extrinsic citations before writing tests.

**Not fixed:** one additional "confirmed" audit finding (`SubtensorModule.StakeAdded`) shares the identical bare-positional-array shape as 9 *other* findings the same audit correctly refuted as intentional design (`StakeRemoved`/`StakeMoved`/`StakeTransferred`/`StakeSwapped`/`AxonServed`/`NeuronRegistered`/`AlphaBurned`/`AlphaRecycled`/`TimelockedWeightsCommitted`) — fixing it alone would be inconsistent with deliberately leaving those 9 untouched.

## Test plan

- [x] Live-verified all 4 fixes directly via the real decode pipeline before writing any test (see commit body for the exact node -e invocations / real block-event citations used)
- [x] Added regression tests using real production block/event/extrinsic citations for all 4 fixes, plus a `MultiAddress::Id`-inside-nested-call regression test proving the enum-tree fix doesn't break existing account decoding
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npx vitest run --coverage` on both touched source files — 100% statements/branches/functions/lines
- [x] `npm test` — 256/256 files, 7596/7596 tests green (full suite)