### PR TITLE
feat(ui): add mg-focus-ring to ProfileTabs and EndpointKindTabs tab buttons

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -29,7 +29,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             aria-selected={active}
             onClick={() => onChange(k)}
             className={classNames(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              "mg-focus-ring inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -38,7 +38,7 @@ export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defa
                   })
                 }
                 className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  "mg-focus-ring relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
                   isActive
                     ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
                     : "text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
Closes #3451

## Summary
Adds the existing `mg-focus-ring` utility to the tab `<button>` in **ProfileTabs**
(`apps/ui/src/components/metagraphed/profile-tabs.tsx`) and **EndpointKindTabs**
(`apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx`), so keyboard-focused tabs get a
visible focus ring — matching the rest of the design system.

## Why
Both tab strips built their `className` via `classNames(...)` with **no** focus-visible/outline
class, so a keyboard user tabbing through them got no visible focus indicator. Every other
interactive tile already uses `mg-focus-ring` (e.g. `hero-subnet-chips.tsx`), whose
`:focus-visible` rule (`packages/ui-kit/src/styles.css`) draws the two-layer `--ring`/`--accent`
box-shadow. These two tab strips were the outliers.

## Change
- `profile-tabs.tsx`: prepend `mg-focus-ring` to the tab button's base class list.
- `endpoint-kind-tabs.tsx`: prepend `mg-focus-ring` to the `role="tab"` button's base class list.

Pure a11y styling — no new component, no behaviour/layout change; the ring is `:focus-visible`-scoped
so it only appears on keyboard focus.

## Validation
- `eslint` + `prettier --check` clean on both files.
- Change is two class-string additions; no type or logic impact.
