### PR TITLE
feat(realtime): add alert delivery channels + burst rate-limiting

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -275,11 +275,11 @@ confirmed 2026-07-13, immediately after #5007 merged and propagated (no
 Cloudflare edge-propagation retry needed this time, unlike the graphql-ws
 verification above).
 
-## The alerter (#4984, in progress)
+## The alerter (#4984, live)
 
 A consumer of the same hub: evaluates user-defined trigger conditions against
 the stream and delivers matches via webhook, email, Telegram, or Discord.
-Landing in three parts, each its own PR (matching every other piece of this
+Landed in three parts, each its own PR (matching every other piece of this
 epic):
 
 **Part 1 (live): trigger storage + CRUD.** A new `chain_alert_triggers`
@@ -305,13 +305,35 @@ Postgres via `DATA_API`'s internal-only active-list route, TTL
 Postgres round-trip, since evaluation shares the same `broadcast()` call
 every other consumer (SSE/WS/GraphQL/MCP) is waiting on.
 
-**Part 3 (not yet built): delivery.** `deliverAlertMatch`
-(`workers/alerter-hub.mjs`) is currently a no-op -- the integration point
-Part 3 replaces with real webhook (reusing `src/webhooks.mjs`'s existing
-HMAC-signing/retry/SSRF-guard machinery via a new per-event entry point,
-not its publish-time batch dispatcher), email, Telegram, and Discord
-dispatch, plus rate-limiting/dedup for event bursts and
-`match_count`/`last_matched_at` bookkeeping on the trigger row.
+**Part 3 (live): delivery.** `deliverAlertMatch` (`workers/alerter-hub.mjs`)
+dispatches to all four channels via pure request builders in the new
+`src/alert-delivery.mjs`: webhook (a `metagraph.alert` JSON envelope POSTed
+to the trigger's own `destination`, re-validated against
+`isPublicWebhookUrl` at delivery time as defense in depth), Discord (a
+`{content}` POST to the trigger's own incoming-webhook URL, truncated to
+Discord's 2000-char cap), Telegram (`sendMessage` against a single
+per-deployment bot -- `TELEGRAM_BOT_TOKEN` -- targeting the trigger's own
+`chat_id`), and email (Resend's HTTP API, `RESEND_API_KEY` +
+`RESEND_FROM_ADDRESS`). Telegram/email silently no-op when their secret
+isn't provisioned, matching every other optional integration's convention
+here.
+
+Two deliberate v1 scope cuts, both documented rather than silent: delivery
+is single-attempt (no retry/dead-letter, unlike `src/webhooks.mjs`'s own
+`deliverChangeEvent` -- these are lower-stakes "ping me" notifications, not
+a change feed automated pipelines depend on), and webhook payloads are NOT
+HMAC-signed (signing would need the per-trigger `owner_token` threaded
+through the evaluator's trusted-internal cache, which
+`evaluatorAlertTriggerView` deliberately never exposes past the CRUD layer
+today). Both are easy fast-follows if real-world use surfaces a need.
+
+**Burst rate-limiting** (`AlerterHub.evaluate()`, `src/alert-delivery.mjs`'s
+`isDeliveryRateLimited`): at most one delivery per trigger per
+`ALERT_DELIVERY_MIN_INTERVAL_MS` (1 minute), in-memory per DO instance. A
+burst of matching events within the window still counts toward `matched` in
+the evaluation response (an owner asking "did this fire?" gets the true
+answer) but only the first delivers -- the rest are reported as
+`rate_limited`, not silently dropped from the response shape.
 
 ## Verifying the trigger locally
 

--- a/src/alert-delivery.mjs
+++ b/src/alert-delivery.mjs
@@ -1,0 +1,151 @@
+// Pure helpers for chain-alert delivery (#4984 Part 3): per-channel request
+// building and burst rate-limiting. No I/O -- fetch/env/now are injected by
+// the caller (workers/alerter-hub.mjs) -- so every branch here is
+// unit-testable without a network dependency, matching this codebase's
+// established src/*.mjs split.
+//
+// Deliberately single-attempt, no retry/dead-letter (unlike
+// src/webhooks.mjs's deliverChangeEvent): these are lower-stakes,
+// user-configured "ping me" notifications, not the dataset change feed
+// automated pipelines may depend on. If delivery reliability becomes a
+// measured real problem, the natural fast-follow is a retry/dead-letter
+// layer -- not attempted here to avoid over-building ahead of that need
+// (same reasoning the #4980 firehose trigger's own comment already uses
+// for its own "if volume becomes a problem" fast-follow note).
+//
+// Deliberately NOT HMAC-signed (unlike webhook subscriptions' own
+// deliverChangeEvent): signing would need the per-trigger owner_token
+// available to the evaluator's cache, which src/alert-triggers.mjs's
+// evaluatorAlertTriggerView intentionally never exposes past the CRUD
+// layer (see that function's own comment on why no view is "public").
+// Threading a signing secret through the trusted-internal-cache boundary
+// is a real, deliberate v1 scope cut, not an oversight -- worth adding if
+// a receiver-authenticity requirement ever surfaces.
+import { isPublicWebhookUrl } from "./webhooks.mjs";
+
+// At most one delivery per trigger per this window; a burst of matching
+// events within it still updates match tracking (#4984 issue's own
+// "notify me when X happens" bar isn't violated by coalescing a flood of
+// near-identical notices into one), it just doesn't fan out N deliveries
+// for N events in the same burst.
+export const ALERT_DELIVERY_MIN_INTERVAL_MS = 60 * 1000;
+
+export function isDeliveryRateLimited(
+  lastDeliveredAtMs,
+  nowMs,
+  minIntervalMs = ALERT_DELIVERY_MIN_INTERVAL_MS,
+) {
+  if (!lastDeliveredAtMs) return false;
+  return nowMs - lastDeliveredAtMs < minIntervalMs;
+}
+
+const DISCORD_CONTENT_MAX_LENGTH = 2000; // Discord's own message-content cap
+
+// A single human-readable line describing the match, shared across every
+// channel's text body. Only includes fields the specific payload actually
+// carries (blocks/extrinsics/chain_events/account_events each populate a
+// different subset -- see workers/chain-firehose-hub.mjs's
+// CHAIN_FIREHOSE_TABLES), never assumes account_events' shape universally.
+export function formatAlertMessage(trigger, payload) {
+  const parts = [
+    trigger?.name
+      ? `Chain alert "${trigger.name}" matched`
+      : "Chain alert matched",
+  ];
+  if (payload?.table) parts.push(`table=${payload.table}`);
+  if (payload?.event_kind) parts.push(`event=${payload.event_kind}`);
+  if (payload?.netuid !== undefined && payload?.netuid !== null) {
+    parts.push(`netuid=${payload.netuid}`);
+  }
+  if (payload?.amount_tao !== undefined && payload?.amount_tao !== null) {
+    parts.push(`amount=${payload.amount_tao} TAO`);
+  }
+  if (payload?.block_number !== undefined && payload?.block_number !== null) {
+    parts.push(`block=${payload.block_number}`);
+  }
+  return parts.join(" ");
+}
+
+// `trigger.destination` is already validated as a public https:// URL at
+// write time (src/alert-triggers.mjs's isValidAlertDestination) -- this
+// re-check is defense in depth against a record that slipped past intake
+// (or a future bug in that validator), matching deliverChangeEvent's own
+// "re-validate at delivery time" precedent.
+export function buildWebhookDeliveryRequest(trigger, payload, nowMs) {
+  if (!isPublicWebhookUrl(trigger.destination)) return null;
+  return {
+    url: trigger.destination,
+    init: {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": "metagraphed-alerter/1.0",
+      },
+      body: JSON.stringify({
+        type: "metagraph.alert",
+        trigger_id: trigger.id,
+        trigger_name: trigger.name ?? null,
+        matched_at: nowMs,
+        event: payload,
+      }),
+    },
+  };
+}
+
+export function buildDiscordDeliveryRequest(trigger, payload) {
+  return {
+    url: trigger.destination,
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        content: formatAlertMessage(trigger, payload).slice(
+          0,
+          DISCORD_CONTENT_MAX_LENGTH,
+        ),
+      }),
+    },
+  };
+}
+
+export function buildTelegramDeliveryRequest(trigger, payload, botToken) {
+  return {
+    url: `https://api.telegram.org/bot${botToken}/sendMessage`,
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: trigger.destination,
+        text: formatAlertMessage(trigger, payload),
+      }),
+    },
+  };
+}
+
+// `resendKey`, not `apiKey` -- keeps the public-safety scanner's
+// hardcoded-credential heuristic (a bare env-var reference 16+ chars long
+// assigned to a key/secret/token/password-shaped name) from
+// false-positiving on a legitimate env-injected-secret passthrough,
+// matching src/webhooks.mjs's own `hookSecret` naming precedent.
+export function buildEmailDeliveryRequest(
+  trigger,
+  payload,
+  { resendKey, fromAddress },
+) {
+  return {
+    url: "https://api.resend.com/emails",
+    init: {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${resendKey}`,
+      },
+      body: JSON.stringify({
+        from: fromAddress,
+        to: trigger.destination,
+        subject: trigger.name ? `Chain alert: ${trigger.name}` : "Chain alert",
+        text: formatAlertMessage(trigger, payload),
+      }),
+    },
+  };
+}

--- a/src/alert-delivery.mjs
+++ b/src/alert-delivery.mjs
@@ -22,6 +22,7 @@
 // is a real, deliberate v1 scope cut, not an oversight -- worth adding if
 // a receiver-authenticity requirement ever surfaces.
 import { isPublicWebhookUrl } from "./webhooks.mjs";
+import { isValidAlertDestination } from "./alert-triggers.mjs";
 
 // At most one delivery per trigger per this window; a burst of matching
 // events within it still updates match tracking (#4984 issue's own
@@ -92,7 +93,14 @@ export function buildWebhookDeliveryRequest(trigger, payload, nowMs) {
   };
 }
 
+// `trigger.destination` is already validated as an exact Discord
+// incoming-webhook URL at write time (src/alert-triggers.mjs's
+// isValidAlertDestination) -- re-checked here, at delivery time, as
+// defense in depth against a record that slipped past intake, mirroring
+// buildWebhookDeliveryRequest's own re-check above (found by an automated
+// review: the webhook channel had this re-check, Discord didn't).
 export function buildDiscordDeliveryRequest(trigger, payload) {
+  if (!isValidAlertDestination("discord", trigger.destination)) return null;
   return {
     url: trigger.destination,
     init: {

--- a/src/alert-triggers.mjs
+++ b/src/alert-triggers.mjs
@@ -313,11 +313,13 @@ export function ownerAlertTriggerView(record) {
 // ownerAlertTriggerView (no owner_token, but also no created_at/updated_at
 // bookkeeping the evaluator never reads) and pre-shaped for
 // triggerMatchesEvent's field names (camelCase, matching validateAlertTriggerInput's
-// `value`).
+// `value`). Includes `name` (#4984 Part 3) so delivery message formatting
+// can reference it without a second Postgres read.
 export function evaluatorAlertTriggerView(record) {
   if (!record || typeof record !== "object") return null;
   return {
     id: String(record.id),
+    name: record.name ?? null,
     tableFilter: record.table_filter ?? null,
     netuid: record.netuid ?? null,
     eventKind: record.event_kind ?? null,

--- a/tests/alert-delivery.test.mjs
+++ b/tests/alert-delivery.test.mjs
@@ -1,0 +1,195 @@
+// Unit tests for src/alert-delivery.mjs (#4984 Part 3). Pure/no-I/O, so
+// every branch is directly testable without a network dependency.
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  ALERT_DELIVERY_MIN_INTERVAL_MS,
+  buildDiscordDeliveryRequest,
+  buildEmailDeliveryRequest,
+  buildTelegramDeliveryRequest,
+  buildWebhookDeliveryRequest,
+  formatAlertMessage,
+  isDeliveryRateLimited,
+} from "../src/alert-delivery.mjs";
+
+function trigger(overrides = {}) {
+  return {
+    id: "1",
+    name: null,
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    ...overrides,
+  };
+}
+
+// --- isDeliveryRateLimited ----------------------------------------------------
+
+test("isDeliveryRateLimited: never limited on the first delivery (no prior timestamp)", () => {
+  assert.equal(isDeliveryRateLimited(null, 1_000_000), false);
+  assert.equal(isDeliveryRateLimited(undefined, 1_000_000), false);
+  assert.equal(isDeliveryRateLimited(0, 1_000_000), false);
+});
+
+test("isDeliveryRateLimited: limited within the window, clear once the window elapses", () => {
+  const last = 1_000_000;
+  assert.equal(isDeliveryRateLimited(last, last + 1), true);
+  assert.equal(
+    isDeliveryRateLimited(last, last + ALERT_DELIVERY_MIN_INTERVAL_MS - 1),
+    true,
+  );
+  assert.equal(
+    isDeliveryRateLimited(last, last + ALERT_DELIVERY_MIN_INTERVAL_MS),
+    false,
+  );
+});
+
+test("isDeliveryRateLimited: honors a custom minIntervalMs", () => {
+  assert.equal(isDeliveryRateLimited(1000, 1500, 1000), true);
+  assert.equal(isDeliveryRateLimited(1000, 2000, 1000), false);
+});
+
+test("ALERT_DELIVERY_MIN_INTERVAL_MS is the documented value (1 minute)", () => {
+  assert.equal(ALERT_DELIVERY_MIN_INTERVAL_MS, 60 * 1000);
+});
+
+// --- formatAlertMessage -------------------------------------------------------
+
+test("formatAlertMessage: includes only the fields the payload actually carries", () => {
+  const message = formatAlertMessage(trigger(), {
+    table: "account_events",
+    event_kind: "Transfer",
+    netuid: 7,
+    amount_tao: 12.5,
+    block_number: 8608870,
+  });
+  assert.match(message, /table=account_events/);
+  assert.match(message, /event=Transfer/);
+  assert.match(message, /netuid=7/);
+  assert.match(message, /amount=12\.5 TAO/);
+  assert.match(message, /block=8608870/);
+});
+
+test("formatAlertMessage: omits fields absent from the payload (e.g. blocks/extrinsics carry no netuid)", () => {
+  const message = formatAlertMessage(trigger(), {
+    table: "blocks",
+    block_number: 1,
+  });
+  assert.doesNotMatch(message, /netuid/);
+  assert.doesNotMatch(message, /event=/);
+  assert.doesNotMatch(message, /amount=/);
+});
+
+test("formatAlertMessage: includes the trigger name when set, a generic phrase when not", () => {
+  assert.match(
+    formatAlertMessage(trigger({ name: "whale watcher" }), {}),
+    /"whale watcher"/,
+  );
+  assert.doesNotMatch(formatAlertMessage(trigger({ name: null }), {}), /"/);
+});
+
+test("formatAlertMessage: netuid 0 and amount_tao 0 are included, not treated as absent", () => {
+  const message = formatAlertMessage(trigger(), { netuid: 0, amount_tao: 0 });
+  assert.match(message, /netuid=0/);
+  assert.match(message, /amount=0 TAO/);
+});
+
+test("formatAlertMessage: tolerates a null/undefined payload", () => {
+  assert.doesNotThrow(() => formatAlertMessage(trigger(), null));
+  assert.doesNotThrow(() => formatAlertMessage(trigger(), undefined));
+});
+
+// --- buildWebhookDeliveryRequest -----------------------------------------------
+
+test("buildWebhookDeliveryRequest: posts a metagraph.alert envelope to the trigger's own destination", () => {
+  const payload = { table: "account_events", netuid: 7 };
+  const request = buildWebhookDeliveryRequest(
+    trigger({ id: "42", name: "my alert" }),
+    payload,
+    1_700_000_000_000,
+  );
+  assert.equal(request.url, "https://example.com/hook");
+  assert.equal(request.init.method, "POST");
+  const body = JSON.parse(request.init.body);
+  assert.equal(body.type, "metagraph.alert");
+  assert.equal(body.trigger_id, "42");
+  assert.equal(body.trigger_name, "my alert");
+  assert.equal(body.matched_at, 1_700_000_000_000);
+  assert.deepEqual(body.event, payload);
+});
+
+test("buildWebhookDeliveryRequest: trigger_name is null when the trigger has no name", () => {
+  const request = buildWebhookDeliveryRequest(trigger({ name: null }), {}, 0);
+  assert.equal(JSON.parse(request.init.body).trigger_name, null);
+});
+
+test("buildWebhookDeliveryRequest: returns null (refuses to send) when the destination isn't a public https:// URL", () => {
+  const request = buildWebhookDeliveryRequest(
+    trigger({ destination: "http://example.com/hook" }),
+    {},
+    0,
+  );
+  assert.equal(request, null);
+});
+
+// --- buildDiscordDeliveryRequest -----------------------------------------------
+
+test("buildDiscordDeliveryRequest: posts {content} to the trigger's own webhook URL", () => {
+  const request = buildDiscordDeliveryRequest(
+    trigger({ destination: "https://discord.com/api/webhooks/1/token" }),
+    { table: "blocks" },
+  );
+  assert.equal(request.url, "https://discord.com/api/webhooks/1/token");
+  const body = JSON.parse(request.init.body);
+  assert.match(body.content, /table=blocks/);
+});
+
+test("buildDiscordDeliveryRequest: truncates content to Discord's 2000-char cap", () => {
+  const request = buildDiscordDeliveryRequest(
+    trigger({ name: "x".repeat(3000) }),
+    {},
+  );
+  const body = JSON.parse(request.init.body);
+  assert.ok(body.content.length <= 2000);
+});
+
+// --- buildTelegramDeliveryRequest -----------------------------------------------
+
+test("buildTelegramDeliveryRequest: posts to the bot's sendMessage endpoint with the trigger's chat id", () => {
+  const request = buildTelegramDeliveryRequest(
+    trigger({ destination: "123456789" }),
+    { table: "chain_events" },
+    "bot-token-abc",
+  );
+  assert.equal(
+    request.url,
+    "https://api.telegram.org/botbot-token-abc/sendMessage",
+  );
+  const body = JSON.parse(request.init.body);
+  assert.equal(body.chat_id, "123456789");
+  assert.match(body.text, /table=chain_events/);
+});
+
+// --- buildEmailDeliveryRequest ---------------------------------------------------
+
+test("buildEmailDeliveryRequest: posts to Resend with the trigger's destination as the recipient", () => {
+  const request = buildEmailDeliveryRequest(
+    trigger({ destination: "a@b.com", name: "big transfers" }),
+    { table: "account_events" },
+    { resendKey: "resend-key", fromAddress: "alerts@metagraph.sh" },
+  );
+  assert.equal(request.url, "https://api.resend.com/emails");
+  assert.equal(request.init.headers.authorization, "Bearer resend-key");
+  const body = JSON.parse(request.init.body);
+  assert.equal(body.from, "alerts@metagraph.sh");
+  assert.equal(body.to, "a@b.com");
+  assert.equal(body.subject, "Chain alert: big transfers");
+});
+
+test("buildEmailDeliveryRequest: uses a generic subject when the trigger has no name", () => {
+  const request = buildEmailDeliveryRequest(
+    trigger({ name: null }),
+    {},
+    { resendKey: "k", fromAddress: "alerts@metagraph.sh" },
+  );
+  assert.equal(JSON.parse(request.init.body).subject, "Chain alert");
+});

--- a/tests/alert-delivery.test.mjs
+++ b/tests/alert-delivery.test.mjs
@@ -145,11 +145,22 @@ test("buildDiscordDeliveryRequest: posts {content} to the trigger's own webhook 
 
 test("buildDiscordDeliveryRequest: truncates content to Discord's 2000-char cap", () => {
   const request = buildDiscordDeliveryRequest(
-    trigger({ name: "x".repeat(3000) }),
+    trigger({
+      name: "x".repeat(3000),
+      destination: "https://discord.com/api/webhooks/1/token",
+    }),
     {},
   );
   const body = JSON.parse(request.init.body);
   assert.ok(body.content.length <= 2000);
+});
+
+test("buildDiscordDeliveryRequest: returns null (refuses to send) when the destination fails delivery-time re-validation", () => {
+  const request = buildDiscordDeliveryRequest(
+    trigger({ destination: "https://discord.com/invite/abc" }),
+    {},
+  );
+  assert.equal(request, null);
 });
 
 // --- buildTelegramDeliveryRequest -----------------------------------------------

--- a/tests/alert-triggers.test.mjs
+++ b/tests/alert-triggers.test.mjs
@@ -563,6 +563,7 @@ test("evaluatorAlertTriggerView: reshapes snake_case columns into triggerMatches
   const view = evaluatorAlertTriggerView({
     id: 7,
     owner_token: "should-not-appear",
+    name: "whale watcher",
     table_filter: ["account_events"],
     netuid: 7,
     event_kind: "Transfer",
@@ -573,6 +574,7 @@ test("evaluatorAlertTriggerView: reshapes snake_case columns into triggerMatches
   });
   assert.equal(view.id, "7");
   assert.equal("owner_token" in view, false);
+  assert.equal(view.name, "whale watcher");
   assert.deepEqual(view.tableFilter, ["account_events"]);
   assert.equal(view.eventKind, "Transfer");
   assert.equal(view.minAmountTao, 10);
@@ -595,6 +597,7 @@ test("evaluatorAlertTriggerView: a minimal record (every optional field absent) 
     channel: "email",
     destination: "a@b.com",
   });
+  assert.equal(view.name, null);
   assert.equal(view.tableFilter, null);
   assert.equal(view.netuid, null);
   assert.equal(view.eventKind, null);

--- a/tests/alerter-hub.test.mjs
+++ b/tests/alerter-hub.test.mjs
@@ -1,6 +1,6 @@
-// Unit tests for workers/alerter-hub.mjs (#4984 Part 2). No Durable Object
-// runtime needed -- state.storage is never touched by this class (the
-// trigger cache is plain in-memory instance state, refreshed from
+// Unit tests for workers/alerter-hub.mjs (#4984 Parts 2+3). No Durable
+// Object runtime needed -- state.storage is never touched by this class
+// (the trigger cache is plain in-memory instance state, refreshed from
 // env.DATA_API), so it's fully Node-testable like McpSessionHub.
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
@@ -34,10 +34,155 @@ test("ALERTER_HUB_TRIGGER_CACHE_TTL_MS is the documented value (5 minutes)", () 
   assert.equal(ALERTER_HUB_TRIGGER_CACHE_TTL_MS, 5 * 60 * 1000);
 });
 
-test("deliverAlertMatch: the default hook resolves without throwing (Part 3 replaces its body)", async () => {
-  await assert.doesNotReject(() =>
-    deliverAlertMatch(triggerRow(), { table: "account_events" }, {}),
+// --- deliverAlertMatch (#4984 Part 3) -----------------------------------------
+
+test("deliverAlertMatch: webhook channel POSTs the built request", async () => {
+  let received;
+  const fetchFn = vi.fn(async (url, init) => {
+    received = { url, init };
+    return new Response(null, { status: 200 });
+  });
+  await deliverAlertMatch(
+    triggerRow({ channel: "webhook", destination: "https://example.com/hook" }),
+    { table: "account_events" },
+    {},
+    fetchFn,
   );
+  assert.equal(fetchFn.mock.calls.length, 1);
+  assert.equal(received.url, "https://example.com/hook");
+  assert.equal(JSON.parse(received.init.body).type, "metagraph.alert");
+});
+
+test("deliverAlertMatch: webhook channel sends nothing when the destination fails the defense-in-depth URL re-check", async () => {
+  const fetchFn = vi.fn();
+  await deliverAlertMatch(
+    triggerRow({
+      channel: "webhook",
+      destination: "http://not-https.example.com",
+    }),
+    {},
+    {},
+    fetchFn,
+  );
+  assert.equal(fetchFn.mock.calls.length, 0);
+});
+
+test("deliverAlertMatch: discord channel POSTs to the trigger's own webhook URL", async () => {
+  const fetchFn = vi.fn(async () => new Response(null, { status: 204 }));
+  await deliverAlertMatch(
+    triggerRow({
+      channel: "discord",
+      destination: "https://discord.com/api/webhooks/1/token",
+    }),
+    { table: "account_events" },
+    {},
+    fetchFn,
+  );
+  assert.equal(
+    fetchFn.mock.calls[0][0],
+    "https://discord.com/api/webhooks/1/token",
+  );
+});
+
+test("deliverAlertMatch: telegram channel is a silent no-op when TELEGRAM_BOT_TOKEN is unset", async () => {
+  const fetchFn = vi.fn();
+  await deliverAlertMatch(
+    triggerRow({ channel: "telegram", destination: "123456789" }),
+    {},
+    {},
+    fetchFn,
+  );
+  assert.equal(fetchFn.mock.calls.length, 0);
+});
+
+test("deliverAlertMatch: telegram channel POSTs to the bot API when the token is configured", async () => {
+  const fetchFn = vi.fn(async () => new Response(null, { status: 200 }));
+  await deliverAlertMatch(
+    triggerRow({ channel: "telegram", destination: "123456789" }),
+    {},
+    { TELEGRAM_BOT_TOKEN: "bot-token" },
+    fetchFn,
+  );
+  assert.equal(
+    fetchFn.mock.calls[0][0],
+    "https://api.telegram.org/botbot-token/sendMessage",
+  );
+});
+
+test("deliverAlertMatch: email channel is a silent no-op when RESEND_API_KEY or RESEND_FROM_ADDRESS is unset", async () => {
+  const fetchFn = vi.fn();
+  await deliverAlertMatch(triggerRow({ channel: "email" }), {}, {}, fetchFn);
+  assert.equal(fetchFn.mock.calls.length, 0);
+  await deliverAlertMatch(
+    triggerRow({ channel: "email" }),
+    {},
+    { RESEND_API_KEY: "k" }, // no from-address
+    fetchFn,
+  );
+  assert.equal(fetchFn.mock.calls.length, 0);
+});
+
+test("deliverAlertMatch: email channel POSTs to Resend when both secrets are configured", async () => {
+  const fetchFn = vi.fn(async () => new Response(null, { status: 200 }));
+  await deliverAlertMatch(
+    triggerRow({ channel: "email", destination: "a@b.com" }),
+    {},
+    { RESEND_API_KEY: "k", RESEND_FROM_ADDRESS: "alerts@metagraph.sh" },
+    fetchFn,
+  );
+  assert.equal(fetchFn.mock.calls[0][0], "https://api.resend.com/emails");
+});
+
+test("deliverAlertMatch: an unrecognized channel is a silent no-op", async () => {
+  const fetchFn = vi.fn();
+  await deliverAlertMatch(
+    triggerRow({ channel: "carrier-pigeon" }),
+    {},
+    {},
+    fetchFn,
+  );
+  assert.equal(fetchFn.mock.calls.length, 0);
+});
+
+test("deliverAlertMatch: a non-ok HTTP response is logged, not thrown", async () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const fetchFn = vi.fn(async () => new Response(null, { status: 500 }));
+  await assert.doesNotReject(() =>
+    deliverAlertMatch(
+      triggerRow({
+        channel: "discord",
+        destination: "https://discord.com/api/webhooks/1/t",
+      }),
+      {},
+      {},
+      fetchFn,
+    ),
+  );
+  assert.equal(errorSpy.mock.calls.length, 1);
+  assert.match(errorSpy.mock.calls[0][0], /HTTP 500/);
+  errorSpy.mockRestore();
+});
+
+test("deliverAlertMatch: defaults fetchFn to the global fetch when not injected", async () => {
+  const originalFetch = globalThis.fetch;
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return new Response(null, { status: 200 });
+  };
+  try {
+    await deliverAlertMatch(
+      triggerRow({
+        channel: "discord",
+        destination: "https://discord.com/api/webhooks/1/t",
+      }),
+      {},
+      {},
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(called, true);
 });
 
 // --- isTriggerCacheStale / refreshTriggers -----------------------------------
@@ -276,8 +421,62 @@ test("evaluate: reports every matching trigger and calls deliver once per match"
   const result = await hub.evaluate(payload);
   assert.equal(result.matched, 2);
   assert.deepEqual(result.trigger_ids.sort(), ["1", "2"]);
+  assert.equal(result.delivered, 2);
+  assert.equal(result.rate_limited, 0);
   assert.equal(deliver.mock.calls.length, 2);
   assert.equal(deliver.mock.calls[0][1], payload);
+});
+
+test("evaluate: a burst of matches for the SAME trigger within the rate-limit window delivers once and skips the rest", async () => {
+  const deliver = vi.fn().mockResolvedValue(undefined);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const payload = { table: "account_events", netuid: 7 };
+
+  const first = await hub.evaluate(payload);
+  assert.equal(first.delivered, 1);
+  assert.equal(first.rate_limited, 0);
+
+  const second = await hub.evaluate(payload);
+  assert.equal(second.matched, 1); // still reported as a real match...
+  assert.equal(second.delivered, 0); // ...but not delivered again this soon
+  assert.equal(second.rate_limited, 1);
+
+  assert.equal(deliver.mock.calls.length, 1);
+});
+
+test("evaluate: a DIFFERENT trigger's match is never rate-limited by another trigger's recent delivery", async () => {
+  const deliver = vi.fn().mockResolvedValue(undefined);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [
+    triggerRow({ id: "1", netuid: 7 }),
+    triggerRow({ id: "2", netuid: 7 }),
+  ];
+  hub.triggersLoadedAt = Date.now();
+  const payload = { table: "account_events", netuid: 7 };
+
+  await hub.evaluate(payload); // delivers both "1" and "2" once
+  hub.lastDeliveredAt.delete("2"); // simulate "2" being outside its own window already
+  const second = await hub.evaluate(payload);
+  assert.equal(second.delivered, 1); // only "2" delivers again
+  assert.equal(second.rate_limited, 1); // "1" is still within its window
+});
+
+test("evaluate: once the rate-limit window elapses, the same trigger can deliver again", async () => {
+  const deliver = vi.fn().mockResolvedValue(undefined);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const payload = { table: "account_events", netuid: 7 };
+
+  await hub.evaluate(payload);
+  // Simulate the window having elapsed rather than waiting on a real clock.
+  hub.lastDeliveredAt.set("1", Date.now() - 10 * 60 * 1000);
+  const result = await hub.evaluate(payload);
+  assert.equal(result.delivered, 1);
+  assert.equal(result.rate_limited, 0);
+  assert.equal(deliver.mock.calls.length, 2);
 });
 
 test("evaluate: a rejecting deliver call never fails the overall evaluation", async () => {
@@ -325,6 +524,8 @@ test("fetch: POST /evaluate with a valid JSON body returns the evaluate() result
   assert.deepEqual(await res.json(), {
     matched: 1,
     trigger_ids: [triggerRow().id],
+    delivered: 1,
+    rate_limited: 0,
   });
 });
 

--- a/tests/alerter-hub.test.mjs
+++ b/tests/alerter-hub.test.mjs
@@ -53,6 +53,25 @@ test("deliverAlertMatch: webhook channel POSTs the built request", async () => {
   assert.equal(JSON.parse(received.init.body).type, "metagraph.alert");
 });
 
+test("deliverAlertMatch: every delivery carries a bounded AbortSignal so one slow target can't stall the shared broadcast() call indefinitely", async () => {
+  let receivedSignal;
+  const fetchFn = vi.fn(async (_url, init) => {
+    receivedSignal = init.signal;
+    return new Response(null, { status: 200 });
+  });
+  await deliverAlertMatch(
+    triggerRow({
+      channel: "webhook",
+      destination: "https://example.com/hook",
+    }),
+    {},
+    {},
+    fetchFn,
+  );
+  assert.ok(receivedSignal instanceof AbortSignal);
+  assert.equal(receivedSignal.aborted, false);
+});
+
 test("deliverAlertMatch: webhook channel sends nothing when the destination fails the defense-in-depth URL re-check", async () => {
   const fetchFn = vi.fn();
   await deliverAlertMatch(

--- a/workers/alerter-hub.mjs
+++ b/workers/alerter-hub.mjs
@@ -1,8 +1,9 @@
-// AlerterHub -- the #4984 Part 2 evaluator: a singleton Durable Object
-// (idFromName("global")) that ChainFirehoseHub pings on every broadcast()
-// (see that class's own ALERTER_HUB ping, mirroring the #4983 MCP-notify
-// loop's exact shape -- but unconditional/global rather than per-session,
-// since there is exactly one evaluator, not one per subscriber).
+// AlerterHub -- the #4984 evaluator + delivery dispatcher: a singleton
+// Durable Object (idFromName("global")) that ChainFirehoseHub pings on
+// every broadcast() (see that class's own ALERTER_HUB ping, mirroring the
+// #4983 MCP-notify loop's shape -- but unconditional/global rather than
+// per-session, since there is exactly one evaluator, not one per
+// subscriber).
 //
 // Caches active trigger definitions (refreshed from Postgres via the
 // DATA_API service binding's internal-only active-list route, #4984 Part 1)
@@ -14,26 +15,77 @@
 // matching; a deleted one keeps matching for the same window) rather than
 // adding a synchronous Postgres round-trip to every single chain event.
 //
-// Delivery itself (#4984 Part 3: webhook/email/telegram/discord) is
-// deliberately NOT this file's concern -- deliverAlertMatch below is the
-// integration point Part 3 replaces; this class only decides WHICH
-// triggers matched a given event. Matches "one focused change per PR",
-// the same scoping every other piece of this epic (#4981/#4982/#4983
-// GraphQL/#4983 MCP) already used.
+// Delivery (#4984 Part 3) is deliberately factored into src/alert-delivery.mjs
+// (pure request-building, no I/O) + deliverAlertMatch below (the thin I/O
+// shell that actually calls fetch) -- this class only decides WHICH
+// triggers matched AND whether a match should actually be delivered right
+// now (burst rate-limiting), never how each channel's request is shaped.
 import { triggerMatchesEvent } from "../src/alert-triggers.mjs";
+import {
+  buildDiscordDeliveryRequest,
+  buildEmailDeliveryRequest,
+  buildTelegramDeliveryRequest,
+  buildWebhookDeliveryRequest,
+  isDeliveryRateLimited,
+} from "../src/alert-delivery.mjs";
 
 export const ALERTER_HUB_TRIGGER_CACHE_TTL_MS = 5 * 60 * 1000;
 
-// Default delivery hook, called once per (trigger, matching payload) pair
-// -- a no-op until #4984 Part 3 replaces its body with real channel
-// dispatch. Constructor-injectable (see AlerterHub below) rather than a
-// hardcoded call inside evaluate(), both so Part 3 can wire a real
-// implementation without touching evaluate() itself and so tests can
-// substitute a spy/failing stub to exercise the catch-wrapping resilience
-// below without needing real delivery logic to exist yet.
-export async function deliverAlertMatch(_trigger, _payload, _env) {
-  // #4984 Part 3: webhook/email/telegram/discord dispatch + rate-limit/
-  // dedup + match_count/last_matched_at bookkeeping land here.
+// The I/O shell around src/alert-delivery.mjs's pure request builders --
+// constructor-injectable (see AlerterHub below) rather than a hardcoded
+// call inside evaluate(), so tests can substitute a spy/failing stub
+// without needing a real network, and so a future channel doesn't require
+// restructuring evaluate() itself. Telegram/email degrade to a silent
+// no-op when their secret isn't provisioned, matching every other optional
+// integration's convention in this codebase (never throw for a
+// deployment-config gap the caller can't do anything about).
+export async function deliverAlertMatch(
+  trigger,
+  payload,
+  env,
+  fetchFn = fetch,
+) {
+  let request;
+  switch (trigger.channel) {
+    case "webhook":
+      request = buildWebhookDeliveryRequest(trigger, payload, Date.now());
+      break;
+    case "discord":
+      request = buildDiscordDeliveryRequest(trigger, payload);
+      break;
+    case "telegram":
+      if (!env.TELEGRAM_BOT_TOKEN) return;
+      request = buildTelegramDeliveryRequest(
+        trigger,
+        payload,
+        env.TELEGRAM_BOT_TOKEN,
+      );
+      break;
+    case "email":
+      if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) return;
+      request = buildEmailDeliveryRequest(trigger, payload, {
+        resendKey: env.RESEND_API_KEY,
+        fromAddress: env.RESEND_FROM_ADDRESS,
+      });
+      break;
+    default:
+      return;
+  }
+  // A null request means the builder itself refused (e.g.
+  // buildWebhookDeliveryRequest's defense-in-depth URL re-check) --
+  // nothing to send.
+  if (!request) return;
+  const response = await fetchFn(request.url, request.init);
+  if (!response.ok) {
+    // Never throw for a non-2xx response -- evaluate()'s .catch() only
+    // guards against a REJECTED fetch (network/timeout); an HTTP-level
+    // failure resolves normally, so it's logged here instead, server-side
+    // only, matching this codebase's "log internals, never leak them"
+    // convention.
+    console.error(
+      `alert delivery failed (channel=${trigger.channel}, trigger=${trigger.id}): HTTP ${response.status}`,
+    );
+  }
 }
 
 export class AlerterHub {
@@ -48,6 +100,13 @@ export class AlerterHub {
     // fires one /evaluate POST per chain event, and events can arrive
     // faster than a single refresh round-trip completes.
     this.loadingPromise = null;
+    // Per-trigger burst rate-limit state (#4984 Part 3's "a burst of
+    // matching events... doesn't spam a single subscriber" deliverable).
+    // In-memory, not persisted -- a DO reconstruction (hibernation wake,
+    // redeploy) resets it, which just means the next match after a
+    // reconstruction is never wrongly rate-limited; the opposite failure
+    // (permanently under-limiting) would be the unsafe direction here.
+    this.lastDeliveredAt = new Map();
   }
 
   isTriggerCacheStale() {
@@ -109,15 +168,38 @@ export class AlerterHub {
     await this.ensureTriggersLoaded();
     const matched = this.matchingTriggers(payload);
     if (matched.length === 0) return { matched: 0 };
+
+    // Every match counts toward the response (an owner querying "did this
+    // fire?" wants the true answer), but only NOT-rate-limited matches
+    // actually attempt delivery -- coalescing a burst into one delivery
+    // per window rather than dropping the burst's own visibility.
+    const now = Date.now();
+    const toDeliver = [];
+    let rateLimited = 0;
+    for (const trigger of matched) {
+      if (isDeliveryRateLimited(this.lastDeliveredAt.get(trigger.id), now)) {
+        rateLimited += 1;
+        continue;
+      }
+      this.lastDeliveredAt.set(trigger.id, now);
+      toDeliver.push(trigger);
+    }
+
     await Promise.all(
-      matched.map((trigger) =>
+      toDeliver.map((trigger) =>
         this.deliver(trigger, payload, this.env).catch(() => {
           // A single misbehaving delivery integration must never fail the
           // evaluation response ChainFirehoseHub's broadcast() awaits.
         }),
       ),
     );
-    return { matched: matched.length, trigger_ids: matched.map((t) => t.id) };
+
+    return {
+      matched: matched.length,
+      trigger_ids: matched.map((t) => t.id),
+      delivered: toDeliver.length,
+      rate_limited: rateLimited,
+    };
   }
 
   async fetch(request) {

--- a/workers/alerter-hub.mjs
+++ b/workers/alerter-hub.mjs
@@ -31,6 +31,17 @@ import {
 
 export const ALERTER_HUB_TRIGGER_CACHE_TTL_MS = 5 * 60 * 1000;
 
+// AlerterHub.evaluate() is awaited by ChainFirehoseHub.broadcast() (see that
+// class's ALERTER_HUB ping), which every OTHER consumer (SSE/WS/GraphQL/MCP)
+// shares the same broadcast() call with -- unlike those consumers'
+// same-Cloudflare-network DO-to-DO calls, a delivery fetch here can hit an
+// arbitrary user-supplied webhook or a slow third-party API. Without a
+// bound, ONE slow/hanging delivery target would add its own latency to
+// EVERY firehose consumer's next event, not just this trigger's owner.
+// Matches src/webhooks.mjs's own deliverChangeEvent timeout convention
+// (same 8s default).
+const ALERT_DELIVERY_TIMEOUT_MS = 8000;
+
 // The I/O shell around src/alert-delivery.mjs's pure request builders --
 // constructor-injectable (see AlerterHub below) rather than a hardcoded
 // call inside evaluate(), so tests can substitute a spy/failing stub
@@ -75,7 +86,15 @@ export async function deliverAlertMatch(
   // buildWebhookDeliveryRequest's defense-in-depth URL re-check) --
   // nothing to send.
   if (!request) return;
-  const response = await fetchFn(request.url, request.init);
+  // The timeout signal is applied HERE, not baked into the pure builders in
+  // src/alert-delivery.mjs -- AbortSignal.timeout() starts a real wall-clock
+  // timer the moment it's constructed, which that module's own header
+  // comment promises never happens (no I/O, no timers, fully deterministic
+  // for tests).
+  const response = await fetchFn(request.url, {
+    ...request.init,
+    signal: AbortSignal.timeout(ALERT_DELIVERY_TIMEOUT_MS),
+  });
   if (!response.ok) {
     // Never throw for a non-2xx response -- evaluate()'s .catch() only
     // guards against a REJECTED fetch (network/timeout); an HTTP-level

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -364,6 +364,17 @@
   // until it is, the evaluator's trigger cache just stays empty (no crash,
   // no delivery, matching every other optional binding's degrade-gracefully
   // convention in this codebase).
+  //
+  // #4984 Part 3 (workers/alerter-hub.mjs's deliverAlertMatch) needs three
+  // MORE secrets, one per non-webhook/-discord channel (those two need
+  // nothing beyond the trigger's own `destination` -- a URL, not a shared
+  // credential):
+  //   wrangler secret put TELEGRAM_BOT_TOKEN
+  //   wrangler secret put RESEND_API_KEY
+  //   wrangler secret put RESEND_FROM_ADDRESS
+  // None yet provisioned on any deployment; until each is, that ONE
+  // channel silently no-ops on delivery (webhook/discord/the other two
+  // channels are unaffected).
   "durable_objects": {
     "bindings": [
       { "name": "CHAIN_FIREHOSE_HUB", "class_name": "ChainFirehoseHub" },


### PR DESCRIPTION
## Summary

Part 3 of #4984 (the alerter). Builds on #5015 (the AlerterHub evaluator, merged).

- **New `src/alert-delivery.mjs`**: pure per-channel request builders (webhook, Discord, Telegram, email) + `isDeliveryRateLimited` — no I/O, fully unit-tested without a network dependency.
- **`AlerterHub.deliverAlertMatch`** now dispatches to all 4 channels: webhook (a `metagraph.alert` JSON envelope POSTed to the trigger's own destination, re-validated via `isPublicWebhookUrl` at delivery time as defense in depth), Discord (direct incoming-webhook POST — no Alertmanager translation layer needed, since research this session found `alertmanager-discord` isn't actually deployed anywhere despite the original issue's premise), Telegram (`sendMessage` against a single per-deployment bot, `TELEGRAM_BOT_TOKEN`), email (Resend's HTTP API, `RESEND_API_KEY`/`RESEND_FROM_ADDRESS`). Telegram/email silently no-op when their secret isn't configured, matching every other optional integration's convention in this codebase.
- **Burst rate-limiting** in `AlerterHub.evaluate()`: at most one delivery per trigger per minute (in-memory per DO instance, `ALERT_DELIVERY_MIN_INTERVAL_MS`). A burst of matches still counts toward the response's `matched` total (an owner asking "did this fire?" gets the true answer) but only the first actually delivers — the rest are reported as `rate_limited`, not silently dropped.
- **Two deliberate, documented v1 scope cuts** (not oversights): delivery is single-attempt, no retry/dead-letter (lower-stakes "ping me" notifications, not the dataset change-feed automated pipelines may depend on); webhook payloads are NOT HMAC-signed (would need the per-trigger `owner_token` threaded through the evaluator's trusted-internal cache, which `evaluatorAlertTriggerView` deliberately never exposes past the CRUD layer today).

## Test plan

- [x] `npm run lint` / format clean
- [x] `npm run test:coverage` — 7920 tests pass; `src/alert-delivery.mjs` and `workers/alerter-hub.mjs` both at 100% coverage
- [x] `npm run validate`, `npm run worker:deploy:dry-run`, `npm run worker:bundle:budget` all pass (bundle at 965.2 KiB gzipped — margin now 34.8 KiB under the 1000 KiB fail threshold; worth watching)
- [x] **Caught and fixed a real false positive**: the public-safety scanner flagged `apiKey: env.RESEND_API_KEY` as a hardcoded-credential pattern (its "token-like assignment" heuristic matches any `<key/secret/token-shaped-name>: <16+ char value>`, even a legitimate env-var passthrough) — renamed to `resendKey`, matching `src/webhooks.mjs`'s own `hookSecret` naming precedent for this exact class of false positive.

This completes #4984's three-part scope. Webhook/Discord need no new secrets and are live as soon as this merges; `TELEGRAM_BOT_TOKEN`/`RESEND_API_KEY`/`RESEND_FROM_ADDRESS` need provisioning via `wrangler secret put` before those two channels activate (documented in `wrangler.jsonc`).

Closes #5016