### PR TITLE
feat(registry): add SN126 Poker44 live benchmark dashboard surface

### DIFF
--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -51,6 +51,24 @@
         "https://api.poker44.net/api/v1/benchmark"
       ],
       "url": "https://api.poker44.net/api/v1/benchmark"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-dashboard",
+      "kind": "dashboard",
+      "name": "Poker44 live benchmark dashboard",
+      "notes": "Public no-auth Poker44 (SN126) web dashboard at poker44.net/dashboard — the 'Live Benchmark for Bot Detection' leaderboard showing per-round miner scores, validator fleet status, and cycle progress across the subnet's competition rounds. Served on the official poker44.net platform linked from the Poker44/Poker44-subnet README; distinct from the api.poker44.net JSON benchmark/health endpoints.",
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/README.md"
+      ],
+      "url": "https://poker44.net/dashboard"
     }
   ],
   "website_url": "https://poker44.net/"


### PR DESCRIPTION
Closes #4178

## Summary
Registers **SN126 Poker44**'s public **live benchmark dashboard** — the "Live Benchmark for Bot Detection" leaderboard web UI, a public metrics surface the registry didn't yet have.

## Surface
- kind: `dashboard`
- url: `https://poker44.net/dashboard`
- provider: `poker44` (existing)

## Proof of ownership (airtight)
- Served on the official **poker44.net** platform, linked from the `Poker44/Poker44-subnet` README (already the registered `source-repo`, and `website_url`).

## Verified live + public
- `GET https://poker44.net/dashboard` → **HTTP 200**, `<title>Poker44 - Live Benchmark for Bot Detection</title>` — the live leaderboard (per-round miner scores, validator fleet status, cycle progress). No auth.

## Scope note (#4178)
#4178 asks for SN126's OpenAPI spec. Poker44 exposes no public OpenAPI; this registers the subnet's public metrics **dashboard** (mirroring the accepted W&B/Grafana dashboard pattern for SN108/SN27/SN79).

## Non-duplication
Distinct from the existing `api.poker44.net/health` (subnet-api) and `api.poker44.net/api/v1/benchmark` (data-artifact JSON) surfaces — this is the human-facing web dashboard on the `poker44.net` host. No open PR targets SN126.

## Validation (local)
- `npx prettier --check` → clean · `npm run validate:surface` → passes · `npm run scan:public-safety` → passes · single file, pure append.
