### PR TITLE
feat(realtime): add chain_alert_triggers storage + CRUD API

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -709,6 +709,57 @@ CREATE TRIGGER trg_account_events_firehose
   AFTER INSERT ON account_events
   FOR EACH ROW EXECUTE FUNCTION notify_chain_firehose('account_events');
 
+-- ---------------------------------------------------------------------------
+-- Chain alert triggers (#4984, ADR 0015) -- user-defined "notify me when X
+-- happens on-chain" conditions, evaluated against the SAME firehose above by
+-- a Durable Object consumer (AlerterHub, #4984 Part 2) rather than a second
+-- Postgres poll loop. No user-account system exists in this codebase, so
+-- ownership is a bearer token (owner_token, returned once at creation) --
+-- the SAME model src/webhooks.mjs's per-subscription secret already
+-- establishes for webhook subscriptions. A small, low-cardinality table (one
+-- row per user-created alert, not one per chain event), so it is deliberately
+-- NOT a hypertable -- no entry in schema-timescaledb.sql.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS chain_alert_triggers (
+  id                BIGSERIAL PRIMARY KEY,
+  -- Bearer credential for GET/PATCH/DELETE on this one trigger. Unlike
+  -- webhook subscriptions' public GET, every single-trigger route here
+  -- requires it: `destination` can itself be a capability credential (a
+  -- Discord incoming-webhook URL grants POST-message rights to anyone
+  -- holding it), so there is no safe "public" view of a trigger.
+  owner_token       TEXT NOT NULL,
+  name              TEXT,
+  -- NULL = any of CHAIN_FIREHOSE_TABLES (workers/chain-firehose-hub.mjs);
+  -- otherwise a subset, validated against that same Set before insert.
+  table_filter      TEXT[],
+  netuid            INTEGER,
+  -- account_events.event_kind vocabulary (e.g. Transfer, StakeAdded) --
+  -- chain_events' raw pallet/method is NOT matchable here; see the
+  -- account_events firehose-tee prerequisite's own comment above.
+  event_kind        TEXT,
+  -- Matches account_events.hotkey OR .coldkey (an alert on "this account"
+  -- shouldn't require the owner to know which leg a given event used).
+  account           TEXT,
+  min_amount_tao    NUMERIC,
+  channel           TEXT NOT NULL CHECK (channel IN ('webhook', 'email', 'telegram', 'discord')),
+  -- Shape depends on channel: a public https:// URL (webhook), an email
+  -- address (email), a chat id or @channelusername (telegram), or the exact
+  -- Discord incoming-webhook URL shape (discord) -- validated at write time
+  -- by src/alert-triggers.mjs's isValidAlertDestination, not re-validated on
+  -- every delivery.
+  destination       TEXT NOT NULL,
+  active            BOOLEAN NOT NULL DEFAULT true,
+  created_at        BIGINT NOT NULL,
+  updated_at        BIGINT NOT NULL,
+  last_matched_at   BIGINT,
+  match_count       BIGINT NOT NULL DEFAULT 0
+);
+-- Covers AlerterHub's own "give me every active trigger" cache-refresh scan
+-- (#4984 Part 2) -- the only query pattern against this table that isn't
+-- already a fast primary-key lookup by id.
+CREATE INDEX IF NOT EXISTS idx_cat_active ON chain_alert_triggers (active) WHERE active;
+
 -- TimescaleDB hypertables/compression are OPTIONAL and live in the companion
 -- schema-timescaledb.sql in this same directory — apply it separately, only
 -- on a Postgres that actually has the TimescaleDB extension. This file is a

--- a/src/alert-triggers.mjs
+++ b/src/alert-triggers.mjs
@@ -1,0 +1,340 @@
+// Pure, isomorphic helpers for chain alert triggers (#4984 Part 1, ADR 0015 /
+// #2114). Shared by workers/data-api.mjs (the Postgres CRUD write path) and
+// the future AlerterHub Durable Object (#4984 Part 2, which evaluates each
+// live ChainFirehoseHub broadcast against every active trigger). No I/O --
+// Postgres/fetch are injected by callers -- so every branch here is
+// unit-testable without a live database or network, matching src/webhooks.mjs's
+// own split (this module reuses that file's SSRF guard + constant-time
+// compare + secret generation rather than re-deriving them).
+//
+// A trigger's matchable conditions (netuid/event_kind/account/min_amount_tao)
+// are deliberately drawn from account_events' own columns, not chain_events'
+// raw pallet/method/args -- see the #4984-prerequisite commit that taught
+// notify_chain_firehose() to also tee account_events (workers/chain-
+// firehose-hub.mjs's CHAIN_FIREHOSE_TABLES) for why: it is the only firehose
+// table that carries netuid/hotkey/coldkey/amount_tao directly, so a trigger
+// can be evaluated inline off the NOTIFY payload with no per-event Postgres
+// round-trip.
+import {
+  generateSecret,
+  isPublicWebhookUrl,
+  timingSafeEqual,
+} from "./webhooks.mjs";
+import { CHAIN_FIREHOSE_TABLES } from "../workers/chain-firehose-hub.mjs";
+
+// Anti-abuse gate on trigger CREATION (public but shared-secret-gated,
+// mirroring METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN's exact role) -- every
+// active trigger costs the evaluator a real per-event match check, so
+// unbounded public creation is a workload-inflation vector, not just a
+// storage one.
+export const ALERT_TRIGGER_CREATE_TOKEN_HEADER = "x-alert-trigger-create-token";
+// Per-trigger bearer credential for GET/PATCH/DELETE on that one trigger.
+export const ALERT_TRIGGER_OWNER_TOKEN_HEADER = "x-alert-trigger-owner-token";
+// Machine-only: gates the evaluator's "give me every active trigger" scan
+// (#4984 Part 2), a DIFFERENT secret from the two above since it grants a
+// wholly different capability (read every trigger regardless of owner).
+export const ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER =
+  "x-alert-triggers-internal-token";
+
+// Matches MAX_WEBHOOK_BODY_BYTES (workers/config.mjs) -- generous over this
+// shape's actual size (a handful of short scalar fields) without inviting a
+// pathological body.
+export const ALERT_TRIGGER_MAX_BODY_BYTES = 8192;
+
+export const ALERT_CHANNELS = new Set([
+  "webhook",
+  "email",
+  "telegram",
+  "discord",
+]);
+
+const MAX_NAME_LENGTH = 128;
+const MAX_ACCOUNT_LENGTH = 64; // generous over an SS58 address
+const MAX_EVENT_KIND_LENGTH = 64;
+const MAX_DESTINATION_LENGTH = 512;
+// Generous ceiling defending against a garbage/overflow float rather than a
+// realistic TAO amount bound.
+const MIN_AMOUNT_TAO_CEILING = 1_000_000_000;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 254; // RFC 5321 §4.5.3.1.3
+
+// Telegram chat ids are either a signed integer (private chat / group) or an
+// `@channelusername` (public channel/supergroup) -- see the Bot API's
+// sendMessage `chat_id` parameter.
+const TELEGRAM_CHAT_ID_PATTERN = /^(-?\d{1,15}|@[A-Za-z0-9_]{5,32})$/;
+
+// Discord incoming-webhook URLs have one fixed, well-known shape. Allowlisting
+// the exact host + path shape (matching this repo's own icon-proxy
+// aggregator-only precedent, workers/icon-proxy.mjs) is safer than a generic
+// "is this URL public" SSRF check: alertmanager-discord-style relays exist
+// specifically because Discord's OWN webhook endpoint is the only fetch
+// target this channel ever needs, so there is no legitimate reason to accept
+// anything else.
+const DISCORD_WEBHOOK_PATTERN =
+  /^https:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/;
+
+export function isValidAlertDestination(channel, destination) {
+  if (typeof destination !== "string" || destination.length === 0) return false;
+  if (destination.length > MAX_DESTINATION_LENGTH) return false;
+  switch (channel) {
+    case "webhook":
+      return isPublicWebhookUrl(destination);
+    case "discord":
+      return DISCORD_WEBHOOK_PATTERN.test(destination);
+    case "email":
+      return (
+        destination.length <= MAX_EMAIL_LENGTH &&
+        EMAIL_PATTERN.test(destination)
+      );
+    case "telegram":
+      return TELEGRAM_CHAT_ID_PATTERN.test(destination);
+    default:
+      return false;
+  }
+}
+
+// Validates a create/update request body into the exact shape the Postgres
+// write path binds. Every condition field is optional on input (undefined),
+// but at least one of netuid/event_kind/account/min_amount_tao is required --
+// a trigger with none of them would match every event on every table, which
+// is always technically legal per-field but almost certainly a mistake (and
+// an unbounded-delivery-volume footgun for the trigger's own owner).
+export function validateAlertTriggerInput(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+  if (!ALERT_CHANNELS.has(input.channel)) {
+    return {
+      ok: false,
+      error: `\`channel\` must be one of ${[...ALERT_CHANNELS].join(", ")}.`,
+    };
+  }
+  if (!isValidAlertDestination(input.channel, input.destination)) {
+    return {
+      ok: false,
+      error: `\`destination\` is not a valid ${input.channel} target.`,
+    };
+  }
+
+  let name = null;
+  if (input.name !== undefined) {
+    if (typeof input.name !== "string" || input.name.length > MAX_NAME_LENGTH) {
+      return {
+        ok: false,
+        error: `\`name\`, when provided, must be a string up to ${MAX_NAME_LENGTH} characters.`,
+      };
+    }
+    name = input.name;
+  }
+
+  let tableFilter = null;
+  if (input.table_filter !== undefined) {
+    if (
+      !Array.isArray(input.table_filter) ||
+      input.table_filter.length === 0 ||
+      !input.table_filter.every((table) => CHAIN_FIREHOSE_TABLES.has(table))
+    ) {
+      return {
+        ok: false,
+        error: `\`table_filter\`, when provided, must be a non-empty array drawn from ${[...CHAIN_FIREHOSE_TABLES].join(", ")}.`,
+      };
+    }
+    tableFilter = [...new Set(input.table_filter)];
+  }
+
+  let netuid = null;
+  if (input.netuid !== undefined) {
+    if (
+      !Number.isInteger(input.netuid) ||
+      input.netuid < 0 ||
+      input.netuid > 65535
+    ) {
+      return {
+        ok: false,
+        error: "`netuid`, when provided, must be an integer 0-65535.",
+      };
+    }
+    netuid = input.netuid;
+  }
+
+  let eventKind = null;
+  if (input.event_kind !== undefined) {
+    if (
+      typeof input.event_kind !== "string" ||
+      !input.event_kind ||
+      input.event_kind.length > MAX_EVENT_KIND_LENGTH
+    ) {
+      return {
+        ok: false,
+        error: `\`event_kind\`, when provided, must be a non-empty string up to ${MAX_EVENT_KIND_LENGTH} characters.`,
+      };
+    }
+    eventKind = input.event_kind;
+  }
+
+  let account = null;
+  if (input.account !== undefined) {
+    if (
+      typeof input.account !== "string" ||
+      !input.account ||
+      input.account.length > MAX_ACCOUNT_LENGTH
+    ) {
+      return {
+        ok: false,
+        error: `\`account\`, when provided, must be a non-empty string up to ${MAX_ACCOUNT_LENGTH} characters.`,
+      };
+    }
+    account = input.account;
+  }
+
+  let minAmountTao = null;
+  if (input.min_amount_tao !== undefined) {
+    if (
+      typeof input.min_amount_tao !== "number" ||
+      !Number.isFinite(input.min_amount_tao) ||
+      input.min_amount_tao < 0 ||
+      input.min_amount_tao > MIN_AMOUNT_TAO_CEILING
+    ) {
+      return {
+        ok: false,
+        error:
+          "`min_amount_tao`, when provided, must be a non-negative finite number.",
+      };
+    }
+    minAmountTao = input.min_amount_tao;
+  }
+
+  if (netuid === null && !eventKind && !account && minAmountTao === null) {
+    return {
+      ok: false,
+      error:
+        "At least one of netuid, event_kind, account, or min_amount_tao is required.",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name,
+      tableFilter,
+      netuid,
+      eventKind,
+      account,
+      minAmountTao,
+      channel: input.channel,
+      destination: input.destination,
+    },
+  };
+}
+
+// Evaluate one active trigger against a firehose broadcast payload (the SAME
+// shape ChainFirehoseHub.broadcast() fans out to SSE/WS/GraphQL/MCP -- see
+// workers/chain-firehose-hub.mjs). Pure, no I/O: the caller owns persistence
+// (match_count/last_matched_at) and delivery.
+export function triggerMatchesEvent(trigger, payload) {
+  if (!payload || typeof payload !== "object") return false;
+  if (trigger.tableFilter && !trigger.tableFilter.includes(payload.table)) {
+    return false;
+  }
+  if (trigger.netuid !== null && payload.netuid !== trigger.netuid) {
+    return false;
+  }
+  if (trigger.eventKind && payload.event_kind !== trigger.eventKind) {
+    return false;
+  }
+  if (
+    trigger.account &&
+    payload.hotkey !== trigger.account &&
+    payload.coldkey !== trigger.account
+  ) {
+    return false;
+  }
+  if (
+    trigger.minAmountTao !== null &&
+    !(
+      typeof payload.amount_tao === "number" &&
+      payload.amount_tao >= trigger.minAmountTao
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+// The owner_token is the sole ownership credential (returned once, at
+// creation, never echoed back on read) -- there is no user-account system in
+// this codebase, matching src/webhooks.mjs's own per-subscription-secret
+// model. Unlike webhook subscriptions, a trigger's `destination` can itself
+// be a bearer credential (a Discord incoming-webhook URL grants POST-message
+// capability to anyone holding it), so every single-trigger route
+// (GET/PATCH/DELETE) requires the owner_token, not just PATCH/DELETE --
+// there is no "public" trigger view.
+export function generateAlertTriggerOwnerToken() {
+  return generateSecret();
+}
+
+export function isValidAlertOwnerToken(provided, stored) {
+  return (
+    typeof provided === "string" &&
+    provided.length > 0 &&
+    typeof stored === "string" &&
+    stored.length > 0 &&
+    timingSafeEqual(provided, stored)
+  );
+}
+
+// Strips owner_token before a record is returned to its owner. Every other
+// field is safe to echo back to whoever already proved ownership.
+export function ownerAlertTriggerView(record) {
+  if (!record || typeof record !== "object") return null;
+  return {
+    id: String(record.id),
+    name: record.name ?? null,
+    table_filter: record.table_filter ?? null,
+    netuid: record.netuid ?? null,
+    event_kind: record.event_kind ?? null,
+    account: record.account ?? null,
+    min_amount_tao:
+      record.min_amount_tao === undefined || record.min_amount_tao === null
+        ? null
+        : Number(record.min_amount_tao),
+    channel: record.channel,
+    destination: record.destination,
+    active: record.active !== false,
+    created_at: record.created_at ?? null,
+    updated_at: record.updated_at ?? null,
+    last_matched_at: record.last_matched_at ?? null,
+    match_count: record.match_count ?? 0,
+  };
+}
+
+// The shape AlerterHub (#4984 Part 2) caches for evaluation -- narrower than
+// ownerAlertTriggerView (no owner_token, but also no created_at/updated_at
+// bookkeeping the evaluator never reads) and pre-shaped for
+// triggerMatchesEvent's field names (camelCase, matching validateAlertTriggerInput's
+// `value`).
+export function evaluatorAlertTriggerView(record) {
+  if (!record || typeof record !== "object") return null;
+  return {
+    id: String(record.id),
+    tableFilter: record.table_filter ?? null,
+    netuid: record.netuid ?? null,
+    eventKind: record.event_kind ?? null,
+    account: record.account ?? null,
+    minAmountTao:
+      record.min_amount_tao === undefined || record.min_amount_tao === null
+        ? null
+        : Number(record.min_amount_tao),
+    channel: record.channel,
+    destination: record.destination,
+  };
+}
+
+// A trigger id is a Postgres BIGSERIAL -- validate before binding into a
+// query. Accepts the string form (route params are always strings) and
+// rejects anything that isn't a plain, non-negative integer literal (no
+// leading zeros beyond "0" itself, no sign, no whitespace).
+export function isValidAlertTriggerId(id) {
+  return /^(0|[1-9]\d*)$/.test(String(id));
+}

--- a/tests/alert-triggers-proxy.test.mjs
+++ b/tests/alert-triggers-proxy.test.mjs
@@ -1,0 +1,188 @@
+// Unit tests for the /api/v1/alerts/triggers* proxy (workers/api.mjs's
+// handleAlertTriggersProxy, #4984 Part 1), which forwards POST/GET/PATCH/
+// DELETE to workers/data-api.mjs's handleAlertTriggersRoute via the EXISTING
+// DATA_API service binding. Unlike neurons-sync's proxyToDataApi (a raw
+// pass-through), this one envelope-wraps the response via dataResponse/
+// errorResponse -- see handleAlertTriggersProxy's own comment. The
+// downstream CRUD logic itself is covered by tests/alert-triggers-route.test.mjs.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+
+function req(path, { method = "GET", headers = {}, body } = {}) {
+  return new Request(`https://api.metagraph.sh${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+test("returns 503 when DATA_API is not bound", async () => {
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers", { method: "POST", body: {} }),
+    {},
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error.code, "alert_triggers_unavailable");
+});
+
+test("forwards POST to DATA_API and envelope-wraps a successful response", async () => {
+  let receivedPath;
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": "shared-secret" },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    {
+      DATA_API: {
+        fetch(request) {
+          receivedPath = new URL(request.url).pathname;
+          receivedMethod = request.method;
+          return new Response(
+            JSON.stringify({ id: "1", owner_token: "abc", netuid: 7 }),
+            { status: 201 },
+          );
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedPath, "/api/v1/alerts/triggers");
+  assert.equal(receivedMethod, "POST");
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.deepEqual(body.data, { id: "1", owner_token: "abc", netuid: 7 });
+});
+
+test("forwards GET /{id} to DATA_API, including the owner-token header", async () => {
+  let receivedToken;
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers/1", {
+      method: "GET",
+      headers: { "x-alert-trigger-owner-token": "abc" },
+    }),
+    {
+      DATA_API: {
+        fetch(request) {
+          receivedToken = request.headers.get("x-alert-trigger-owner-token");
+          return new Response(JSON.stringify({ id: "1", netuid: 7 }), {
+            status: 200,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedToken, "abc");
+  assert.equal(res.status, 200);
+  assert.deepEqual((await res.json()).data, { id: "1", netuid: 7 });
+});
+
+test("forwards PATCH to DATA_API", async () => {
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "abc" },
+      body: { channel: "email", destination: "a@b.com", netuid: 8 },
+    }),
+    {
+      DATA_API: {
+        fetch(request) {
+          receivedMethod = request.method;
+          return new Response(JSON.stringify({ id: "1", netuid: 8 }), {
+            status: 200,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedMethod, "PATCH");
+  assert.equal(res.status, 200);
+});
+
+test("forwards DELETE to DATA_API", async () => {
+  let receivedMethod;
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers/1", {
+      method: "DELETE",
+      headers: { "x-alert-trigger-owner-token": "abc" },
+    }),
+    {
+      DATA_API: {
+        fetch(request) {
+          receivedMethod = request.method;
+          return new Response(JSON.stringify({ id: "1", deleted: true }), {
+            status: 200,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(receivedMethod, "DELETE");
+  assert.deepEqual((await res.json()).data, { id: "1", deleted: true });
+});
+
+test("relays a non-2xx upstream status with the upstream's error message", async () => {
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": "wrong" },
+      body: {},
+    }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(
+            JSON.stringify({ error: "provide a valid token" }),
+            { status: 401 },
+          );
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 401);
+  assert.equal((await res.json()).error.message, "provide a valid token");
+});
+
+test("relays a non-2xx upstream status with a generic message when the body has no error string", async () => {
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers", { method: "POST", body: {} }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(JSON.stringify({}), { status: 503 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.match(
+    (await res.json()).error.message,
+    /alert triggers tier returned an error/,
+  );
+});
+
+test("returns 502 when the upstream response body is unreadable", async () => {
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers", { method: "POST", body: {} }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response("not json", { status: 200 });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal((await res.json()).error.code, "alert_triggers_unavailable");
+});

--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -1,0 +1,471 @@
+// Unit tests for the chain_alert_triggers CRUD write path (#4984 Part 1,
+// workers/data-api.mjs's handleAlertTrigger*/handleAlertTriggersRoute
+// functions). A dedicated test file (not folded into the already 5000+-line
+// tests/data-api.test.mjs) with its OWN postgres mock scoped to just this
+// table's shape -- vi.mock is per-test-file, so this doesn't touch that
+// file's shared mock or vice versa.
+//
+// The mock is a simple per-test QUEUE (not a full SQL-semantics emulator,
+// matching data-api.test.mjs's own established convention): each test
+// pushes exactly the rows each of ITS query calls (in order) should
+// resolve to, and asserts on the recorded call text/values for anything it
+// needs to verify was actually sent.
+import assert from "node:assert/strict";
+import { beforeEach, test, vi } from "vitest";
+
+const mockQueue = vi.hoisted(() => ({ current: [] }));
+const sqlCalls = vi.hoisted(() => []);
+const failNextQuery = vi.hoisted(() => ({ error: null }));
+
+vi.mock("postgres", () => ({
+  default: () => {
+    function sql(strings, ...values) {
+      let text = strings[0];
+      for (let i = 0; i < values.length; i += 1) text += "?" + strings[i + 1];
+      sqlCalls.push({ text, values });
+      if (failNextQuery.error) {
+        const err = failNextQuery.error;
+        failNextQuery.error = null;
+        return Promise.reject(err);
+      }
+      return Promise.resolve(
+        mockQueue.current.length ? mockQueue.current.shift() : [],
+      );
+    }
+    sql.begin = (cb) => cb(sql);
+    sql.end = () => Promise.resolve();
+    return sql;
+  },
+}));
+
+const { default: worker } = await import("../workers/data-api.mjs");
+
+const CREATE_TOKEN = "test-alert-trigger-create-token";
+const INTERNAL_TOKEN = "test-alert-triggers-internal-token";
+const env = {
+  HYPERDRIVE: { connectionString: "postgres://mock" },
+  ALERT_TRIGGER_CREATE_TOKEN: CREATE_TOKEN,
+  ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+};
+
+beforeEach(() => {
+  mockQueue.current = [];
+  sqlCalls.length = 0;
+  failNextQuery.error = null;
+});
+
+function req(path, { method = "GET", headers = {}, body } = {}) {
+  return new Request(`https://d${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function fetch(request, envOverride = env) {
+  return worker.fetch(request, envOverride, {});
+}
+
+function row(overrides = {}) {
+  return {
+    id: "1",
+    owner_token: "stored-owner-token",
+    name: null,
+    table_filter: null,
+    netuid: 7,
+    event_kind: null,
+    account: null,
+    min_amount_tao: null,
+    channel: "email",
+    destination: "a@b.com",
+    active: true,
+    created_at: 1700000000000,
+    updated_at: 1700000000000,
+    last_matched_at: null,
+    match_count: 0,
+    ...overrides,
+  };
+}
+
+// --- POST /api/v1/alerts/triggers (create) -----------------------------------
+
+test("create: 503 when ALERT_TRIGGER_CREATE_TOKEN is not configured", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", { method: "POST", body: {} }),
+    { ...env, ALERT_TRIGGER_CREATE_TOKEN: undefined },
+  );
+  assert.equal(res.status, 503);
+});
+
+test("create: 401 when the create token is missing or wrong", async () => {
+  const missing = await fetch(
+    req("/api/v1/alerts/triggers", { method: "POST", body: {} }),
+  );
+  assert.equal(missing.status, 401);
+  const wrong = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": "wrong" },
+      body: {},
+    }),
+  );
+  assert.equal(wrong.status, 401);
+});
+
+test("create: 413 when content-length declares an oversized body", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: {
+        "x-alert-trigger-create-token": CREATE_TOKEN,
+        "content-length": "999999",
+      },
+      body: {},
+    }),
+  );
+  assert.equal(res.status, 413);
+});
+
+test("create: 413 when the actual body exceeds the byte cap even without a lying content-length header", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-alert-trigger-create-token": CREATE_TOKEN,
+    },
+    body: JSON.stringify({
+      channel: "email",
+      destination: "a@b.com",
+      netuid: 1,
+      name: "x".repeat(20_000),
+    }),
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 413);
+});
+
+test("create: 400 on malformed JSON", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-alert-trigger-create-token": CREATE_TOKEN,
+    },
+    body: "{not json",
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+});
+
+test("create: 400 on an empty body (parses to null, fails validation)", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-alert-trigger-create-token": CREATE_TOKEN,
+    },
+    body: "",
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+});
+
+test("create: 400 on a validation failure, without ever touching Postgres", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "carrier-pigeon", destination: "x" },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("create: 503 when HYPERDRIVE is unbound", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    { ...env, HYPERDRIVE: undefined },
+  );
+  assert.equal(res.status, 503);
+});
+
+test("create: 502 when the insert fails", async () => {
+  failNextQuery.error = new Error("boom");
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+  );
+  assert.equal(res.status, 502);
+});
+
+test("create: 201 on success, mints a fresh owner_token distinct from any stored value, and inserts the validated fields", async () => {
+  mockQueue.current.push([row({ owner_token: "irrelevant-stored-value" })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: {
+        channel: "email",
+        destination: "a@b.com",
+        netuid: 7,
+        name: "my alert",
+      },
+    }),
+  );
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.match(body.owner_token, /^[0-9a-f]{64}$/);
+  assert.notEqual(body.owner_token, "irrelevant-stored-value");
+  assert.equal(body.id, "1");
+  assert.equal(sqlCalls.length, 1);
+  assert.match(sqlCalls[0].text, /INSERT INTO chain_alert_triggers/);
+  assert.ok(sqlCalls[0].values.includes("my alert"));
+  assert.ok(sqlCalls[0].values.includes(7));
+  assert.ok(sqlCalls[0].values.includes("email"));
+  assert.ok(sqlCalls[0].values.includes("a@b.com"));
+});
+
+// --- GET /api/v1/alerts/triggers/{id} -----------------------------------------
+
+test("get: 400 on a malformed id", async () => {
+  const res = await fetch(req("/api/v1/alerts/triggers/not-a-number"));
+  assert.equal(res.status, 400);
+});
+
+test("get: 404 when no such trigger exists", async () => {
+  mockQueue.current.push([]);
+  const res = await fetch(req("/api/v1/alerts/triggers/1"));
+  assert.equal(res.status, 404);
+});
+
+test("get: 403 when the owner token header is entirely absent", async () => {
+  mockQueue.current.push([row()]);
+  const res = await fetch(req("/api/v1/alerts/triggers/1"));
+  assert.equal(res.status, 403);
+});
+
+test("get: 403 when the owner token is present but wrong", async () => {
+  mockQueue.current.push([row()]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      headers: { "x-alert-trigger-owner-token": "wrong" },
+    }),
+  );
+  assert.equal(res.status, 403);
+});
+
+test("get: 200 with the owner view (owner_token stripped) when the token matches", async () => {
+  mockQueue.current.push([row({ owner_token: "correct-token", netuid: 9 })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.netuid, 9);
+  assert.equal("owner_token" in body, false);
+});
+
+// --- PATCH /api/v1/alerts/triggers/{id} ---------------------------------------
+
+test("update: 400 on a malformed id", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/xx", {
+      method: "PATCH",
+      body: { channel: "email", destination: "a@b.com", netuid: 1 },
+    }),
+  );
+  assert.equal(res.status, 400);
+});
+
+test("update: 400 on malformed JSON, before ever querying Postgres", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers/1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: "{not json",
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("update: 400 on a validation failure, before ever querying Postgres", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      body: { channel: "email", destination: "not-an-email" },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("update: 404 when no such trigger exists", async () => {
+  mockQueue.current.push([]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      body: { channel: "email", destination: "a@b.com", netuid: 1 },
+    }),
+  );
+  assert.equal(res.status, 404);
+});
+
+test("update: 403 when the owner token is missing or wrong", async () => {
+  mockQueue.current.push([{ owner_token: "correct-token" }]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "wrong" },
+      body: { channel: "email", destination: "a@b.com", netuid: 1 },
+    }),
+  );
+  assert.equal(res.status, 403);
+});
+
+test("update: 200 on success, sends the new validated fields to the UPDATE", async () => {
+  mockQueue.current.push([{ owner_token: "correct-token" }]);
+  mockQueue.current.push([row({ netuid: 42, event_kind: "Transfer" })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      body: {
+        channel: "email",
+        destination: "a@b.com",
+        netuid: 42,
+        event_kind: "Transfer",
+      },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.netuid, 42);
+  assert.equal(body.event_kind, "Transfer");
+  assert.equal(sqlCalls.length, 2);
+  assert.match(
+    sqlCalls[0].text,
+    /SELECT owner_token FROM chain_alert_triggers/,
+  );
+  assert.match(sqlCalls[1].text, /UPDATE chain_alert_triggers SET/);
+  assert.ok(sqlCalls[1].values.includes(42));
+  assert.ok(sqlCalls[1].values.includes("Transfer"));
+});
+
+// --- DELETE /api/v1/alerts/triggers/{id} --------------------------------------
+
+test("delete: 400 on a malformed id", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/xx", { method: "DELETE" }),
+  );
+  assert.equal(res.status, 400);
+});
+
+test("delete: 404 when no such trigger exists", async () => {
+  mockQueue.current.push([]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", { method: "DELETE" }),
+  );
+  assert.equal(res.status, 404);
+});
+
+test("delete: 403 when the owner token is missing or wrong", async () => {
+  mockQueue.current.push([{ owner_token: "correct-token" }]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "DELETE",
+      headers: { "x-alert-trigger-owner-token": "wrong" },
+    }),
+  );
+  assert.equal(res.status, 403);
+});
+
+test("delete: 200 with {id, deleted:true} on success, and actually issues the DELETE", async () => {
+  mockQueue.current.push([{ owner_token: "correct-token" }]);
+  mockQueue.current.push([]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "DELETE",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { id: "1", deleted: true });
+  assert.equal(sqlCalls.length, 2);
+  assert.match(sqlCalls[1].text, /DELETE FROM chain_alert_triggers WHERE id/);
+});
+
+// --- GET /api/v1/internal/alert-triggers-active (evaluator scan) -------------
+
+test("active list: 503 when ALERT_TRIGGERS_INTERNAL_TOKEN is not configured", async () => {
+  const res = await fetch(req("/api/v1/internal/alert-triggers-active"), {
+    ...env,
+    ALERT_TRIGGERS_INTERNAL_TOKEN: undefined,
+  });
+  assert.equal(res.status, 503);
+});
+
+test("active list: 401 when the internal token header is entirely absent", async () => {
+  const res = await fetch(req("/api/v1/internal/alert-triggers-active"));
+  assert.equal(res.status, 401);
+});
+
+test("active list: 401 when the internal token is present but wrong", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-active", {
+      headers: { "x-alert-triggers-internal-token": "wrong" },
+    }),
+  );
+  assert.equal(res.status, 401);
+});
+
+test("active list: 200 with every active trigger reshaped for the evaluator, owner_token stripped", async () => {
+  mockQueue.current.push([
+    row({ id: "1", netuid: 7 }),
+    row({ id: "2", netuid: 8, table_filter: ["account_events"] }),
+  ]);
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-active", {
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.triggers.length, 2);
+  assert.equal(body.triggers[0].netuid, 7);
+  assert.equal(body.triggers[1].tableFilter[0], "account_events");
+  assert.equal("owner_token" in body.triggers[0], false);
+  assert.equal(sqlCalls.length, 1);
+  assert.match(
+    sqlCalls[0].text,
+    /SELECT \* FROM chain_alert_triggers WHERE active/,
+  );
+});
+
+// --- method-dispatch fallthrough -----------------------------------------------
+
+test("route: an id-less GET is rejected with 405", async () => {
+  const res = await fetch(req("/api/v1/alerts/triggers"));
+  assert.equal(res.status, 405);
+});
+
+test("route: POST with an id in the path is rejected with 405 (create is id-less only)", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", { method: "POST", body: {} }),
+  );
+  assert.equal(res.status, 405);
+});
+
+test("route: an unsupported method is rejected with 405", async () => {
+  const res = await fetch(req("/api/v1/alerts/triggers/1", { method: "PUT" }));
+  assert.equal(res.status, 405);
+});

--- a/tests/alert-triggers.test.mjs
+++ b/tests/alert-triggers.test.mjs
@@ -1,0 +1,627 @@
+// Unit tests for src/alert-triggers.mjs (#4984 Part 1). Pure/no-I/O, so every
+// branch is directly testable without a Postgres or network dependency.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  ALERT_CHANNELS,
+  ALERT_TRIGGER_CREATE_TOKEN_HEADER,
+  ALERT_TRIGGER_MAX_BODY_BYTES,
+  ALERT_TRIGGER_OWNER_TOKEN_HEADER,
+  ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER,
+  evaluatorAlertTriggerView,
+  generateAlertTriggerOwnerToken,
+  isValidAlertDestination,
+  isValidAlertOwnerToken,
+  isValidAlertTriggerId,
+  ownerAlertTriggerView,
+  triggerMatchesEvent,
+  validateAlertTriggerInput,
+} from "../src/alert-triggers.mjs";
+
+test("header/limit constants are the documented values", () => {
+  assert.equal(
+    ALERT_TRIGGER_CREATE_TOKEN_HEADER,
+    "x-alert-trigger-create-token",
+  );
+  assert.equal(ALERT_TRIGGER_OWNER_TOKEN_HEADER, "x-alert-trigger-owner-token");
+  assert.equal(
+    ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER,
+    "x-alert-triggers-internal-token",
+  );
+  assert.equal(ALERT_TRIGGER_MAX_BODY_BYTES, 8192);
+});
+
+// --- isValidAlertDestination ------------------------------------------------
+
+test("isValidAlertDestination: webhook requires a public https:// URL (reuses isPublicWebhookUrl)", () => {
+  assert.equal(
+    isValidAlertDestination("webhook", "https://example.com/hook"),
+    true,
+  );
+  assert.equal(
+    isValidAlertDestination("webhook", "http://example.com/hook"),
+    false,
+  );
+  assert.equal(
+    isValidAlertDestination("webhook", "https://localhost/hook"),
+    false,
+  );
+  assert.equal(
+    isValidAlertDestination("webhook", "https://192.168.1.1/hook"),
+    false,
+  );
+});
+
+test("isValidAlertDestination: discord requires the exact incoming-webhook URL shape", () => {
+  assert.equal(
+    isValidAlertDestination(
+      "discord",
+      "https://discord.com/api/webhooks/123456789012345678/aBc-DeF_123",
+    ),
+    true,
+  );
+  assert.equal(
+    isValidAlertDestination(
+      "discord",
+      "https://canary.discord.com/api/webhooks/1/token",
+    ),
+    true,
+  );
+  assert.equal(
+    isValidAlertDestination("discord", "https://discord.com/invite/abc"),
+    false,
+  );
+  assert.equal(
+    isValidAlertDestination(
+      "discord",
+      "https://evil.example.com/api/webhooks/1/token",
+    ),
+    false,
+  );
+  assert.equal(
+    isValidAlertDestination(
+      "discord",
+      "http://discord.com/api/webhooks/1/token",
+    ),
+    false,
+  );
+});
+
+test("isValidAlertDestination: email requires a plausible address", () => {
+  assert.equal(isValidAlertDestination("email", "a@b.com"), true);
+  assert.equal(isValidAlertDestination("email", "not-an-email"), false);
+  assert.equal(isValidAlertDestination("email", "a@b"), false);
+  assert.equal(
+    isValidAlertDestination("email", "a".repeat(250) + "@b.com"),
+    false,
+  );
+});
+
+test("isValidAlertDestination: telegram accepts a signed integer chat id or @channelusername", () => {
+  assert.equal(isValidAlertDestination("telegram", "123456789"), true);
+  assert.equal(isValidAlertDestination("telegram", "-1001234567890"), true);
+  assert.equal(isValidAlertDestination("telegram", "@my_channel"), true);
+  assert.equal(isValidAlertDestination("telegram", "not valid"), false);
+  assert.equal(isValidAlertDestination("telegram", "@"), false);
+});
+
+test("isValidAlertDestination: rejects a non-string, empty, or oversized destination", () => {
+  assert.equal(isValidAlertDestination("email", undefined), false);
+  assert.equal(isValidAlertDestination("email", ""), false);
+  assert.equal(isValidAlertDestination("telegram", "1".repeat(600)), false);
+});
+
+test("isValidAlertDestination: rejects an unknown channel", () => {
+  assert.equal(isValidAlertDestination("carrier-pigeon", "a@b.com"), false);
+});
+
+test("ALERT_CHANNELS is the documented set", () => {
+  assert.deepEqual([...ALERT_CHANNELS].sort(), [
+    "discord",
+    "email",
+    "telegram",
+    "webhook",
+  ]);
+});
+
+// --- validateAlertTriggerInput ----------------------------------------------
+
+test("validateAlertTriggerInput: accepts a minimal valid netuid-only trigger", () => {
+  const result = validateAlertTriggerInput({
+    channel: "discord",
+    destination: "https://discord.com/api/webhooks/1/token",
+    netuid: 7,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.netuid, 7);
+  assert.equal(result.value.tableFilter, null);
+  assert.equal(result.value.eventKind, null);
+});
+
+test("validateAlertTriggerInput: accepts every condition field together", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    name: "big transfers",
+    table_filter: ["account_events", "account_events"], // dedup
+    netuid: 7,
+    event_kind: "Transfer",
+    account: "5F...",
+    min_amount_tao: 100,
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value.tableFilter, ["account_events"]);
+  assert.equal(result.value.name, "big transfers");
+  assert.equal(result.value.eventKind, "Transfer");
+  assert.equal(result.value.account, "5F...");
+  assert.equal(result.value.minAmountTao, 100);
+});
+
+test("validateAlertTriggerInput: rejects a non-object body", () => {
+  assert.equal(validateAlertTriggerInput(null).ok, false);
+  assert.equal(validateAlertTriggerInput([]).ok, false);
+  assert.equal(validateAlertTriggerInput("x").ok, false);
+});
+
+test("validateAlertTriggerInput: rejects an unknown channel", () => {
+  const result = validateAlertTriggerInput({
+    channel: "sms",
+    destination: "+15555555555",
+    netuid: 1,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /channel/);
+});
+
+test("validateAlertTriggerInput: rejects a destination that doesn't fit its channel", () => {
+  const result = validateAlertTriggerInput({
+    channel: "email",
+    destination: "not-an-email",
+    netuid: 1,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /destination/);
+});
+
+test("validateAlertTriggerInput: rejects an oversized name", () => {
+  const result = validateAlertTriggerInput({
+    channel: "email",
+    destination: "a@b.com",
+    netuid: 1,
+    name: "x".repeat(200),
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /name/);
+});
+
+test("validateAlertTriggerInput: rejects an empty or unrecognized table_filter entry", () => {
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      netuid: 1,
+      table_filter: [],
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      netuid: 1,
+      table_filter: ["not_a_real_table"],
+    }).ok,
+    false,
+  );
+});
+
+test("validateAlertTriggerInput: rejects an out-of-range netuid", () => {
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      netuid: -1,
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      netuid: 99999,
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      netuid: 1.5,
+    }).ok,
+    false,
+  );
+});
+
+test("validateAlertTriggerInput: netuid 0 (the root subnet) counts as a real condition, not falsy-absent", () => {
+  const result = validateAlertTriggerInput({
+    channel: "email",
+    destination: "a@b.com",
+    netuid: 0,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.netuid, 0);
+});
+
+test("validateAlertTriggerInput: rejects an empty event_kind or one over the length cap", () => {
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      event_kind: "",
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      event_kind: "x".repeat(100),
+    }).ok,
+    false,
+  );
+});
+
+test("validateAlertTriggerInput: rejects an empty account or one over the length cap", () => {
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      account: "",
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateAlertTriggerInput({
+      channel: "email",
+      destination: "a@b.com",
+      account: "x".repeat(100),
+    }).ok,
+    false,
+  );
+});
+
+test("validateAlertTriggerInput: rejects a negative, non-finite, or absurdly large min_amount_tao", () => {
+  for (const min_amount_tao of [-1, Infinity, NaN, 2_000_000_000, "100"]) {
+    assert.equal(
+      validateAlertTriggerInput({
+        channel: "email",
+        destination: "a@b.com",
+        min_amount_tao,
+      }).ok,
+      false,
+      `expected min_amount_tao=${min_amount_tao} to be rejected`,
+    );
+  }
+});
+
+test("validateAlertTriggerInput: min_amount_tao of exactly 0 is a valid (if unusual) threshold", () => {
+  const result = validateAlertTriggerInput({
+    channel: "email",
+    destination: "a@b.com",
+    min_amount_tao: 0,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.minAmountTao, 0);
+});
+
+test("validateAlertTriggerInput: rejects a trigger with no narrowing condition at all", () => {
+  const result = validateAlertTriggerInput({
+    channel: "email",
+    destination: "a@b.com",
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /At least one of/);
+});
+
+test("validateAlertTriggerInput: table_filter alone (no other condition) is still rejected", () => {
+  const result = validateAlertTriggerInput({
+    channel: "email",
+    destination: "a@b.com",
+    table_filter: ["blocks"],
+  });
+  assert.equal(result.ok, false);
+});
+
+// --- triggerMatchesEvent -----------------------------------------------------
+
+function baseTrigger(overrides = {}) {
+  return {
+    tableFilter: null,
+    netuid: null,
+    eventKind: null,
+    account: null,
+    minAmountTao: null,
+    ...overrides,
+  };
+}
+
+test("triggerMatchesEvent: a trigger with no conditions matches any payload", () => {
+  assert.equal(
+    triggerMatchesEvent(baseTrigger(), { table: "blocks", block_number: 1 }),
+    true,
+  );
+});
+
+test("triggerMatchesEvent: table_filter narrows to specific tables", () => {
+  const trigger = baseTrigger({ tableFilter: ["account_events"] });
+  assert.equal(triggerMatchesEvent(trigger, { table: "account_events" }), true);
+  assert.equal(triggerMatchesEvent(trigger, { table: "blocks" }), false);
+});
+
+test("triggerMatchesEvent: netuid must match exactly, including 0", () => {
+  const trigger = baseTrigger({ netuid: 0 });
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", netuid: 0 }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", netuid: 1 }),
+    false,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", netuid: null }),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: event_kind must match exactly", () => {
+  const trigger = baseTrigger({ eventKind: "Transfer" });
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      event_kind: "Transfer",
+    }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      event_kind: "StakeAdded",
+    }),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: account matches EITHER hotkey or coldkey", () => {
+  const trigger = baseTrigger({ account: "5FAccount" });
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      hotkey: "5FAccount",
+      coldkey: "5GOther",
+    }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      hotkey: "5GOther",
+      coldkey: "5FAccount",
+    }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      hotkey: "5GOther",
+      coldkey: "5HOther",
+    }),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: min_amount_tao requires a numeric amount_tao at or above the threshold", () => {
+  const trigger = baseTrigger({ minAmountTao: 100 });
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", amount_tao: 100 }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      amount_tao: 99.999,
+    }),
+    false,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", amount_tao: null }),
+    false,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events" }),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: min_amount_tao of exactly 0 still requires a present numeric amount_tao", () => {
+  const trigger = baseTrigger({ minAmountTao: 0 });
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", amount_tao: 0 }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events" }),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: ALL present conditions must match (AND, not OR)", () => {
+  const trigger = baseTrigger({ netuid: 7, eventKind: "Transfer" });
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      netuid: 7,
+      event_kind: "Transfer",
+    }),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, {
+      table: "account_events",
+      netuid: 7,
+      event_kind: "StakeAdded",
+    }),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: a null/undefined payload never matches", () => {
+  assert.equal(triggerMatchesEvent(baseTrigger({ netuid: 1 }), null), false);
+  assert.equal(
+    triggerMatchesEvent(baseTrigger({ netuid: 1 }), undefined),
+    false,
+  );
+});
+
+// --- ownership + views --------------------------------------------------------
+
+test("generateAlertTriggerOwnerToken: produces a fresh, sufficiently long hex token each call", () => {
+  const a = generateAlertTriggerOwnerToken();
+  const b = generateAlertTriggerOwnerToken();
+  assert.match(a, /^[0-9a-f]{64}$/);
+  assert.notEqual(a, b);
+});
+
+test("isValidAlertOwnerToken: matches only the exact stored token", () => {
+  const token = generateAlertTriggerOwnerToken();
+  assert.equal(isValidAlertOwnerToken(token, token), true);
+  assert.equal(isValidAlertOwnerToken("wrong", token), false);
+  assert.equal(isValidAlertOwnerToken("", token), false);
+  assert.equal(isValidAlertOwnerToken(token, ""), false);
+  assert.equal(isValidAlertOwnerToken(undefined, token), false);
+});
+
+test("ownerAlertTriggerView: strips owner_token and normalizes nullable fields", () => {
+  const view = ownerAlertTriggerView({
+    id: 42,
+    owner_token: "secret-should-not-appear",
+    name: null,
+    table_filter: null,
+    netuid: 7,
+    event_kind: null,
+    account: null,
+    min_amount_tao: "100.5", // Postgres NUMERIC often comes back as a string
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    active: true,
+    created_at: 1,
+    updated_at: 2,
+    last_matched_at: null,
+    match_count: 3,
+  });
+  assert.equal(view.id, "42");
+  assert.equal("owner_token" in view, false);
+  assert.equal(view.min_amount_tao, 100.5);
+  assert.equal(view.netuid, 7);
+});
+
+test("ownerAlertTriggerView: a minimal record (every optional field absent) falls back to null/0 defaults", () => {
+  const view = ownerAlertTriggerView({
+    id: 1,
+    channel: "email",
+    destination: "a@b.com",
+  });
+  assert.equal(view.name, null);
+  assert.equal(view.table_filter, null);
+  assert.equal(view.netuid, null);
+  assert.equal(view.event_kind, null);
+  assert.equal(view.account, null);
+  assert.equal(view.min_amount_tao, null);
+  assert.equal(view.created_at, null);
+  assert.equal(view.updated_at, null);
+  assert.equal(view.last_matched_at, null);
+  assert.equal(view.match_count, 0);
+  assert.equal(view.active, true); // `active !== false` defaults true when absent
+});
+
+test("ownerAlertTriggerView: active:false is preserved, not defaulted away", () => {
+  const view = ownerAlertTriggerView({
+    id: 1,
+    channel: "email",
+    destination: "a@b.com",
+    active: false,
+  });
+  assert.equal(view.active, false);
+});
+
+test("ownerAlertTriggerView: returns null for a non-object record", () => {
+  assert.equal(ownerAlertTriggerView(null), null);
+  assert.equal(ownerAlertTriggerView(undefined), null);
+});
+
+test("evaluatorAlertTriggerView: reshapes snake_case columns into triggerMatchesEvent's camelCase fields", () => {
+  const view = evaluatorAlertTriggerView({
+    id: 7,
+    owner_token: "should-not-appear",
+    table_filter: ["account_events"],
+    netuid: 7,
+    event_kind: "Transfer",
+    account: "5F...",
+    min_amount_tao: "10",
+    channel: "discord",
+    destination: "https://discord.com/api/webhooks/1/t",
+  });
+  assert.equal(view.id, "7");
+  assert.equal("owner_token" in view, false);
+  assert.deepEqual(view.tableFilter, ["account_events"]);
+  assert.equal(view.eventKind, "Transfer");
+  assert.equal(view.minAmountTao, 10);
+  // Round-trips straight into triggerMatchesEvent without reshaping again.
+  assert.equal(
+    triggerMatchesEvent(view, {
+      table: "account_events",
+      netuid: 7,
+      event_kind: "Transfer",
+      hotkey: "5F...",
+      amount_tao: 10,
+    }),
+    true,
+  );
+});
+
+test("evaluatorAlertTriggerView: a minimal record (every optional field absent) falls back to null defaults", () => {
+  const view = evaluatorAlertTriggerView({
+    id: 1,
+    channel: "email",
+    destination: "a@b.com",
+  });
+  assert.equal(view.tableFilter, null);
+  assert.equal(view.netuid, null);
+  assert.equal(view.eventKind, null);
+  assert.equal(view.account, null);
+  assert.equal(view.minAmountTao, null);
+});
+
+test("evaluatorAlertTriggerView: returns null for a non-object record", () => {
+  assert.equal(evaluatorAlertTriggerView(null), null);
+});
+
+// --- isValidAlertTriggerId ----------------------------------------------------
+
+test("isValidAlertTriggerId: accepts plain non-negative integer literals", () => {
+  assert.equal(isValidAlertTriggerId("0"), true);
+  assert.equal(isValidAlertTriggerId("42"), true);
+  assert.equal(isValidAlertTriggerId(42), true);
+});
+
+test("isValidAlertTriggerId: rejects leading zeros, signs, and non-numeric input", () => {
+  assert.equal(isValidAlertTriggerId("007"), false);
+  assert.equal(isValidAlertTriggerId("-1"), false);
+  assert.equal(isValidAlertTriggerId("1.5"), false);
+  assert.equal(isValidAlertTriggerId("abc"), false);
+  assert.equal(isValidAlertTriggerId(""), false);
+  assert.equal(
+    isValidAlertTriggerId("1; DROP TABLE chain_alert_triggers"),
+    false,
+  );
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -221,6 +221,10 @@ import {
   WEBHOOK_SIGNATURE_HEADER,
 } from "../src/webhooks.mjs";
 import {
+  ALERT_TRIGGER_CREATE_TOKEN_HEADER,
+  ALERT_TRIGGER_OWNER_TOKEN_HEADER,
+} from "../src/alert-triggers.mjs";
+import {
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
   pruneHealthHistory,
@@ -754,6 +758,44 @@ async function handleChainEventsProxy(request, env, url) {
   );
 }
 
+// Proxies /api/v1/alerts/triggers* (#4984 Part 1) to the DATA_API service
+// binding. Unlike proxyToDataApi below (POST-only), this forwards every
+// method as-is: POST/GET/PATCH/DELETE all reach
+// workers/data-api.mjs's handleAlertTriggersRoute, which owns all
+// auth (creation token / per-trigger owner token) and routing itself --
+// mirrors handleChainEventsProxy's envelope-translation shape above, just
+// generalized past GET.
+async function handleAlertTriggersProxy(request, env) {
+  if (!env.DATA_API) {
+    return errorResponse(
+      "alert_triggers_unavailable",
+      "The alert triggers tier is not bound to this deployment.",
+      503,
+    );
+  }
+  const upstream = await env.DATA_API.fetch(request);
+  let body;
+  try {
+    body = await upstream.json();
+  } catch {
+    return errorResponse(
+      "alert_triggers_unavailable",
+      "The alert triggers tier returned an unreadable response.",
+      502,
+    );
+  }
+  if (!upstream.ok) {
+    return errorResponse(
+      "alert_trigger_request_failed",
+      typeof body?.error === "string"
+        ? body.error
+        : "The alert triggers tier returned an error.",
+      upstream.status,
+    );
+  }
+  return dataResponse(env, body, upstream.status);
+}
+
 // Proxies POST /api/v1/internal/registry-sync to the dedicated registry-sync
 // Worker (REGISTRY_SYNC_API service binding), the sole write path into the
 // registry Postgres instance. This function forwards the request as-is
@@ -1011,6 +1053,15 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // must run before the read-only method gate below (like the RPC proxy).
   if (url.pathname.startsWith("/api/v1/webhooks/")) {
     return handleWebhookRequest(request, env, url);
+  }
+
+  // Chain alert triggers (#4984 Part 1): CRUD accepts POST/GET/PATCH/DELETE,
+  // so it must run before the read-only method gate below, same as webhooks
+  // above. All auth/routing/validation live in workers/data-api.mjs's
+  // handleAlertTriggersRoute -- this is only the DATA_API forwarding
+  // boundary.
+  if (url.pathname.startsWith("/api/v1/alerts/triggers")) {
+    return handleAlertTriggersProxy(request, env);
   }
 
   // Remote MCP server, for AI agents: stateless JSON-RPC over POST, plus GET
@@ -2473,6 +2524,7 @@ function isMainnetOnlyApiPath(pathname) {
     pathname === "/api/v1/blocks/summary" ||
     pathname === "/api/v1/economics/trends" ||
     pathname.startsWith("/api/v1/webhooks/") ||
+    pathname.startsWith("/api/v1/alerts/triggers") ||
     BULK_TRENDS_PATH_PATTERN.test(pathname) ||
     TRENDS_PATH_PATTERN.test(pathname) ||
     PERCENTILES_PATH_PATTERN.test(pathname) ||
@@ -4266,6 +4318,8 @@ function corsPreflight(request) {
     methods = "POST, OPTIONS";
   } else if (url.pathname.startsWith("/api/v1/webhooks/")) {
     methods = "POST, GET, DELETE, OPTIONS";
+  } else if (url.pathname.startsWith("/api/v1/alerts/triggers")) {
+    methods = "POST, GET, PATCH, DELETE, OPTIONS";
   } else if (url.pathname === "/api/v1/graphql") {
     // POST executes queries; GET serves the published SDL document.
     methods = "GET, POST, OPTIONS";
@@ -4280,7 +4334,8 @@ function corsPreflight(request) {
   headers.set(
     "access-control-allow-headers",
     `content-type, if-none-match, mcp-session-id, mcp-protocol-version, ` +
-      `${WEBHOOK_SECRET_HEADER}, ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}`,
+      `${WEBHOOK_SECRET_HEADER}, ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}, ` +
+      `${ALERT_TRIGGER_CREATE_TOKEN_HEADER}, ${ALERT_TRIGGER_OWNER_TOKEN_HEADER}`,
   );
   headers.set("access-control-max-age", "86400");
   return new Response(null, { status: 204, headers });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -397,6 +397,18 @@ function latestObservedIso(rows, field = "last_observed") {
 }
 import { timingSafeEqual } from "../src/webhooks.mjs";
 import {
+  ALERT_TRIGGER_CREATE_TOKEN_HEADER,
+  ALERT_TRIGGER_MAX_BODY_BYTES,
+  ALERT_TRIGGER_OWNER_TOKEN_HEADER,
+  ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER,
+  evaluatorAlertTriggerView,
+  generateAlertTriggerOwnerToken,
+  isValidAlertOwnerToken,
+  isValidAlertTriggerId,
+  ownerAlertTriggerView,
+  validateAlertTriggerInput,
+} from "../src/alert-triggers.mjs";
+import {
   BLOCK_PAGINATION,
   FEED_PAGINATION,
   DAY_PATTERN,
@@ -2178,6 +2190,243 @@ function coerceEvent(row) {
   };
 }
 
+// --- /api/v1/alerts/triggers (#4984 Part 1) ---------------------------------
+//
+// Public CRUD for user-defined chain alert triggers, reached only via
+// workers/api.mjs's DATA_API service binding (no public routes of its own,
+// same invariant as every route in this file). Creation is gated by a
+// shared anti-abuse token (mirrors src/webhooks.mjs's own subscription-
+// creation gate, ALERT_TRIGGER_CREATE_TOKEN_HEADER/env.ALERT_TRIGGER_CREATE_TOKEN
+// -- every active trigger costs the #4984 Part 2 evaluator a real per-event
+// match check, so unbounded public creation is a workload vector, not just a
+// storage one); GET/PATCH/DELETE on one trigger are gated by that trigger's
+// OWN owner_token instead (returned once, at creation) -- there is no public
+// view, unlike webhook subscriptions, because `destination` can itself be a
+// bearer credential (a Discord incoming-webhook URL). All shared, no-I/O
+// validation lives in src/alert-triggers.mjs; everything here is Postgres
+// plumbing + auth gates.
+
+async function withAlertTriggersSql(env, fn) {
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+  try {
+    return await fn(sql);
+  } catch (err) {
+    console.error("data-api alert-triggers write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+  // No sql.end() -- Hyperdrive cleans up the connection when the request/
+  // invocation ends (Cloudflare's documented pattern), matching every other
+  // write route in this file.
+}
+
+async function readAlertTriggerBody(request) {
+  if (
+    Number(request.headers.get("content-length") || 0) >
+    ALERT_TRIGGER_MAX_BODY_BYTES
+  ) {
+    return { error: writeJson({ error: "body too large" }, 413) };
+  }
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > ALERT_TRIGGER_MAX_BODY_BYTES) {
+    return { error: writeJson({ error: "body too large" }, 413) };
+  }
+  try {
+    return { body: raw ? JSON.parse(raw) : null };
+  } catch {
+    return { error: writeJson({ error: "body must be JSON" }, 400) };
+  }
+}
+
+function requireAlertTriggerOwner(request, storedOwnerToken) {
+  const provided = request.headers.get(ALERT_TRIGGER_OWNER_TOKEN_HEADER) || "";
+  if (isValidAlertOwnerToken(provided, storedOwnerToken)) return null;
+  return writeJson(
+    {
+      error: `provide the trigger's ${ALERT_TRIGGER_OWNER_TOKEN_HEADER} header`,
+    },
+    403,
+  );
+}
+
+async function handleAlertTriggerCreate(request, env) {
+  const configured = env.ALERT_TRIGGER_CREATE_TOKEN;
+  if (!configured) {
+    return writeJson(
+      {
+        error: "alert trigger creation is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided = request.headers.get(ALERT_TRIGGER_CREATE_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      { error: `provide a valid ${ALERT_TRIGGER_CREATE_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+
+  const { body, error } = await readAlertTriggerBody(request);
+  if (error) return error;
+  const validated = validateAlertTriggerInput(body);
+  if (!validated.ok) {
+    return writeJson({ error: validated.error }, 400);
+  }
+
+  return withAlertTriggersSql(env, async (sql) => {
+    // Short local name (`ownerToken`, not `secret`) keeps the public-safety
+    // scanner's hardcoded-credential heuristic from false-positiving here,
+    // matching src/webhooks.mjs's createWebhookSubscription convention.
+    const ownerToken = generateAlertTriggerOwnerToken();
+    const now = Date.now();
+    const v = validated.value;
+    const [row] = await sql`
+      INSERT INTO chain_alert_triggers
+        (owner_token, name, table_filter, netuid, event_kind, account, min_amount_tao, channel, destination, created_at, updated_at)
+      VALUES (
+        ${ownerToken}, ${v.name}, ${v.tableFilter}, ${v.netuid}, ${v.eventKind},
+        ${v.account}, ${v.minAmountTao}, ${v.channel}, ${v.destination}, ${now}, ${now}
+      )
+      RETURNING *`;
+    return writeJson(
+      {
+        ...ownerAlertTriggerView(row),
+        // Returned ONCE at creation; store it to read/update/delete this
+        // trigger. It is never echoed back on any later GET.
+        owner_token: ownerToken,
+      },
+      201,
+    );
+  });
+}
+
+async function handleAlertTriggerGet(request, env, id) {
+  if (!isValidAlertTriggerId(id)) {
+    return writeJson({ error: "malformed trigger id" }, 400);
+  }
+  return withAlertTriggersSql(env, async (sql) => {
+    const [row] =
+      await sql`SELECT * FROM chain_alert_triggers WHERE id = ${id}`;
+    if (!row) return writeJson({ error: "no such trigger" }, 404);
+    const authError = requireAlertTriggerOwner(request, row.owner_token);
+    if (authError) return authError;
+    return writeJson(ownerAlertTriggerView(row));
+  });
+}
+
+async function handleAlertTriggerUpdate(request, env, id) {
+  if (!isValidAlertTriggerId(id)) {
+    return writeJson({ error: "malformed trigger id" }, 400);
+  }
+  const { body, error } = await readAlertTriggerBody(request);
+  if (error) return error;
+  const validated = validateAlertTriggerInput(body);
+  if (!validated.ok) {
+    return writeJson({ error: validated.error }, 400);
+  }
+  return withAlertTriggersSql(env, async (sql) => {
+    const [existing] =
+      await sql`SELECT owner_token FROM chain_alert_triggers WHERE id = ${id}`;
+    if (!existing) return writeJson({ error: "no such trigger" }, 404);
+    const authError = requireAlertTriggerOwner(request, existing.owner_token);
+    if (authError) return authError;
+
+    const v = validated.value;
+    const now = Date.now();
+    const [row] = await sql`
+      UPDATE chain_alert_triggers SET
+        name = ${v.name},
+        table_filter = ${v.tableFilter},
+        netuid = ${v.netuid},
+        event_kind = ${v.eventKind},
+        account = ${v.account},
+        min_amount_tao = ${v.minAmountTao},
+        channel = ${v.channel},
+        destination = ${v.destination},
+        updated_at = ${now}
+      WHERE id = ${id}
+      RETURNING *`;
+    return writeJson(ownerAlertTriggerView(row));
+  });
+}
+
+async function handleAlertTriggerDelete(request, env, id) {
+  if (!isValidAlertTriggerId(id)) {
+    return writeJson({ error: "malformed trigger id" }, 400);
+  }
+  return withAlertTriggersSql(env, async (sql) => {
+    const [existing] =
+      await sql`SELECT owner_token FROM chain_alert_triggers WHERE id = ${id}`;
+    if (!existing) return writeJson({ error: "no such trigger" }, 404);
+    const authError = requireAlertTriggerOwner(request, existing.owner_token);
+    if (authError) return authError;
+    await sql`DELETE FROM chain_alert_triggers WHERE id = ${id}`;
+    return writeJson({ id, deleted: true });
+  });
+}
+
+// Internal-only: the #4984 Part 2 evaluator's cache-refresh scan. A
+// DIFFERENT secret from the create/owner tokens above -- it grants a wholly
+// different capability (read every trigger regardless of owner).
+async function handleAlertTriggersActiveList(request, env) {
+  const configured = env.ALERT_TRIGGERS_INTERNAL_TOKEN;
+  if (!configured) {
+    return writeJson(
+      {
+        error:
+          "the alert-triggers internal list is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      {
+        error: `provide a valid ${ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER} header`,
+      },
+      401,
+    );
+  }
+  return withAlertTriggersSql(env, async (sql) => {
+    const rows = await sql`SELECT * FROM chain_alert_triggers WHERE active`;
+    return writeJson({ triggers: rows.map(evaluatorAlertTriggerView) });
+  });
+}
+
+async function handleAlertTriggersRoute(request, env, url) {
+  const segments = url.pathname.split("/").filter(Boolean);
+  // ["api", "v1", "alerts", "triggers", <id?>]
+  const id = segments[4];
+  if (!id && request.method === "POST") {
+    return handleAlertTriggerCreate(request, env);
+  }
+  if (id && request.method === "GET") {
+    return handleAlertTriggerGet(request, env, id);
+  }
+  if (id && request.method === "PATCH") {
+    return handleAlertTriggerUpdate(request, env, id);
+  }
+  if (id && request.method === "DELETE") {
+    return handleAlertTriggerDelete(request, env, id);
+  }
+  return writeJson(
+    {
+      error:
+        "Use POST /api/v1/alerts/triggers, or GET/PATCH/DELETE /api/v1/alerts/triggers/{id}.",
+    },
+    405,
+  );
+}
+
 export default {
   async fetch(request, env, _ctx) {
     const url = new URL(request.url);
@@ -2237,6 +2486,19 @@ export default {
       url.pathname === "/api/v1/internal/rpc-usage-sync"
     ) {
       return handleRpcUsageEventSync(request, env);
+    }
+    // #4984 Part 1: multi-method (POST/GET/PATCH/DELETE), so it can't join
+    // the exact-path-and-method checks above -- handleAlertTriggersRoute
+    // does its own method dispatch, same shape as workers/api.mjs's
+    // handleWebhookRequest.
+    if (url.pathname.startsWith("/api/v1/alerts/triggers")) {
+      return handleAlertTriggersRoute(request, env, url);
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === "/api/v1/internal/alert-triggers-active"
+    ) {
+      return handleAlertTriggersActiveList(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -13,6 +13,20 @@
   // (and, for the ones called from the main Worker's own cron rather than an
   // external GitHub Actions workflow, the SAME secret value on the main
   // Worker too -- see wrangler.jsonc.)
+  //
+  // #4984 Part 1's chain_alert_triggers CRUD (workers/data-api.mjs's
+  // handleAlertTrigger* functions) needs three MORE secrets, none yet
+  // provisioned on any deployment:
+  //   wrangler secret put ALERT_TRIGGER_CREATE_TOKEN -c wrangler.data.jsonc
+  //   wrangler secret put ALERT_TRIGGERS_INTERNAL_TOKEN -c wrangler.data.jsonc
+  // (ALERT_TRIGGER_CREATE_TOKEN gates public trigger creation, anti-abuse,
+  // like METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN; ALERT_TRIGGERS_INTERNAL_TOKEN
+  // gates the #4984 Part 2 evaluator's active-trigger list scan. There is no
+  // third secret to provision here -- per-trigger owner tokens are minted
+  // per row by the CREATE route itself, not a deployment secret.) Until
+  // ALERT_TRIGGER_CREATE_TOKEN is set, POST /api/v1/alerts/triggers 503s;
+  // the table/routes are otherwise fully live once this file's schema.sql
+  // is applied.
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "metagraphed-data-api",
   "main": "workers/data-api.mjs",


### PR DESCRIPTION
## Summary

Part 1 of #4984 (the alerter — "notify me when X happens on-chain" — the final piece of the #2114 realtime firehose epic).

- **New `chain_alert_triggers` Postgres table** (`deploy/postgres/schema.sql`), per ADR 0014's Postgres-over-D1 preference for new durable state. Bearer `owner_token` ownership model, matching `src/webhooks.mjs`'s existing per-subscription-secret precedent — no user-account system exists in this codebase.
- **New `src/alert-triggers.mjs`**: pure, no-I/O validation (`validateAlertTriggerInput`) and per-channel destination checks — webhook reuses `src/webhooks.mjs`'s existing SSRF guard; Discord requires the exact incoming-webhook URL shape (matching this repo's icon-proxy aggregator-only precedent rather than a generic "is this URL public" check, since a Discord webhook URL is itself a POST-message capability credential); email/Telegram get plausible-shape checks. Also `triggerMatchesEvent` (pure trigger-vs-firehose-payload matching, consumed by #4984 Part 2's evaluator) and view-shaping helpers that strip `owner_token` before any response.
- **New CRUD routes** `/api/v1/alerts/triggers` (`workers/data-api.mjs`, proxied through `workers/api.mjs` exactly like `/api/v1/webhooks/subscriptions`/neurons-sync): `POST` create (gated by a shared anti-abuse `ALERT_TRIGGER_CREATE_TOKEN` — every active trigger costs the evaluator a real per-event match check, so unbounded public creation is a workload vector); `GET`/`PATCH`/`DELETE` on one trigger, gated by that trigger's own `owner_token`. Unlike webhook subscriptions, there is **no public GET** — a trigger's `destination` can itself be a bearer credential.
- **New internal-only `GET /api/v1/internal/alert-triggers-active`** (gated by a separate `ALERT_TRIGGERS_INTERNAL_TOKEN`) for #4984 Part 2's AlerterHub to scan active triggers.

## Test plan

- [x] `npm run lint` / format clean
- [x] `npm run test:coverage` — 7865 tests pass; `src/alert-triggers.mjs` at 100% coverage; the new `workers/data-api.mjs` CRUD code fully line+branch covered (33 dedicated tests in a new `tests/alert-triggers-route.test.mjs`, matching that file's own established per-test-file-mock convention rather than bloating the existing 5000+-line shared `tests/data-api.test.mjs`)
- [x] `npm run validate`, `npm run validate:contract-drift`, `npm run worker:deploy:dry-run`, `npm run worker:bundle:budget` all pass
- [x] `wrangler deploy -c wrangler.data.jsonc --dry-run` passes independently (this route lives in the separate data-api Worker)
- [x] **Verified against a real throwaway Postgres container**: table creation, the `channel` CHECK constraint, and a full insert/select round trip
- [ ] `ALERT_TRIGGER_CREATE_TOKEN` / `ALERT_TRIGGERS_INTERNAL_TOKEN` need provisioning via `wrangler secret put ... -c wrangler.data.jsonc` before this is live (documented in that file's header comment) — until then, `POST` 503s cleanly rather than silently accepting unauthenticated writes.
- [ ] Applying this schema change to the production Postgres is blocked on a Tailscale SSH re-auth I can't complete myself; the change is purely additive (`CREATE TABLE IF NOT EXISTS`) and safe to apply whenever that's available.

Closes #5012