### PR TITLE
fix(graphql): flatten global health status_counts onto GlobalHealth count fields

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -914,10 +914,19 @@ const rootValue = {
     const snapshot = await loadLiveHealth(context);
     const result = snapshot ? buildGlobalHealth(snapshot, {}) : null;
     if (!result) return null;
-    // GlobalHealth exposes the rollup counts flat; buildGlobalHealth nests them
-    // under `global`.
+    // GlobalHealth declares the per-status counts flat, but buildGlobalHealth
+    // nests them under `global.status_counts` (the shape GET /api/v1/health
+    // serves). Spreading `global` verbatim only surfaces `surface_count` and
+    // leaves ok_count/degraded_count/failed_count/unknown_count null, so flatten
+    // status_counts onto the declared fields.
+    const global = result.global || {};
+    const counts = global.status_counts || {};
     return {
-      ...(result.global || {}),
+      surface_count: global.surface_count ?? null,
+      ok_count: counts.ok ?? null,
+      degraded_count: counts.degraded ?? null,
+      failed_count: counts.failed ?? null,
+      unknown_count: counts.unknown ?? null,
       generated_at: result.generated_at,
       operational_observed_at: result.operational_observed_at,
       health_source: result.health_source,

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1121,13 +1121,18 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     assert.equal(second.body.data.endpoints.items[0].id, "e2");
   });
 
-  test("health lifts the live rollup and exposes per-subnet summaries", async () => {
+  test("health flattens the live global rollup counts and exposes per-subnet summaries", async () => {
     const env = fixtureEnv(
       {},
       {
         kv: {
           [KV_HEALTH_CURRENT]: {
-            summary: { status: "degraded", ok_count: 40, surface_count: 50 },
+            // The production shape the prober persists: nested status_counts,
+            // not flat ok_count/... (see health-prober.mjs / liveFromD1Rows).
+            summary: {
+              surface_count: 50,
+              status_counts: { ok: 40, degraded: 5, failed: 3, unknown: 2 },
+            },
             subnets: [
               { netuid: 1, status: "ok" },
               { netuid: 2, status: "failed" },
@@ -1137,12 +1142,15 @@ describe("graphql — surfaces / endpoints / health roots", () => {
       },
     );
     const { status, body } = await gql(
-      "{ health { status ok_count surface_count health_source subnets { netuid status } } }",
+      "{ health { surface_count ok_count degraded_count failed_count unknown_count health_source subnets { netuid status } } }",
       env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.health.status, "degraded");
+    assert.equal(body.data.health.surface_count, 50);
     assert.equal(body.data.health.ok_count, 40);
+    assert.equal(body.data.health.degraded_count, 5);
+    assert.equal(body.data.health.failed_count, 3);
+    assert.equal(body.data.health.unknown_count, 2);
     assert.equal(body.data.health.health_source, "live-cron-prober");
     assert.equal(body.data.health.subnets.length, 2);
     assert.equal(body.data.health.subnets[1].status, "failed");


### PR DESCRIPTION
## Summary
The GraphQL `health` root resolver spread the live global rollup (`result.global`)
into the flat `GlobalHealth` type. The prober persists the global summary as
`{ surface_count, status_counts: { ok, degraded, failed, unknown } }` — the same
nested shape `GET /api/v1/health` serves (health-prober.mjs:644,
health-serving.mjs:1420 `liveFromD1Rows`, global-operational-health.mjs). Because
the counts live under `status_counts`, spreading `global` verbatim surfaced only
`surface_count` and left `ok_count`, `degraded_count`, `failed_count`, and
`unknown_count` resolving to `null` for every production query. Per-subnet
`SubnetHealth` was already correct (its summaries come from summarizeGroup/
summarizeRows, which are flat).

## Fix
- `src/graphql.mjs` — flatten `global.status_counts` onto the declared
  `ok_count/degraded_count/failed_count/unknown_count` fields (keeping
  `surface_count`) instead of spreading the nested object.
- `tests/graphql.test.mjs` — the prior test injected a fabricated flat summary
  (`{ status: "degraded", ok_count: 40 }`) that no producer emits, masking the
  bug. Updated to the real nested production shape and asserted all four counts
  plus `surface_count` now resolve.

Fields the global rollup does not compute (`status`, `avg_latency_ms`,
`latency_sample_count`, `last_checked`, `last_ok`) remain null, matching the
REST/MCP `/api/v1/health` global payload.

## Validation
- `npx vitest run tests/graphql.test.mjs` — 103 passed
- `npx vitest run tests/health-serving.test.mjs tests/api-coverage.test.mjs` — 386 passed
- `npx eslint src/graphql.mjs tests/graphql.test.mjs` — clean

Closes #<companion-issue>
