### PR TITLE
feat(registry): add SN26 Perturb dashboard surface

### DIFF
--- a/registry/subnets/perturb.json
+++ b/registry/subnets/perturb.json
@@ -56,6 +56,25 @@
         "submitted_by": "dalledajay-coder"
       },
       "notes": "Public no-auth GET returning SN26 Perturb's current emission burn rate as JSON ({\"burnRate\":0.5} observed at submission time). The endpoint is declared as BURN_RATE_ENDPOINT in the subnet's validator source (perturbnet/constants.py in the official repo, pinned above) and is served from api.perturbai.io, the same host as the already-registered health surface."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-26-perturb-leaderboard",
+      "kind": "dashboard",
+      "name": "Perturb miner leaderboard",
+      "notes": "Public no-auth web leaderboard for SN26 Perturb at leaderboard.perturbai.io (page title \"Leaderboard — Perturb\") ranking miners by UID/hotkey with incentive, average score, RMSE, and normalized score. Fed by the leaderboard reports validators submit each scoring round (perturbnet/constants.py LEADERBOARD_API_URL). Hosted on the subnet's official perturbai.io domain; distinct host from the api.perturbai.io API.",
+      "provider": "perturb",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/0xsigurd/Perturb/blob/main/README.md",
+        "https://www.perturbai.io/"
+      ],
+      "url": "https://leaderboard.perturbai.io/"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN26 Perturb** — the subnet's public miner leaderboard page, a surface kind the file did not yet have.

- **url:** https://leaderboard.perturbai.io/ (public, no-auth; page title "Leaderboard — Perturb")
- **source_urls (proof):** https://github.com/0xsigurd/Perturb/blob/main/README.md documents the leaderboard-reporting system (`perturbnet/constants.py` `LEADERBOARD_API_URL`) that feeds it; hosted on the subnet's official https://www.perturbai.io/ domain
- **kind:** dashboard (new kind; existing surfaces are subnet-api / data-artifact)
- **host:** leaderboard.perturbai.io — distinct from api.perturbai.io

Verified live: HTTP 200, ranks miners by UID/hotkey with incentive, average score, RMSE, and normalized score.

## Validation
- `npm run validate:surface -- registry/subnets/perturb.json` → passed (3 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #4022