### PR TITLE
fix(staging): refuse Postgres hyperparams prune on partial snapshots

### DIFF
--- a/scripts/fetch-subnet-hyperparams.py
+++ b/scripts/fetch-subnet-hyperparams.py
@@ -94,6 +94,11 @@ def to_flag(value):
     return 1 if value else 0
 
 
+def coverage_snapshot_complete(rows_count, netuids_count, errors):
+    """True only when every active netuid produced a hyperparameter row."""
+    return not errors and rows_count == netuids_count
+
+
 def main():
     import bittensor as bt  # lazy: keeps this module loadable (e.g. for unit
     # tests) without the heavy SDK installed, matching fetch-events.py's/
@@ -227,16 +232,29 @@ def main():
         )
 
     os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
-    with open(OUT, "w") as fh:
-        json.dump(rows, fh)
-    sys.stderr.write(
-        f"wrote {len(rows)} subnet hyperparameter row(s) "
-        f"({len(errors)} error(s)) -> {OUT}\n"
-    )
-    for err in errors:
-        sys.stderr.write(f"  {err}\n")
-    if errors or len(rows) != len(netuids):
+    if not coverage_snapshot_complete(len(rows), len(netuids), errors):
+        if errors:
+            sys.stderr.write(
+                "subnet-hyperparams fetch incomplete; refusing to stage partial snapshot\n"
+            )
+        else:
+            sys.stderr.write(
+                f"subnet-hyperparams fetch row count mismatch "
+                f"({len(rows)}/{len(netuids)}); refusing to stage partial snapshot\n"
+            )
+        for err in errors:
+            sys.stderr.write(f"  {err}\n")
         sys.exit(1)
+    payload = {
+        "rows": rows,
+        "expected_netuid_count": len(netuids),
+        "captured_at": captured_at,
+    }
+    with open(OUT, "w") as fh:
+        json.dump(payload, fh)
+    sys.stderr.write(
+        f"wrote {len(rows)} subnet hyperparameter row(s) -> {OUT}\n"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/sign-staged-neurons.mjs
+++ b/scripts/sign-staged-neurons.mjs
@@ -14,6 +14,7 @@ const parsed = JSON.parse(readFileSync(inputPath, "utf8"));
 let rows;
 let refreshed_netuids;
 let captured_at;
+let expected_netuid_count;
 let payload;
 if (Array.isArray(parsed)) {
   rows = parsed;
@@ -22,10 +23,16 @@ if (Array.isArray(parsed)) {
   rows = parsed.rows;
   refreshed_netuids = parsed.refreshed_netuids;
   captured_at = parsed.captured_at;
+  expected_netuid_count = parsed.expected_netuid_count;
   if (!Array.isArray(rows)) {
     throw new Error("staged payload rows must be a JSON array");
   }
-  payload = JSON.stringify({ rows, refreshed_netuids, captured_at });
+  payload = JSON.stringify({
+    rows,
+    refreshed_netuids,
+    captured_at,
+    expected_netuid_count,
+  });
 } else {
   throw new Error("staged payload must be a JSON array or staging object");
 }
@@ -35,4 +42,6 @@ const envelope = { schema_version: 1, hmac_sha256, rows };
 if (refreshed_netuids !== undefined)
   envelope.refreshed_netuids = refreshed_netuids;
 if (captured_at !== undefined) envelope.captured_at = captured_at;
+if (expected_netuid_count !== undefined)
+  envelope.expected_netuid_count = expected_netuid_count;
 writeFileSync(outputPath, `${JSON.stringify(envelope)}\n`);

--- a/scripts/test_fetch_subnet_hyperparams.py
+++ b/scripts/test_fetch_subnet_hyperparams.py
@@ -33,6 +33,7 @@ u16_ratio = _fsh.u16_ratio
 rao_to_tao_exact = _fsh.rao_to_tao_exact
 to_flag = _fsh.to_flag
 to_float = _fsh.to_float
+coverage_snapshot_complete = _fsh.coverage_snapshot_complete
 
 
 class _Info:
@@ -79,24 +80,62 @@ class FetchCompletenessTest(unittest.TestCase):
                     with mock.patch.object(sys, "argv", ["fetch-subnet-hyperparams.py"]):
                         with self.assertRaises(SystemExit) as cm:
                             _fsh.main()
+            if not os.path.exists(out):
+                return cm.exception.code, []
             with open(out) as fh:
-                rows = json.load(fh)
+                data = json.load(fh)
+            rows = data["rows"] if isinstance(data, dict) else data
             return cm.exception.code, rows
 
     def test_per_netuid_exception_fails_instead_of_signing_partial_snapshot(self):
         code, rows = self.run_main({1: _Hp(), 2: RuntimeError("rpc failed")})
         self.assertEqual(code, 1)
-        self.assertEqual([row["netuid"] for row in rows], [1])
+        self.assertEqual(rows, [])
 
     def test_empty_hyperparameters_response_fails_instead_of_signing_partial_snapshot(self):
         code, rows = self.run_main({1: _Hp(), 2: None})
         self.assertEqual(code, 1)
-        self.assertEqual([row["netuid"] for row in rows], [1])
+        self.assertEqual(rows, [])
 
     def test_empty_active_netuid_discovery_fails_instead_of_signing_empty_snapshot(self):
         code, rows = self.run_main({}, infos=[])
         self.assertEqual(code, 1)
         self.assertEqual(rows, [])
+
+    def test_successful_fetch_emits_completeness_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "hyperparams.json")
+
+            class _SubtensorApi:
+                def __init__(self, network):
+                    self.metagraphs = types.SimpleNamespace(
+                        get_all_metagraphs_info=lambda all_mechanisms: [_Info(1), _Info(2)]
+                    )
+                    self.subnets = types.SimpleNamespace(
+                        get_subnet_hyperparameters=lambda netuid: _Hp()
+                    )
+
+            fake_bt = types.SimpleNamespace(SubtensorApi=_SubtensorApi)
+            with mock.patch.object(_fsh, "OUT", out):
+                with mock.patch.dict(sys.modules, {"bittensor": fake_bt}):
+                    with mock.patch.object(sys, "argv", ["fetch-subnet-hyperparams.py"]):
+                        _fsh.main()
+            with open(out) as fh:
+                payload = json.load(fh)
+            self.assertEqual(payload["expected_netuid_count"], 2)
+            self.assertEqual(len(payload["rows"]), 2)
+            self.assertIn("captured_at", payload)
+
+
+class CoverageSnapshotCompleteTest(unittest.TestCase):
+    def test_complete_when_all_netuids_succeeded(self):
+        self.assertTrue(coverage_snapshot_complete(129, 129, []))
+
+    def test_incomplete_when_any_fetch_failed(self):
+        self.assertFalse(coverage_snapshot_complete(128, 129, ["netuid=8: timeout"]))
+
+    def test_incomplete_when_row_count_short(self):
+        self.assertFalse(coverage_snapshot_complete(128, 129, []))
 
 
 class U16RatioTest(unittest.TestCase):

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3110,7 +3110,10 @@ test("subnet-hyperparams-sync rejects an empty array (400)", async () => {
 test("subnet-hyperparams-sync upserts subnet_hyperparams and reports written/pruned counts", async () => {
   const res = await postSubnetHyperparams(
     {
-      rows: [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+      rows: [
+        hyperparamsSyncRow({ netuid: 8 }),
+        hyperparamsSyncRow({ netuid: 9 }),
+      ],
       expected_netuid_count: 2,
     },
     { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
@@ -3125,7 +3128,10 @@ test("subnet-hyperparams-sync upserts subnet_hyperparams and reports written/pru
 test("subnet-hyperparams-sync skips prune when expected_netuid_count is unmet", async () => {
   const res = await postSubnetHyperparams(
     {
-      rows: [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+      rows: [
+        hyperparamsSyncRow({ netuid: 8 }),
+        hyperparamsSyncRow({ netuid: 9 }),
+      ],
       expected_netuid_count: 129,
     },
     { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
@@ -3161,7 +3167,10 @@ test("subnet-hyperparams-sync skips legacy prune when row count collapsed vs Pos
 test("subnet-hyperparams-sync prunes with scalar positional binds, not a bound array", async () => {
   await postSubnetHyperparams(
     {
-      rows: [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+      rows: [
+        hyperparamsSyncRow({ netuid: 8 }),
+        hyperparamsSyncRow({ netuid: 9 }),
+      ],
       expected_netuid_count: 2,
     },
     { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -49,6 +49,7 @@ const rollupFailure = vi.hoisted(() => ({ error: null }));
 const subnetHyperparamsSyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetHyperparamsPruneRows = vi.hoisted(() => ({ current: [] }));
 const subnetHyperparamsLatestHashes = vi.hoisted(() => ({ current: [] }));
+const subnetHyperparamsPriorCount = vi.hoisted(() => ({ current: 0 }));
 // State for the account-identity-sync write route's tests only (#4832
 // gap-closure). No prune-rows hook -- unlike subnet_hyperparams, this table
 // has no purge step (see handleAccountIdentitySync's own header comment).
@@ -168,6 +169,9 @@ vi.mock("postgres", () => ({
       if (/SELECT DISTINCT ON \(netuid\) netuid, hyperparams_hash/.test(text)) {
         return Promise.resolve(subnetHyperparamsLatestHashes.current);
       }
+      if (/SELECT COUNT\(\*\).*FROM subnet_hyperparams/.test(text)) {
+        return Promise.resolve([{ c: subnetHyperparamsPriorCount.current }]);
+      }
       if (/SELECT DISTINCT ON \(netuid\) netuid, identity_hash/.test(text)) {
         return Promise.resolve(subnetIdentityLatestHashes.current);
       }
@@ -242,6 +246,7 @@ beforeEach(() => {
   subnetHyperparamsSyncFailure.error = null;
   subnetHyperparamsPruneRows.current = [];
   subnetHyperparamsLatestHashes.current = [];
+  subnetHyperparamsPriorCount.current = 0;
   accountIdentitySyncFailure.error = null;
   accountIdentityLatestHashes.current = [];
   subnetIdentitySyncFailure.error = null;
@@ -3104,7 +3109,10 @@ test("subnet-hyperparams-sync rejects an empty array (400)", async () => {
 
 test("subnet-hyperparams-sync upserts subnet_hyperparams and reports written/pruned counts", async () => {
   const res = await postSubnetHyperparams(
-    [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+    {
+      rows: [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+      expected_netuid_count: 2,
+    },
     { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
   );
   expect(res.status).toBe(200);
@@ -3114,9 +3122,48 @@ test("subnet-hyperparams-sync upserts subnet_hyperparams and reports written/pru
   expect(queryText()).toMatch(/DELETE FROM subnet_hyperparams\b/);
 });
 
+test("subnet-hyperparams-sync skips prune when expected_netuid_count is unmet", async () => {
+  const res = await postSubnetHyperparams(
+    {
+      rows: [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+      expected_netuid_count: 129,
+    },
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({
+    ok: true,
+    subnet_hyperparams_written: 2,
+    deregistered_pruned: 0,
+    prune_skipped: true,
+  });
+  expect(queryText()).toMatch(/INSERT INTO subnet_hyperparams\b/);
+  expect(queryText()).not.toMatch(/DELETE FROM subnet_hyperparams\b/);
+});
+
+test("subnet-hyperparams-sync skips legacy prune when row count collapsed vs Postgres", async () => {
+  subnetHyperparamsPriorCount.current = 4;
+  const res = await postSubnetHyperparams([hyperparamsSyncRow({ netuid: 8 })], {
+    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({
+    ok: true,
+    subnet_hyperparams_written: 1,
+    deregistered_pruned: 0,
+    prune_skipped: true,
+  });
+  expect(queryText()).not.toMatch(/DELETE FROM subnet_hyperparams\b/);
+});
+
 test("subnet-hyperparams-sync prunes with scalar positional binds, not a bound array", async () => {
   await postSubnetHyperparams(
-    [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+    {
+      rows: [hyperparamsSyncRow({ netuid: 8 }), hyperparamsSyncRow({ netuid: 9 })],
+      expected_netuid_count: 2,
+    },
     { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
   );
   const pruneCall = sqlCalls.find((c) =>
@@ -3158,9 +3205,13 @@ test("subnet-hyperparams-sync defaults a missing optional column to null rather 
 
 test("subnet-hyperparams-sync reports deregistered_pruned from the DELETE's returned row count", async () => {
   subnetHyperparamsPruneRows.current = [{ netuid: 99 }];
-  const res = await postSubnetHyperparams([hyperparamsSyncRow()], {
-    secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
-  });
+  const res = await postSubnetHyperparams(
+    {
+      rows: [hyperparamsSyncRow()],
+      expected_netuid_count: 1,
+    },
+    { secret: SUBNET_HYPERPARAMS_SYNC_SECRET },
+  );
   const body = await res.json();
   expect(body.deregistered_pruned).toBe(1);
 });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1025,6 +1025,10 @@ async function handleSubnetHyperparamsSync(request, env) {
 
   const rows = incoming.map(coerceSubnetHyperparamsSyncRow);
   const netuids = incoming.map((row) => row.netuid);
+  const expectedNetuidCount =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed.expected_netuid_count
+      : undefined;
 
   const sql = postgres(env.HYPERDRIVE.connectionString, {
     max: 5,
@@ -1076,16 +1080,35 @@ async function handleSubnetHyperparamsSync(request, env) {
           captured_at = EXCLUDED.captured_at
         WHERE subnet_hyperparams.captured_at <= EXCLUDED.captured_at`;
 
-      // Prune subnets no longer in the snapshot (deregistered/removed) --
-      // scalar positional binds via sql.unsafe, not a bound array, avoiding
-      // the same fetch_types:false ANY()/array-bind landmine documented on
-      // handleNeuronsSync's own prune above. `netuids` is never empty here
-      // -- the earlier `!incoming.length` check guarantees at least one row.
+      // Prune subnets no longer in the snapshot (deregistered/removed) only when
+      // the completeness contract is satisfied — mirror loadStagedSubnetHyperparams
+      // and refuse to mass-delete on a partial snapshot.
+      const hasCompletenessContract = Number.isInteger(expectedNetuidCount);
+      let canPrune = true;
+      if (hasCompletenessContract) {
+        if (expectedNetuidCount <= 0 || rows.length !== expectedNetuidCount) {
+          canPrune = false;
+          console.warn(
+            `subnet-hyperparams-sync: incomplete snapshot (${rows.length}/${expectedNetuidCount}); skipping prune`,
+          );
+        }
+      } else {
+        const [{ c: priorCount }] =
+          await sql`SELECT COUNT(*)::int AS c FROM subnet_hyperparams`;
+        if (priorCount > 0 && rows.length < priorCount / 2) {
+          canPrune = false;
+          console.warn(
+            `subnet-hyperparams-sync: legacy snapshot row count collapsed (${rows.length}/${priorCount}); skipping prune`,
+          );
+        }
+      }
       const placeholders = netuids.map((_, i) => `$${i + 1}::int`).join(", ");
-      const pruned = await sql.unsafe(
-        `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${placeholders}) RETURNING netuid`,
-        netuids,
-      );
+      const pruned = canPrune
+        ? await sql.unsafe(
+            `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${placeholders}) RETURNING netuid`,
+            netuids,
+          )
+        : [];
 
       // Diff-and-append into subnet_hyperparams_history (mirrors D1's
       // recordSubnetHyperparamsChanges) -- hashed on the RAW incoming rows
@@ -1131,6 +1154,7 @@ async function handleSubnetHyperparamsSync(request, env) {
         subnet_hyperparams_written: rows.length,
         deregistered_pruned: pruned.length,
         history_appended: changedRows.length,
+        ...(canPrune ? {} : { prune_skipped: true }),
       });
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Postgres is now the sole subnet-hyperparams write path (`handleSubnetHyperparamsSync`), but it still ran an unconditional `DELETE … NOT IN` after upsert — a partial authenticated POST could mass-delete hyperparams for every missing netuid.
- Stamp `expected_netuid_count` through `fetch-subnet-hyperparams.py` → `sign-staged-neurons.mjs` → the sync handler, and skip prune when the completeness contract is unmet.
- Legacy bare-array envelopes fall back to the same row-count-collapse guard used on D1 (skip prune when coverage dropped >50% vs live table).

## Test plan
- [x] `npm test -- tests/data-api.test.mjs -t subnet-hyperparams-sync`
- [x] `python scripts/test_fetch_subnet_hyperparams.py`
- [ ] CI Validate (test, checks, changes, ui, python)
- [ ] Superagent Security Scan
- [ ] codecov/patch
