### PR TITLE
feat(realtime): add the box-side chain-firehose relay

### DIFF
--- a/deploy/chain-firehose-relay.Dockerfile
+++ b/deploy/chain-firehose-relay.Dockerfile
@@ -1,0 +1,33 @@
+# Box-side relay for the realtime chain-event firehose (#4981, ADR 0015).
+# A tiny always-on process: LISTEN chain_firehose on the box's own Postgres,
+# forward each notification to the Cloudflare Durable Object ingest endpoint
+# (#4982). Never writes to Postgres, never in indexer-rs's critical path --
+# see scripts/chain-firehose-relay.mjs's own header comment for why this is
+# safe by construction, unlike the retired streamer (docs/adr/0014).
+#
+# Deployed the same way the (also retired) metagraphed-streamer was: the
+# Ansible `chain-firehose-relay` role in JSONbored/metagraphed-infra copies
+# this Dockerfile + scripts/chain-firehose-relay.mjs into
+# roles/chain-firehose-relay/files/ and builds directly on the indexer box
+# (no cross-compilation concern -- this is a single small ESM file + one npm
+# dependency). Re-run that role after updating either file to rebuild with
+# the latest fix.
+#
+# Local:  docker build -f deploy/chain-firehose-relay.Dockerfile -t metagraphed-chain-firehose-relay .
+FROM node:22.23.1-alpine
+RUN adduser --disabled-password --uid 10001 relay
+WORKDIR /app
+
+# Single pinned dependency (matches the root package.json's own postgres.js
+# pin, the same driver workers/data-api.mjs uses) -- never auto-pull a future
+# release independently of the rest of the repo.
+RUN npm install --no-audit --no-fund postgres@3.4.9
+
+COPY scripts/chain-firehose-relay.mjs ./scripts/chain-firehose-relay.mjs
+
+ENV NODE_ENV=production
+
+USER relay
+# Provide at runtime (NOT baked in): DATABASE_URL, CHAIN_FIREHOSE_SYNC_SECRET,
+# and optionally CHAIN_FIREHOSE_INGEST_URL (defaults to the production hub).
+CMD ["node", "scripts/chain-firehose-relay.mjs"]

--- a/deploy/chain-firehose-relay.Dockerfile
+++ b/deploy/chain-firehose-relay.Dockerfile
@@ -15,7 +15,8 @@
 #
 # Local:  docker build -f deploy/chain-firehose-relay.Dockerfile -t metagraphed-chain-firehose-relay .
 FROM node:22.23.1-alpine
-RUN adduser --disabled-password --uid 10001 relay
+# BusyBox adduser (Alpine's) -- -D skips setting a password, -u pins the uid.
+RUN adduser -D -u 10001 relay
 WORKDIR /app
 
 # Single pinned dependency (matches the root package.json's own postgres.js

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -1,0 +1,215 @@
+// Box-side relay for the realtime chain-event firehose (#4981, ADR 0015).
+//
+// A tiny always-on process: LISTEN chain_firehose on the indexer box's own
+// Postgres (deploy/postgres/schema.sql's notify_chain_firehose() trigger,
+// #4980), and forward each notification to the Cloudflare Durable Object's
+// ingest endpoint (workers/chain-firehose-hub.mjs, #4982) over HTTPS.
+//
+// Deliberately a PURE consumer: it opens its own dedicated Postgres
+// connection for LISTEN only, never writes anything, and is never in
+// indexer-rs's critical path -- unlike the retired metagraphed-streamer
+// (docs/adr/0014, whose synchronous push from the live-follow process into
+// a blocking write path starved the same connection servicing the chain-head
+// subscription), a stalled or unreachable ingest endpoint here can only ever
+// stall THIS process's own best-effort forwarding, never indexer-rs's writes
+// or Postgres's durability. Best-effort by design: the firehose has no
+// durability guarantee (see docs/realtime-firehose.md) -- a notification
+// that can't be forwarded after a bounded number of retries is dropped, not
+// queued indefinitely or retried forever.
+//
+// Deployed the same way the retired streamer was: an Ansible role in
+// JSONbored/metagraphed-infra (roles/chain-firehose-relay/) builds
+// deploy/chain-firehose-relay.Dockerfile directly on the indexer box,
+// COPYing this script in. See that Dockerfile's own header comment.
+//
+// Run: DATABASE_URL=... CHAIN_FIREHOSE_INGEST_URL=... \
+//      CHAIN_FIREHOSE_SYNC_SECRET=... node scripts/chain-firehose-relay.mjs
+
+import postgres from "postgres";
+
+export const CHAIN_FIREHOSE_LISTEN_CHANNEL = "chain_firehose";
+export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
+export const DEFAULT_CHAIN_FIREHOSE_INGEST_URL =
+  "https://api.metagraph.sh/api/v1/internal/chain-firehose-ingest";
+
+// Drop-oldest bound: caps this process's own memory under a sustained ingest
+// outage. Generous over any plausible per-block NOTIFY burst (see the
+// trigger's own row-vs-statement-level tradeoff note in schema.sql) while
+// still bounded.
+export const CHAIN_FIREHOSE_QUEUE_MAX_SIZE = 5_000;
+
+// A notification is retried this many times (with backoff) before being
+// dropped -- best-effort, not at-least-once (see this module's header).
+export const CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS = 3;
+export const CHAIN_FIREHOSE_BACKOFF_BASE_MS = 500;
+export const CHAIN_FIREHOSE_BACKOFF_MAX_MS = 15_000;
+
+// --- pure, unit-tested logic ----------------------------------------------------
+
+// Validates the process env this relay needs. Throws (rather than returning
+// a result object) so a misconfigured deploy fails loudly at startup instead
+// of silently no-op'ing -- there's no partial-config mode worth degrading to.
+export function parseRelayConfig(env) {
+  const databaseUrl = env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+  const syncSecret = env.CHAIN_FIREHOSE_SYNC_SECRET;
+  if (!syncSecret) {
+    throw new Error("CHAIN_FIREHOSE_SYNC_SECRET is required");
+  }
+  const ingestUrl =
+    env.CHAIN_FIREHOSE_INGEST_URL || DEFAULT_CHAIN_FIREHOSE_INGEST_URL;
+  return { databaseUrl, syncSecret, ingestUrl };
+}
+
+// Exponential backoff, capped -- attempt is 0-indexed (the first retry after
+// an initial failed attempt).
+export function computeBackoffDelayMs(
+  attempt,
+  {
+    baseMs = CHAIN_FIREHOSE_BACKOFF_BASE_MS,
+    maxMs = CHAIN_FIREHOSE_BACKOFF_MAX_MS,
+  } = {},
+) {
+  return Math.min(baseMs * 2 ** attempt, maxMs);
+}
+
+// A bounded FIFO queue that drops its OLDEST entry once full, rather than
+// growing unboundedly or rejecting the newest arrival -- under a sustained
+// ingest outage, the most recent chain state is more useful to a
+// newly-reconnecting subscriber than the oldest backlog.
+export function createBoundedDropOldestQueue(
+  maxSize = CHAIN_FIREHOSE_QUEUE_MAX_SIZE,
+) {
+  const items = [];
+  let dropped = 0;
+  return {
+    push(item) {
+      items.push(item);
+      if (items.length > maxSize) {
+        items.shift();
+        dropped += 1;
+      }
+    },
+    shift() {
+      return items.shift();
+    },
+    get size() {
+      return items.length;
+    },
+    get droppedCount() {
+      return dropped;
+    },
+  };
+}
+
+// Forwards one notification payload to the hub's ingest endpoint. `fetchImpl`
+// is injected so this is testable without a real network call -- the
+// long-running LISTEN/retry loop below is the only caller in production.
+export async function forwardChainFirehoseNotification(
+  payload,
+  { ingestUrl, syncSecret },
+  fetchImpl = fetch,
+) {
+  const response = await fetchImpl(ingestUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      [CHAIN_FIREHOSE_INGEST_TOKEN_HEADER]: syncSecret,
+    },
+    body: payload,
+  });
+  return { ok: response.ok, status: response.status };
+}
+
+// Drains one queued payload with bounded retry/backoff. Returns true if the
+// payload was forwarded successfully, false if it was dropped after
+// exhausting CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS -- never throws (a
+// forwarding failure must never crash the relay's LISTEN loop).
+export async function forwardWithRetry(
+  payload,
+  config,
+  {
+    fetchImpl = fetch,
+    sleepImpl = (ms) => new Promise((r) => setTimeout(r, ms)),
+    onDrop,
+  } = {},
+) {
+  for (
+    let attempt = 0;
+    attempt < CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      const result = await forwardChainFirehoseNotification(
+        payload,
+        config,
+        fetchImpl,
+      );
+      if (result.ok) return true;
+    } catch {
+      // network error -- fall through to retry/backoff below
+    }
+    if (attempt < CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS - 1) {
+      await sleepImpl(computeBackoffDelayMs(attempt));
+    }
+  }
+  onDrop?.(payload);
+  return false;
+}
+
+/* v8 ignore start -- the long-running LISTEN/drain loop needs a real
+   Postgres connection and process lifecycle (SIGTERM/SIGINT); every decision
+   it makes (config validation, backoff timing, queue bounding, retry count)
+   is delegated to the pure functions above and unit-tested directly (see
+   tests/chain-firehose-relay.test.mjs). This file is intentionally outside
+   vitest.config.mjs's coverage.include, matching every other standalone
+   deploy/-tier process in this repo (e.g. deploy/wss-lb, tested via `node
+   --test` instead) -- see that config's own comment for the convention. */
+async function main() {
+  const config = parseRelayConfig(process.env);
+  const sql = postgres(config.databaseUrl);
+  const queue = createBoundedDropOldestQueue();
+  let draining = false;
+  let shuttingDown = false;
+
+  async function drain() {
+    if (draining) return;
+    draining = true;
+    while (queue.size > 0 && !shuttingDown) {
+      const payload = queue.shift();
+      await forwardWithRetry(payload, config, {
+        onDrop: () =>
+          console.error(
+            `[chain-firehose-relay] dropped a notification after ${CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS} attempts`,
+          ),
+      });
+    }
+    draining = false;
+  }
+
+  await sql.listen(CHAIN_FIREHOSE_LISTEN_CHANNEL, (payload) => {
+    queue.push(payload);
+    void drain();
+  });
+  console.log(
+    `[chain-firehose-relay] listening on ${CHAIN_FIREHOSE_LISTEN_CHANNEL}, forwarding to ${config.ingestUrl}`,
+  );
+
+  const shutdown = async () => {
+    shuttingDown = true;
+    await sql.end({ timeout: 5 });
+    process.exit(0);
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error("[chain-firehose-relay] fatal:", error);
+    process.exit(1);
+  });
+}
+/* v8 ignore stop */

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -198,6 +198,9 @@ async function main() {
   );
 
   const shutdown = async () => {
+    // Doesn't wait for an in-flight forwardWithRetry to finish -- a
+    // notification mid-retry at shutdown is dropped, same as any other
+    // best-effort drop this relay makes (see this file's header comment).
     shuttingDown = true;
     await sql.end({ timeout: 5 });
     process.exit(0);

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -1,0 +1,227 @@
+// Unit tests for scripts/chain-firehose-relay.mjs's pure logic (#4981, ADR
+// 0015). The long-running LISTEN/drain loop (main()) needs a real Postgres
+// connection and process lifecycle and is intentionally excluded from
+// vitest.config.mjs's coverage.include (matching deploy/wss-lb's
+// node --test convention for standalone deploy/-tier processes) -- see that
+// function's own /* v8 ignore */ comment. Every decision it makes is tested
+// directly here instead.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  CHAIN_FIREHOSE_BACKOFF_BASE_MS,
+  CHAIN_FIREHOSE_BACKOFF_MAX_MS,
+  CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
+  CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS,
+  computeBackoffDelayMs,
+  createBoundedDropOldestQueue,
+  forwardChainFirehoseNotification,
+  forwardWithRetry,
+  parseRelayConfig,
+} from "../scripts/chain-firehose-relay.mjs";
+
+// --- parseRelayConfig -------------------------------------------------------
+
+test("parseRelayConfig: throws when DATABASE_URL is missing", () => {
+  assert.throws(
+    () => parseRelayConfig({ CHAIN_FIREHOSE_SYNC_SECRET: "shh" }),
+    /DATABASE_URL is required/,
+  );
+});
+
+test("parseRelayConfig: throws when CHAIN_FIREHOSE_SYNC_SECRET is missing", () => {
+  assert.throws(
+    () => parseRelayConfig({ DATABASE_URL: "postgres://x" }),
+    /CHAIN_FIREHOSE_SYNC_SECRET is required/,
+  );
+});
+
+test("parseRelayConfig: defaults CHAIN_FIREHOSE_INGEST_URL to the production hub", () => {
+  const config = parseRelayConfig({
+    DATABASE_URL: "postgres://x",
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+  });
+  assert.equal(
+    config.ingestUrl,
+    "https://api.metagraph.sh/api/v1/internal/chain-firehose-ingest",
+  );
+});
+
+test("parseRelayConfig: honors an explicit CHAIN_FIREHOSE_INGEST_URL override", () => {
+  const config = parseRelayConfig({
+    DATABASE_URL: "postgres://x",
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_INGEST_URL: "https://staging.example.com/ingest",
+  });
+  assert.equal(config.ingestUrl, "https://staging.example.com/ingest");
+});
+
+// --- computeBackoffDelayMs ---------------------------------------------------
+
+test("computeBackoffDelayMs: doubles per attempt, capped at maxMs", () => {
+  assert.equal(computeBackoffDelayMs(0), CHAIN_FIREHOSE_BACKOFF_BASE_MS);
+  assert.equal(computeBackoffDelayMs(1), CHAIN_FIREHOSE_BACKOFF_BASE_MS * 2);
+  assert.equal(computeBackoffDelayMs(2), CHAIN_FIREHOSE_BACKOFF_BASE_MS * 4);
+  assert.equal(computeBackoffDelayMs(20), CHAIN_FIREHOSE_BACKOFF_MAX_MS);
+});
+
+test("computeBackoffDelayMs: honors custom baseMs/maxMs", () => {
+  assert.equal(computeBackoffDelayMs(1, { baseMs: 100, maxMs: 1000 }), 200);
+  assert.equal(computeBackoffDelayMs(10, { baseMs: 100, maxMs: 1000 }), 1000);
+});
+
+// --- createBoundedDropOldestQueue --------------------------------------------
+
+test("createBoundedDropOldestQueue: push/shift behaves as a plain FIFO under capacity", () => {
+  const queue = createBoundedDropOldestQueue(3);
+  queue.push("a");
+  queue.push("b");
+  assert.equal(queue.size, 2);
+  assert.equal(queue.shift(), "a");
+  assert.equal(queue.shift(), "b");
+  assert.equal(queue.shift(), undefined);
+  assert.equal(queue.size, 0);
+});
+
+test("createBoundedDropOldestQueue: drops the OLDEST entry once over maxSize, keeping size bounded", () => {
+  const queue = createBoundedDropOldestQueue(2);
+  queue.push("a");
+  queue.push("b");
+  queue.push("c"); // over capacity -- "a" is dropped
+  assert.equal(queue.size, 2);
+  assert.equal(queue.droppedCount, 1);
+  assert.equal(queue.shift(), "b");
+  assert.equal(queue.shift(), "c");
+});
+
+test("createBoundedDropOldestQueue: defaults to CHAIN_FIREHOSE_QUEUE_MAX_SIZE when no size is given", () => {
+  const queue = createBoundedDropOldestQueue();
+  assert.equal(queue.droppedCount, 0);
+});
+
+// --- forwardChainFirehoseNotification ----------------------------------------
+
+test("forwardChainFirehoseNotification: POSTs the payload with the sync-token header, returns ok/status", async () => {
+  let received;
+  const fetchImpl = async (url, init) => {
+    received = { url, init };
+    return new Response("{}", { status: 202 });
+  };
+  const result = await forwardChainFirehoseNotification(
+    '{"table":"blocks","block_number":1}',
+    { ingestUrl: "https://hub.example.com/ingest", syncSecret: "shh" },
+    fetchImpl,
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 202);
+  assert.equal(received.url, "https://hub.example.com/ingest");
+  assert.equal(received.init.method, "POST");
+  assert.equal(
+    received.init.headers[CHAIN_FIREHOSE_INGEST_TOKEN_HEADER],
+    "shh",
+  );
+  assert.equal(received.init.body, '{"table":"blocks","block_number":1}');
+});
+
+test("forwardChainFirehoseNotification: a non-2xx response is reported as not ok", async () => {
+  const fetchImpl = async () => new Response("{}", { status: 401 });
+  const result = await forwardChainFirehoseNotification(
+    "{}",
+    { ingestUrl: "https://hub.example.com/ingest", syncSecret: "shh" },
+    fetchImpl,
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 401);
+});
+
+// --- forwardWithRetry ---------------------------------------------------------
+
+test("forwardWithRetry: succeeds immediately without sleeping when the first attempt is ok", async () => {
+  let calls = 0;
+  let slept = 0;
+  const ok = await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response("{}", { status: 202 });
+      },
+      sleepImpl: async () => {
+        slept += 1;
+      },
+    },
+  );
+  assert.equal(ok, true);
+  assert.equal(calls, 1);
+  assert.equal(slept, 0);
+});
+
+test("forwardWithRetry: retries with backoff on failure, succeeds on a later attempt", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const ok = await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response("{}", { status: calls < 2 ? 500 : 202 });
+      },
+      sleepImpl: async (ms) => {
+        sleeps.push(ms);
+      },
+    },
+  );
+  assert.equal(ok, true);
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [CHAIN_FIREHOSE_BACKOFF_BASE_MS]);
+});
+
+test("forwardWithRetry: a thrown network error is treated as a failed attempt, not a crash", async () => {
+  let calls = 0;
+  const ok = await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => {
+        calls += 1;
+        throw new Error("network down");
+      },
+      sleepImpl: async () => {},
+    },
+  );
+  assert.equal(ok, false);
+  assert.equal(calls, CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS);
+});
+
+test("forwardWithRetry: drops the payload and calls onDrop after exhausting all attempts", async () => {
+  let dropped;
+  const ok = await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => new Response("{}", { status: 500 }),
+      sleepImpl: async () => {},
+      onDrop: (payload) => {
+        dropped = payload;
+      },
+    },
+  );
+  assert.equal(ok, false);
+  assert.equal(dropped, "{}");
+});
+
+test("forwardWithRetry: never sleeps after the final attempt (no wasted delay before dropping)", async () => {
+  let sleeps = 0;
+  await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => new Response("{}", { status: 500 }),
+      sleepImpl: async () => {
+        sleeps += 1;
+      },
+    },
+  );
+  assert.equal(sleeps, CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS - 1);
+});


### PR DESCRIPTION
## Summary

- `scripts/chain-firehose-relay.mjs` — a tiny always-on process for the indexer box: `LISTEN chain_firehose` on the box's own Postgres (#4980's trigger) and forward each notification to `ChainFirehoseHub`'s ingest endpoint (#4982, `POST /api/v1/internal/chain-firehose-ingest`) over HTTPS.
- Pure consumer by construction: a dedicated Postgres connection for LISTEN only, never writes, never touches indexer-rs's own connection — an ingest outage can only ever stall this process's own best-effort forwarding, never indexer-rs's writes or Postgres's durability (the exact failure mode ADR 0015 documents avoiding, unlike the retired streamer per ADR 0014).
- Bounded retry (3 attempts, exponential backoff capped at 15s) then drop; bounded drop-oldest queue (5,000) under sustained outage — best-effort, no durability guarantee, matching docs/realtime-firehose.md.
- `deploy/chain-firehose-relay.Dockerfile` — matches the retired streamer's exact box-deployment shape (source lives here, an Ansible role in `metagraphed-infra` builds directly on the box).

## Coverage note

Matches `deploy/wss-lb`'s precedent for standalone deploy/-tier processes: `scripts/chain-firehose-relay.mjs` is intentionally outside `vitest.config.mjs`'s `coverage.include` (the long-running LISTEN/process-lifecycle loop needs a real Postgres connection). Every decision it makes (config validation, backoff timing, queue bounding, retry/drop) is a pure function, unit-tested directly in `tests/chain-firehose-relay.test.mjs`.

Closes #4981

## Test plan

- [x] `npm run lint` / `npm run format:check`
- [x] `npm run build` (no unintended contract drift)
- [x] `npm run test:coverage` (full suite green)
- [x] `node --check scripts/chain-firehose-relay.mjs`
- [ ] Ansible role + actual box deployment: tracked as a follow-up in `metagraphed-infra` (private repo)