### PR TITLE
fix(realtime): graphql-ws hibernation staleness + subscription cap

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -576,14 +576,26 @@ CREATE TABLE IF NOT EXISTS indexer_cursor (
 -- Realtime firehose tee (ADR 0015, #4980)
 -- ---------------------------------------------------------------------------
 
--- Fires AFTER a row is already durably committed to blocks/extrinsics/
--- chain_events -- by construction this can never affect whether that write
--- itself succeeded, so it adds zero risk to indexer-rs's live-follow
--- reliability (ADR 0015 -- this design deliberately replaces a direct push
--- from indexer-rs's own process with this trigger specifically to avoid
--- that risk). Payload is a compact reference, not the full row, to stay
--- well under Postgres's 8000-byte NOTIFY payload cap; a subscriber that
--- wants full row detail re-fetches by primary key.
+-- CORRECTED 2026-07-13 (found by adversarial review, ADR 0015's own text has
+-- the same correction): an AFTER ROW trigger fires WITHIN the same
+-- transaction as the triggering INSERT, after the row is written but BEFORE
+-- that transaction commits -- NOT "after the row is already durably
+-- committed" as an earlier version of this comment claimed. The
+-- EXCEPTION WHEN OTHERS THEN NULL handler below catches any error the
+-- trigger's OWN execution raises (e.g. a future oversized-payload bug), so
+-- a bug in this function's own logic can't fail the insert. It CANNOT catch
+-- a failure at Postgres's commit-time NOTIFY-queue-capacity check
+-- (PreCommit_Notify), which runs after this function has already returned --
+-- per the Postgres docs, if that shared queue is full at commit,
+-- "transactions calling NOTIFY will fail at commit", which would include
+-- indexer-rs's own insert. This is a narrow, low-likelihood tail risk (the
+-- queue only backs up if some session holds LISTEN open across a very long
+-- transaction elsewhere on this database -- this deployment's only listener,
+-- the #4981 relay, never does), not a zero-risk guarantee -- worth
+-- monitoring queue depth if a second real listener is ever added, not
+-- worth over-engineering against today. Payload is a compact reference, not
+-- the full row, to stay well under Postgres's 8000-byte NOTIFY payload cap;
+-- a subscriber that wants full row detail re-fetches by primary key.
 --
 -- Row-level (FOR EACH ROW), not statement-level: simpler to reason about
 -- for a first cut, at the cost of one NOTIFY per row rather than one per

--- a/docs/adr/0015-realtime-firehose-architecture.md
+++ b/docs/adr/0015-realtime-firehose-architecture.md
@@ -44,15 +44,26 @@ firehose's two halves live.
 
 1. **The tee is Postgres's own `LISTEN`/`NOTIFY`, driven by an `AFTER INSERT`
    trigger on `blocks`/`extrinsics`/`chain_events` — not a push from
-   `indexer-rs`.** A trigger fires only after a row is durably committed; by
-   construction it cannot affect whether that commit succeeded. `indexer-rs`
-   requires zero code changes and has zero awareness the firehose exists.
-   This is the load-bearing safety property of the whole design — see #4980.
+   `indexer-rs`.** `indexer-rs` requires zero code changes and has zero
+   awareness the firehose exists. This is the load-bearing safety property of
+   the whole design — see #4980.
+   **Corrected 2026-07-13** (found by adversarial review): an earlier version
+   of this line claimed the trigger "fires only after a row is durably
+   committed" and "by construction cannot affect whether that commit
+   succeeded" — this overstated the guarantee. An `AFTER ROW` trigger
+   actually fires _within_ the same transaction, before commit; its own
+   `EXCEPTION` handler (`deploy/postgres/schema.sql`) catches errors from the
+   trigger's own logic, but cannot catch a commit-time NOTIFY-queue-capacity
+   failure (`PreCommit_Notify`, which per the Postgres docs would fail the
+   whole transaction, including the row insert). See that file's own comment
+   for the accurate, narrow tail-risk this design actually carries — real,
+   not zero, but bounded and low-likelihood given this deployment's only
+   listener (the #4981 relay) never holds a long transaction open.
 2. **A new, separate box-side relay process bridges Postgres to Cloudflare**
    (#4981), subscribing via `LISTEN` and forwarding to the Durable Object over
    HTTP with a bounded, drop-oldest retry policy. If this process is down,
    lagging, or can't reach Cloudflare, the only consequence is the firehose
-   stalls — `indexer-rs` and Postgres are completely unaffected. This process
+   stalls, per the corrected note above — this process
    is new self-hosted infrastructure (Docker container on the indexer box,
    Ansible-managed per the existing `streamer` role's precedent in
    `deploy/README.md`), not a Cloudflare-side component.

--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -22,11 +22,23 @@ indexer-rs → (writes, as it always has) → Postgres
 ```
 
 `indexer-rs` requires **zero code changes** and has **zero awareness** any of
-this exists — the trigger only fires after a row is already durably
-committed, so a firehose outage (relay down, Cloudflare unreachable, the
+this exists — a firehose outage (relay down, Cloudflare unreachable, the
 Durable Object itself failing) has exactly one consequence: the live
-subscription feed stalls. `indexer-rs`'s writes and Postgres's durability are
-completely unaffected, by construction.
+subscription feed stalls. `indexer-rs`'s writes are unaffected in every
+_normal_ failure mode of the downstream firehose (relay/Cloudflare/DO issues
+never reach Postgres at all — they're purely downstream of the already-fired
+`NOTIFY`).
+
+One caveat, corrected 2026-07-13 after an earlier overstated claim here (found
+by adversarial review): the trigger fires _within_ the same transaction as
+the insert, before commit — not "after the row is already durably committed."
+Its own `EXCEPTION` handler catches errors in its own logic, but Postgres's
+commit-time NOTIFY-queue-capacity check happens after the trigger returns and
+isn't catchable by it; if that shared queue is ever full at commit, the whole
+transaction (including the row insert) fails. See
+`deploy/postgres/schema.sql`'s own comment for why this is a narrow,
+low-likelihood tail risk given this deployment's single listener (the #4981
+relay), not a zero-risk guarantee.
 
 ## The trigger (`deploy/postgres/schema.sql`)
 
@@ -105,6 +117,35 @@ equivalent), so instead of relying on one, total concurrent WS connections
 are capped (`CHAIN_FIREHOSE_MAX_WS_CONNECTIONS`) and a dead socket is
 reconciled via try/catch around `send()` plus the hibernation runtime's own
 `state.getWebSockets()` pruning.
+
+**Hibernation survival (found by adversarial review, 2026-07-13):** a
+Durable Object is reconstructed from scratch (constructor runs again) on
+every hibernation wake, idle eviction, and Worker code deploy. The
+`WebSocket` objects themselves survive that cycle (`state.getWebSockets()`,
+tag included), but `graphqlWsSockets`/`graphqlWsServer` are fresh,
+in-memory-only state that does not -- an earlier version of this class let a
+graphql-ws socket that survived reconstruction but was no longer in the
+fresh `graphqlWsSockets` WeakMap silently fall through to the plain-firehose
+send path, corrupting the wire protocol for that client (raw JSON instead of
+a framed `graphql-transport-ws` message) on every redeploy a graphql-ws
+client happened to be connected across. Fixed: `broadcast()`/
+`webSocketMessage` now detect this case (tagged via
+`state.getWebSockets(GRAPHQL_WS_SOCKET_TAG)`, absent from `graphqlWsSockets`)
+and close the socket with `1012` ("Service Restart") instead, so the
+client's own reconnect logic re-establishes a fresh handshake -- graphql-ws
+has no session-resumption mechanism, so silently trying to "fix" the stale
+connection in place isn't an option.
+
+GraphQL `chainEvents` subscriptions are ALSO capped
+(`CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS`, also found by adversarial
+review): graphql-ws multiplexes many independent subscriptions over one
+WebSocket connection and only rejects a _duplicate_ operation id, never a
+total count, so the WS connection cap alone doesn't bound subscription count
+-- a single connection could otherwise open unboundedly many subscriptions,
+each one costing a real `execute()`+`send()` on every future `broadcast()`.
+`subscribeChainEvents` returns `null` at the cap; `src/graphql.mjs`'s
+resolver turns that into a clear `GraphQLError` rather than hanging the
+client on a stream that will never yield.
 
 Testability: this repo has no Durable Object-capable test harness (no
 `@cloudflare/vitest-pool-workers`/Miniflare). Every actual decision the hub

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -385,8 +385,20 @@ schema.getSubscriptionType().getFields().chainEvents.subscribe =
         "chainEvents is only reachable over the WebSocket transport (Sec-WebSocket-Protocol: graphql-transport-ws) at /api/v1/graphql.",
       );
     }
-    const topics = args.tables?.length ? new Set(args.tables) : null;
+    // Distinguish omitted (undefined -> null, no filter, matches everything)
+    // from an EXPLICIT empty list (tables: [] -> an empty Set, matches
+    // nothing) -- consistent with the SSE/WS firehose's own
+    // parseChainFirehoseTopics semantics (an all-unrecognized topics= string
+    // also collapses to an empty Set, never silently falling back to
+    // "everything"). Previously both cases collapsed to null.
+    const topics = args.tables === undefined ? null : new Set(args.tables);
     const repeater = hub.subscribeChainEvents(topics);
+    if (!repeater) {
+      throw new GraphQLError(
+        "The realtime chain firehose has reached its maximum number of " +
+          "concurrent GraphQL subscriptions; try again later.",
+      );
+    }
     try {
       for await (const payload of repeater) {
         yield { chainEvents: payload };

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
+  CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
   CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK,
@@ -393,8 +394,19 @@ test("formatChainFirehoseSseFrame: frames a payload as an SSE `chain` event", ()
 
 // --- ChainFirehoseHub: fetch/handleIngest/broadcast/SSE (Node-testable) ---------
 
-function stubState(webSockets = []) {
-  return { getWebSockets: () => webSockets };
+// `graphqlWsTaggedSockets` defaults to empty -- every existing plain-firehose
+// test's mock sockets are untagged, matching real state.getWebSockets(tag)
+// semantics where a tag-scoped query returns only sockets accepted with
+// that tag. Pass a non-empty list to simulate a socket that IS
+// graphql-ws-tagged (see the hibernation-staleness tests below).
+function stubState(webSockets = [], graphqlWsTaggedSockets = []) {
+  return {
+    getWebSockets: (tag) => {
+      if (tag === undefined) return webSockets;
+      if (tag === GRAPHQL_WS_SOCKET_TAG) return graphqlWsTaggedSockets;
+      return [];
+    },
+  };
 }
 
 test("ChainFirehoseHub.fetch: 404s on an unrecognized path", async () => {
@@ -735,14 +747,96 @@ test("ChainFirehoseHub.unsubscribeChainEvents: unsubscribing a repeater not in t
   assert.doesNotThrow(() => hub.unsubscribeChainEvents(foreign));
 });
 
-test("ChainFirehoseHub.broadcast: a graphql-ws-tagged WebSocket is excluded from the plain firehose send() loop", () => {
+test("ChainFirehoseHub.broadcast: a REGISTERED graphql-ws-tagged WebSocket is excluded from the plain firehose send() loop", () => {
   const sent = [];
   const ws = { deserializeAttachment: () => null };
-  const hub = new ChainFirehoseHub(stubState([ws]), {});
+  const hub = new ChainFirehoseHub(stubState([ws], [ws]), {});
   hub.graphqlWsSockets.set(ws, { onMessageCb: async () => {} });
   ws.send = (message) => sent.push(message); // would fail the test if called
   hub.broadcast({ table: "blocks", block_number: 1 });
   assert.equal(sent.length, 0);
+});
+
+// --- Hibernation-survival staleness (Bug 1, found by adversarial review) --------
+//
+// A Durable Object is reconstructed from scratch (constructor runs again) on
+// every hibernation wake / idle eviction / Worker redeploy. The WebSocket
+// objects themselves survive (state.getWebSockets(), tag included), but
+// graphqlWsSockets/graphqlWsServer are fresh, in-memory-only state that does
+// NOT. A socket tagged graphql-ws at accept time but absent from the fresh
+// graphqlWsSockets WeakMap is exactly that scenario -- these tests assert it
+// gets closed (forcing a clean client reconnect) rather than silently
+// misrouted through the plain-firehose send path (wire-protocol corruption)
+// or having its messages silently dropped.
+
+test("ChainFirehoseHub.broadcast: a STALE graphql-ws-tagged WebSocket (tagged but unregistered) is closed, not sent to or silently skipped", () => {
+  const sent = [];
+  let closedWith;
+  const ws = {
+    deserializeAttachment: () => null,
+    send: (message) => sent.push(message),
+    close: (code, reason) => {
+      closedWith = [code, reason];
+    },
+  };
+  const hub = new ChainFirehoseHub(stubState([ws], [ws]), {});
+  // Deliberately NOT registered in hub.graphqlWsSockets -- simulates a
+  // post-hibernation-reconstruction instance that never re-opened it.
+  hub.broadcast({ table: "blocks", block_number: 1 });
+  assert.equal(sent.length, 0);
+  assert.equal(closedWith[0], 1012);
+});
+
+test("ChainFirehoseHub.webSocketMessage: a STALE graphql-ws-tagged WebSocket is closed rather than silently dropping the message", async () => {
+  let closedWith;
+  const ws = {
+    close: (code, reason) => {
+      closedWith = [code, reason];
+    },
+  };
+  const hub = new ChainFirehoseHub(stubState([ws], [ws]), {});
+  await hub.webSocketMessage(ws, "some graphql-ws protocol message");
+  assert.equal(closedWith[0], 1012);
+});
+
+test("ChainFirehoseHub.webSocketMessage: an untagged (genuinely plain) socket with no graphqlWsSockets entry stays a silent no-op", async () => {
+  const ws = { close: () => assert.fail("should not be closed") };
+  const hub = new ChainFirehoseHub(stubState([ws]), {}); // not tagged
+  await assert.doesNotReject(() => hub.webSocketMessage(ws, "ignored"));
+});
+
+test("ChainFirehoseHub.isGraphqlWsTaggedSocket / closeStaleGraphqlWsSocket: direct unit coverage", () => {
+  const ws = { close: () => {} };
+  const taggedHub = new ChainFirehoseHub(stubState([ws], [ws]), {});
+  assert.equal(taggedHub.isGraphqlWsTaggedSocket(ws), true);
+  const untaggedHub = new ChainFirehoseHub(stubState([ws]), {});
+  assert.equal(untaggedHub.isGraphqlWsTaggedSocket(ws), false);
+  assert.doesNotThrow(() => taggedHub.closeStaleGraphqlWsSocket(ws));
+  assert.doesNotThrow(() =>
+    taggedHub.closeStaleGraphqlWsSocket({
+      close: () => {
+        throw new Error("already closed");
+      },
+    }),
+  );
+});
+
+// --- CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS (Finding 1, found by adversarial review) --
+
+test("ChainFirehoseHub.subscribeChainEvents: returns null (not a repeater) once at CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS; i += 1) {
+    assert.notEqual(hub.subscribeChainEvents(null), null);
+  }
+  assert.equal(
+    hub.chainEventSubscribers.size,
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
+  );
+  assert.equal(hub.subscribeChainEvents(null), null);
+  assert.equal(
+    hub.chainEventSubscribers.size,
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
+  );
 });
 
 test("GRAPHQL_WS_SOCKET_TAG is the documented tag string", () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1877,7 +1877,23 @@ describe("Subscription.chainEvents", () => {
     pending.catch(() => {}); // left permanently pending; not under test here
   });
 
-  test("an empty tables argument is treated as no filter (null), not an empty Set", async () => {
+  test("an omitted tables argument means no filter (null, matches everything)", async () => {
+    let receivedTopics = "unset";
+    const hub = fakeChainFirehose();
+    const originalSubscribe = hub.subscribeChainEvents.bind(hub);
+    hub.subscribeChainEvents = (topics) => {
+      receivedTopics = topics;
+      return originalSubscribe(topics);
+    };
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table } }",
+      hub,
+    );
+    result[Symbol.asyncIterator]().next(); // trigger the generator body
+    assert.equal(receivedTopics, null);
+  });
+
+  test("an EXPLICIT empty tables argument means an empty Set (matches nothing) -- consistent with the SSE/WS firehose's own all-unrecognized-topics semantics, not silently 'everything'", async () => {
     let receivedTopics = "unset";
     const hub = fakeChainFirehose();
     const originalSubscribe = hub.subscribeChainEvents.bind(hub);
@@ -1890,7 +1906,8 @@ describe("Subscription.chainEvents", () => {
       hub,
     );
     result[Symbol.asyncIterator]().next(); // trigger the generator body
-    assert.equal(receivedTopics, null);
+    assert.ok(receivedTopics instanceof Set);
+    assert.equal(receivedTopics.size, 0);
   });
 
   test("returns a clear GraphQLError when reached without the graphql-ws WS transport (no context.chainFirehose)", async () => {
@@ -1908,6 +1925,26 @@ describe("Subscription.chainEvents", () => {
     await assert.rejects(
       () => result[Symbol.asyncIterator]().next(),
       /graphql-transport-ws/,
+    );
+  });
+
+  test("returns a clear GraphQLError when subscribeChainEvents reports the hub is at capacity (CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS)", async () => {
+    // subscribeChainEvents returns null (not a repeater) once
+    // ChainFirehoseHub.chainEventSubscribers is at its cap -- the resolver
+    // must throw immediately rather than treating null as an empty stream
+    // (which would otherwise hang the client forever with no error and no
+    // events).
+    const hub = {
+      subscribeChainEvents: () => null,
+      unsubscribeChainEvents() {},
+    };
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table } }",
+      hub,
+    );
+    await assert.rejects(
+      () => result[Symbol.asyncIterator]().next(),
+      /maximum number of concurrent GraphQL subscriptions/,
     );
   });
 

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -79,6 +79,18 @@ export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
 export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
 
+// graphql-ws multiplexes many independent `subscribe` operations over ONE
+// WebSocket connection (the library only rejects a *duplicate* operation id
+// on the same socket, never a total count -- confirmed against its own
+// source, no size limit exists there). Without this, the WS connection cap
+// above bounds sockets but not subscriptions: a single raw client speaking
+// the wire protocol directly (no compliant library required) could open
+// unboundedly many `chainEvents` subscriptions on one socket, each one
+// costing a real execute()+send() on every future broadcast(). This is a
+// GLOBAL cap (matching CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS/_WS_CONNECTIONS'
+// own global-not-per-IP shape) checked in subscribeChainEvents below.
+export const CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS = 1000;
+
 // Hibernation tag distinguishing a graphql-ws socket from a plain firehose
 // one -- webSocketMessage/webSocketClose/webSocketError route on
 // graphqlWsSockets.has(ws) directly rather than this tag (a WeakMap lookup
@@ -316,7 +328,16 @@ export class ChainFirehoseHub {
   // Registered as context.chainFirehose by graphqlWsServer above; called from
   // src/graphql.mjs's chainEventsSubscribe field resolver. Mirrors the SSE/WS
   // firehose's own topic-filter semantics (chainFirehoseMatchesTopics).
+  // Returns null (not a repeater) at CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
+  // -- the resolver must throw a GraphQLError for that case, never treat
+  // null as "no filter"/an empty stream.
   subscribeChainEvents(topics) {
+    if (
+      this.chainEventSubscribers.size >=
+      CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
+    ) {
+      return null;
+    }
     const repeater = createAsyncRepeater();
     this.chainEventSubscribers.add({ repeater, topics });
     return repeater;
@@ -446,6 +467,38 @@ export class ChainFirehoseHub {
     });
   }
 
+  // Bounds-check helper for the hibernation-survival bug described in
+  // closeStaleGraphqlWsSocket's comment: is `ws` tagged graphql-ws
+  // (survives hibernation/reconstruction via state.getWebSockets(tag)),
+  // regardless of whether THIS DO instance's in-memory graphqlWsSockets
+  // WeakMap still has a live entry for it?
+  isGraphqlWsTaggedSocket(ws) {
+    return this.state.getWebSockets(GRAPHQL_WS_SOCKET_TAG).includes(ws);
+  }
+
+  // A Durable Object is reconstructed from scratch (constructor runs again)
+  // on every hibernation wake, idle eviction, AND on every Worker code
+  // deploy -- graphqlWsSockets/chainEventSubscribers/graphqlWsServer are all
+  // fresh, in-memory-only state that does NOT survive that cycle. The
+  // WebSocket objects themselves DO survive (state.getWebSockets() still
+  // returns them, tag included), but graphql-ws's own protocol state for
+  // them (has connection_init been acked, which subscriptions are active)
+  // lived only in the now-replaced graphqlWsServer and has no resumption
+  // mechanism. Rather than let such a socket silently fall through to the
+  // plain-firehose send path (raw JSON onto what the client expects to be a
+  // framed graphql-transport-ws stream -- exactly the wire-protocol
+  // corruption this class's other comments warn about) or silently drop its
+  // incoming messages, close it cleanly (1012 "Service Restart" is the
+  // semantically correct RFC 6455 code) so the client's own reconnect logic
+  // re-establishes a fresh handshake against the current graphqlWsServer.
+  closeStaleGraphqlWsSocket(ws) {
+    try {
+      ws.close(1012, "durable object restarted; reconnect");
+    } catch {
+      // already closed
+    }
+  }
+
   async webSocketMessage(ws, message) {
     // graphql-ws sockets: every incoming protocol message (connection_init,
     // subscribe, complete, ping/pong) is handled entirely by graphql-ws
@@ -461,6 +514,10 @@ export class ChainFirehoseHub {
           ? message
           : new TextDecoder().decode(message);
       await entry.onMessageCb(text);
+      return;
+    }
+    if (this.isGraphqlWsTaggedSocket(ws)) {
+      this.closeStaleGraphqlWsSocket(ws);
     }
   }
 
@@ -517,14 +574,30 @@ export class ChainFirehoseHub {
       }
     }
 
+    // Computed once per broadcast (not per-socket .includes() -- O(n) not
+    // O(n^2)): every socket tagged graphql-ws at accept time, regardless of
+    // whether this DO instance's in-memory graphqlWsSockets still recognizes
+    // it (see closeStaleGraphqlWsSocket's comment for why the two can
+    // diverge after a hibernation/reconstruction cycle).
+    const graphqlWsTagged = new Set(
+      this.state.getWebSockets(GRAPHQL_WS_SOCKET_TAG),
+    );
     for (const ws of this.state.getWebSockets()) {
-      // graphql-ws sockets are NOT plain firehose sockets -- sending a bare
-      // JSON payload onto one here would corrupt the graphql-transport-ws
-      // wire protocol (a real client only ever expects framed {type: "next",
-      // ...} messages). Their delivery goes through chainEventSubscribers
-      // below instead, via graphql-js's own subscribe() calling this
-      // adapter's send() with a properly framed message.
-      if (this.graphqlWsSockets.has(ws)) continue;
+      if (graphqlWsTagged.has(ws)) {
+        // graphql-ws sockets are NOT plain firehose sockets -- sending a bare
+        // JSON payload onto one here would corrupt the graphql-transport-ws
+        // wire protocol (a real client only ever expects framed {type: "next",
+        // ...} messages). A REGISTERED one's delivery goes through
+        // chainEventSubscribers below instead, via graphql-js's own
+        // subscribe() calling this adapter's send() with a properly framed
+        // message. An UNREGISTERED-but-tagged one is stale (survived
+        // hibernation, but this instance never re-opened it) -- close it
+        // rather than silently misrouting or ignoring it.
+        if (!this.graphqlWsSockets.has(ws)) {
+          this.closeStaleGraphqlWsSocket(ws);
+        }
+        continue;
+      }
       let topics = null;
       try {
         const attachment = ws.deserializeAttachment();


### PR DESCRIPTION
## Summary

Found by a multi-agent adversarial review of today's realtime firehose work (`workers/chain-firehose-hub.mjs`, `src/graphql.mjs`) — two real bugs already live in production, plus a correction to an overstated safety claim.

- **Severe:** `graphqlWsSockets`/`graphqlWsServer` are fresh, in-memory-only state that does not survive a Durable Object hibernation wake, idle eviction, or Worker redeploy — but the underlying WebSocket connection does (`state.getWebSockets()` still returns it). A reconstructed instance's `broadcast()`/`webSocketMessage` misclassified such a socket as a plain firehose connection, sending raw unframed JSON onto what the client expects to be a `graphql-transport-ws`-framed stream — corrupting the wire protocol on every redeploy a graphql-ws client happened to stay connected across. Fixed: detect the tagged-but-unregistered case via `state.getWebSockets(GRAPHQL_WS_SOCKET_TAG)` and close the socket (`1012` "Service Restart") instead, forcing a clean client reconnect — graphql-ws has no session-resumption mechanism, so trying to fake resumption in place isn't an option.
- `graphql-ws` multiplexes unbounded subscriptions over one WebSocket connection (the library only rejects a *duplicate* operation id, never a total count — confirmed against its own source). Added `CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS`, a global cap matching the existing SSE/WS connection caps' own shape; `subscribeChainEvents` returns `null` at the cap and the GraphQL resolver turns that into a clear `GraphQLError`.
- Corrected an overstated safety claim in ADR 0015 / `schema.sql` / `docs/realtime-firehose.md`: an `AFTER ROW` trigger fires *within* the same transaction as the insert, before commit — not "after the row is already durably committed." A commit-time NOTIFY-queue-capacity failure isn't catchable by the trigger's own exception handler and could fail the whole transaction (including the row insert). Narrow, low-likelihood tail risk given this deployment's single listener, not the zero-risk guarantee previously documented.
- Minor: `chainEvents(tables: [])` now correctly matches nothing (an empty `Set`), consistent with the SSE/WS firehose's own `parseChainFirehoseTopics` semantics — previously collapsed to `null` ("everything"), same as an omitted argument.

Deferred (lower severity, tracked in #5004): per-IP sub-quota on the global connection/subscription caps, and a ~1-block cleanup-delay window when a GraphQL subscription disconnects before its first event (spec-correct async-generator `.return()` queueing behavior, self-heals).

## Test plan

- [x] `npm run lint` / `npm run format:check`
- [x] `npm run build` (no unintended contract drift)
- [x] `npm run test:coverage` (full suite green; `chain-firehose-hub.mjs` 100% covered)
- [x] `npm run validate` / `npm run worker:deploy:dry-run` / `npm run worker:bundle:budget`
- [ ] Live verification post-deploy: reconnect a real graphql-ws client across a deploy boundary and confirm it gets closed cleanly (1012) rather than receiving corrupted data — will verify and report back.