### PR TITLE
fix(data-api): stop dropping auth_required/public_safe from RPC pool artifacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11812,7 +11812,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5957,6 +5957,8 @@ export interface components {
         };
         RpcPoolEndpoint: {
             archive_support?: boolean | null;
+            /** @description Structural pool-eligibility input: whether the endpoint requires auth (#4979). */
+            auth_required?: boolean;
             /** @enum {unknown} */
             health_source: "probe-derived" | "missing-probe" | "not-monitored";
             health_stale: boolean;
@@ -5970,6 +5972,8 @@ export interface components {
             pool_eligibility_reasons?: string[];
             pool_eligible: boolean;
             provider: string;
+            /** @description Structural pool-eligibility input: whether the endpoint is safe for public proxying (#4979). */
+            public_safe?: boolean;
             score: number;
             score_reasons?: components["schemas"]["EndpointScoreReason"][];
             status: components["schemas"]["HealthStatus"];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13892,6 +13892,10 @@
               "null"
             ]
           },
+          "auth_required": {
+            "description": "Structural pool-eligibility input: whether the endpoint requires auth (#4979).",
+            "type": "boolean"
+          },
           "health_source": {
             "enum": [
               "probe-derived",
@@ -13948,6 +13952,10 @@
           },
           "provider": {
             "type": "string"
+          },
+          "public_safe": {
+            "description": "Structural pool-eligibility input: whether the endpoint is safe for public proxying (#4979).",
+            "type": "boolean"
           },
           "score": {
             "type": "integer"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5957,6 +5957,8 @@ export interface components {
         };
         RpcPoolEndpoint: {
             archive_support?: boolean | null;
+            /** @description Structural pool-eligibility input: whether the endpoint requires auth (#4979). */
+            auth_required?: boolean;
             /** @enum {unknown} */
             health_source: "probe-derived" | "missing-probe" | "not-monitored";
             health_stale: boolean;
@@ -5970,6 +5972,8 @@ export interface components {
             pool_eligibility_reasons?: string[];
             pool_eligible: boolean;
             provider: string;
+            /** @description Structural pool-eligibility input: whether the endpoint is safe for public proxying (#4979). */
+            public_safe?: boolean;
             score: number;
             score_reasons?: components["schemas"]["EndpointScoreReason"][];
             status: components["schemas"]["HealthStatus"];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -13870,6 +13870,10 @@
               "null"
             ]
           },
+          "auth_required": {
+            "description": "Structural pool-eligibility input: whether the endpoint requires auth (#4979).",
+            "type": "boolean"
+          },
           "health_source": {
             "enum": [
               "probe-derived",
@@ -13926,6 +13930,10 @@
           },
           "provider": {
             "type": "string"
+          },
+          "public_safe": {
+            "description": "Structural pool-eligibility input: whether the endpoint is safe for public proxying (#4979).",
+            "type": "boolean"
           },
           "score": {
             "type": "integer"

--- a/schemas/components/07-endpoints-rpc.schema.json
+++ b/schemas/components/07-endpoints-rpc.schema.json
@@ -209,6 +209,14 @@
           "provider": {
             "type": "string"
           },
+          "auth_required": {
+            "type": "boolean",
+            "description": "Structural pool-eligibility input: whether the endpoint requires auth (#4979)."
+          },
+          "public_safe": {
+            "type": "boolean",
+            "description": "Structural pool-eligibility input: whether the endpoint is safe for public proxying (#4979)."
+          },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"
           },

--- a/scripts/lib/endpoint-artifacts.mjs
+++ b/scripts/lib/endpoint-artifacts.mjs
@@ -313,6 +313,8 @@ function endpointPool(id, kind, endpoints) {
       poolEndpoints.find((endpoint) => endpoint.pool_eligible)?.id || null,
     endpoints: poolEndpoints.map((endpoint) => ({
       archive_support: endpoint.archive_support,
+      auth_required: endpoint.auth_required,
+      public_safe: endpoint.public_safe,
       id: endpoint.id,
       surface_id: endpoint.surface_id,
       surface_key: endpoint.surface_key,

--- a/tests/endpoint-artifacts.test.mjs
+++ b/tests/endpoint-artifacts.test.mjs
@@ -411,6 +411,15 @@ describe("buildEndpointPoolArtifact", () => {
     );
     assert.equal(rpcById.get("endpoint-a").pool_eligible, true);
     assert.equal(rpcById.get("endpoint-c").pool_eligible, false);
+    // auth_required/public_safe must survive onto the served pool endpoint
+    // objects themselves, not just feed the pool_eligible computed here: the
+    // Worker's live overlay (overlayRpcPoolEligibility, src/health-serving.mjs)
+    // re-derives eligibility from THESE serialized fields on every request, so
+    // if they're dropped here the live proxy permanently excludes every
+    // endpoint regardless of real health (a production 503 outage, not caught
+    // by only asserting pool_eligible on this build-time snapshot).
+    assert.equal(rpcById.get("endpoint-a").auth_required, false);
+    assert.equal(rpcById.get("endpoint-a").public_safe, true);
 
     const wssPool = poolsById.get("finney-wss");
     assert.equal(wssPool.endpoint_count, 1);


### PR DESCRIPTION
## Summary
`POST /rpc/v1/finney` currently returns 503 for every request — live-confirmed. `endpointPool()` (`scripts/lib/endpoint-artifacts.mjs`) builds each served pool endpoint from an explicit field allowlist that never included `auth_required`/`public_safe`, even though both fields are correctly present on the registry source and the intermediate `rpc-endpoints.json` artifact. Both `rpc/pools.json` and `endpoint-pools.json` are built through this same function.

The Worker's live health overlay (`overlayRpcPoolEligibility`, `src/health-serving.mjs`, shipped in #4958 earlier today) re-derives `pool_eligible` on every request from these same serialized fields — `undefined !== false` and `undefined !== true` both evaluate `true`, so every endpoint fails the structural eligibility check regardless of real health. This is the actual root cause of the ongoing finney-RPC outage; #4958 fixed a real but secondary bug in the overlay's staleness-recompute logic without catching that the fields never reached the artifact at all.

Closes #4978

## Fix
Add `auth_required`/`public_safe` to `endpointPool()`'s per-endpoint output object. Both are already part of the documented contract (`schemas/components/07-endpoints-rpc.schema.json`) for this shape — no schema change needed.

## Testing
- Local `npm run build`: confirmed `dist/metagraph-r2/metagraph/rpc/pools.json` now carries correct `auth_required`/`public_safe` for all 5 finney-rpc pool endpoints (previously all `null`).
- New regression test asserting these fields survive onto the served pool endpoint objects (not just the build-time `pool_eligible` computation, which was already correct and didn't catch this). Verified it fails pre-fix (`undefined !== false`) and passes post-fix.
- Full suite: 7597/7597 passing.
- `eslint`/`prettier --check` clean.

## Expected outcome
Once merged and the next build+publish cycle runs, `GET /api/v1/rpc/pools` should show `eligible_count > 0` for `finney-rpc`, and `POST /rpc/v1/finney` should serve real proxied responses instead of 503.