### PR TITLE
fix(realtime): alerter evaluate()-path follow-ups (match-count persistence, rate-limit rollback, Map pruning)

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -378,9 +378,8 @@ Part 3's own history:
   `mapBounded` (exported from `src/webhooks.mjs`, `ALERT_DELIVERY_CONCURRENCY`
   = 8) instead of an unbounded `Promise.all`.
 
-Findings investigated and deliberately deferred, each filed as its own
-tracked issue rather than silently dropped or rushed in under time
-pressure:
+One finding remains deliberately deferred as its own tracked issue rather
+than rushed in under time pressure:
 
 - [#5021](https://github.com/JSONbored/metagraphed/issues/5021) -- neither
   this alerter's webhook/Discord delivery nor the pre-existing
@@ -389,18 +388,21 @@ pressure:
   defense turns out to be Node-only (`scripts/dispatch-webhooks.mjs`'s cron
   script) and was never reachable from the live Worker in the first place.
   A real fix needs DNS-over-HTTPS via `fetch()`, shared across both paths.
-- [#5022](https://github.com/JSONbored/metagraphed/issues/5022) --
-  `match_count`/`last_matched_at` are schema columns and appear in the
-  owner-facing response shape, but nothing writes them; needs a new
-  internal write-back route.
-- [#5023](https://github.com/JSONbored/metagraphed/issues/5023) -- the
-  burst rate-limit timestamp is set before delivery is attempted, so a
-  failed/timed-out delivery still consumes the window as if it had
-  succeeded.
-- [#5024](https://github.com/JSONbored/metagraphed/issues/5024) -- low
-  severity, tracked for visibility: `lastDeliveredAt`'s in-memory Map is
-  never explicitly pruned (bounded in practice by how often the singleton
-  DO reconstructs).
+
+Three more findings from the same review -- [#5022](https://github.com/JSONbored/metagraphed/issues/5022)
+(`match_count`/`last_matched_at` were schema columns nothing wrote to),
+[#5023](https://github.com/JSONbored/metagraphed/issues/5023) (the burst
+rate-limit timestamp was set before delivery was even attempted, so a
+failed delivery silently consumed the window as if it had succeeded), and
+[#5024](https://github.com/JSONbored/metagraphed/issues/5024) (the
+`lastDeliveredAt` Map was never pruned) -- have since shipped. `evaluate()`
+now writes match counts back to Postgres concurrently with the delivery
+fan-out (bounded by its own `ALERT_TRIGGER_MATCH_WRITEBACK_TIMEOUT_MS`,
+best-effort, never adding to the fan-out's own latency), rolls the
+rate-limit timestamp back on a failed/non-2xx/timed-out delivery so the
+very next match retries immediately instead of waiting out the window, and
+prunes `lastDeliveredAt` of any trigger id no longer active at the end of
+every successful `refreshTriggers()`.
 
 ## Verifying the trigger locally
 

--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -34,6 +34,25 @@ vi.mock("postgres", () => ({
     }
     sql.begin = (cb) => cb(sql);
     sql.end = () => Promise.resolve();
+    // sql.unsafe(text, params) -- the #5022 match write-back's batched
+    // UPDATE builds its own placeholder text (plain scalar positional
+    // binds) rather than a bound JS array, matching workers/data-api.mjs's
+    // established neurons-sync-prune/compare-health convention (see that
+    // route's own comment for why: this Worker's Hyperdrive
+    // fetch_types:false setting breaks postgres.js's automatic
+    // ARRAY-literal serialization). Recorded into the SAME sqlCalls list
+    // so existing assertions work unchanged regardless of call form.
+    sql.unsafe = (text, params = []) => {
+      sqlCalls.push({ text, values: params });
+      if (failNextQuery.error) {
+        const err = failNextQuery.error;
+        failNextQuery.error = null;
+        return Promise.reject(err);
+      }
+      return Promise.resolve(
+        mockQueue.current.length ? mockQueue.current.shift() : [],
+      );
+    };
     return sql;
   },
 }));
@@ -626,6 +645,143 @@ test("active list: 200 with every active trigger reshaped for the evaluator, own
     sqlCalls[0].text,
     /SELECT \* FROM chain_alert_triggers WHERE active/,
   );
+});
+
+// --- POST /api/v1/internal/alert-triggers/matched (#5022 write-back) ---------
+
+test("matched writeback: 503 when ALERT_TRIGGERS_INTERNAL_TOKEN is not configured", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      body: { trigger_ids: ["1"] },
+    }),
+    { ...env, ALERT_TRIGGERS_INTERNAL_TOKEN: undefined },
+  );
+  assert.equal(res.status, 503);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 401 when the internal token header is entirely absent", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      body: { trigger_ids: ["1"] },
+    }),
+  );
+  assert.equal(res.status, 401);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 401 when the internal token is present but wrong", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": "wrong" },
+      body: { trigger_ids: ["1"] },
+    }),
+  );
+  assert.equal(res.status, 401);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 400 on malformed JSON body", async () => {
+  const request = new Request(
+    "https://d/api/v1/internal/alert-triggers/matched",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-alert-triggers-internal-token": INTERNAL_TOKEN,
+      },
+      body: "{not json",
+    },
+  );
+  const res = await fetch(request);
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 400 when trigger_ids is missing", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+      body: {},
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 400 when trigger_ids is not an array", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+      body: { trigger_ids: "1" },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 400 when trigger_ids is an empty array", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+      body: { trigger_ids: [] },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 400 when every id in trigger_ids is malformed (filters to empty)", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+      body: { trigger_ids: ["not-an-id", "-1", "1.5", null] },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("matched writeback: 200, filters out malformed ids, and issues a single batched UPDATE incrementing match_count and setting last_matched_at", async () => {
+  mockQueue.current.push([{ id: "1" }, { id: "2" }]);
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+      body: { trigger_ids: ["1", "2", "not-an-id"] },
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { updated: 2 });
+  assert.equal(sqlCalls.length, 1);
+  const call = sqlCalls[0];
+  assert.match(call.text, /UPDATE chain_alert_triggers/);
+  assert.match(call.text, /match_count = match_count \+ 1/);
+  assert.match(call.text, /last_matched_at = \$1/);
+  assert.match(call.text, /WHERE id IN \(\$2::bigint, \$3::bigint\)/);
+  // $1 is the shared `now` timestamp; $2.. are the validated ids, in
+  // order, with the malformed one already filtered out.
+  assert.equal(typeof call.values[0], "number");
+  assert.deepEqual(call.values.slice(1), ["1", "2"]);
+});
+
+test("matched writeback: 502 when the UPDATE itself fails", async () => {
+  failNextQuery.error = new Error("boom");
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers/matched", {
+      method: "POST",
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+      body: { trigger_ids: ["1"] },
+    }),
+  );
+  assert.equal(res.status, 502);
 });
 
 // --- method-dispatch fallthrough -----------------------------------------------

--- a/tests/alerter-hub.test.mjs
+++ b/tests/alerter-hub.test.mjs
@@ -36,13 +36,13 @@ test("ALERTER_HUB_TRIGGER_CACHE_TTL_MS is the documented value (5 minutes)", () 
 
 // --- deliverAlertMatch (#4984 Part 3) -----------------------------------------
 
-test("deliverAlertMatch: webhook channel POSTs the built request", async () => {
+test("deliverAlertMatch: webhook channel POSTs the built request and resolves true on a confirmed 2xx", async () => {
   let received;
   const fetchFn = vi.fn(async (url, init) => {
     received = { url, init };
     return new Response(null, { status: 200 });
   });
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({ channel: "webhook", destination: "https://example.com/hook" }),
     { table: "account_events" },
     {},
@@ -51,6 +51,7 @@ test("deliverAlertMatch: webhook channel POSTs the built request", async () => {
   assert.equal(fetchFn.mock.calls.length, 1);
   assert.equal(received.url, "https://example.com/hook");
   assert.equal(JSON.parse(received.init.body).type, "metagraph.alert");
+  assert.equal(result, true);
 });
 
 test("deliverAlertMatch: every delivery carries a bounded AbortSignal so one slow target can't stall the shared broadcast() call indefinitely", async () => {
@@ -72,9 +73,9 @@ test("deliverAlertMatch: every delivery carries a bounded AbortSignal so one slo
   assert.equal(receivedSignal.aborted, false);
 });
 
-test("deliverAlertMatch: webhook channel sends nothing when the destination fails the defense-in-depth URL re-check", async () => {
+test("deliverAlertMatch: webhook channel sends nothing and resolves false when the destination fails the defense-in-depth URL re-check", async () => {
   const fetchFn = vi.fn();
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({
       channel: "webhook",
       destination: "http://not-https.example.com",
@@ -84,11 +85,12 @@ test("deliverAlertMatch: webhook channel sends nothing when the destination fail
     fetchFn,
   );
   assert.equal(fetchFn.mock.calls.length, 0);
+  assert.equal(result, false);
 });
 
-test("deliverAlertMatch: discord channel POSTs to the trigger's own webhook URL", async () => {
+test("deliverAlertMatch: discord channel POSTs to the trigger's own webhook URL and resolves true on a confirmed 2xx", async () => {
   const fetchFn = vi.fn(async () => new Response(null, { status: 204 }));
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({
       channel: "discord",
       destination: "https://discord.com/api/webhooks/1/token",
@@ -101,22 +103,24 @@ test("deliverAlertMatch: discord channel POSTs to the trigger's own webhook URL"
     fetchFn.mock.calls[0][0],
     "https://discord.com/api/webhooks/1/token",
   );
+  assert.equal(result, true);
 });
 
-test("deliverAlertMatch: telegram channel is a silent no-op when TELEGRAM_BOT_TOKEN is unset", async () => {
+test("deliverAlertMatch: telegram channel is a silent no-op (resolves false) when TELEGRAM_BOT_TOKEN is unset", async () => {
   const fetchFn = vi.fn();
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({ channel: "telegram", destination: "123456789" }),
     {},
     {},
     fetchFn,
   );
   assert.equal(fetchFn.mock.calls.length, 0);
+  assert.equal(result, false);
 });
 
-test("deliverAlertMatch: telegram channel POSTs to the bot API when the token is configured", async () => {
+test("deliverAlertMatch: telegram channel POSTs to the bot API and resolves true when the token is configured", async () => {
   const fetchFn = vi.fn(async () => new Response(null, { status: 200 }));
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({ channel: "telegram", destination: "123456789" }),
     {},
     { TELEGRAM_BOT_TOKEN: "bot-token" },
@@ -126,48 +130,59 @@ test("deliverAlertMatch: telegram channel POSTs to the bot API when the token is
     fetchFn.mock.calls[0][0],
     "https://api.telegram.org/botbot-token/sendMessage",
   );
+  assert.equal(result, true);
 });
 
-test("deliverAlertMatch: email channel is a silent no-op when RESEND_API_KEY or RESEND_FROM_ADDRESS is unset", async () => {
+test("deliverAlertMatch: email channel is a silent no-op (resolves false) when RESEND_API_KEY or RESEND_FROM_ADDRESS is unset", async () => {
   const fetchFn = vi.fn();
-  await deliverAlertMatch(triggerRow({ channel: "email" }), {}, {}, fetchFn);
+  const first = await deliverAlertMatch(
+    triggerRow({ channel: "email" }),
+    {},
+    {},
+    fetchFn,
+  );
   assert.equal(fetchFn.mock.calls.length, 0);
-  await deliverAlertMatch(
+  assert.equal(first, false);
+  const second = await deliverAlertMatch(
     triggerRow({ channel: "email" }),
     {},
     { RESEND_API_KEY: "k" }, // no from-address
     fetchFn,
   );
   assert.equal(fetchFn.mock.calls.length, 0);
+  assert.equal(second, false);
 });
 
-test("deliverAlertMatch: email channel POSTs to Resend when both secrets are configured", async () => {
+test("deliverAlertMatch: email channel POSTs to Resend and resolves true when both secrets are configured", async () => {
   const fetchFn = vi.fn(async () => new Response(null, { status: 200 }));
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({ channel: "email", destination: "a@b.com" }),
     {},
     { RESEND_API_KEY: "k", RESEND_FROM_ADDRESS: "alerts@metagraph.sh" },
     fetchFn,
   );
   assert.equal(fetchFn.mock.calls[0][0], "https://api.resend.com/emails");
+  assert.equal(result, true);
 });
 
-test("deliverAlertMatch: an unrecognized channel is a silent no-op", async () => {
+test("deliverAlertMatch: an unrecognized channel is a silent no-op (resolves false)", async () => {
   const fetchFn = vi.fn();
-  await deliverAlertMatch(
+  const result = await deliverAlertMatch(
     triggerRow({ channel: "carrier-pigeon" }),
     {},
     {},
     fetchFn,
   );
   assert.equal(fetchFn.mock.calls.length, 0);
+  assert.equal(result, false);
 });
 
-test("deliverAlertMatch: a non-ok HTTP response is logged, not thrown", async () => {
+test("deliverAlertMatch: a non-ok HTTP response is logged, not thrown, and resolves false", async () => {
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const fetchFn = vi.fn(async () => new Response(null, { status: 500 }));
-  await assert.doesNotReject(() =>
-    deliverAlertMatch(
+  let result;
+  await assert.doesNotReject(async () => {
+    result = await deliverAlertMatch(
       triggerRow({
         channel: "discord",
         destination: "https://discord.com/api/webhooks/1/t",
@@ -175,11 +190,31 @@ test("deliverAlertMatch: a non-ok HTTP response is logged, not thrown", async ()
       {},
       {},
       fetchFn,
-    ),
-  );
+    );
+  });
   assert.equal(errorSpy.mock.calls.length, 1);
   assert.match(errorSpy.mock.calls[0][0], /HTTP 500/);
+  assert.equal(result, false);
   errorSpy.mockRestore();
+});
+
+test("deliverAlertMatch: a rejected fetch (network error) propagates as a rejection rather than being swallowed here", async () => {
+  const fetchFn = vi.fn(async () => {
+    throw new Error("network down");
+  });
+  await assert.rejects(
+    () =>
+      deliverAlertMatch(
+        triggerRow({
+          channel: "discord",
+          destination: "https://discord.com/api/webhooks/1/t",
+        }),
+        {},
+        {},
+        fetchFn,
+      ),
+    /network down/,
+  );
 });
 
 test("deliverAlertMatch: defaults fetchFn to the global fetch when not injected", async () => {
@@ -356,6 +391,55 @@ test("refreshTriggers: keeps the stale cache and never throws when upstream.json
   assert.equal(hub.triggers[0].id, "existing");
 });
 
+// --- refreshTriggers: lastDeliveredAt pruning (#5024) -------------------------
+
+test("refreshTriggers: prunes lastDeliveredAt entries for trigger ids no longer present in the fresh triggers list", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        async () =>
+          new Response(
+            JSON.stringify({ triggers: [triggerRow({ id: "1" })] }),
+            { status: 200 },
+          ),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  // "1" is still active after the refresh; "2" and "3" are stale (deleted
+  // or deactivated triggers whose rate-limit bookkeeping should not live
+  // forever).
+  hub.lastDeliveredAt.set("1", Date.now());
+  hub.lastDeliveredAt.set("2", Date.now());
+  hub.lastDeliveredAt.set("3", Date.now());
+  await hub.refreshTriggers();
+  assert.deepEqual([...hub.lastDeliveredAt.keys()], ["1"]);
+});
+
+test("refreshTriggers: never prunes lastDeliveredAt when the refresh fails (stale cache kept, not the trigger of a fetch that didn't happen)", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(
+        async () =>
+          new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  hub.lastDeliveredAt.set("stale-but-untouched", Date.now());
+  await hub.refreshTriggers();
+  assert.equal(hub.lastDeliveredAt.has("stale-but-untouched"), true);
+});
+
+test("refreshTriggers: never prunes lastDeliveredAt when DATA_API/token is unbound (refresh skipped entirely)", async () => {
+  const hub = new AlerterHub({}, {});
+  hub.lastDeliveredAt.set("untouched", Date.now());
+  await hub.refreshTriggers();
+  assert.equal(hub.lastDeliveredAt.has("untouched"), true);
+});
+
 // --- ensureTriggersLoaded -----------------------------------------------------
 
 test("ensureTriggersLoaded: refreshes when the cache is stale", async () => {
@@ -445,7 +529,7 @@ test("evaluate: returns {matched:0} and never calls deliver when nothing matches
 });
 
 test("evaluate: reports every matching trigger and calls deliver once per match", async () => {
-  const deliver = vi.fn().mockResolvedValue(undefined);
+  const deliver = vi.fn().mockResolvedValue(true);
   const hub = new AlerterHub({}, {}, { deliver });
   hub.triggers = [
     triggerRow({ id: "1", netuid: 7 }),
@@ -464,7 +548,7 @@ test("evaluate: reports every matching trigger and calls deliver once per match"
 });
 
 test("evaluate: a burst of matches for the SAME trigger within the rate-limit window delivers once and skips the rest", async () => {
-  const deliver = vi.fn().mockResolvedValue(undefined);
+  const deliver = vi.fn().mockResolvedValue(true);
   const hub = new AlerterHub({}, {}, { deliver });
   hub.triggers = [triggerRow({ netuid: 7 })];
   hub.triggersLoadedAt = Date.now();
@@ -483,7 +567,7 @@ test("evaluate: a burst of matches for the SAME trigger within the rate-limit wi
 });
 
 test("evaluate: a DIFFERENT trigger's match is never rate-limited by another trigger's recent delivery", async () => {
-  const deliver = vi.fn().mockResolvedValue(undefined);
+  const deliver = vi.fn().mockResolvedValue(true);
   const hub = new AlerterHub({}, {}, { deliver });
   hub.triggers = [
     triggerRow({ id: "1", netuid: 7 }),
@@ -500,7 +584,7 @@ test("evaluate: a DIFFERENT trigger's match is never rate-limited by another tri
 });
 
 test("evaluate: once the rate-limit window elapses, the same trigger can deliver again", async () => {
-  const deliver = vi.fn().mockResolvedValue(undefined);
+  const deliver = vi.fn().mockResolvedValue(true);
   const hub = new AlerterHub({}, {}, { deliver });
   hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
   hub.triggersLoadedAt = Date.now();
@@ -515,13 +599,77 @@ test("evaluate: once the rate-limit window elapses, the same trigger can deliver
   assert.equal(deliver.mock.calls.length, 2);
 });
 
-test("evaluate: a rejecting deliver call never fails the overall evaluation", async () => {
+test("evaluate: a rejecting deliver call never fails the overall evaluation, and rolls back the rate-limit exactly like an explicit false return (#5023)", async () => {
   const deliver = vi.fn().mockRejectedValue(new Error("delivery exploded"));
   const hub = new AlerterHub({}, {}, { deliver });
-  hub.triggers = [triggerRow({ netuid: 7 })];
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
   hub.triggersLoadedAt = Date.now();
   const result = await hub.evaluate({ table: "account_events", netuid: 7 });
   assert.equal(result.matched, 1);
+  assert.equal(result.delivered, 1); // still counted as "attempted"
+  // The optimistic set is rolled back on a rejection exactly like an
+  // explicit `false` return -- no prior entry existed, so it's deleted
+  // outright, leaving the trigger free to retry on the very next match.
+  assert.equal(hub.lastDeliveredAt.has("1"), false);
+});
+
+// --- evaluate: rate-limit rollback on failed delivery (#5023) -----------------
+
+test("evaluate: an explicit `false` return from deliver rolls back the optimistic rate-limit set (no prior entry -> deleted outright)", async () => {
+  const deliver = vi.fn().mockResolvedValue(false);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.equal(result.delivered, 1); // still attempted
+  assert.equal(hub.lastDeliveredAt.has("1"), false);
+});
+
+test("evaluate: a failed delivery lets the VERY NEXT matching event retry immediately instead of waiting out the rate-limit window", async () => {
+  const deliver = vi.fn().mockResolvedValue(false);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const payload = { table: "account_events", netuid: 7 };
+
+  const first = await hub.evaluate(payload);
+  assert.equal(first.delivered, 1);
+  assert.equal(first.rate_limited, 0);
+
+  // No sleep, no clock mocking -- if the rollback hadn't happened, this
+  // second call (fired immediately after the first) would be rate-limited.
+  const second = await hub.evaluate(payload);
+  assert.equal(second.delivered, 1);
+  assert.equal(second.rate_limited, 0);
+  assert.equal(deliver.mock.calls.length, 2);
+});
+
+test("evaluate: a failed delivery rolls back to the PRIOR timestamp (not a full delete) when an earlier successful delivery already set one", async () => {
+  const deliver = vi.fn();
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const oldTimestamp = Date.now() - 10 * 60 * 1000; // well outside the window
+  hub.lastDeliveredAt.set("1", oldTimestamp);
+
+  deliver.mockResolvedValueOnce(false);
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.equal(result.delivered, 1); // attempted, but failed
+  // Rolled back to the exact prior value, not deleted -- the Map still
+  // reflects "last known good delivery was a while ago", which is also
+  // "not currently rate-limited", so behavior is equivalent either way,
+  // but this asserts the documented rollback mechanics precisely.
+  assert.equal(hub.lastDeliveredAt.get("1"), oldTimestamp);
+});
+
+test("evaluate: a SUCCESSFUL delivery keeps the optimistic set in place (no rollback)", async () => {
+  const deliver = vi.fn().mockResolvedValue(true);
+  const hub = new AlerterHub({}, {}, { deliver });
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const before = Date.now();
+  await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.ok(hub.lastDeliveredAt.get("1") >= before);
 });
 
 test("evaluate: caps the delivery fan-out at ALERT_DELIVERY_CONCURRENCY (8) in-flight deliveries -- a broad-condition trigger set matching MANY distinct triggers on one event must not open one outbound fetch per match", async () => {
@@ -585,6 +733,187 @@ test("evaluate: triggers a refresh first when the cache is stale", async () => {
   const result = await hub.evaluate({ table: "account_events", netuid: 7 });
   assert.equal(refreshed, true);
   assert.equal(result.matched, 1);
+});
+
+// --- writeBackMatchCounts (#5022) ----------------------------------------------
+
+test("writeBackMatchCounts: no-op when DATA_API is unbound", async () => {
+  const hub = new AlerterHub(
+    {},
+    { ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN },
+  );
+  await assert.doesNotReject(() => hub.writeBackMatchCounts(["1"]));
+});
+
+test("writeBackMatchCounts: no-op when ALERT_TRIGGERS_INTERNAL_TOKEN is unset", async () => {
+  let called = false;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        called = true;
+        return new Response(null, { status: 200 });
+      }),
+    },
+  );
+  await hub.writeBackMatchCounts(["1"]);
+  assert.equal(called, false);
+});
+
+test("writeBackMatchCounts: no-op when triggerIds is empty", async () => {
+  let called = false;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        called = true;
+        return new Response(null, { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.writeBackMatchCounts([]);
+  assert.equal(called, false);
+});
+
+test("writeBackMatchCounts: POSTs the matched trigger ids with the correct URL/header/body/timeout", async () => {
+  let received;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url, init) => {
+        received = { url: String(url), init };
+        return new Response(null, { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.writeBackMatchCounts(["1", "2"]);
+  assert.equal(
+    received.url,
+    "https://data-api.internal/api/v1/internal/alert-triggers/matched",
+  );
+  assert.equal(received.init.method, "POST");
+  assert.equal(
+    received.init.headers["x-alert-triggers-internal-token"],
+    INTERNAL_TOKEN,
+  );
+  assert.deepEqual(JSON.parse(received.init.body), {
+    trigger_ids: ["1", "2"],
+  });
+  assert.ok(received.init.signal instanceof AbortSignal);
+});
+
+test("writeBackMatchCounts: logs but never throws on a non-ok response", async () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => new Response(null, { status: 500 })),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await assert.doesNotReject(() => hub.writeBackMatchCounts(["1"]));
+  assert.equal(errorSpy.mock.calls.length, 1);
+  assert.match(errorSpy.mock.calls[0][0], /HTTP 500/);
+  errorSpy.mockRestore();
+});
+
+test("writeBackMatchCounts: never throws when the fetch itself rejects (network error / AbortSignal timeout)", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        throw new Error("timeout");
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await assert.doesNotReject(() => hub.writeBackMatchCounts(["1"]));
+});
+
+// --- evaluate: write-back integration (#5022) ----------------------------------
+
+test("evaluate: writes back the FULL matched trigger id list, including a match that was rate-limited (not just the ones that clear it)", async () => {
+  let receivedBody;
+  const deliver = vi.fn().mockResolvedValue(true);
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (_url, init) => {
+        receivedBody = JSON.parse(init.body);
+        return new Response(null, { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+    { deliver },
+  );
+  hub.triggers = [
+    triggerRow({ id: "1", netuid: 7 }),
+    triggerRow({ id: "2", netuid: 7 }),
+  ];
+  hub.triggersLoadedAt = Date.now();
+  hub.lastDeliveredAt.set("1", Date.now()); // "1" starts inside its rate-limit window
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.equal(result.rate_limited, 1);
+  assert.equal(result.delivered, 1);
+  assert.deepEqual(receivedBody.trigger_ids.sort(), ["1", "2"]);
+});
+
+test("evaluate: the delivery fan-out and the match-count write-back run CONCURRENTLY, not sequentially", async () => {
+  let resolveDelivery;
+  const deliver = vi.fn(
+    () =>
+      new Promise((resolve) => {
+        resolveDelivery = () => resolve(true);
+      }),
+  );
+  let writebackObserved = false;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        writebackObserved = true;
+        return new Response(null, { status: 200 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+    { deliver },
+  );
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const evaluatePromise = hub.evaluate({ table: "account_events", netuid: 7 });
+  // Let every microtask-queued step run -- if the write-back were
+  // sequenced AFTER the delivery fan-out (the bug this test guards
+  // against), it could never have started yet, since delivery is
+  // deliberately held open below.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(writebackObserved, true);
+  resolveDelivery();
+  await evaluatePromise;
+});
+
+test("evaluate: a write-back failure never affects the evaluate() response shape", async () => {
+  const deliver = vi.fn().mockResolvedValue(true);
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async () => {
+        throw new Error("data-api unreachable");
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+    { deliver },
+  );
+  hub.triggers = [triggerRow({ id: "1", netuid: 7 })];
+  hub.triggersLoadedAt = Date.now();
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.deepEqual(result, {
+    matched: 1,
+    trigger_ids: ["1"],
+    delivered: 1,
+    rate_limited: 0,
+  });
 });
 
 // --- fetch (the /evaluate route) -----------------------------------------------

--- a/workers/alerter-hub.mjs
+++ b/workers/alerter-hub.mjs
@@ -61,6 +61,18 @@ const ALERT_DELIVERY_CONCURRENCY = 8;
 // (same 8s default).
 const ALERT_DELIVERY_TIMEOUT_MS = 8000;
 
+// #5022: the internal write-back that reports EVERY matched trigger id (not
+// just the ones that clear the burst rate-limit -- match_count means "this
+// trigger's conditions were satisfied", independent of delivery) so
+// workers/data-api.mjs can persist chain_alert_triggers.match_count/
+// last_matched_at. Deliberately much tighter than ALERT_DELIVERY_TIMEOUT_MS:
+// this is a same-Cloudflare-network Worker-to-Worker call (like
+// ALERT_TRIGGER_REFRESH_TIMEOUT_MS above), not a fetch to an arbitrary
+// user-supplied endpoint, AND it runs CONCURRENTLY with the delivery
+// fan-out (see evaluate() below) rather than adding to its latency, so a
+// generous bound here would only cost something on the failure path.
+export const ALERT_TRIGGER_MATCH_WRITEBACK_TIMEOUT_MS = 3000;
+
 // The I/O shell around src/alert-delivery.mjs's pure request builders --
 // constructor-injectable (see AlerterHub below) rather than a hardcoded
 // call inside evaluate(), so tests can substitute a spy/failing stub
@@ -69,6 +81,16 @@ const ALERT_DELIVERY_TIMEOUT_MS = 8000;
 // no-op when their secret isn't provisioned, matching every other optional
 // integration's convention in this codebase (never throw for a
 // deployment-config gap the caller can't do anything about).
+//
+// #5023 contract: resolves `true` on a CONFIRMED 2xx delivery, `false` in
+// every other resolved case (non-2xx response, a builder returning null,
+// an unrecognized channel, or a telegram/email no-op from an unset
+// secret). A thrown/rejected fetch (network error, the AbortSignal timeout
+// below) is NOT swallowed here -- it propagates as a rejection so
+// evaluate()'s own wrapping can distinguish "delivery definitely did not
+// succeed" (this function's `false`) from "delivery attempt itself
+// failed" (a rejection), though both are treated identically for the
+// rate-limit rollback decision.
 export async function deliverAlertMatch(
   trigger,
   payload,
@@ -84,7 +106,7 @@ export async function deliverAlertMatch(
       request = buildDiscordDeliveryRequest(trigger, payload);
       break;
     case "telegram":
-      if (!env.TELEGRAM_BOT_TOKEN) return;
+      if (!env.TELEGRAM_BOT_TOKEN) return false;
       request = buildTelegramDeliveryRequest(
         trigger,
         payload,
@@ -92,19 +114,19 @@ export async function deliverAlertMatch(
       );
       break;
     case "email":
-      if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) return;
+      if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) return false;
       request = buildEmailDeliveryRequest(trigger, payload, {
         resendKey: env.RESEND_API_KEY,
         fromAddress: env.RESEND_FROM_ADDRESS,
       });
       break;
     default:
-      return;
+      return false;
   }
   // A null request means the builder itself refused (e.g.
   // buildWebhookDeliveryRequest's defense-in-depth URL re-check) --
   // nothing to send.
-  if (!request) return;
+  if (!request) return false;
   // The timeout signal is applied HERE, not baked into the pure builders in
   // src/alert-delivery.mjs -- AbortSignal.timeout() starts a real wall-clock
   // timer the moment it's constructed, which that module's own header
@@ -115,15 +137,17 @@ export async function deliverAlertMatch(
     signal: AbortSignal.timeout(ALERT_DELIVERY_TIMEOUT_MS),
   });
   if (!response.ok) {
-    // Never throw for a non-2xx response -- evaluate()'s .catch() only
-    // guards against a REJECTED fetch (network/timeout); an HTTP-level
+    // Never throw for a non-2xx response -- evaluate()'s own wrapping only
+    // needs to catch a REJECTED fetch (network/timeout); an HTTP-level
     // failure resolves normally, so it's logged here instead, server-side
     // only, matching this codebase's "log internals, never leak them"
     // convention.
     console.error(
       `alert delivery failed (channel=${trigger.channel}, trigger=${trigger.id}): HTTP ${response.status}`,
     );
+    return false;
   }
+  return true;
 }
 
 export class AlerterHub {
@@ -187,6 +211,21 @@ export class AlerterHub {
       if (Array.isArray(body?.triggers)) {
         this.triggers = body.triggers;
         this.triggersLoadedAt = Date.now();
+        // #5024: prune any lastDeliveredAt entry for a trigger id that is
+        // no longer present in the fresh active-trigger list (deleted or
+        // deactivated since the last refresh) -- otherwise a Durable
+        // Object that lives across many refresh cycles accumulates one
+        // permanently-stale Map entry per retired trigger. One pass,
+        // O(active triggers); only runs after a SUCCESSFUL refresh (never
+        // on a failed/skipped one, since a stale-but-still-valid cache
+        // must not have its rate-limit state pruned against a fetch that
+        // didn't actually happen).
+        const activeTriggerIds = new Set(this.triggers.map((t) => t.id));
+        for (const triggerId of this.lastDeliveredAt.keys()) {
+          if (!activeTriggerIds.has(triggerId)) {
+            this.lastDeliveredAt.delete(triggerId);
+          }
+        }
       }
     } catch {
       // Best-effort refresh -- keep serving the stale cache rather than
@@ -203,6 +242,50 @@ export class AlerterHub {
     );
   }
 
+  // #5022: best-effort write-back reporting EVERY matched trigger id (the
+  // FULL matched list, not just the ones that clear the burst rate-limit)
+  // to workers/data-api.mjs's internal match-count route, so
+  // chain_alert_triggers.match_count/last_matched_at reflect real values.
+  // No-op when DATA_API/ALERT_TRIGGERS_INTERNAL_TOKEN isn't provisioned,
+  // matching refreshTriggers()'s own optional-integration convention.
+  // Never throws -- called from evaluate() alongside the delivery fan-out
+  // via Promise.allSettled, and a write-back failure must never affect
+  // evaluate()'s response or reject out of that call.
+  async writeBackMatchCounts(triggerIds) {
+    if (
+      !this.env.DATA_API ||
+      !this.env.ALERT_TRIGGERS_INTERNAL_TOKEN ||
+      triggerIds.length === 0
+    ) {
+      return;
+    }
+    try {
+      const response = await this.env.DATA_API.fetch(
+        "https://data-api.internal/api/v1/internal/alert-triggers/matched",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-alert-triggers-internal-token":
+              this.env.ALERT_TRIGGERS_INTERNAL_TOKEN,
+          },
+          body: JSON.stringify({ trigger_ids: triggerIds }),
+          signal: AbortSignal.timeout(ALERT_TRIGGER_MATCH_WRITEBACK_TIMEOUT_MS),
+        },
+      );
+      if (!response.ok) {
+        console.error(
+          `alert match-count write-back failed: HTTP ${response.status}`,
+        );
+      }
+    } catch {
+      // Best-effort -- match_count is an analytics aid, not something
+      // delivery or rate-limiting logic depends on; losing an increment
+      // here (a slow/unreachable DATA_API, a timeout) is fine, an
+      // exception propagating out of evaluate() is not.
+    }
+  }
+
   async evaluate(payload) {
     await this.ensureTriggersLoaded();
     const matched = this.matchingTriggers(payload);
@@ -214,22 +297,70 @@ export class AlerterHub {
     // per window rather than dropping the burst's own visibility.
     const now = Date.now();
     const toDeliver = [];
+    // #5023: the value each rate-limited-clearing trigger's lastDeliveredAt
+    // entry held BEFORE this call's optimistic set below (undefined if it
+    // had none) -- kept so a failed delivery can be rolled back to exactly
+    // that prior state instead of just guessing "delete it".
+    const priorLastDeliveredAt = new Map();
     let rateLimited = 0;
     for (const trigger of matched) {
-      if (isDeliveryRateLimited(this.lastDeliveredAt.get(trigger.id), now)) {
+      const prior = this.lastDeliveredAt.get(trigger.id);
+      if (isDeliveryRateLimited(prior, now)) {
         rateLimited += 1;
         continue;
       }
+      // Optimistic set BEFORE delivery is attempted -- this protects
+      // against a burst of near-simultaneous matches for the SAME trigger
+      // (within one evaluate() call, or racing across two evaluate() calls)
+      // both queueing a duplicate concurrent delivery attempt. Do NOT
+      // remove this: it is rolled back below (not left in place) when the
+      // delivery attempt does not actually succeed.
+      priorLastDeliveredAt.set(trigger.id, prior);
       this.lastDeliveredAt.set(trigger.id, now);
       toDeliver.push(trigger);
     }
 
-    await mapBounded(toDeliver, ALERT_DELIVERY_CONCURRENCY, (trigger) =>
-      this.deliver(trigger, payload, this.env).catch(() => {
-        // A single misbehaving delivery integration must never fail the
-        // evaluation response ChainFirehoseHub's broadcast() awaits.
-      }),
+    // #5022: the delivery fan-out and the match-count write-back run
+    // CONCURRENTLY (Promise.allSettled), never sequentially -- sequencing
+    // them would ADD the two latencies together, pushing evaluate()'s own
+    // worst case toward ChainFirehoseHub.broadcast()'s
+    // ALERTER_HUB_EVALUATE_TIMEOUT_MS ceiling (15s) that wraps this whole
+    // call. Neither promise here can reject (each swallows its own
+    // failures internally), so allSettled is defensive, not load-bearing.
+    const deliveryPromise = mapBounded(
+      toDeliver,
+      ALERT_DELIVERY_CONCURRENCY,
+      async (trigger) => {
+        // #5023: capture success/failure instead of relying on the old
+        // implicit "resolved == succeeded" convention -- a REJECTED
+        // deliver() (network error, delivery timeout) is treated
+        // identically to an explicit `false` return for the rollback
+        // decision below; either way, a single misbehaving delivery
+        // integration must never fail the evaluation response
+        // ChainFirehoseHub's broadcast() awaits.
+        let succeeded;
+        try {
+          succeeded = (await this.deliver(trigger, payload, this.env)) === true;
+        } catch {
+          succeeded = false;
+        }
+        if (succeeded) return;
+        // Roll back the optimistic set above: a delivery that did NOT
+        // succeed must not consume the rate-limit window, so the VERY NEXT
+        // matching event for this trigger retries immediately rather than
+        // waiting out the full window.
+        const prior = priorLastDeliveredAt.get(trigger.id);
+        if (prior === undefined) {
+          this.lastDeliveredAt.delete(trigger.id);
+        } else {
+          this.lastDeliveredAt.set(trigger.id, prior);
+        }
+      },
     );
+    const writebackPromise = this.writeBackMatchCounts(
+      matched.map((t) => t.id),
+    );
+    await Promise.allSettled([deliveryPromise, writebackPromise]);
 
     return {
       matched: matched.length,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2529,7 +2529,7 @@ async function handleAlertTriggersMatchedWriteback(request, env) {
     const updated = await sql.unsafe(
       `UPDATE chain_alert_triggers
        SET match_count = match_count + 1,
-           last_matched_at = $1
+           last_matched_at = $1::bigint
        WHERE id IN (${placeholders})
        RETURNING id`,
       [now, ...ids],

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2474,6 +2474,70 @@ async function handleAlertTriggersActiveList(request, env) {
   });
 }
 
+// Internal-only: the #5022 evaluator write-back. AlerterHub.evaluate()
+// (workers/alerter-hub.mjs) POSTs the FULL matched-trigger id list for a
+// chain event here -- every id whose conditions were satisfied, regardless
+// of whether the burst rate-limiter actually let it deliver -- so
+// chain_alert_triggers.match_count/last_matched_at reflect "this trigger's
+// conditions were satisfied", independent of delivery. Gated the SAME way
+// as the active-list route above: a DIFFERENT capability from the
+// create/owner tokens (write access to every trigger's own bookkeeping
+// columns, not just its own row), so it reuses that same
+// ALERT_TRIGGERS_INTERNAL_TOKEN secret rather than minting a third one.
+async function handleAlertTriggersMatchedWriteback(request, env) {
+  const configured = env.ALERT_TRIGGERS_INTERNAL_TOKEN;
+  if (!configured) {
+    return writeJson(
+      {
+        error:
+          "the alert-triggers match write-back is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      {
+        error: `provide a valid ${ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER} header`,
+      },
+      401,
+    );
+  }
+  const { body, error } = await readAlertTriggerBody(request);
+  if (error) return error;
+  const ids = Array.isArray(body?.trigger_ids)
+    ? body.trigger_ids.filter(isValidAlertTriggerId).map(String)
+    : [];
+  if (ids.length === 0) {
+    return writeJson(
+      { error: "trigger_ids must be a non-empty array of trigger ids" },
+      400,
+    );
+  }
+  return withAlertTriggersSql(env, async (sql) => {
+    const now = Date.now();
+    // Plain scalar positional binds via sql.unsafe, NOT a bound JS array
+    // (`id = ANY($1)`) -- see the neurons-sync prune query's own comment
+    // (handleNeuronsSync, above) for why: this Worker's Hyperdrive
+    // fetch_types:false setting breaks postgres.js's automatic
+    // ARRAY-literal serialization, while scalar binds are unaffected.
+    // $1 is the shared `now` timestamp; $2.. are the (already
+    // isValidAlertTriggerId-validated) ids.
+    const placeholders = ids.map((_, i) => `$${i + 2}::bigint`).join(", ");
+    const updated = await sql.unsafe(
+      `UPDATE chain_alert_triggers
+       SET match_count = match_count + 1,
+           last_matched_at = $1
+       WHERE id IN (${placeholders})
+       RETURNING id`,
+      [now, ...ids],
+    );
+    return writeJson({ updated: updated.length });
+  });
+}
+
 async function handleAlertTriggersRoute(request, env, url) {
   const segments = url.pathname.split("/").filter(Boolean);
   // ["api", "v1", "alerts", "triggers", <id?>]
@@ -2571,6 +2635,14 @@ export default {
       url.pathname === "/api/v1/internal/alert-triggers-active"
     ) {
       return handleAlertTriggersActiveList(request, env);
+    }
+    // #5022: the evaluator's own write-back for match_count/last_matched_at
+    // -- see handleAlertTriggersMatchedWriteback's own header comment.
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/alert-triggers/matched"
+    ) {
+      return handleAlertTriggersMatchedWriteback(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);


### PR DESCRIPTION
## Summary

Closes #5022, #5023, #5024 -- three related follow-ups from #5025's adversarial review, bundled into one change since they all touch the same hot `AlerterHub.evaluate()` path.

- **#5022 (match-count persistence)**: `match_count`/`last_matched_at` were schema columns nothing wrote to. Added `POST /api/v1/internal/alert-triggers/matched` (gated like the existing active-list route), called from `evaluate()` for every matched trigger. Runs **concurrently** with the delivery fan-out (`Promise.allSettled`), not sequentially after it, so it never adds to `evaluate()`'s own latency budget (bounded by `ChainFirehoseHub.broadcast()`'s 15s outer ceiling). Best-effort: bounded by its own 3s timeout, never fails the response.
- **#5023 (rate-limit consumed on failed delivery)**: the burst rate-limit timestamp was set *before* delivery was even attempted, so a failed/timed-out/non-2xx delivery silently swallowed every match for the next 60s as if it had succeeded. `deliverAlertMatch` now returns an explicit success/failure boolean; `evaluate()` keeps the optimistic set-before-send (still needed to prevent duplicate concurrent sends for the same trigger) but rolls the timestamp back on failure, so the very next match retries immediately.
- **#5024 (Map pruning)**: `lastDeliveredAt` is now pruned of any trigger id no longer active, at the end of every successful `refreshTriggers()`.

Also fixes two nits: a `::bigint` cast consistency gap in the new write-back query's timestamp bind, and updates `docs/realtime-firehose.md`'s deferred-findings section (previously listed all three as still-open).

Built and independently adversarially reviewed (approved, no blocker/high findings) before landing.

## Test plan

- [x] `npx vitest run` -- 265 files pass
- [x] `npm run test:coverage` -- unsharded; `workers/alerter-hub.mjs` fully covered, `workers/data-api.mjs`'s only uncovered lines are pre-existing/unrelated
- [x] `npm run lint` / `npx prettier --check`