### PR TITLE
Add Recall public API health endpoint

### DIFF
--- a/registry/providers/recall.json
+++ b/registry/providers/recall.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "recall",
+  "kind": "subnet-team",
+  "name": "Recall",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://recall.network/"
+}

--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 31,
-  "name": "Recall",
-  "slug": "recall",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,17 +6,7 @@
     "rag",
     "retrieval"
   ],
-  "source_repo": null,
-  "website_url": null,
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN31 Recall. Public chain/directory sources show the subnet renamed from Halftime to Recall. Backprop currently describes a RAG/retrieval subnet, but no official live website, source repository, API, OpenAPI schema, or docs site is verified.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Public chain/directory sources show a recent Halftime to Recall identity change.",
       "The historical candlestao.com reference currently times out to simple probes and is not promoted.",
@@ -32,7 +17,40 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
-  "surfaces": []
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "Recall",
+  "netuid": 31,
+  "notes": "Reviewed overlay for SN31 Recall. Public chain/directory sources show the subnet renamed from Halftime to Recall. Backprop currently describes a RAG/retrieval subnet, but no official live website, source repository, API, OpenAPI schema, or docs site is verified.",
+  "schema_version": 1,
+  "slug": "recall",
+  "source_repo": null,
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-recall-subnet-api",
+      "kind": "subnet-api",
+      "name": "Recall API health",
+      "provider": "recall",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "luckydicer"
+      },
+      "source_urls": [
+        "https://docs.recall.network/raw/reference/endpoints/health.md"
+      ],
+      "url": "https://api.competitions.recall.network/api/health"
+    }
+  ],
+  "website_url": null
 }


### PR DESCRIPTION
## Summary

Add SN31 Recall's public no-auth API health endpoint from the official Recall docs. This is a live endpoint at `https://api.competitions.recall.network/api/health`.

## Template Used

Subnet surface

Closes #4032