### PR TITLE
feat(registry): add SN98 ForeverMoney analytics dashboard surface

### DIFF
--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -117,6 +117,24 @@
         "confidence": "medium"
       },
       "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official SN98-ForeverMoney/forever-money repository as min_compute.yml. Documents baseline CPU, memory, storage, and network bandwidth requirements for SN98 ForeverMoney miners and validators."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-98-forevermoney-dashboard",
+      "kind": "dashboard",
+      "name": "ForeverMoney analytics dashboard",
+      "notes": "Public no-auth ForeverMoney (SN98) analytics dashboard at dashboard.forevermoney.ai — a Plotly metrics UI (\"Overview — ForeverMoney\") with TVL-by-pair, APR-window, and vault-lifetime panels for the subnet's Aerodrome / Uniswap-V3 concentrated-liquidity pools on Base. Served on the official forevermoney.ai platform (README: SN98, mainnet netuid 98); distinct from the /api/vaults/tvl JSON endpoint already listed.",
+      "provider": "forevermoney",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money/blob/main/README.md"
+      ],
+      "url": "https://dashboard.forevermoney.ai/"
     }
   ],
   "social": {


### PR DESCRIPTION
Closes #4124

## Summary
Registers **SN98 ForeverMoney**'s public **analytics dashboard** — a Plotly metrics UI, a substantial public surface (new kind for this subnet).

## Surface
- kind: `dashboard`
- url: `https://dashboard.forevermoney.ai/`
- provider: `forevermoney` (existing)

## Proof of ownership (airtight)
- Served on the official **forevermoney.ai** platform; the `SN98-ForeverMoney/forever-money` README (already the registered `source-repo`) declares **"Subnet ID: 374 (Testnet) / 98 (Mainnet)"**.

## Verified live + public
- `GET https://dashboard.forevermoney.ai/` → **HTTP 200**, `<title>Overview — ForeverMoney</title>` — a Plotly dashboard (loads cdn.plot.ly) with TVL-by-pair, APR-window, and vault-lifetime panels for the subnet's Aerodrome/Uniswap-V3 pools on Base. No auth.

## Scope note (#4124)
#4124 asks for SN98's OpenAPI spec. ForeverMoney exposes no public OpenAPI; this registers the subnet's public metrics **dashboard** (a new surface kind for SN98).

## Non-duplication
SN98 currently has website, source-repo, a `subnet-api` (`dashboard.forevermoney.ai/api/vaults/tvl` — a JSON endpoint) and a `min_compute.yml` data-artifact — but **no `dashboard`**. This registers the human analytics UI at the dashboard root (distinct purpose/kind from the JSON API path). No open PR targets SN98.

## Validation (local)
- `npx prettier --check` → clean · `npm run validate:surface` → passes · `npm run scan:public-safety` → passes · single file, pure append.
