### PR TITLE
fix(ssrf): align RPC proxy hostname guard with webhook and prober parity

### DIFF
--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -244,4 +244,23 @@ describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
     const hostname = new URL("https://[64:ff9b::7f00:1]/").hostname;
     assert.equal(isPrivateOrLocalHostname(hostname), true);
   });
+
+  test("rejects special-use IPv4 ranges the webhook/probe guards already block (#1538)", () => {
+    assert.equal(isPrivateOrLocalHostname("192.0.0.1"), true);
+    assert.equal(isPrivateOrLocalHostname("198.18.0.1"), true);
+    assert.equal(isPrivateOrLocalHostname("224.0.0.1"), true);
+    assert.equal(isPrivateOrLocalHostname("240.0.0.1"), true);
+    assert.equal(isPrivateOrLocalHostname("223.255.255.255"), false);
+  });
+
+  test("rejects IPv6 site-local, multicast, discard-only, and NAT64 local-use literals", () => {
+    assert.equal(isPrivateOrLocalHostname("fec0::1"), true);
+    assert.equal(isPrivateOrLocalHostname("ff02::1"), true);
+    assert.equal(isPrivateOrLocalHostname("100::1"), true);
+    // Unlike the well-known 64:ff9b::/96 prefix, 64:ff9b:1::/48 tunnels a v4
+    // the embedded-v4 check cannot decode — e.g. cloud metadata 169.254.169.254.
+    assert.equal(isPrivateOrLocalHostname("64:ff9b:1::a9fe:a9fe"), true);
+    // Well-known NAT64 of a public v4 (8.8.8.8) stays reachable.
+    assert.equal(isPrivateOrLocalHostname("64:ff9b::808:808"), false);
+  });
 });

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -1150,8 +1150,9 @@ function isSafeRpcEndpointUrl(value) {
 
 // Shared IPv4 private/CGNAT-range predicate — applied both to a bare IPv4
 // hostname and to the v4 address embedded in an IPv4-mapped/compatible/6to4/
-// NAT64 IPv6 literal (see below). [first, second] are the leading two octets.
-function isPrivateIpv4Octets([first, second]) {
+// NAT64 IPv6 literal (see below).
+function isPrivateIpv4Octets(octets) {
+  const [first, second, third] = octets;
   return (
     first === 0 ||
     first === 10 ||
@@ -1159,6 +1160,9 @@ function isPrivateIpv4Octets([first, second]) {
     (first === 169 && second === 254) ||
     (first === 172 && second >= 16 && second <= 31) ||
     (first === 192 && second === 168) ||
+    (first === 192 && second === 0 && third === 0) || // 192.0.0.0/24 IETF protocol assignments
+    (first === 198 && second >= 18 && second <= 19) || // 198.18.0.0/15 benchmarking (RFC 2544)
+    first >= 224 || // 224.0.0.0/3 multicast + reserved (incl. 255/8 broadcast)
     // 100.64.0.0/10 CGNAT — the webhook, build, and health-probe SSRF guards
     // already block this range (#2312/#2313); keep this guard at parity.
     (first === 100 && second >= 64 && second <= 127)
@@ -1184,9 +1188,12 @@ export function isPrivateOrLocalHostname(hostname) {
   if (
     host === "::" ||
     host === "::1" ||
+    host.startsWith("100:") || // 0100::/8 discard-only (RFC 6666)
+    host.startsWith("64:ff9b:1:") || // NAT64 local-use 64:ff9b:1::/48 (RFC 8215)
     host.startsWith("fc") ||
     host.startsWith("fd") ||
-    host.startsWith("fe80")
+    host.startsWith("fe") || // fe00::/8 reserved (link-local + deprecated site-local)
+    host.startsWith("ff") // ff00::/8 multicast — not global unicast (#1538)
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary
- Bring `isPrivateOrLocalHostname` in the RPC proxy in line with the webhook, build, and health-probe SSRF guards — it had drifted and was missing several non-public ranges:
  - Special-use IPv4: `192.0.0.0/24`, `198.18.0.0/15`, `224.0.0.0/3`
  - IPv6: `fe00::/8` site-local (e.g. `fec0::`), `ff00::/8` multicast, `0100::/8` discard-only, `64:ff9b:1::/48` NAT64 local-use
- Well-known NAT64 of a public v4 (`64:ff9b::808:808` = 8.8.8.8) remains allowed via the existing embedded-v4 check.

## Why
Defense-in-depth for outbound RPC proxy fetches. A trusted upstream origin that resolves to a special-use / site-local / multicast / discard / NAT64-local address could otherwise be treated as safe.

## Test plan
- [x] `npm test -- tests/rpc-endpoint-selection.test.mjs`
- [ ] CI Validate (test, checks, changes, ui, python)
- [ ] Superagent Security Scan
- [ ] codecov/patch
