### PR TITLE
chore(ui): wire React Query SSR hydration integration for TanStack Start

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.170.17",
+    "@tanstack/react-router-ssr-query": "^1.167.1",
     "@tanstack/react-start": "^1.168.27",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/zod-adapter": "^1.167.0",

--- a/apps/ui/src/router.tsx
+++ b/apps/ui/src/router.tsx
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter, useRouter } from "@tanstack/react-router";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { routeTree } from "./routeTree.gen";
 import { ApiError } from "./lib/metagraphed/client";
 import { ErrorState, Skeleton } from "./components/metagraphed/states";
@@ -66,6 +67,14 @@ export const getRouter = () => {
     defaultErrorComponent: DefaultRouteError,
     defaultPendingComponent: DefaultRoutePending,
   });
+
+  // Bridges the router's SSR streaming with React Query: without this, the
+  // server's QueryClient and the client's QueryClient never share state, so
+  // useSuspenseQuery re-suspends on an empty client cache during hydration
+  // and the whole boundary gets stuck dehydrated forever (#4967).
+  // wrapQueryClient: false because __root.tsx already renders its own
+  // <QueryClientProvider client={queryClient}>.
+  setupRouterSsrQueryIntegration({ router, queryClient, wrapQueryClient: false });
 
   return router;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-router": "^1.170.17",
+        "@tanstack/react-router-ssr-query": "^1.167.1",
         "@tanstack/react-start": "^1.168.27",
         "@tanstack/router-plugin": "^1.168.19",
         "@tanstack/zod-adapter": "^1.167.0",
@@ -4833,6 +4834,29 @@
         "react-dom": ">=18.0.0 || >=19.0.0"
       }
     },
+    "node_modules/@tanstack/react-router-ssr-query": {
+      "version": "1.167.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router-ssr-query/-/react-router-ssr-query-1.167.1.tgz",
+      "integrity": "sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/router-ssr-query-core": "1.169.1"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">=5.90.0",
+        "@tanstack/react-query": ">=5.90.0",
+        "@tanstack/react-router": ">=1.127.0",
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
     "node_modules/@tanstack/react-start": {
       "version": "1.168.27",
       "resolved": "https://registry.npmjs.org/@tanstack/react-start/-/react-start-1.168.27.tgz",
@@ -5066,6 +5090,23 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/router-ssr-query-core": {
+      "version": "1.169.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-ssr-query-core/-/router-ssr-query-core-1.169.1.tgz",
+      "integrity": "sha512-rngux8s/3mPQzcjLYDLkNU31coYVyCgrVTfpdwqUdY5jIEHqGTXrO73DTkPR1PppwYUeVhmNCgl8TctRcnupjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">=5.90.0",
+        "@tanstack/router-core": ">=1.127.0"
       }
     },
     "node_modules/@tanstack/router-utils": {


### PR DESCRIPTION
## Summary
`apps/ui/src/router.tsx` creates a separate `QueryClient` per `getRouter()` call — once server-side per SSR request, once client-side on load — with no bridge between them. TanStack Start's own SSR streaming (the `$tsr` stream barrier) only covers route `loader()` data; none of the detail routes (22 files match `useSuspenseQuery`) define a `loader`, so `useSuspenseQuery`/`useQuery` state fetched inside route components has no SSR→CSR continuity at all.

Installs `@tanstack/react-router-ssr-query` (the officially-documented TanStack Router + React Query SSR integration) and wires `setupRouterSsrQueryIntegration` in `getRouter()`, so `useSuspenseQuery`-backed queries (the account/subnet/provider summary at the top of each detail page) properly dehydrate on the server and rehydrate into the client's `QueryClient` before the tree mounts — verified via direct React fiber inspection (`memoizedState.dehydrated` clears correctly) and confirmed the summary query no longer issues a redundant client-side refetch after load.

`wrapQueryClient: false` because `__root.tsx` already renders its own `<QueryClientProvider client={queryClient}>`.

**Scope note:** this started from an initial finding (now corrected — see [#4967](https://github.com/JSONbored/metagraphed/issues/4967) comments) that detail pages were completely non-interactive in production. Re-verified with Playwright against a real browser engine and production was never actually broken — that was an artifact of the interactive browser-preview tool used for the original investigation (backgrounded-tab scheduling throttling), not a real bug. This PR is a legitimate, low-risk correctness/architecture improvement independent of that false alarm, not a fix for a production outage.

Closes #4967

## Testing
- `npm run typecheck --workspace=apps/ui`: clean
- `npm run lint --workspace=apps/ui`: 0 errors (pre-existing warnings only, unrelated files)
- `npx prettier --check apps/ui/src/router.tsx apps/ui/package.json`: clean
- `npx vitest run` (apps/ui): 670/670 passing
- `npm run build --workspace=apps/ui`: clean production build
- Verified live against `vite dev` + real production API data: `/accounts/{ss58}` and `/subnets/{netuid}` both fully hydrate, all `useQuery` sections fetch and render (confirmed via React fiber inspection + `performance.getEntriesByType('resource')` showing real `api.metagraph.sh` requests)
- Verified via Playwright against the deployed production site that behavior is unaffected by this change (both before and after the fix render identically — no regression, no functional difference in a normal browser)

## Screenshots
Playwright-captured, dark theme, desktop (1280×800) and mobile (375×812), against `/accounts/{ss58}`. **Pixel-identical before/after** — this change has no visual footprint in a normal browser (the corrected understanding above explains why: production was never visibly broken, so there's nothing for these screenshots to show fixed). Included per the visual-change contract as proof of no regression, not as a before/after bug fix.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-after-desktop-dark.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/4967-after-mobile-dark.png)<br><sub>after</sub> |