### PR TITLE
fix(data-api): bump refresh-subnet-hyperparams's bittensor pin to 10.5.0

### DIFF
--- a/.github/workflows/refresh-subnet-hyperparams.yml
+++ b/.github/workflows/refresh-subnet-hyperparams.yml
@@ -46,7 +46,7 @@ jobs:
       # get_subnet_hyperparameters(netuid) call per subnet (no bulk variant exists
       # for this call — see scripts/fetch-subnet-hyperparams.py's docstring).
       - name: Fetch subnet hyperparameters (Bittensor SDK)
-        run: uvx --from bittensor==10.4.0 python scripts/fetch-subnet-hyperparams.py
+        run: uvx --from bittensor==10.5.0 python scripts/fetch-subnet-hyperparams.py
         env:
           # Same hidden chain-RPC secret as the metagraph/events fetches (ADR 0012).
           # Unset → the script defaults to "finney"; set it to the private node URL


### PR DESCRIPTION
## Summary
`GET /api/v1/subnets/{netuid}/hyperparameters` always returns `owner_cut_enabled: false`, `owner_cut_auto_lock_enabled: false`, `min_childkey_take_ratio: null`, `burn_half_life: null`, `burn_increase_mult: null`, and `activity_cutoff_factor: null` for every subnet — not because these fields are fabricated (an earlier hypothesis, corrected below), but because `.github/workflows/refresh-subnet-hyperparams.yml` pins `bittensor==10.4.0`, and that version's `SubnetHyperparameters` dataclass has no fallback/spillover mechanism at all — these 6 real chain fields are 100% inaccessible under 10.4.0 regardless of how `scripts/fetch-subnet-hyperparams.py` accesses them.

`bittensor==10.5.0` (current PyPI latest — also what the script's own docstring already claims to have been verified against, so this bump makes the pin match what was actually tested) adds a `hyperparameters` spillover dict + `__getattr__` fallback for untyped chain fields, making all 6 correctly readable.

Root-caused by writing a standalone diagnostic (`uv run --with bittensor==10.4.0` vs `10.5.0`) that directly compared `dataclasses.fields(SubnetHyperparameters)` between the two pinned versions against live `finney` data — 10.4.0 has 32 typed fields and no spillover; 10.5.0 has 34 typed fields plus a spillover dict containing `owner_cut_enabled=True`, `burn_half_life=360`, etc. for real subnets.

Cross-checked the sibling `fetch-metagraph-native.py` script (same 10.4.0 pin) for the same version-skew risk: its `MetagraphInfo` dataclass has an identical field set between 10.4.0 and 10.5.0, so it's unaffected — this is scoped to `fetch-subnet-hyperparams.py` only.

Closes #4973

## Testing
- Live end-to-end run: `SUBNET_HYPERPARAMS_JSON=/tmp/out.json uvx --from bittensor==10.5.0 python scripts/fetch-subnet-hyperparams.py` → 129/129 subnet rows, 0 errors, all 6 previously-null/false fields now populated with real, correctly-varying values (verified distinct-value counts per field, not just non-null)
- `python3 scripts/test_fetch_subnet_hyperparams.py`: 19/19 passing (fake-SDK-based, version-independent, confirms no regression)
- YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- No schema/contract changes needed — `schemas/components/05-subnets.schema.json` already types all 6 fields as nullable; this is a data-correctness fix only, not a contract change