### PR TITLE
feat(registry): add SN86 TaoMarketCap candle-chart data-artifact (#4108)

### DIFF
--- a/registry/subnets/subnet-86.json
+++ b/registry/subnets/subnet-86.json
@@ -50,6 +50,25 @@
         "https://backprop.finance/dtao/subnets/86-subnet-86"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/86"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-86-taomarketcap-candle-chart",
+      "kind": "data-artifact",
+      "name": "SN86 TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/86/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN86's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 86. A standalone historical price/volume dataset, distinct from the point-in-time /subnets/86 snapshot already registered. SN86 exposes no first-party API; this indexed feed is the concrete public JSON data endpoint for netuid 86, documented in the TaoMarketCap developer API (its public-oas3.json lists this GET with an optional API key, i.e. no-auth access is supported).",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh171112"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://backprop.finance/dtao/subnets/86-subnet-86"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/86/candle-chart/"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers **SN86**'s public **OHLCV candle-chart dataset** as a `data-artifact` surface — a no-auth
JSON time-series of SN86's alpha-token price/volume, and the concrete public API data endpoint the
registry did not yet capture for SN86. Append-only: one new surface on the existing subnet file,
nothing else changed.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/86/candle-chart/`
- **provider:** `taomarketcap` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership / authority

- Same official host and authority basis as SN86's already-registered
  `sn-86-taomarketcap-subnet-snapshot` surface (`api.taomarketcap.com`, a provider-claimed on-chain
  indexer). SN86 publishes no verified first-party API, repo, or dataset, so this indexed on-chain
  feed is the concrete public data/API surface — the same pattern the existing SN86 surface established.
- `source_url`s: the TaoMarketCap developer API docs and the Backprop Finance dTAO page for SN86
  (the same proof the existing SN86 surface uses). The endpoint is listed in TaoMarketCap's
  `public-oas3.json` with an **optional** API key (no-auth access supported).

## Verified live + public + safe

- `GET https://api.taomarketcap.com/public/v1/subnets/86/candle-chart/` → **HTTP 200**,
  `application/json`, ~223 KB, **no auth**.
- Real payload: an array of hourly OHLCV candles, each scoped to `subnet_id: 86`, with
  `period_name`, `timestamp`, `block_number`, `open/high/low/close`, `volume`, `start_volume`,
  `tao_price_usd/eur`.
- Public-safe: price/volume time-series only — no wallet/hotkey strings. `scan:public-safety` clean.

## Non-duplication

Distinct from SN86's existing `sn-86-taomarketcap-subnet-snapshot` surface — that is the
point-in-time `/public/v1/subnets/86` state snapshot; this is a different URL and a different
dataset (a historical price/volume time-series). No open PR targets SN86.

## Validation (local)

- `npm run validate:surface -- registry/subnets/subnet-86.json` → passes (2 surfaces)
- `npm run scan:public-safety` → passes
- `git diff --stat` → single file, 19-line pure append

## Template Used

- Subnet surface

Closes #4108
