### PR TITLE
fix(data-api): use TG_ARGV, not TG_TABLE_NAME, in the firehose trigger

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -593,11 +593,24 @@ CREATE TABLE IF NOT EXISTS indexer_cursor (
 -- a `REFERENCING NEW TABLE AS new_rows` transition table, batching one
 -- NOTIFY per INSERT statement -- not attempted here to avoid over-building
 -- ahead of measured need.
+--
+-- Which logical table fired is passed as an explicit trigger argument
+-- (TG_ARGV[0]), NOT read from TG_TABLE_NAME: on a TimescaleDB hypertable,
+-- inserts are physically routed to a per-time-range CHUNK table (e.g.
+-- `_hyper_1_379_chunk`), and a trigger attached to the hypertable is
+-- transparently propagated to (and fires on) that chunk -- so TG_TABLE_NAME
+-- inside the function body is the CHUNK's internal name, never the logical
+-- hypertable name 'blocks'/'extrinsics'/'chain_events'. Verified live
+-- (2026-07-12): a debug trigger using TG_TABLE_NAME on a real indexer-rs
+-- insert observed the value `_hyper_1_379_chunk`, not `blocks` -- confirming
+-- an earlier version of this function that branched on TG_TABLE_NAME was a
+-- silent no-op on every real insert (always took the ELSE branch, never
+-- notified) despite creating and attaching without error.
 CREATE OR REPLACE FUNCTION notify_chain_firehose() RETURNS TRIGGER AS $$
 DECLARE
   payload JSONB;
 BEGIN
-  IF TG_TABLE_NAME = 'blocks' THEN
+  IF TG_ARGV[0] = 'blocks' THEN
     payload := jsonb_build_object(
       'table', 'blocks',
       'block_number', NEW.block_number,
@@ -606,7 +619,7 @@ BEGIN
       'event_count', NEW.event_count,
       'observed_at', NEW.observed_at
     );
-  ELSIF TG_TABLE_NAME = 'extrinsics' THEN
+  ELSIF TG_ARGV[0] = 'extrinsics' THEN
     payload := jsonb_build_object(
       'table', 'extrinsics',
       'block_number', NEW.block_number,
@@ -617,7 +630,7 @@ BEGIN
       'success', NEW.success,
       'observed_at', NEW.observed_at
     );
-  ELSIF TG_TABLE_NAME = 'chain_events' THEN
+  ELSIF TG_ARGV[0] = 'chain_events' THEN
     payload := jsonb_build_object(
       'table', 'chain_events',
       'block_number', NEW.block_number,
@@ -645,17 +658,17 @@ $$ LANGUAGE plpgsql;
 DROP TRIGGER IF EXISTS trg_blocks_firehose ON blocks;
 CREATE TRIGGER trg_blocks_firehose
   AFTER INSERT ON blocks
-  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose();
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose('blocks');
 
 DROP TRIGGER IF EXISTS trg_extrinsics_firehose ON extrinsics;
 CREATE TRIGGER trg_extrinsics_firehose
   AFTER INSERT ON extrinsics
-  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose();
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose('extrinsics');
 
 DROP TRIGGER IF EXISTS trg_chain_events_firehose ON chain_events;
 CREATE TRIGGER trg_chain_events_firehose
   AFTER INSERT ON chain_events
-  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose();
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose('chain_events');
 
 -- TimescaleDB hypertables/compression are OPTIONAL and live in the companion
 -- schema-timescaledb.sql in this same directory — apply it separately, only

--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -31,7 +31,14 @@ completely unaffected, by construction.
 ## The trigger (`deploy/postgres/schema.sql`)
 
 `notify_chain_firehose()` is a single `plpgsql` function, reused by three
-`AFTER INSERT ... FOR EACH ROW` triggers (one per table). Payload is a
+`AFTER INSERT ... FOR EACH ROW` triggers (one per table), each passed its
+logical table name as an explicit trigger argument (`EXECUTE FUNCTION
+notify_chain_firehose('blocks')`, read inside as `TG_ARGV[0]`). This is
+deliberate, not stylistic: on a TimescaleDB hypertable, `TG_TABLE_NAME`
+inside the function body resolves to the physical per-time-range CHUNK name
+(e.g. `_hyper_1_379_chunk`), never the logical hypertable name — an earlier
+version of this function branched on `TG_TABLE_NAME` and was a silent no-op
+on every real insert as a result (verified live 2026-07-12). Payload is a
 compact reference — table name + primary-key fields + a couple of headline
 columns — not the full row, to stay well under Postgres's 8000-byte `NOTIFY`
 payload cap. A subscriber that wants full row detail re-fetches by primary


### PR DESCRIPTION
## Summary
#4980's `notify_chain_firehose()` branched on `TG_TABLE_NAME` to select the right payload shape per table. On a TimescaleDB hypertable, inserts are physically routed to a per-time-range chunk (e.g. `_hyper_1_379_chunk`), and a trigger attached to the hypertable transparently fires on that chunk — so `TG_TABLE_NAME` inside the function body resolves to the chunk's internal name, never the logical hypertable name `'blocks'`/`'extrinsics'`/`'chain_events'`. The function always fell through to its `ELSE RETURN NEW;` branch and silently never notified, on every real insert, despite the `CREATE FUNCTION`/`CREATE TRIGGER` statements succeeding without any error — my PR merging #4980 claimed live-verification, but that verification only checked SQL syntax validity (a rolled-back dry-run), not actual functional firing behavior against a real insert.

## Fix
Pass the logical table name as an explicit trigger argument instead (`EXECUTE FUNCTION notify_chain_firehose('blocks')`, read inside as `TG_ARGV[0]`) — reliable regardless of which chunk physically receives the row.

## Testing
- Root-caused via a temporary debug trigger that emitted `TG_TABLE_NAME` directly — confirmed live it resolves to `_hyper_1_379_chunk`, not `blocks`, for a real `indexer-rs` insert. Debug trigger/function dropped immediately after confirming.
- Fix validated in a rolled-back transaction against the live indexer Postgres, then applied for real.
- **Properly re-verified this time**: a 25-second `LISTEN chain_firehose` session against the live database captured real, correctly-shaped notifications from a genuine `indexer-rs`-inserted block (#8607915) — both `blocks` and `extrinsics` payloads observed with correct field values (`call_module`/`call_function`/`extrinsic_index` etc. all populated correctly).
- Already applied to the live indexer Postgres (this is a data-infra fix, same pattern as #4980 itself — no code path in this repo executes the SQL, it's applied directly via the documented `deploy/postgres/schema.sql` convention).