### PR TITLE
feat(registry): add SN17 404—GEN dashboard surface

### DIFF
--- a/registry/subnets/404-gen.json
+++ b/registry/subnets/404-gen.json
@@ -68,6 +68,24 @@
         "https://gen.404.xyz/api/health"
       ],
       "url": "https://gen.404.xyz/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-17-404-gen-dashboard",
+      "kind": "dashboard",
+      "name": "404—GEN Grafana metrics dashboard",
+      "notes": "Public no-auth Grafana dashboard for SN17 404—GEN at dashboard.404.xyz/d/main/404-gen/ (anonymous viewing enabled; /api/health returns {\"database\":\"ok\"}). Visualizes live subnet generation and validator metrics. Linked as the \"404-GEN Dashboard\" from the official 404-Repo/three-gen-subnet README. Distinct host from the gen.404.xyz gateway portal and the www.404.xyz website.",
+      "provider": "404-gen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/404-Repo/three-gen-subnet/blob/main/README.md"
+      ],
+      "url": "https://dashboard.404.xyz/d/main/404-gen/"
     }
   ],
   "website_url": "https://www.404.xyz/"


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN17 404—GEN** — the subnet's public Grafana metrics dashboard, a surface kind the subnet file did not yet have.

- **url:** https://dashboard.404.xyz/d/main/404-gen/ (public, no-auth Grafana; anonymous viewing enabled)
- **source_url (proof):** https://github.com/404-Repo/three-gen-subnet/blob/main/README.md — links this exact URL as the **"404-GEN Dashboard"**
- **kind:** dashboard (new kind; existing surfaces are sdk / data-artifact / subnet-api)
- **host:** dashboard.404.xyz — distinct from gen.404.xyz (gateway portal) and www.404.xyz (website)

Verified live: dashboard root, /d/main/404-gen/, /api/health, /metrics all return HTTP 200 with no login redirect (Grafana anonymous access). `/api/health` returns `{"database":"ok","version":"13.0.1"}`.

## Validation

- `npm run validate:surface -- registry/subnets/404-gen.json` → passed (4 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #4014