### PR TITLE
feat(registry): add SN39 Basilica telemetry metrics dashboard surface

### DIFF
--- a/registry/subnets/basilica.json
+++ b/registry/subnets/basilica.json
@@ -147,6 +147,24 @@
         "https://github.com/one-covenant/basilica/blob/1a75c1cb7c62caabe929b280931f0e074e2757f2/crates/basilica-validator/tests/fixtures/lshw/a100_sxm5_30vcpu.json"
       ],
       "url": "https://raw.githubusercontent.com/one-covenant/basilica/1a75c1cb7c62caabe929b280931f0e074e2757f2/crates/basilica-validator/tests/fixtures/lshw/a100_sxm5_30vcpu.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-39-basilica-telemetry",
+      "kind": "dashboard",
+      "name": "Basilica telemetry metrics dashboard",
+      "notes": "Public no-auth Prometheus metrics endpoint for SN39 Basilica's production cluster — an expression-browser UI at basilica-telemetry.tplr.ai/graph plus an open query API at /api/v1/query. Serves live basilica_* series (e.g. basilica_api_http_requests_total, basilica_billing_* across the basilica-ecs production cluster: api/billing/incentive/payments). Named as the subnet's telemetry backend in the official one-covenant/basilica repo — scripts/validator/telemetry/config.alloy remote-writes to basilica-telemetry.tplr.ai; netuid 39 per config/validator.toml.example. Distinct host from basilica.ai.",
+      "provider": "basilica",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/one-covenant/basilica/blob/main/scripts/validator/telemetry/config.alloy"
+      ],
+      "url": "https://basilica-telemetry.tplr.ai/graph"
     }
   ],
   "website_url": "https://www.basilica.ai/"


### PR DESCRIPTION
Closes #4041

## Summary
Registers **SN39 Basilica**'s public **telemetry metrics dashboard** — the subnet's live Prometheus metrics endpoint (a new surface kind for SN39).

## Surface
- kind: `dashboard`
- url: `https://basilica-telemetry.tplr.ai/graph`
- provider: `basilica` (existing)

## Proof of ownership (airtight)
- The official `one-covenant/basilica` repo names this host as the subnet's telemetry backend: `scripts/validator/telemetry/config.alloy` remote-writes to `https://basilica-telemetry.tplr.ai/api/v1/write`. netuid **39** is set in `config/validator.toml.example` and `config/miner.toml.example`. That repo is the registered `source-repo`.

## Verified live + public
- `GET https://basilica-telemetry.tplr.ai/graph` → **HTTP 200** (Prometheus UI). `GET /api/v1/query?query=up` → **HTTP 200** JSON with real production series: `cluster="basilica-ecs"`, services `billing/incentive/payments`, and `basilica_*` metric families (`basilica_api_http_requests_total`, `basilica_billing_*`). No auth.

## Scope note (#4041)
#4041 asks for SN39's OpenAPI spec. Basilica exposes no public OpenAPI; this registers the subnet's public metrics **dashboard/telemetry** surface.

## Non-duplication
SN39 has source-repo/website/example/docs/subnet-api/data-artifact but **no `dashboard`**. This telemetry endpoint is a new kind on a distinct host (`basilica-telemetry.tplr.ai`). No open PR targets SN39.

## Validation (local)
- `npx prettier --check` → clean · `npm run validate:surface` → passes · `npm run scan:public-safety` → passes · single file, pure append.
