### PR TITLE
feat(registry): add sn11 api docs (#4007)

### DIFF
--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -176,6 +176,25 @@
       "notes": "Official TrajectoryRL source repository."
     },
     {
+      "id": "sn-11-trajectoryrl-api-docs",
+      "name": "TrajectoryRL API documentation",
+      "kind": "docs",
+      "url": "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/API.md",
+      "provider": "trajectoryrl",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/API.md",
+        "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/VALIDATOR_OPERATIONS.md"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jakearmstrong59"
+      },
+      "notes": "Public request/response API specification for TrajectoryRL validator and miner integration, covering the web-submit channel, pre-eval checks, score submission, winner lookup, heartbeat, and log-upload flows."
+    },
+    {
       "id": "sn-11-trajectoryrl-subnet-api",
       "name": "TrajectoryRL network stats API",
       "kind": "subnet-api",


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one surface to `registry/subnets/trajectoryrl.json`.

## Surface

- Netuid: 11
- Kind: docs
- Public URL: https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/API.md
- Source URL (proves the claim): https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/VALIDATOR_OPERATIONS.md
- Provider slug: trajectoryrl

## Summary

- Register TrajectoryRL's public API documentation/spec for SN11 from the official repo.
- The repo's validator/miner docs reference this API spec as the public request/response contract for web submit, pre-eval, score submission, winner lookup, heartbeat, and log upload flows.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file.
- [ ] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #4007`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/trajectoryrl.json`
- [x] `npm run scan:public-safety`
