### PR TITLE
fix(ui): hide the back-to-top pill near the page bottom so it can't obscure the last row

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -596,16 +596,24 @@ function AnimatedNumber({
     }
   );
 }
+var BOTTOM_HIDE_GAP = 96;
 function BackToTop({ threshold = 600 }) {
   const [visible, setVisible] = React3.useState(false);
   React3.useEffect(() => {
     if (typeof window === "undefined") return;
     function onScroll() {
-      setVisible(window.scrollY > threshold);
+      const scrolledPast = window.scrollY > threshold;
+      const doc = document.documentElement;
+      const distanceToBottom = doc.scrollHeight - (window.scrollY + window.innerHeight);
+      setVisible(scrolledPast && distanceToBottom > BOTTOM_HIDE_GAP);
     }
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
   }, [threshold]);
   const onClick = () => {
     if (typeof window === "undefined") return;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -567,16 +567,24 @@ function AnimatedNumber({
     }
   );
 }
+var BOTTOM_HIDE_GAP = 96;
 function BackToTop({ threshold = 600 }) {
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     if (typeof window === "undefined") return;
     function onScroll() {
-      setVisible(window.scrollY > threshold);
+      const scrolledPast = window.scrollY > threshold;
+      const doc = document.documentElement;
+      const distanceToBottom = doc.scrollHeight - (window.scrollY + window.innerHeight);
+      setVisible(scrolledPast && distanceToBottom > BOTTOM_HIDE_GAP);
     }
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
   }, [threshold]);
   const onClick = () => {
     if (typeof window === "undefined") return;

--- a/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
+++ b/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
@@ -8,17 +8,32 @@ import { classNames } from "@/lib/format";
  * or router state, so it never collides with hash-based scroll handlers
  * (see `useHashScroll` / `SectionQuickJump`).
  */
+// #3987: the pill sits `fixed` at the bottom-right, so when a page is scrolled
+// to its very end the last row of content lands directly under it (e.g. the
+// Reward Drift table's final row). Hide the pill once the viewport is within
+// this many px of the document bottom — its footprint (bottom offset + height)
+// plus a little clearance — so it can never obscure the final content.
+const BOTTOM_HIDE_GAP = 96;
+
 export function BackToTop({ threshold = 600 }: { threshold?: number }) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     function onScroll() {
-      setVisible(window.scrollY > threshold);
+      const scrolledPast = window.scrollY > threshold;
+      const doc = document.documentElement;
+      const distanceToBottom =
+        doc.scrollHeight - (window.scrollY + window.innerHeight);
+      setVisible(scrolledPast && distanceToBottom > BOTTOM_HIDE_GAP);
     }
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
   }, [threshold]);
 
   const onClick = () => {


### PR DESCRIPTION
## Summary
The floating `BackToTop` pill (`packages/ui-kit/src/components/metagraphed/back-to-top.tsx`) is `position: fixed` at the bottom-right, so when a page is scrolled to its very end the last row of content lands directly under it — e.g. on the subnet **Reward Drift** table (#3652) the final "DIVIDENDS TOP 10%" value is obscured, showing only "6." instead of the full figure.

## Change
- Hide the pill once the viewport is within `BOTTOM_HIDE_GAP` (96px — the pill's bottom offset + height + clearance) of the document bottom, so it can never sit over the final content. Recomputed on `scroll` **and** `resize`.
- Purely a visibility-threshold change in the shared `BackToTop` component; the pill still appears normally elsewhere (where it doesn't reach the bottom), and its click/keyboard behaviour is untouched.
- Regenerates the ui-kit `dist` (`index.js`/`index.cjs`) per package convention.

Closes #3987

## Screenshots
Each page scrolled to its **very bottom** (`scrollTo(0, scrollHeight)`). **Before** the pill sits over the last content (`opacity 1`); **after** it's hidden near the bottom (`opacity 0`). Verified at desktop + mobile, both themes; theme forced via `localStorage`.

| Viewport · Theme | Before (pill overlaps) | After (pill hidden) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/before-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/after-desktop-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/before-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3987-assets/3987/after-mobile-dark.png) |

## Testing
- `npm run build --workspace=packages/ui-kit` + ui-kit `tsc --noEmit`: clean. Verified interactively (Playwright): at page bottom the pill is `opacity 0` (after) vs `opacity 1` (before) at the identical scroll position; still shows at mid-scroll.