### PR TITLE
feat(registry): add SN62 Ridges TaoMarketCap candle-chart data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-taomarketcap-candle-chart",
+      "kind": "data-artifact",
+      "name": "Ridges TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/62/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN62 Ridges's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 62. A distinct price/volume dataset -- not provided by Ridges's first-party agent API surfaces -- documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/62/candle-chart/"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

Registers **SN62 Ridges**'s public **OHLCV candle-chart dataset** as a `data-artifact` surface — a no-auth JSON time-series of Ridges's alpha-token price/volume, a dataset the registry did not yet capture.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/62/candle-chart/`
- **provider:** `taomarketcap` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership / authority

- `source_url`s: the TaoMarketCap developer API docs and `tensorplex-labs/subnet-docs/data/62/subnet.json` (confirms SN62 Ridges's identity). `api.taomarketcap.com` is a provider-claimed on-chain indexer; the endpoint is listed in its public OpenAPI with an optional API key (no-auth access supported).

## Verified live + public + safe

- `GET https://api.taomarketcap.com/public/v1/subnets/62/candle-chart/` → **HTTP 200**, `application/json`, ~224 KB, **no auth**.
- Real payload: an array of hourly OHLCV candles, each scoped to `subnet_id: 62`, with `period_name`, `timestamp`, `block_number`, `open/high/low/close`, `volume`, `start_volume`, `tao_price_usd/eur`.
- Public-safe: scanned the full body for SS58/base58 wallet or hotkey strings → **zero matches**; price/volume time-series only.

## Non-duplication

Distinct from Ridges's existing surfaces — `source-repo`, the first-party `subnet-api` (`/retrieval/top-agents`) and `openapi` on `agent-upload.ridges.ai`. This is a different host and a different dataset: an on-chain **price/volume** time-series, which the first-party agent API does not provide. No open PR targets SN62.

## Scope note (relative to #4069)

#4069 asks for SN62 Ridges's public **data artifact**. This standalone, machine-readable OHLCV price/volume dataset is exactly that, on a reliably-reachable indexer host.

## Validation (local)

- `npm run validate:surface -- registry/subnets/ridges.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/ridges.json` → clean
- `git diff --stat` → single file, 19-line pure append (no top-level metadata or other surfaces touched)

## Template Used

- Subnet surface

Closes #4069
