### PR TITLE
feat(ui): add copy buttons on blocks table hash and author cells

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -17,6 +17,8 @@ import {
   DownloadCsvButton,
   StatTile,
   Sparkline,
+  CopyButton,
+  CopyableCode,
 } from "@jsonbored/ui-kit";
 import {
   PageSizeSelect,
@@ -390,20 +392,28 @@ function BlocksTable() {
                   </Link>
                 </td>
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  <Link
-                    to="/blocks/$ref"
-                    params={{ ref: b.block_hash || String(b.block_number) }}
-                    className="hover:text-ink-strong"
-                    title={b.block_hash}
-                  >
-                    {shortHash(b.block_hash)}
-                  </Link>
+                  <span className="inline-flex items-center gap-1 min-w-0">
+                    <Link
+                      to="/blocks/$ref"
+                      params={{ ref: b.block_hash || String(b.block_number) }}
+                      className="hover:text-ink-strong truncate"
+                      title={b.block_hash}
+                    >
+                      {shortHash(b.block_hash)}
+                    </Link>
+                    {b.block_hash ? <CopyButton value={b.block_hash} label="block hash" /> : null}
+                  </span>
                 </td>
                 <td
                   className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
                   title={b.author ?? undefined}
                 >
-                  <AccountCell ss58={b.author} fallback={shortHash(b.author) ?? "—"} />
+                  <AccountCell
+                    ss58={b.author}
+                    fallback={
+                      b.author ? <CopyableCode value={b.author} className="max-w-full" /> : "—"
+                    }
+                  />
                 </td>
                 <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
                   {formatNumber(b.extrinsic_count ?? 0)}


### PR DESCRIPTION
## Summary

Adds a copy-to-clipboard affordance to the Hash and Author cells in the blocks table's desktop `<table>` view, using the same `CopyButton`/`CopyableCode` primitives already shipped on the extrinsics table's twin issue (#3396, landed in #4362). The Hash cell keeps its existing navigation to the block detail page — the copy control sits alongside the `<Link>`, not nested inside it. The Author cell's `AccountCell` fallback (used when `author` isn't a resolvable ss58) now gets `CopyableCode` instead of plain truncated text, matching what the extrinsics table's Signer column already does.

## What Changed

- `apps/ui/src/routes/blocks.index.tsx`: import `CopyButton`/`CopyableCode` from `@jsonbored/ui-kit`; wrap the Hash cell's `<Link>` in a `<span className="inline-flex items-center gap-1 min-w-0">` alongside a `CopyButton`; give `AccountCell`'s fallback in the Author cell a `CopyableCode` instead of a bare string.

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` (678 tests passing)
- `npm run test:e2e --workspace=apps/ui` (24/24 responsive-overflow checks passing)
- `npm run build --workspace=apps/ui`

## Screenshots

The change is confined to the desktop `<table>` view — `ListShell` renders the table at `md:block` and up, with the mobile card list (`md:hidden`) untouched, per this issue's explicit non-goal. Mobile capture is omitted since that view is provably unaffected (different, unmodified code path).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3395-desktop-dark-after.png)<br><sub>after</sub> |

Closes #3395
