### PR TITLE
fix(ui): bridge React Query SSR→CSR state so detail pages finish hydrating

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.170.17",
+    "@tanstack/react-router-ssr-query": "^1.167.1",
     "@tanstack/react-start": "^1.168.27",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/zod-adapter": "^1.167.0",

--- a/apps/ui/src/router.tsx
+++ b/apps/ui/src/router.tsx
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter, useRouter } from "@tanstack/react-router";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { routeTree } from "./routeTree.gen";
 import { ApiError } from "./lib/metagraphed/client";
 import { ErrorState, Skeleton } from "./components/metagraphed/states";
@@ -66,6 +67,14 @@ export const getRouter = () => {
     defaultErrorComponent: DefaultRouteError,
     defaultPendingComponent: DefaultRoutePending,
   });
+
+  // #4967: bridge React Query's SSR→CSR state through TanStack Router's stream.
+  // Without this, route components' `useSuspenseQuery` re-suspend during the
+  // hydration commit against an empty client cache — leaving the Suspense
+  // boundary permanently "dehydrated", so no sibling `useQuery` effects (and
+  // their fetches) ever run on detail pages. `wrapQueryClient: false` keeps the
+  // existing manual <QueryClientProvider> in __root.tsx as the single provider.
+  setupRouterSsrQueryIntegration({ router, queryClient, wrapQueryClient: false });
 
   return router;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-router": "^1.170.17",
+        "@tanstack/react-router-ssr-query": "^1.167.1",
         "@tanstack/react-start": "^1.168.27",
         "@tanstack/router-plugin": "^1.168.19",
         "@tanstack/zod-adapter": "^1.167.0",
@@ -4833,6 +4834,29 @@
         "react-dom": ">=18.0.0 || >=19.0.0"
       }
     },
+    "node_modules/@tanstack/react-router-ssr-query": {
+      "version": "1.167.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router-ssr-query/-/react-router-ssr-query-1.167.1.tgz",
+      "integrity": "sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/router-ssr-query-core": "1.169.1"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0",
+        "@tanstack/query-core": ">=5.90.0",
+        "@tanstack/react-router": ">=1.127.0",
+        "@tanstack/react-query": ">=5.90.0"
+      }
+    },
     "node_modules/@tanstack/react-start": {
       "version": "1.168.27",
       "resolved": "https://registry.npmjs.org/@tanstack/react-start/-/react-start-1.168.27.tgz",
@@ -5066,6 +5090,23 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/router-ssr-query-core": {
+      "version": "1.169.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-ssr-query-core/-/router-ssr-query-core-1.169.1.tgz",
+      "integrity": "sha512-rngux8s/3mPQzcjLYDLkNU31coYVyCgrVTfpdwqUdY5jIEHqGTXrO73DTkPR1PppwYUeVhmNCgl8TctRcnupjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/router-core": ">=1.127.0",
+        "@tanstack/query-core": ">=5.90.0"
       }
     },
     "node_modules/@tanstack/router-utils": {


### PR DESCRIPTION
## Summary
Detail routes (accounts, subnets, providers, blocks, extrinsics, validators) mix a blocking `useSuspenseQuery` with sibling `useQuery` calls and define no `loader`, so their React Query state has **no SSR→CSR continuity**. `getRouter()` creates a `QueryClient` per call with no dehydrate/HydrationBoundary wiring, so on the client `useSuspenseQuery` re-suspends during the hydration commit against an empty cache, the Suspense boundary is left permanently `dehydrated`, and every sibling `useQuery` effect (and its fetch) never runs — detail pages render as inert SSR HTML and fire zero further API requests.

## Fix (as specified in the issue)
- Add `@tanstack/react-router-ssr-query` to `apps/ui/package.json` (+ its `@tanstack/router-ssr-query-core` transitive in `package-lock.json`).
- Call `setupRouterSsrQueryIntegration({ router, queryClient, wrapQueryClient: false })` in `getRouter()` (`apps/ui/src/router.tsx`), keeping the manual `<QueryClientProvider>` in `__root.tsx`. Streams resolved `useSuspenseQuery` state to the client and rehydrates the `QueryClient` before the tree mounts.

Three files, no visual/route/component change. Closes #4967

## Verification
- `tsc --noEmit` + `vite build` clean.
- Served the build; `/accounts/{ss58}` (Playwright) hydrates and fires **24** client-side `/api/v1/*` requests across sections. Local `wrangler dev` doesn't reproduce the production stream barrier, so a local before/after diff isn't meaningful — this is the exact official TanStack SSR-query integration the issue prescribes, and is a no-op where hydration already succeeds.