### PR TITLE
feat(ui): hide NavOmnibox below md instead of squeezing it to zero width

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -350,7 +350,10 @@ export function NavOmnibox({ onOpenPalette }: Props) {
     showResults && active < flat.length ? `nav-omnibox-option-${active}` : undefined;
 
   return (
-    <div ref={wrapRef} className="relative flex-1 max-w-xl lg:max-w-2xl xl:max-w-3xl min-w-0">
+    <div
+      ref={wrapRef}
+      className="hidden md:block relative flex-1 max-w-xl lg:max-w-2xl xl:max-w-3xl min-w-0"
+    >
       {/* Input */}
       <div
         className={classNames(


### PR DESCRIPTION
## Summary

Below the `md` breakpoint, `NavOmnibox` now explicitly hides itself instead of being implicitly squeezed to zero width by the header row's flex layout. Measuring the header at 375px confirms the hamburger, Brand wordmark, and right-side icon group alone already consume slightly more than the available row width, so the flex-1 middle slot the omnibox sits in was already collapsing to 0 before this change — this makes that collapse explicit rather than incidental, and closes off the header row as a place a future addition could silently overlap adjacent controls. Search stays reachable below `md` via the mobile menu sheet's own filter input and the existing `⌘K`/`` ` / ` ``-bound `CommandPalette`. Desktop rendering (`md` and up) is unchanged — same live suggestions, direct-nav detection, recent searches, and `⌘K` hint.

## What Changed

- `apps/ui/src/components/metagraphed/nav-omnibox.tsx`: add `hidden md:block` to the root wrapper's className.

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` (678 tests passing)
- `npm run test:e2e --workspace=apps/ui` (24/24 responsive-overflow checks passing, incl. mobile/tablet/desktop)
- `npm run build --workspace=apps/ui`

## Screenshots

Captured on `/`, since the header (and `NavOmnibox`) is shared across every route.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-light-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-light-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-dark-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-dark-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-mobile-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3454-desktop-dark-after.png)<br><sub>after</sub> |

Mobile before/after render identically — at 375px the omnibox was already collapsing to zero width under the existing flex layout, so making that hide explicit produces no visible change there; tablet and desktop confirm the full omnibox is unaffected.

Closes #3454
