### PR TITLE
feat(registry): add SN117 BrainPlay minimum compute requirements data-artifact

### DIFF
--- a/registry/subnets/brainplay.json
+++ b/registry/subnets/brainplay.json
@@ -110,6 +110,24 @@
         "https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/deploy/miner.py"
       ],
       "url": "https://raw.githubusercontent.com/shiftlayer-llc/brainplay-subnet/main/deploy/profiles/codenames.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-117-brainplay-min-compute",
+      "kind": "data-artifact",
+      "name": "BrainPlay minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification (min_compute.yml) at the root of the official SN117 BrainPlay repository shiftlayer-llc/brainplay-subnet — baseline CPU, GPU/VRAM, memory, storage, OS, and bandwidth floors for operators. Distinct from the deploy/profiles/codenames.json gameplay profile; served read-only via raw.githubusercontent from the same netuid-117 repo (the README registers the subnet with --netuid 117).",
+      "provider": "shiftlayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/shiftlayer-llc/brainplay-subnet/main/min_compute.yml"
     }
   ]
 }


### PR DESCRIPTION
Closes #4160

## Summary
Registers **SN117 BrainPlay**'s public **minimum-compute requirements** file (`min_compute.yml`) — the operator hardware spec, a public no-auth data artifact the registry didn't yet have.

## Surface
- kind: `data-artifact`
- url: `https://raw.githubusercontent.com/shiftlayer-llc/brainplay-subnet/main/min_compute.yml`
- provider: `shiftlayer` (existing)

## Proof of ownership (airtight)
- Served from the root of the official SN117 repo `shiftlayer-llc/brainplay-subnet` (already the registered `source-repo`); the README registers the subnet with **`--netuid 117`**.

## Verified live + public
- `GET` the raw URL → **HTTP 200**, `# Use this document to specify the minimum compute requirements…` (YAML hardware floors: CPU, GPU/VRAM, memory, storage, OS, bandwidth). No auth.

## Scope note (#4160)
#4160 asks for SN117's OpenAPI spec. BrainPlay exposes no public OpenAPI; this registers a real public machine-readable data artifact (the operator compute spec) instead.

## Non-duplication
Distinct from the existing `codenames.json` gameplay-profile data-artifact (different file, different purpose — hardware spec vs game profile) and the `/api/health` subnet-api. No open PR targets SN117.

## Validation (local)
- `npx prettier --check` → clean · `npm run validate:surface` → passes · `npm run scan:public-safety` → passes · single file, pure append.
