### PR TITLE
feat(realtime): tee account_events into the chain firehose

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -651,6 +651,23 @@ BEGIN
       'method', NEW.method,
       'observed_at', NEW.observed_at
     );
+  ELSIF TG_ARGV[0] = 'account_events' THEN
+    -- #4984 prerequisite: blocks/extrinsics/chain_events carry no netuid/
+    -- hotkey/coldkey/amount_tao -- the alerter's own example trigger
+    -- conditions ("netuid=X", "account=Z", "amount_tao > N") need this
+    -- curated tier's columns directly, so it gets its own firehose branch
+    -- rather than requiring every alert evaluation to re-fetch by PK.
+    payload := jsonb_build_object(
+      'table', 'account_events',
+      'block_number', NEW.block_number,
+      'event_index', NEW.event_index,
+      'event_kind', NEW.event_kind,
+      'hotkey', NEW.hotkey,
+      'coldkey', NEW.coldkey,
+      'netuid', NEW.netuid,
+      'amount_tao', NEW.amount_tao,
+      'observed_at', NEW.observed_at
+    );
   ELSE
     RETURN NEW;
   END IF;
@@ -681,6 +698,16 @@ DROP TRIGGER IF EXISTS trg_chain_events_firehose ON chain_events;
 CREATE TRIGGER trg_chain_events_firehose
   AFTER INSERT ON chain_events
   FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose('chain_events');
+
+-- #4984 prerequisite (see notify_chain_firehose()'s account_events branch
+-- above). account_events is ALSO a TimescaleDB hypertable
+-- (schema-timescaledb.sql), so this trigger fires on its per-time-range
+-- chunk exactly like the three above -- TG_ARGV[0] carries the logical name
+-- for the same reason.
+DROP TRIGGER IF EXISTS trg_account_events_firehose ON account_events;
+CREATE TRIGGER trg_account_events_firehose
+  AFTER INSERT ON account_events
+  FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose('account_events');
 
 -- TimescaleDB hypertables/compression are OPTIONAL and live in the companion
 -- schema-timescaledb.sql in this same directory — apply it separately, only

--- a/docs/adr/0015-realtime-firehose-architecture.md
+++ b/docs/adr/0015-realtime-firehose-architecture.md
@@ -59,6 +59,10 @@ firehose's two halves live.
    for the accurate, narrow tail-risk this design actually carries — real,
    not zero, but bounded and low-likelihood given this deployment's only
    listener (the #4981 relay) never holds a long transaction open.
+   **Extended 2026-07-13** (#4984 prerequisite): the trigger now also fires on
+   `account_events` inserts. None of the original three tables carry
+   netuid/hotkey/coldkey/amount_tao, which the alerter's own example trigger
+   conditions need directly, without a per-event Postgres round-trip.
 2. **A new, separate box-side relay process bridges Postgres to Cloudflare**
    (#4981), subscribing via `LISTEN` and forwarding to the Durable Object over
    HTTP with a bounded, drop-oldest retry policy. If this process is down,

--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -1,7 +1,8 @@
 # Realtime chain-event firehose (#2114, ADR 0015)
 
 The `chain_firehose` Postgres channel: a compact, best-effort NOTIFY stream of
-every row landing in `blocks`/`extrinsics`/`chain_events`, decoupled from
+every row landing in `blocks`/`extrinsics`/`chain_events`/`account_events`
+(the last added for #4984 -- see below), decoupled from
 `indexer-rs`'s own write path so nothing downstream of it can ever affect
 whether `indexer-rs` keeps following the chain head. See ADR 0015 for why this
 shape was chosen over a direct push from `indexer-rs` (the retired
@@ -98,9 +99,10 @@ One global instance (`idFromName("global")`) owns two endpoints:
   public data `/api/v1/chain-events` already serves, pushed instead of
   polled). SSE by default (`event: chain` frames, JSON payload matching the
   trigger's NOTIFY shape); a WebSocket `Upgrade` header on the same path gets
-  the WS transport instead. Both support `?topics=blocks,extrinsics,chain_events`
-  (comma-separated, defaults to all three) to avoid forcing a client to
-  consume the full firehose.
+  the WS transport instead. Both support
+  `?topics=blocks,extrinsics,chain_events,account_events` (comma-separated,
+  defaults to all four) to avoid forcing a client to consume the full
+  firehose.
 
 Bounded per-connection buffering: an SSE client whose `ReadableStream`
 controller falls behind (`desiredSize < 0` against a 64-frame
@@ -285,7 +287,8 @@ Discord.
 ```sh
 psql "$DATABASE_URL" -c "LISTEN chain_firehose;"
 # in another session, insert (or wait for indexer-rs to insert) a row into
-# blocks/extrinsics/chain_events — the LISTENing session prints a Notification
+# blocks/extrinsics/chain_events/account_events — the LISTENing session
+# prints a Notification
 ```
 
 ## Provisioning + verifying the hub (#4982)

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -324,7 +324,7 @@ export const SDL = `
   # path) -- POSTing a subscription operation to the regular query endpoint
   # returns a standard GraphQL error, same as any other GraphQL server.
   type Subscription {
-    "Live chain events as they land (blocks/extrinsics/chain_events), optionally filtered to one or more tables. Field shape mirrors the #4980 NOTIFY payload -- only the fields relevant to the event's table are populated."
+    "Live chain events as they land (blocks/extrinsics/chain_events/account_events), optionally filtered to one or more tables. Field shape mirrors the #4980 NOTIFY payload -- only the fields relevant to the event's table are populated."
     chainEvents(tables: [ChainFirehoseTable!]): ChainEvent!
   }
 
@@ -332,6 +332,7 @@ export const SDL = `
     blocks
     extrinsics
     chain_events
+    account_events
   }
 
   type ChainEvent {
@@ -354,12 +355,22 @@ export const SDL = `
     signer: String
     "extrinsics only"
     success: Boolean
-    "chain_events only"
+    "chain_events / account_events (event index within the block)"
     event_index: Int
     "chain_events only"
     pallet: String
     "chain_events only"
     method: String
+    "account_events only -- the curated kind (e.g. Transfer, StakeAdded)"
+    event_kind: String
+    "account_events only"
+    hotkey: String
+    "account_events only"
+    coldkey: String
+    "account_events only"
+    netuid: Int
+    "account_events only"
+    amount_tao: Float
   }
 `;
 

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -204,6 +204,13 @@ test("parseChainFirehoseTopics: trims whitespace around entries", () => {
   assert.deepEqual([...topics].sort(), ["blocks", "chain_events"]);
 });
 
+test("parseChainFirehoseTopics: account_events is a recognized topic (#4984 prerequisite)", () => {
+  const topics = parseChainFirehoseTopics(
+    new URLSearchParams("topics=account_events"),
+  );
+  assert.deepEqual([...topics], ["account_events"]);
+});
+
 test("parseChainFirehoseTopics: drops unknown table names silently", () => {
   const topics = parseChainFirehoseTopics(
     new URLSearchParams("topics=blocks,not_a_real_table"),
@@ -267,6 +274,25 @@ test("validateChainFirehoseIngestPayload: accepts a well-formed chain_events pay
     }),
   );
   assert.equal(result.ok, true);
+});
+
+test("validateChainFirehoseIngestPayload: accepts a well-formed account_events payload (#4984 prerequisite)", () => {
+  const result = validateChainFirehoseIngestPayload(
+    JSON.stringify({
+      table: "account_events",
+      block_number: 8608870,
+      event_index: 4,
+      event_kind: "Transfer",
+      hotkey: "5F...",
+      coldkey: "5G...",
+      netuid: 7,
+      amount_tao: 12.5,
+      observed_at: "2026-07-13T02:00:00.000Z",
+    }),
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.payload.netuid, 7);
+  assert.equal(result.payload.amount_tao, 12.5);
 });
 
 test("validateChainFirehoseIngestPayload: accepts a boolean field (e.g. extrinsics.success)", () => {
@@ -850,6 +876,7 @@ test("CHAIN_FIREHOSE_INGEST_TOKEN_HEADER and CHAIN_FIREHOSE_TABLES are the docum
     "x-chain-firehose-sync-token",
   );
   assert.deepEqual([...CHAIN_FIREHOSE_TABLES].sort(), [
+    "account_events",
     "blocks",
     "chain_events",
     "extrinsics",

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -52,11 +52,15 @@ import { MCP_CHAIN_STREAM_RESOURCE_URI } from "./mcp-session-hub.mjs";
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 
 // Matches deploy/postgres/schema.sql's notify_chain_firehose() trigger --
-// the only three tables it ever fires `table:` for.
+// the only four tables it ever fires `table:` for. account_events (#4984
+// prerequisite) carries netuid/hotkey/coldkey/amount_tao directly, unlike
+// the other three -- the alerter's trigger conditions need those columns
+// without a per-event Postgres round-trip.
 export const CHAIN_FIREHOSE_TABLES = new Set([
   "blocks",
   "extrinsics",
   "chain_events",
+  "account_events",
 ]);
 
 // Headroom over Postgres's 8000-byte NOTIFY payload cap (the trigger's own


### PR DESCRIPTION
## Summary

Prerequisite for #4984 (the alerter), discovered while starting it: `blocks`/`extrinsics`/`chain_events` are the only tables `notify_chain_firehose()` fires on today, and none of them carry `netuid`/`hotkey`/`coldkey`/`amount_tao` — the alerter's own example trigger conditions ("netuid=X AND event_kind=Y", "account=Z", "amount_tao > N") can't be evaluated from the existing firehose payload alone.

`account_events` (the curated tier) already has exactly these columns and is also a TimescaleDB hypertable (`schema-timescaledb.sql`) like the other three, so this adds a fourth `trg_account_events_firehose` trigger using the same `TG_ARGV[0]`-not-`TG_TABLE_NAME` pattern the earlier tables already established (the chunk-name gotcha documented in the trigger's own comment). Also:
- `account_events` added to `CHAIN_FIREHOSE_TABLES` (`workers/chain-firehose-hub.mjs`) — SSE/WS `?topics=` filtering and ingest validation recognize it automatically (both are already generic over the Set).
- `account_events` added to the GraphQL `ChainFirehoseTable` enum, plus new `ChainEvent` fields (`event_kind`/`hotkey`/`coldkey`/`netuid`/`amount_tao`).
- ADR 0015 and `docs/realtime-firehose.md` updated.

## Test plan

- [x] `npm run lint` / format clean
- [x] `npm run test:coverage` — 7782 tests pass; `workers/chain-firehose-hub.mjs` at 100% coverage
- [x] `npm run validate` and `npm run worker:deploy:dry-run` pass
- [x] **Verified against a real throwaway Postgres container** (not just a syntax read): applied the full modified `schema.sql` cleanly, inserted a real row into each of the four tables, confirmed each fires the exact expected `NOTIFY` payload (including a regression check that the original three tables' triggers are unaffected).
- [ ] Live application to the production Postgres (indexer box) — blocked on a Tailscale SSH re-auth I can't complete myself; the change is additive/idempotent (`CREATE OR REPLACE FUNCTION`, `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER`) and safe to apply whenever that's available.

Closes #5010