### PR TITLE
feat(ui): add focus-visible ring to ProfileTabs and EndpointKindTabs

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -29,7 +29,8 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             aria-selected={active}
             onClick={() => onChange(k)}
             className={classNames(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              // !rounded-full overrides mg-focus-ring's hardcoded 6px ring radius.
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring !rounded-full",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -38,7 +38,7 @@ export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defa
                   })
                 }
                 className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
                   isActive
                     ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
                     : "text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
## Summary

Wires the existing `mg-focus-ring` utility into `ProfileTabs` and `EndpointKindTabs` so keyboard-focused tabs get a visible ring, matching the rest of the design system. Both components were confirmed to have zero `focus:`/`mg-focus*` classes before this change.

`EndpointKindTabs`' tab buttons are `rounded-full` (a pill), but `mg-focus-ring:focus-visible` hardcodes `border-radius: 6px` for its default (rectangular) consumers — applied verbatim, the ring would clip square across the pill's rounded ends. Rather than editing the shared utility (used elsewhere, e.g. `hero-subnet-chips.tsx`, for genuinely rectangular tiles) or adding a new CSS class, `EndpointKindTabs` also gets `!rounded-full` on the same button, which overrides the ring's radius back to a full pill via Tailwind's important-modifier — no CSS file touched, no risk to the existing rectangular usage.

## What Changed

- `apps/ui/src/components/metagraphed/profile-tabs.tsx`: add `mg-focus-ring` to the tab `<button>`'s `classNames(...)` call.
- `apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx`: add `mg-focus-ring !rounded-full` to the tab `<button>`'s `classNames(...)` call — the `!rounded-full` keeps the ring's shape matching the button's own `rounded-full`.
- No changes to `styles.css` (`packages/ui-kit/src/styles.css`, where `.mg-focus-ring` now actually lives post the ui-kit migration) — the utility is reused as-is.

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` (678 tests passing)
- `npm run test:e2e --workspace=apps/ui` (24/24 responsive-overflow checks passing)
- `npm run build --workspace=apps/ui`
- Verified both rings via keyboard focus in a local preview (Playwright `.focus()`, matching `:focus-visible` semantics)

## Screenshots

`EndpointKindTabs` (`/endpoints`) at all 3 viewports × 2 themes, tabbed to the second pill ("RPC"):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-light-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-light-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-dark-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-dark-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-mobile-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-endpoints-desktop-dark-after.png)<br><sub>after</sub> |

`ProfileTabs` (`/subnets/1`), desktop only — the ring's shape/color is a fixed `box-shadow`, not a responsive property, so it doesn't vary by viewport width the way layout does; only desktop is shown to keep this table a reasonable size:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3451-profile-desktop-dark-after.png)<br><sub>after</sub> |

Closes #3451
