### PR TITLE
fix(realtime): adversarial-review remediation for the #4984 alerter

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -335,6 +335,73 @@ the evaluation response (an owner asking "did this fire?" gets the true
 answer) but only the first delivers -- the rest are reported as
 `rate_limited`, not silently dropped from the response shape.
 
+**Part 4 (live): adversarial-review remediation.** After Part 3 merged, a
+dedicated adversarial-review pass (independent security/correctness/
+resource-exhaustion lenses, each candidate finding re-verified by two
+skeptical agents before being treated as real) surfaced six confirmed
+issues, all fixed on top of the merged code rather than folded silently into
+Part 3's own history:
+
+- **PATCH-as-full-replace on `chain_alert_triggers`** (the most severe
+  finding): `handleAlertTriggerUpdate` originally validated a PATCH body
+  directly against the CREATE-shared validator, so any condition field the
+  caller didn't resend was silently defaulted to unset -- unintentionally
+  _widening_ a trigger's match scope on every partial edit (e.g. renaming a
+  netuid-scoped trigger without resending `netuid` dropped the netuid filter
+  entirely). Fixed by merging the incoming body onto the existing row before
+  validating (`omitNullValues` + merge in `workers/data-api.mjs`). An
+  explicit `null` in a PATCH body is a no-op (keeps the existing value), not
+  a clear -- `validateAlertTriggerInput` rejects a real `null` for most
+  fields, so there's currently no supported way to explicitly clear an
+  optional condition field via PATCH short of delete + recreate.
+- **Existence oracle via differentiated 403/404**: GET/PATCH/DELETE all
+  returned 403 for "wrong owner token" vs 404 for "no such trigger",
+  letting an unauthenticated caller enumerate trigger existence over
+  sequential ids with zero credentials. `requireAlertTriggerOwner` now
+  returns the same 404 either way.
+- **Unbounded trigger creation**: `ALERT_TRIGGER_CREATE_TOKEN` is a shared
+  anti-abuse secret, not a per-user credential -- it didn't bound request
+  _volume_ from a legitimate holder, and every created row is a permanent
+  per-event cost in `AlerterHub.matchingTriggers()`'s scan. A
+  Workers-native rate limiter (`ALERT_TRIGGER_CREATE_RATE_LIMITER`, 10/min
+  per IP, `wrangler.data.jsonc`) now gates creation; skipped when unbound
+  (local dev/CI).
+- **Two missing timeouts**: `AlerterHub.refreshTriggers()`'s Hyperdrive
+  fetch (`ALERT_TRIGGER_REFRESH_TIMEOUT_MS`, 4s) and
+  `ChainFirehoseHub.broadcast()`'s own ping to the `AlerterHub` singleton
+  (`ALERTER_HUB_EVALUATE_TIMEOUT_MS`, 15s, `workers/chain-firehose-hub.mjs`)
+  both had no independent ceiling -- a slow Postgres query or a slow
+  delivery fan-out could stall `broadcast()` itself, delaying every OTHER
+  firehose consumer's (SSE/WS/GraphQL/MCP) response, not just the alerter's.
+- **Unbounded delivery-fan-out concurrency**: a single chain event can match
+  many distinct triggers; `evaluate()`'s delivery loop now runs through
+  `mapBounded` (exported from `src/webhooks.mjs`, `ALERT_DELIVERY_CONCURRENCY`
+  = 8) instead of an unbounded `Promise.all`.
+
+Findings investigated and deliberately deferred, each filed as its own
+tracked issue rather than silently dropped or rushed in under time
+pressure:
+
+- [#5021](https://github.com/JSONbored/metagraphed/issues/5021) -- neither
+  this alerter's webhook/Discord delivery nor the pre-existing
+  webhook-subscription delivery (`src/webhooks.mjs`) actually re-resolves
+  DNS at request time; the codebase's own `resolveHostnames`-based SSRF
+  defense turns out to be Node-only (`scripts/dispatch-webhooks.mjs`'s cron
+  script) and was never reachable from the live Worker in the first place.
+  A real fix needs DNS-over-HTTPS via `fetch()`, shared across both paths.
+- [#5022](https://github.com/JSONbored/metagraphed/issues/5022) --
+  `match_count`/`last_matched_at` are schema columns and appear in the
+  owner-facing response shape, but nothing writes them; needs a new
+  internal write-back route.
+- [#5023](https://github.com/JSONbored/metagraphed/issues/5023) -- the
+  burst rate-limit timestamp is set before delivery is attempted, so a
+  failed/timed-out delivery still consumes the window as if it had
+  succeeded.
+- [#5024](https://github.com/JSONbored/metagraphed/issues/5024) -- low
+  severity, tracked for visibility: `lastDeliveredAt`'s in-memory Map is
+  never explicitly pruned (bounded in practice by how often the singleton
+  DO reconstructs).
+
 ## Verifying the trigger locally
 
 ```sh

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -613,8 +613,10 @@ export async function deliverChangeEvent({
 }
 
 // Bounded-concurrency map: drains `items` through at most `concurrency` in-flight
-// `fn` calls. Shared by the fresh fan-out and the redelivery sweep.
-async function mapBounded(items, concurrency, fn) {
+// `fn` calls. Shared by the fresh fan-out and the redelivery sweep -- exported
+// (#4984 Part 3 adversarial-review fix) so workers/alerter-hub.mjs's own
+// delivery fan-out can reuse it rather than duplicating this logic.
+export async function mapBounded(items, concurrency, fn) {
   const list = [...(items || [])];
   // Place each result at its INPUT index, not in completion order — workers
   // resolve concurrently (and the per-item work does real async I/O: crypto

--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -450,12 +450,16 @@ test("update: 200 on success, sends the new validated fields to the UPDATE", asy
   assert.ok(sqlCalls[1].values.includes("Transfer"));
 });
 
-test("update: omitting a field on PATCH keeps the existing row's value (partial-update semantics, not full-replace)", async () => {
+test("update: omitting a field on PATCH keeps the existing row's value (partial-update semantics, not full-replace), including a non-null min_amount_tao", async () => {
   mockQueue.current.push([
     row({
       owner_token: "correct-token",
       netuid: 7,
       event_kind: "Transfer",
+      // A non-null existing min_amount_tao specifically exercises the
+      // Number(existing.min_amount_tao) branch of the merge's ternary --
+      // every OTHER fixture in this file uses row()'s default (null).
+      min_amount_tao: "12.5", // Postgres numeric columns come back as strings
       channel: "email",
       destination: "a@b.com",
     }),
@@ -465,10 +469,10 @@ test("update: omitting a field on PATCH keeps the existing row's value (partial-
     req("/api/v1/alerts/triggers/1", {
       method: "PATCH",
       headers: { "x-alert-trigger-owner-token": "correct-token" },
-      // Only renaming -- netuid/event_kind/channel/destination are NOT
-      // resent, and must survive the update untouched (the exact bug the
-      // adversarial review found: a shared CREATE validator's "omitted ->
-      // unset" default would otherwise silently drop them).
+      // Only renaming -- netuid/event_kind/min_amount_tao/channel/destination
+      // are NOT resent, and must survive the update untouched (the exact bug
+      // the adversarial review found: a shared CREATE validator's
+      // "omitted -> unset" default would otherwise silently drop them).
       body: { name: "renamed" },
     }),
   );
@@ -476,6 +480,7 @@ test("update: omitting a field on PATCH keeps the existing row's value (partial-
   assert.equal(sqlCalls.length, 2);
   assert.ok(sqlCalls[1].values.includes(7));
   assert.ok(sqlCalls[1].values.includes("Transfer"));
+  assert.ok(sqlCalls[1].values.includes(12.5));
   assert.ok(sqlCalls[1].values.includes("email"));
   assert.ok(sqlCalls[1].values.includes("a@b.com"));
   assert.ok(sqlCalls[1].values.includes("renamed"));

--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -233,6 +233,48 @@ test("create: 201 on success, mints a fresh owner_token distinct from any stored
   assert.ok(sqlCalls[0].values.includes("a@b.com"));
 });
 
+test("create: 429 when ALERT_TRIGGER_CREATE_RATE_LIMITER rejects the request, without ever touching Postgres", async () => {
+  const limiter = { limit: vi.fn(async () => ({ success: false })) };
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    { ...env, ALERT_TRIGGER_CREATE_RATE_LIMITER: limiter },
+  );
+  assert.equal(res.status, 429);
+  assert.equal(sqlCalls.length, 0);
+  assert.equal(limiter.limit.mock.calls.length, 1);
+});
+
+test("create: 201 when ALERT_TRIGGER_CREATE_RATE_LIMITER allows the request", async () => {
+  const limiter = { limit: vi.fn(async () => ({ success: true })) };
+  mockQueue.current.push([row()]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+    { ...env, ALERT_TRIGGER_CREATE_RATE_LIMITER: limiter },
+  );
+  assert.equal(res.status, 201);
+  assert.equal(limiter.limit.mock.calls.length, 1);
+});
+
+test("create: skips rate limiting entirely when ALERT_TRIGGER_CREATE_RATE_LIMITER is unbound (local dev/CI)", async () => {
+  mockQueue.current.push([row()]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "email", destination: "a@b.com", netuid: 7 },
+    }),
+  );
+  assert.equal(res.status, 201);
+});
+
 // --- GET /api/v1/alerts/triggers/{id} -----------------------------------------
 
 test("get: 400 on a malformed id", async () => {
@@ -246,20 +288,22 @@ test("get: 404 when no such trigger exists", async () => {
   assert.equal(res.status, 404);
 });
 
-test("get: 403 when the owner token header is entirely absent", async () => {
+test("get: 404 (not 403) when the owner token header is entirely absent -- indistinguishable from a nonexistent id", async () => {
   mockQueue.current.push([row()]);
   const res = await fetch(req("/api/v1/alerts/triggers/1"));
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
-test("get: 403 when the owner token is present but wrong", async () => {
+test("get: 404 (not 403) when the owner token is present but wrong -- prevents an existence oracle over sequential ids", async () => {
   mockQueue.current.push([row()]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
       headers: { "x-alert-trigger-owner-token": "wrong" },
     }),
   );
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
 test("get: 200 with the owner view (owner_token stripped) when the token matches", async () => {
@@ -298,15 +342,62 @@ test("update: 400 on malformed JSON, before ever querying Postgres", async () =>
   assert.equal(sqlCalls.length, 0);
 });
 
-test("update: 400 on a validation failure, before ever querying Postgres", async () => {
+test("update: 400 on an empty body (parses to null), before ever querying Postgres -- the merge helper needs a real object", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers/1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: "",
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("update: 400 when the body parses to a JSON array, before ever querying Postgres", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers/1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: "[]",
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("update: 400 when the body parses to a JSON primitive (not an object), before ever querying Postgres", async () => {
+  const request = new Request("https://d/api/v1/alerts/triggers/1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: "5",
+  });
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("update: 400 on a validation failure, after loading (but never writing) the existing row -- merge-then-validate needs the row first, unlike CREATE", async () => {
+  mockQueue.current.push([row({ owner_token: "correct-token" })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      body: { channel: "email", destination: "not-an-email" },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 1);
+  assert.match(sqlCalls[0].text, /SELECT \* FROM chain_alert_triggers/);
+});
+
+test("update: 404 (not 400) on a validation failure when the trigger doesn't exist -- existence is checked before validation", async () => {
+  mockQueue.current.push([]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
       method: "PATCH",
       body: { channel: "email", destination: "not-an-email" },
     }),
   );
-  assert.equal(res.status, 400);
-  assert.equal(sqlCalls.length, 0);
+  assert.equal(res.status, 404);
 });
 
 test("update: 404 when no such trigger exists", async () => {
@@ -320,8 +411,8 @@ test("update: 404 when no such trigger exists", async () => {
   assert.equal(res.status, 404);
 });
 
-test("update: 403 when the owner token is missing or wrong", async () => {
-  mockQueue.current.push([{ owner_token: "correct-token" }]);
+test("update: 404 (not 403) when the owner token is missing or wrong -- prevents an existence oracle over sequential ids", async () => {
+  mockQueue.current.push([row({ owner_token: "correct-token" })]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
       method: "PATCH",
@@ -329,11 +420,12 @@ test("update: 403 when the owner token is missing or wrong", async () => {
       body: { channel: "email", destination: "a@b.com", netuid: 1 },
     }),
   );
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
 test("update: 200 on success, sends the new validated fields to the UPDATE", async () => {
-  mockQueue.current.push([{ owner_token: "correct-token" }]);
+  mockQueue.current.push([row({ owner_token: "correct-token" })]);
   mockQueue.current.push([row({ netuid: 42, event_kind: "Transfer" })]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
@@ -352,13 +444,92 @@ test("update: 200 on success, sends the new validated fields to the UPDATE", asy
   assert.equal(body.netuid, 42);
   assert.equal(body.event_kind, "Transfer");
   assert.equal(sqlCalls.length, 2);
-  assert.match(
-    sqlCalls[0].text,
-    /SELECT owner_token FROM chain_alert_triggers/,
-  );
+  assert.match(sqlCalls[0].text, /SELECT \* FROM chain_alert_triggers/);
   assert.match(sqlCalls[1].text, /UPDATE chain_alert_triggers SET/);
   assert.ok(sqlCalls[1].values.includes(42));
   assert.ok(sqlCalls[1].values.includes("Transfer"));
+});
+
+test("update: omitting a field on PATCH keeps the existing row's value (partial-update semantics, not full-replace)", async () => {
+  mockQueue.current.push([
+    row({
+      owner_token: "correct-token",
+      netuid: 7,
+      event_kind: "Transfer",
+      channel: "email",
+      destination: "a@b.com",
+    }),
+  ]);
+  mockQueue.current.push([row({ netuid: 7, event_kind: "Transfer" })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      // Only renaming -- netuid/event_kind/channel/destination are NOT
+      // resent, and must survive the update untouched (the exact bug the
+      // adversarial review found: a shared CREATE validator's "omitted ->
+      // unset" default would otherwise silently drop them).
+      body: { name: "renamed" },
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(sqlCalls.length, 2);
+  assert.ok(sqlCalls[1].values.includes(7));
+  assert.ok(sqlCalls[1].values.includes("Transfer"));
+  assert.ok(sqlCalls[1].values.includes("email"));
+  assert.ok(sqlCalls[1].values.includes("a@b.com"));
+  assert.ok(sqlCalls[1].values.includes("renamed"));
+});
+
+test("update: an explicit null on PATCH is a no-op, NOT a clear -- the existing value survives (validateAlertTriggerInput rejects a real null for most fields, so PATCH can't safely route an intentional-clear through the CREATE-shared validator)", async () => {
+  mockQueue.current.push([
+    row({
+      owner_token: "correct-token",
+      netuid: 7,
+      event_kind: "Transfer",
+      channel: "email",
+      destination: "a@b.com",
+    }),
+  ]);
+  mockQueue.current.push([row({ netuid: 7, event_kind: "Transfer" })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      body: {
+        netuid: null,
+        channel: "email",
+        destination: "a@b.com",
+      },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.netuid, 7);
+  assert.equal(sqlCalls.length, 2);
+  assert.ok(sqlCalls[1].values.includes(7));
+});
+
+test("update: a PATCH that only touches an unrelated field still validates cleanly when other existing fields are already null", async () => {
+  mockQueue.current.push([
+    row({
+      owner_token: "correct-token",
+      netuid: null,
+      event_kind: null,
+      account: "5F...",
+      channel: "email",
+      destination: "a@b.com",
+    }),
+  ]);
+  mockQueue.current.push([row({ name: "renamed" })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      body: { name: "renamed" },
+    }),
+  );
+  assert.equal(res.status, 200);
 });
 
 // --- DELETE /api/v1/alerts/triggers/{id} --------------------------------------
@@ -378,7 +549,7 @@ test("delete: 404 when no such trigger exists", async () => {
   assert.equal(res.status, 404);
 });
 
-test("delete: 403 when the owner token is missing or wrong", async () => {
+test("delete: 404 (not 403) when the owner token is missing or wrong -- prevents an existence oracle over sequential ids", async () => {
   mockQueue.current.push([{ owner_token: "correct-token" }]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
@@ -386,7 +557,8 @@ test("delete: 403 when the owner token is missing or wrong", async () => {
       headers: { "x-alert-trigger-owner-token": "wrong" },
     }),
   );
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
 test("delete: 200 with {id, deleted:true} on success, and actually issues the DELETE", async () => {

--- a/tests/alerter-hub.test.mjs
+++ b/tests/alerter-hub.test.mjs
@@ -274,6 +274,23 @@ test("refreshTriggers: fetches the internal active-list route with the correct U
   assert.notEqual(hub.triggersLoadedAt, 0);
 });
 
+test("refreshTriggers: the DATA_API fetch carries a bounded AbortSignal so a slow Postgres query can't stall ChainFirehoseHub's own broadcast()-wide wait", async () => {
+  let receivedSignal;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (_url, init) => {
+        receivedSignal = init.signal;
+        return new Response(JSON.stringify({ triggers: [] }), { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.refreshTriggers();
+  assert.ok(receivedSignal instanceof AbortSignal);
+  assert.equal(receivedSignal.aborted, false);
+});
+
 test("refreshTriggers: keeps the stale cache when the upstream response is not ok", async () => {
   const hub = new AlerterHub(
     {},
@@ -505,6 +522,49 @@ test("evaluate: a rejecting deliver call never fails the overall evaluation", as
   hub.triggersLoadedAt = Date.now();
   const result = await hub.evaluate({ table: "account_events", netuid: 7 });
   assert.equal(result.matched, 1);
+});
+
+test("evaluate: caps the delivery fan-out at ALERT_DELIVERY_CONCURRENCY (8) in-flight deliveries -- a broad-condition trigger set matching MANY distinct triggers on one event must not open one outbound fetch per match", async () => {
+  const TRIGGER_COUNT = 20;
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const resolvers = [];
+  const deliver = vi.fn(
+    () =>
+      new Promise((resolve) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        resolvers.push(() => {
+          inFlight -= 1;
+          resolve();
+        });
+      }),
+  );
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = Array.from({ length: TRIGGER_COUNT }, (_, i) =>
+    triggerRow({ id: String(i), netuid: 7 }),
+  );
+  hub.triggersLoadedAt = Date.now();
+
+  const evaluatePromise = hub.evaluate({ table: "account_events", netuid: 7 });
+  // Let every microtask-queued deliver() call actually start.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(inFlight, 8);
+  assert.equal(maxInFlight, 8);
+
+  // Drain in waves of 8, confirming the cap holds throughout, not just at
+  // the start.
+  while (resolvers.length > 0) {
+    const wave = resolvers.splice(0, resolvers.length);
+    wave.forEach((r) => r());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.ok(inFlight <= 8);
+  }
+
+  const result = await evaluatePromise;
+  assert.equal(result.delivered, TRIGGER_COUNT);
+  assert.equal(deliver.mock.calls.length, TRIGGER_COUNT);
+  assert.equal(maxInFlight, 8);
 });
 
 test("evaluate: triggers a refresh first when the cache is stale", async () => {

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -13,6 +13,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
+  ALERTER_HUB_EVALUATE_TIMEOUT_MS,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
@@ -1055,6 +1056,25 @@ test("broadcast: an unreachable/erroring AlerterHub is best-effort -- doesn't th
     hub.broadcast({ table: "account_events", block_number: 1 }),
   );
   assert.equal(alerterHub.calls.length, 1);
+});
+
+test("broadcast: the ALERTER_HUB ping carries a bounded AbortSignal, so a slow/stuck AlerterHub.evaluate() can't stall broadcast() (and therefore handleIngest's response) indefinitely", async () => {
+  const alerterHub = fakeAlerterHubBinding();
+  const hub = new ChainFirehoseHub(stubState(), { ALERTER_HUB: alerterHub });
+  await hub.broadcast({ table: "account_events", block_number: 1 });
+  assert.equal(alerterHub.calls.length, 1);
+  const { signal } = alerterHub.calls[0].init;
+  assert.ok(signal instanceof AbortSignal);
+  assert.equal(signal.aborted, false);
+});
+
+test("ALERTER_HUB_EVALUATE_TIMEOUT_MS is generous enough to cover AlerterHub's own worst-case refresh+delivery cycle", () => {
+  // Documents the reasoning, not just the number: workers/alerter-hub.mjs's
+  // own ALERT_TRIGGER_REFRESH_TIMEOUT_MS (4000) plus ALERT_DELIVERY_TIMEOUT_MS
+  // (8000, but bounded-concurrency so one slow batch, not summed across every
+  // match) should together stay comfortably under this ceiling.
+  assert.equal(ALERTER_HUB_EVALUATE_TIMEOUT_MS, 15_000);
+  assert.ok(ALERTER_HUB_EVALUATE_TIMEOUT_MS > 4000 + 8000);
 });
 
 test("broadcast: pings ALERTER_HUB unconditionally, unlike the per-session MCP loop -- no subscribe step required", async () => {

--- a/workers/alerter-hub.mjs
+++ b/workers/alerter-hub.mjs
@@ -21,6 +21,7 @@
 // triggers matched AND whether a match should actually be delivered right
 // now (burst rate-limiting), never how each channel's request is shaped.
 import { triggerMatchesEvent } from "../src/alert-triggers.mjs";
+import { mapBounded } from "../src/webhooks.mjs";
 import {
   buildDiscordDeliveryRequest,
   buildEmailDeliveryRequest,
@@ -30,6 +31,24 @@ import {
 } from "../src/alert-delivery.mjs";
 
 export const ALERTER_HUB_TRIGGER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Found by adversarial review: this Worker-to-Worker call is on the SAME
+// synchronous path every single firehose event blocks on (via
+// ChainFirehoseHub.broadcast()'s ALERTER_HUB ping) -- an internal
+// Cloudflare-to-Cloudflare Hyperdrive round trip, so a much tighter bound
+// than the per-channel delivery timeout below is appropriate; a Postgres
+// query that's still running after this long is not going to finish in
+// time to matter anyway.
+const ALERT_TRIGGER_REFRESH_TIMEOUT_MS = 4000;
+
+// Found by adversarial review: a single chain event can match many DISTINCT
+// triggers (the per-trigger burst rate-limiter only throttles repeats of
+// the SAME trigger, not how many different triggers fire on one event) --
+// an unbounded Promise.all could open one outbound fetch per match,
+// exhausting this Durable Object invocation's concurrent-subrequest budget
+// under a large, broad-condition trigger set. Matches src/webhooks.mjs's
+// own dispatchChangeEvent concurrency default.
+const ALERT_DELIVERY_CONCURRENCY = 8;
 
 // AlerterHub.evaluate() is awaited by ChainFirehoseHub.broadcast() (see that
 // class's ALERTER_HUB ping), which every OTHER consumer (SSE/WS/GraphQL/MCP)
@@ -160,6 +179,7 @@ export class AlerterHub {
             "x-alert-triggers-internal-token":
               this.env.ALERT_TRIGGERS_INTERNAL_TOKEN,
           },
+          signal: AbortSignal.timeout(ALERT_TRIGGER_REFRESH_TIMEOUT_MS),
         },
       );
       if (!upstream.ok) return;
@@ -204,13 +224,11 @@ export class AlerterHub {
       toDeliver.push(trigger);
     }
 
-    await Promise.all(
-      toDeliver.map((trigger) =>
-        this.deliver(trigger, payload, this.env).catch(() => {
-          // A single misbehaving delivery integration must never fail the
-          // evaluation response ChainFirehoseHub's broadcast() awaits.
-        }),
-      ),
+    await mapBounded(toDeliver, ALERT_DELIVERY_CONCURRENCY, (trigger) =>
+      this.deliver(trigger, payload, this.env).catch(() => {
+        // A single misbehaving delivery integration must never fail the
+        // evaluation response ChainFirehoseHub's broadcast() awaits.
+      }),
     );
 
     return {

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -67,6 +67,16 @@ export const CHAIN_FIREHOSE_TABLES = new Set([
 // payload is already far smaller than this -- see the trigger's comment).
 export const CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES = 16_000;
 
+// Found by adversarial review: bounds how long broadcast() will WAIT on the
+// #4984 AlerterHub singleton's own /evaluate call (see below), independent
+// of whatever AlerterHub's own internal timeouts add up to (a worst-case
+// ~4s trigger-cache refresh plus an ~8s-per-batch bounded-concurrency
+// delivery fan-out -- workers/alerter-hub.mjs's ALERT_TRIGGER_REFRESH_TIMEOUT_MS
+// and ALERT_DELIVERY_TIMEOUT_MS). Generous enough not to truncate a normal
+// evaluate() cycle, but a real ceiling so a slow/stuck evaluator can no
+// longer stall handleIngest()'s response to the box-side relay indefinitely.
+export const ALERTER_HUB_EVALUATE_TIMEOUT_MS = 15_000;
+
 // Per-field string length bound -- generous over every string field the
 // trigger actually emits (call_module/call_function/pallet/method/signer/
 // block_hash), catching a malformed or hostile ingest payload as a clean 400
@@ -708,6 +718,15 @@ export class ChainFirehoseHub {
     // evaluator, not one per subscriber, so no membership Set to check
     // first. Best-effort: an unreachable/erroring AlerterHub never blocks
     // ingest or any other broadcast population.
+    //
+    // Bounded (found by adversarial review): AlerterHub.evaluate() can
+    // itself take a while (a Postgres trigger-cache refresh, plus a
+    // delivery fan-out to arbitrary user-supplied targets) -- without an
+    // independent ceiling HERE, a slow evaluate() for ANY reason blocks
+    // broadcast() (and therefore handleIngest's response to the box-side
+    // relay) for however long that takes. This timeout only bounds how
+    // long broadcast() WAITS; it does not cancel AlerterHub's own
+    // in-flight work, which continues independently.
     if (this.env.ALERTER_HUB) {
       try {
         const stub = this.env.ALERTER_HUB.get(
@@ -717,6 +736,7 @@ export class ChainFirehoseHub {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(ALERTER_HUB_EVALUATE_TIMEOUT_MS),
         });
       } catch {
         // best-effort -- see the comment above

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -226,6 +226,7 @@ import {
   UPTIME_WINDOWS,
   MAX_UPTIME_ROWS,
   RPC_USAGE_BUCKETS,
+  resolveClientIp,
 } from "./config.mjs";
 import {
   formatBulkTrends,
@@ -2244,15 +2245,15 @@ async function readAlertTriggerBody(request) {
   }
 }
 
+// Returns the SAME 404 a nonexistent id gets (found by adversarial review:
+// returning 403 here would let an unauthenticated caller distinguish
+// "wrong token" from "no such trigger" purely from the status code,
+// building an existence oracle over sequential ids with zero credentials --
+// exactly the "no public view" property this route is designed to have).
 function requireAlertTriggerOwner(request, storedOwnerToken) {
   const provided = request.headers.get(ALERT_TRIGGER_OWNER_TOKEN_HEADER) || "";
   if (isValidAlertOwnerToken(provided, storedOwnerToken)) return null;
-  return writeJson(
-    {
-      error: `provide the trigger's ${ALERT_TRIGGER_OWNER_TOKEN_HEADER} header`,
-    },
-    403,
-  );
+  return writeJson({ error: "no such trigger" }, 404);
 }
 
 async function handleAlertTriggerCreate(request, env) {
@@ -2271,6 +2272,24 @@ async function handleAlertTriggerCreate(request, env) {
       { error: `provide a valid ${ALERT_TRIGGER_CREATE_TOKEN_HEADER} header` },
       401,
     );
+  }
+
+  // Found by adversarial review: ALERT_TRIGGER_CREATE_TOKEN is a SHARED
+  // anti-abuse secret, not a per-user credential -- anyone holding it could
+  // otherwise script unbounded trigger creation, and every row becomes a
+  // permanent per-event cost in AlerterHub.matchingTriggers()'s O(active
+  // triggers) scan. Skipped when unbound (local dev/CI), matching every
+  // other optional rate-limiter binding's convention in this codebase.
+  if (env.ALERT_TRIGGER_CREATE_RATE_LIMITER?.limit) {
+    const { success } = await env.ALERT_TRIGGER_CREATE_RATE_LIMITER.limit({
+      key: resolveClientIp(request),
+    });
+    if (!success) {
+      return writeJson(
+        { error: "too many alert trigger creation requests; slow down" },
+        429,
+      );
+    }
   }
 
   const { body, error } = await readAlertTriggerBody(request);
@@ -2321,22 +2340,75 @@ async function handleAlertTriggerGet(request, env, id) {
   });
 }
 
+// Fields present in a PATCH body with a real (non-null) value OVERRIDE the
+// existing row; fields OMITTED keep whatever the row already has (true
+// partial-update semantics, the bug the adversarial review found: a naive
+// full-replace here silently NULLs out -- and so WIDENS the match scope of
+// -- every condition field the caller didn't resend). A field explicitly
+// sent as `null` is ALSO treated as "keep the existing value", not as "clear
+// it": validateAlertTriggerInput (shared with CREATE) only recognizes "not
+// provided" via `!== undefined` and actively REJECTS an explicit `null` for
+// most fields (e.g. `netuid: null` fails its `Number.isInteger` check), so
+// there is no way to route an intentional-clear through that validator
+// without special-casing PATCH-only null handling inside a CREATE-shared
+// function. Both the existing-row base and the incoming body have their
+// null-valued keys stripped before merging -- for the base, this turns a
+// legitimately-unset existing field (stored as SQL NULL) into "not
+// provided" so it doesn't round-trip back in and fail validation; for the
+// body, it means an explicit `null` degrades to a no-op rather than a 400.
+// There is currently no supported way to explicitly clear an optional
+// condition field back to unset via PATCH -- only DELETE + recreate.
+function omitNullValues(obj) {
+  const out = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null) out[key] = value;
+  }
+  return out;
+}
+
 async function handleAlertTriggerUpdate(request, env, id) {
   if (!isValidAlertTriggerId(id)) {
     return writeJson({ error: "malformed trigger id" }, 400);
   }
   const { body, error } = await readAlertTriggerBody(request);
   if (error) return error;
-  const validated = validateAlertTriggerInput(body);
-  if (!validated.ok) {
-    return writeJson({ error: validated.error }, 400);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return writeJson({ error: "Request body must be a JSON object." }, 400);
   }
   return withAlertTriggersSql(env, async (sql) => {
     const [existing] =
-      await sql`SELECT owner_token FROM chain_alert_triggers WHERE id = ${id}`;
+      await sql`SELECT * FROM chain_alert_triggers WHERE id = ${id}`;
     if (!existing) return writeJson({ error: "no such trigger" }, 404);
     const authError = requireAlertTriggerOwner(request, existing.owner_token);
     if (authError) return authError;
+
+    // Found by adversarial review: validating the raw PATCH body directly
+    // (the original version of this function) meant validateAlertTriggerInput's
+    // CREATE-oriented "omitted -> null" defaulting silently NULLed out any
+    // condition field the caller didn't resend, unintentionally WIDENING a
+    // trigger's match scope on every partial edit (e.g. renaming a
+    // netuid-scoped trigger without resending netuid would drop the netuid
+    // filter entirely). Merging onto the existing row first fixes this.
+    const merged = {
+      ...omitNullValues({
+        name: existing.name,
+        table_filter: existing.table_filter,
+        netuid: existing.netuid,
+        event_kind: existing.event_kind,
+        account: existing.account,
+        min_amount_tao:
+          existing.min_amount_tao === null
+            ? null
+            : Number(existing.min_amount_tao),
+        channel: existing.channel,
+        destination: existing.destination,
+      }),
+      ...omitNullValues(body),
+    };
+    const validated = validateAlertTriggerInput(merged);
+    if (!validated.ok) {
+      return writeJson({ error: validated.error }, 400);
+    }
 
     const v = validated.value;
     const now = Date.now();

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -62,4 +62,24 @@
       "localConnectionString": "postgresql://postgres:postgres@localhost:5432/metagraphed",
     },
   ],
+  // Found by adversarial review (#4984 Part 3): ALERT_TRIGGER_CREATE_TOKEN
+  // alone doesn't bound REQUEST VOLUME from a legitimate token holder --
+  // every created row becomes a permanent per-event cost in AlerterHub's
+  // O(active triggers) match scan. Namespace id is local to THIS Worker's
+  // own bindings (Cloudflare's Workers-native rate-limiting API, not the
+  // older account-wide Rate Limiting Rules product) -- reusing "1001" here
+  // does not collide with wrangler.jsonc's own RPC_RATE_LIMITER using the
+  // same id, since ratelimit namespaces are scoped per Worker script.
+  // Skipped when unbound (local dev/CI), matching every other optional
+  // rate-limiter's convention in this codebase.
+  "ratelimits": [
+    {
+      "name": "ALERT_TRIGGER_CREATE_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": {
+        "limit": 10,
+        "period": 60,
+      },
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

Follow-up to #5017 (#4984 Part 3, already merged). A dedicated adversarial-review pass over the full alerter (trigger CRUD + evaluator + delivery) — independent security/correctness/resource-exhaustion lenses, each candidate finding re-verified by two skeptical agents before being treated as real — surfaced six confirmed issues, all fixed here:

- **PATCH-as-full-replace on `chain_alert_triggers`** (most severe): `handleAlertTriggerUpdate` validated the raw PATCH body directly against the CREATE-shared validator, so any condition field the caller didn't resend was silently defaulted to unset — unintentionally *widening* a trigger's match scope on every partial edit. Fixed by merging the incoming body onto the existing row before validating.
- **Existence oracle via differentiated 403/404**: GET/PATCH/DELETE returned 403 for "wrong owner token" vs 404 for "no such trigger", letting an unauthenticated caller enumerate trigger existence over sequential ids. Unified to 404 either way.
- **Unbounded trigger creation**: `ALERT_TRIGGER_CREATE_TOKEN` didn't bound request *volume* from a legitimate holder, and every row is a permanent per-event cost in the evaluator's scan. Added a Workers-native rate limiter (10/min per IP), skipped when unbound.
- **Two missing timeouts** on the path every firehose event shares: `AlerterHub.refreshTriggers()`'s Hyperdrive fetch, and `ChainFirehoseHub.broadcast()`'s own ping to the AlerterHub singleton — a slow Postgres query or slow delivery fan-out could stall every OTHER firehose consumer (SSE/WS/GraphQL/MCP), not just the alerter.
- **Unbounded delivery-fan-out concurrency**: a single event can match many distinct triggers; the delivery loop now runs through `mapBounded` (exported from `src/webhooks.mjs`, concurrency 8) instead of an unbounded `Promise.all`.

Four findings were investigated and deliberately deferred as their own tracked issues rather than rushed in:
- #5021 — DNS-resolution SSRF gap, shared with the pre-existing webhook-subscription delivery path (the codebase's own DNS-resolving defense turns out to be Node-only and was never reachable from the live Worker).
- #5022 — `match_count`/`last_matched_at` persistence.
- #5023 — burst rate-limit timestamp is set before delivery is attempted, so a failed delivery still consumes the window.
- #5024 — low severity, `lastDeliveredAt` Map pruning.

`docs/realtime-firehose.md` documents all of the above.

## Test plan

- [x] `npx vitest run` — 265 files / 7933 tests pass
- [x] `npm run test:coverage` — 99.51%/97.98%/99.49%/99.69% overall; new lines in `workers/data-api.mjs` fully covered
- [x] `npm run lint` / `npx prettier --check` on touched files
- [x] `npm run validate` / `npm run validate:contract-drift`
- [x] `npm run worker:deploy:dry-run` and `wrangler deploy -c wrangler.data.jsonc --dry-run` (validates the new `ratelimits` block)
- [x] `npm run worker:bundle:budget`