### PR TITLE
fix(realtime): cap firehose SSE subscribers

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -93,7 +93,9 @@ One global instance (`idFromName("global")`) owns two endpoints:
 Bounded per-connection buffering: an SSE client whose `ReadableStream`
 controller falls behind (`desiredSize < 0` against a 64-frame
 `CountQueuingStrategy` high-water mark) is dropped rather than left to grow
-memory unboundedly. WebSocket connections use the hibernation API
+memory unboundedly. Total concurrent SSE subscribers are capped
+(`CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS`) before a new stream is admitted,
+bounding the global hub fanout set. WebSocket connections use the hibernation API
 (`state.acceptWebSocket`, `WebSocket.serializeAttachment`/
 `deserializeAttachment` for the per-connection topic filter,
 `state.getWebSockets()` for fanout) so an idle subscriber doesn't pin the

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -15,6 +15,7 @@ import { test } from "vitest";
 import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
+  CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
   CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK,
   CHAIN_FIREHOSE_TABLES,
   ChainFirehoseHub,
@@ -302,6 +303,27 @@ test("ChainFirehoseHub /subscribe (SSE): responds with a text/event-stream and a
   const { value } = await reader.read();
   assert.equal(new TextDecoder().decode(value), ": connected\n\n");
   await reader.cancel();
+});
+
+test("ChainFirehoseHub /subscribe (SSE): rejects new clients at the global connection cap", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const responses = [];
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS; i += 1) {
+    const res = await hub.fetch(
+      new Request("https://chain-firehose-hub.internal/subscribe"),
+    );
+    responses.push(res);
+  }
+
+  assert.equal(hub.sseClients.size, CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS);
+  const capped = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/subscribe"),
+  );
+  assert.equal(capped.status, 503);
+  assert.equal(await capped.text(), "too many connections");
+
+  await Promise.all(responses.map((res) => res.body.cancel()));
+  assert.equal(hub.sseClients.size, 0);
 });
 
 test("ChainFirehoseHub /subscribe (SSE) -> broadcast: a connected client receives a matching event, not a filtered-out one", async () => {

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -42,13 +42,13 @@ export const CHAIN_FIREHOSE_MAX_FIELD_STRING_BYTES = 256;
 
 // SSE: how many queued-but-unflushed frames a client may accumulate (via the
 // stream's CountQueuingStrategy) before it's treated as stalled and dropped.
-// WS: hard cap on concurrent hibernated sockets this hub instance accepts --
-// Cloudflare's WebSocket object exposes no confirmed, documented backpressure
-// signal (no verified `bufferedAmount` equivalent for hibernatable sockets),
-// so a per-message byte watermark isn't a reliable primitive here; capping
-// total connections bounds the DO's worst-case fanout cost directly instead,
-// with per-send try/catch as the second line of defense against dead sockets.
+// Hard caps on concurrent clients this hub instance accepts bound the DO's
+// worst-case fanout set. Cloudflare's WebSocket object exposes no confirmed,
+// documented backpressure signal (no verified `bufferedAmount` equivalent for
+// hibernatable sockets), so a per-message byte watermark isn't a reliable WS
+// primitive here; the connection cap plus per-send try/catch are the bounds.
 export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
+export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
 
 function utf8ByteLength(value) {
@@ -200,6 +200,10 @@ export class ChainFirehoseHub {
       return new Response(null, { status: 101, webSocket: client });
     }
     /* v8 ignore stop */
+
+    if (this.sseClients.size >= CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS) {
+      return new Response("too many connections", { status: 503 });
+    }
 
     const encoder = new TextEncoder();
     const clients = this.sseClients;


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated clients from exhausting the global ChainFirehoseHub by opening arbitrarily many long-lived SSE connections and amplifying CPU/memory fanout cost.

### Description
- Add a global SSE connection limit `CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000` to `workers/chain-firehose-hub.mjs`.
- Reject new SSE `subscribe` requests with `503 "too many connections"` when the hub's `sseClients` set has reached the cap in `handleSubscribe`.
- Add a regression test to `tests/chain-firehose-hub.test.mjs` that opens connections up to the cap, verifies the next request is rejected, and confirms cancellation cleans up the client set.
- Update `docs/realtime-firehose.md` to document the new SSE global subscriber cap alongside existing per-connection buffering and WS limits.

### Testing
- Ran unit tests for the modified surfaces with `npm test -- tests/chain-firehose-hub.test.mjs tests/chain-firehose-routes.test.mjs`, and both test files passed.
- Ran linting with `npm run lint` and formatting check `npm run format:check`, which completed (ESLint reports the Markdown doc is ignored by the linter configuration).
- Ran a targeted coverage run `npm run test:coverage -- tests/chain-firehose-hub.test.mjs tests/chain-firehose-routes.test.mjs` where the selected tests passed but the run enforces global repo coverage thresholds and therefore reported coverage threshold failures when only the subset was selected; a full `npm run test:coverage` in this checkout failed because generated `public/` artifacts (e.g. `public/metagraph/providers.json`) are missing causing unrelated artifact-backed tests to fail with `ENOENT`/404 errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a542a1df1d8832ca1267539405ccc35)