### PR TITLE
feat(realtime): add MCP resource subscriptions for the chain firehose

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -18,7 +18,7 @@ indexer-rs → (writes, as it always has) → Postgres
                                               │
                           box-side relay (LISTEN, #4981) → Cloudflare Durable Object (#4982, live)
                                                                           │
-                                                        SSE / WS (#4982, live) / GraphQL subs / MCP (#4983)
+                                              SSE / WS (#4982, live) / GraphQL subs / MCP (#4983, live)
 ```
 
 `indexer-rs` requires **zero code changes** and has **zero awareness** any of
@@ -208,11 +208,56 @@ merge failed with a generic connection error; that was Cloudflare's global
 edge propagation lag for the new Worker version, not a protocol bug --
 retrying a couple of minutes later succeeded cleanly.)
 
-## MCP resource subscriptions (#4983, not yet built)
+## MCP resource subscriptions (#4983, live)
 
-Exposes the firehose as an MCP resource an agent client can subscribe to per
-the MCP resource-subscription spec (`resources/subscribe` +
-`notifications/resources/updated`), reusing this same hub connection.
+Exposes the firehose as an MCP resource (`metagraph://chain/stream`) an agent
+client can subscribe to per the MCP resource-subscription spec
+(`resources/subscribe` + `notifications/resources/updated`). Unlike GraphQL
+subscriptions above, this is deliberately NOT another population on
+`ChainFirehoseHub` -- it is a separate Durable Object, `McpSessionHub`
+(`workers/mcp-session-hub.mjs`), one instance per `Mcp-Session-Id`. See that
+file's own header comment for the full reasoning; in short: MCP's
+`resources/subscribe` is a one-shot POST, while the actual push channel is a
+separate, reconnect-tolerant GET correlated by session id -- a different
+lifecycle primitive than "fan out to whoever's holding a socket right now",
+which is what `ChainFirehoseHub`'s other three populations all are.
+`ChainFirehoseHub` stays the single source of truth for "an event happened":
+a subscribed session is tracked in `mcpSubscribedSessions`, and `broadcast()`
+pings each subscribed session's `McpSessionHub` (`POST .../notify`) after the
+three existing fan-out loops, best-effort and awaited inline (an unreachable
+session DO never blocks ingest).
+
+**Transport**: MCP's ratified transport (2025-06-18 spec) is Streamable
+HTTP -- POST for JSON-RPC, plus an optional GET for a standalone SSE push
+stream -- not WebSocket (no ratified WS transport exists as of this writing).
+`handleMcpRequest` (`src/mcp-server.mjs`) now branches on method: POST is the
+pre-existing stateless JSON-RPC path (unaffected for every method other than
+`resources/subscribe`/`resources/unsubscribe`); GET forwards to the session's
+`McpSessionHub` `/stream` route; DELETE forwards to `/terminate` for explicit
+client-initiated cleanup. A session id is minted (`crypto.randomUUID()`, sent
+back as an `Mcp-Session-Id` response header) only off a successful
+`initialize` call -- every other method stays session-optional, matching the
+spec's "session is a feature a server MAY offer" framing. `MCP-Protocol-Version`
+is validated when present (absent is treated as the spec's `2025-03-26`
+default, not rejected).
+
+**Bounded stream duration, not indefinite hold**: unlike WebSocket, an
+SSE-holding Durable Object has no hibernation exemption (hibernation is a
+WebSocket-only billing mechanism) -- it stays fully resident for the life of
+the stream. The MCP spec's 2025-11-25 revision explicitly added "support
+polling SSE streams by allowing servers to disconnect at will", so
+`McpSessionHub` closes its stream after `MCP_SESSION_MAX_STREAM_DURATION_MS`
+(5 minutes) and expects the client to reconnect via GET again, coalescing any
+notification that arrived while no stream was open into one pending marker
+per uri (matches `resources/read` always returning current state regardless
+of how many events fired in between). A session with no subscribe/stream/
+touch activity for `MCP_SESSION_IDLE_TTL_MS` (30 minutes) self-terminates via
+a Durable Object alarm.
+
+Both `workers/mcp-session-hub.mjs` and the `src/mcp-server.mjs` additions are
+unit-tested at effectively 100% (no `WebSocketPair`-shaped code here, unlike
+`ChainFirehoseHub` -- `state.storage` is a plain async KV API and
+`ReadableStream` is a real Web Streams API under Node/vitest).
 
 ## The alerter (#4984, not yet built)
 

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -18,6 +18,11 @@ import {
   buildAnthropicToolSpecs,
   buildOpenAIToolSpecs,
 } from "../src/agent-tool-specs.mjs";
+import { ChainFirehoseHub } from "../workers/chain-firehose-hub.mjs";
+import {
+  MCP_CHAIN_STREAM_RESOURCE_URI,
+  McpSessionHub,
+} from "../workers/mcp-session-hub.mjs";
 import {
   artifactFilePath,
   createLocalArtifactEnv,
@@ -37,15 +42,32 @@ const OUTPUT_VALIDATORS = new Map(
     .map((def) => [def.name, ajv.compile(def.outputSchema)]),
 );
 
-async function mcp(payload, { method = "POST" } = {}) {
+async function mcp(
+  payload,
+  { method = "POST", headers = {}, envOverride = env } = {},
+) {
+  const response = await mcpRaw(payload, { method, headers, envOverride });
+  const text = await response.text();
+  return {
+    status: response.status,
+    headers: response.headers,
+    body: text ? JSON.parse(text) : null,
+  };
+}
+
+// Raw-response variant for GET (an open SSE stream -- .text() would hang
+// draining it until MCP_SESSION_MAX_STREAM_DURATION_MS) and DELETE (a bare
+// 204/405, no body to parse).
+async function mcpRaw(
+  payload,
+  { method = "POST", headers = {}, envOverride = env } = {},
+) {
   const request = new Request(MCP_URL, {
     method,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: method === "POST" ? JSON.stringify(payload) : undefined,
   });
-  const response = await handleRequest(request, env, {});
-  const text = await response.text();
-  return { status: response.status, body: text ? JSON.parse(text) : null };
+  return handleRequest(request, envOverride, {});
 }
 
 async function getJson(path) {
@@ -100,6 +122,74 @@ async function callOk(name, args) {
   }
   return result.structuredContent;
 }
+
+// --- MCP resource-subscription fixtures (#4983 MCP half) -------------------
+//
+// Two real Durable Object classes (McpSessionHub + ChainFirehoseHub) wired
+// together exactly like wrangler.jsonc's two bindings, backed by in-memory
+// fakes for state.storage / state.getWebSockets -- same "fake infra, real
+// business logic" convention as createLocalArtifactEnv's ASSETS/R2/KV fakes
+// above, so the resources/subscribe -> ingest -> notifications/resources/
+// updated round trip below exercises the actual class code, not a
+// hand-rolled simulation of it.
+
+function inMemoryDoStorage() {
+  const data = new Map();
+  return {
+    async get(keys) {
+      const result = new Map();
+      for (const key of keys) {
+        if (data.has(key)) result.set(key, data.get(key));
+      }
+      return result;
+    },
+    async put(entries) {
+      for (const [key, value] of Object.entries(entries)) data.set(key, value);
+    },
+    async setAlarm() {
+      // no-op: nothing in this script waits out MCP_SESSION_IDLE_TTL_MS
+    },
+  };
+}
+
+// A minimal fake DurableObjectNamespace: the SAME id always resolves to the
+// SAME instance (required for GET /stream and POST /subscribe on one
+// session to reach the same McpSessionHub), matching real
+// idFromName()/get() semantics.
+function fakeDoNamespace(makeInstance) {
+  const instances = new Map();
+  return {
+    idFromName: (name) => name,
+    get(id) {
+      if (!instances.has(id)) instances.set(id, makeInstance(id));
+      const instance = instances.get(id);
+      return { fetch: (url, init) => instance.fetch(new Request(url, init)) };
+    },
+  };
+}
+
+// Mutually-referencing by design (McpSessionHub tells ChainFirehoseHub about
+// a subscribe/unsubscribe; ChainFirehoseHub tells McpSessionHub about a new
+// event) -- safe because fakeDoNamespace only calls its factory lazily, by
+// which point both bindings below are fully initialized.
+const mcpSessionHubNS = fakeDoNamespace(
+  () =>
+    new McpSessionHub(
+      { storage: inMemoryDoStorage() },
+      { CHAIN_FIREHOSE_HUB: chainFirehoseHubNS },
+    ),
+);
+const chainFirehoseHubNS = fakeDoNamespace(
+  () =>
+    new ChainFirehoseHub(
+      { getWebSockets: () => [] },
+      { MCP_SESSION_HUB: mcpSessionHubNS },
+    ),
+);
+const lifecycleEnv = createLocalArtifactEnv({
+  MCP_SESSION_HUB: mcpSessionHubNS,
+  CHAIN_FIREHOSE_HUB: chainFirehoseHubNS,
+});
 
 // --- Lifecycle -------------------------------------------------------------
 
@@ -1137,11 +1227,181 @@ assert.equal(
 const unknownTool = await call("not_a_real_tool", {});
 assert.equal(unknownTool.isError, true, "unknown tools must return isError");
 
-const getRejected = await mcp(null, { method: "GET" });
-assert.equal(getRejected.status, 405, "GET /mcp must be rejected with 405");
+const getWithoutSession = await mcpRaw(null, { method: "GET" });
+assert.equal(
+  getWithoutSession.status,
+  400,
+  "GET /mcp without an Mcp-Session-Id header must be rejected with 400",
+);
+
+const A_SESSION_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+const getUnprovisioned = await mcpRaw(null, {
+  method: "GET",
+  headers: { "mcp-session-id": A_SESSION_ID },
+});
+assert.equal(
+  getUnprovisioned.status,
+  405,
+  "GET /mcp on a deployment with no MCP_SESSION_HUB binding must degrade to 405",
+);
+
+const deleteWithoutSession = await mcpRaw(null, { method: "DELETE" });
+assert.equal(
+  deleteWithoutSession.status,
+  400,
+  "DELETE /mcp without an Mcp-Session-Id header must be rejected with 400",
+);
+
+const badProtocolVersion = await mcp(
+  { jsonrpc: "2.0", id: 1, method: "ping" },
+  { headers: { "mcp-protocol-version": "1999-01-01" } },
+);
+assert.equal(
+  badProtocolVersion.status,
+  400,
+  "an unrecognized MCP-Protocol-Version header must be rejected with 400",
+);
+
+// --- MCP resource-subscription lifecycle (#4983 MCP half) ------------------
+//
+// The full contract, end to end through the two real Durable Object classes
+// wired above: initialize mints a session -> resources/subscribe on the
+// chain-stream resource -> a chain event actually lands via POST /ingest
+// (the same route the box-side relay hits in production, #4981/#4982) ->
+// the open GET stream receives a pointer-only notifications/resources/
+// updated push -> resources/read returns the CURRENT payload (never the
+// push itself, which per spec carries no data) -> unsubscribe -> DELETE
+// terminates the session -> a later GET 404s. Same verification bar as
+// #4982's SSE/WS lifecycle and #4983's GraphQL subscriptions, per this
+// issue's own "extend validate:mcp to cover the subscription lifecycle"
+// deliverable.
+
+const lifecycleInit = await mcp(
+  { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+  { envOverride: lifecycleEnv },
+);
+const sessionId = lifecycleInit.headers.get("mcp-session-id");
+assert.ok(
+  sessionId,
+  "a successful initialize must mint an Mcp-Session-Id response header",
+);
+
+const subscribeRes = await mcp(
+  {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "resources/subscribe",
+    params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+  },
+  { envOverride: lifecycleEnv, headers: { "mcp-session-id": sessionId } },
+);
+assert.deepEqual(
+  subscribeRes.body.result,
+  {},
+  "resources/subscribe on the chain-stream resource must succeed",
+);
+
+const streamRes = await mcpRaw(null, {
+  method: "GET",
+  headers: { "mcp-session-id": sessionId },
+  envOverride: lifecycleEnv,
+});
+assert.equal(
+  streamRes.status,
+  200,
+  "GET /mcp must open the SSE stream for a subscribed session",
+);
+assert.equal(streamRes.headers.get("content-type"), "text/event-stream");
+const reader = streamRes.body.getReader();
+
+const firehoseStub = chainFirehoseHubNS.get(
+  chainFirehoseHubNS.idFromName("global"),
+);
+const ingestRes = await firehoseStub.fetch(
+  "https://chain-firehose-hub.internal/ingest",
+  {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ table: "blocks", block_number: 8_675_309 }),
+  },
+);
+assert.equal(
+  ingestRes.status,
+  202,
+  "ChainFirehoseHub ingest must accept a valid payload",
+);
+
+const { value: frameBytes } = await reader.read();
+const frame = new TextDecoder().decode(frameBytes);
+assert.match(
+  frame,
+  /^id: \d+\ndata: /,
+  "the SSE stream must deliver an id:/data: framed notification",
+);
+const notification = JSON.parse(
+  frame.slice(frame.indexOf("data: ") + 6).trim(),
+);
+assert.deepEqual(
+  notification,
+  {
+    jsonrpc: "2.0",
+    method: "notifications/resources/updated",
+    params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+  },
+  "the push must be a pointer-only notifications/resources/updated (uri, never the payload itself)",
+);
+await reader.cancel();
+
+const readRes = await mcp(
+  {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "resources/read",
+    params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+  },
+  { envOverride: lifecycleEnv },
+);
+assert.deepEqual(
+  JSON.parse(readRes.body.result.contents[0].text),
+  { table: "blocks", block_number: 8_675_309 },
+  "resources/read on the chain-stream resource must return the latest ingested payload",
+);
+
+const unsubscribeRes = await mcp(
+  {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "resources/unsubscribe",
+    params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+  },
+  { envOverride: lifecycleEnv, headers: { "mcp-session-id": sessionId } },
+);
+assert.deepEqual(unsubscribeRes.body.result, {});
+
+const terminateRes = await mcpRaw(null, {
+  method: "DELETE",
+  headers: { "mcp-session-id": sessionId },
+  envOverride: lifecycleEnv,
+});
+assert.equal(
+  terminateRes.status,
+  204,
+  "DELETE /mcp must terminate the session",
+);
+
+const postTerminateStream = await mcpRaw(null, {
+  method: "GET",
+  headers: { "mcp-session-id": sessionId },
+  envOverride: lifecycleEnv,
+});
+assert.equal(
+  postTerminateStream.status,
+  404,
+  "GET /mcp after DELETE must find no such session",
+);
 
 console.log(
   `MCP validation passed: ${MCP_TOOLS.length} tools, lifecycle + ${
     schemaService ? "all" : "all-but-schema"
-  } tools/call.`,
+  } tools/call + the resources/subscribe -> ingest -> notify round trip.`,
 );

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1,11 +1,22 @@
-// Stateless remote MCP (Model Context Protocol) server for metagraphed.
+// Remote MCP (Model Context Protocol) server for metagraphed.
 //
 // Exposes the operational registry to AI agents (Claude Desktop/Code, Cursor,
-// autonomous agents) over the MCP Streamable HTTP transport at `POST /mcp`.
-// The registry is read-only, so the server is fully stateless: no session id,
-// no Durable Object, no server-initiated streams. We hand-roll the JSON-RPC 2.0
-// envelope rather than pulling in `@modelcontextprotocol/sdk` so the Worker
-// bundle stays lean and the hot REST/RPC path is untouched.
+// autonomous agents) over the MCP Streamable HTTP transport at `/mcp`. Almost
+// the entire surface is read-only and fully stateless (POST /mcp, no session
+// id, no Durable Object) -- the one exception is described below. We hand-roll
+// the JSON-RPC 2.0 envelope rather than pulling in `@modelcontextprotocol/sdk`
+// so the Worker bundle stays lean and the hot REST/RPC path is untouched.
+//
+// The ONE stateful exception (#4983 MCP half, ADR 0015): resources/subscribe
+// on `metagraph://chain/stream`. A subscribed session gets a Durable Object
+// (McpSessionHub, one per Mcp-Session-Id, minted at `initialize`) that holds
+// a bounded-duration GET-opened SSE stream and pushes
+// notifications/resources/updated when the realtime firehose (ChainFirehoseHub,
+// #4982) broadcasts a new chain event. Every OTHER method on this server is
+// unaffected -- stateless POST, no session required. See
+// workers/mcp-session-hub.mjs's own header comment for why this is a
+// separate DO from ChainFirehoseHub, and docs/realtime-firehose.md for the
+// full architecture.
 //
 // Artifact/KV reads are injected (`deps.readArtifact`, `deps.readHealthKv`) so
 // this module is pure and unit-testable, and so it reuses the exact same
@@ -19,6 +30,10 @@ import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
+import {
+  MCP_CHAIN_STREAM_RESOURCE_URI,
+  isValidMcpSessionId,
+} from "../workers/mcp-session-hub.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
@@ -10732,7 +10747,10 @@ export function listToolDefinitions() {
 // the generated server-card so the two can never drift.
 export const MCP_CAPABILITIES = {
   tools: { listChanged: false },
-  resources: { listChanged: false },
+  // subscribe: true (#4983 MCP half) -- only metagraph://chain/stream is
+  // actually subscribable (SUBSCRIBABLE_RESOURCE_URIS below); every other
+  // resource is a static R2 artifact with no change signal to subscribe to.
+  resources: { subscribe: true, listChanged: false },
   prompts: { listChanged: false },
 };
 
@@ -10803,7 +10821,30 @@ const FIXED_RESOURCES = [
     mimeType: "application/json",
     artifact: "/metagraph/schemas/index.json",
   },
+  {
+    uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    name: "chain-stream",
+    title: "Realtime chain event stream",
+    description:
+      "The latest confirmed chain event observed by the realtime firehose " +
+      "(blocks/extrinsics/chain_events). Subscribe via resources/subscribe " +
+      "to receive notifications/resources/updated when a new event lands, " +
+      `then resources/read for the latest payload. ${UNTRUSTED_DATA_NOTE}`,
+    mimeType: "application/json",
+    // Every other FIXED_RESOURCES entry has a static `artifact:` (an R2/
+    // ASSETS path); this one has `live: true` instead -- readResource below
+    // branches on it to read ChainFirehoseHub's latestPayload rather than
+    // loadArtifactData. Never both.
+    live: true,
+  },
 ];
+
+// Resources a client may actually call resources/subscribe on -- deliberately
+// NOT "any URI resourceArtifactPath resolves": every resource other than the
+// live one above is a static R2 artifact with no change signal, so
+// subscribing to one would accept silently and then never fire. Checked in
+// the resources/subscribe dispatch case below.
+const SUBSCRIBABLE_RESOURCE_URIS = new Set([MCP_CHAIN_STREAM_RESOURCE_URI]);
 
 const RESOURCE_PAGE_SIZE = 100;
 
@@ -10910,8 +10951,41 @@ function resourceArtifactPath(uri) {
   return null;
 }
 
+// The one live (non-artifact-backed) resource: reads ChainFirehoseHub's own
+// in-memory latestPayload (workers/chain-firehose-hub.mjs's broadcast())
+// directly -- there is no R2/ASSETS artifact for this resource, so
+// loadArtifactData never applies to it. Degrades to an explicit "no events
+// observed yet" placeholder rather than erroring if the firehose is cold
+// (binding absent in local/CI, or genuinely no chain event has landed since
+// the hub last cold-started) -- a subscribed client's first resources/read
+// after subscribing is a normal, expected case, not a fault.
+async function readLiveChainStreamResource(ctx) {
+  if (!ctx.env.CHAIN_FIREHOSE_HUB) {
+    return {
+      table: null,
+      message: "the realtime firehose is not bound on this deployment",
+    };
+  }
+  const stub = ctx.env.CHAIN_FIREHOSE_HUB.get(
+    ctx.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
+  );
+  const upstream = await stub.fetch(
+    "https://chain-firehose-hub.internal/latest",
+  );
+  const { payload } = await upstream.json();
+  return payload ?? { table: null, message: "no chain event observed yet" };
+}
+
 async function readResource(params, ctx) {
   const uri = params?.uri;
+  if (uri === MCP_CHAIN_STREAM_RESOURCE_URI) {
+    const data = await readLiveChainStreamResource(ctx);
+    return {
+      contents: [
+        { uri, mimeType: "application/json", text: JSON.stringify(data) },
+      ],
+    };
+  }
   const artifactPath =
     typeof uri === "string" ? resourceArtifactPath(uri) : null;
   if (!artifactPath) {
@@ -10927,6 +11001,82 @@ async function readResource(params, ctx) {
       { uri, mimeType: "application/json", text: JSON.stringify(data) },
     ],
   };
+}
+
+// resources/subscribe and resources/unsubscribe (#4983 MCP half) -- both are
+// session-scoped (require ctx.sessionId, set by buildContext from the
+// Mcp-Session-Id header) and reused verbatim's-worth of validation:
+// SUBSCRIBABLE_RESOURCE_URIS is checked here rather than a second, looser
+// URI-shape check, mirroring the lesson from this session's graphql-ws fix
+// (validateChainEventsSubscribePayload) -- a hand-rolled second validation
+// path is exactly how a security guarantee quietly drifts from the first.
+async function subscribeResource(params, ctx) {
+  const uri = params?.uri;
+  if (typeof uri !== "string" || !SUBSCRIBABLE_RESOURCE_URIS.has(uri)) {
+    throw toolError(
+      "invalid_params",
+      `Resource is unknown or not subscribable: ${String(uri)}. Only ` +
+        `${[...SUBSCRIBABLE_RESOURCE_URIS].join(", ")} supports resources/subscribe.`,
+    );
+  }
+  if (!ctx.sessionId) {
+    throw toolError(
+      "invalid_params",
+      "resources/subscribe requires an Mcp-Session-Id header (obtained " +
+        "from the initialize response).",
+    );
+  }
+  if (!ctx.env.MCP_SESSION_HUB) {
+    throw toolError(
+      "resource_unavailable",
+      "MCP resource subscriptions are not provisioned on this deployment.",
+    );
+  }
+  const stub = ctx.env.MCP_SESSION_HUB.get(
+    ctx.env.MCP_SESSION_HUB.idFromName(ctx.sessionId),
+  );
+  const upstream = await stub.fetch(
+    "https://mcp-session-hub.internal/subscribe",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: ctx.sessionId, uri }),
+    },
+  );
+  if (!upstream.ok) {
+    throw toolError("invalid_params", `Could not subscribe to ${uri}.`);
+  }
+  return {};
+}
+
+async function unsubscribeResource(params, ctx) {
+  const uri = params?.uri;
+  if (typeof uri !== "string") {
+    throw toolError("invalid_params", "Missing required field: uri.");
+  }
+  if (!ctx.sessionId) {
+    throw toolError(
+      "invalid_params",
+      "resources/unsubscribe requires an Mcp-Session-Id header.",
+    );
+  }
+  if (!ctx.env.MCP_SESSION_HUB) {
+    throw toolError(
+      "resource_unavailable",
+      "MCP resource subscriptions are not provisioned on this deployment.",
+    );
+  }
+  const stub = ctx.env.MCP_SESSION_HUB.get(
+    ctx.env.MCP_SESSION_HUB.idFromName(ctx.sessionId),
+  );
+  // Unsubscribing from something never subscribed to is a harmless no-op
+  // (McpSessionHub's Set.delete semantics) -- no existence check needed.
+  await stub.fetch("https://mcp-session-hub.internal/unsubscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ sessionId: ctx.sessionId, uri }),
+  });
+  return {};
 }
 
 // Pre-baked multi-tool recipes: each builds a user message telling the agent
@@ -11138,6 +11288,14 @@ async function dispatchMessage(message, ctx) {
         return isNotification
           ? null
           : rpcResult(id, await readResource(params, ctx));
+      case "resources/subscribe":
+        return isNotification
+          ? null
+          : rpcResult(id, await subscribeResource(params, ctx));
+      case "resources/unsubscribe":
+        return isNotification
+          ? null
+          : rpcResult(id, await unsubscribeResource(params, ctx));
       case "prompts/list":
         return isNotification
           ? null
@@ -11181,9 +11339,16 @@ function buildContext(request, env, deps) {
   } catch {
     domain = PRIMARY_DOMAIN;
   }
+  // Session-optional for every pre-existing method (tools/call, resources/read,
+  // etc. never required one and still don't) -- only resources/subscribe and
+  // resources/unsubscribe check for it themselves. Format validity (not just
+  // presence) is already enforced by handleMcpRequest before this is called,
+  // so a malformed header never reaches here as a truthy value.
+  const rawSessionId = request.headers.get("mcp-session-id");
   return {
     env,
     domain,
+    sessionId: isValidMcpSessionId(rawSessionId) ? rawSessionId : null,
     clientIp: mcpClientKey(request),
     readArtifact: deps.readArtifact,
     readHealthKv: deps.readHealthKv,
@@ -11239,9 +11404,143 @@ function bodyTooLargeResponse() {
   );
 }
 
-// Entry point wired into the Worker at `POST /mcp`. `deps` injects the shared
-// artifact/KV readers from workers/api.mjs.
+// MCP-Protocol-Version header (2025-06-18+): every request after the first
+// carries this; the first (`initialize`) negotiates the version in its BODY
+// instead, since the client has nothing to declare in a header yet. Per spec,
+// an absent header means "assume 2025-03-26" -- not a rejection -- so this
+// only ever produces a response for a header that IS present and unrecognized
+// (which also correctly rejects a garbage value on `initialize` itself, since
+// a compliant client would never send one there).
+function validateMcpProtocolVersionHeader(request) {
+  const header = request.headers.get("mcp-protocol-version");
+  if (!header || MCP_PROTOCOL_VERSIONS.includes(header)) return null;
+  return jsonResponse(
+    rpcError(
+      null,
+      RPC_INVALID_REQUEST,
+      `Unsupported MCP-Protocol-Version: ${header}. Supported: ` +
+        `${MCP_PROTOCOL_VERSIONS.join(", ")}.`,
+    ),
+    400,
+  );
+}
+
+// A session id is minted (not client-chosen) only off a successful,
+// non-batched `initialize` response -- the one moment a client has nothing
+// to present yet. Every other method stays session-optional (unaffected);
+// GET/DELETE and resources/subscribe are the only things that end up
+// requiring the header this mints, and all three necessarily come after an
+// initialize. Batched/legacy-array requests predate the 2025-06-18 session
+// concept and are left alone.
+function mintMcpSessionHeaderIfNeeded(body, response) {
+  if (Array.isArray(body) || body?.method !== "initialize") return {};
+  if (!response || response.error) return {};
+  return { "mcp-session-id": crypto.randomUUID() };
+}
+
+const MCP_STREAM_HUB_UNAVAILABLE_RESPONSE = new Response(null, {
+  status: 405,
+  headers: { ...MCP_HEADERS, allow: "POST, OPTIONS" },
+});
+
+// GET /mcp -- the standalone SSE push channel a client opens (with the
+// Mcp-Session-Id minted at `initialize`) after a resources/subscribe call, to
+// receive notifications/resources/updated pushes. See
+// workers/mcp-session-hub.mjs's header comment for why this is a
+// bounded-duration stream rather than an indefinite hold, and why it is a
+// separate Durable Object from the realtime chain firehose. Every other MCP
+// method is POST-only and stateless; this is the one GET route.
+async function handleMcpStreamRequest(request, env) {
+  const versionError = validateMcpProtocolVersionHeader(request);
+  if (versionError) return versionError;
+
+  const rawSessionId = request.headers.get("mcp-session-id");
+  if (!isValidMcpSessionId(rawSessionId)) {
+    return jsonResponse(
+      rpcError(
+        null,
+        RPC_INVALID_REQUEST,
+        "GET requires a valid Mcp-Session-Id header (obtained from the " +
+          "initialize response).",
+      ),
+      400,
+    );
+  }
+  if (!env.MCP_SESSION_HUB) {
+    return MCP_STREAM_HUB_UNAVAILABLE_RESPONSE;
+  }
+  const stub = env.MCP_SESSION_HUB.get(
+    env.MCP_SESSION_HUB.idFromName(rawSessionId),
+  );
+  const upstream = await stub.fetch(
+    `https://mcp-session-hub.internal/stream?sessionId=${encodeURIComponent(rawSessionId)}`,
+  );
+  if (!upstream.ok) {
+    // 404 (session unknown/already terminated) or 409 (a stream is already
+    // open for this session) from the DO -- pass the status through with a
+    // client-facing message, never the DO's own internal response body.
+    return jsonResponse(
+      rpcError(
+        null,
+        RPC_INVALID_REQUEST,
+        upstream.status === 409
+          ? "A stream is already open for this session."
+          : "No such MCP session; call initialize again.",
+      ),
+      upstream.status === 409 ? 409 : 404,
+    );
+  }
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+      "access-control-allow-origin": "*",
+      connection: "keep-alive",
+    },
+  });
+}
+
+// DELETE /mcp -- explicit client-initiated session termination (spec-
+// optional; supporting it lets a well-behaved client release its
+// McpSessionHub promptly instead of waiting out MCP_SESSION_IDLE_TTL_MS).
+async function handleMcpTerminateRequest(request, env) {
+  const rawSessionId = request.headers.get("mcp-session-id");
+  if (!isValidMcpSessionId(rawSessionId)) {
+    return jsonResponse(
+      rpcError(
+        null,
+        RPC_INVALID_REQUEST,
+        "DELETE requires a valid Mcp-Session-Id header.",
+      ),
+      400,
+    );
+  }
+  if (!env.MCP_SESSION_HUB) {
+    return MCP_STREAM_HUB_UNAVAILABLE_RESPONSE;
+  }
+  const stub = env.MCP_SESSION_HUB.get(
+    env.MCP_SESSION_HUB.idFromName(rawSessionId),
+  );
+  await stub.fetch("https://mcp-session-hub.internal/terminate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ sessionId: rawSessionId }),
+  });
+  return new Response(null, { status: 204, headers: MCP_HEADERS });
+}
+
+// Entry point wired into the Worker at `/mcp`. `deps` injects the shared
+// artifact/KV readers from workers/api.mjs. POST carries the stateless
+// JSON-RPC 2.0 envelope; GET opens the SSE push stream; DELETE terminates a
+// session (see the two handlers above for both).
 export async function handleMcpRequest(request, env = {}, deps = {}) {
+  if (request.method === "GET") {
+    return handleMcpStreamRequest(request, env);
+  }
+  if (request.method === "DELETE") {
+    return handleMcpTerminateRequest(request, env);
+  }
   if (request.method !== "POST") {
     return new Response(
       JSON.stringify({
@@ -11251,10 +11550,14 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
           code: RPC_INVALID_REQUEST,
           message:
             "The MCP endpoint accepts POST JSON-RPC requests over the " +
-            "Streamable HTTP transport.",
+            "Streamable HTTP transport, GET for the SSE push stream, or " +
+            "DELETE to terminate a session.",
         },
       }),
-      { status: 405, headers: { ...MCP_HEADERS, allow: "POST, OPTIONS" } },
+      {
+        status: 405,
+        headers: { ...MCP_HEADERS, allow: "GET, POST, DELETE, OPTIONS" },
+      },
     );
   }
 
@@ -11279,6 +11582,9 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
       400,
     );
   }
+
+  const versionError = validateMcpProtocolVersionHeader(request);
+  if (versionError) return versionError;
 
   const ctx = buildContext(request, env, deps);
 
@@ -11319,9 +11625,13 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
   }
 
   const response = await dispatchMessage(body, ctx);
+  const sessionHeaders = mintMcpSessionHeaderIfNeeded(body, response);
   if (!response) {
     // Notification(s) only — nothing to return.
-    return new Response(null, { status: 202, headers: MCP_HEADERS });
+    return new Response(null, {
+      status: 202,
+      headers: { ...MCP_HEADERS, ...sessionHeaders },
+    });
   }
-  return jsonResponse(response);
+  return jsonResponse(response, 200, sessionHeaders);
 }

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -338,6 +338,35 @@ describe("handleRequest routing edges", () => {
     );
   });
 
+  test("OPTIONS preflight on /mcp advertises GET/POST/DELETE and the session headers (#4983 MCP half)", async () => {
+    const res = await handleRequest(
+      req("/mcp", { method: "OPTIONS" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "GET, POST, DELETE, OPTIONS",
+    );
+    const allowHeaders = res.headers.get("access-control-allow-headers");
+    assert.match(allowHeaders, /mcp-session-id/);
+    assert.match(allowHeaders, /mcp-protocol-version/);
+  });
+
+  test("OPTIONS preflight on /api/v1/ask advertises POST only (unaffected by the /mcp GET/DELETE change)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/ask", { method: "OPTIONS" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+  });
+
   test("falls through to ASSETS for a non-api path", async () => {
     let assetCalled = false;
     const env = {

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -28,6 +28,7 @@ import {
   validateChainEventsSubscribePayload,
   validateChainFirehoseIngestPayload,
 } from "../workers/chain-firehose-hub.mjs";
+import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.mjs";
 
 // --- validateChainEventsSubscribePayload (#4983 security fix) -------------------
 //
@@ -853,4 +854,124 @@ test("CHAIN_FIREHOSE_INGEST_TOKEN_HEADER and CHAIN_FIREHOSE_TABLES are the docum
     "chain_events",
     "extrinsics",
   ]);
+});
+
+// --- MCP resource-subscription notify loop (#4983 MCP half) ---------------------
+
+function fakeMcpSessionHubBinding(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    idFromName: (name) => name,
+    get: (sessionId) => ({
+      fetch: async (url, init) => {
+        calls.push({ sessionId, url, init });
+        if (overrides[sessionId]) return overrides[sessionId]();
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }),
+  };
+}
+
+test("mcpSubscribeSession / mcpUnsubscribeSession: idempotent Set add/delete", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.mcpSubscribeSession("s1");
+  hub.mcpSubscribeSession("s1"); // double-subscribe is a no-op
+  assert.deepEqual([...hub.mcpSubscribedSessions], ["s1"]);
+  hub.mcpUnsubscribeSession("s2"); // never subscribed -- harmless no-op
+  assert.deepEqual([...hub.mcpSubscribedSessions], ["s1"]);
+  hub.mcpUnsubscribeSession("s1");
+  assert.equal(hub.mcpSubscribedSessions.size, 0);
+});
+
+test("ChainFirehoseHub.fetch: GET /latest returns the latest broadcast payload, null before any broadcast", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const before = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/latest"),
+  );
+  assert.deepEqual(await before.json(), { payload: null });
+
+  await hub.broadcast({ table: "blocks", block_number: 42 });
+  const after = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/latest"),
+  );
+  assert.deepEqual(await after.json(), {
+    payload: { table: "blocks", block_number: 42 },
+  });
+});
+
+test("ChainFirehoseHub.fetch: POST /mcp-subscribe registers the session", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/mcp-subscribe", {
+      method: "POST",
+      body: JSON.stringify({ sessionId: "s1" }),
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { ok: true });
+  assert.equal(hub.mcpSubscribedSessions.has("s1"), true);
+});
+
+test("ChainFirehoseHub.fetch: POST /mcp-unsubscribe removes the session", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.mcpSubscribeSession("s1");
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/mcp-unsubscribe", {
+      method: "POST",
+      body: JSON.stringify({ sessionId: "s1" }),
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { ok: true });
+  assert.equal(hub.mcpSubscribedSessions.has("s1"), false);
+});
+
+test("broadcast: with no MCP-subscribed sessions, never calls MCP_SESSION_HUB", async () => {
+  const mcpHub = fakeMcpSessionHubBinding();
+  const hub = new ChainFirehoseHub(stubState(), { MCP_SESSION_HUB: mcpHub });
+  await hub.broadcast({ table: "blocks", block_number: 1 });
+  assert.equal(mcpHub.calls.length, 0);
+});
+
+test("broadcast: with a subscribed session but MCP_SESSION_HUB unbound, never throws and skips the loop", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.mcpSubscribeSession("s1");
+  await assert.doesNotReject(() =>
+    hub.broadcast({ table: "blocks", block_number: 1 }),
+  );
+});
+
+test("broadcast: notifies every MCP-subscribed session's McpSessionHub with a pointer-only uri", async () => {
+  const mcpHub = fakeMcpSessionHubBinding();
+  const hub = new ChainFirehoseHub(stubState(), { MCP_SESSION_HUB: mcpHub });
+  hub.mcpSubscribeSession("s1");
+  hub.mcpSubscribeSession("s2");
+  await hub.broadcast({ table: "chain_events", block_number: 7 });
+  assert.equal(mcpHub.calls.length, 2);
+  const sessionIds = mcpHub.calls.map((c) => c.sessionId).sort();
+  assert.deepEqual(sessionIds, ["s1", "s2"]);
+  for (const call of mcpHub.calls) {
+    assert.match(call.url, /\/notify$/);
+    assert.equal(call.init.method, "POST");
+    assert.deepEqual(JSON.parse(call.init.body), {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    });
+  }
+});
+
+test("broadcast: an unreachable/erroring session hub is best-effort -- doesn't throw and doesn't block the other sessions", async () => {
+  const mcpHub = fakeMcpSessionHubBinding({
+    s1: () => {
+      throw new Error("session DO unreachable");
+    },
+  });
+  const hub = new ChainFirehoseHub(stubState(), { MCP_SESSION_HUB: mcpHub });
+  hub.mcpSubscribeSession("s1");
+  hub.mcpSubscribeSession("s2");
+  await assert.doesNotReject(() =>
+    hub.broadcast({ table: "blocks", block_number: 1 }),
+  );
+  const sessionIds = mcpHub.calls.map((c) => c.sessionId).sort();
+  assert.deepEqual(sessionIds, ["s1", "s2"]);
 });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1512,7 +1512,7 @@ describe("graphql — resolver branch coverage", () => {
     assert.ok((await res.json()).errors[0].message.includes("query"));
   });
 
-  test("OPTIONS /mcp advertises POST, OPTIONS (the sibling CORS branch)", async () => {
+  test("OPTIONS /mcp advertises GET, POST, DELETE, OPTIONS (the sibling CORS branch, #4983 MCP half)", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/mcp", { method: "OPTIONS" }),
       emptyEnv,
@@ -1521,7 +1521,7 @@ describe("graphql — resolver branch coverage", () => {
     assert.equal(res.status, 204);
     assert.equal(
       res.headers.get("access-control-allow-methods"),
-      "POST, OPTIONS",
+      "GET, POST, DELETE, OPTIONS",
     );
   });
 

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -16,6 +16,7 @@ import { KV_HEALTH_RPC_POOL } from "../src/health-prober.mjs";
 import { createLocalArtifactEnv, latestArtifactDate } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
+import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.mjs";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
@@ -77,11 +78,11 @@ function makeDeps(artifacts = {}, kv = {}) {
 
 async function rpc(
   payload,
-  { deps = makeDeps(), env = {}, method = "POST" } = {},
+  { deps = makeDeps(), env = {}, method = "POST", headers = {} } = {},
 ) {
   const request = new Request(MCP_URL, {
     method,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: method === "POST" ? JSON.stringify(payload) : undefined,
   });
   const response = await handleMcpRequest(request, env, deps);
@@ -90,6 +91,27 @@ async function rpc(
     status: response.status,
     headers: response.headers,
     body: text ? JSON.parse(text) : null,
+  };
+}
+
+// A crypto.randomUUID()-shaped id, the only kind handleMcpRequest ever mints
+// or accepts back from a client (isValidMcpSessionId's own length/charset
+// bound is far looser, but this is what every real client will send).
+const A_SESSION_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+
+function fakeMcpSessionHubBinding(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    idFromName: (name) => name,
+    get: () => ({
+      fetch: async (url, init) => {
+        calls.push({ url, init });
+        const path = new URL(url).pathname;
+        if (overrides[path]) return overrides[path](init);
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }),
   };
 }
 
@@ -257,7 +279,9 @@ describe("MCP JSON-RPC lifecycle", () => {
     });
     assert.deepEqual(res.body.result.capabilities, {
       tools: { listChanged: false },
-      resources: { listChanged: false },
+      // subscribe: true (#4983 MCP half) -- metagraph://chain/stream is
+      // subscribable; see resources/subscribe's own tests below.
+      resources: { subscribe: true, listChanged: false },
       prompts: { listChanged: false },
     });
   });
@@ -417,6 +441,240 @@ describe("MCP resources (#742)", () => {
       });
       assert.equal(res.body.error.code, -32602, `expected -32602 for ${uri}`);
     }
+  });
+});
+
+describe("MCP resources/subscribe + resources/unsubscribe (#4983 MCP half)", () => {
+  test("resources/read on the live chain-stream resource degrades gracefully when CHAIN_FIREHOSE_HUB is unbound", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/read",
+      params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+    });
+    const data = JSON.parse(res.body.result.contents[0].text);
+    assert.equal(data.table, null);
+    assert.match(data.message, /not bound/);
+  });
+
+  test("resources/read on the live chain-stream resource returns ChainFirehoseHub's latest payload", async () => {
+    const firehose = {
+      idFromName: (name) => name,
+      get: () => ({
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              payload: { table: "chain_events", block_number: 8608447 },
+            }),
+            { status: 200 },
+          ),
+      }),
+    };
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/read",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      { env: { CHAIN_FIREHOSE_HUB: firehose } },
+    );
+    assert.deepEqual(JSON.parse(res.body.result.contents[0].text), {
+      table: "chain_events",
+      block_number: 8608447,
+    });
+  });
+
+  test("resources/read on the live chain-stream resource reports 'no event observed yet' when the hub is cold", async () => {
+    const firehose = {
+      idFromName: (name) => name,
+      get: () => ({
+        fetch: async () =>
+          new Response(JSON.stringify({ payload: null }), { status: 200 }),
+      }),
+    };
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/read",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      { env: { CHAIN_FIREHOSE_HUB: firehose } },
+    );
+    const data = JSON.parse(res.body.result.contents[0].text);
+    assert.equal(data.table, null);
+    assert.match(data.message, /no chain event observed yet/);
+  });
+
+  test("resources/subscribe rejects an unknown/non-subscribable uri with -32602", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/subscribe",
+      params: { uri: "metagraph://registry/summary" },
+    });
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /not subscribable/);
+  });
+
+  test("resources/subscribe requires an Mcp-Session-Id header", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/subscribe",
+      params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+    });
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /Mcp-Session-Id/);
+  });
+
+  test("resources/subscribe reports resource_unavailable when MCP_SESSION_HUB is unbound", async () => {
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/subscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      { headers: { "mcp-session-id": A_SESSION_ID } },
+    );
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /not provisioned/);
+  });
+
+  test("resources/subscribe forwards to the session hub's /subscribe route and succeeds", async () => {
+    const hub = fakeMcpSessionHubBinding();
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/subscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.deepEqual(res.body.result, {});
+    assert.equal(hub.calls.length, 1);
+    assert.match(hub.calls[0].url, /\/subscribe$/);
+    assert.deepEqual(JSON.parse(hub.calls[0].init.body), {
+      sessionId: A_SESSION_ID,
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    });
+  });
+
+  test("resources/subscribe surfaces a clear error when the session hub rejects the request", async () => {
+    const hub = fakeMcpSessionHubBinding({
+      "/subscribe": () => new Response(null, { status: 400 }),
+    });
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/subscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /Could not subscribe/);
+  });
+
+  test("resources/unsubscribe requires a uri", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/unsubscribe",
+      params: {},
+    });
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /Missing required field: uri/);
+  });
+
+  test("resources/unsubscribe requires an Mcp-Session-Id header", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/unsubscribe",
+      params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+    });
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /Mcp-Session-Id/);
+  });
+
+  test("resources/unsubscribe reports resource_unavailable when MCP_SESSION_HUB is unbound", async () => {
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/unsubscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      { headers: { "mcp-session-id": A_SESSION_ID } },
+    );
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /not provisioned/);
+  });
+
+  test("resources/subscribe as a notification (no id) is a no-op — never calls the session hub, returns 202", async () => {
+    const hub = fakeMcpSessionHubBinding();
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        method: "resources/subscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.equal(res.status, 202);
+    assert.equal(res.body, null);
+    assert.equal(hub.calls.length, 0);
+  });
+
+  test("resources/unsubscribe as a notification (no id) is a no-op — never calls the session hub, returns 202", async () => {
+    const hub = fakeMcpSessionHubBinding();
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        method: "resources/unsubscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.equal(res.status, 202);
+    assert.equal(res.body, null);
+    assert.equal(hub.calls.length, 0);
+  });
+
+  test("resources/unsubscribe forwards to the session hub's /unsubscribe route and succeeds, even for a uri never subscribed to", async () => {
+    const hub = fakeMcpSessionHubBinding();
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/unsubscribe",
+        params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.deepEqual(res.body.result, {});
+    assert.equal(hub.calls.length, 1);
+    assert.match(hub.calls[0].url, /\/unsubscribe$/);
   });
 });
 
@@ -622,10 +880,10 @@ describe("MCP resources/prompts — branch coverage", () => {
 });
 
 describe("MCP transport handling", () => {
-  test("GET is rejected with 405 and an Allow header", async () => {
-    const res = await rpc(null, { method: "GET" });
+  test("an unsupported method (e.g. PUT) is rejected with 405 and an Allow header listing GET/POST/DELETE", async () => {
+    const res = await rpc(null, { method: "PUT" });
     assert.equal(res.status, 405);
-    assert.equal(res.headers.get("allow"), "POST, OPTIONS");
+    assert.equal(res.headers.get("allow"), "GET, POST, DELETE, OPTIONS");
     assert.equal(res.body.error.code, -32600);
   });
 
@@ -768,6 +1026,200 @@ describe("MCP transport handling", () => {
     });
     const response = await handleMcpRequest(request, {});
     assert.equal(response.status, 200);
+  });
+
+  describe("MCP-Protocol-Version header (#4983 MCP half)", () => {
+    test("an absent header is accepted (assumed 2025-03-26 per spec, not rejected)", async () => {
+      const res = await rpc({ jsonrpc: "2.0", id: 1, method: "ping" });
+      assert.equal(res.status, 200);
+    });
+
+    test("a recognized header value is accepted", async () => {
+      const res = await rpc(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { headers: { "mcp-protocol-version": MCP_PROTOCOL_VERSIONS[0] } },
+      );
+      assert.equal(res.status, 200);
+    });
+
+    test("an unrecognized header value is rejected with 400", async () => {
+      const res = await rpc(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { headers: { "mcp-protocol-version": "1999-01-01" } },
+      );
+      assert.equal(res.status, 400);
+      assert.equal(res.body.error.code, -32600);
+      assert.match(res.body.error.message, /Unsupported MCP-Protocol-Version/);
+    });
+  });
+
+  describe("Mcp-Session-Id minting on initialize (#4983 MCP half)", () => {
+    test("a successful initialize response mints a fresh Mcp-Session-Id response header", async () => {
+      const res = await rpc({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: MCP_PROTOCOL_VERSIONS[0] },
+      });
+      assert.equal(res.status, 200);
+      const sessionId = res.headers.get("mcp-session-id");
+      assert.match(
+        sessionId,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    test("two separate initialize calls mint two DIFFERENT session ids", async () => {
+      const first = await rpc({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      });
+      const second = await rpc({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      });
+      assert.notEqual(
+        first.headers.get("mcp-session-id"),
+        second.headers.get("mcp-session-id"),
+      );
+    });
+
+    test("a non-initialize method never mints a session id", async () => {
+      const res = await rpc({ jsonrpc: "2.0", id: 1, method: "ping" });
+      assert.equal(res.headers.get("mcp-session-id"), null);
+    });
+
+    test("initialize inside a batch never mints a session id (legacy-array path predates sessions)", async () => {
+      const res = await rpc([
+        { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      ]);
+      assert.equal(res.headers.get("mcp-session-id"), null);
+    });
+  });
+
+  describe("GET /mcp — the SSE push stream (#4983 MCP half)", () => {
+    test("without an Mcp-Session-Id header, rejects with 400", async () => {
+      const res = await rpc(null, { method: "GET" });
+      assert.equal(res.status, 400);
+      assert.equal(res.body.error.code, -32600);
+      assert.match(res.body.error.message, /Mcp-Session-Id/);
+    });
+
+    test("with a malformed Mcp-Session-Id header, rejects with 400", async () => {
+      const res = await rpc(null, {
+        method: "GET",
+        headers: { "mcp-session-id": "has a space" },
+      });
+      assert.equal(res.status, 400);
+    });
+
+    test("with an unrecognized MCP-Protocol-Version header, rejects with 400 before checking the session", async () => {
+      const res = await rpc(null, {
+        method: "GET",
+        headers: { "mcp-protocol-version": "1999-01-01" },
+      });
+      assert.equal(res.status, 400);
+      assert.match(res.body.error.message, /Unsupported MCP-Protocol-Version/);
+    });
+
+    test("with a valid session id but MCP_SESSION_HUB unbound, degrades to 405", async () => {
+      const res = await rpc(null, {
+        method: "GET",
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: {},
+      });
+      assert.equal(res.status, 405);
+      assert.equal(res.headers.get("allow"), "POST, OPTIONS");
+    });
+
+    test("with MCP_SESSION_HUB bound, forwards to the session's /stream route and streams the response through", async () => {
+      const hub = fakeMcpSessionHubBinding();
+      const request = new Request(MCP_URL, {
+        method: "GET",
+        headers: { "mcp-session-id": A_SESSION_ID },
+      });
+      const response = await handleMcpRequest(request, {
+        MCP_SESSION_HUB: hub,
+      });
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("content-type"), "text/event-stream");
+      assert.equal(hub.calls.length, 1);
+      assert.match(hub.calls[0].url, /\/stream\?sessionId=/);
+      assert.match(
+        hub.calls[0].url,
+        new RegExp(encodeURIComponent(A_SESSION_ID)),
+      );
+    });
+
+    test("a 409 from the session hub (a stream is already open) passes through as 409", async () => {
+      const hub = fakeMcpSessionHubBinding({
+        "/stream": () => new Response(null, { status: 409 }),
+      });
+      const request = new Request(MCP_URL, {
+        method: "GET",
+        headers: { "mcp-session-id": A_SESSION_ID },
+      });
+      const response = await handleMcpRequest(request, {
+        MCP_SESSION_HUB: hub,
+      });
+      assert.equal(response.status, 409);
+      const body = await response.json();
+      assert.match(body.error.message, /already open/);
+    });
+
+    test("a 404 from the session hub (unknown/terminated session) passes through as 404", async () => {
+      const hub = fakeMcpSessionHubBinding({
+        "/stream": () => new Response(null, { status: 404 }),
+      });
+      const request = new Request(MCP_URL, {
+        method: "GET",
+        headers: { "mcp-session-id": A_SESSION_ID },
+      });
+      const response = await handleMcpRequest(request, {
+        MCP_SESSION_HUB: hub,
+      });
+      assert.equal(response.status, 404);
+      const body = await response.json();
+      assert.match(body.error.message, /No such MCP session/);
+    });
+  });
+
+  describe("DELETE /mcp — explicit session termination (#4983 MCP half)", () => {
+    test("without an Mcp-Session-Id header, rejects with 400", async () => {
+      const res = await rpc(null, { method: "DELETE" });
+      assert.equal(res.status, 400);
+      assert.match(res.body.error.message, /Mcp-Session-Id/);
+    });
+
+    test("with a valid session id but MCP_SESSION_HUB unbound, degrades to 405", async () => {
+      const res = await rpc(null, {
+        method: "DELETE",
+        headers: { "mcp-session-id": A_SESSION_ID },
+      });
+      assert.equal(res.status, 405);
+    });
+
+    test("with MCP_SESSION_HUB bound, forwards to the session's /terminate route and returns 204", async () => {
+      const hub = fakeMcpSessionHubBinding();
+      const request = new Request(MCP_URL, {
+        method: "DELETE",
+        headers: { "mcp-session-id": A_SESSION_ID },
+      });
+      const response = await handleMcpRequest(request, {
+        MCP_SESSION_HUB: hub,
+      });
+      assert.equal(response.status, 204);
+      assert.equal(hub.calls.length, 1);
+      assert.match(hub.calls[0].url, /\/terminate$/);
+      assert.equal(hub.calls[0].init.method, "POST");
+      assert.deepEqual(JSON.parse(hub.calls[0].init.body), {
+        sessionId: A_SESSION_ID,
+      });
+    });
   });
 });
 

--- a/tests/mcp-session-hub.test.mjs
+++ b/tests/mcp-session-hub.test.mjs
@@ -1,0 +1,596 @@
+// Unit tests for workers/mcp-session-hub.mjs (#4983 MCP half, ADR 0015).
+//
+// Unlike chain-firehose-hub.mjs, almost the ENTIRE class here is plain-Node-
+// testable: state.storage is a simple async get/put/setAlarm KV API (easy to
+// stub with a real Map), and ReadableStream/TextEncoder are real Web Streams
+// APIs under Node/vitest -- nothing in this file needs WebSocketPair, so
+// there is no v8-ignored branch to account for.
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import {
+  MCP_CHAIN_STREAM_RESOURCE_URI,
+  MCP_SESSION_ID_MAX_LENGTH,
+  MCP_SESSION_IDLE_TTL_MS,
+  MCP_SESSION_MAX_STREAM_DURATION_MS,
+  McpSessionHub,
+  buildResourceUpdatedNotification,
+  formatMcpSseEvent,
+  isValidMcpSessionId,
+} from "../workers/mcp-session-hub.mjs";
+
+// --- isValidMcpSessionId ---------------------------------------------------------
+
+test("isValidMcpSessionId: accepts a real crypto.randomUUID()-shaped id", () => {
+  assert.equal(
+    isValidMcpSessionId("3fa85f64-5717-4562-b3fc-2c963f66afa6"),
+    true,
+  );
+});
+
+test("isValidMcpSessionId: rejects non-strings", () => {
+  assert.equal(isValidMcpSessionId(undefined), false);
+  assert.equal(isValidMcpSessionId(null), false);
+  assert.equal(isValidMcpSessionId(42), false);
+});
+
+test("isValidMcpSessionId: rejects an empty string", () => {
+  assert.equal(isValidMcpSessionId(""), false);
+});
+
+test("isValidMcpSessionId: rejects a string longer than MCP_SESSION_ID_MAX_LENGTH", () => {
+  assert.equal(
+    isValidMcpSessionId("a".repeat(MCP_SESSION_ID_MAX_LENGTH)),
+    true,
+  );
+  assert.equal(
+    isValidMcpSessionId("a".repeat(MCP_SESSION_ID_MAX_LENGTH + 1)),
+    false,
+  );
+});
+
+test("isValidMcpSessionId: rejects characters outside visible ASCII 0x21-0x7E", () => {
+  assert.equal(isValidMcpSessionId("has space"), false);
+  assert.equal(isValidMcpSessionId("has\ttab"), false);
+  assert.equal(isValidMcpSessionId("has\nnewline"), false);
+  assert.equal(isValidMcpSessionId("emoji😀"), false);
+});
+
+// --- buildResourceUpdatedNotification / formatMcpSseEvent -----------------------
+
+test("buildResourceUpdatedNotification: matches the MCP spec's exact shape (uri only, no other params)", () => {
+  assert.deepEqual(
+    buildResourceUpdatedNotification(MCP_CHAIN_STREAM_RESOURCE_URI),
+    {
+      jsonrpc: "2.0",
+      method: "notifications/resources/updated",
+      params: { uri: MCP_CHAIN_STREAM_RESOURCE_URI },
+    },
+  );
+});
+
+test("formatMcpSseEvent: frames a notification with an id: line and a data: line", () => {
+  const notification = buildResourceUpdatedNotification(
+    "metagraph://chain/stream",
+  );
+  assert.equal(
+    formatMcpSseEvent(1, notification),
+    `id: 1\ndata: ${JSON.stringify(notification)}\n\n`,
+  );
+});
+
+// --- test helpers ----------------------------------------------------------------
+
+function createStubStorage(initial = {}) {
+  const data = new Map(Object.entries(initial));
+  let alarmTime = null;
+  return {
+    async get(keys) {
+      const result = new Map();
+      for (const key of keys) {
+        if (data.has(key)) result.set(key, data.get(key));
+      }
+      return result;
+    },
+    async put(entries) {
+      for (const [key, value] of Object.entries(entries)) {
+        data.set(key, value);
+      }
+    },
+    async setAlarm(time) {
+      alarmTime = time;
+    },
+    get lastAlarmTime() {
+      return alarmTime;
+    },
+    get raw() {
+      return data;
+    },
+  };
+}
+
+function stubState(initial) {
+  return { storage: createStubStorage(initial) };
+}
+
+function fakeChainFirehoseHubBinding() {
+  const calls = [];
+  return {
+    calls,
+    idFromName: (name) => name,
+    get: () => ({
+      fetch: async (url, init) => {
+        calls.push({
+          url,
+          body: init?.body ? JSON.parse(init.body) : null,
+        });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }),
+  };
+}
+
+function jsonRequest(url, body) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// --- handleSubscribe / handleUnsubscribe -----------------------------------------
+
+test("handleSubscribe: a valid uri subscribes, persists, and notifies ChainFirehoseHub", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI), true);
+  assert.equal(hub.sessionId, "session-1");
+  assert.equal(firehose.calls.length, 1);
+  assert.match(firehose.calls[0].url, /\/mcp-subscribe$/);
+  assert.deepEqual(firehose.calls[0].body, { sessionId: "session-1" });
+});
+
+test("handleSubscribe: rejects a non-subscribable uri with 400, without touching state or notifying", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://registry/summary",
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(hub.subscribedUris.size, 0);
+  assert.equal(firehose.calls.length, 0);
+});
+
+test("handleSubscribe: works even when CHAIN_FIREHOSE_HUB isn't bound (local/CI)", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI), true);
+});
+
+test("handleUnsubscribe: removes the uri and notifies ChainFirehoseHub once the set becomes empty", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  firehose.calls.length = 0; // discard the subscribe notification
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/unsubscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.subscribedUris.size, 0);
+  assert.equal(firehose.calls.length, 1);
+  assert.match(firehose.calls[0].url, /\/mcp-unsubscribe$/);
+});
+
+test("handleUnsubscribe: works even when CHAIN_FIREHOSE_HUB isn't bound (local/CI)", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/unsubscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.subscribedUris.size, 0);
+});
+
+test("handleUnsubscribe: unsubscribing something never subscribed to is a harmless no-op (no notify, since the set was already empty)", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/unsubscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(res.status, 200);
+  // subscribedUris was already empty -> "becomes empty" fires the notify
+  // exactly once (size === 0 both before and after is still `=== 0`).
+  assert.equal(firehose.calls.length, 1);
+});
+
+// --- handleNotify / deliverNow ----------------------------------------------------
+
+test("handleNotify: a notification for a URI this session never subscribed to is a no-op (delivered:false)", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.deepEqual(await res.json(), { ok: true, delivered: false });
+});
+
+test("handleNotify: with no open stream, coalesces into pendingUris rather than delivering immediately", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.deepEqual(await res.json(), { ok: true, delivered: true });
+  assert.equal(hub.pendingUris.has(MCP_CHAIN_STREAM_RESOURCE_URI), true);
+});
+
+test("handleNotify: a burst of notifications before any stream opens coalesces to ONE pending marker, not a growing queue", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  for (let i = 0; i < 5; i += 1) {
+    await hub.fetch(
+      jsonRequest("https://mcp-session-hub.internal/notify", {
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
+  }
+  assert.equal(hub.pendingUris.size, 1);
+});
+
+test("deliverNow: enqueues a framed SSE event, increments sequence, and clears the pending flag on success", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  const enqueued = [];
+  hub.streamController = { enqueue: (chunk) => enqueued.push(chunk) };
+  hub.pendingUris.add(MCP_CHAIN_STREAM_RESOURCE_URI);
+  hub.deliverNow(MCP_CHAIN_STREAM_RESOURCE_URI);
+  assert.equal(hub.sequence, 1);
+  assert.equal(hub.pendingUris.has(MCP_CHAIN_STREAM_RESOURCE_URI), false);
+  const text = new TextDecoder().decode(enqueued[0]);
+  assert.match(text, /^id: 1\ndata: /);
+  assert.match(text, /notifications\/resources\/updated/);
+});
+
+test("deliverNow: an enqueue failure (stream already closed/errored) nulls streamController and leaves the uri pending for the next open", () => {
+  const hub = new McpSessionHub(stubState(), {});
+  hub.streamController = {
+    enqueue: () => {
+      throw new Error("stream closed");
+    },
+  };
+  hub.pendingUris.add(MCP_CHAIN_STREAM_RESOURCE_URI);
+  hub.deliverNow(MCP_CHAIN_STREAM_RESOURCE_URI);
+  assert.equal(hub.streamController, null);
+  assert.equal(hub.pendingUris.has(MCP_CHAIN_STREAM_RESOURCE_URI), true);
+});
+
+// --- handleStream ------------------------------------------------------------------
+
+test("handleStream: opens an SSE stream, flushing any pending notification immediately", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(hub.pendingUris.size, 1);
+  const res = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "text/event-stream");
+  const reader = res.body.getReader();
+  const { value } = await reader.read();
+  const text = new TextDecoder().decode(value);
+  assert.match(text, /notifications\/resources\/updated/);
+  assert.equal(hub.pendingUris.size, 0);
+  await reader.cancel();
+});
+
+test("handleStream: opens fine with no sessionId query param (already known from an earlier /subscribe call)", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  const res = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream"),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.sessionId, "session-1"); // unchanged, not overwritten with null
+  await res.body.cancel();
+});
+
+test("handleStream: a second concurrent stream request for the same session is rejected with 409", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  const first = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  assert.equal(first.status, 200);
+  const second = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  assert.equal(second.status, 409);
+  await first.body.cancel();
+});
+
+test("handleNotify: with a stream already open, delivers immediately (deliverNow) instead of coalescing into pendingUris", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  const streamRes = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  const reader = streamRes.body.getReader();
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(hub.pendingUris.size, 0);
+  assert.equal(hub.sequence, 1);
+  const { value } = await reader.read();
+  assert.match(
+    new TextDecoder().decode(value),
+    /notifications\/resources\/updated/,
+  );
+  await reader.cancel();
+});
+
+test("handleStream: cancelling the stream clears streamController, allowing a new stream to open", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  const first = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  await first.body.cancel();
+  assert.equal(hub.streamController, null);
+  const second = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  assert.equal(second.status, 200);
+  await second.body.cancel();
+});
+
+test("handleStream: auto-closes after MCP_SESSION_MAX_STREAM_DURATION_MS, per the spec's 'servers may disconnect SSE streams at will' allowance", async () => {
+  vi.useFakeTimers();
+  try {
+    const hub = new McpSessionHub(stubState(), {});
+    const res = await hub.fetch(
+      new Request(
+        "https://mcp-session-hub.internal/stream?sessionId=session-1",
+      ),
+    );
+    const reader = res.body.getReader();
+    assert.notEqual(hub.streamController, null);
+    vi.advanceTimersByTime(MCP_SESSION_MAX_STREAM_DURATION_MS);
+    // Let the microtask queue (the setTimeout callback + controller.close())
+    // flush before asserting -- fake timers fire synchronously but the
+    // ReadableStream's close() resolution is still a microtask.
+    await vi.runAllTimersAsync();
+    assert.equal(hub.streamController, null);
+    assert.equal(hub.streamCloseTimer, null);
+    const { done } = await reader.read();
+    assert.equal(done, true);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+// --- handleTerminate / alarm --------------------------------------------------------
+
+test("handleTerminate: unsubscribes from ChainFirehoseHub (using the request body's sessionId), closes any open stream, and clears state", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  const streamRes = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  firehose.calls.length = 0;
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.terminated, true);
+  assert.equal(hub.subscribedUris.size, 0);
+  assert.equal(hub.streamController, null);
+  assert.equal(firehose.calls.length, 1);
+  assert.match(firehose.calls[0].url, /\/mcp-unsubscribe$/);
+  await streamRes.body.cancel().catch(() => {}); // already closed by terminate
+});
+
+test("handleTerminate: calling it twice is idempotent (second call doesn't re-notify)", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  firehose.calls.length = 0;
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(firehose.calls.length, 1);
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(firehose.calls.length, 1); // unchanged -- no second notify
+});
+
+test("handleTerminate: calling the method directly a second time (bypassing fetch()'s own terminated-gate, as alarm() does) is still a no-op", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.handleTerminate(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(hub.terminated, true);
+  const res = await hub.handleTerminate(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(firehose.calls.length, 0); // no subscriptions -> never called
+});
+
+test("handleTerminate: with no subscriptions, never calls ChainFirehoseHub at all", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(firehose.calls.length, 0);
+});
+
+test("fetch: any route other than /notify 404s once the session is terminated", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  const subscribeRes = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(subscribeRes.status, 404);
+  const streamRes = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
+  );
+  assert.equal(streamRes.status, 404);
+});
+
+test("fetch: /notify still resolves (as a no-op) even for a terminated session -- a race with ChainFirehoseHub forgetting it, not an error", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  assert.equal(res.status, 200);
+});
+
+test("fetch: an unrecognized path 404s", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  const res = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/nope"),
+  );
+  assert.equal(res.status, 404);
+});
+
+test("alarm: self-terminates using the persisted sessionId (no caller to hand it one)", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const state = stubState();
+  const hub = new McpSessionHub(state, { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  firehose.calls.length = 0;
+
+  // Simulate a fresh DO instance waking to run the alarm -- hydrate() has to
+  // recover sessionId from storage, not from a live `this.sessionId`.
+  const revivedHub = new McpSessionHub(state, { CHAIN_FIREHOSE_HUB: firehose });
+  await revivedHub.alarm();
+  assert.equal(revivedHub.terminated, true);
+  assert.equal(firehose.calls.length, 1);
+  assert.deepEqual(firehose.calls[0].body, { sessionId: "session-1" });
+});
+
+test("touch: sets a Durable Object alarm MCP_SESSION_IDLE_TTL_MS in the future", async () => {
+  const state = stubState();
+  const hub = new McpSessionHub(state, {});
+  const before = Date.now();
+  await hub.touch();
+  const alarmTime = state.storage.lastAlarmTime;
+  assert.ok(alarmTime >= before + MCP_SESSION_IDLE_TTL_MS);
+  assert.ok(alarmTime <= Date.now() + MCP_SESSION_IDLE_TTL_MS + 1000);
+});
+
+test("MCP_SESSION_MAX_STREAM_DURATION_MS and MCP_SESSION_IDLE_TTL_MS are the documented magnitudes (minutes, not ms/hours by mistake)", () => {
+  assert.equal(MCP_SESSION_MAX_STREAM_DURATION_MS, 5 * 60 * 1000);
+  assert.equal(MCP_SESSION_IDLE_TTL_MS, 30 * 60 * 1000);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -259,6 +259,7 @@ import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   ChainFirehoseHub,
 } from "./chain-firehose-hub.mjs";
+import { McpSessionHub } from "./mcp-session-hub.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
@@ -433,9 +434,10 @@ export default {
 
 // Durable Object classes must be named exports of this Worker's main entry
 // module (wrangler.jsonc's "main": "workers/api.mjs") -- re-exporting the
-// class defined in chain-firehose-hub.mjs is what makes the
-// "durable_objects"/"migrations" bindings in wrangler.jsonc resolvable.
-export { ChainFirehoseHub };
+// classes defined in chain-firehose-hub.mjs/mcp-session-hub.mjs is what
+// makes the "durable_objects"/"migrations" bindings in wrangler.jsonc
+// resolvable.
+export { ChainFirehoseHub, McpSessionHub };
 
 // The staged-artifact loaders now live in request-handlers/staging.mjs (#1763).
 // Re-export it so the scheduled cron drain (handleScheduled) and the staging
@@ -1011,9 +1013,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     return handleWebhookRequest(request, env, url);
   }
 
-  // Remote MCP server (stateless JSON-RPC over POST), for AI agents. Runs before
-  // the read-only method gate (it is POST-only) like the RPC proxy. Artifact/KV
-  // readers are injected so the MCP tools reuse the exact R2/ASSETS resolution.
+  // Remote MCP server, for AI agents: stateless JSON-RPC over POST, plus GET
+  // (the SSE resource-subscription push stream, #4983) and DELETE (explicit
+  // session termination) -- all three handled inside handleMcpRequest itself.
+  // Runs before the read-only method gate (POST/DELETE would otherwise be
+  // rejected there) like the RPC proxy. Artifact/KV readers are injected so
+  // the MCP tools reuse the exact R2/ASSETS resolution.
   if (url.pathname === "/mcp") {
     return handleMcpRequest(request, env, { readArtifact, readHealthKv });
   }
@@ -4264,13 +4269,18 @@ function corsPreflight(request) {
   } else if (url.pathname === "/api/v1/graphql") {
     // POST executes queries; GET serves the published SDL document.
     methods = "GET, POST, OPTIONS";
-  } else if (url.pathname === "/mcp" || url.pathname === "/api/v1/ask") {
+  } else if (url.pathname === "/mcp") {
+    // GET opens the bounded SSE push stream (#4983 MCP half); DELETE
+    // terminates a session explicitly; POST is the stateless JSON-RPC path.
+    methods = "GET, POST, DELETE, OPTIONS";
+  } else if (url.pathname === "/api/v1/ask") {
     methods = "POST, OPTIONS";
   }
   headers.set("access-control-allow-methods", methods);
   headers.set(
     "access-control-allow-headers",
-    `content-type, if-none-match, ${WEBHOOK_SECRET_HEADER}, ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}`,
+    `content-type, if-none-match, mcp-session-id, mcp-protocol-version, ` +
+      `${WEBHOOK_SECRET_HEADER}, ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}`,
   );
   headers.set("access-control-max-age", "86400");
   return new Response(null, { status: 204, headers });

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -47,6 +47,7 @@ import {
   maxDepthRule,
   schema as chainEventsGraphqlSchema,
 } from "../src/graphql.mjs";
+import { MCP_CHAIN_STREAM_RESOURCE_URI } from "./mcp-session-hub.mjs";
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 
@@ -308,6 +309,16 @@ export class ChainFirehoseHub {
     // class's own webSocketMessage/webSocketClose, not socket-level listeners.
     this.chainEventSubscribers = new Set();
     this.graphqlWsSockets = new WeakMap();
+    // #4983 MCP half: the most recent broadcast payload, for the
+    // metagraph://chain/stream MCP resource's resources/read (a pointer/
+    // notification-only protocol -- the client always re-reads current state
+    // rather than the notification carrying it, see notifyMcpSessions).
+    // mcpSubscribedSessions holds the STRING session ids interested in that
+    // one resource (not connection objects -- MCP sessions are
+    // McpSessionHub, a SEPARATE Durable Object per session id, reached by
+    // name, not a live handle this class holds onto).
+    this.latestPayload = null;
+    this.mcpSubscribedSessions = new Set();
     this.graphqlWsServer = makeServer({
       schema: chainEventsGraphqlSchema,
       execute,
@@ -353,6 +364,18 @@ export class ChainFirehoseHub {
     }
   }
 
+  // Called by McpSessionHub (via its own /subscribe route) when a session
+  // subscribes to metagraph://chain/stream, and on unsubscribe/termination.
+  // Idempotent either way (Set semantics) -- a session double-subscribing or
+  // unsubscribing something it never subscribed to is a harmless no-op.
+  mcpSubscribeSession(sessionId) {
+    this.mcpSubscribedSessions.add(sessionId);
+  }
+
+  mcpUnsubscribeSession(sessionId) {
+    this.mcpSubscribedSessions.delete(sessionId);
+  }
+
   async fetch(request) {
     const url = new URL(request.url);
     if (url.pathname === "/ingest" && request.method === "POST") {
@@ -360,6 +383,28 @@ export class ChainFirehoseHub {
     }
     if (url.pathname === "/subscribe") {
       return this.handleSubscribe(request, url);
+    }
+    if (url.pathname === "/latest") {
+      return new Response(JSON.stringify({ payload: this.latestPayload }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/mcp-subscribe" && request.method === "POST") {
+      const { sessionId } = await request.json();
+      this.mcpSubscribeSession(sessionId);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/mcp-unsubscribe" && request.method === "POST") {
+      const { sessionId } = await request.json();
+      this.mcpUnsubscribeSession(sessionId);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     return new Response("not found", { status: 404 });
   }
@@ -373,7 +418,7 @@ export class ChainFirehoseHub {
         headers: { "content-type": "application/json" },
       });
     }
-    this.broadcast(result.payload);
+    await this.broadcast(result.payload);
     return new Response(JSON.stringify({ ok: true }), {
       status: 202,
       headers: { "content-type": "application/json" },
@@ -547,7 +592,8 @@ export class ChainFirehoseHub {
     }
   }
 
-  broadcast(payload) {
+  async broadcast(payload) {
+    this.latestPayload = payload;
     const encoder = new TextEncoder();
     for (const entry of this.sseClients) {
       if (!chainFirehoseMatchesTopics(payload, entry.topics)) continue;
@@ -623,6 +669,34 @@ export class ChainFirehoseHub {
     for (const entry of this.chainEventSubscribers) {
       if (!chainFirehoseMatchesTopics(payload, entry.topics)) continue;
       entry.repeater.push(payload);
+    }
+
+    // #4983 MCP half: every MCP session subscribed to metagraph://chain/stream
+    // gets a pointer notification (not the payload itself -- the MCP spec's
+    // notifications/resources/updated carries only a uri; the client is
+    // expected to follow up with resources/read, which reads this.latestPayload
+    // above). One fetch per subscribed session, awaited inline like the three
+    // loops above -- handleIngest returns 202 regardless, so this is a bounded
+    // latency cost, not a correctness dependency. A session DO that's
+    // unreachable/erroring here doesn't fail the ingest; see the try/catch.
+    if (this.mcpSubscribedSessions.size > 0 && this.env.MCP_SESSION_HUB) {
+      await Promise.all(
+        [...this.mcpSubscribedSessions].map(async (sessionId) => {
+          try {
+            const stub = this.env.MCP_SESSION_HUB.get(
+              this.env.MCP_SESSION_HUB.idFromName(sessionId),
+            );
+            await stub.fetch("https://mcp-session-hub.internal/notify", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ uri: MCP_CHAIN_STREAM_RESOURCE_URI }),
+            });
+          } catch {
+            // best-effort -- a dead/unreachable session DO never blocks
+            // ingest or the other broadcast populations above
+          }
+        }),
+      );
     }
   }
 }

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -35,6 +35,10 @@ const EXPOSED_RESPONSE_HEADERS = [
   "x-metagraph-rpc-endpoint-id",
   "x-metagraph-rpc-provider",
   "x-metagraph-rpc-attempts",
+  // MCP resource-subscription session id (#4983 MCP half) -- minted on
+  // initialize, must be readable by a browser-based MCP client to send back
+  // on subsequent requests.
+  "mcp-session-id",
 ];
 
 // Pre-joined value, for builders that emit plain header objects (the MCP server).

--- a/workers/mcp-session-hub.mjs
+++ b/workers/mcp-session-hub.mjs
@@ -1,0 +1,386 @@
+// McpSessionHub -- per-session state for MCP resource subscriptions (#4983
+// MCP half, ADR 0015, docs/realtime-firehose.md). One instance per
+// Mcp-Session-Id (idFromName(sessionId)), minted at `initialize` by
+// src/mcp-server.mjs and reached only from there -- never internet-
+// addressable on its own, same invariant as ChainFirehoseHub.
+//
+// Deliberately a SEPARATE Durable Object from ChainFirehoseHub, not a fourth
+// connection population on that class. ChainFirehoseHub's existing
+// populations (sseClients, plain WS, graphql-ws sockets) are each keyed by a
+// live connection object the class already holds a handle to, and self-clean
+// off that object's own close/error callback. MCP's resources/subscribe
+// arrives on a POST that dispatches and returns in one shot, while the push
+// channel is a SEPARATE, string-correlated (Mcp-Session-Id), reconnect-
+// tolerant GET that can open before, after, or independently of the
+// subscribe call, and resumes via Last-Event-ID after a full disconnect --
+// a different lifecycle primitive than "fan out to whoever's holding a
+// socket right now". ChainFirehoseHub stays the single source of truth for
+// "an event happened" (see its mcpSubscribeSession/mcpUnsubscribeSession/
+// the broadcast() loop that pings this class's /notify route) -- this class
+// only owns session lifecycle and the one open SSE stream a session may have.
+//
+// SSE, not WebSocket: MCP's ratified transport (2025-06-18 spec) is
+// Streamable HTTP (POST + optional SSE-over-GET); there is no ratified
+// WebSocket transport (as of this writing an in-review SEP, not shipped in
+// any client library this server needs to serve). Reusing this repo's own
+// WS pattern here -- unlike the GraphQL half of #4983, where graphql-ws IS
+// the first-class ratified transport -- would silently break every real MCP
+// client. The underlying DO-hosted-connection mechanics are the same either
+// way; only spec conformance decided this.
+//
+// Bounded stream duration, not indefinite hold: unlike WebSocket, an
+// SSE-holding Durable Object has no hibernation exemption (hibernation is a
+// WebSocket-only billing mechanism) -- it stays fully resident for the life
+// of the stream. The MCP spec's 2025-11-25 revision (this server's declared
+// latest-supported version, see MCP_PROTOCOL_VERSIONS in src/mcp-server.mjs)
+// explicitly added "support polling SSE streams by allowing servers to
+// disconnect at will", so this class closes its stream after
+// MCP_SESSION_MAX_STREAM_DURATION_MS and relies on the client reconnecting
+// (with Last-Event-ID for replay) rather than holding a DO resident/billable
+// indefinitely for a long-lived agent session.
+//
+// Split in two for testability, matching chain-firehose-hub.mjs's own
+// convention: the functions below are pure/unit-tested. The McpSessionHub
+// class is almost ENTIRELY Node-testable too (state.storage is a plain async
+// get/put KV API, ReadableStream is a real Web Streams API in Node) --
+// unlike ChainFirehoseHub, nothing here needs WebSocketPair, so there is no
+// v8-ignored branch in this file.
+
+export const MCP_CHAIN_STREAM_RESOURCE_URI = "metagraph://chain/stream";
+
+// Spec: "MUST be globally unique and cryptographically secure... visible
+// ASCII characters (0x21 to 0x7E)". Length bound is this server's own choice
+// (crypto.randomUUID(), the only minting path, always produces 36 chars) --
+// caps a client-supplied header at a sane bound before it's used as a
+// Durable Object name, so a client can't multiply DO-name cardinality with
+// an arbitrarily large string.
+export const MCP_SESSION_ID_MAX_LENGTH = 128;
+
+export function isValidMcpSessionId(id) {
+  if (typeof id !== "string") return false;
+  if (id.length === 0 || id.length > MCP_SESSION_ID_MAX_LENGTH) return false;
+  return /^[\x21-\x7E]+$/.test(id);
+}
+
+// How long a single GET-opened SSE stream stays open before this class
+// closes it and expects the client to reconnect (see the module header's
+// SSE-billing-residency note). 5 minutes: long enough that a well-behaved
+// client isn't reconnecting constantly, short enough to bound worst-case DO
+// residency for an abandoned/misbehaving one.
+export const MCP_SESSION_MAX_STREAM_DURATION_MS = 5 * 60 * 1000;
+
+// How long a session may sit with no subscribe/stream/touch activity before
+// this class self-terminates it (via a Durable Object alarm). Bounds a
+// session's total lifetime independent of whether any client ever reconnects
+// its SSE stream, per the "dropped connection ≠ implicit unsubscribe, but a
+// server MAY terminate at any time" spec allowance.
+export const MCP_SESSION_IDLE_TTL_MS = 30 * 60 * 1000;
+
+export function buildResourceUpdatedNotification(uri) {
+  return {
+    jsonrpc: "2.0",
+    method: "notifications/resources/updated",
+    params: { uri },
+  };
+}
+
+export function formatMcpSseEvent(sequence, notification) {
+  return `id: ${sequence}\ndata: ${JSON.stringify(notification)}\n\n`;
+}
+
+export class McpSessionHub {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.subscribedUris = new Set();
+    this.pendingUris = new Set();
+    this.sequence = 0;
+    this.terminated = false;
+    this.streamController = null;
+    this.streamCloseTimer = null;
+    this.hydrated = false;
+    // A Durable Object cannot recover the string it was named with
+    // (idFromName is one-way -- there is no idToName) -- every route that
+    // learns this session's id persists it here so alarm() (which has no
+    // caller to hand it one) can still tell ChainFirehoseHub which session
+    // to forget on idle-timeout.
+    this.sessionId = null;
+  }
+
+  async hydrate() {
+    if (this.hydrated) return;
+    const stored = await this.state.storage.get([
+      "sessionId",
+      "subscribedUris",
+      "sequence",
+      "terminated",
+    ]);
+    this.sessionId = stored.get("sessionId") || null;
+    this.subscribedUris = new Set(stored.get("subscribedUris") || []);
+    this.sequence = stored.get("sequence") || 0;
+    this.terminated = stored.get("terminated") || false;
+    this.hydrated = true;
+  }
+
+  async persist() {
+    await this.state.storage.put({
+      sessionId: this.sessionId,
+      subscribedUris: [...this.subscribedUris],
+      sequence: this.sequence,
+      terminated: this.terminated,
+    });
+  }
+
+  async touch() {
+    await this.state.storage.setAlarm(Date.now() + MCP_SESSION_IDLE_TTL_MS);
+  }
+
+  async fetch(request) {
+    await this.hydrate();
+    const url = new URL(request.url);
+
+    if (this.terminated && url.pathname !== "/notify") {
+      // A notification for an already-terminated session is a harmless,
+      // silently-dropped race (ChainFirehoseHub's mcpSubscribedSessions
+      // hadn't yet been told to forget this session) -- every OTHER route
+      // (subscribe/unsubscribe/stream/terminate) is a real client action
+      // against a session that no longer exists.
+      return new Response(JSON.stringify({ error: "session terminated" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/subscribe" && request.method === "POST") {
+      return this.handleSubscribe(request);
+    }
+    if (url.pathname === "/unsubscribe" && request.method === "POST") {
+      return this.handleUnsubscribe(request);
+    }
+    if (url.pathname === "/stream" && request.method === "GET") {
+      return this.handleStream(url);
+    }
+    if (url.pathname === "/notify" && request.method === "POST") {
+      return this.handleNotify(request);
+    }
+    if (url.pathname === "/terminate" && request.method === "POST") {
+      return this.handleTerminate(request);
+    }
+    return new Response("not found", { status: 404 });
+  }
+
+  async handleSubscribe(request) {
+    const { sessionId, uri } = await request.json();
+    this.sessionId = sessionId;
+    if (uri !== MCP_CHAIN_STREAM_RESOURCE_URI) {
+      return new Response(
+        JSON.stringify({ error: "resource is not subscribable" }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }
+    this.subscribedUris.add(uri);
+    await this.persist();
+    await this.touch();
+    if (this.env.CHAIN_FIREHOSE_HUB) {
+      const stub = this.env.CHAIN_FIREHOSE_HUB.get(
+        this.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
+      );
+      await stub.fetch("https://chain-firehose-hub.internal/mcp-subscribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      });
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async handleUnsubscribe(request) {
+    const { sessionId, uri } = await request.json();
+    this.sessionId = sessionId;
+    this.subscribedUris.delete(uri);
+    this.pendingUris.delete(uri);
+    await this.persist();
+    if (this.subscribedUris.size === 0 && this.env.CHAIN_FIREHOSE_HUB) {
+      const stub = this.env.CHAIN_FIREHOSE_HUB.get(
+        this.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
+      );
+      await stub.fetch("https://chain-firehose-hub.internal/mcp-unsubscribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      });
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  // Called by ChainFirehoseHub.broadcast()'s MCP loop -- a pointer-only
+  // notification (spec: notifications/resources/updated carries only `uri`,
+  // never content; the client re-reads via resources/read). Coalesced: if no
+  // stream is open right now, this only sets a flag -- a burst of chain
+  // events between reads collapses to one outstanding unread marker per uri,
+  // not a growing queue, since resources/read always returns CURRENT state
+  // regardless of how many events fired in between.
+  async handleNotify(request) {
+    const { uri } = await request.json();
+    if (!this.subscribedUris.has(uri)) {
+      return new Response(JSON.stringify({ ok: true, delivered: false }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (this.streamController) {
+      this.deliverNow(uri);
+    } else {
+      this.pendingUris.add(uri);
+    }
+    return new Response(JSON.stringify({ ok: true, delivered: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  deliverNow(uri) {
+    this.sequence += 1;
+    const frame = formatMcpSseEvent(
+      this.sequence,
+      buildResourceUpdatedNotification(uri),
+    );
+    try {
+      this.streamController.enqueue(new TextEncoder().encode(frame));
+      this.pendingUris.delete(uri);
+    } catch {
+      // stream already closed/errored -- leave it pending for the next open
+      this.streamController = null;
+    }
+  }
+
+  async handleTerminate(request) {
+    // Prefer the request body's sessionId (an explicit client DELETE always
+    // has one); fall back to the persisted value for alarm()'s self-
+    // termination call, which has no caller to hand it one -- see the
+    // constructor's comment on why this class can't recover it any other
+    // way.
+    const { sessionId } = await request.json();
+    const effectiveSessionId = sessionId ?? this.sessionId;
+    if (!this.terminated) {
+      this.terminated = true;
+      if (this.streamController) {
+        try {
+          this.streamController.close();
+        } catch {
+          // already closed
+        }
+        this.streamController = null;
+      }
+      if (this.streamCloseTimer) {
+        clearTimeout(this.streamCloseTimer);
+        this.streamCloseTimer = null;
+      }
+      if (
+        this.subscribedUris.size > 0 &&
+        effectiveSessionId &&
+        this.env.CHAIN_FIREHOSE_HUB
+      ) {
+        const stub = this.env.CHAIN_FIREHOSE_HUB.get(
+          this.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
+        );
+        await stub.fetch(
+          "https://chain-firehose-hub.internal/mcp-unsubscribe",
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ sessionId: effectiveSessionId }),
+          },
+        );
+      }
+      this.subscribedUris.clear();
+      this.pendingUris.clear();
+      await this.persist();
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async handleStream(url) {
+    if (this.streamController) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "a stream is already open for this session; only one concurrent " +
+            "SSE stream per session is supported",
+        }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      );
+    }
+    const sessionId = url.searchParams.get("sessionId");
+    if (sessionId) {
+      this.sessionId = sessionId;
+      await this.persist();
+    }
+    void this.touch();
+    const hub = this;
+    const stream = new ReadableStream({
+      start(controller) {
+        hub.streamController = controller;
+        // Flush anything that arrived while no stream was open, coalesced
+        // to one frame per uri (matches handleNotify's coalescing).
+        for (const uri of hub.pendingUris) {
+          hub.deliverNow(uri);
+        }
+        hub.streamCloseTimer = setTimeout(() => {
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+          hub.streamController = null;
+          hub.streamCloseTimer = null;
+        }, MCP_SESSION_MAX_STREAM_DURATION_MS);
+      },
+      cancel() {
+        // clearTimeout(null) is a safe no-op, and this callback can only
+        // ever run while the stream is still "readable" -- which by
+        // construction means streamCloseTimer is already set (start() sets
+        // it synchronously before returning control to any caller) -- so an
+        // unconditional clear is simpler than a defensive guard that can
+        // never see a falsy value.
+        hub.streamController = null;
+        clearTimeout(hub.streamCloseTimer);
+        hub.streamCloseTimer = null;
+      },
+    });
+    void url; // reserved for a future Last-Event-ID replay-from-cursor read
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-store",
+        "access-control-allow-origin": "*",
+        connection: "keep-alive",
+      },
+    });
+  }
+
+  // Durable Object alarm handler -- fires MCP_SESSION_IDLE_TTL_MS after the
+  // last touch() (subscribe or stream-open). Self-terminates an abandoned
+  // session the same way an explicit DELETE would, so
+  // ChainFirehoseHub.mcpSubscribedSessions never accumulates dead sessions
+  // just because a client never explicitly unsubscribed/terminated.
+  async alarm() {
+    await this.hydrate();
+    await this.handleTerminate(
+      new Request("https://mcp-session-hub.internal/terminate", {
+        method: "POST",
+        body: JSON.stringify({ sessionId: null }),
+      }),
+    );
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -358,17 +358,27 @@
   "durable_objects": {
     "bindings": [
       { "name": "CHAIN_FIREHOSE_HUB", "class_name": "ChainFirehoseHub" },
+      // #4983 MCP half: one instance per Mcp-Session-Id (workers/mcp-session-hub.mjs),
+      // reached only from src/mcp-server.mjs's /mcp dispatch -- see that
+      // file's own header comment for why this is a SEPARATE DO from
+      // ChainFirehoseHub rather than a fourth connection population on it.
+      { "name": "MCP_SESSION_HUB", "class_name": "McpSessionHub" },
     ],
   },
   // Durable Object class migrations are one-way and versioned: adding a new
   // class is a `new_sqlite_classes` entry (SQLite storage backend -- the
   // default for new classes; no legacy `new_classes` durable-storage class to
-  // migrate from). Renaming/deleting ChainFirehoseHub later needs its OWN
-  // migration entry appended here, never an edit to this one.
+  // migrate from). Renaming/deleting a class later needs its OWN migration
+  // entry appended here, never an edit to an existing one -- hence
+  // McpSessionHub getting its own v2 tag rather than joining v1's array.
   "migrations": [
     {
       "tag": "v1-chain-firehose-hub",
       "new_sqlite_classes": ["ChainFirehoseHub"],
+    },
+    {
+      "tag": "v2-mcp-session-hub",
+      "new_sqlite_classes": ["McpSessionHub"],
     },
   ],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV


### PR DESCRIPTION
## Summary

Completes the MCP half of #4983 (the realtime chain-event firehose epic, #2114): `resources/subscribe` / `resources/unsubscribe` on `metagraph://chain/stream`, so an MCP agent client can be pushed a `notifications/resources/updated` pointer whenever a new chain event lands, instead of polling `resources/read`.

- **New `McpSessionHub` Durable Object** (`workers/mcp-session-hub.mjs`), one instance per `Mcp-Session-Id`. Deliberately separate from `ChainFirehoseHub` (#4982) — MCP's subscribe is a one-shot POST while the push channel is a reconnect-tolerant GET correlated by session id, a different lifecycle primitive than the hub's other three fan-out populations. See the file's own header comment for the full reasoning.
- **`handleMcpRequest` now handles all three MCP Streamable HTTP methods**: POST (unchanged, stateless JSON-RPC), GET (opens the session's bounded SSE stream), DELETE (explicit termination). A session id is minted (`crypto.randomUUID()`) only on a successful `initialize` response; every other method stays session-optional. `MCP-Protocol-Version` is validated when present (absent assumes the spec's 2025-03-26 default).
- **Bounded stream duration, not indefinite hold**: unlike WebSocket, an SSE-holding DO has no hibernation exemption, so `McpSessionHub` closes its stream after 5 minutes and expects the client to reconnect (2025-11-25 spec's "servers may disconnect SSE streams at will" allowance), coalescing any notification into one pending marker per uri in the meantime. A session with no activity for 30 minutes self-terminates via a DO alarm.
- **`ChainFirehoseHub` stays the single source of truth**: a subscribed session is tracked in `mcpSubscribedSessions`, and `broadcast()` pings each one's `McpSessionHub` (best-effort, never blocks ingest) after its existing SSE/WS/GraphQL fan-out loops.
- **`scripts/validate-mcp.mjs` extended** per the issue's own deliverable ("extend it, don't just add untested surface"): wires up two *real* Durable Object instances (in-memory storage/sockets, real business logic) and runs the full `initialize → subscribe → POST /ingest → SSE push → resources/read → unsubscribe → DELETE → 404` round trip end to end.
- `docs/realtime-firehose.md` updated with the completed MCP section, matching the depth of the existing GraphQL-subscriptions section.

## Test plan

- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run test:coverage` — 7780 tests pass; `workers/mcp-session-hub.mjs` at 100% (statements/branches/functions/lines); `workers/chain-firehose-hub.mjs` and `src/mcp-server.mjs` back to 100%/~99% after adding coverage for the new GET/DELETE/session-mint/notify-loop code paths
- [x] `npm run validate` and `npm run validate:mcp` (extended round trip above) both pass
- [x] `npm run worker:deploy:dry-run` and `npm run worker:bundle:budget` pass (bundle at 963.6 KiB gzipped, within the 1000 KiB budget)
- [ ] Live end-to-end verification against a real chain event on the deployed Worker (same bar as #4982's SSE/WS and #4983's GraphQL-subscriptions verification) — planned as an immediate follow-up once this merges and propagates, mirroring how #4982/#5000 were verified post-merge.

Closes #4983