### PR TITLE
feat(registry): add SN114 SOMA platform OpenAPI schema surface

### DIFF
--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -178,6 +178,25 @@
         "https://thesoma.ai/"
       ],
       "url": "https://thesoma.ai/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-114-soma-openapi",
+      "kind": "openapi",
+      "name": "SOMA platform OpenAPI schema",
+      "notes": "Public no-auth OpenAPI 3.1 schema for the SN114 SOMA platform API (title 'MCP-subnet'), served at platform.thesoma.ai/openapi.json with interactive Swagger UI at /docs. The official DendriteHQ/SOMA validator config (validator/.env.example) declares NETUID=114 and PLATFORM_URL=https://platform.thesoma.ai, tying this host to the subnet. The individual data endpoints require an API key, but the schema document and docs are fully public.",
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "schema_status": "machine-readable",
+      "source_urls": [
+        "https://github.com/DendriteHQ/SOMA/blob/main/validator/.env.example"
+      ],
+      "url": "https://platform.thesoma.ai/openapi.json"
     }
   ],
   "website_url": "https://thesoma.ai/"


### PR DESCRIPTION
Closes #4153

## Summary
Registers **SN114 SOMA**'s public **OpenAPI 3.1 schema** — the exact machine-readable spec the issue asks for.

## Surface
- kind: `openapi`
- url: `https://platform.thesoma.ai/openapi.json`
- provider: `soma` (existing)

## Proof of ownership (airtight)
- The official `DendriteHQ/SOMA` validator config `validator/.env.example` declares **`NETUID=114`** and **`PLATFORM_URL=https://platform.thesoma.ai`** — tying `platform.thesoma.ai` directly to SN114. That repo is already registered as the subnet's `source-repo`.

## Verified live + public
- `GET https://platform.thesoma.ai/openapi.json` → **HTTP 200**, `{"openapi":"3.1.0","info":{"title":"MCP-subnet","version":"0.1.0"},"paths":{ … ~40 paths … }}`. Interactive Swagger UI at `/docs` (also 200). The schema + docs are fully public (no auth); only the individual data endpoints require an API key.

## Non-duplication
The existing SOMA surfaces are all on the `thesoma.ai` host (website, dashboards, `/mcp` data-artifact, `/api/health`); there is **no `openapi` surface** and nothing on `platform.thesoma.ai`. This is a distinct host + kind.

## Validation (local)
- `npx prettier --check registry/subnets/soma.json` → clean
- `npm run validate:surface -- registry/subnets/soma.json` → passes (8 surfaces)
- `npm run scan:public-safety` → passes
- single file, 19-line pure append, no generated artifacts.
