### PR TITLE
feat(registry): add SN73 MetaHash TaoMarketCap candle-chart data-artifact (#4089)

### DIFF
--- a/registry/subnets/metahash.json
+++ b/registry/subnets/metahash.json
@@ -53,6 +53,25 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/73"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-73-taomarketcap-candle-chart",
+      "kind": "data-artifact",
+      "name": "MetaHash TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/73/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN73 MetaHash's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 73. A standalone historical price/volume dataset, distinct from the point-in-time /subnets/73 snapshot already registered. Documented in the TaoMarketCap developer API (its public-oas3.json lists this GET with an optional API key, i.e. no-auth access is supported).",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/73/candle-chart/"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers **SN73 MetaHash**'s public **OHLCV candle-chart dataset** as a `data-artifact` surface — a no-auth JSON time-series of MetaHash's alpha-token price/volume the registry did not yet capture.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/73/candle-chart/`
- **provider:** `taomarketcap` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership / authority

- Same official host and authority basis as SN73's already-registered `sn-73-taomarketcap-subnet-api` surface (`api.taomarketcap.com`, a provider-claimed on-chain indexer). MetaHash publishes no verified first-party API (its own docs/source URLs do not resolve), so this indexed on-chain feed is the concrete public data surface — exactly the pattern the existing SN73 surface established.
- `source_url`s: the TaoMarketCap developer API docs and `tensorplex-labs/subnet-docs/data/73/subnet.json` (the same proof the existing SN73 surface uses). The endpoint is listed in TaoMarketCap's `public-oas3.json` with an **optional** API key (no-auth access supported).

## Verified live + public + safe

- `GET https://api.taomarketcap.com/public/v1/subnets/73/candle-chart/` → **HTTP 200**, `application/json`, ~224 KB, **no auth**.
- Real payload: an array of hourly OHLCV candles (~720 records, ~30 days), each scoped to `subnet_id: 73`, with `period_name`, `timestamp`, `block_number`, `open/high/low/close`, `volume`, `start_volume`, `tao_price_usd/eur`.
- Public-safe: scanned the full body for SS58/base58 wallet or hotkey strings → **zero matches**; price/volume time-series only.

## Non-duplication

Distinct from SN73's only existing surface — the point-in-time `/public/v1/subnets/73` state snapshot (`subnet-api`). This is a different URL and a different dataset (a historical price/volume time-series), registered as `data-artifact`. No open PR targets SN73.

## Scope note (relative to #4089)

#4089 asks for SN73 MetaHash's public **data artifact**. This standalone, machine-readable OHLCV price/volume dataset is exactly that.

## Validation (local)

- `npm run validate:surface -- registry/subnets/metahash.json` → passes (2 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/metahash.json` → clean
- `git diff --stat` → single file, 19-line pure append

## Template Used

- Subnet surface

Closes #4089
