### PR TITLE
feat(registry): add SN30 Endure Network TaoMarketCap candle-chart data-artifact (#4031)

### DIFF
--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -99,6 +99,25 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/30"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-30-taomarketcap-candle-chart",
+      "kind": "data-artifact",
+      "name": "Endure Network TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/30/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN30 Endure Network's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 30. A standalone historical price/volume dataset, distinct from the point-in-time /subnets/30 snapshot already registered. Documented in the TaoMarketCap developer API (its public-oas3.json lists this GET with an optional API key, i.e. no-auth access is supported).",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh171112"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/30/candle-chart/"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Registers **SN30 Endure Network**'s public **OHLCV candle-chart dataset** as a `data-artifact`
surface — a no-auth JSON time-series of Endure's alpha-token price/volume the registry did not yet
capture. Append-only: one new surface on the existing subnet file, nothing else changed.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/30/candle-chart/`
- **provider:** `taomarketcap` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership / authority

- Same official host and authority basis as SN30's already-registered
  `sn-30-taomarketcap-subnet-api` surface (`api.taomarketcap.com`, a provider-claimed on-chain
  indexer). Endure publishes a website and docs but no verified first-party public API, so this
  indexed on-chain feed is the concrete public data surface — the same pattern the existing SN30
  surface established.
- `source_url`s: the TaoMarketCap developer API docs and `tensorplex-labs/subnet-docs/data/30/subnet.json`
  (the same proof the existing SN30 surface uses). The endpoint is listed in TaoMarketCap's
  `public-oas3.json` with an **optional** API key (no-auth access supported).

## Verified live + public + safe

- `GET https://api.taomarketcap.com/public/v1/subnets/30/candle-chart/` → **HTTP 200**,
  `application/json`, ~223 KB, **no auth**.
- Real payload: an array of hourly OHLCV candles, each scoped to `subnet_id: 30`, with
  `period_name`, `timestamp`, `block_number`, `open/high/low/close`, `volume`, `start_volume`,
  `tao_price_usd/eur`.
- Public-safe: price/volume time-series only — no SS58/base58 wallet or hotkey strings.
  `scan:public-safety` clean.

## Non-duplication

Distinct from SN30's existing `sn-30-taomarketcap-subnet-api` surface — that is the point-in-time
`/public/v1/subnets/30` state snapshot; this is a different URL and a different dataset (a historical
price/volume time-series), registered as `data-artifact`. No open PR targets SN30.

## Validation (local)

- `npm run validate:surface -- registry/subnets/endure-network.json` → passes (4 surfaces)
- `npm run scan:public-safety` → passes
- `git diff --stat` → single file, 19-line pure append

## Template Used

- Subnet surface

Closes #4031
