### PR TITLE
fix(mcp): enforce rate limit for GET/DELETE and require subscribed sessions for streams

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11522,11 +11522,24 @@ async function handleMcpTerminateRequest(request, env) {
   const stub = env.MCP_SESSION_HUB.get(
     env.MCP_SESSION_HUB.idFromName(rawSessionId),
   );
-  await stub.fetch("https://mcp-session-hub.internal/terminate", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ sessionId: rawSessionId }),
-  });
+  const upstream = await stub.fetch(
+    "https://mcp-session-hub.internal/terminate",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: rawSessionId }),
+    },
+  );
+  if (!upstream.ok) {
+    return jsonResponse(
+      rpcError(
+        null,
+        RPC_INVALID_REQUEST,
+        "No such MCP session; call initialize again.",
+      ),
+      404,
+    );
+  }
   return new Response(null, { status: 204, headers: MCP_HEADERS });
 }
 
@@ -11535,6 +11548,9 @@ async function handleMcpTerminateRequest(request, env) {
 // JSON-RPC 2.0 envelope; GET opens the SSE push stream; DELETE terminates a
 // session (see the two handlers above for both).
 export async function handleMcpRequest(request, env = {}, deps = {}) {
+  const rateLimitResponse = await enforceMcpRateLimit(request, env);
+  if (rateLimitResponse) return rateLimitResponse;
+
   if (request.method === "GET") {
     return handleMcpStreamRequest(request, env);
   }
@@ -11560,9 +11576,6 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
       },
     );
   }
-
-  const rateLimitResponse = await enforceMcpRateLimit(request, env);
-  if (rateLimitResponse) return rateLimitResponse;
 
   const contentLength = Number(request.headers.get("content-length") || 0);
   if (contentLength > MAX_MCP_BODY_BYTES) {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -985,6 +985,29 @@ describe("MCP transport handling", () => {
     assert.equal(body.error.code, -32600);
   });
 
+  test("the MCP rate limiter also covers GET and DELETE before session routing", async () => {
+    for (const method of ["GET", "DELETE"]) {
+      const hub = fakeMcpSessionHubBinding();
+      const response = await handleMcpRequest(
+        new Request(MCP_URL, {
+          method,
+          headers: { "mcp-session-id": A_SESSION_ID },
+        }),
+        {
+          MCP_SESSION_HUB: hub,
+          MCP_RATE_LIMITER: {
+            async limit() {
+              return { success: false };
+            },
+          },
+        },
+        makeDeps(),
+      );
+      assert.equal(response.status, 429);
+      assert.equal(hub.calls.length, 0);
+    }
+  });
+
   test("the MCP rate limiter is enforced before body parsing", async () => {
     let rateLimitKey;
     const request = new Request(MCP_URL, {
@@ -1219,6 +1242,22 @@ describe("MCP transport handling", () => {
       assert.deepEqual(JSON.parse(hub.calls[0].init.body), {
         sessionId: A_SESSION_ID,
       });
+    });
+
+    test("a 404 from the session hub (unknown session) passes through as 404", async () => {
+      const hub = fakeMcpSessionHubBinding({
+        "/terminate": () => new Response(null, { status: 404 }),
+      });
+      const request = new Request(MCP_URL, {
+        method: "DELETE",
+        headers: { "mcp-session-id": A_SESSION_ID },
+      });
+      const response = await handleMcpRequest(request, {
+        MCP_SESSION_HUB: hub,
+      });
+      assert.equal(response.status, 404);
+      const body = await response.json();
+      assert.match(body.error.message, /No such MCP session/);
     });
   });
 });

--- a/tests/mcp-session-hub.test.mjs
+++ b/tests/mcp-session-hub.test.mjs
@@ -357,6 +357,12 @@ test("handleStream: opens fine with no sessionId query param (already known from
 
 test("handleStream: a second concurrent stream request for the same session is rejected with 409", async () => {
   const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
   const first = await hub.fetch(
     new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
   );
@@ -397,6 +403,12 @@ test("handleNotify: with a stream already open, delivers immediately (deliverNow
 
 test("handleStream: cancelling the stream clears streamController, allowing a new stream to open", async () => {
   const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
   const first = await hub.fetch(
     new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
   );
@@ -413,6 +425,12 @@ test("handleStream: auto-closes after MCP_SESSION_MAX_STREAM_DURATION_MS, per th
   vi.useFakeTimers();
   try {
     const hub = new McpSessionHub(stubState(), {});
+    await hub.fetch(
+      jsonRequest("https://mcp-session-hub.internal/subscribe", {
+        sessionId: "session-1",
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
     const res = await hub.fetch(
       new Request(
         "https://mcp-session-hub.internal/stream?sessionId=session-1",
@@ -490,6 +508,13 @@ test("handleTerminate: calling it twice is idempotent (second call doesn't re-no
 test("handleTerminate: calling the method directly a second time (bypassing fetch()'s own terminated-gate, as alarm() does) is still a no-op", async () => {
   const firehose = fakeChainFirehoseHubBinding();
   const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  firehose.calls.length = 0;
   await hub.handleTerminate(
     jsonRequest("https://mcp-session-hub.internal/terminate", {
       sessionId: "session-1",
@@ -502,22 +527,65 @@ test("handleTerminate: calling the method directly a second time (bypassing fetc
     }),
   );
   assert.equal(res.status, 200);
-  assert.equal(firehose.calls.length, 0); // no subscriptions -> never called
+  assert.equal(firehose.calls.length, 1); // unchanged -- no second notify
 });
 
-test("handleTerminate: with no subscriptions, never calls ChainFirehoseHub at all", async () => {
+test("handleTerminate: with a known but unsubscribed session, never calls ChainFirehoseHub at all", async () => {
   const firehose = fakeChainFirehoseHubBinding();
   const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
   await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/unsubscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  firehose.calls.length = 0;
+  const res = await hub.fetch(
     jsonRequest("https://mcp-session-hub.internal/terminate", {
       sessionId: "session-1",
     }),
   );
+  assert.equal(res.status, 200);
   assert.equal(firehose.calls.length, 0);
+});
+
+test("handleStream: rejects an arbitrary session id that has not subscribed", async () => {
+  const state = stubState();
+  const hub = new McpSessionHub(state, {});
+  const res = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=attacker"),
+  );
+  assert.equal(res.status, 404);
+  assert.equal(state.storage.raw.size, 0);
+  assert.equal(state.storage.lastAlarmTime, null);
+});
+
+test("handleTerminate: rejects an arbitrary session id without persisting a tombstone", async () => {
+  const state = stubState();
+  const hub = new McpSessionHub(state, {});
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "attacker",
+    }),
+  );
+  assert.equal(res.status, 404);
+  assert.equal(state.storage.raw.size, 0);
 });
 
 test("fetch: any route other than /notify 404s once the session is terminated", async () => {
   const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
   await hub.fetch(
     jsonRequest("https://mcp-session-hub.internal/terminate", {
       sessionId: "session-1",
@@ -538,6 +606,12 @@ test("fetch: any route other than /notify 404s once the session is terminated", 
 
 test("fetch: /notify still resolves (as a no-op) even for a terminated session -- a race with ChainFirehoseHub forgetting it, not an error", async () => {
   const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
   await hub.fetch(
     jsonRequest("https://mcp-session-hub.internal/terminate", {
       sessionId: "session-1",

--- a/workers/mcp-session-hub.mjs
+++ b/workers/mcp-session-hub.mjs
@@ -265,8 +265,16 @@ export class McpSessionHub {
     // has one); fall back to the persisted value for alarm()'s self-
     // termination call, which has no caller to hand it one -- see the
     // constructor's comment on why this class can't recover it any other
-    // way.
+    // way. A client-supplied id is authority only after this object already
+    // knows the session from resources/subscribe; otherwise DELETE must not
+    // create/persist a tombstone for an arbitrary Durable Object name.
     const { sessionId } = await request.json();
+    if (!this.sessionId || (sessionId && sessionId !== this.sessionId)) {
+      return new Response(JSON.stringify({ error: "session not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    }
     const effectiveSessionId = sessionId ?? this.sessionId;
     if (!this.terminated) {
       this.terminated = true;
@@ -310,6 +318,17 @@ export class McpSessionHub {
   }
 
   async handleStream(url) {
+    const sessionId = url.searchParams.get("sessionId");
+    if (
+      !this.sessionId ||
+      (sessionId && sessionId !== this.sessionId) ||
+      !this.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI)
+    ) {
+      return new Response(JSON.stringify({ error: "session not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    }
     if (this.streamController) {
       return new Response(
         JSON.stringify({
@@ -319,11 +338,6 @@ export class McpSessionHub {
         }),
         { status: 409, headers: { "content-type": "application/json" } },
       );
-    }
-    const sessionId = url.searchParams.get("sessionId");
-    if (sessionId) {
-      this.sessionId = sessionId;
-      await this.persist();
     }
     void this.touch();
     const hub = this;


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated attackers from opening many long-lived SSE streams or persisting tombstones by choosing arbitrary session IDs and bypassing the MCP rate limiter.
- Ensure the MCP GET/DELETE paths only act on server-minted, initialized sessions that previously subscribed to the chain stream.

### Description
- Apply `enforceMcpRateLimit` at the top of `handleMcpRequest` so `GET` and `DELETE` cannot route around the configured MCP rate limiter (`src/mcp-server.mjs`).
- Forward a 404 when the McpSessionHub reports an unknown session on terminate instead of returning success for arbitrary IDs (`src/mcp-server.mjs`).
- Harden `McpSessionHub` so `handleTerminate` rejects client-supplied IDs unless the DO already knows the session, and `handleStream` requires a known matching session that has subscribed to `metagraph://chain/stream` before opening an SSE stream (`workers/mcp-session-hub.mjs`).
- Add regression tests covering GET/DELETE rate-limiter behavior and that arbitrary session IDs do not create persisted state or alarms (`tests/mcp-server.test.mjs`, `tests/mcp-session-hub.test.mjs`).

### Testing
- Added/updated unit tests in `tests/mcp-server.test.mjs` and `tests/mcp-session-hub.test.mjs` that assert GET/DELETE are rate-limited and that unknown session IDs yield 404 and do not persist state; the new tests are included in the commit.
- Performed static/syntax checks with `node --check` on `src/`/`workers/`/`tests/` and ran targeted Node smoke checks which confirmed GET returns `429` when the limiter denies and the `McpSessionHub` rejects unknown streams while accepting subscribed streams (manual Node invocations succeeded).
- Full `npm test` could not be executed in this environment because `npm install` failed due to a registry permission/lockfile mismatch (stale `node_modules` / `tinyrainbow` version and a `403` fetching `graphql-ws-6.1.0.tgz`), so CI should run the full suite; added tests are intended to run under normal CI where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a544d540e40832c803deb047b6b6602)