### PR TITLE
feat(registry): add SN62 Ridges latest-set problems data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-latest-set-problems",
+      "kind": "data-artifact",
+      "name": "Ridges latest evaluation-set problems catalog",
+      "notes": "Public no-auth GET /evaluation-sets/all-latest-set-problems on agent-upload.ridges.ai returning the machine-readable catalog of benchmark problems in the current evaluation set (problem_name, benchmark_family, problem_suite_name, execution_spec with Harbor task s3_key). Defined in the official ridgesai/ridges api/endpoints/evaluation_sets.py and listed in the platform OpenAPI spec; distinct from the top-agents leaderboard subnet-api already registered.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "Lang-bt"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/main/api/endpoints/evaluation_sets.py",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends a surface on exactly one subnet manifest —
`registry/subnets/ridges.json`.

Closes #4069

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems
- Source URL (proves the claim):
  - https://github.com/ridgesai/ridges/blob/main/api/endpoints/evaluation_sets.py
  - https://agent-upload.ridges.ai/openapi.json
- Provider slug: ridges

## Summary

Adds the public benchmark-problems catalog for SN62 Ridges: a no-auth JSON feed
listing every problem in the current evaluation set (problem name, benchmark
family, Harbor task execution spec). The route is implemented in the official
`ridgesai/ridges` repository and documented in the platform OpenAPI spec. This
is distinct from the existing top-agents leaderboard `subnet-api` surface.

## Checklist

- [x] Changes exactly one `registry/subnets/ridges.json` file (append-only).
- [x] Generated with `npm run surface:add` then hand-polished metadata.
- [x] The `url` is public and safe for read-only probes; the `source_url`
      independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data,
      private URLs, private dashboards, validator internals, or generated
      `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #4069`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the Gittensory gate and may be
merged automatically after public checks pass.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)