### PR TITLE
feat(data-api): add the chain_firehose Postgres NOTIFY tee

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -572,6 +572,91 @@ CREATE TABLE IF NOT EXISTS indexer_cursor (
   CONSTRAINT indexer_cursor_singleton CHECK (id = 1)
 );
 
+-- ---------------------------------------------------------------------------
+-- Realtime firehose tee (ADR 0015, #4980)
+-- ---------------------------------------------------------------------------
+
+-- Fires AFTER a row is already durably committed to blocks/extrinsics/
+-- chain_events -- by construction this can never affect whether that write
+-- itself succeeded, so it adds zero risk to indexer-rs's live-follow
+-- reliability (ADR 0015 -- this design deliberately replaces a direct push
+-- from indexer-rs's own process with this trigger specifically to avoid
+-- that risk). Payload is a compact reference, not the full row, to stay
+-- well under Postgres's 8000-byte NOTIFY payload cap; a subscriber that
+-- wants full row detail re-fetches by primary key.
+--
+-- Row-level (FOR EACH ROW), not statement-level: simpler to reason about
+-- for a first cut, at the cost of one NOTIFY per row rather than one per
+-- batch insert. indexer-rs batch-inserts many extrinsics/chain_events per
+-- block, so a busy block can fire dozens of NOTIFYs. If that volume becomes
+-- a real problem, the natural fast-follow is a statement-level trigger with
+-- a `REFERENCING NEW TABLE AS new_rows` transition table, batching one
+-- NOTIFY per INSERT statement -- not attempted here to avoid over-building
+-- ahead of measured need.
+CREATE OR REPLACE FUNCTION notify_chain_firehose() RETURNS TRIGGER AS $$
+DECLARE
+  payload JSONB;
+BEGIN
+  IF TG_TABLE_NAME = 'blocks' THEN
+    payload := jsonb_build_object(
+      'table', 'blocks',
+      'block_number', NEW.block_number,
+      'block_hash', NEW.block_hash,
+      'extrinsic_count', NEW.extrinsic_count,
+      'event_count', NEW.event_count,
+      'observed_at', NEW.observed_at
+    );
+  ELSIF TG_TABLE_NAME = 'extrinsics' THEN
+    payload := jsonb_build_object(
+      'table', 'extrinsics',
+      'block_number', NEW.block_number,
+      'extrinsic_index', NEW.extrinsic_index,
+      'call_module', NEW.call_module,
+      'call_function', NEW.call_function,
+      'signer', NEW.signer,
+      'success', NEW.success,
+      'observed_at', NEW.observed_at
+    );
+  ELSIF TG_TABLE_NAME = 'chain_events' THEN
+    payload := jsonb_build_object(
+      'table', 'chain_events',
+      'block_number', NEW.block_number,
+      'event_index', NEW.event_index,
+      'pallet', NEW.pallet,
+      'method', NEW.method,
+      'observed_at', NEW.observed_at
+    );
+  ELSE
+    RETURN NEW;
+  END IF;
+  -- pg_notify raises an error if payload exceeds 8000 bytes; the fields
+  -- above are all short scalars, so this should never realistically trip,
+  -- but a truncation fallback is safer than letting a future column
+  -- addition silently break every insert on this table.
+  BEGIN
+    PERFORM pg_notify('chain_firehose', payload::text);
+  EXCEPTION WHEN OTHERS THEN
+    NULL; -- never let firehose delivery failure affect the write itself.
+  END;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_blocks_firehose ON blocks;
+CREATE TRIGGER trg_blocks_firehose
+  AFTER INSERT ON blocks
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose();
+
+DROP TRIGGER IF EXISTS trg_extrinsics_firehose ON extrinsics;
+CREATE TRIGGER trg_extrinsics_firehose
+  AFTER INSERT ON extrinsics
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose();
+
+DROP TRIGGER IF EXISTS trg_chain_events_firehose ON chain_events;
+CREATE TRIGGER trg_chain_events_firehose
+  AFTER INSERT ON chain_events
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose();
+
 -- TimescaleDB hypertables/compression are OPTIONAL and live in the companion
 -- schema-timescaledb.sql in this same directory — apply it separately, only
 -- on a Postgres that actually has the TimescaleDB extension. This file is a

--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -1,0 +1,79 @@
+# Realtime chain-event firehose (#2114, ADR 0015)
+
+The `chain_firehose` Postgres channel: a compact, best-effort NOTIFY stream of
+every row landing in `blocks`/`extrinsics`/`chain_events`, decoupled from
+`indexer-rs`'s own write path so nothing downstream of it can ever affect
+whether `indexer-rs` keeps following the chain head. See ADR 0015 for why this
+shape was chosen over a direct push from `indexer-rs` (the retired
+`metagraphed-streamer`'s exact failure mode, documented in ADR 0014).
+
+## How it works
+
+```
+indexer-rs → (writes, as it always has) → Postgres
+                                              │
+                              AFTER INSERT trigger (deploy/postgres/schema.sql)
+                                              │
+                                    pg_notify('chain_firehose', <payload>)
+                                              │
+                          box-side relay (LISTEN, #4981) → Cloudflare Durable Object (#4982)
+                                                                          │
+                                                        SSE / WS / GraphQL subs / MCP (#4982, #4983)
+```
+
+`indexer-rs` requires **zero code changes** and has **zero awareness** any of
+this exists — the trigger only fires after a row is already durably
+committed, so a firehose outage (relay down, Cloudflare unreachable, the
+Durable Object itself failing) has exactly one consequence: the live
+subscription feed stalls. `indexer-rs`'s writes and Postgres's durability are
+completely unaffected, by construction.
+
+## The trigger (`deploy/postgres/schema.sql`)
+
+`notify_chain_firehose()` is a single `plpgsql` function, reused by three
+`AFTER INSERT ... FOR EACH ROW` triggers (one per table). Payload is a
+compact reference — table name + primary-key fields + a couple of headline
+columns — not the full row, to stay well under Postgres's 8000-byte `NOTIFY`
+payload cap. A subscriber that wants full row detail re-fetches by primary
+key. Any error raised inside the trigger (e.g. a future oversized payload) is
+swallowed, not propagated — firehose delivery must never be able to fail an
+insert.
+
+Row-level, not statement-level: simpler for a first cut, at the cost of one
+`NOTIFY` per row rather than one per batch insert. If per-block NOTIFY volume
+becomes a real bottleneck, the documented fast-follow is a statement-level
+trigger with a `REFERENCING NEW TABLE AS new_rows` transition table.
+
+## The relay (#4981, not yet built)
+
+A new, small, self-hosted process on the indexer box — `LISTEN
+chain_firehose;`, forward each notification to the Durable Object over HTTP,
+bounded retry/drop-oldest under sustained Cloudflare-side unavailability.
+Deployed via the same Ansible-managed convention as the (retired) `streamer`
+role — see [`JSONbored/metagraphed-infra`](https://github.com/JSONbored/metagraphed-infra)
+— not an ad-hoc SSH-installed process. Unlike the old streamer, this relay is
+a pure consumer: it never writes to Postgres and is never in `indexer-rs`'s
+critical path, so there is no equivalent of the old blocking-retry-starves-the-subscription
+failure mode to guard against here.
+
+## The hub + transports (#4982, #4983, not yet built)
+
+A single Cloudflare Durable Object (`ChainFirehoseHub`) receives relay
+forwards on an authenticated internal endpoint and fans them out over SSE
+(`GET /api/v1/chain/stream`), WebSocket, a GraphQL `Subscription` type, and
+MCP resource subscriptions — one hub, four transports.
+
+## The alerter (#4984, not yet built)
+
+A consumer of the same hub: evaluates user-defined trigger conditions against
+the stream and delivers matches via webhook (reusing the existing
+`/api/v1/webhooks/subscriptions` infrastructure), email, Telegram, or
+Discord.
+
+## Verifying the trigger locally
+
+```sh
+psql "$DATABASE_URL" -c "LISTEN chain_firehose;"
+# in another session, insert (or wait for indexer-rs to insert) a row into
+# blocks/extrinsics/chain_events — the LISTENing session prints a Notification
+```


### PR DESCRIPTION
## Summary
First of 5 sub-issues for #2114 (Durable Object firehose), per ADR 0015. Adds `AFTER INSERT` triggers on `blocks`/`extrinsics`/`chain_events` that fire `pg_notify('chain_firehose', <compact payload>)` after each row is already durably committed — this is the decoupling point ADR 0015 designs around, so `indexer-rs`'s own write path needs zero code changes and has zero awareness this exists.

Closes #4980

## Testing
- Syntax validated against the live indexer Postgres inside a rolled-back transaction (`BEGIN; ...; ROLLBACK;`) before opening this PR — function and all three triggers created cleanly, no errors.
- No CI test applies `deploy/postgres/schema.sql` automatically (checked — nothing in `.github/workflows/` does), so this validation is the only pre-merge check; will re-verify live via a `LISTEN`/insert test once merged.
- Docs-only sibling addition (`docs/realtime-firehose.md`), no code paths touched outside the SQL file.