### PR TITLE
feat(realtime): add the AlerterHub evaluator Durable Object

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -275,12 +275,43 @@ confirmed 2026-07-13, immediately after #5007 merged and propagated (no
 Cloudflare edge-propagation retry needed this time, unlike the graphql-ws
 verification above).
 
-## The alerter (#4984, not yet built)
+## The alerter (#4984, in progress)
 
 A consumer of the same hub: evaluates user-defined trigger conditions against
-the stream and delivers matches via webhook (reusing the existing
-`/api/v1/webhooks/subscriptions` infrastructure), email, Telegram, or
-Discord.
+the stream and delivers matches via webhook, email, Telegram, or Discord.
+Landing in three parts, each its own PR (matching every other piece of this
+epic):
+
+**Part 1 (live): trigger storage + CRUD.** A new `chain_alert_triggers`
+Postgres table (`deploy/postgres/schema.sql`) and public CRUD routes at
+`/api/v1/alerts/triggers` (`workers/data-api.mjs`, proxied through
+`workers/api.mjs`). Ownership is a bearer `owner_token` (returned once, at
+creation) -- matching the webhook-subscription secret model, since no
+user-account system exists here -- and unlike webhook subscriptions there is
+NO public GET: a trigger's `destination` can itself be a capability
+credential (a Discord incoming-webhook URL). Trigger conditions
+(netuid/event_kind/account/min_amount_tao) are drawn from `account_events`'
+own columns, which is exactly why that table got its own firehose-tee
+prerequisite above -- none of `blocks`/`extrinsics`/`chain_events` carry
+those fields.
+
+**Part 2 (live): the AlerterHub evaluator.** A new singleton Durable Object
+(`workers/alerter-hub.mjs`, `idFromName("global")`) that `ChainFirehoseHub`
+pings unconditionally on every `broadcast()` -- mirroring the #4983
+MCP-notify loop's shape, but without a per-session Set, since there is
+exactly one evaluator. Caches active trigger definitions (refreshed from
+Postgres via `DATA_API`'s internal-only active-list route, TTL
+`ALERTER_HUB_TRIGGER_CACHE_TTL_MS` = 5 minutes) rather than a per-event
+Postgres round-trip, since evaluation shares the same `broadcast()` call
+every other consumer (SSE/WS/GraphQL/MCP) is waiting on.
+
+**Part 3 (not yet built): delivery.** `deliverAlertMatch`
+(`workers/alerter-hub.mjs`) is currently a no-op -- the integration point
+Part 3 replaces with real webhook (reusing `src/webhooks.mjs`'s existing
+HMAC-signing/retry/SSRF-guard machinery via a new per-event entry point,
+not its publish-time batch dispatcher), email, Telegram, and Discord
+dispatch, plus rate-limiting/dedup for event bursts and
+`match_count`/`last_matched_at` bookkeeping on the trigger row.
 
 ## Verifying the trigger locally
 

--- a/tests/alerter-hub.test.mjs
+++ b/tests/alerter-hub.test.mjs
@@ -1,0 +1,354 @@
+// Unit tests for workers/alerter-hub.mjs (#4984 Part 2). No Durable Object
+// runtime needed -- state.storage is never touched by this class (the
+// trigger cache is plain in-memory instance state, refreshed from
+// env.DATA_API), so it's fully Node-testable like McpSessionHub.
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import {
+  ALERTER_HUB_TRIGGER_CACHE_TTL_MS,
+  AlerterHub,
+  deliverAlertMatch,
+} from "../workers/alerter-hub.mjs";
+
+const INTERNAL_TOKEN = "test-internal-token";
+
+function fakeDataApi(handler) {
+  return { fetch: handler };
+}
+
+function triggerRow(overrides = {}) {
+  return {
+    id: "1",
+    tableFilter: null,
+    netuid: 7,
+    eventKind: null,
+    account: null,
+    minAmountTao: null,
+    channel: "email",
+    destination: "a@b.com",
+    ...overrides,
+  };
+}
+
+test("ALERTER_HUB_TRIGGER_CACHE_TTL_MS is the documented value (5 minutes)", () => {
+  assert.equal(ALERTER_HUB_TRIGGER_CACHE_TTL_MS, 5 * 60 * 1000);
+});
+
+test("deliverAlertMatch: the default hook resolves without throwing (Part 3 replaces its body)", async () => {
+  await assert.doesNotReject(() =>
+    deliverAlertMatch(triggerRow(), { table: "account_events" }, {}),
+  );
+});
+
+// --- isTriggerCacheStale / refreshTriggers -----------------------------------
+
+test("isTriggerCacheStale: true before any load, false immediately after a successful refresh", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        async () =>
+          new Response(JSON.stringify({ triggers: [] }), { status: 200 }),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  assert.equal(hub.isTriggerCacheStale(), true);
+  await hub.refreshTriggers();
+  assert.equal(hub.isTriggerCacheStale(), false);
+});
+
+test("refreshTriggers: a no-op when DATA_API is unbound", async () => {
+  const hub = new AlerterHub(
+    {},
+    { ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN },
+  );
+  await hub.refreshTriggers();
+  assert.deepEqual(hub.triggers, []);
+  assert.equal(hub.triggersLoadedAt, 0);
+});
+
+test("refreshTriggers: a no-op when ALERT_TRIGGERS_INTERNAL_TOKEN is unset", async () => {
+  let called = false;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        called = true;
+        return new Response(JSON.stringify({ triggers: [] }), { status: 200 });
+      }),
+    },
+  );
+  await hub.refreshTriggers();
+  assert.equal(called, false);
+  assert.deepEqual(hub.triggers, []);
+});
+
+test("refreshTriggers: fetches the internal active-list route with the correct URL and header", async () => {
+  let receivedUrl;
+  let receivedToken;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url, init) => {
+        receivedUrl = String(url);
+        receivedToken = init.headers["x-alert-triggers-internal-token"];
+        return new Response(JSON.stringify({ triggers: [triggerRow()] }), {
+          status: 200,
+        });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.refreshTriggers();
+  assert.equal(
+    receivedUrl,
+    "https://data-api.internal/api/v1/internal/alert-triggers-active",
+  );
+  assert.equal(receivedToken, INTERNAL_TOKEN);
+  assert.equal(hub.triggers.length, 1);
+  assert.notEqual(hub.triggersLoadedAt, 0);
+});
+
+test("refreshTriggers: keeps the stale cache when the upstream response is not ok", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        async () =>
+          new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  hub.triggers = [triggerRow({ id: "existing" })];
+  await hub.refreshTriggers();
+  assert.equal(hub.triggers[0].id, "existing");
+  assert.equal(hub.triggersLoadedAt, 0);
+});
+
+test("refreshTriggers: keeps the stale cache when the body's triggers field isn't an array", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        async () =>
+          new Response(JSON.stringify({ triggers: "not-an-array" }), {
+            status: 200,
+          }),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  hub.triggers = [triggerRow({ id: "existing" })];
+  await hub.refreshTriggers();
+  assert.equal(hub.triggers[0].id, "existing");
+});
+
+test("refreshTriggers: keeps the stale cache and never throws when the fetch itself rejects", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        throw new Error("network down");
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  hub.triggers = [triggerRow({ id: "existing" })];
+  await assert.doesNotReject(() => hub.refreshTriggers());
+  assert.equal(hub.triggers[0].id, "existing");
+});
+
+test("refreshTriggers: keeps the stale cache and never throws when upstream.json() itself throws", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        async () => new Response("not json", { status: 200 }),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  hub.triggers = [triggerRow({ id: "existing" })];
+  await assert.doesNotReject(() => hub.refreshTriggers());
+  assert.equal(hub.triggers[0].id, "existing");
+});
+
+// --- ensureTriggersLoaded -----------------------------------------------------
+
+test("ensureTriggersLoaded: refreshes when the cache is stale", async () => {
+  let calls = 0;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ triggers: [] }), { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.ensureTriggersLoaded();
+  assert.equal(calls, 1);
+});
+
+test("ensureTriggersLoaded: skips the refresh entirely once the cache is fresh", async () => {
+  let calls = 0;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ triggers: [] }), { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.ensureTriggersLoaded();
+  await hub.ensureTriggersLoaded();
+  assert.equal(calls, 1);
+});
+
+test("ensureTriggersLoaded: coalesces concurrent stale-cache calls into ONE refresh", async () => {
+  let calls = 0;
+  let resolveFetch;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        () =>
+          new Promise((resolve) => {
+            calls += 1;
+            resolveFetch = () =>
+              resolve(
+                new Response(JSON.stringify({ triggers: [] }), {
+                  status: 200,
+                }),
+              );
+          }),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  const first = hub.ensureTriggersLoaded();
+  const second = hub.ensureTriggersLoaded();
+  resolveFetch();
+  await Promise.all([first, second]);
+  assert.equal(calls, 1);
+});
+
+// --- matchingTriggers / evaluate -----------------------------------------------
+
+test("matchingTriggers: filters the cache via triggerMatchesEvent", () => {
+  const hub = new AlerterHub({}, {});
+  hub.triggers = [
+    triggerRow({ id: "1", netuid: 7 }),
+    triggerRow({ id: "2", netuid: 8 }),
+  ];
+  const matches = hub.matchingTriggers({ table: "account_events", netuid: 7 });
+  assert.deepEqual(
+    matches.map((t) => t.id),
+    ["1"],
+  );
+});
+
+test("evaluate: returns {matched:0} and never calls deliver when nothing matches", async () => {
+  const deliver = vi.fn();
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ netuid: 7 })];
+  hub.triggersLoadedAt = Date.now(); // fresh -- skip the refresh path
+  const result = await hub.evaluate({ table: "account_events", netuid: 99 });
+  assert.deepEqual(result, { matched: 0 });
+  assert.equal(deliver.mock.calls.length, 0);
+});
+
+test("evaluate: reports every matching trigger and calls deliver once per match", async () => {
+  const deliver = vi.fn().mockResolvedValue(undefined);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [
+    triggerRow({ id: "1", netuid: 7 }),
+    triggerRow({ id: "2", netuid: 7 }),
+    triggerRow({ id: "3", netuid: 8 }),
+  ];
+  hub.triggersLoadedAt = Date.now();
+  const payload = { table: "account_events", netuid: 7 };
+  const result = await hub.evaluate(payload);
+  assert.equal(result.matched, 2);
+  assert.deepEqual(result.trigger_ids.sort(), ["1", "2"]);
+  assert.equal(deliver.mock.calls.length, 2);
+  assert.equal(deliver.mock.calls[0][1], payload);
+});
+
+test("evaluate: a rejecting deliver call never fails the overall evaluation", async () => {
+  const deliver = vi.fn().mockRejectedValue(new Error("delivery exploded"));
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.equal(result.matched, 1);
+});
+
+test("evaluate: triggers a refresh first when the cache is stale", async () => {
+  let refreshed = false;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        refreshed = true;
+        return new Response(
+          JSON.stringify({ triggers: [triggerRow({ netuid: 7 })] }),
+          { status: 200 },
+        );
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.equal(refreshed, true);
+  assert.equal(result.matched, 1);
+});
+
+// --- fetch (the /evaluate route) -----------------------------------------------
+
+test("fetch: POST /evaluate with a valid JSON body returns the evaluate() result", async () => {
+  const hub = new AlerterHub({}, {});
+  hub.triggers = [triggerRow({ netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const res = await hub.fetch(
+    new Request("https://alerter-hub.internal/evaluate", {
+      method: "POST",
+      body: JSON.stringify({ table: "account_events", netuid: 7 }),
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), {
+    matched: 1,
+    trigger_ids: [triggerRow().id],
+  });
+});
+
+test("fetch: POST /evaluate with malformed JSON returns 400", async () => {
+  const hub = new AlerterHub({}, {});
+  const res = await hub.fetch(
+    new Request("https://alerter-hub.internal/evaluate", {
+      method: "POST",
+      body: "not json",
+    }),
+  );
+  assert.equal(res.status, 400);
+});
+
+test("fetch: an unrecognized path 404s", async () => {
+  const hub = new AlerterHub({}, {});
+  const res = await hub.fetch(new Request("https://alerter-hub.internal/nope"));
+  assert.equal(res.status, 404);
+});
+
+test("fetch: GET /evaluate (wrong method) 404s", async () => {
+  const hub = new AlerterHub({}, {});
+  const res = await hub.fetch(
+    new Request("https://alerter-hub.internal/evaluate"),
+  );
+  assert.equal(res.status, 404);
+});

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -1002,3 +1002,71 @@ test("broadcast: an unreachable/erroring session hub is best-effort -- doesn't t
   const sessionIds = mcpHub.calls.map((c) => c.sessionId).sort();
   assert.deepEqual(sessionIds, ["s1", "s2"]);
 });
+
+// --- ALERTER_HUB ping (#4984 Part 2) ---------------------------------------------
+
+function fakeAlerterHubBinding(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    idFromName: (name) => name,
+    get: (name) => ({
+      fetch: async (url, init) => {
+        calls.push({ name, url, init });
+        if (overrides[name]) return overrides[name]();
+        return new Response(JSON.stringify({ matched: 0 }), { status: 200 });
+      },
+    }),
+  };
+}
+
+test("broadcast: with ALERTER_HUB unbound, never throws and skips the ping", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  await assert.doesNotReject(() =>
+    hub.broadcast({ table: "account_events", block_number: 1 }),
+  );
+});
+
+test("broadcast: pings ALERTER_HUB's singleton /evaluate route with the full payload", async () => {
+  const alerterHub = fakeAlerterHubBinding();
+  const hub = new ChainFirehoseHub(stubState(), { ALERTER_HUB: alerterHub });
+  const payload = {
+    table: "account_events",
+    block_number: 7,
+    netuid: 7,
+    amount_tao: 12.5,
+  };
+  await hub.broadcast(payload);
+  assert.equal(alerterHub.calls.length, 1);
+  assert.equal(alerterHub.calls[0].name, "global");
+  assert.match(alerterHub.calls[0].url, /\/evaluate$/);
+  assert.equal(alerterHub.calls[0].init.method, "POST");
+  assert.deepEqual(JSON.parse(alerterHub.calls[0].init.body), payload);
+});
+
+test("broadcast: an unreachable/erroring AlerterHub is best-effort -- doesn't throw and doesn't block ingest", async () => {
+  const alerterHub = fakeAlerterHubBinding({
+    global: () => {
+      throw new Error("alerter hub unreachable");
+    },
+  });
+  const hub = new ChainFirehoseHub(stubState(), { ALERTER_HUB: alerterHub });
+  await assert.doesNotReject(() =>
+    hub.broadcast({ table: "account_events", block_number: 1 }),
+  );
+  assert.equal(alerterHub.calls.length, 1);
+});
+
+test("broadcast: pings ALERTER_HUB unconditionally, unlike the per-session MCP loop -- no subscribe step required", async () => {
+  const alerterHub = fakeAlerterHubBinding();
+  const mcpHub = fakeMcpSessionHubBinding();
+  const hub = new ChainFirehoseHub(stubState(), {
+    ALERTER_HUB: alerterHub,
+    MCP_SESSION_HUB: mcpHub,
+  });
+  // No mcpSubscribeSession call -- the MCP loop should stay silent while the
+  // alerter ping still fires.
+  await hub.broadcast({ table: "account_events", block_number: 1 });
+  assert.equal(alerterHub.calls.length, 1);
+  assert.equal(mcpHub.calls.length, 0);
+});

--- a/workers/alerter-hub.mjs
+++ b/workers/alerter-hub.mjs
@@ -1,0 +1,143 @@
+// AlerterHub -- the #4984 Part 2 evaluator: a singleton Durable Object
+// (idFromName("global")) that ChainFirehoseHub pings on every broadcast()
+// (see that class's own ALERTER_HUB ping, mirroring the #4983 MCP-notify
+// loop's exact shape -- but unconditional/global rather than per-session,
+// since there is exactly one evaluator, not one per subscriber).
+//
+// Caches active trigger definitions (refreshed from Postgres via the
+// DATA_API service binding's internal-only active-list route, #4984 Part 1)
+// rather than querying Postgres per chain event -- evaluation must stay
+// fast enough to never become the bottleneck in ChainFirehoseHub's
+// broadcast() fan-out, which every OTHER consumer (SSE/WS/GraphQL/MCP)
+// shares the same request with. A stale cache degrades gracefully (a
+// brand-new trigger takes up to ALERTER_HUB_TRIGGER_CACHE_TTL_MS to start
+// matching; a deleted one keeps matching for the same window) rather than
+// adding a synchronous Postgres round-trip to every single chain event.
+//
+// Delivery itself (#4984 Part 3: webhook/email/telegram/discord) is
+// deliberately NOT this file's concern -- deliverAlertMatch below is the
+// integration point Part 3 replaces; this class only decides WHICH
+// triggers matched a given event. Matches "one focused change per PR",
+// the same scoping every other piece of this epic (#4981/#4982/#4983
+// GraphQL/#4983 MCP) already used.
+import { triggerMatchesEvent } from "../src/alert-triggers.mjs";
+
+export const ALERTER_HUB_TRIGGER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Default delivery hook, called once per (trigger, matching payload) pair
+// -- a no-op until #4984 Part 3 replaces its body with real channel
+// dispatch. Constructor-injectable (see AlerterHub below) rather than a
+// hardcoded call inside evaluate(), both so Part 3 can wire a real
+// implementation without touching evaluate() itself and so tests can
+// substitute a spy/failing stub to exercise the catch-wrapping resilience
+// below without needing real delivery logic to exist yet.
+export async function deliverAlertMatch(_trigger, _payload, _env) {
+  // #4984 Part 3: webhook/email/telegram/discord dispatch + rate-limit/
+  // dedup + match_count/last_matched_at bookkeeping land here.
+}
+
+export class AlerterHub {
+  constructor(state, env, { deliver = deliverAlertMatch } = {}) {
+    this.state = state;
+    this.env = env;
+    this.deliver = deliver;
+    this.triggers = [];
+    this.triggersLoadedAt = 0;
+    // Coalesces concurrent evaluate() calls that all find the cache stale
+    // into ONE refresh request rather than one per call -- broadcast()
+    // fires one /evaluate POST per chain event, and events can arrive
+    // faster than a single refresh round-trip completes.
+    this.loadingPromise = null;
+  }
+
+  isTriggerCacheStale() {
+    return (
+      Date.now() - this.triggersLoadedAt > ALERTER_HUB_TRIGGER_CACHE_TTL_MS
+    );
+  }
+
+  async ensureTriggersLoaded() {
+    if (!this.isTriggerCacheStale()) return;
+    if (!this.loadingPromise) {
+      this.loadingPromise = this.refreshTriggers().finally(() => {
+        this.loadingPromise = null;
+      });
+    }
+    return this.loadingPromise;
+  }
+
+  async refreshTriggers() {
+    if (!this.env.DATA_API || !this.env.ALERT_TRIGGERS_INTERNAL_TOKEN) {
+      // Not provisioned on this deployment -- keep whatever was cached
+      // before (possibly still empty). Never throw: a cold/unconfigured
+      // evaluator must not block ChainFirehoseHub's ingest path, which
+      // awaits this indirectly via evaluate().
+      return;
+    }
+    try {
+      const upstream = await this.env.DATA_API.fetch(
+        "https://data-api.internal/api/v1/internal/alert-triggers-active",
+        {
+          headers: {
+            "x-alert-triggers-internal-token":
+              this.env.ALERT_TRIGGERS_INTERNAL_TOKEN,
+          },
+        },
+      );
+      if (!upstream.ok) return;
+      const body = await upstream.json();
+      if (Array.isArray(body?.triggers)) {
+        this.triggers = body.triggers;
+        this.triggersLoadedAt = Date.now();
+      }
+    } catch {
+      // Best-effort refresh -- keep serving the stale cache rather than
+      // throwing out of evaluate().
+    }
+  }
+
+  // Pure decision given the CURRENT cache -- exported behavior is really
+  // triggerMatchesEvent (src/alert-triggers.mjs, already unit-tested);
+  // this just applies it across every cached trigger.
+  matchingTriggers(payload) {
+    return this.triggers.filter((trigger) =>
+      triggerMatchesEvent(trigger, payload),
+    );
+  }
+
+  async evaluate(payload) {
+    await this.ensureTriggersLoaded();
+    const matched = this.matchingTriggers(payload);
+    if (matched.length === 0) return { matched: 0 };
+    await Promise.all(
+      matched.map((trigger) =>
+        this.deliver(trigger, payload, this.env).catch(() => {
+          // A single misbehaving delivery integration must never fail the
+          // evaluation response ChainFirehoseHub's broadcast() awaits.
+        }),
+      ),
+    );
+    return { matched: matched.length, trigger_ids: matched.map((t) => t.id) };
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/evaluate" && request.method === "POST") {
+      let payload;
+      try {
+        payload = await request.json();
+      } catch {
+        return new Response(JSON.stringify({ error: "invalid JSON body" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      const result = await this.evaluate(payload);
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }
+}

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -264,6 +264,7 @@ import {
   ChainFirehoseHub,
 } from "./chain-firehose-hub.mjs";
 import { McpSessionHub } from "./mcp-session-hub.mjs";
+import { AlerterHub } from "./alerter-hub.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
@@ -441,7 +442,7 @@ export default {
 // classes defined in chain-firehose-hub.mjs/mcp-session-hub.mjs is what
 // makes the "durable_objects"/"migrations" bindings in wrangler.jsonc
 // resolvable.
-export { ChainFirehoseHub, McpSessionHub };
+export { ChainFirehoseHub, McpSessionHub, AlerterHub };
 
 // The staged-artifact loaders now live in request-handlers/staging.mjs (#1763).
 // Re-export it so the scheduled cron drain (handleScheduled) and the staging

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -702,5 +702,25 @@ export class ChainFirehoseHub {
         }),
       );
     }
+
+    // #4984 Part 2: the alerter evaluator. A SINGLETON (idFromName("global")),
+    // unlike the per-session MCP loop above -- there is exactly one
+    // evaluator, not one per subscriber, so no membership Set to check
+    // first. Best-effort: an unreachable/erroring AlerterHub never blocks
+    // ingest or any other broadcast population.
+    if (this.env.ALERTER_HUB) {
+      try {
+        const stub = this.env.ALERTER_HUB.get(
+          this.env.ALERTER_HUB.idFromName("global"),
+        );
+        await stub.fetch("https://alerter-hub.internal/evaluate", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      } catch {
+        // best-effort -- see the comment above
+      }
+    }
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -355,6 +355,15 @@
   // #4981 relay's ingest secret is provisioned the same way every other
   // *_SYNC_SECRET is: `wrangler secret put CHAIN_FIREHOSE_SYNC_SECRET`
   // (see docs/realtime-firehose.md).
+  //
+  // #4984 Part 2: AlerterHub calls the DATA_API service binding's internal
+  // active-trigger-list route directly, so this Worker needs the SAME
+  // ALERT_TRIGGERS_INTERNAL_TOKEN value already provisioned on
+  // wrangler.data.jsonc (`wrangler secret put ALERT_TRIGGERS_INTERNAL_TOKEN`
+  // -- see that file's own comment). Not yet provisioned on any deployment;
+  // until it is, the evaluator's trigger cache just stays empty (no crash,
+  // no delivery, matching every other optional binding's degrade-gracefully
+  // convention in this codebase).
   "durable_objects": {
     "bindings": [
       { "name": "CHAIN_FIREHOSE_HUB", "class_name": "ChainFirehoseHub" },
@@ -363,6 +372,13 @@
       // file's own header comment for why this is a SEPARATE DO from
       // ChainFirehoseHub rather than a fourth connection population on it.
       { "name": "MCP_SESSION_HUB", "class_name": "McpSessionHub" },
+      // #4984 Part 2: the alerter evaluator, a SINGLETON (idFromName("global"),
+      // like ChainFirehoseHub itself) -- pinged unconditionally on every
+      // broadcast(), unlike McpSessionHub's per-session Set, since there is
+      // exactly one evaluator. See workers/alerter-hub.mjs's own header
+      // comment for why it stays a separate DO rather than in-memory state
+      // on ChainFirehoseHub.
+      { "name": "ALERTER_HUB", "class_name": "AlerterHub" },
     ],
   },
   // Durable Object class migrations are one-way and versioned: adding a new
@@ -379,6 +395,10 @@
     {
       "tag": "v2-mcp-session-hub",
       "new_sqlite_classes": ["McpSessionHub"],
+    },
+    {
+      "tag": "v3-alerter-hub",
+      "new_sqlite_classes": ["AlerterHub"],
     },
   ],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV


### PR DESCRIPTION
## Summary

Part 2 of #4984 (the alerter). Builds on #5013 (trigger storage + CRUD, merged).

- **New singleton `AlerterHub` Durable Object** (`workers/alerter-hub.mjs`, `idFromName("global")`), pinged unconditionally by `ChainFirehoseHub.broadcast()` on every chain event — mirrors the #4983 MCP-notify loop's shape but without a per-session Set, since there is exactly one evaluator (not one per subscriber).
- **Caches active trigger definitions** from Part 1's `chain_alert_triggers` table, refreshed via `DATA_API`'s internal-only active-list route (`ALERTER_HUB_TRIGGER_CACHE_TTL_MS` = 5 minutes), coalescing concurrent stale-cache refreshes into one in-flight request. Evaluation shares the SAME `broadcast()` call every other consumer (SSE/WS/GraphQL/MCP) is waiting on, so a synchronous per-event Postgres round-trip wasn't an option.
- **`deliverAlertMatch`** is a deliberately no-op, constructor-injectable delivery hook — the exact integration point #4984 Part 3 replaces with real webhook/email/Telegram/Discord dispatch, without needing to restructure `evaluate()` itself. Constructor injection (rather than a hardcoded call) also makes the catch-wrapping resilience genuinely unit-testable now (a rejecting `deliver` never fails the overall evaluation).
- New `ALERTER_HUB` Durable Object binding + `v3-alerter-hub` migration (`wrangler.jsonc`), plus a note on the `ALERT_TRIGGERS_INTERNAL_TOKEN` secret this Worker now also needs (shared with `wrangler.data.jsonc`).

## Test plan

- [x] `npm run lint` / format clean
- [x] `npm run test:coverage` — 7891 tests pass; `workers/alerter-hub.mjs` at 100% coverage (22 dedicated tests); `ChainFirehoseHub`'s new AlerterHub-ping wiring also at 100% coverage
- [x] `npm run validate`, `npm run worker:deploy:dry-run`, `npm run worker:bundle:budget` all pass (bundle at 964.4 KiB gzipped — within the 1000 KiB budget, but the margin is narrowing; worth watching as Part 3 adds more code)

Closes #5014