### PR TITLE
feat(registry): add SN62 Ridges evaluation-set problems dataset data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-evaluation-problems",
+      "kind": "data-artifact",
+      "name": "Ridges latest evaluation-set problems dataset",
+      "notes": "Public no-auth JSON dataset of the current SN62 Ridges evaluation-set problems -- the SWE-bench-family coding tasks agents are scored against. Each entry carries set_id, set_group, problem_name, benchmark_family, problem_suite_name, and an execution_spec (task s3_key, sha256 digest, dataset_name). Served from agent-upload.ridges.ai, the DEFAULT_API_BASE_URL of the official ridgesai/ridges miner CLI (same host as the registered subnet-api and OpenAPI surfaces) and documented in that API's OpenAPI spec. A distinct standalone dataset, not the /retrieval/top-agents leaderboard already registered.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://agent-upload.ridges.ai/openapi.json",
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/commands/upload.py#L21"
+      ],
+      "url": "https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

Registers **SN62 Ridges**'s public **evaluation-set problems dataset** as a `data-artifact` surface — the SWE-bench-family coding tasks agents are scored against. It's the subnet's core public benchmark dataset, and the registry did not yet capture it.

## Surface

- **kind:** `data-artifact`
- **url:** `https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems`
- **provider:** `ridges` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- `source_url` 1: `https://agent-upload.ridges.ai/openapi.json` — the official Ridges agent API's own OpenAPI spec (already a registered surface), which documents this `/evaluation-sets/all-latest-set-problems` endpoint.
- `source_url` 2: `https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/commands/upload.py#L21` — the official `ridgesai/ridges` miner CLI defines `agent-upload.ridges.ai` as its `DEFAULT_API_BASE_URL`, establishing first-party ownership (the same proof the registered OpenAPI/subnet-api surfaces use).

## Verified live + public + safe

- `GET https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems` → **HTTP 200**, `application/json`, ~61 KB, **no auth**.
- Real payload: an array of evaluation problems, each with `set_id`, `set_group`, `problem_name` (e.g. `astropy__astropy-13579`), `benchmark_family` (`swe-bench`), `problem_suite_name`, and an `execution_spec` (task `s3_key`, `sha256` digest, `dataset_name`).
- Public-safe: scanned the full body for SS58/base58 wallet or hotkey strings → **zero matches**; problem definitions only, no secrets.

## Non-duplication

Distinct from Ridges's existing surfaces — `source-repo`, the `subnet-api` (`/retrieval/top-agents` leaderboard), and the `openapi` spec. This is a different URL and a standalone dataset (the evaluation problems), not the leaderboard API. No open PR targets SN62 (the earlier #4474 registered `.py` source files and was closed; this registers the genuine data endpoint instead).

## Scope note (relative to #4069)

#4069 asks for SN62 Ridges's public **data artifact**. This no-auth JSON problems dataset — the concrete, machine-readable public data the subnet's evaluation is built on — is exactly that.

## Validation (local)

- `npm run validate:surface -- registry/subnets/ridges.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/ridges.json` → clean
- `git diff --stat` → single file, 19-line pure append (no top-level metadata or other surfaces touched)

## Template Used

- Subnet surface

Closes #4069
