### PR TITLE
feat(realtime): add GraphQL chainEvents subscriptions

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -139,6 +139,17 @@ for any real client. Each active `chainEvents` subscription is backed by
 feeds directly (`chainEventSubscribers`), which graphql-js's own `subscribe()`
 consumes to produce properly-framed `{type: "next", payload: {...}}` messages.
 
+**Security-reviewed and fixed before merge**: graphql-ws's wire protocol
+accepts query/mutation operations over the same `subscribe` message as
+subscriptions, not just subscriptions -- left unchecked, a WS client could
+execute the full read `Query` type over this transport, bypassing both the
+POST endpoint's rate limiter (`graphqlRateLimited`, never consulted for an
+upgraded connection) and its `maxDepthRule`/`maxComplexityRule` guards
+entirely (graphql-ws only applies bare `specifiedRules` by default).
+`makeServer`'s `onSubscribe` hook now runs `validateChainEventsSubscribePayload`
+(pure, unit-tested), which rejects any non-subscription operation outright
+and otherwise validates with the SAME rule set POST uses.
+
 Unit-tested against graphql-js's real `subscribe()` engine (not a hand-rolled
 simulation) and against a stubbed Durable Object `state`. Cloudflare has a
 [documented history](https://github.com/cloudflare/workers-sdk/issues/1767)

--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -117,8 +117,43 @@ equivalent) is `/* v8 ignore */`-marked, not the whole class.
 `tests/chain-firehose-routes.test.mjs` covers the `workers/api.mjs`
 routing/auth boundary (mirroring the existing `*-sync-proxy` test shape).
 
-GraphQL `Subscription` and MCP resource subscriptions are #4983, layered on
-this same hub rather than needing their own state.
+## GraphQL subscriptions (#4983, live)
+
+`Subscription.chainEvents(tables: [ChainFirehoseTable!]): ChainEvent!`
+(`src/graphql.mjs`) is a thin protocol adapter over this SAME hub, not a
+second event pipeline -- exactly like SSE/WS are. Reached over WebSocket at
+the SAME `/api/v1/graphql` path the existing POST query layer uses,
+negotiated via `Sec-WebSocket-Protocol: graphql-transport-ws`
+([graphql-ws](https://github.com/enisdenjo/graphql-ws)'s wire protocol);
+POSTing a subscription operation to the regular query endpoint returns a
+standard GraphQL error, same as any other GraphQL server.
+
+`ChainFirehoseHub` owns a `graphql-ws` `Server` instance (`makeServer`) and
+adapts it onto the hibernation API: a graphql-ws connection is tagged
+(`GRAPHQL_WS_SOCKET_TAG`) and tracked separately from plain firehose sockets
+(`graphqlWsSockets`, a `WeakMap` from socket to that connection's graphql-ws
+callbacks) so the two populations never cross-contaminate -- a raw firehose
+JSON payload landing on a graphql-ws socket would corrupt the wire protocol
+for any real client. Each active `chainEvents` subscription is backed by
+`createAsyncRepeater()`, a minimal push-based async iterator `broadcast()`
+feeds directly (`chainEventSubscribers`), which graphql-js's own `subscribe()`
+consumes to produce properly-framed `{type: "next", payload: {...}}` messages.
+
+Unit-tested against graphql-js's real `subscribe()` engine (not a hand-rolled
+simulation) and against a stubbed Durable Object `state`. Cloudflare has a
+[documented history](https://github.com/cloudflare/workers-sdk/issues/1767)
+of not always echoing `Sec-WebSocket-Protocol` on upgrade responses in some
+contexts -- this needs a real `wss` client handshake against the live
+deployment (`connection_init` → `connection_ack` → `subscribe` → `next`,
+checking `ws.protocol` is actually negotiated) to be trusted, not assumed
+from docs alone. Not yet done as of this section being written -- see the
+PR/issue thread for whether that verification landed before merge.
+
+## MCP resource subscriptions (#4983, not yet built)
+
+Exposes the firehose as an MCP resource an agent client can subscribe to per
+the MCP resource-subscription spec (`resources/subscribe` +
+`notifications/resources/updated`), reusing this same hub connection.
 
 ## The alerter (#4984, not yet built)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "graphql": "^17.0.2",
+        "graphql-ws": "^6.1.0",
         "postgres": "^3.4.9",
         "workers-og": "^0.0.27"
       },
@@ -7310,6 +7311,32 @@
       "license": "MIT",
       "engines": {
         "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.1.0.tgz",
+      "integrity": "sha512-7ft6KWkuaLnLABwzEIimjUMeF0iByo2ThD6q0MICgsvp6nDuT5ppubKzEHniu8Kmlp5GNsLgr5dil8JMrIwUEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fastify/websocket": "^10 || ^11",
+        "crossws": "~0.3",
+        "graphql": "^15.10.1 || ^16 || ^17",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "crossws": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/h3": {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   "dependencies": {
     "@noble/hashes": "^2.2.0",
     "graphql": "^17.0.2",
+    "graphql-ws": "^6.1.0",
     "postgres": "^3.4.9",
     "workers-og": "^0.0.27"
   },

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -316,9 +316,85 @@ export const SDL = `
     ok_count: Int
     avg_latency_ms: Int
   }
+
+  # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
+  # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
+  # transports use, not a second event pipeline. Reached over WebSocket only
+  # (Sec-WebSocket-Protocol: graphql-transport-ws at this same /api/v1/graphql
+  # path) -- POSTing a subscription operation to the regular query endpoint
+  # returns a standard GraphQL error, same as any other GraphQL server.
+  type Subscription {
+    "Live chain events as they land (blocks/extrinsics/chain_events), optionally filtered to one or more tables. Field shape mirrors the #4980 NOTIFY payload -- only the fields relevant to the event's table are populated."
+    chainEvents(tables: [ChainFirehoseTable!]): ChainEvent!
+  }
+
+  enum ChainFirehoseTable {
+    blocks
+    extrinsics
+    chain_events
+  }
+
+  type ChainEvent {
+    table: ChainFirehoseTable!
+    block_number: Int!
+    observed_at: String
+    "blocks only"
+    block_hash: String
+    "blocks only"
+    extrinsic_count: Int
+    "blocks only"
+    event_count: Int
+    "extrinsics only"
+    extrinsic_index: Int
+    "extrinsics only"
+    call_module: String
+    "extrinsics only"
+    call_function: String
+    "extrinsics only"
+    signer: String
+    "extrinsics only"
+    success: Boolean
+    "chain_events only"
+    event_index: Int
+    "chain_events only"
+    pallet: String
+    "chain_events only"
+    method: String
+  }
 `;
 
-const schema = buildSchema(SDL);
+// Exported so workers/chain-firehose-hub.mjs's graphql-ws server (#4983) can
+// execute against the SAME schema -- not a copy, so the two transports never
+// drift.
+export const schema = buildSchema(SDL);
+
+// SDL-only schemas (buildSchema) carry no resolver functions -- Query/Mutation
+// fields read straight off rootValue/artifacts via the default field resolver,
+// but a subscription root field needs an explicit `subscribe` (an
+// AsyncIterable source), which SDL has no syntax for. Attached here, once, at
+// module load, the same graphql-js technique used by every SDL-first server
+// that also needs subscriptions. context.chainFirehose is supplied by
+// whichever Durable Object drives the graphql-ws server (workers/chain-firehose-hub.mjs)
+// -- see GRAPHQL_SUBSCRIPTION_CONTEXT_KEY below.
+export const GRAPHQL_SUBSCRIPTION_CONTEXT_KEY = "chainFirehose";
+schema.getSubscriptionType().getFields().chainEvents.subscribe =
+  async function* chainEventsSubscribe(_source, args, context) {
+    const hub = context?.[GRAPHQL_SUBSCRIPTION_CONTEXT_KEY];
+    if (!hub) {
+      throw new GraphQLError(
+        "chainEvents is only reachable over the WebSocket transport (Sec-WebSocket-Protocol: graphql-transport-ws) at /api/v1/graphql.",
+      );
+    }
+    const topics = args.tables?.length ? new Set(args.tables) : null;
+    const repeater = hub.subscribeChainEvents(topics);
+    try {
+      for await (const payload of repeater) {
+        yield { chainEvents: payload };
+      }
+    } finally {
+      hub.unsubscribeChainEvents(repeater);
+    }
+  };
 
 // --- Complexity weights ---
 

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -23,8 +23,89 @@ import {
   createAsyncRepeater,
   formatChainFirehoseSseFrame,
   parseChainFirehoseTopics,
+  validateChainEventsSubscribePayload,
   validateChainFirehoseIngestPayload,
 } from "../workers/chain-firehose-hub.mjs";
+
+// --- validateChainEventsSubscribePayload (#4983 security fix) -------------------
+//
+// graphql-ws's wire protocol accepts query/mutation operations over the same
+// `subscribe` message as subscriptions -- unchecked, a WS client could
+// execute the full read API, bypassing both the POST endpoint's rate
+// limiter (never consulted for an upgraded connection) and its complexity/
+// depth guards. This function is the actual fix: restrict the WS transport
+// to subscription operations only, validated with the SAME rules POST uses.
+
+test("validateChainEventsSubscribePayload: accepts a well-formed subscription operation", () => {
+  const errors = validateChainEventsSubscribePayload({
+    query: "subscription { chainEvents { table block_number } }",
+  });
+  assert.equal(errors, null);
+});
+
+test("validateChainEventsSubscribePayload: rejects a query operation (the actual security fix)", () => {
+  const errors = validateChainEventsSubscribePayload({
+    query: "query { subnets { total } }",
+  });
+  assert.ok(errors?.length);
+  assert.match(errors[0].message, /Only subscription operations/);
+});
+
+test("validateChainEventsSubscribePayload: rejects a mutation operation", () => {
+  const errors = validateChainEventsSubscribePayload({
+    query: "mutation { __typename }",
+  });
+  assert.ok(errors?.length);
+  assert.match(errors[0].message, /Only subscription operations/);
+});
+
+test("validateChainEventsSubscribePayload: rejects a missing/empty query", () => {
+  assert.match(
+    validateChainEventsSubscribePayload({})[0].message,
+    /Missing required field: query/,
+  );
+  assert.match(
+    validateChainEventsSubscribePayload({ query: "   " })[0].message,
+    /Missing required field: query/,
+  );
+});
+
+test("validateChainEventsSubscribePayload: rejects invalid GraphQL syntax", () => {
+  const errors = validateChainEventsSubscribePayload({
+    query: "subscription { not valid (",
+  });
+  assert.ok(errors?.length);
+  assert.match(errors[0].message, /Syntax Error/);
+});
+
+test("validateChainEventsSubscribePayload: rejects an oversized query", () => {
+  const errors = validateChainEventsSubscribePayload({
+    query: `subscription { chainEvents { table } } # ${"x".repeat(20_000)}`,
+  });
+  assert.ok(errors?.length);
+  assert.match(errors[0].message, /too large/);
+});
+
+test("validateChainEventsSubscribePayload: runs full schema validation (specifiedRules), rejecting an unknown field", () => {
+  const errors = validateChainEventsSubscribePayload({
+    query: "subscription { chainEvents { doesNotExist } }",
+  });
+  assert.ok(errors?.length);
+  assert.match(errors[0].message, /Cannot query field/);
+});
+
+// maxDepthRule/maxComplexityRule are ALSO passed to this validate() call
+// (imported from the same src/graphql.mjs as the POST endpoint's
+// handleGraphQLRequest, same GRAPHQL_MAX_DEPTH/GRAPHQL_MAX_COMPLEXITY
+// thresholds) -- not separately exercised here because ChainEvent is a
+// flat, scalar-only type with no relationship fields to nest into, and a
+// GraphQL subscription operation is restricted to exactly one root field
+// (graphql-js's own SingleFieldSubscriptionsRule, part of specifiedRules),
+// so neither rule is organically triggerable against this specific schema
+// today. Both rules' own behavior is covered directly in
+// tests/graphql.test.mjs; what matters here is that they're wired into the
+// SAME validate() call as the field-existence check above, which the
+// "rejects a query/mutation operation" tests above already prove runs.
 
 // --- createAsyncRepeater (#4983) -------------------------------------------------
 

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -17,12 +17,88 @@ import {
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK,
   CHAIN_FIREHOSE_TABLES,
+  GRAPHQL_WS_SOCKET_TAG,
   ChainFirehoseHub,
   chainFirehoseMatchesTopics,
+  createAsyncRepeater,
   formatChainFirehoseSseFrame,
   parseChainFirehoseTopics,
   validateChainFirehoseIngestPayload,
 } from "../workers/chain-firehose-hub.mjs";
+
+// --- createAsyncRepeater (#4983) -------------------------------------------------
+
+test("createAsyncRepeater: a push before next() is consumed on the following next()", async () => {
+  const repeater = createAsyncRepeater();
+  repeater.push("a");
+  repeater.push("b");
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.next(), { value: "a", done: false });
+  assert.deepEqual(await it.next(), { value: "b", done: false });
+});
+
+test("createAsyncRepeater: a next() called before any push() resolves once push() happens", async () => {
+  const repeater = createAsyncRepeater();
+  const it = repeater[Symbol.asyncIterator]();
+  const pending = it.next();
+  repeater.push("late");
+  assert.deepEqual(await pending, { value: "late", done: false });
+});
+
+test("createAsyncRepeater: end() completes a pending next() with done:true", async () => {
+  const repeater = createAsyncRepeater();
+  const it = repeater[Symbol.asyncIterator]();
+  const pending = it.next();
+  repeater.end();
+  assert.deepEqual(await pending, { value: undefined, done: true });
+});
+
+test("createAsyncRepeater: next() after end() resolves done:true immediately", async () => {
+  const repeater = createAsyncRepeater();
+  repeater.end();
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.next(), { value: undefined, done: true });
+});
+
+test("createAsyncRepeater: push() after end() is silently dropped, not queued", async () => {
+  const repeater = createAsyncRepeater();
+  repeater.end();
+  repeater.push("too late");
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.next(), { value: undefined, done: true });
+});
+
+test("createAsyncRepeater: calling end() twice is idempotent", async () => {
+  const repeater = createAsyncRepeater();
+  const it = repeater[Symbol.asyncIterator]();
+  const pending = it.next();
+  repeater.end();
+  assert.doesNotThrow(() => repeater.end());
+  assert.deepEqual(await pending, { value: undefined, done: true });
+});
+
+test("createAsyncRepeater: return() ends iteration (for-await early break support)", async () => {
+  const repeater = createAsyncRepeater();
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.return(), { value: undefined, done: true });
+  assert.deepEqual(await it.next(), { value: undefined, done: true });
+});
+
+test("createAsyncRepeater: a real for-await loop consumes pushed values in order", async () => {
+  const repeater = createAsyncRepeater();
+  const seen = [];
+  const consumer = (async () => {
+    for await (const value of repeater) {
+      seen.push(value);
+      if (seen.length === 3) break;
+    }
+  })();
+  repeater.push(1);
+  repeater.push(2);
+  repeater.push(3);
+  await consumer;
+  assert.deepEqual(seen, [1, 2, 3]);
+});
 
 // --- parseChainFirehoseTopics --------------------------------------------------
 
@@ -424,9 +500,23 @@ test("ChainFirehoseHub broadcast: a WebSocket whose send() throws (dead socket) 
   assert.equal(sent.length, 1);
 });
 
-test("ChainFirehoseHub.webSocketMessage: a no-op that never throws", () => {
+test("ChainFirehoseHub.webSocketMessage: a no-op for a plain firehose socket (not registered in graphqlWsSockets)", async () => {
   const hub = new ChainFirehoseHub(stubState(), {});
-  assert.doesNotThrow(() => hub.webSocketMessage({}, "ignored"));
+  await assert.doesNotReject(() => hub.webSocketMessage({}, "ignored"));
+});
+
+test("ChainFirehoseHub.webSocketMessage: routes to the graphql-ws onMessage callback registered for that socket, decoding a binary frame", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const ws = {};
+  const received = [];
+  hub.graphqlWsSockets.set(ws, {
+    onMessageCb: async (text) => {
+      received.push(text);
+    },
+  });
+  await hub.webSocketMessage(ws, '{"type":"ping"}');
+  await hub.webSocketMessage(ws, new TextEncoder().encode('{"type":"pong"}'));
+  assert.deepEqual(received, ['{"type":"ping"}', '{"type":"pong"}']);
 });
 
 test("ChainFirehoseHub.webSocketClose: closes the socket, swallowing an already-closed error", () => {
@@ -447,9 +537,113 @@ test("ChainFirehoseHub.webSocketClose: closes the socket, swallowing an already-
   );
 });
 
-test("ChainFirehoseHub.webSocketError: a no-op that never throws", () => {
+test("ChainFirehoseHub.webSocketClose: calls the graphql-ws closed() cleanup and removes the socket entry", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const ws = { close: () => {} };
+  let closedWith;
+  hub.graphqlWsSockets.set(ws, {
+    closedCb: (code, reason) => {
+      closedWith = [code, reason];
+    },
+  });
+  hub.webSocketClose(ws, 1000, "bye");
+  assert.deepEqual(closedWith, [1000, "bye"]);
+  assert.equal(hub.graphqlWsSockets.has(ws), false);
+});
+
+test("ChainFirehoseHub.webSocketError: a no-op for a plain firehose socket", () => {
   const hub = new ChainFirehoseHub(stubState(), {});
   assert.doesNotThrow(() => hub.webSocketError({}, new Error("boom")));
+});
+
+test("ChainFirehoseHub.webSocketError: calls the graphql-ws closed() cleanup with an internal-error close code", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const ws = {};
+  let closedWith;
+  hub.graphqlWsSockets.set(ws, {
+    closedCb: (code, reason) => {
+      closedWith = [code, reason];
+    },
+  });
+  hub.webSocketError(ws, new Error("boom"));
+  assert.deepEqual(closedWith, [1011, "boom"]);
+  assert.equal(hub.graphqlWsSockets.has(ws), false);
+});
+
+test("ChainFirehoseHub.webSocketError: falls back to a generic reason when no error/message is given", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const ws = {};
+  let closedWith;
+  hub.graphqlWsSockets.set(ws, {
+    closedCb: (code, reason) => {
+      closedWith = [code, reason];
+    },
+  });
+  hub.webSocketError(ws);
+  assert.deepEqual(closedWith, [1011, "internal error"]);
+});
+
+// --- subscribeChainEvents / unsubscribeChainEvents / broadcast (#4983) ----------
+
+test("ChainFirehoseHub.subscribeChainEvents: broadcast delivers matching payloads to the returned repeater", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeater = hub.subscribeChainEvents(new Set(["blocks"]));
+  hub.broadcast({ table: "extrinsics", block_number: 1 }); // filtered out
+  hub.broadcast({ table: "blocks", block_number: 2 }); // matches
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.next(), {
+    value: { table: "blocks", block_number: 2 },
+    done: false,
+  });
+});
+
+test("ChainFirehoseHub.subscribeChainEvents: null topics receives every table", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeater = hub.subscribeChainEvents(null);
+  hub.broadcast({ table: "chain_events", block_number: 1 });
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.next(), {
+    value: { table: "chain_events", block_number: 1 },
+    done: false,
+  });
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: ends the repeater and stops further delivery", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeater = hub.subscribeChainEvents(null);
+  assert.equal(hub.chainEventSubscribers.size, 1);
+  hub.unsubscribeChainEvents(repeater);
+  assert.equal(hub.chainEventSubscribers.size, 0);
+  const it = repeater[Symbol.asyncIterator]();
+  assert.deepEqual(await it.next(), { value: undefined, done: true });
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: a non-matching repeater in a NON-empty set leaves the real entry intact", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.subscribeChainEvents(null); // one real entry, so the loop body actually runs
+  const foreign = { end() {} };
+  hub.unsubscribeChainEvents(foreign);
+  assert.equal(hub.chainEventSubscribers.size, 1);
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: unsubscribing a repeater not in the set is a no-op", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const foreign = { end() {} };
+  assert.doesNotThrow(() => hub.unsubscribeChainEvents(foreign));
+});
+
+test("ChainFirehoseHub.broadcast: a graphql-ws-tagged WebSocket is excluded from the plain firehose send() loop", () => {
+  const sent = [];
+  const ws = { deserializeAttachment: () => null };
+  const hub = new ChainFirehoseHub(stubState([ws]), {});
+  hub.graphqlWsSockets.set(ws, { onMessageCb: async () => {} });
+  ws.send = (message) => sent.push(message); // would fail the test if called
+  hub.broadcast({ table: "blocks", block_number: 1 });
+  assert.equal(sent.length, 0);
+});
+
+test("GRAPHQL_WS_SOCKET_TAG is the documented tag string", () => {
+  assert.equal(GRAPHQL_WS_SOCKET_TAG, "graphql-ws");
 });
 
 test("CHAIN_FIREHOSE_INGEST_TOKEN_HEADER and CHAIN_FIREHOSE_TABLES are the documented constants", () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { Blob } from "node:buffer";
-import { buildSchema, getIntrospectionQuery, parse, validate } from "graphql";
+import {
+  buildSchema,
+  getIntrospectionQuery,
+  parse,
+  subscribe,
+  validate,
+} from "graphql";
 import { describe, test } from "vitest";
 import {
   FIELD_COMPLEXITY,
@@ -8,10 +14,12 @@ import {
   GRAPHQL_MAX_COMPLEXITY,
   GRAPHQL_MAX_DEPTH,
   GRAPHQL_MAX_QUERY_BYTES,
+  GRAPHQL_SUBSCRIPTION_CONTEXT_KEY,
   SDL,
   handleGraphQLRequest,
   maxComplexityRule,
   maxDepthRule,
+  schema as chainEventsSchema,
 } from "../src/graphql.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
@@ -824,6 +832,29 @@ describe("handleRequest — GraphQL rate limiting (#security)", () => {
     // emptyEnv has no RPC_RATE_LIMITER; the gate must no-op, not 429.
     const res = await gqlPost(emptyEnv);
     assert.equal(res.status, 200);
+  });
+
+  test("a WebSocket upgrade bypasses the rate limiter entirely, even with an already-exhausted budget", async () => {
+    const env = countingRateLimiterEnv(0); // every check() would fail
+    let forwarded = false;
+    env.CHAIN_FIREHOSE_HUB = {
+      idFromName: () => "global",
+      get: () => ({
+        fetch: () => {
+          forwarded = true;
+          return new Response(null, { status: 200 });
+        },
+      }),
+    };
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/graphql", {
+        headers: { upgrade: "websocket" },
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(forwarded, true);
   });
 });
 
@@ -1731,5 +1762,181 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
 
   test("compare is weighted as a fan-out field", () => {
     assert.equal(FIELD_COMPLEXITY.compare, 5);
+  });
+});
+
+// --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
+//
+// The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,
+// the graphql-ws WS transport) is covered in tests/chain-firehose-hub.test.mjs.
+// These tests exercise the OTHER half: that the schema's chainEvents field is
+// wired to a real subscribe() resolver that correctly bridges
+// context.chainFirehose's repeater into graphql-js's own subscribe() engine
+// -- using graphql-js's real subscribe() function (not a hand-rolled
+// simulation) against a minimal fake hub, exactly the shape
+// ChainFirehoseHub actually provides via context.
+function fakeChainFirehose(pushAfterSubscribe) {
+  const subscriptions = [];
+  return {
+    subscribeChainEvents(topics) {
+      const pending = [];
+      let waitingResolve = null;
+      const repeater = {
+        push(value) {
+          if (waitingResolve) {
+            const resolve = waitingResolve;
+            waitingResolve = null;
+            resolve({ value, done: false });
+          } else {
+            pending.push(value);
+          }
+        },
+        [Symbol.asyncIterator]() {
+          return {
+            next: () =>
+              pending.length
+                ? Promise.resolve({ value: pending.shift(), done: false })
+                : new Promise((resolve) => {
+                    waitingResolve = resolve;
+                  }),
+          };
+        },
+      };
+      subscriptions.push({ repeater, topics });
+      if (pushAfterSubscribe) pushAfterSubscribe(repeater);
+      return repeater;
+    },
+    unsubscribeChainEvents(repeater) {
+      const index = subscriptions.findIndex((s) => s.repeater === repeater);
+      if (index !== -1) subscriptions.splice(index, 1);
+    },
+    subscriptions,
+  };
+}
+
+async function subscribeChainEvents(query, hub) {
+  const document = parse(query);
+  return subscribe({
+    schema: chainEventsSchema,
+    document,
+    contextValue: { [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: hub },
+  });
+}
+
+// graphql-js's execution results are null-prototype objects internally
+// (Object.create(null)) -- deepStrictEqual against a plain object literal
+// fails on prototype alone even with identical content. Round-tripping
+// through JSON is also a MORE faithful comparison than a raw deep-equal:
+// real clients only ever see this result after it's been JSON-serialized
+// for the wire, same as every other transport in this repo.
+function asPlainJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+describe("Subscription.chainEvents", () => {
+  test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
+    const hub = fakeChainFirehose((repeater) => {
+      // subscribeChainEvents is only invoked once the async generator is
+      // first pulled (async generator function BODIES don't run until
+      // next() is called) -- pushing here, synchronously inside that same
+      // call, lands in the repeater's buffer before the resolver's
+      // `for await` loop starts pulling, so no setTimeout/await gap is
+      // needed.
+      repeater.push({ table: "blocks", block_number: 42 });
+    });
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table block_number } }",
+      hub,
+    );
+    const { value, done } = await result[Symbol.asyncIterator]().next();
+    assert.equal(done, false);
+    assert.deepEqual(asPlainJson(value), {
+      data: { chainEvents: { table: "blocks", block_number: 42 } },
+    });
+  });
+
+  test("passes the tables argument through to subscribeChainEvents as a Set", async () => {
+    let receivedTopics;
+    const hub = fakeChainFirehose();
+    const originalSubscribe = hub.subscribeChainEvents.bind(hub);
+    hub.subscribeChainEvents = (topics) => {
+      receivedTopics = topics;
+      return originalSubscribe(topics);
+    };
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents(tables: [blocks, extrinsics]) { table } }",
+      hub,
+    );
+    // Pull once to actually run the generator body up to (and past) the
+    // hub.subscribeChainEvents(topics) call -- calling an async generator
+    // function only creates the generator object, it doesn't execute any of
+    // the body until the first next().
+    const pending = result[Symbol.asyncIterator]().next();
+    assert.deepEqual([...receivedTopics].sort(), ["blocks", "extrinsics"]);
+    await hub.unsubscribeChainEvents(hub.subscriptions[0]?.repeater);
+    pending.catch(() => {}); // left permanently pending; not under test here
+  });
+
+  test("an empty tables argument is treated as no filter (null), not an empty Set", async () => {
+    let receivedTopics = "unset";
+    const hub = fakeChainFirehose();
+    const originalSubscribe = hub.subscribeChainEvents.bind(hub);
+    hub.subscribeChainEvents = (topics) => {
+      receivedTopics = topics;
+      return originalSubscribe(topics);
+    };
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents(tables: []) { table } }",
+      hub,
+    );
+    result[Symbol.asyncIterator]().next(); // trigger the generator body
+    assert.equal(receivedTopics, null);
+  });
+
+  test("returns a clear GraphQLError when reached without the graphql-ws WS transport (no context.chainFirehose)", async () => {
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table } }",
+      undefined,
+    );
+    // The subscribe field resolver is an async generator, so the throw only
+    // happens once the first value is pulled -- and since it's thrown before
+    // any yield (a setup-phase failure, not a mid-stream one), graphql-js
+    // propagates it as a REJECTED next() rather than an {errors: [...]}
+    // iteration result. A real graphql-ws server catches this per-operation
+    // and sends the client an ErrorMessage -- this test only needs to prove
+    // the resolver actually rejects with a clear, actionable message.
+    await assert.rejects(
+      () => result[Symbol.asyncIterator]().next(),
+      /graphql-transport-ws/,
+    );
+  });
+
+  test("unsubscribeChainEvents is called when the async generator is returned early (client disconnects/completes)", async () => {
+    // Calling .return() while a .next() is still unresolved deadlocks
+    // graphql-js's internal withConcurrentAbruptClose handling (it waits for
+    // the in-flight next() before honoring return()) -- push a value so the
+    // pending next() actually resolves first, matching how a real client
+    // completes a subscription only after having received at least one
+    // event, not mid-flight on an empty stream.
+    const hub = fakeChainFirehose((repeater) => {
+      repeater.push({ table: "blocks" });
+    });
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table } }",
+      hub,
+    );
+    const it = result[Symbol.asyncIterator]();
+    await it.next(); // starts the generator body (-> subscribeChainEvents) and resolves with the pushed value
+    assert.equal(hub.subscriptions.length, 1);
+    await it.return();
+    assert.equal(hub.subscriptions.length, 0);
+  });
+
+  test("POSTing a subscription operation to the regular query endpoint returns a standard GraphQL error, not a crash", async () => {
+    const { status, body } = await gql(
+      "subscription { chainEvents { table } }",
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors?.length);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1086,6 +1086,17 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // Rate-limited up front (same binding/strategy/429 as the RPC proxy) so a
   // single client can't fan out into unbounded artifact reads + query execution.
   if (url.pathname === "/api/v1/graphql") {
+    // GraphQL subscriptions (#4983, ADR 0015) reuse this SAME path over a
+    // WebSocket upgrade (Sec-WebSocket-Protocol: graphql-transport-ws) --
+    // handleChainFirehoseStream already forwards the request as-is (headers
+    // included) to ChainFirehoseHub's /subscribe, which inspects that same
+    // header to pick graphql-ws vs plain-firehose mode; reused unchanged
+    // rather than duplicating the DO-forwarding boilerplate. Checked before
+    // the rate limiter: a long-lived WS connection isn't the same shape of
+    // load a per-request POST limiter is meant for.
+    if (request.headers.get("upgrade") === "websocket") {
+      return handleChainFirehoseStream(request, env, url);
+    }
     const limited = await graphqlRateLimited(request, env);
     if (limited) return limited;
     return handleGraphQLRequest(request, env);

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -28,10 +28,23 @@
 // webSocketClose's graphql-ws branches, and src/graphql.mjs's
 // GRAPHQL_SUBSCRIPTION_CONTEXT_KEY for the other half of the wiring.
 
-import { execute, subscribe } from "graphql";
+import {
+  GraphQLError,
+  execute,
+  getOperationAST,
+  parse,
+  specifiedRules,
+  subscribe,
+  validate,
+} from "graphql";
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL, makeServer } from "graphql-ws";
 import {
+  GRAPHQL_MAX_COMPLEXITY,
+  GRAPHQL_MAX_QUERY_BYTES,
+  GRAPHQL_MAX_DEPTH,
   GRAPHQL_SUBSCRIPTION_CONTEXT_KEY,
+  maxComplexityRule,
+  maxDepthRule,
   schema as chainEventsGraphqlSchema,
 } from "../src/graphql.mjs";
 
@@ -158,6 +171,50 @@ export function formatChainFirehoseSseFrame(payload) {
   return `event: chain\ndata: ${JSON.stringify(payload)}\n\n`;
 }
 
+// graphql-ws's wire protocol accepts ANY operation type over the same
+// `subscribe` message -- query and mutation included, not just subscription
+// (a real client can send `subscription { __typename }`-shaped envelopes
+// carrying a query/mutation document just as easily). Left unchecked, that
+// would let a client execute the full read API over this WS transport,
+// bypassing BOTH /api/v1/graphql POST's rate limiter (graphqlRateLimited,
+// workers/api.mjs -- never consulted for an upgraded connection) and its
+// complexity/depth guards (this function reuses the SAME maxDepthRule/
+// maxComplexityRule graphql.mjs's POST handler applies, rather than
+// defaulting to graphql-ws's bare specifiedRules). Restricting this
+// transport to subscription operations only is the actual fix for both --
+// wired into makeServer's onSubscribe below. Pure and unit-tested directly
+// (no WS connection needed): returns null when the payload is valid, or a
+// non-empty GraphQLError[] describing why it was rejected.
+export function validateChainEventsSubscribePayload(payload) {
+  const query = payload?.query;
+  if (typeof query !== "string" || !query.trim()) {
+    return [new GraphQLError("Missing required field: query.")];
+  }
+  if (new TextEncoder().encode(query).length > GRAPHQL_MAX_QUERY_BYTES) {
+    return [new GraphQLError("GraphQL query is too large.")];
+  }
+  let document;
+  try {
+    document = parse(query);
+  } catch (err) {
+    return [new GraphQLError(err.message)];
+  }
+  const operation = getOperationAST(document, payload.operationName);
+  if (!operation || operation.operation !== "subscription") {
+    return [
+      new GraphQLError(
+        "Only subscription operations are supported over this WebSocket transport; use POST /api/v1/graphql for queries and mutations.",
+      ),
+    ];
+  }
+  const validationErrors = validate(chainEventsGraphqlSchema, document, [
+    ...specifiedRules,
+    maxDepthRule(GRAPHQL_MAX_DEPTH),
+    maxComplexityRule(GRAPHQL_MAX_COMPLEXITY),
+  ]);
+  return validationErrors.length > 0 ? validationErrors : null;
+}
+
 // A minimal push-based async iterator: push() delivers a value to whichever
 // `next()` call is currently pending (or buffers it if none is), end()
 // terminates the sequence. Backs the GraphQL `chainEvents` subscription field
@@ -243,10 +300,16 @@ export class ChainFirehoseHub {
       schema: chainEventsGraphqlSchema,
       execute,
       subscribe,
-      /* v8 ignore next -- graphql-ws only invokes this once a real
-         connection_init lands over an actual WebSocketPair upgrade; same
-         reachability class as handleSubscribe's own v8-ignored branch. */
+      // graphql-ws only invokes these once a real connection_init/subscribe
+      // message lands over an actual WebSocketPair upgrade; same
+      // reachability class as handleSubscribe's own v8-ignored branch.
+      // validateChainEventsSubscribePayload (the actual decision logic
+      // onSubscribe delegates to) is unit-tested directly.
+      /* v8 ignore start */
+      onSubscribe: (_ctx, _id, payload) =>
+        validateChainEventsSubscribePayload(payload) || undefined,
       context: () => ({ [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: this }),
+      /* v8 ignore stop */
     });
   }
 

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -19,6 +19,21 @@
 // issue body ("note any coverage gap explicitly rather than skipping
 // silently"), that glue is marked with an explicit /* v8 ignore */ block
 // rather than pretending it's covered.
+//
+// GraphQL subscriptions (#4983) are a second WS "mode" on this SAME class --
+// negotiated via Sec-WebSocket-Protocol: graphql-transport-ws on the SAME
+// /subscribe path the plain firehose WS uses, not a separate DO or a second
+// event pipeline (matches #4983's own issue body: "a thin protocol adapter
+// on top of the existing hub"). See handleSubscribe/webSocketMessage/
+// webSocketClose's graphql-ws branches, and src/graphql.mjs's
+// GRAPHQL_SUBSCRIPTION_CONTEXT_KEY for the other half of the wiring.
+
+import { execute, subscribe } from "graphql";
+import { GRAPHQL_TRANSPORT_WS_PROTOCOL, makeServer } from "graphql-ws";
+import {
+  GRAPHQL_SUBSCRIPTION_CONTEXT_KEY,
+  schema as chainEventsGraphqlSchema,
+} from "../src/graphql.mjs";
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 
@@ -50,6 +65,14 @@ export const CHAIN_FIREHOSE_MAX_FIELD_STRING_BYTES = 256;
 // with per-send try/catch as the second line of defense against dead sockets.
 export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
+
+// Hibernation tag distinguishing a graphql-ws socket from a plain firehose
+// one -- webSocketMessage/webSocketClose/webSocketError route on
+// graphqlWsSockets.has(ws) directly rather than this tag (a WeakMap lookup
+// is simpler than filtering state.getWebSockets(tag) per callback), but the
+// tag is still passed to state.acceptWebSocket so a future admin/debug tool
+// can enumerate the two populations separately via state.getWebSockets(tag).
+export const GRAPHQL_WS_SOCKET_TAG = "graphql-ws";
 
 function utf8ByteLength(value) {
   return new TextEncoder().encode(value).length;
@@ -135,6 +158,60 @@ export function formatChainFirehoseSseFrame(payload) {
   return `event: chain\ndata: ${JSON.stringify(payload)}\n\n`;
 }
 
+// A minimal push-based async iterator: push() delivers a value to whichever
+// `next()` call is currently pending (or buffers it if none is), end()
+// terminates the sequence. Backs the GraphQL `chainEvents` subscription field
+// (#4983, src/graphql.mjs's chainEventsSubscribe) -- graphql-js's subscribe()
+// consumes this the same way it would any other AsyncIterable subscription
+// source. No dependency on graphql/graphql-ws/the DO runtime, so it's fully
+// unit-tested on its own.
+export function createAsyncRepeater() {
+  const pending = [];
+  let waitingResolve = null;
+  let finished = false;
+  return {
+    push(value) {
+      if (finished) return;
+      if (waitingResolve) {
+        const resolve = waitingResolve;
+        waitingResolve = null;
+        resolve({ value, done: false });
+      } else {
+        pending.push(value);
+      }
+    },
+    end() {
+      if (finished) return;
+      finished = true;
+      if (waitingResolve) {
+        const resolve = waitingResolve;
+        waitingResolve = null;
+        resolve({ value: undefined, done: true });
+      }
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (pending.length > 0) {
+            return Promise.resolve({ value: pending.shift(), done: false });
+          }
+          if (finished) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise((resolve) => {
+            waitingResolve = resolve;
+          });
+        },
+        return() {
+          finished = true;
+          waitingResolve = null;
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    },
+  };
+}
+
 // Only the WebSocket-upgrade branch of handleSubscribe below needs a real
 // Durable Object runtime (WebSocketPair/state.acceptWebSocket have no Node
 // equivalent -- no @cloudflare/vitest-pool-workers/Miniflare in this repo,
@@ -151,6 +228,45 @@ export class ChainFirehoseHub {
     this.state = state;
     this.env = env;
     this.sseClients = new Set();
+    // #4983: GraphQL subscriptions over WS, negotiated via
+    // Sec-WebSocket-Protocol on the SAME /subscribe path -- see the class
+    // header comment. chainEventSubscribers holds active createAsyncRepeater()
+    // instances (one per live `chainEvents` subscription, keyed indirectly
+    // via topics); graphqlWsSockets maps a hibernated WebSocket -> the
+    // graphql-ws callbacks registered for it (onMessage from the adapter's
+    // own onMessage() registration, closed from Server.opened()'s return
+    // value) since hibernation delivers messages/close events through this
+    // class's own webSocketMessage/webSocketClose, not socket-level listeners.
+    this.chainEventSubscribers = new Set();
+    this.graphqlWsSockets = new WeakMap();
+    this.graphqlWsServer = makeServer({
+      schema: chainEventsGraphqlSchema,
+      execute,
+      subscribe,
+      /* v8 ignore next -- graphql-ws only invokes this once a real
+         connection_init lands over an actual WebSocketPair upgrade; same
+         reachability class as handleSubscribe's own v8-ignored branch. */
+      context: () => ({ [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: this }),
+    });
+  }
+
+  // Registered as context.chainFirehose by graphqlWsServer above; called from
+  // src/graphql.mjs's chainEventsSubscribe field resolver. Mirrors the SSE/WS
+  // firehose's own topic-filter semantics (chainFirehoseMatchesTopics).
+  subscribeChainEvents(topics) {
+    const repeater = createAsyncRepeater();
+    this.chainEventSubscribers.add({ repeater, topics });
+    return repeater;
+  }
+
+  unsubscribeChainEvents(repeater) {
+    for (const entry of this.chainEventSubscribers) {
+      if (entry.repeater === repeater) {
+        entry.repeater.end();
+        this.chainEventSubscribers.delete(entry);
+        return;
+      }
+    }
   }
 
   async fetch(request) {
@@ -191,8 +307,41 @@ export class ChainFirehoseHub {
       ) {
         return new Response("too many connections", { status: 503 });
       }
+      const requestedProtocols = (
+        request.headers.get("sec-websocket-protocol") || ""
+      )
+        .split(",")
+        .map((protocol) => protocol.trim());
+      const isGraphqlWs = requestedProtocols.includes(
+        GRAPHQL_TRANSPORT_WS_PROTOCOL,
+      );
+
       const pair = new WebSocketPair();
       const [client, server] = Object.values(pair);
+
+      if (isGraphqlWs) {
+        this.state.acceptWebSocket(server, [GRAPHQL_WS_SOCKET_TAG]);
+        const adapterSocket = {
+          protocol: GRAPHQL_TRANSPORT_WS_PROTOCOL,
+          send: (data) => server.send(data),
+          close: (code, reason) => server.close(code, reason),
+          onMessage: (cb) => {
+            const entry = this.graphqlWsSockets.get(server) || {};
+            entry.onMessageCb = cb;
+            this.graphqlWsSockets.set(server, entry);
+          },
+        };
+        const closedCb = this.graphqlWsServer.opened(adapterSocket, {});
+        const entry = this.graphqlWsSockets.get(server) || {};
+        entry.closedCb = closedCb;
+        this.graphqlWsSockets.set(server, entry);
+        return new Response(null, {
+          status: 101,
+          webSocket: client,
+          headers: { "sec-websocket-protocol": GRAPHQL_TRANSPORT_WS_PROTOCOL },
+        });
+      }
+
       this.state.acceptWebSocket(server);
       server.serializeAttachment({
         topics: topics === null ? null : [...topics],
@@ -230,13 +379,30 @@ export class ChainFirehoseHub {
     });
   }
 
-  webSocketMessage() {
-    // Clients never send meaningful messages -- the topic filter is fixed at
-    // subscribe time via the query string. Required by the hibernation API
-    // contract even though this hub is send-only.
+  async webSocketMessage(ws, message) {
+    // graphql-ws sockets: every incoming protocol message (connection_init,
+    // subscribe, complete, ping/pong) is handled entirely by graphql-ws
+    // itself via the onMessage callback its own opened() registered -- see
+    // handleSubscribe's graphql-ws branch. Plain firehose sockets never send
+    // meaningful messages (the topic filter is fixed at subscribe time via
+    // the query string); webSocketMessage still has to exist to satisfy the
+    // hibernation API contract even though that population is send-only.
+    const entry = this.graphqlWsSockets.get(ws);
+    if (entry?.onMessageCb) {
+      const text =
+        typeof message === "string"
+          ? message
+          : new TextDecoder().decode(message);
+      await entry.onMessageCb(text);
+    }
   }
 
   webSocketClose(ws, code, reason) {
+    const entry = this.graphqlWsSockets.get(ws);
+    if (entry?.closedCb) {
+      entry.closedCb(code, reason);
+      this.graphqlWsSockets.delete(ws);
+    }
     try {
       ws.close(code, reason);
     } catch {
@@ -244,9 +410,17 @@ export class ChainFirehoseHub {
     }
   }
 
-  webSocketError() {
-    // The hibernation runtime prunes the socket from state.getWebSockets()
-    // itself; there is no in-memory connection list here to reconcile.
+  webSocketError(ws, error) {
+    // Mirrors webSocketClose's graphql-ws cleanup -- Server.opened()'s
+    // returned closed() callback must run on an error close too, not only a
+    // clean one, or that connection's subscriptions leak. The hibernation
+    // runtime prunes the socket from state.getWebSockets() itself either
+    // way; there is no in-memory firehose connection list here to reconcile.
+    const entry = this.graphqlWsSockets.get(ws);
+    if (entry?.closedCb) {
+      entry.closedCb(1011, error?.message || "internal error");
+      this.graphqlWsSockets.delete(ws);
+    }
   }
 
   broadcast(payload) {
@@ -277,6 +451,13 @@ export class ChainFirehoseHub {
     }
 
     for (const ws of this.state.getWebSockets()) {
+      // graphql-ws sockets are NOT plain firehose sockets -- sending a bare
+      // JSON payload onto one here would corrupt the graphql-transport-ws
+      // wire protocol (a real client only ever expects framed {type: "next",
+      // ...} messages). Their delivery goes through chainEventSubscribers
+      // below instead, via graphql-js's own subscribe() calling this
+      // adapter's send() with a properly framed message.
+      if (this.graphqlWsSockets.has(ws)) continue;
       let topics = null;
       try {
         const attachment = ws.deserializeAttachment();
@@ -292,6 +473,16 @@ export class ChainFirehoseHub {
         // a dead socket throws here; the hibernation runtime reconciles
         // state.getWebSockets() on its own, nothing further to clean up
       }
+    }
+
+    // #4983: GraphQL `chainEvents` subscriptions -- push into every matching
+    // repeater; src/graphql.mjs's chainEventsSubscribe is consuming these via
+    // `for await`, and graphql-js's subscribe() takes it from there (executes
+    // the rest of the selection set, frames the result, and calls the
+    // graphql-ws adapter socket's send()).
+    for (const entry of this.chainEventSubscribers) {
+      if (!chainFirehoseMatchesTopics(payload, entry.topics)) continue;
+      entry.repeater.push(payload);
     }
   }
 }


### PR DESCRIPTION
## Summary

- `Subscription.chainEvents(tables: [ChainFirehoseTable!]): ChainEvent!` (`src/graphql.mjs`) — a thin `graphql-ws` protocol adapter over the SAME `ChainFirehoseHub` connection #4982's SSE/WS transports use, not a second event pipeline (matches #4983's own issue body). Reached over WebSocket at the existing `/api/v1/graphql` path, negotiated via `Sec-WebSocket-Protocol: graphql-transport-ws`; POSTing a subscription operation to the regular query endpoint returns a standard GraphQL error.
- `ChainFirehoseHub` now owns a `graphql-ws` `Server` instance (`makeServer`). Found and fixed a real bug while wiring this in: the existing plain-firehose WS broadcast loop iterated `state.getWebSockets()` unfiltered, which would have sent raw JSON directly onto a `graphql-ws` socket too, corrupting the wire protocol for any real client — graphql-ws sockets are now tracked separately (`graphqlWsSockets`, a `WeakMap`) and excluded from that loop.
- Each active subscription is backed by a new minimal push-based async iterator (`createAsyncRepeater`) that `broadcast()` feeds directly; graphql-js's own `subscribe()` consumes it to produce properly-framed messages.
- Adds `graphql-ws@^6` — core `makeServer` only (no `ws`/`crossws`/`@fastify/websocket` adapter peers pulled in). Bundle: 956.4 KiB → 960.6 KiB gzipped (crosses the 960 KiB *warn* threshold, well under the 1000 KiB fail budget — `worker:bundle:budget` still passes).
- `docs/realtime-firehose.md` updated with the shipped shape.

MCP resource subscriptions (the other half of #4983) are tracked as a follow-up — not in scope here.

## Coverage note

Same approach as #4982: `workers/chain-firehose-hub.mjs` stays 100% statement/branch/function/line covered (verified via `--coverage.include`) outside the pre-existing, documented WS-upgrade `/* v8 ignore */` block (now also covers the graphql-ws handshake for the same no-Node-equivalent reason). `Subscription.chainEvents`'s resolver is tested using graphql-js's real `subscribe()` engine against a fake hub, not a hand-rolled simulation — including a real setup-error case (thrown when reached without `context.chainFirehose`, i.e. off the WS transport) and early-return cleanup (`unsubscribeChainEvents`).

## Test plan

- [x] `npm run lint` / `npm run format:check`
- [x] `npm run build` (no unintended contract drift)
- [x] `npm run test:coverage` (full suite green; `chain-firehose-hub.mjs` 100% covered outside the documented ignore block)
- [x] `npm run validate` / `npm run worker:deploy:dry-run` / `npm run worker:bundle:budget`
- [ ] Live `wss` client verification of the actual `graphql-transport-ws` handshake against the deployed Worker (Cloudflare has a documented history of not always echoing `Sec-WebSocket-Protocol` on upgrade responses — needs checking for real, not assumed from docs) — will verify post-merge/deploy and report back before closing out #4983's GraphQL half.