### PR TITLE
feat(registry): add SN62 Ridges latest-set problems data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -92,6 +92,27 @@
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
     }
+,
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-latest-set-problems",
+      "kind": "data-artifact",
+      "name": "Ridges latest evaluation-set problems catalog",
+      "notes": "Public no-auth GET /evaluation-sets/all-latest-set-problems on agent-upload.ridges.ai returning the machine-readable catalog of benchmark problems in the current evaluation set (problem_name, benchmark_family, problem_suite_name, execution_spec with Harbor task s3_key). The route is defined at api/endpoints/evaluation_sets.py#L76 in ridgesai/ridges and listed as /evaluation-sets/all-latest-set-problems in the platform OpenAPI spec; distinct from the top-agents leaderboard subnet-api already registered.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "Lang-bt"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/endpoints/evaluation_sets.py#L76",
+        "https://raw.githubusercontent.com/ridgesai/ridges/06459e91e0e219dec56dfa98109967ec1c739700/api/endpoints/evaluation_sets.py",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems"
+    }
   ],
   "contact": "hello@ridges.ai"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends a surface on exactly one subnet manifest —
`registry/subnets/ridges.json`.

Closes #4069

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems
- Source URL (proves the claim):
  - https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/endpoints/evaluation_sets.py#L76
  - https://raw.githubusercontent.com/ridgesai/ridges/06459e91e0e219dec56dfa98109967ec1c739700/api/endpoints/evaluation_sets.py
  - https://agent-upload.ridges.ai/openapi.json
- Provider slug: ridges

## Summary

Adds the public benchmark-problems catalog for SN62 Ridges: a no-auth JSON feed
listing every problem in the current evaluation set. The route is commit-pinned
to ridgesai/ridges `api/endpoints/evaluation_sets.py#L76` and cross-referenced in
the platform OpenAPI spec. This is distinct from the existing top-agents
retrieval `subnet-api` surface.

## Checklist

- [x] Changes exactly one `registry/subnets/ridges.json` file (append-only).
- [x] `authority: community` and `review.state: community-submitted`.
- [x] Public `url` plus commit-pinned `source_urls` with line anchor.
- [x] No generated artifacts, secrets, or private URLs.
- [x] Does not duplicate an existing surface.
- [x] Links tracked issue `Closes #4069`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`
