### PR TITLE
feat(realtime): per-IP SSE/WS/GraphQL sub-quota for the chain firehose

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -149,6 +149,25 @@ each one costing a real `execute()`+`send()` on every future `broadcast()`.
 resolver turns that into a clear `GraphQLError` rather than hanging the
 client on a stream that will never yield.
 
+**Per-IP sub-quotas (#5004):** every cap above is global, so one actor
+looping past it could otherwise lock out every other client of that
+transport. `CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP` (20, `resolveClientIp`)
+bounds SSE connections, plain-firehose WS connections, and graphql-ws
+socket upgrades per IP -- well under the global caps, tracked via
+`sseClientsByIp`/`wsClientsByIp` and released on the same
+connect/disconnect lifecycle hooks the underlying `sseClients`/
+`state.getWebSockets()` bookkeeping already uses, so the two can never
+drift apart. A WS-connection cap alone doesn't bound how many `chainEvents`
+subscriptions get multiplexed onto one already-open graphql-ws socket
+(graphql-ws itself imposes no per-socket subscription limit), so
+`CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP` (20) is a second,
+independent sub-quota on subscription count, with the connecting IP
+threaded from the WS upgrade through graphql-ws's own `opened()`/`context()`
+extension point (`ctx.extra.ip` -> `context.clientIp`) into
+`subscribeChainEvents`. All four per-IP Maps are in-memory only and reset
+to empty on every Durable Object reconstruction, the same hibernation-reset
+convention every other in-memory Map on this class already follows.
+
 Testability: this repo has no Durable Object-capable test harness (no
 `@cloudflare/vitest-pool-workers`/Miniflare). Every actual decision the hub
 makes (topic parsing/matching, ingest payload validation, SSE framing) is a

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -403,7 +403,12 @@ schema.getSubscriptionType().getFields().chainEvents.subscribe =
     // also collapses to an empty Set, never silently falling back to
     // "everything"). Previously both cases collapsed to null.
     const topics = args.tables === undefined ? null : new Set(args.tables);
-    const repeater = hub.subscribeChainEvents(topics);
+    // context.clientIp is set by workers/chain-firehose-hub.mjs's
+    // graphqlWsServer context() callback from ctx.extra.ip (itself populated
+    // by handleSubscribe's opened(adapterSocket, { ip: clientIp }) call) --
+    // threaded through so subscribeChainEvents can enforce its per-IP
+    // subscription-count cap alongside the global one (#5004 item 2).
+    const repeater = hub.subscribeChainEvents(topics, context.clientIp);
     if (!repeater) {
       throw new GraphQLError(
         "The realtime chain firehose has reached its maximum number of " +

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -17,6 +17,7 @@ import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
   CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
+  CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
   CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK,
@@ -1052,6 +1053,127 @@ test("ChainFirehoseHub.subscribeChainEvents: returns null (not a repeater) once 
     hub.chainEventSubscribers.size,
     CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
   );
+});
+
+// --- CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP (#5004 item 2) -------------
+//
+// The per-IP counterpart to the global cap above: CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
+// bounds how many graphql-ws SOCKETS one IP can open, but graphql-ws itself
+// imposes no per-socket subscription-count limit -- so without this, a single
+// IP using just one of its (already capped) sockets could still multiplex its
+// way up to the ENTIRE global CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS budget.
+// clientIp is threaded from handleSubscribe's WS-upgrade branch through
+// graphql-ws's opened()/context() chain into src/graphql.mjs's
+// chainEventsSubscribe resolver as context.clientIp, which passes it here as
+// subscribeChainEvents's second argument -- see that resolver and
+// graphqlWsServer's context callback in the source for the other half of the
+// wiring (not Node-testable; same v8-ignored reachability class as every
+// other WS-accept-path branch in this file). subscribeChainEvents/
+// unsubscribeChainEvents are plain methods, though, so the actual cap logic
+// under test here is called directly, the same way the global-cap test above
+// does.
+
+test("ChainFirehoseHub.subscribeChainEvents: rejects a new subscription from the SAME IP at the per-IP cap, well below the global cap", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  assert.ok(
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP <
+      CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
+  );
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP; i += 1) {
+    assert.notEqual(hub.subscribeChainEvents(null, "203.0.113.9"), null);
+  }
+  assert.equal(
+    hub.chainEventSubscribersByIp.get("203.0.113.9"),
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP,
+  );
+
+  const capped = hub.subscribeChainEvents(null, "203.0.113.9");
+  assert.equal(capped, null);
+  // The per-IP rejection didn't consume any of the global budget beyond this
+  // IP's own subscriptions -- proves the rejection came from the per-IP
+  // check, not CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS.
+  assert.equal(
+    hub.chainEventSubscribers.size,
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP,
+  );
+});
+
+test("ChainFirehoseHub.subscribeChainEvents: a DIFFERENT IP is unaffected by another IP's per-IP cap", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP; i += 1) {
+    hub.subscribeChainEvents(null, "203.0.113.9");
+  }
+  const otherIpRepeater = hub.subscribeChainEvents(null, "198.51.100.4");
+  assert.notEqual(otherIpRepeater, null);
+  assert.equal(hub.chainEventSubscribersByIp.get("198.51.100.4"), 1);
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: releases the subscribing IP's slot, freeing room for a new subscription from the same IP", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeaters = [];
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP; i += 1) {
+    repeaters.push(hub.subscribeChainEvents(null, "203.0.113.9"));
+  }
+  assert.equal(hub.subscribeChainEvents(null, "203.0.113.9"), null); // capped
+
+  hub.unsubscribeChainEvents(repeaters[0]);
+  assert.equal(
+    hub.chainEventSubscribersByIp.get("203.0.113.9"),
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP - 1,
+  );
+
+  const reconnected = hub.subscribeChainEvents(null, "203.0.113.9");
+  assert.notEqual(reconnected, null);
+  assert.equal(
+    hub.chainEventSubscribersByIp.get("203.0.113.9"),
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP,
+  );
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: deletes (not zeroes) the IP's map entry once its last subscription ends", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeater = hub.subscribeChainEvents(null, "203.0.113.9");
+  assert.equal(hub.chainEventSubscribersByIp.get("203.0.113.9"), 1);
+  hub.unsubscribeChainEvents(repeater);
+  assert.equal(hub.chainEventSubscribersByIp.has("203.0.113.9"), false);
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: a defensive no-op when the entry carries a clientIp that was never (or is no longer) tracked in chainEventSubscribersByIp", () => {
+  // Structurally shouldn't happen via the normal subscribeChainEvents path
+  // (which always pairs the entry's clientIp with an increment), but this
+  // mirrors the same defensive shape releaseWsIpSlot/removeSseClient already
+  // use elsewhere in this class for an untracked IP -- seeded directly here
+  // (like several other tests in this file seed hub.sseClients/
+  // hub.graphqlWsSockets directly) to exercise that guard as its own branch.
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeater = createAsyncRepeater();
+  const entry = { repeater, topics: null, clientIp: "203.0.113.9" };
+  hub.chainEventSubscribers.add(entry);
+  assert.doesNotThrow(() => hub.unsubscribeChainEvents(repeater));
+  assert.equal(hub.chainEventSubscribersByIp.has("203.0.113.9"), false);
+});
+
+test("ChainFirehoseHub.subscribeChainEvents: an undefined clientIp (e.g. a caller not going through the real WS/graphql-ws path) skips the per-IP check entirely, sharing no bucket and never getting capped by it", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  for (
+    let i = 0;
+    i < CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP + 5;
+    i += 1
+  ) {
+    assert.notEqual(hub.subscribeChainEvents(null), null);
+  }
+  assert.equal(
+    hub.chainEventSubscribers.size,
+    CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP + 5,
+  );
+  assert.equal(hub.chainEventSubscribersByIp.size, 0);
+});
+
+test("ChainFirehoseHub.unsubscribeChainEvents: unsubscribing a repeater that was subscribed with no clientIp doesn't touch chainEventSubscribersByIp", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const repeater = hub.subscribeChainEvents(null);
+  assert.doesNotThrow(() => hub.unsubscribeChainEvents(repeater));
+  assert.equal(hub.chainEventSubscribersByIp.size, 0);
 });
 
 test("GRAPHQL_WS_SOCKET_TAG is the documented tag string", () => {

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -15,6 +15,7 @@ import { test } from "vitest";
 import {
   ALERTER_HUB_EVALUATE_TIMEOUT_MS,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
+  CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
   CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
@@ -505,16 +506,23 @@ test("ChainFirehoseHub /subscribe (SSE): responds with a text/event-stream and a
 test("ChainFirehoseHub /subscribe (SSE): rejects new clients at the global connection cap", async () => {
   const hub = new ChainFirehoseHub(stubState(), {});
   const responses = [];
+  // Spread across many distinct IPs, well under the per-IP cap each (#5004
+  // item 1's dedicated tests further below cover THAT cap specifically) --
+  // this test is about the pre-existing GLOBAL cap, independent of it.
   for (let i = 0; i < CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS; i += 1) {
     const res = await hub.fetch(
-      new Request("https://chain-firehose-hub.internal/subscribe"),
+      new Request("https://chain-firehose-hub.internal/subscribe", {
+        headers: { "cf-connecting-ip": `198.51.100.${i % 100}` },
+      }),
     );
     responses.push(res);
   }
 
   assert.equal(hub.sseClients.size, CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS);
   const capped = await hub.fetch(
-    new Request("https://chain-firehose-hub.internal/subscribe"),
+    new Request("https://chain-firehose-hub.internal/subscribe", {
+      headers: { "cf-connecting-ip": "198.51.100.250" }, // a fresh IP, nowhere near its own per-IP cap
+    }),
   );
   assert.equal(capped.status, 503);
   assert.equal(await capped.text(), "too many connections");
@@ -586,6 +594,115 @@ test("ChainFirehoseHub /subscribe (SSE): cancelling the stream removes it from s
   assert.equal(hub.sseClients.size, 1);
   await res.body.cancel();
   assert.equal(hub.sseClients.size, 0);
+});
+
+// --- SSE per-IP connection sub-quota (#5004 item 1) -------------------------------
+//
+// CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS is a GLOBAL cap (tested above); this is
+// the per-IP sub-quota checked alongside it, so one IP can't consume the
+// entire global budget in a loop. subscribeRequest below builds a real
+// Request the same way every other test in this file does, just with a
+// cf-connecting-ip header attached (mirroring tests/config.test.mjs's own
+// fakeRequest pattern for resolveClientIp, but as a real Request since
+// handleSubscribe is exercised through hub.fetch here, not called directly).
+function subscribeRequest(ip, query = "") {
+  return new Request(
+    `https://chain-firehose-hub.internal/subscribe${query}`,
+    ip ? { headers: { "cf-connecting-ip": ip } } : undefined,
+  );
+}
+
+test("ChainFirehoseHub /subscribe (SSE): rejects a new client from the SAME IP at the per-IP cap, well below the global cap", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const responses = [];
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP; i += 1) {
+    responses.push(await hub.fetch(subscribeRequest("203.0.113.9")));
+  }
+  assert.equal(hub.sseClients.size, CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP);
+  assert.ok(
+    CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP < CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
+  );
+
+  const capped = await hub.fetch(subscribeRequest("203.0.113.9"));
+  assert.equal(capped.status, 503);
+  assert.equal(await capped.text(), "too many connections");
+  // The per-IP cap didn't consume any of the global budget beyond this IP's
+  // own connections -- the rejection is purely from sseClientsByIp, not
+  // sseClients hitting CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS.
+  assert.equal(hub.sseClients.size, CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP);
+
+  await Promise.all(responses.map((res) => res.body.cancel()));
+});
+
+test("ChainFirehoseHub /subscribe (SSE): a DIFFERENT IP is unaffected by another IP's per-IP cap", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const responses = [];
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP; i += 1) {
+    responses.push(await hub.fetch(subscribeRequest("203.0.113.9")));
+  }
+  const otherIp = await hub.fetch(subscribeRequest("198.51.100.4"));
+  assert.equal(otherIp.status, 200);
+  await Promise.all([...responses, otherIp].map((res) => res.body.cancel()));
+});
+
+test("ChainFirehoseHub /subscribe (SSE): cancelling one connection frees that IP's slot for a new one", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const responses = [];
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP; i += 1) {
+    responses.push(await hub.fetch(subscribeRequest("203.0.113.9")));
+  }
+  await responses[0].body.cancel();
+  assert.equal(
+    hub.sseClientsByIp.get("203.0.113.9"),
+    CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP - 1,
+  );
+
+  const reconnected = await hub.fetch(subscribeRequest("203.0.113.9"));
+  assert.equal(reconnected.status, 200);
+  assert.equal(
+    hub.sseClientsByIp.get("203.0.113.9"),
+    CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
+  );
+
+  await Promise.all(
+    [...responses.slice(1), reconnected].map((res) => res.body.cancel()),
+  );
+});
+
+test("ChainFirehoseHub /subscribe (SSE): requests with no cf-connecting-ip header share the anonymous bucket", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const responses = [];
+  for (let i = 0; i < CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP; i += 1) {
+    responses.push(await hub.fetch(subscribeRequest(null)));
+  }
+  const capped = await hub.fetch(subscribeRequest(null));
+  assert.equal(capped.status, 503);
+  await Promise.all(responses.map((res) => res.body.cancel()));
+});
+
+test("ChainFirehoseHub broadcast: dropping a stalled SSE client also releases its per-IP slot (not just sseClients)", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const res = await hub.fetch(subscribeRequest("203.0.113.9"));
+  assert.equal(hub.sseClientsByIp.get("203.0.113.9"), 1);
+  for (let i = 0; i < CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK + 5; i += 1) {
+    hub.broadcast({ table: "blocks", block_number: i });
+  }
+  assert.equal(hub.sseClients.size, 0);
+  assert.equal(hub.sseClientsByIp.has("203.0.113.9"), false);
+  await res.body.cancel();
+});
+
+test("ChainFirehoseHub.addSseClient: a second connection from the same IP increments rather than overwrites the count", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.addSseClient({ ip: "203.0.113.9" });
+  hub.addSseClient({ ip: "203.0.113.9" });
+  assert.equal(hub.sseClientsByIp.get("203.0.113.9"), 2);
+});
+
+test("ChainFirehoseHub.removeSseClient: a no-op (does not throw or touch sseClientsByIp) when the entry was never registered", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  assert.doesNotThrow(() => hub.removeSseClient({ ip: "203.0.113.9" }));
+  assert.equal(hub.sseClientsByIp.size, 0);
 });
 
 test("ChainFirehoseHub broadcast: fans out to WebSockets via the stubbed state.getWebSockets(), honoring their attached topic filter", () => {
@@ -724,6 +841,76 @@ test("ChainFirehoseHub.webSocketError: falls back to a generic reason when no er
   });
   hub.webSocketError(ws);
   assert.deepEqual(closedWith, [1011, "internal error"]);
+});
+
+// --- releaseWsIpSlot / per-IP WS connection sub-quota (#5004 item 1) ------------
+//
+// The accept-time increment itself lives inside handleSubscribe's
+// WebSocket-upgrade branch, which is /* v8 ignore */-marked in the source
+// (WebSocketPair/state.acceptWebSocket have no Node equivalent -- same
+// convention as every other WS-accept-path test gap in this file). The
+// RELEASE half, though, runs inside webSocketClose/webSocketError -- both
+// already exercised under plain Node/vitest above via stubbed `ws` objects
+// -- so releaseWsIpSlot's branches are tested directly here the same way,
+// by seeding hub.wsClientsByIp directly (mirroring how other tests in this
+// file seed hub.sseClients/hub.graphqlWsSockets directly) rather than
+// needing a real accept step.
+
+test("ChainFirehoseHub.webSocketClose: releases the per-IP WS slot recorded in the socket's attachment", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.wsClientsByIp.set("203.0.113.9", 1);
+  const ws = {
+    deserializeAttachment: () => ({ topics: null, ip: "203.0.113.9" }),
+    close: () => {},
+  };
+  hub.webSocketClose(ws, 1000, "bye");
+  assert.equal(hub.wsClientsByIp.has("203.0.113.9"), false);
+});
+
+test("ChainFirehoseHub.webSocketClose: decrements (not deletes) when other connections from the same IP remain", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.wsClientsByIp.set("203.0.113.9", 3);
+  const ws = {
+    deserializeAttachment: () => ({ ip: "203.0.113.9" }),
+    close: () => {},
+  };
+  hub.webSocketClose(ws, 1000, "bye");
+  assert.equal(hub.wsClientsByIp.get("203.0.113.9"), 2);
+});
+
+test("ChainFirehoseHub.webSocketError: also releases the per-IP WS slot (not just webSocketClose)", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.wsClientsByIp.set("198.51.100.4", 1);
+  const ws = { deserializeAttachment: () => ({ ip: "198.51.100.4" }) };
+  hub.webSocketError(ws, new Error("boom"));
+  assert.equal(hub.wsClientsByIp.has("198.51.100.4"), false);
+});
+
+test("ChainFirehoseHub.releaseWsIpSlot: a no-op when the attachment has no ip (e.g. a legacy/malformed attachment)", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  hub.wsClientsByIp.set("203.0.113.9", 1);
+  assert.doesNotThrow(() =>
+    hub.releaseWsIpSlot({ deserializeAttachment: () => ({ topics: null }) }),
+  );
+  // Unrelated IP's count is untouched -- nothing to attribute the release to.
+  assert.equal(hub.wsClientsByIp.get("203.0.113.9"), 1);
+});
+
+test("ChainFirehoseHub.releaseWsIpSlot: a no-op when deserializeAttachment returns null", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  assert.doesNotThrow(() =>
+    hub.releaseWsIpSlot({ deserializeAttachment: () => null }),
+  );
+});
+
+test("ChainFirehoseHub.releaseWsIpSlot: a no-op when this DO instance never recorded that IP (e.g. a socket accepted by a prior, now-replaced instance)", () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  assert.doesNotThrow(() =>
+    hub.releaseWsIpSlot({
+      deserializeAttachment: () => ({ ip: "203.0.113.9" }),
+    }),
+  );
+  assert.equal(hub.wsClientsByIp.has("203.0.113.9"), false);
 });
 
 // --- subscribeChainEvents / unsubscribeChainEvents / broadcast (#4983) ----------

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1814,12 +1814,12 @@ function fakeChainFirehose(pushAfterSubscribe) {
   };
 }
 
-async function subscribeChainEvents(query, hub) {
+async function subscribeChainEvents(query, hub, clientIp) {
   const document = parse(query);
   return subscribe({
     schema: chainEventsSchema,
     document,
-    contextValue: { [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: hub },
+    contextValue: { [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: hub, clientIp },
   });
 }
 
@@ -1926,6 +1926,45 @@ describe("Subscription.chainEvents", () => {
       () => result[Symbol.asyncIterator]().next(),
       /graphql-transport-ws/,
     );
+  });
+
+  test("passes context.clientIp through to subscribeChainEvents as the second argument (#5004 item 2)", async () => {
+    // context.clientIp is populated by workers/chain-firehose-hub.mjs's
+    // graphqlWsServer context() callback (from ctx.extra.ip, itself set by
+    // handleSubscribe's opened(adapterSocket, { ip: clientIp }) call) -- not
+    // Node-testable end-to-end, so this proves the resolver's half of that
+    // wiring: it reads context.clientIp and forwards it, letting
+    // ChainFirehoseHub.subscribeChainEvents enforce its per-IP cap.
+    let receivedClientIp = "unset";
+    const hub = fakeChainFirehose();
+    const originalSubscribe = hub.subscribeChainEvents.bind(hub);
+    hub.subscribeChainEvents = (topics, clientIp) => {
+      receivedClientIp = clientIp;
+      return originalSubscribe(topics);
+    };
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table } }",
+      hub,
+      "203.0.113.9",
+    );
+    result[Symbol.asyncIterator]().next(); // trigger the generator body
+    assert.equal(receivedClientIp, "203.0.113.9");
+  });
+
+  test("an absent context.clientIp is passed through as undefined, not crashing or defaulting to a fabricated IP", async () => {
+    let receivedClientIp = "unset";
+    const hub = fakeChainFirehose();
+    const originalSubscribe = hub.subscribeChainEvents.bind(hub);
+    hub.subscribeChainEvents = (topics, clientIp) => {
+      receivedClientIp = clientIp;
+      return originalSubscribe(topics);
+    };
+    const result = await subscribeChainEvents(
+      "subscription { chainEvents { table } }",
+      hub,
+    );
+    result[Symbol.asyncIterator]().next(); // trigger the generator body
+    assert.equal(receivedClientIp, undefined);
   });
 
   test("returns a clear GraphQLError when subscribeChainEvents reports the hub is at capacity (CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS)", async () => {

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -121,6 +121,20 @@ export const CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP = 20;
 // own global-not-per-IP shape) checked in subscribeChainEvents below.
 export const CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS = 1000;
 
+// #5004 item 2: the per-IP counterpart to the global cap above. The
+// WS-connection-count cap (CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP) bounds how
+// many graphql-ws SOCKETS one IP can open, but graphql-ws imposes no
+// per-socket limit on how many `chainEvents` subscriptions get multiplexed
+// onto a single already-open socket -- so a single IP, using just ONE of its
+// (now capped) connections, could still multiplex its way up to the entire
+// global CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS budget on its own. Checked
+// in subscribeChainEvents below, in ADDITION to the global cap, the same
+// "sub-quota alongside the global cap" shape CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
+// already established for SSE/WS connections. Reuses that same 20 value --
+// no principled reason found for GraphQL-subscription headroom to differ
+// from connection headroom, and it's still generous for any real client.
+export const CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP = 20;
+
 // Hibernation tag distinguishing a graphql-ws socket from a plain firehose
 // one -- webSocketMessage/webSocketClose/webSocketError route on
 // graphqlWsSockets.has(ws) directly rather than this tag (a WeakMap lookup
@@ -352,6 +366,15 @@ export class ChainFirehoseHub {
     // value) since hibernation delivers messages/close events through this
     // class's own webSocketMessage/webSocketClose, not socket-level listeners.
     this.chainEventSubscribers = new Set();
+    // #5004 item 2: live `chainEvents` GraphQL-subscription count per client
+    // IP -- the per-IP sub-quota counterpart to sseClientsByIp/wsClientsByIp
+    // above, same Map-of-counts shape. Incremented in subscribeChainEvents,
+    // decremented in unsubscribeChainEvents (looked up via the clientIp
+    // stashed on each chainEventSubscribers entry, since unsubscribe is only
+    // ever called with the repeater, not the IP). Same hibernation-survival
+    // convention as every other in-memory Map on this class: resets to empty
+    // on a fresh DO reconstruction, not meant to survive it.
+    this.chainEventSubscribersByIp = new Map();
     this.graphqlWsSockets = new WeakMap();
     // #4983 MCP half: the most recent broadcast payload, for the
     // metagraph://chain/stream MCP resource's resources/read (a pointer/
@@ -375,7 +398,17 @@ export class ChainFirehoseHub {
       /* v8 ignore start */
       onSubscribe: (_ctx, _id, payload) =>
         validateChainEventsSubscribePayload(payload) || undefined,
-      context: () => ({ [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: this }),
+      // #5004 item 2: ctx.extra is whatever this.graphqlWsServer.opened() was
+      // called with as its second argument (graphql-ws's own Context.extra
+      // field -- confirmed against its type definitions, not guessed) --
+      // handleSubscribe's isGraphqlWs branch below passes { ip: clientIp }.
+      // Threading it into context makes it reachable as context.clientIp in
+      // src/graphql.mjs's chainEventsSubscribe resolver, which passes it on
+      // to subscribeChainEvents for the per-IP subscription-count cap.
+      context: (ctx) => ({
+        [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]: this,
+        clientIp: ctx.extra.ip,
+      }),
       /* v8 ignore stop */
     });
   }
@@ -383,30 +416,50 @@ export class ChainFirehoseHub {
   // Registered as context.chainFirehose by graphqlWsServer above; called from
   // src/graphql.mjs's chainEventsSubscribe field resolver. Mirrors the SSE/WS
   // firehose's own topic-filter semantics (chainFirehoseMatchesTopics).
-  // Returns null (not a repeater) at CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
-  // -- the resolver must throw a GraphQLError for that case, never treat
-  // null as "no filter"/an empty stream.
+  // Returns null (not a repeater) at either the global cap
+  // (CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS) or the per-IP cap
+  // (CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP) -- the resolver must
+  // throw a GraphQLError for either case, never treat null as "no filter"/an
+  // empty stream.
   //
-  // #5004 item 1 KNOWN GAP (deliberately NOT fixed by this pass): this method
-  // receives only `topics`, not the request/IP, so CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
-  // stays a GLOBAL cap with no per-IP sub-quota, unlike the SSE/WS connection
-  // caps above it. The per-IP fix added elsewhere in this file bounds how
-  // many separate graphql-ws SOCKETS one IP can open (handleSubscribe's
-  // WS-upgrade branch), but NOT how many `chainEvents` subscriptions one IP
-  // multiplexes within a single already-open socket -- that would require
-  // threading the request/IP through graphql-ws's onSubscribe/context
-  // callback chain into this method, a deeper change explicitly scoped out
-  // of #5004 item 1 (see the issue body). Left as an explicit, intentional
-  // gap rather than silently dropped -- a candidate for a follow-up issue.
-  subscribeChainEvents(topics) {
+  // #5004 item 2: `clientIp` is threaded from the WS upgrade through
+  // graphql-ws's opened()/context() chain into src/graphql.mjs's
+  // chainEventsSubscribe resolver, which passes it here as context.clientIp
+  // -- see graphqlWsServer's context callback above for how ctx.extra.ip gets
+  // there. This closes the gap the WS-connection-count cap alone left open:
+  // that cap bounds how many graphql-ws SOCKETS one IP can open, but not how
+  // many `chainEvents` subscriptions get multiplexed onto a single
+  // already-open socket (graphql-ws itself imposes no per-socket subscription
+  // limit), so one IP could otherwise consume the entire global
+  // CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS budget through just one
+  // connection. `clientIp` may be undefined for callers that don't go
+  // through the real WS/graphql-ws path (e.g. existing unit tests calling
+  // this with one argument) -- treated as the same untracked/anonymous
+  // bucket handleSubscribe's SSE/WS branches already use for a missing IP
+  // (resolveClientIp can itself return undefined), so the per-IP check is
+  // simply skipped rather than crashing or double-counting under a bogus key.
+  subscribeChainEvents(topics, clientIp) {
     if (
       this.chainEventSubscribers.size >=
       CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
     ) {
       return null;
     }
+    if (
+      clientIp &&
+      (this.chainEventSubscribersByIp.get(clientIp) || 0) >=
+        CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP
+    ) {
+      return null;
+    }
     const repeater = createAsyncRepeater();
-    this.chainEventSubscribers.add({ repeater, topics });
+    this.chainEventSubscribers.add({ repeater, topics, clientIp });
+    if (clientIp) {
+      this.chainEventSubscribersByIp.set(
+        clientIp,
+        (this.chainEventSubscribersByIp.get(clientIp) || 0) + 1,
+      );
+    }
     return repeater;
   }
 
@@ -415,6 +468,16 @@ export class ChainFirehoseHub {
       if (entry.repeater === repeater) {
         entry.repeater.end();
         this.chainEventSubscribers.delete(entry);
+        if (entry.clientIp) {
+          const count = this.chainEventSubscribersByIp.get(entry.clientIp);
+          if (count) {
+            if (count <= 1) {
+              this.chainEventSubscribersByIp.delete(entry.clientIp);
+            } else {
+              this.chainEventSubscribersByIp.set(entry.clientIp, count - 1);
+            }
+          }
+        }
         return;
       }
     }
@@ -542,7 +605,14 @@ export class ChainFirehoseHub {
             this.graphqlWsSockets.set(server, entry);
           },
         };
-        const closedCb = this.graphqlWsServer.opened(adapterSocket, {});
+        // #5004 item 2: `extra` (this call's second argument) is what
+        // graphql-ws exposes as ctx.extra to the context() callback above --
+        // passing { ip: clientIp } here is what makes context.clientIp (and
+        // therefore the per-IP GraphQL-subscription cap in
+        // subscribeChainEvents) possible at all.
+        const closedCb = this.graphqlWsServer.opened(adapterSocket, {
+          ip: clientIp,
+        });
         const entry = this.graphqlWsSockets.get(server) || {};
         entry.closedCb = closedCb;
         this.graphqlWsSockets.set(server, entry);

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -38,6 +38,7 @@ import {
   validate,
 } from "graphql";
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL, makeServer } from "graphql-ws";
+import { resolveClientIp } from "./config.mjs";
 import {
   GRAPHQL_MAX_COMPLEXITY,
   GRAPHQL_MAX_QUERY_BYTES,
@@ -93,6 +94,20 @@ export const CHAIN_FIREHOSE_MAX_FIELD_STRING_BYTES = 256;
 export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
 export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
+
+// #5004 item 1: the two caps above are GLOBAL -- one IP looping connection
+// attempts can legitimately consume the entire budget and lock out every
+// other client of that transport. This is a per-IP sub-quota (resolved via
+// resolveClientIp, workers/config.mjs -- the SAME cf-connecting-ip-only
+// resolution workers/data-api.mjs's rate limiters already use, not a
+// separate IP-extraction scheme) checked in ADDITION to, not instead of, the
+// global caps above. Deliberately well under them (20 vs. 1000): generous
+// enough for any real client (a browser tab or two, a reconnect race) while
+// still bounding a single actor to a small slice of the global budget rather
+// than all of it. SSE and WS share this same constant (no principled reason
+// found for the two transports to need different per-IP headroom) -- see
+// handleSubscribe's SSE branch and WS-upgrade branch below.
+export const CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP = 20;
 
 // graphql-ws multiplexes many independent `subscribe` operations over ONE
 // WebSocket connection (the library only rejects a *duplicate* operation id
@@ -312,6 +327,21 @@ export class ChainFirehoseHub {
     this.state = state;
     this.env = env;
     this.sseClients = new Set();
+    // #5004 item 1: live SSE/WS connection count per client IP, mirroring
+    // sseClients/state.getWebSockets() but keyed by resolveClientIp(request)
+    // instead of by connection -- the per-IP sub-quota above. Both WS "modes"
+    // (plain firehose and graphql-ws) share wsClientsByIp: they both accept a
+    // WebSocketPair from the SAME handleSubscribe entry point and both count
+    // against the same per-IP WS budget (see handleSubscribe's WS-upgrade
+    // branch). Like every other piece of this class's in-memory state, these
+    // reset to empty on a fresh DO reconstruction (hibernation wake, idle
+    // eviction, or a code deploy) -- see the class header comment and
+    // closeStaleGraphqlWsSocket's comment for this class's own established
+    // hibernation-survival convention; the bar here is the same one: keep
+    // increment/decrement paired within a single DO lifetime, not survive
+    // reconstruction.
+    this.sseClientsByIp = new Map();
+    this.wsClientsByIp = new Map();
     // #4983: GraphQL subscriptions over WS, negotiated via
     // Sec-WebSocket-Protocol on the SAME /subscribe path -- see the class
     // header comment. chainEventSubscribers holds active createAsyncRepeater()
@@ -356,6 +386,18 @@ export class ChainFirehoseHub {
   // Returns null (not a repeater) at CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
   // -- the resolver must throw a GraphQLError for that case, never treat
   // null as "no filter"/an empty stream.
+  //
+  // #5004 item 1 KNOWN GAP (deliberately NOT fixed by this pass): this method
+  // receives only `topics`, not the request/IP, so CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS
+  // stays a GLOBAL cap with no per-IP sub-quota, unlike the SSE/WS connection
+  // caps above it. The per-IP fix added elsewhere in this file bounds how
+  // many separate graphql-ws SOCKETS one IP can open (handleSubscribe's
+  // WS-upgrade branch), but NOT how many `chainEvents` subscriptions one IP
+  // multiplexes within a single already-open socket -- that would require
+  // threading the request/IP through graphql-ws's onSubscribe/context
+  // callback chain into this method, a deeper change explicitly scoped out
+  // of #5004 item 1 (see the issue body). Left as an explicit, intentional
+  // gap rather than silently dropped -- a candidate for a follow-up issue.
   subscribeChainEvents(topics) {
     if (
       this.chainEventSubscribers.size >=
@@ -450,6 +492,20 @@ export class ChainFirehoseHub {
       ) {
         return new Response("too many connections", { status: 503 });
       }
+      // #5004 item 1: per-IP sub-quota, checked in addition to the global cap
+      // above. Applies to BOTH WS "modes" below (plain firehose and
+      // graphql-ws) -- both accept a WebSocketPair from this same branch and
+      // share wsClientsByIp, so one IP can't work around the cap by opening
+      // graphql-ws sockets instead of plain ones (or vice versa). Same 503
+      // shape as the global-cap response above; no need for a distinct error
+      // -- a client can't act on the difference and both mean "try later".
+      const clientIp = resolveClientIp(request);
+      if (
+        (this.wsClientsByIp.get(clientIp) || 0) >=
+        CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
+      ) {
+        return new Response("too many connections", { status: 503 });
+      }
       const requestedProtocols = (
         request.headers.get("sec-websocket-protocol") || ""
       )
@@ -464,6 +520,18 @@ export class ChainFirehoseHub {
 
       if (isGraphqlWs) {
         this.state.acceptWebSocket(server, [GRAPHQL_WS_SOCKET_TAG]);
+        // #5004 item 1: stamp the accepting IP into the attachment (like the
+        // plain-firehose branch below stamps topics) so webSocketClose/
+        // webSocketError -- which only ever receive the ws, not the original
+        // request -- can look it up to release this IP's wsClientsByIp slot.
+        // graphql-ws itself never reads this attachment, and this branch
+        // never sets `topics` (that's a plain-firehose-only concept), so
+        // there's no key collision to worry about.
+        server.serializeAttachment({ ip: clientIp });
+        this.wsClientsByIp.set(
+          clientIp,
+          (this.wsClientsByIp.get(clientIp) || 0) + 1,
+        );
         const adapterSocket = {
           protocol: GRAPHQL_TRANSPORT_WS_PROTOCOL,
           send: (data) => server.send(data),
@@ -486,9 +554,17 @@ export class ChainFirehoseHub {
       }
 
       this.state.acceptWebSocket(server);
+      // #5004 item 1: `ip` alongside `topics` in the SAME attachment object
+      // -- webSocketClose/webSocketError read it back via
+      // ws.deserializeAttachment() to release this IP's wsClientsByIp slot.
       server.serializeAttachment({
         topics: topics === null ? null : [...topics],
+        ip: clientIp,
       });
+      this.wsClientsByIp.set(
+        clientIp,
+        (this.wsClientsByIp.get(clientIp) || 0) + 1,
+      );
       return new Response(null, { status: 101, webSocket: client });
     }
     /* v8 ignore stop */
@@ -497,18 +573,37 @@ export class ChainFirehoseHub {
       return new Response("too many connections", { status: 503 });
     }
 
+    // #5004 item 1: per-IP sub-quota, checked in addition to the global cap
+    // above. Same 503 shape as the global-cap response -- see the WS-upgrade
+    // branch's identical comment above for why no distinct error is used.
+    const clientIp = resolveClientIp(request);
+    if (
+      (this.sseClientsByIp.get(clientIp) || 0) >=
+      CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
+    ) {
+      return new Response("too many connections", { status: 503 });
+    }
+
     const encoder = new TextEncoder();
-    const clients = this.sseClients;
+    // `hub`, not `this` -- start()/cancel() below are plain-function
+    // properties of the object literal passed to ReadableStream, so `this`
+    // inside them is that literal, not the ChainFirehoseHub instance; the
+    // original code worked around this the same way (a captured `clients`
+    // local). addSseClient/removeSseClient are the single add/remove path
+    // for BOTH this.sseClients and this.sseClientsByIp, so the two can never
+    // drift out of sync -- broadcast()'s own two cleanup paths below route
+    // through removeSseClient too, not a direct sseClients.delete().
+    const hub = this;
     let entry;
     const stream = new ReadableStream(
       {
         start(controller) {
-          entry = { controller, topics };
-          clients.add(entry);
+          entry = { controller, topics, ip: clientIp };
+          hub.addSseClient(entry);
           controller.enqueue(encoder.encode(": connected\n\n"));
         },
         cancel() {
-          clients.delete(entry);
+          hub.removeSseClient(entry);
         },
       },
       new CountQueuingStrategy({
@@ -524,6 +619,66 @@ export class ChainFirehoseHub {
         connection: "keep-alive",
       },
     });
+  }
+
+  // #5004 item 1: the single add path for an SSE client -- registers `entry`
+  // in BOTH this.sseClients (the existing global-cap membership set) and
+  // this.sseClientsByIp (the per-IP sub-quota), together, so the two never
+  // drift apart. `entry.ip` is set by handleSubscribe's SSE branch above.
+  addSseClient(entry) {
+    this.sseClients.add(entry);
+    this.sseClientsByIp.set(
+      entry.ip,
+      (this.sseClientsByIp.get(entry.ip) || 0) + 1,
+    );
+  }
+
+  // The single removal path for an SSE client -- used by the stream's own
+  // cancel() callback AND both of broadcast()'s cleanup paths (a stalled
+  // client past the high-water mark, and a client whose enqueue() throws),
+  // replacing what used to be three separate `sseClients.delete(entry)`
+  // call sites. Keeping this as one shared method is what guarantees
+  // sseClients and sseClientsByIp stay paired -- see addSseClient above.
+  // A no-op if `entry` was never actually a member (nothing to release).
+  removeSseClient(entry) {
+    if (!this.sseClients.delete(entry)) return;
+    const count = this.sseClientsByIp.get(entry.ip);
+    if (!count) return;
+    if (count <= 1) {
+      this.sseClientsByIp.delete(entry.ip);
+    } else {
+      this.sseClientsByIp.set(entry.ip, count - 1);
+    }
+  }
+
+  // #5004 item 1: releases a closed/errored WS connection's per-IP slot,
+  // reversing the increment made at accept time in handleSubscribe's
+  // WS-upgrade branch (both the plain-firehose and graphql-ws sub-branches
+  // stamp {ip} into the SAME serializeAttachment() call the topics filter
+  // already uses, precisely so this lookup works for either kind of
+  // socket). Called from both webSocketClose and webSocketError so every
+  // disconnect path -- clean close or the runtime reporting an error --
+  // releases the slot; an unreleased slot would let a client ratchet down
+  // its own remaining budget forever across repeated reconnects. A socket
+  // accepted by a PRIOR (now-replaced) DO instance has no entry in THIS
+  // instance's in-memory wsClientsByIp -- fresh per this class's own
+  // hibernation-survival convention (see closeStaleGraphqlWsSocket's
+  // comment) -- so this is a safe no-op for it, not an underflow.
+  releaseWsIpSlot(ws) {
+    let ip;
+    try {
+      ip = ws.deserializeAttachment()?.ip;
+    } catch {
+      return;
+    }
+    if (!ip) return;
+    const count = this.wsClientsByIp.get(ip);
+    if (!count) return;
+    if (count <= 1) {
+      this.wsClientsByIp.delete(ip);
+    } else {
+      this.wsClientsByIp.set(ip, count - 1);
+    }
   }
 
   // Bounds-check helper for the hibernation-survival bug described in
@@ -581,6 +736,9 @@ export class ChainFirehoseHub {
   }
 
   webSocketClose(ws, code, reason) {
+    // #5004 item 1: release this socket's per-IP WS slot on every close,
+    // graphql-ws or plain firehose alike -- see releaseWsIpSlot's comment.
+    this.releaseWsIpSlot(ws);
     const entry = this.graphqlWsSockets.get(ws);
     if (entry?.closedCb) {
       entry.closedCb(code, reason);
@@ -594,6 +752,10 @@ export class ChainFirehoseHub {
   }
 
   webSocketError(ws, error) {
+    // #5004 item 1: same per-IP release as webSocketClose -- an error close
+    // must free the slot too, or a flaky/dropped connection never gets its
+    // budget back. See releaseWsIpSlot's comment.
+    this.releaseWsIpSlot(ws);
     // Mirrors webSocketClose's graphql-ws cleanup -- Server.opened()'s
     // returned closed() callback must run on an error close too, not only a
     // clean one, or that connection's subscriptions leak. The hibernation
@@ -622,7 +784,10 @@ export class ChainFirehoseHub {
         } catch {
           // already closed
         }
-        this.sseClients.delete(entry);
+        // #5004 item 1: removeSseClient, not a direct sseClients.delete(),
+        // so this IP's sseClientsByIp slot is released too -- see
+        // addSseClient/removeSseClient's comments.
+        this.removeSseClient(entry);
         continue;
       }
       try {
@@ -630,7 +795,7 @@ export class ChainFirehoseHub {
           encoder.encode(formatChainFirehoseSseFrame(payload)),
         );
       } catch {
-        this.sseClients.delete(entry);
+        this.removeSseClient(entry);
       }
     }
 

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -433,11 +433,14 @@ export class ChainFirehoseHub {
   // limit), so one IP could otherwise consume the entire global
   // CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS budget through just one
   // connection. `clientIp` may be undefined for callers that don't go
-  // through the real WS/graphql-ws path (e.g. existing unit tests calling
-  // this with one argument) -- treated as the same untracked/anonymous
-  // bucket handleSubscribe's SSE/WS branches already use for a missing IP
-  // (resolveClientIp can itself return undefined), so the per-IP check is
-  // simply skipped rather than crashing or double-counting under a bogus key.
+  // through the real WS/graphql-ws path -- in production, context.clientIp
+  // is always populated (resolveClientIp, workers/config.mjs, falls back to
+  // a fixed "anonymous" bucket rather than ever returning undefined), so the
+  // only real source of a falsy clientIp here is a direct programmatic call
+  // with one argument (e.g. existing unit tests) -- treated the same
+  // untracked/anonymous-bucket way handleSubscribe's SSE/WS branches already
+  // handle a missing IP, so the per-IP check is simply skipped rather than
+  // crashing or double-counting under a bogus key.
   subscribeChainEvents(topics, clientIp) {
     if (
       this.chainEventSubscribers.size >=


### PR DESCRIPTION
## Summary

Closes #5004. `CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS`/`_WS_CONNECTIONS`/`_GRAPHQL_SUBSCRIPTIONS` were all global-only caps -- one actor looping past them could lock out every other client of that transport. Adds a per-IP sub-quota (`resolveClientIp`, well under the global caps) across all three:

- `CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP` (20): bounds SSE connections, plain-firehose WS connections, and graphql-ws socket upgrades per IP. Tracked via `sseClientsByIp`/`wsClientsByIp`, hooked into the exact same connect/disconnect lifecycle points the existing `sseClients`/`state.getWebSockets()` bookkeeping already uses, so the two can never drift apart.
- `CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP` (20): a WS-connection cap alone doesn't bound how many `chainEvents` subscriptions get multiplexed onto one already-open graphql-ws socket (graphql-ws imposes no per-socket subscription limit) -- one IP could otherwise consume the entire global 1000-subscription budget through a single connection. The connecting IP is threaded from the WS upgrade through graphql-ws's own `opened()`/`context()` extension point (`ctx.extra.ip` -> `context.clientIp`, verified against graphql-ws's actual type definitions) into `subscribeChainEvents`.

Landed in two commits: the SSE/WS base, then closing the GraphQL-subscription gap a first adversarial-review pass flagged (the base commit's own comment had incorrectly claimed that gap was excluded by the issue itself, when it was actually an implementation-time scoping call -- fixed both the gap and the comment). A second adversarial-review pass approved the result outright.

## Test plan

- [x] `npx vitest run` -- 265 files pass
- [x] `npm run test:coverage` -- unsharded; `workers/chain-firehose-hub.mjs` reached 100% statements/branches/functions/lines (closing a pre-existing branch gap as a side effect); `src/graphql.mjs`'s only uncovered branches are pre-existing and unrelated to this diff
- [x] `npm run lint` / `npx prettier --check`