### PR TITLE
feat(ui): extract shared SegmentedToggle primitive

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1467,47 +1467,79 @@ function CopyableCode({
     }
   );
 }
+function SegmentedToggle({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "div",
+    {
+      role: "tablist",
+      "aria-label": ariaLabel,
+      className: classNames(
+        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
+        className
+      ),
+      children: options.map(
+        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
+          const active = v === value;
+          return /* @__PURE__ */ jsxRuntime.jsxs(
+            "button",
+            {
+              type: "button",
+              role: "tab",
+              "aria-selected": active,
+              "aria-label": optionAriaLabel ?? label,
+              title: title ?? label,
+              onClick: () => onChange(v),
+              className: classNames(
+                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
+                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
+              ),
+              children: [
+                Icon ? /* @__PURE__ */ jsxRuntime.jsx(Icon, { className: "size-3.5" }) : null,
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: label })
+              ]
+            },
+            v
+          );
+        }
+      )
+    }
+  );
+}
 function DensityToggle({
   value,
   onChange,
   className
 }) {
   const options = [
-    { value: "comfortable", label: "Comfortable", Icon: lucideReact.Rows3 },
-    { value: "compact", label: "Compact", Icon: lucideReact.Rows2 }
+    {
+      value: "comfortable",
+      label: "Comfortable",
+      Icon: lucideReact.Rows3,
+      ariaLabel: "Comfortable row density",
+      title: "Comfortable rows"
+    },
+    {
+      value: "compact",
+      label: "Compact",
+      Icon: lucideReact.Rows2,
+      ariaLabel: "Compact row density",
+      title: "Compact rows"
+    }
   ];
   return /* @__PURE__ */ jsxRuntime.jsx(
-    "div",
+    SegmentedToggle,
     {
-      role: "tablist",
-      "aria-label": "Row density",
-      className: classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className
-      ),
-      children: options.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return /* @__PURE__ */ jsxRuntime.jsxs(
-          "button",
-          {
-            type: "button",
-            role: "tab",
-            "aria-selected": active,
-            "aria-label": `${label} row density`,
-            title: `${label} rows`,
-            onClick: () => onChange(v),
-            className: classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
-            ),
-            children: [
-              /* @__PURE__ */ jsxRuntime.jsx(Icon, { className: "size-3.5" }),
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: label })
-            ]
-          },
-          v
-        );
-      })
+      options,
+      value,
+      onChange,
+      ariaLabel: "Row density",
+      className
     }
   );
 }
@@ -2437,9 +2469,24 @@ function TableState({
   );
 }
 var OPTIONS = [
-  { value: "table", label: "Table", Icon: lucideReact.List },
-  { value: "grid", label: "Grid", Icon: lucideReact.LayoutGrid },
-  { value: "matrix", label: "Matrix", Icon: lucideReact.Grid3x3 }
+  {
+    value: "table",
+    label: "Table",
+    Icon: lucideReact.List,
+    ariaLabel: "Switch to table view"
+  },
+  {
+    value: "grid",
+    label: "Grid",
+    Icon: lucideReact.LayoutGrid,
+    ariaLabel: "Switch to grid view"
+  },
+  {
+    value: "matrix",
+    label: "Matrix",
+    Icon: lucideReact.Grid3x3,
+    ariaLabel: "Switch to matrix view"
+  }
 ];
 function ViewModeToggle({
   value,
@@ -2449,37 +2496,13 @@ function ViewModeToggle({
 }) {
   const available = OPTIONS.filter((o) => options.includes(o.value));
   return /* @__PURE__ */ jsxRuntime.jsx(
-    "div",
+    SegmentedToggle,
     {
-      role: "tablist",
-      "aria-label": "View mode",
-      className: classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className
-      ),
-      children: available.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return /* @__PURE__ */ jsxRuntime.jsxs(
-          "button",
-          {
-            type: "button",
-            role: "tab",
-            "aria-selected": active,
-            "aria-label": `Switch to ${label.toLowerCase()} view`,
-            title: label,
-            onClick: () => onChange(v),
-            className: classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
-            ),
-            children: [
-              /* @__PURE__ */ jsxRuntime.jsx(Icon, { className: "size-3.5" }),
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: label })
-            ]
-          },
-          v
-        );
-      })
+      options: available,
+      value,
+      onChange,
+      ariaLabel: "View mode",
+      className
     }
   );
 }

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1438,47 +1438,79 @@ function CopyableCode({
     }
   );
 }
+function SegmentedToggle({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className
+}) {
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      role: "tablist",
+      "aria-label": ariaLabel,
+      className: classNames(
+        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
+        className
+      ),
+      children: options.map(
+        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
+          const active = v === value;
+          return /* @__PURE__ */ jsxs(
+            "button",
+            {
+              type: "button",
+              role: "tab",
+              "aria-selected": active,
+              "aria-label": optionAriaLabel ?? label,
+              title: title ?? label,
+              onClick: () => onChange(v),
+              className: classNames(
+                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
+                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
+              ),
+              children: [
+                Icon ? /* @__PURE__ */ jsx(Icon, { className: "size-3.5" }) : null,
+                /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: label })
+              ]
+            },
+            v
+          );
+        }
+      )
+    }
+  );
+}
 function DensityToggle({
   value,
   onChange,
   className
 }) {
   const options = [
-    { value: "comfortable", label: "Comfortable", Icon: Rows3 },
-    { value: "compact", label: "Compact", Icon: Rows2 }
+    {
+      value: "comfortable",
+      label: "Comfortable",
+      Icon: Rows3,
+      ariaLabel: "Comfortable row density",
+      title: "Comfortable rows"
+    },
+    {
+      value: "compact",
+      label: "Compact",
+      Icon: Rows2,
+      ariaLabel: "Compact row density",
+      title: "Compact rows"
+    }
   ];
   return /* @__PURE__ */ jsx(
-    "div",
+    SegmentedToggle,
     {
-      role: "tablist",
-      "aria-label": "Row density",
-      className: classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className
-      ),
-      children: options.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return /* @__PURE__ */ jsxs(
-          "button",
-          {
-            type: "button",
-            role: "tab",
-            "aria-selected": active,
-            "aria-label": `${label} row density`,
-            title: `${label} rows`,
-            onClick: () => onChange(v),
-            className: classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
-            ),
-            children: [
-              /* @__PURE__ */ jsx(Icon, { className: "size-3.5" }),
-              /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: label })
-            ]
-          },
-          v
-        );
-      })
+      options,
+      value,
+      onChange,
+      ariaLabel: "Row density",
+      className
     }
   );
 }
@@ -2408,9 +2440,24 @@ function TableState({
   );
 }
 var OPTIONS = [
-  { value: "table", label: "Table", Icon: List },
-  { value: "grid", label: "Grid", Icon: LayoutGrid },
-  { value: "matrix", label: "Matrix", Icon: Grid3x3 }
+  {
+    value: "table",
+    label: "Table",
+    Icon: List,
+    ariaLabel: "Switch to table view"
+  },
+  {
+    value: "grid",
+    label: "Grid",
+    Icon: LayoutGrid,
+    ariaLabel: "Switch to grid view"
+  },
+  {
+    value: "matrix",
+    label: "Matrix",
+    Icon: Grid3x3,
+    ariaLabel: "Switch to matrix view"
+  }
 ];
 function ViewModeToggle({
   value,
@@ -2420,37 +2467,13 @@ function ViewModeToggle({
 }) {
   const available = OPTIONS.filter((o) => options.includes(o.value));
   return /* @__PURE__ */ jsx(
-    "div",
+    SegmentedToggle,
     {
-      role: "tablist",
-      "aria-label": "View mode",
-      className: classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className
-      ),
-      children: available.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return /* @__PURE__ */ jsxs(
-          "button",
-          {
-            type: "button",
-            role: "tab",
-            "aria-selected": active,
-            "aria-label": `Switch to ${label.toLowerCase()} view`,
-            title: label,
-            onClick: () => onChange(v),
-            className: classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
-            ),
-            children: [
-              /* @__PURE__ */ jsx(Icon, { className: "size-3.5" }),
-              /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: label })
-            ]
-          },
-          v
-        );
-      })
+      options: available,
+      value,
+      onChange,
+      ariaLabel: "View mode",
+      className
     }
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/density-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/density-toggle.tsx
@@ -1,5 +1,8 @@
 import { Rows3, Rows2 } from "lucide-react";
-import { classNames } from "@/lib/format";
+import {
+  SegmentedToggle,
+  type SegmentedToggleOption,
+} from "@/components/ui/segmented-toggle";
 
 export type Density = "comfortable" | "compact";
 
@@ -17,43 +20,29 @@ export function DensityToggle({
   onChange: (v: Density) => void;
   className?: string;
 }) {
-  const options: Array<{ value: Density; label: string; Icon: typeof Rows3 }> =
-    [
-      { value: "comfortable", label: "Comfortable", Icon: Rows3 },
-      { value: "compact", label: "Compact", Icon: Rows2 },
-    ];
+  const options: Array<SegmentedToggleOption<Density>> = [
+    {
+      value: "comfortable",
+      label: "Comfortable",
+      Icon: Rows3,
+      ariaLabel: "Comfortable row density",
+      title: "Comfortable rows",
+    },
+    {
+      value: "compact",
+      label: "Compact",
+      Icon: Rows2,
+      ariaLabel: "Compact row density",
+      title: "Compact rows",
+    },
+  ];
   return (
-    <div
-      role="tablist"
-      aria-label="Row density"
-      className={classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className,
-      )}
-    >
-      {options.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return (
-          <button
-            key={v}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            aria-label={`${label} row density`}
-            title={`${label} rows`}
-            onClick={() => onChange(v)}
-            className={classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active
-                ? "bg-surface text-ink-strong"
-                : "text-ink-muted hover:text-ink-strong",
-            )}
-          >
-            <Icon className="size-3.5" />
-            <span className="hidden sm:inline">{label}</span>
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedToggle
+      options={options}
+      value={value}
+      onChange={onChange}
+      ariaLabel="Row density"
+      className={className}
+    />
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,12 +1,30 @@
 import { LayoutGrid, List, Grid3x3 } from "lucide-react";
-import { classNames } from "@/lib/format";
+import {
+  SegmentedToggle,
+  type SegmentedToggleOption,
+} from "@/components/ui/segmented-toggle";
 
 export type ViewMode = "table" | "grid" | "matrix";
 
-const OPTIONS: Array<{ value: ViewMode; label: string; Icon: typeof List }> = [
-  { value: "table", label: "Table", Icon: List },
-  { value: "grid", label: "Grid", Icon: LayoutGrid },
-  { value: "matrix", label: "Matrix", Icon: Grid3x3 },
+const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
+  {
+    value: "table",
+    label: "Table",
+    Icon: List,
+    ariaLabel: "Switch to table view",
+  },
+  {
+    value: "grid",
+    label: "Grid",
+    Icon: LayoutGrid,
+    ariaLabel: "Switch to grid view",
+  },
+  {
+    value: "matrix",
+    label: "Matrix",
+    Icon: Grid3x3,
+    ariaLabel: "Switch to matrix view",
+  },
 ];
 
 /**
@@ -26,37 +44,12 @@ export function ViewModeToggle({
 }) {
   const available = OPTIONS.filter((o) => options.includes(o.value));
   return (
-    <div
-      role="tablist"
-      aria-label="View mode"
-      className={classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className,
-      )}
-    >
-      {available.map(({ value: v, label, Icon }) => {
-        const active = v === value;
-        return (
-          <button
-            key={v}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            aria-label={`Switch to ${label.toLowerCase()} view`}
-            title={label}
-            onClick={() => onChange(v)}
-            className={classNames(
-              "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-              active
-                ? "bg-surface text-ink-strong"
-                : "text-ink-muted hover:text-ink-strong",
-            )}
-          >
-            <Icon className="size-3.5" />
-            <span className="hidden sm:inline">{label}</span>
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedToggle
+      options={available}
+      value={value}
+      onChange={onChange}
+      ariaLabel="View mode"
+      className={className}
+    />
   );
 }

--- a/packages/ui-kit/src/components/ui/segmented-toggle.tsx
+++ b/packages/ui-kit/src/components/ui/segmented-toggle.tsx
@@ -1,0 +1,67 @@
+import { type ComponentType } from "react";
+import { classNames } from "@/lib/format";
+
+export interface SegmentedToggleOption<T extends string> {
+  value: T;
+  label: string;
+  Icon?: ComponentType<{ className?: string }>;
+  /** Falls back to `label` when omitted. */
+  ariaLabel?: string;
+  /** Falls back to `label` when omitted. */
+  title?: string;
+}
+
+/**
+ * Shared `role="tablist"`/`role="tab"`/`aria-selected` segmented switch —
+ * the common wrapper/button markup behind ViewModeToggle and DensityToggle.
+ */
+export function SegmentedToggle<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className,
+}: {
+  options: SegmentedToggleOption<T>[];
+  value: T;
+  onChange: (v: T) => void;
+  ariaLabel: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={classNames(
+        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
+        className,
+      )}
+    >
+      {options.map(
+        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
+          const active = v === value;
+          return (
+            <button
+              key={v}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              aria-label={optionAriaLabel ?? label}
+              title={title ?? label}
+              onClick={() => onChange(v)}
+              className={classNames(
+                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
+                active
+                  ? "bg-surface text-ink-strong"
+                  : "text-ink-muted hover:text-ink-strong",
+              )}
+            >
+              {Icon ? <Icon className="size-3.5" /> : null}
+              <span className="hidden sm:inline">{label}</span>
+            </button>
+          );
+        },
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

`ViewModeToggle` and `DensityToggle` were two independently hand-rolled `role="tablist"`/`role="tab"` segmented switches with byte-for-byte identical wrapper and button markup. Extracts the shared shape into a new `SegmentedToggle` primitive and has both delegate to it, with `ViewModeToggle`/`DensityToggle` keeping their existing exported signatures and `ViewMode`/`Density` types untouched — so none of their four call sites (`subnets.index.tsx`, `surfaces.tsx`, `providers.index.tsx`, `endpoints.tsx`) needed to change.

## What Changed

- Adds `packages/ui-kit/src/components/ui/segmented-toggle.tsx`: a `SegmentedToggle<T>` component taking an `options` list (`{ value, label, Icon?, ariaLabel?, title? }[]`), `value`, `onChange`, `ariaLabel`, and `className`, rendering the shared `role="tablist"`/`role="tab"`/`aria-selected` wrapper and button markup. Per-option `ariaLabel`/`title` are optional and fall back to `label`, since `ViewModeToggle` and `DensityToggle` use different phrasing for each (`"Switch to table view"` vs. `"Comfortable row density"`) — the primitive doesn't hardcode a phrase.
- `packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx` and `.../density-toggle.tsx`: replace the inline markup with a `SegmentedToggle` call, passing each option's exact prior `ariaLabel`/`title` text so the rendered DOM is unchanged.
- Rebuilt and committed `packages/ui-kit/dist/index.js`/`index.cjs` (matches this repo's existing convention for `packages/ui-kit` source changes).

**`SettingsPopover` was left as-is.** Its local `SegmentBtn`/`SegmentedRow` use `aria-pressed` toggle-button semantics, not `role="tab"`/`aria-selected` — a different ARIA contract, not just a styling variant. They're also visually distinct (`w-full`/`flex-1` sizing vs. auto-width, `rounded-sm` vs `rounded`, `bg-surface/40` wrapper vs `bg-card`, `shadow-sm` active state vs none). Reconciling them into `SegmentedToggle` would mean either forcing a mismatched ARIA semantic onto `SettingsPopover` or growing the primitive's API just for one caller with a different tablist shape — neither is worth it for a component that already works correctly. Per the issue's own fallback: wired the primitive through `ViewModeToggle`/`DensityToggle` only.

## Validation

- `npm run lint --workspace=packages/ui-kit` / `apps/ui`
- `npm run typecheck --workspace=packages/ui-kit` / `apps/ui`
- `npm run test --workspace=packages/ui-kit` (52 tests) and `npm test --workspace=apps/ui` (678 tests)
- `npm run test:e2e --workspace=apps/ui` (24/24 responsive-overflow checks passing)
- `npm run build --workspace=packages/ui-kit` / `apps/ui`
- **DOM byte-diff**: rendered `outerHTML` of `[aria-label="View mode"]` and `[aria-label="Row density"]` compared before/after across all four call sites (`/subnets`, `/surfaces`, `/providers`, `/endpoints`) via a headless Playwright script — identical in every case.

## Screenshots

`/subnets`, where both `ViewModeToggle` and `DensityToggle` render together. Rendered DOM is confirmed byte-identical (see Validation), so these are expected — and shown — to have **no visible difference**.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-light-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-light-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-dark-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-dark-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-mobile-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3426-desktop-dark-after.png)<br><sub>after</sub> |

Closes #3426
