### PR TITLE
feat(registry): add SN79 MVTRX Grafana metrics dashboard surface

### DIFF
--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -98,6 +98,22 @@
       },
       "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
       "url": "https://mvtrx.exchange/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-79-mvtrx-grafana-dashboard",
+      "kind": "dashboard",
+      "name": "MVTRX Grafana metrics dashboard",
+      "notes": "Public no-auth Grafana metrics dashboard for SN79 MVTRX, where miner/validator Prometheus telemetry is published. The official taos-im/sn-79 README links it (Grafana badge to taos.simulate.trading) and tells operators \"your data will still appear at taos.simulate.trading\". Distinct from the mvtrx.exchange trading host and the taos.im site.",
+      "provider": "taos-im",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
+      "url": "https://taos.simulate.trading/"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4096

## Summary
Registers **SN79 MVTRX**'s public **Grafana metrics dashboard** — the subnet's public telemetry surface, which the registry didn't yet have.

## Surface
- kind: `dashboard`
- url: `https://taos.simulate.trading/`
- provider: `taos-im` (existing)

## Proof of ownership (airtight)
- The official `taos-im/sn-79` README (netuid 79: *"MVTRX operates as a Bittensor subnet at netuid 79"*) links this exact host: a **Grafana badge → `https://taos.simulate.trading`**, and instructs operators that *"your data will still appear at [taos.simulate.trading](https://taos.simulate.trading/?orgId=1)"*.

## Verified live + public
- `GET https://taos.simulate.trading/` → **HTTP 200** (Grafana app). `GET /api/health` → **HTTP 200** `{"database":"ok"}` — live, no auth.

## Scope note (#4096)
#4096 asks for SN79's OpenAPI spec. MVTRX exposes no public OpenAPI; its genuine public machine-usable surface is this Grafana metrics dashboard where miner/validator Prometheus telemetry is published.

## Non-duplication
The existing MVTRX surfaces are on different hosts — `taos.im` (website), `simulate.trading/taos-im-paper` (data-artifact), `mvtrx.exchange/health` (subnet-api). `taos.simulate.trading` is a distinct host + a `dashboard` kind. No open PR targets SN79.

## Validation (local)
- `npx prettier --check` → clean · `npm run validate:surface` → passes (5 surfaces) · `npm run scan:public-safety` → passes · single file, 16-line pure append.
