### PR TITLE
fix(data-api): cap rpc_usage_events.attempts fallback at RPC_MAX_ATTEMPTS

### DIFF
--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
@@ -243,7 +243,8 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
 
   test("records a null endpoint_id telemetry event when all upstreams fail", async () => {
     // Drives the served-event recordRpcUsage with a 502 bare response: the
-    // attempts header is absent so `Number(null) || candidates.length`
+    // attempts header is absent (proxyWithFailover's exhausted-pool path never
+    // sets it) so `Number(null) || Math.min(candidates.length, RPC_MAX_ATTEMPTS)`
     // supplies the attempt count, and endpoint_id falls back through `?? null`.
     const db = captureDb();
     const ctx = { waitUntil: () => {} };
@@ -270,7 +271,54 @@ describe("handleRpcProxyRequest telemetry + cache path", () => {
       // The served telemetry event was bound: endpoint_id null, attempts = 2.
       const served = db.events.at(-1);
       assert.equal(served[2], null); // endpoint_id ?? null
-      assert.equal(served[6], 2); // attempts || candidates.length
+      assert.equal(served[6], 2); // attempts || Math.min(candidates.length, RPC_MAX_ATTEMPTS)
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("caps the fallback attempts count at RPC_MAX_ATTEMPTS when the pool has more eligible endpoints than the failover cap", async () => {
+    // A 4-endpoint pool exceeds RPC_MAX_ATTEMPTS (3): proxyWithFailover only
+    // ever tries `Math.min(orderedEndpoints.length, RPC_MAX_ATTEMPTS)` of them,
+    // so the fallback attempt count reported when its attempts header is absent
+    // must match that cap, not the full (uncapped) candidate count — otherwise
+    // rpc_usage_events.attempts is inflated whenever the eligible pool > 3.
+    const db = captureDb();
+    const ctx = { waitUntil: () => {} };
+    const original = globalThis.fetch;
+    const fetchFn = scriptedFetch(
+      () => {
+        throw new Error("net");
+      },
+      () => {
+        throw new Error("net");
+      },
+      () => {
+        throw new Error("net");
+      },
+    );
+    globalThis.fetch = fetchFn;
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
+        rpcEnv(
+          poolWith(
+            ep("a", SAFE_A),
+            ep("b", SAFE_B),
+            ep("c", "https://entrypoint-finney.opentensor.ai"),
+            ep("d", "https://lite.chain.opentensor.ai"),
+          ),
+          { METAGRAPH_HEALTH_DB: db },
+        ),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      const body = await errorJson(res, 502);
+      assert.equal(body.error.code, "rpc_upstream_unavailable");
+      // Only 3 upstream calls were actually made (the failover cap), not 4.
+      assert.equal(fetchFn.calls.length, 3);
+      const served = db.events.at(-1);
+      assert.equal(served[6], 3); // capped, not the uncapped 4-candidate count
     } finally {
       globalThis.fetch = original;
     }

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -573,9 +573,13 @@ export async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     provider: response.headers.get("x-metagraph-rpc-provider"),
     ok: Boolean(servedEndpointId),
     status: response.status,
+    // The exhausted-pool path (proxyWithFailover's final errorResponse) never
+    // sets x-metagraph-rpc-attempts, so this falls through to the uncapped
+    // candidate count unless clamped to the same limit proxyWithFailover
+    // itself attempts against (Math.min(orderedEndpoints.length, maxAttempts)).
     attempts:
       Number(response.headers.get("x-metagraph-rpc-attempts")) ||
-      candidates.length,
+      Math.min(candidates.length, RPC_MAX_ATTEMPTS),
     latency_ms: Date.now() - startedAt,
     cache: cacheKey ? "miss" : "bypass",
   });


### PR DESCRIPTION
## Summary
`recordRpcUsage`'s `attempts` field (`workers/request-handlers/rpc-proxy.mjs:576-578`) reads `Number(response.headers.get("x-metagraph-rpc-attempts")) || candidates.length`. The exhausted-pool path in `proxyWithFailover` (its final `errorResponse(...)` return, line ~1010) never sets that header — only the served-success path (`streamRpcResponse`) does — so every all-upstreams-failed telemetry event falls through to the raw `candidates.length`.

But `proxyWithFailover` itself only ever attempts `Math.min(orderedEndpoints.length, RPC_MAX_ATTEMPTS)` (3) candidates before giving up (line ~895). So whenever the eligible pool exceeds 3 endpoints, the recorded `attempts` count is inflated to the full (uncapped) candidate count instead of the true, capped number of upstreams actually tried.

Found via a systematic audit for the "silent default masks a wrong value" bug class (same class as #4973 — a stale `bittensor==10.4.0` SDK pin silently zeroing 6 subnet-hyperparameter fields). Not currently observable in production (the finney pool's `eligible_count` is 0 right now, which routes through a separate, already-correct `attempts:0` branch), but a real, confirmed defect that will start over-reporting `rpc_usage_events.attempts` the moment pool eligibility recovers above 3 endpoints.

## Fix
Cap the fallback the same way `proxyWithFailover` itself caps its attempt loop: `Math.min(candidates.length, RPC_MAX_ATTEMPTS)` instead of the raw, uncapped `candidates.length`.

## Testing
- New regression test: `caps the fallback attempts count at RPC_MAX_ATTEMPTS when the pool has more eligible endpoints than the failover cap` — a 4-endpoint pool where all upstreams fail; asserts only 3 fetch calls are actually made and the telemetry event records `attempts: 3`, not 4. Verified this test fails (`4 !== 3`) against the pre-fix code and passes against the fix.
- Existing 2-endpoint exhausted-pool test still passes unchanged (2 ≤ 3, so both old and new logic agree there).
- Full suite: 7597/7597 passing (one unrelated `tests/artifacts.test.mjs` flake on the shared CI-adjacent dev machine, confirmed pre-existing/unrelated — passes cleanly 21/21 in isolation with zero working-tree changes).
- `eslint`/`prettier --check` clean on both changed files.