### PR TITLE
fix(registry-sync): revert smart placement, restore Postgres writes

### DIFF
--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -12,14 +12,17 @@
   "main": "workers/registry-sync-api.mjs",
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
-  // Smart placement: run the Worker close to the Hyperdrive origin (the registry
-  // Postgres instance, reached via Cloudflare Tunnel) rather than at the nearest
-  // edge to the caller (GitHub Actions) -- the case for this is if anything
-  // stronger than wrangler.data.jsonc's read-only sibling: a single sync run
-  // does a whole batch of sequential INSERT/UPDATE/DELETE round-trips (one per
-  // provider/subnet/surface), so shaving latency off each round-trip compounds
-  // across the whole batch rather than mattering once per request.
-  "placement": { "mode": "smart" },
+  // Deliberately NOT smart-placed, unlike wrangler.data.jsonc's read-only
+  // sibling: #4767 added `placement: {mode: "smart"}` here, and every
+  // registry-sync write has 502'd ("write failed") since that reached
+  // production -- both the merge-triggered fast path and the 6h full resync
+  // went dark for ~3 days as a result. wrangler.data.jsonc's smart-placed
+  // Worker keeps serving reads fine over a comparable Tunnel+Hyperdrive path
+  // on a different box, so this is specific to this Worker/origin pairing,
+  // not a blanket incompatibility. Reverted to restore the last known-good
+  // state; re-investigate smart placement (e.g. an explicit `placement.host`
+  // pointed at the tunnel origin instead of `mode: "smart"`'s auto-detection)
+  // as deliberate follow-up, not a blind re-add.
   // This is a write path into a database, unlike wrangler.data.jsonc's
   // read-only sibling -- explicitly disabled (wrangler otherwise defaults
   // workers.dev to enabled) so the shared-secret check is the only way in,


### PR DESCRIPTION
## Summary

- Reverts `placement: {mode: "smart"}` on `wrangler.registry.jsonc`, added in #4767, which broke every write to the registry Postgres instance.

## What Changed

- `wrangler.registry.jsonc`: removed the smart-placement config added in #4767 and left a comment explaining why, so it isn't blindly re-added.

## Root cause

Every `registry-sync-api` write has 502'd with `"write failed"` since #4767 merged (2026-07-10 ~10:08 UTC). Confirmed via CI history:

- Last successful write: run [29083328131](https://github.com/JSONbored/metagraphed/actions/runs/29083328131) (2026-07-10 09:31 UTC) — real write (`subnets_written: 1, surfaces_written: 1`), not a no-op.
- First failure: run [29089919344](https://github.com/JSONbored/metagraphed/actions/runs/29089919344) (2026-07-10 11:35 UTC), the very next push touching `registry/subnets/**` — same 502 `write failed` seen in every run since (20+ consecutive failures through today, including this branch's base commits).

Both the merge-triggered fast path (`sync-registry-to-postgres.yml`) and the 6h full resync (`resync-registry-postgres.yml`) have been dark for ~3 days, so the registry Postgres tables are stale for every subnet/surface merged since 2026-07-10.

`wrangler.data.jsonc`'s smart-placed sibling Worker (different box/tunnel, same Tunnel+Hyperdrive shape) is still serving reads fine right now, which rules out a general Postgres/Tunnel outage — this is specific to the registry-sync Worker picking up a placement that can no longer reach its Hyperdrive origin. Reverting restores the last known-good configuration; re-adding smart placement here (e.g. via an explicit `placement.host` pointed at the tunnel origin) is a deliberate follow-up, not a blind re-add.

## Registry Safety

- [x] No linked issue — this is a direct production-infra fix by the repo owner (registry writes have been silently dropped for ~3 days); see the CI run evidence above in place of an issue.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none touched — config-only change).
- [x] R2-only/high-churn detail artifacts are not committed.
- [ ] Public API/OpenAPI/schema changes are intentional and documented. — N/A, no schema/API change.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (file itself clean; 3 pre-existing unrelated warnings elsewhere on main)
- [x] `npm run validate` (pre-existing unrelated `generated:*` failures reproduce identically on main without this change — stale local build artifacts, not caused by this PR)
- [x] `npx vitest run tests/registry-sync-api.test.mjs tests/registry-sync-client.test.mjs` — 33/33 pass
- [x] `git diff --check`

## Follow-up (not in this PR)

Once this merges and the Worker redeploys, the next scheduled run of `resync-registry-postgres.yml` (or a manual `workflow_dispatch`) will backfill the ~3 days of writes that were silently dropped.