### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap candle-chart data-artifact (#4034)

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-candle-chart",
+      "kind": "data-artifact",
+      "name": "Recall TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/31/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN31 Recall's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 31. Recall publishes no verified first-party website or API, so this indexed on-chain price/volume feed -- documented in the TaoMarketCap developer API -- is the subnet's concrete public data artifact.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31/candle-chart/"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Registers **SN31 Recall**'s public **OHLCV candle-chart dataset** as a `data-artifact` surface — a no-auth JSON time-series of Recall's alpha-token price/volume, and Recall's first registered public data surface.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/31/candle-chart/`
- **provider:** `taomarketcap` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership / authority

- Recall publishes no verified first-party website/API (its manifest `source_repo`/`website_url`/`docs_url` are all null), so this indexed on-chain feed from `api.taomarketcap.com` — a provider-claimed on-chain indexer — is the concrete public data surface, the same authority basis accepted for other subnets that lack a first-party host (e.g. the merged SN73 MetaHash candle-chart).
- `source_url`s: the TaoMarketCap developer API docs and `tensorplex-labs/subnet-docs/data/31/subnet.json` (confirms SN31 Recall's identity). The endpoint is listed in TaoMarketCap's public OpenAPI with an optional API key (no-auth access supported).

## Verified live + public + safe

- `GET https://api.taomarketcap.com/public/v1/subnets/31/candle-chart/` → **HTTP 200**, `application/json`, ~223 KB, **no auth**.
- Real payload: an array of hourly OHLCV candles, each scoped to `subnet_id: 31`, with `period_name`, `timestamp`, `block_number`, `open/high/low/close`, `volume`, `start_volume`, `tao_price_usd/eur`.
- Public-safe: scanned the full body for SS58/base58 wallet or hotkey strings → **zero matches**; price/volume time-series only.

## Non-duplication

Recall's manifest currently has no surfaces; this is its first, and no open PR targets SN31.

## Scope note (relative to #4034)

#4034 asks for SN31 Recall's public **data artifact**. This standalone, machine-readable OHLCV price/volume dataset is exactly that.

## Validation (local)

- `npm run validate:surface -- registry/subnets/recall.json` → passes (1 surface)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/recall.json` → clean
- `git diff --stat` → single file, appends one community surface (no top-level metadata touched)

## Template Used

- Subnet surface

Closes #4034
