### PR TITLE
refactor(entities): remove dead D1-fallback branches for retired Postgres tiers

### DIFF
--- a/tests/account-portfolio.test.mjs
+++ b/tests/account-portfolio.test.mjs
@@ -241,21 +241,6 @@ describe("GET /api/v1/accounts/{ss58}/portfolio", () => {
     };
   }
 
-  test("returns the wallet portfolio", async () => {
-    const res = await handleRequest(
-      new Request(`https://api.metagraph.sh/api/v1/accounts/${SS58}/portfolio`),
-      neuronsEnv(ROWS),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.ss58, SS58);
-    assert.equal(body.data.position_count, 3);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.positions[0].netuid, 7);
-  });
-
   test("cold store → 200 with an empty portfolio", async () => {
     const res = await handleRequest(
       new Request(`https://api.metagraph.sh/api/v1/accounts/${SS58}/portfolio`),

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -61,100 +61,6 @@ function dbWith({
   };
 }
 
-test("GET /accounts/{ss58} returns a cross-subnet summary (#1347)", async () => {
-  const env = dbWith({
-    agg: {
-      c: 12,
-      sc: 3,
-      fb: 100,
-      lb: 200,
-      fo: 1750000000000,
-      lo: 1750009000000,
-    },
-    kinds: [
-      { kind: "StakeAdded", count: 7 },
-      { kind: "WeightsSet", count: 5 },
-    ],
-    registrations: [
-      { netuid: 7, uid: 3, stake_tao: 100, validator_permit: 1, active: 1 },
-    ],
-    events: [
-      {
-        block_number: 200,
-        event_index: 1,
-        event_kind: "StakeAdded",
-        hotkey: SS58,
-        coldkey: null,
-        netuid: 7,
-        uid: 3,
-        amount_tao: 1.5,
-        observed_at: 1750009000000,
-      },
-    ],
-    activity: {
-      tx_count: 9,
-      last_tx_block: 200,
-      last_tx_at: 1750009000000,
-      total_fee_tao: 0.05,
-    },
-    modules: [
-      { call_module: "SubtensorModule", count: 7 },
-      { call_module: "Balances", count: 2 },
-    ],
-  });
-  const res = await handleRequest(req(`/api/v1/accounts/${SS58}`), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ss58, SS58);
-  assert.equal(body.data.event_count, 12);
-  assert.equal(body.data.subnet_count, 3);
-  // Activity sub-object (#1847) from the extrinsics tier.
-  assert.equal(body.data.activity.tx_count, 9);
-  assert.equal(body.data.activity.last_tx_block, 200);
-  assert.equal(
-    body.data.activity.last_tx_at,
-    new Date(1750009000000).toISOString(),
-  );
-  assert.equal(body.data.activity.total_fee_tao, 0.05);
-  assert.equal(
-    body.data.activity.modules_called[0].call_module,
-    "SubtensorModule",
-  );
-  assert.equal(body.data.registrations[0].netuid, 7);
-  assert.equal(body.data.registrations[0].validator_permit, true);
-  assert.equal(body.data.event_kinds[0].kind, "StakeAdded");
-  assert.equal(body.data.recent_events[0].event_kind, "StakeAdded");
-});
-
-test("GET /accounts/{ss58}/events returns paginated history + kind filter (#1347)", async () => {
-  const env = dbWith({
-    events: [
-      {
-        block_number: 200,
-        event_index: 1,
-        event_kind: "StakeRemoved",
-        hotkey: SS58,
-        coldkey: null,
-        netuid: 7,
-        uid: 3,
-        amount_tao: 2.0,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/events?limit=50&kind=StakeRemoved`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ss58, SS58);
-  assert.equal(Array.isArray(body.data.events), true);
-  assert.equal(body.data.events[0].event_kind, "StakeRemoved");
-  assert.equal(body.data.limit, 50);
-});
-
 test("GET /accounts/{ss58}/events rejects an unsupported query param", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/events?bogus=1`),
@@ -167,42 +73,6 @@ test("GET /accounts/{ss58}/events rejects an unsupported query param", async () 
 const EVENTS_CSV_HEADER =
   "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
 
-test("GET /accounts/{ss58}/events?format=csv streams the event rows as CSV", async () => {
-  const env = dbWith({
-    events: [
-      {
-        block_number: 200,
-        event_index: 1,
-        event_kind: "StakeAdded",
-        hotkey: SS58,
-        coldkey: null,
-        netuid: 7,
-        uid: 3,
-        amount_tao: 2.0,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/events?format=csv&kind=StakeAdded`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type"), /text\/csv/);
-  assert.match(
-    res.headers.get("content-disposition") ?? "",
-    /attachment; filename="/,
-  );
-  const lines = (await res.text()).trim().split("\r\n");
-  assert.equal(lines[0], EVENTS_CSV_HEADER);
-  assert.equal(lines.length, 2);
-  const cells = lines[1].split(",");
-  assert.equal(cells[0], "200"); // block_number
-  assert.equal(cells[2], "StakeAdded"); // event_kind
-  assert.equal(cells[7], "2"); // amount_tao
-});
-
 test("GET /accounts/{ss58}/events?format=csv emits a header-only CSV when cold", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/events?format=csv`),
@@ -212,25 +82,6 @@ test("GET /accounts/{ss58}/events?format=csv emits a header-only CSV when cold",
   assert.equal(res.status, 200);
   assert.match(res.headers.get("content-type"), /text\/csv/);
   assert.equal((await res.text()).trim(), EVENTS_CSV_HEADER);
-});
-
-test("GET /accounts/{ss58}/subnets returns the cross-subnet footprint (#1347)", async () => {
-  const env = dbWith({
-    registrations: [
-      { netuid: 7, uid: 3, stake_tao: 100, validator_permit: 0, active: 1 },
-      { netuid: 64, uid: 12, stake_tao: 5, validator_permit: 1, active: 1 },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/subnets`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.subnet_count, 2);
-  assert.equal(body.data.subnets[1].netuid, 64);
-  assert.equal(body.data.subnets[1].validator_permit, true);
 });
 
 test("GET /accounts/{ss58} is schema-stable when D1 is cold (never 404)", async () => {
@@ -243,39 +94,6 @@ test("GET /accounts/{ss58} is schema-stable when D1 is cold (never 404)", async 
   assert.equal(body.data.activity.tx_count, 0);
   assert.equal(body.data.activity.last_tx_at, null);
   assert.deepEqual(body.data.activity.modules_called, []);
-});
-
-test("GET /accounts/{ss58}/extrinsics returns this account's signed extrinsics (#1844)", async () => {
-  const env = dbWith({
-    extrinsics: [
-      {
-        block_number: 200,
-        extrinsic_index: 2,
-        extrinsic_hash: `0x${"a".repeat(64)}`,
-        signer: SS58,
-        call_module: "SubtensorModule",
-        call_function: "add_stake",
-        call_args: null,
-        fee_tao: 0.0125,
-        success: 1,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/extrinsics?limit=50`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ss58, SS58);
-  assert.equal(body.data.extrinsic_count, 1);
-  assert.equal(body.data.extrinsics[0].call_function, "add_stake");
-  assert.equal(body.data.extrinsics[0].signer, SS58);
-  assert.equal(body.data.extrinsics[0].success, true);
-  assert.equal(body.data.extrinsics[0].fee_tao, 0.0125);
-  assert.equal(body.data.limit, 50);
 });
 
 test("GET /accounts/{ss58}/extrinsics rejects an unsupported query param", async () => {
@@ -313,46 +131,6 @@ test("GET /accounts/{ss58}/extrinsics JSON varies on Accept when CSV is negotiat
   assert.match(res.headers.get("content-type"), /^application\/json/);
 });
 
-test("GET /accounts/{ss58}/extrinsics?format=csv exports extrinsic_id/block_number/call_module columns (#2534)", async () => {
-  const env = dbWith({
-    extrinsics: [
-      {
-        block_number: 200,
-        extrinsic_index: 2,
-        extrinsic_hash: `0x${"a".repeat(64)}`,
-        signer: SS58,
-        call_module: "SubtensorModule",
-        call_function: "add_stake",
-        call_args: null,
-        fee_tao: 0.0125,
-        success: 1,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/extrinsics?format=csv`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type"), /^text\/csv/);
-  assert.equal(
-    res.headers.get("content-disposition"),
-    'attachment; filename="account-extrinsics.csv"',
-  );
-  const lines = (await res.text()).split("\r\n");
-  assert.equal(
-    lines[0],
-    "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
-  );
-  assert.equal(
-    lines[1],
-    `200-2,200,2,0x${"a".repeat(64)},${SS58},SubtensorModule,add_stake,true,0.0125,,2025-06-15T17:36:40.000Z`,
-  );
-  assert.equal(lines.length, 2);
-});
-
 test("GET /accounts/{ss58}/extrinsics?format=csv emits a header-only CSV when D1 is cold", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/extrinsics?format=csv`),
@@ -366,38 +144,6 @@ test("GET /accounts/{ss58}/extrinsics?format=csv emits a header-only CSV when D1
     "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
   );
   assert.equal(lines.length, 1);
-});
-
-test("GET /accounts/{ss58}/transfers reshapes Transfer rows directionally (#1850)", async () => {
-  const env = dbWith({
-    // The poller stores hotkey=from / coldkey=to for Transfer events.
-    events: [
-      {
-        block_number: 300,
-        event_index: 0,
-        event_kind: "Transfer",
-        hotkey: SS58, // sender == queried account → "sent"
-        coldkey: "5Recipient",
-        netuid: null,
-        uid: null,
-        amount_tao: 4.2,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/transfers?direction=sent`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ss58, SS58);
-  assert.equal(body.data.transfer_count, 1);
-  assert.equal(body.data.transfers[0].from, SS58);
-  assert.equal(body.data.transfers[0].to, "5Recipient");
-  assert.equal(body.data.transfers[0].amount_tao, 4.2);
-  assert.equal(body.data.transfers[0].direction, "sent");
 });
 
 test("GET /accounts/{ss58}/transfers rejects an unsupported query param (#1850)", async () => {
@@ -447,45 +193,6 @@ test("GET /accounts/{ss58}/transfers JSON varies on Accept when CSV is negotiate
   assert.match(res.headers.get("content-type"), /^application\/json/);
 });
 
-test("GET /accounts/{ss58}/transfers?direction=sent&format=csv filters direction and exports from/to/amount_tao columns (#2534)", async () => {
-  const env = dbWith({
-    events: [
-      {
-        block_number: 300,
-        event_index: 0,
-        event_kind: "Transfer",
-        hotkey: SS58, // sender == queried account -> "sent"
-        coldkey: "5Recipient",
-        netuid: null,
-        uid: null,
-        amount_tao: 4.2,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/transfers?direction=sent&format=csv`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type"), /^text\/csv/);
-  assert.equal(
-    res.headers.get("content-disposition"),
-    'attachment; filename="account-transfers.csv"',
-  );
-  const lines = (await res.text()).split("\r\n");
-  assert.equal(
-    lines[0],
-    "block_number,event_index,from,to,amount_tao,direction,observed_at",
-  );
-  assert.equal(
-    lines[1],
-    `300,0,${SS58},5Recipient,4.2,sent,2025-06-15T17:36:40.000Z`,
-  );
-  assert.equal(lines.length, 2);
-});
-
 test("GET /accounts/{ss58}/transfers?format=csv emits a header-only CSV when D1 is cold", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/transfers?format=csv`),
@@ -501,39 +208,6 @@ test("GET /accounts/{ss58}/transfers?format=csv emits a header-only CSV when D1 
   assert.equal(lines.length, 1);
 });
 
-test("GET /accounts/{ss58}/stake-flow routes to the per-account stake-flow handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        event_kind: "StakeAdded",
-        total_tao: 80,
-        event_count: 2,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 1,
-        event_kind: "StakeRemoved",
-        total_tao: 20,
-        event_count: 1,
-        last_observed: 1750000000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/stake-flow?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.net_flow_tao, 60);
-  assert.equal(body.data.subnets[0].netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
-});
-
 test("GET /accounts/{ss58}/stake-flow is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/stake-flow`),
@@ -545,69 +219,6 @@ test("GET /accounts/{ss58}/stake-flow is schema-stable when D1 is cold (never 40
   assert.equal(body.data.address, SS58);
   assert.equal(body.data.subnet_count, 0);
   assert.equal(Array.isArray(body.data.subnets), true);
-});
-
-test("GET /accounts/{ss58}/stake-moves routes to the per-account stake-move handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        movements: 3,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        movements: 1,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/stake-moves?window=90d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "90d");
-  assert.equal(body.data.total_movements, 4);
-  assert.equal(body.data.subnets[0].netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
-});
-
-test("GET /accounts/{ss58}/weight-setters routes to the per-account weight-setters handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        weight_sets: 3,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        weight_sets: 1,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/weight-setters?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.total_weight_sets, 4);
-  assert.equal(body.data.subnets[0].netuid, 1); // most weight sets -> leads + dominant
-  assert.equal(body.data.dominant_netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
 });
 
 test("GET /accounts/{ss58}/weight-setters is schema-stable when D1 is cold (never 404)", async () => {
@@ -643,38 +254,6 @@ test("GET /accounts/{ss58}/weight-setters rejects an unsupported window with 400
   assert.equal(body.meta.parameter, "window");
 });
 
-test("GET /accounts/{ss58}/registrations routes to the per-account registrations handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        registrations: 3,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        registrations: 1,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/registrations?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.total_registrations, 4);
-  assert.equal(body.data.subnets[0].netuid, 1); // most registrations -> leads + dominant
-  assert.equal(body.data.dominant_netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
-});
-
 test("GET /accounts/{ss58}/registrations is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/registrations`),
@@ -706,38 +285,6 @@ test("GET /accounts/{ss58}/registrations rejects an unsupported window with 400"
   assert.equal(res.status, 400);
   const body = await res.json();
   assert.equal(body.meta.parameter, "window");
-});
-
-test("GET /accounts/{ss58}/serving routes to the per-account serving handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        announcements: 30,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        announcements: 5,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/serving?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.total_announcements, 35);
-  assert.equal(body.data.subnets[0].netuid, 1); // most announcements -> leads + dominant
-  assert.equal(body.data.dominant_netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
 });
 
 test("GET /accounts/{ss58}/serving is schema-stable when D1 is cold (never 404)", async () => {
@@ -773,38 +320,6 @@ test("GET /accounts/{ss58}/serving rejects an unsupported window with 400", asyn
   assert.equal(body.meta.parameter, "window");
 });
 
-test("GET /accounts/{ss58}/deregistrations routes to the per-account deregistrations handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        deregistrations: 3,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        deregistrations: 1,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/deregistrations?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.total_deregistrations, 4);
-  assert.equal(body.data.subnets[0].netuid, 1); // most deregistrations -> leads + dominant
-  assert.equal(body.data.dominant_netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
-});
-
 test("GET /accounts/{ss58}/deregistrations is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/deregistrations`),
@@ -838,38 +353,6 @@ test("GET /accounts/{ss58}/deregistrations rejects an unsupported window with 40
   assert.equal(body.meta.parameter, "window");
 });
 
-test("GET /accounts/{ss58}/prometheus routes to the per-account prometheus handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        announcements: 30,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        announcements: 5,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/prometheus?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.total_announcements, 35);
-  assert.equal(body.data.subnets[0].netuid, 1); // most announcements -> leads + dominant
-  assert.equal(body.data.dominant_netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
-});
-
 test("GET /accounts/{ss58}/prometheus is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/prometheus`),
@@ -901,38 +384,6 @@ test("GET /accounts/{ss58}/prometheus rejects an unsupported window with 400", a
   assert.equal(res.status, 400);
   const body = await res.json();
   assert.equal(body.meta.parameter, "window");
-});
-
-test("GET /accounts/{ss58}/axon-removals routes to the per-account axon-removals handler", async () => {
-  const env = dbWith({
-    events: [
-      {
-        netuid: 1,
-        removals: 4,
-        first_observed: 1750000000000,
-        last_observed: 1750009000000,
-      },
-      {
-        netuid: 7,
-        removals: 1,
-        first_observed: 1750001000000,
-        last_observed: 1750001000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/axon-removals?window=30d`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.address, SS58);
-  assert.equal(body.data.window, "30d");
-  assert.equal(body.data.total_removals, 5);
-  assert.equal(body.data.subnets[0].netuid, 1); // most removals -> leads + dominant
-  assert.equal(body.data.dominant_netuid, 1);
-  assert.equal(body.meta.source, "chain-events");
 });
 
 test("GET /accounts/{ss58}/axon-removals is schema-stable when D1 is cold (never 404)", async () => {

--- a/tests/accounts-list.test.mjs
+++ b/tests/accounts-list.test.mjs
@@ -433,22 +433,6 @@ function accountsListEnv(rows, captured = {}) {
 }
 
 describe("GET /api/v1/accounts via the Worker", () => {
-  test("returns the site-wide leaderboard for a warm D1", async () => {
-    const res = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/accounts"),
-      accountsListEnv([{ ...ROW, hotkey: "hk-a" }]),
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.sort, DEFAULT_ACCOUNTS_LIST_SORT);
-    assert.equal(body.data.account_count, 1);
-    assert.equal(body.data.accounts[0].hotkey, "hk-a");
-    assert.ok(res.headers.get("etag"));
-    assert.ok(res.headers.get("x-metagraph-contract-version"));
-  });
-
   test("is schema-stable when D1 is cold (never 404)", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/accounts"),
@@ -490,17 +474,49 @@ describe("GET /api/v1/accounts via the Worker", () => {
     assert.equal(res.status, 400);
   });
 
-  test("?format=csv returns a CSV download of the accounts rows", async () => {
+  test("?format=csv exports the leaderboard rows via the Postgres tier", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            sort: "total_stake",
+            limit: 20,
+            account_count: 1,
+            captured_at: new Date(1750000000000).toISOString(),
+            block_number: 8454388,
+            accounts: [
+              {
+                hotkey: "hk-a",
+                coldkey: "ck-a",
+                coldkey_count: 1,
+                subnet_count: 1,
+                uid_count: 1,
+                validator_count: 1,
+                miner_count: 0,
+                total_stake_tao: 1000.5,
+                total_emission_tao: 22.1,
+                stake_dominance: 1,
+                latest_captured_at: new Date(1750000000000).toISOString(),
+                latest_block_number: 8454388,
+                subnets: [{ netuid: 1, uid: 0 }],
+              },
+            ],
+          }),
+      },
+    };
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/accounts?format=csv"),
-      accountsListEnv([{ ...ROW, hotkey: "hk-a" }]),
+      env,
       ctx,
     );
     assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type") ?? "", /text\/csv/);
-    const text = await res.text();
-    assert.match(text, /^hotkey,coldkey,coldkey_count/);
-    assert.match(text, /hk-a/);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 2);
+    assert.match(lines[1], /^hk-a,ck-a,/);
   });
 
   test("testnet has no variant (mainnet-only neurons-derived leaderboard)", async () => {

--- a/tests/alpha-volume.test.mjs
+++ b/tests/alpha-volume.test.mjs
@@ -504,37 +504,6 @@ function volumeEnv(rows, captured = {}) {
 }
 
 describe("GET /api/v1/subnets/{netuid}/volume via the Worker", () => {
-  test("returns the 24h volume scorecard for a warm D1", async () => {
-    const captured = {};
-    const env = volumeEnv(
-      [
-        {
-          event_kind: STAKE_ADDED_KIND,
-          alpha_volume: 100,
-          tao_volume: 20,
-          event_count: 3,
-        },
-      ],
-      captured,
-    );
-    const res = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/subnets/7/volume"),
-      env,
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.window, "24h");
-    assert.equal(body.data.buy_volume_alpha, 100);
-    assert.equal(body.data.net_volume_alpha, 100);
-    assert.equal(body.data.sentiment, "bullish");
-    // Neither KV (METAGRAPH_CONTROL unbound) nor the R2 fallback (no local
-    // economics.json in this test env) has a market-cap row for this subnet.
-    assert.equal(body.data.vol_mcap_ratio, null);
-    assert.match(captured.sql, /FROM account_events/);
-  });
-
   test("is schema-stable when D1 is cold (never 404)", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/subnets/7/volume"),
@@ -545,50 +514,6 @@ describe("GET /api/v1/subnets/{netuid}/volume via the Worker", () => {
     const body = await res.json();
     assert.equal(body.data.total_volume_alpha, 0);
     assert.equal(body.data.vol_mcap_ratio, null);
-  });
-
-  test("computes vol_mcap_ratio from a warm live economics KV tier", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
-    const env = volumeEnv([
-      {
-        event_kind: STAKE_ADDED_KIND,
-        alpha_volume: 1,
-        tao_volume: 20,
-        event_count: 1,
-      },
-      {
-        event_kind: STAKE_REMOVED_KIND,
-        alpha_volume: 1,
-        tao_volume: 4,
-        event_count: 1,
-      },
-    ]);
-    env.METAGRAPH_CONTROL = {
-      async get(key, opts) {
-        assert.equal(key, "economics:current");
-        assert.deepEqual(opts, { type: "json" });
-        return {
-          schema_version: 1,
-          captured_at: new Date().toISOString(),
-          summary: { with_economics_count: 1 },
-          subnets: [
-            { netuid: 7, emission_share: 1, alpha_market_cap_tao: 480 },
-          ],
-        };
-      },
-    };
-    const res = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/subnets/7/volume"),
-      env,
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    // total_volume_tao = 20 + 4 = 24; ratio = 24/480 = 0.05.
-    assert.equal(body.data.total_volume_tao, 24);
-    assert.equal(body.data.vol_mcap_ratio, 0.05);
-    vi.useRealTimers();
   });
 
   test("a stale live economics KV tier falls back to null (no committed artifact locally)", async () => {
@@ -619,46 +544,6 @@ describe("GET /api/v1/subnets/{netuid}/volume via the Worker", () => {
     );
     const body = await res.json();
     assert.equal(body.data.vol_mcap_ratio, null);
-  });
-
-  test("falls back to the committed economics.json when the live KV tier is cold", async () => {
-    const env = volumeEnv([
-      {
-        event_kind: STAKE_ADDED_KIND,
-        alpha_volume: 1,
-        tao_volume: 20,
-        event_count: 1,
-      },
-      {
-        event_kind: STAKE_REMOVED_KIND,
-        alpha_volume: 1,
-        tao_volume: 4,
-        event_count: 1,
-      },
-    ]);
-    // METAGRAPH_CONTROL stays unset (live tier cold) — only the R2 artifact
-    // fallback (resolveSubnetMarketCapTao's readArtifact branch) is wired.
-    env.METAGRAPH_ARCHIVE = {
-      async get() {
-        return {
-          async json() {
-            return {
-              subnets: [
-                { netuid: 7, emission_share: 1, alpha_market_cap_tao: 480 },
-              ],
-            };
-          },
-        };
-      },
-    };
-    const res = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/subnets/7/volume"),
-      env,
-      ctx,
-    );
-    const body = await res.json();
-    assert.equal(body.data.total_volume_tao, 24);
-    assert.equal(body.data.vol_mcap_ratio, 0.05);
   });
 
   test("an unsupported query param is a 400", async () => {

--- a/tests/block-events.test.mjs
+++ b/tests/block-events.test.mjs
@@ -51,39 +51,6 @@ const ROW = {
   observed_at: 1_750_009_000_000,
 };
 
-test("GET /blocks/{ref}/events returns the events in one block by number (#1852)", async () => {
-  const env = dbWith({ events: [ROW], blockNumber: 1_000_000 });
-  const res = await handleRequest(
-    req("/api/v1/blocks/1000000/events"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.ok, true);
-  assert.equal(body.data.ref, "1000000");
-  assert.equal(body.data.block_number, 1000000);
-  assert.equal(body.data.event_count, 1);
-  assert.equal(body.data.events[0].event_kind, "WeightsSet");
-  assert.ok(res.headers.get("etag"));
-  assert.ok(res.headers.get("x-metagraph-contract-version"));
-});
-
-test("GET /blocks/{ref}/events resolves a 0x block_hash ref to its number", async () => {
-  const hash = `0x${"a".repeat(64)}`;
-  const env = dbWith({ events: [ROW], blockNumber: 1_000_000 });
-  const res = await handleRequest(
-    req(`/api/v1/blocks/${hash}/events`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, hash);
-  assert.equal(body.data.block_number, 1000000);
-  assert.equal(body.data.event_count, 1);
-});
-
 test("GET /blocks/{ref}/events honors ?limit and rejects bad params", async () => {
   const env = dbWith({ events: [ROW], blockNumber: 1_000_000 });
   const ok = await handleRequest(

--- a/tests/blocks-summary.test.mjs
+++ b/tests/blocks-summary.test.mjs
@@ -238,17 +238,6 @@ describe("GET /api/v1/blocks/summary", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/blocks/summary${q}`);
 
-  test("summarizes recent block production", async () => {
-    const res = await handleRequest(req(), blocksEnv(ROWS), {});
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.block_count, 5);
-    assert.equal(body.data.block_time.count, 3);
-    assert.equal(body.data.distinct_authors, 2);
-    assert.equal(body.data.throughput.total_extrinsics, 11);
-  });
-
   test("rejects an unexpected query parameter with 400", async () => {
     const res = await handleRequest(req("?window=7d"), blocksEnv([]), {});
     assert.equal(res.status, 400);

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -367,29 +367,6 @@ function dbWith({ feed, detail, neighbors } = {}) {
   };
 }
 
-test("GET /blocks returns the recent feed newest-first (#1345)", async () => {
-  const env = dbWith({
-    feed: [
-      {
-        block_number: 200,
-        block_hash: "0xb200",
-        parent_hash: "0xb199",
-        author: null,
-        extrinsic_count: 3,
-        event_count: 9,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(req("/api/v1/blocks"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.block_count, 1);
-  assert.equal(body.data.blocks[0].block_number, 200);
-  assert.equal(body.data.blocks[0].extrinsic_count, 3);
-  assert.equal(body.data.limit, 50);
-});
-
 test("GET /blocks clamps limit to <=100 + rejects unsupported params", async () => {
   const env = dbWith({ feed: [] });
   const ok = await handleRequest(req("/api/v1/blocks?limit=999"), env, {});
@@ -420,76 +397,6 @@ test("GET /blocks rejects non-integer numeric filters with 400 (#2310)", async (
   }
 });
 
-test("GET /blocks?cursor= seeks by keyset + emits next_cursor (#1851)", async () => {
-  let boundSql;
-  let boundParams;
-  const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        boundSql = sql;
-        return {
-          bind(...p) {
-            boundParams = p;
-            return {
-              async all() {
-                // Return exactly `limit` rows so a next_cursor is emitted.
-                return {
-                  results: [
-                    { block_number: 150, block_hash: "0x150", observed_at: 1 },
-                  ],
-                };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-  const res = await handleRequest(
-    req(`/api/v1/blocks?limit=1&cursor=${encodeCursor([200])}`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  // Keyset seek (not OFFSET) and the cursor's block_number is bound.
-  assert.ok(/WHERE block_number < \?/.test(boundSql));
-  assert.ok(!/OFFSET/.test(boundSql));
-  assert.equal(boundParams[0], 200);
-  // A full page → next_cursor points past the last row (block 150).
-  assert.equal(body.data.next_cursor, encodeCursor([150]));
-});
-
-test("GET /blocks emits next_cursor when D1 returns numeric-string block_number", async () => {
-  const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        return {
-          bind() {
-            return {
-              async all() {
-                return {
-                  results: [
-                    {
-                      block_number: "150",
-                      block_hash: "0x150",
-                      observed_at: 1,
-                    },
-                  ],
-                };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-  const res = await handleRequest(req("/api/v1/blocks?limit=1"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.next_cursor, encodeCursor([150]));
-});
-
 test("GET /blocks emits next_cursor:null when the page is not full (#1851)", async () => {
   const env = dbWith({
     feed: [{ block_number: 9, block_hash: "0x9", observed_at: 1 }],
@@ -497,80 +404,6 @@ test("GET /blocks emits next_cursor:null when the page is not full (#1851)", asy
   const res = await handleRequest(req("/api/v1/blocks?limit=50"), env, {});
   const body = await res.json();
   assert.equal(body.data.next_cursor, null);
-});
-
-test("GET /blocks/{number} returns detail by block_number (#1345)", async () => {
-  const env = dbWith({
-    detail: {
-      block_number: 1234,
-      block_hash: "0xabc",
-      parent_hash: "0xpar",
-      author: "5Author",
-      extrinsic_count: 5,
-      event_count: 20,
-      observed_at: 1750009000000,
-    },
-  });
-  const res = await handleRequest(req("/api/v1/blocks/1234"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, "1234");
-  assert.equal(body.data.block.block_number, 1234);
-  assert.equal(body.data.block.block_hash, "0xabc");
-});
-
-test("GET /blocks/{ref} emits nearest stored prev/next neighbors (#1853)", async () => {
-  const env = dbWith({
-    detail: { block_number: 1234, block_hash: "0xabc", observed_at: 1 },
-    neighbors: { prev: 1230, next: 1240 }, // gaps skipped (pruned/missing)
-  });
-  const res = await handleRequest(req("/api/v1/blocks/1234"), env, {});
-  const body = await res.json();
-  assert.equal(body.data.prev_block_number, 1230);
-  assert.equal(body.data.next_block_number, 1240);
-});
-
-test("GET /blocks/{ref} resolves neighbors when D1 returns block_number as a string (#1853)", async () => {
-  // D1 can return the INTEGER block_number as a numeric string. The REST detail
-  // handler must coerce the resolved anchor before the MAX/MIN neighbor lookup —
-  // a bare Number.isInteger("1234") is false, which skipped the query and wrongly
-  // reported prev/next_block_number: null for a block that has neighbors.
-  const env = dbWith({
-    detail: { block_number: "1234", block_hash: "0xabc", observed_at: 1 },
-    neighbors: { prev: 1230, next: 1240 },
-  });
-  const res = await handleRequest(req("/api/v1/blocks/1234"), env, {});
-  const body = await res.json();
-  assert.equal(body.data.block.block_number, 1234);
-  assert.equal(body.data.prev_block_number, 1230);
-  assert.equal(body.data.next_block_number, 1240);
-});
-
-test("GET /blocks/{ref} nulls neighbors at a window edge (#1853)", async () => {
-  const env = dbWith({
-    detail: { block_number: 1, block_hash: "0x1", observed_at: 1 },
-    neighbors: { prev: null, next: 2 }, // oldest stored block: no prev
-  });
-  const res = await handleRequest(req("/api/v1/blocks/1"), env, {});
-  const body = await res.json();
-  assert.equal(body.data.prev_block_number, null);
-  assert.equal(body.data.next_block_number, 2);
-});
-
-test("GET /blocks/{hash} resolves a 0x block_hash ref (#1345)", async () => {
-  const hash = `0x${"a".repeat(64)}`;
-  const env = dbWith({
-    detail: {
-      block_number: 9,
-      block_hash: hash,
-      observed_at: 1750009000000,
-    },
-  });
-  const res = await handleRequest(req(`/api/v1/blocks/${hash}`), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, hash);
-  assert.equal(body.data.block.block_hash, hash);
 });
 
 test("GET /blocks/{ref} is schema-stable when cold (block:null, never 404)", async () => {
@@ -657,44 +490,6 @@ for (const badRef of BAD_BLOCK_REFS) {
 
 // A well-formed numeric ref still resolves (the strict matcher must not
 // over-reject the canonical decimal form).
-test("handleBlock resolves a well-formed numeric ref (#2063 regression guard)", async () => {
-  const env = dbWith({
-    detail: { block_number: 1234, block_hash: "0xabc", observed_at: 5 },
-  });
-  const res = await handleBlock(req("/api/v1/blocks/1234"), env, "1234");
-  const body = await res.json();
-  assert.equal(body.data.block.block_number, 1234);
-});
-
-test("GET /blocks/{number}/extrinsics returns the block's extrinsics (#1845)", async () => {
-  const env = dbWith({
-    detail: { block_number: 1234 },
-    feed: [
-      {
-        block_number: 1234,
-        extrinsic_index: 0,
-        extrinsic_hash: `0x${"c".repeat(64)}`,
-        signer: "5Signer",
-        call_module: "Timestamp",
-        call_function: "set",
-        success: 1,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req("/api/v1/blocks/1234/extrinsics"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, "1234");
-  assert.equal(body.data.block_number, 1234);
-  assert.equal(body.data.extrinsic_count, 1);
-  assert.equal(body.data.extrinsics[0].call_function, "set");
-});
-
 test("GET /blocks/{number}/extrinsics is schema-stable when the number is unknown (#1845)", async () => {
   const res = await handleRequest(
     req("/api/v1/blocks/777/extrinsics"),
@@ -707,31 +502,6 @@ test("GET /blocks/{number}/extrinsics is schema-stable when the number is unknow
   assert.equal(body.data.block_number, null);
   assert.equal(body.data.extrinsic_count, 0);
   assert.equal(Array.isArray(body.data.extrinsics), true);
-});
-
-test("GET /blocks/{hash}/extrinsics resolves the hash then lists extrinsics (#1845)", async () => {
-  const hash = `0x${"a".repeat(64)}`;
-  const env = dbWith({
-    detail: { block_number: 9 },
-    feed: [
-      {
-        block_number: 9,
-        extrinsic_index: 1,
-        extrinsic_hash: `0x${"b".repeat(64)}`,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(
-    req(`/api/v1/blocks/${hash}/extrinsics`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, hash);
-  assert.equal(body.data.block_number, 9);
-  assert.equal(body.data.extrinsics[0].extrinsic_index, 1);
 });
 
 test("GET /blocks/{hash}/extrinsics is schema-stable when the hash is unknown (#1845)", async () => {

--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -275,40 +275,6 @@ describe("GET /api/v1/chain/concentration", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/concentration${q}`);
 
-  test("aggregates the neurons tier across all subnets", async () => {
-    const res = await handleRequest(
-      req(),
-      neuronsEnv([
-        {
-          stake_tao: 10,
-          emission_tao: 1,
-          coldkey: "ck-a",
-          validator_permit: 1,
-          netuid: 1,
-          captured_at: 1_700_000_000_000,
-        },
-        {
-          stake_tao: 20,
-          emission_tao: 2,
-          coldkey: "ck-b",
-          validator_permit: 0,
-          netuid: 2,
-          captured_at: 1_700_000_000_000,
-        },
-      ]),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.entity_count, 2);
-    assert.equal(body.data.stake.holders, 2);
-    assert.equal(body.data.stake.total, 30);
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
   test("rejects an unexpected query parameter with 400", async () => {
     const res = await handleRequest(req("?window=7d"), neuronsEnv([]), {});
     assert.equal(res.status, 400);

--- a/tests/chain-performance-handler.test.mjs
+++ b/tests/chain-performance-handler.test.mjs
@@ -7,47 +7,8 @@ import { describe, test } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import { buildOpenApiArtifact } from "../src/contracts.mjs";
-import { CHAIN_PERFORMANCE_READ_COLUMNS } from "../src/chain-performance.mjs";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 import { handleChainPerformance } from "../workers/request-handlers/entities.mjs";
-
-const CAPTURED_MS = 1_700_000_000_000;
-
-const ROWS = [
-  {
-    incentive: 0.6,
-    dividends: 0.5,
-    trust: 0.9,
-    consensus: 0.8,
-    validator_trust: 0.95,
-    active: 1,
-    validator_permit: 1,
-    netuid: 7,
-    captured_at: CAPTURED_MS,
-  },
-  {
-    incentive: 0.3,
-    dividends: 0.1,
-    trust: 0.7,
-    consensus: 0.6,
-    validator_trust: 0.85,
-    active: 1,
-    validator_permit: 1,
-    netuid: 7,
-    captured_at: CAPTURED_MS,
-  },
-  {
-    incentive: 0.1,
-    dividends: 0,
-    trust: 0.4,
-    consensus: 0.3,
-    validator_trust: 0,
-    active: 1,
-    validator_permit: 0,
-    netuid: 12,
-    captured_at: CAPTURED_MS,
-  },
-];
 
 function req(path) {
   return new Request(`https://api.metagraph.sh${path}`);
@@ -105,36 +66,6 @@ async function assertValidComponent(componentName, data) {
 }
 
 describe("handleChainPerformance happy path", () => {
-  test("summarizes reward + score spread across all subnets", async () => {
-    const capture = [];
-    const body = await json(
-      await handleChainPerformance(
-        req("/api/v1/chain/performance"),
-        neuronsEnv(ROWS, capture),
-        url("/api/v1/chain/performance"),
-      ),
-    );
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.neuron_count, 3);
-    assert.equal(body.data.validator_count, 2);
-    assert.equal(body.data.active_count, 3);
-    assert.equal(body.data.incentive.holders, 3);
-    assert.equal(body.data.dividends.holders, 2);
-    assert.equal(body.data.trust.count, 3);
-    assert.equal(body.data.captured_at, new Date(CAPTURED_MS).toISOString());
-    assert.equal(body.meta.source, "metagraph-snapshot");
-    assert.equal(body.meta.artifact_path, "/metagraph/chain/performance.json");
-    assert.equal(body.meta.generated_at, new Date(CAPTURED_MS).toISOString());
-    await assertValidComponent("ChainPerformanceArtifact", body.data);
-    const captured = capture[0];
-    assert.ok(captured);
-    assert.match(captured.sql, /FROM neurons/);
-    assert.doesNotMatch(captured.sql, /WHERE netuid/);
-    assert.equal(captured.params.length, 0);
-    assert.match(captured.sql, new RegExp(CHAIN_PERFORMANCE_READ_COLUMNS));
-  });
-
   test("returns schema-stable null blocks on cold D1", async () => {
     const body = await json(
       await handleChainPerformance(

--- a/tests/chain-performance.test.mjs
+++ b/tests/chain-performance.test.mjs
@@ -230,46 +230,6 @@ describe("GET /api/v1/chain/performance", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/performance${q}`);
 
-  test("summarizes reward + score spread across all subnets", async () => {
-    const res = await handleRequest(
-      req(),
-      neuronsEnv([
-        {
-          incentive: 0.6,
-          dividends: 0.5,
-          trust: 0.9,
-          consensus: 0.8,
-          validator_trust: 0.95,
-          active: 1,
-          validator_permit: 1,
-          netuid: 1,
-          captured_at: 1_700_000_000_000,
-        },
-        {
-          incentive: 0.2,
-          dividends: 0,
-          trust: 0.4,
-          consensus: 0.3,
-          validator_trust: 0,
-          active: 1,
-          validator_permit: 0,
-          netuid: 2,
-          captured_at: 1_700_000_000_000,
-        },
-      ]),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.validator_count, 1);
-    assert.equal(body.data.incentive.holders, 2);
-    assert.equal(body.data.trust.count, 2);
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
   test("rejects an unexpected query parameter with 400", async () => {
     const res = await handleRequest(req("?window=7d"), neuronsEnv([]), {});
     assert.equal(res.status, 400);

--- a/tests/chain-turnover.test.mjs
+++ b/tests/chain-turnover.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { afterEach, describe, test } from "vitest";
+import { describe, test } from "vitest";
 import {
   buildChainTurnover,
   loadChainTurnover,
@@ -382,25 +382,6 @@ describe("GET /api/v1/chain/turnover", () => {
   const request = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/turnover${q}`);
 
-  test("dispatches to the network validator turnover scorecard", async () => {
-    const res = await handleRequest(
-      request(),
-      neuronDailyEnv({
-        bounds: [{ start_date: START, end_date: END }],
-        rows: ROWS,
-      }),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.comparable, true);
-    assert.equal(body.data.subnets[0].netuid, 1);
-    assert.equal(body.meta.source, "metagraph-snapshot");
-    assert.equal(body.meta.artifact_path, "/metagraph/chain/turnover.json");
-  });
-
   test("serves a schema-stable empty scorecard on a cold store", async () => {
     const res = await handleRequest(
       request(),
@@ -448,25 +429,6 @@ describe("GET /api/v1/chain/turnover", () => {
     "netuid,validators_start,validators_end,validators_entered,validators_exited,validator_retention,stability_score";
   const warm = { bounds: [{ start_date: START, end_date: END }], rows: ROWS };
   const cold = { bounds: [{ start_date: null, end_date: null }], rows: [] };
-
-  test("exports the per-subnet churn leaderboard as CSV with ?format=csv", async () => {
-    const res = await handleRequest(
-      request("?window=30d&format=csv"),
-      neuronDailyEnv(warm),
-      {},
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /text\/csv/);
-    assert.match(
-      res.headers.get("content-disposition"),
-      /attachment; filename="chain-turnover\.csv"/,
-    );
-    const lines = (await res.text()).trim().split("\r\n");
-    assert.equal(lines[0], TURNOVER_CSV_HEADER);
-    // Most-volatile first: netuid 1 (churn 2) leads, then the stable netuid 2.
-    assert.equal(lines.length, 3); // header + 2 subnet rows
-    assert.equal(lines[1], "1,2,2,1,1,0.3333,33");
-  });
 
   test("honors Accept: text/csv the same as ?format=csv", async () => {
     const res = await handleRequest(
@@ -561,86 +523,11 @@ describe("readNeuronDailyCacheStamp", () => {
   });
 });
 
-describe("chain/turnover edge cache", () => {
-  let originalCaches;
-  afterEach(() => {
-    globalThis.caches = originalCaches;
-  });
-
-  // The latest neuron_daily snapshot_date the stamp query returns — mutated mid-test to simulate a
-  // rollup refresh. Every SELECT the stamp resolver runs is recorded so the test can assert the
-  // stamp reads neuron_daily (its actual source table), not the live neurons tier.
-  function turnoverEnv(state) {
-    return {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind: () => ({
-              all: () => {
-                // The busting stamp query uses the indexed latest snapshot_date; the window
-                // boundary hits MIN(snapshot_date); the rest is the validator read.
-                if (/ORDER BY snapshot_date DESC LIMIT 1/.test(sql)) {
-                  state.stampSql = sql;
-                  return Promise.resolve({
-                    results: [{ snapshot_date: state.snapshotDate }],
-                  });
-                }
-                if (/MIN\(snapshot_date\)/.test(sql)) {
-                  return Promise.resolve({
-                    results: [{ start_date: START, end_date: END }],
-                  });
-                }
-                return Promise.resolve({ results: ROWS });
-              },
-            }),
-          };
-        },
-      },
-    };
-  }
-
-  test("caches keyed on the neuron_daily stamp and busts when neuron_daily refreshes", async () => {
-    originalCaches = globalThis.caches;
-    const store = new Map();
-    globalThis.caches = {
-      default: {
-        async match(request) {
-          const cached = store.get(request.url);
-          return cached ? cached.clone() : undefined;
-        },
-        async put(request, response) {
-          store.set(request.url, response.clone());
-        },
-      },
-    };
-    const state = { snapshotDate: "2026-06-27", stampSql: null };
-    const env = turnoverEnv(state);
-    const call = () =>
-      handleRequest(
-        new Request("https://api.metagraph.sh/api/v1/chain/turnover"),
-        env,
-        { waitUntil: (promise) => promise },
-      );
-
-    const res = await call();
-    assert.equal(res.status, 200);
-    assert.equal((await res.json()).data.subnet_count, 2);
-    assert.equal(store.size, 1); // the response was cached under the neuron_daily stamp key
-    // The stamp resolver reads neuron_daily (its real source), not the live neurons tier — so a
-    // daily-rollup refresh, and only that, invalidates this neuron_daily-derived artifact.
-    assert.match(state.stampSql, /FROM neuron_daily/);
-    assert.doesNotMatch(state.stampSql, /FROM neurons\b/);
-
-    // Same stamp -> served from the existing cache entry (no new key).
-    await call();
-    assert.equal(store.size, 1);
-
-    // Simulate a neuron_daily rollup refresh: a new snapshot_date -> a new stamp -> a new
-    // cache key, so the stale entry is not reused and the artifact is recomputed and re-cached.
-    state.snapshotDate = "2026-06-28";
-    const refreshed = await call();
-    assert.equal(refreshed.status, 200);
-    assert.equal(store.size, 2); // busted: a second cache entry under the new stamp
-  });
-});
+// #4909 D1 retirement: the "chain/turnover edge cache" describe block that
+// used to live here asserted the edge cache busts when the mocked D1
+// neuron_daily stamp changes. neurons/neuron_daily's D1 write path is
+// retired (#4772) and the tables are dropped in production, so
+// handleChainTurnover no longer queries D1 for its data at all — the
+// response is a fixed schema-stable-empty literal on a Postgres miss and
+// never varies with the D1 fixture, so there is nothing left for a
+// stamp-busts-the-cache assertion to observe.

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -297,38 +297,6 @@ describe("GET /api/v1/chain/yield", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/yield${q}`);
 
-  test("summarizes network yield across all subnets", async () => {
-    const res = await handleRequest(
-      req(),
-      neuronsEnv([
-        {
-          validator_permit: 1,
-          stake_tao: 1000,
-          emission_tao: 50,
-          netuid: 1,
-          captured_at: 1_700_000_000_000,
-        },
-        {
-          validator_permit: 0,
-          stake_tao: 100,
-          emission_tao: 10,
-          netuid: 2,
-          captured_at: 1_700_000_000_000,
-        },
-      ]),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.validator_count, 1);
-    assert.ok(Math.abs(body.data.network_yield - 60 / 1100) < 1e-6);
-    assert.equal(body.data.distribution.count, 2);
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
   test("rejects an unexpected query parameter with 400", async () => {
     const res = await handleRequest(req("?window=7d"), neuronsEnv([]), {});
     assert.equal(res.status, 400);

--- a/tests/extrinsic-detail.test.mjs
+++ b/tests/extrinsic-detail.test.mjs
@@ -6,11 +6,6 @@ import {
   loadBlockChainEvents,
   loadExtrinsicChainEvents,
 } from "../src/data-api-mcp.mjs";
-import { handleExtrinsic } from "../workers/request-handlers/entities.mjs";
-
-function req(path) {
-  return new Request(`https://api.metagraph.sh${path}`);
-}
 
 function d1With(fixtures = {}, capture = []) {
   return async (sql, params) => {
@@ -182,43 +177,6 @@ describe("loadExtrinsicDetail", () => {
     };
     const data = await loadExtrinsicDetail(d1, "4200000-3");
     assert.deepEqual(data.events, []);
-  });
-});
-
-describe("handleExtrinsic via loadExtrinsicDetail", () => {
-  test("returns embedded events through the shared loader", async () => {
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind() {
-              return {
-                all() {
-                  if (
-                    /FROM extrinsics WHERE block_number = \? AND extrinsic_index/.test(
-                      sql,
-                    )
-                  )
-                    return Promise.resolve({ results: [EXTRINSIC] });
-                  if (/FROM account_events/.test(sql))
-                    return Promise.resolve({ results: [EVENT] });
-                  return Promise.resolve({ results: [] });
-                },
-              };
-            },
-          };
-        },
-      },
-    };
-    const res = await handleExtrinsic(
-      req("/api/v1/extrinsics/4200000-3"),
-      env,
-      "4200000-3",
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.events.length, 1);
-    assert.equal(body.data.events[0].event_kind, "WeightsSet");
   });
 });
 

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -578,76 +578,6 @@ function dbWith({ feed, detail, events } = {}) {
   };
 }
 
-test("GET /extrinsics returns the recent feed newest-first (#1345)", async () => {
-  const env = dbWith({
-    feed: [
-      {
-        block_number: 200,
-        extrinsic_index: 2,
-        extrinsic_hash: `0x${"b".repeat(64)}`,
-        signer: "5Signer",
-        call_module: "SubtensorModule",
-        call_function: "add_stake",
-        success: 1,
-        observed_at: 1750009000000,
-      },
-    ],
-  });
-  const res = await handleRequest(req("/api/v1/extrinsics"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.extrinsic_count, 1);
-  assert.equal(body.data.extrinsics[0].block_number, 200);
-  assert.equal(body.data.extrinsics[0].call_function, "add_stake");
-  assert.equal(body.data.extrinsics[0].success, true);
-  assert.equal(body.data.limit, 50);
-});
-
-test("GET /extrinsics?cursor= seeks by the composite keyset + emits next_cursor (#1851)", async () => {
-  let boundSql;
-  let boundParams;
-  const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        boundSql = sql;
-        return {
-          bind(...p) {
-            boundParams = p;
-            return {
-              async all() {
-                return {
-                  results: [
-                    {
-                      block_number: 150,
-                      extrinsic_index: 4,
-                      extrinsic_hash: `0x${"a".repeat(64)}`,
-                      observed_at: 1,
-                    },
-                  ],
-                };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-  const res = await handleRequest(
-    req(`/api/v1/extrinsics?limit=1&cursor=${encodeCursor([200, 2])}`),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  // Row-value seek on the (block_number, extrinsic_index) PK, no OFFSET.
-  assert.ok(/\(block_number, extrinsic_index\) < \(\?, \?\)/.test(boundSql));
-  assert.ok(!/OFFSET/.test(boundSql));
-  assert.ok(boundParams.includes(200));
-  assert.ok(boundParams.includes(2));
-  // Full page → next_cursor past the last row (150, 4).
-  assert.equal(body.data.next_cursor, encodeCursor([150, 4]));
-});
-
 test("GET /extrinsics clamps limit to <=100 + rejects unsupported params", async () => {
   const env = dbWith({ feed: [] });
   const ok = await handleRequest(req("/api/v1/extrinsics?limit=999"), env, {});
@@ -678,142 +608,6 @@ test("GET /extrinsics rejects non-numeric value filters with 400 (#2086)", async
   }
 });
 
-test("GET /extrinsics?block=<n> scopes the feed to one block (#1345)", async () => {
-  let boundSql;
-  const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        boundSql = sql;
-        return {
-          bind() {
-            return {
-              async all() {
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-  const res = await handleRequest(
-    req("/api/v1/extrinsics?block=1234"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.ok(/WHERE block_number = \?/.test(boundSql));
-});
-
-test("GET /extrinsics applies the conjunctive filter set (#1846)", async () => {
-  let boundSql;
-  let boundParams;
-  const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        boundSql = sql;
-        return {
-          bind(...p) {
-            boundParams = p;
-            return {
-              async all() {
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-  // from/to must land inside the retained hot window; an impossible/expired
-  // range (e.g. the 1970 epoch) is intentionally short-circuited before the
-  // WHERE clause is ever built (#1846 DoS hardening), so use a recent window
-  // here to exercise the full conjunctive filter path this test asserts.
-  const toMs = Date.now();
-  const fromMs = toMs - 60_000;
-  const res = await handleRequest(
-    req(
-      `/api/v1/extrinsics?signer=5Signer&call_module=SubtensorModule&call_function=add_stake&success=false&block_start=100&block_end=200&from=${fromMs}&to=${toMs}`,
-    ),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.ok(/signer = \?/.test(boundSql));
-  assert.ok(/call_module = \?/.test(boundSql));
-  assert.ok(/call_function = \?/.test(boundSql));
-  assert.ok(/success = \?/.test(boundSql));
-  assert.ok(/block_number >= \?/.test(boundSql));
-  assert.ok(/block_number <= \?/.test(boundSql));
-  assert.ok(/observed_at >= \?/.test(boundSql));
-  assert.ok(/observed_at <= \?/.test(boundSql));
-  // success=false binds the literal 0 (never !=1, which would leak NULL rows).
-  assert.ok(boundParams.includes(0));
-  assert.ok(boundParams.includes("5Signer"));
-  // limit + offset are the last two bound params.
-  assert.equal(boundParams.at(-2), 50);
-  assert.equal(boundParams.at(-1), 0);
-});
-
-test("GET /extrinsics?success=true binds 1; an invalid success returns 400 (#2575)", async () => {
-  let boundSql;
-  let boundParams;
-  const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        boundSql = sql;
-        return {
-          bind(...p) {
-            boundParams = p;
-            return {
-              async all() {
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-  await handleRequest(req("/api/v1/extrinsics?success=true"), env, {});
-  assert.ok(/success = \?/.test(boundSql));
-  assert.ok(boundParams.includes(1));
-
-  const bad = await handleRequest(
-    req("/api/v1/extrinsics?success=maybe"),
-    env,
-    {},
-  );
-  assert.equal(bad.status, 400);
-  const body = await bad.json();
-  assert.equal(body.ok, false);
-  assert.equal(body.error.code, "invalid_query");
-  assert.equal(body.meta.parameter, "success");
-});
-
-test("GET /extrinsics/{hash} returns detail by extrinsic_hash (#1345)", async () => {
-  const hash = `0x${"c".repeat(64)}`;
-  const env = dbWith({
-    detail: {
-      block_number: 1234,
-      extrinsic_index: 3,
-      extrinsic_hash: hash,
-      signer: "5Signer",
-      call_module: "Balances",
-      call_function: "transfer",
-      success: 0,
-      observed_at: 1750009000000,
-    },
-  });
-  const res = await handleRequest(req(`/api/v1/extrinsics/${hash}`), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, hash);
-  assert.equal(body.data.extrinsic.extrinsic_hash, hash);
-  assert.equal(body.data.extrinsic.call_function, "transfer");
-  assert.equal(body.data.extrinsic.success, false);
-});
-
 test("GET /extrinsics/{hash} is schema-stable when cold (extrinsic:null, never 404)", async () => {
   const hash = `0x${"d".repeat(64)}`;
   const res = await handleRequest(req(`/api/v1/extrinsics/${hash}`), {}, {});
@@ -821,28 +615,6 @@ test("GET /extrinsics/{hash} is schema-stable when cold (extrinsic:null, never 4
   const body = await res.json();
   assert.equal(body.data.ref, hash);
   assert.equal(body.data.extrinsic, null);
-});
-
-test("GET /extrinsics/{block}-{index} resolves by the composite id (#1848)", async () => {
-  const env = dbWith({
-    detail: {
-      block_number: 1234,
-      extrinsic_index: 3,
-      extrinsic_hash: null,
-      call_module: "Timestamp",
-      call_function: "set",
-      success: 1,
-      observed_at: 1750009000000,
-    },
-  });
-  const res = await handleRequest(req("/api/v1/extrinsics/1234-3"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.ref, "1234-3");
-  assert.equal(body.data.extrinsic.block_number, 1234);
-  assert.equal(body.data.extrinsic.extrinsic_index, 3);
-  // A null-hash extrinsic — previously unaddressable — is now reachable.
-  assert.equal(body.data.extrinsic.extrinsic_hash, null);
 });
 
 test("GET /extrinsics/{block}-{index} is schema-stable when cold (#1848)", async () => {
@@ -853,42 +625,6 @@ test("GET /extrinsics/{block}-{index} is schema-stable when cold (#1848)", async
   assert.equal(body.data.extrinsic, null);
   // The events embed (#1849) is always present + empty when the ref is cold.
   assert.deepEqual(body.data.events, []);
-});
-
-test("GET /extrinsics/{ref} embeds the events the extrinsic emitted (#1849)", async () => {
-  const hash = `0x${"e".repeat(64)}`;
-  const env = dbWith({
-    detail: {
-      block_number: 1234,
-      extrinsic_index: 2,
-      extrinsic_hash: hash,
-      call_module: "SubtensorModule",
-      call_function: "add_stake",
-      success: 1,
-      observed_at: 1750009000000,
-    },
-    events: [
-      {
-        block_number: 1234,
-        event_index: 5,
-        event_kind: "StakeAdded",
-        hotkey: "5Hk",
-        coldkey: "5Co",
-        netuid: 7,
-        uid: 3,
-        amount_tao: 1.5,
-        observed_at: 1750009000000,
-        extrinsic_index: 2,
-      },
-    ],
-  });
-  const res = await handleRequest(req(`/api/v1/extrinsics/${hash}`), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.extrinsic.extrinsic_index, 2);
-  assert.equal(body.data.events.length, 1);
-  assert.equal(body.data.events[0].event_kind, "StakeAdded");
-  assert.equal(body.data.events[0].extrinsic_index, 2);
 });
 
 // #2063: the composite "<block>-<index>" parser used split("-") + Number(),
@@ -938,28 +674,6 @@ for (const badRef of [
 
 // A well-formed composite ref still resolves (the strict matcher must not
 // over-reject the canonical "<block>-<index>" form).
-test("handleExtrinsic resolves a well-formed composite ref (#2063 regression guard)", async () => {
-  const env = dbWith({
-    detail: {
-      block_number: 1234,
-      extrinsic_index: 3,
-      extrinsic_hash: null,
-      call_module: "Timestamp",
-      call_function: "set",
-      success: 1,
-      observed_at: 1750009000000,
-    },
-  });
-  const res = await handleExtrinsic(
-    req("/api/v1/extrinsics/1234-3"),
-    env,
-    "1234-3",
-  );
-  const body = await res.json();
-  assert.equal(body.data.extrinsic.block_number, 1234);
-  assert.equal(body.data.extrinsic.extrinsic_index, 3);
-});
-
 test("GET /extrinsics is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(req("/api/v1/extrinsics"), {}, {});
   assert.equal(res.status, 200);

--- a/tests/governance-config-changes.test.mjs
+++ b/tests/governance-config-changes.test.mjs
@@ -31,57 +31,6 @@ function dbWith(feed, captured = {}) {
   };
 }
 
-function configChangeRow(overrides = {}) {
-  return {
-    block_number: 300,
-    extrinsic_index: 3,
-    extrinsic_hash: `0x${"c".repeat(64)}`,
-    signer: "5AdminKey",
-    call_module: "AdminUtils",
-    call_function: "sudo_set_tempo",
-    call_args: JSON.stringify([{ netuid: 5 }, { tempo: 500 }]),
-    success: 1,
-    fee_tao: 0.000123,
-    tip_tao: 0,
-    observed_at: 1750009000000,
-    ...overrides,
-  };
-}
-
-test("GET /api/v1/governance/config-changes returns the AdminUtils-filtered feed newest-first (#4310/2.3)", async () => {
-  const captured = {};
-  const env = dbWith([configChangeRow()], captured);
-  const res = await handleRequest(
-    req("/api/v1/governance/config-changes"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.extrinsic_count, 1);
-  assert.equal(body.data.extrinsics[0].block_number, 300);
-  assert.equal(body.data.extrinsics[0].call_module, "AdminUtils");
-  assert.equal(body.data.extrinsics[0].call_function, "sudo_set_tempo");
-  assert.equal(body.data.extrinsics[0].success, true);
-});
-
-test("GET /api/v1/governance/config-changes hardcodes call_module='AdminUtils' regardless of other filters", async () => {
-  const captured = {};
-  const env = dbWith([], captured);
-  await handleRequest(
-    req("/api/v1/governance/config-changes?call_function=sudo_set_kappa"),
-    env,
-    {},
-  );
-  assert.match(captured.sql, /call_module = \?/);
-  assert.ok(
-    captured.params.includes("AdminUtils"),
-    `expected "AdminUtils" bound in ${JSON.stringify(captured.params)}`,
-  );
-  assert.match(captured.sql, /call_function = \?/);
-  assert.ok(captured.params.includes("sudo_set_kappa"));
-});
-
 test("GET /api/v1/governance/config-changes rejects signer and call_module as query params (both are fixed)", async () => {
   const resSigner = await handleRequest(
     req("/api/v1/governance/config-changes?signer=5Anyone"),
@@ -125,39 +74,6 @@ test("GET /api/v1/governance/config-changes rejects an unsupported success value
   assert.equal(res.status, 400);
 });
 
-test("GET /api/v1/governance/config-changes?success=true binds success=1", async () => {
-  const captured = {};
-  await handleRequest(
-    req("/api/v1/governance/config-changes?success=true"),
-    dbWith([], captured),
-    {},
-  );
-  assert.match(captured.sql, /success = \?/);
-  assert.ok(captured.params.includes(1));
-});
-
-test("GET /api/v1/governance/config-changes?success=false binds success=0", async () => {
-  const captured = {};
-  await handleRequest(
-    req("/api/v1/governance/config-changes?success=false"),
-    dbWith([], captured),
-    {},
-  );
-  assert.match(captured.sql, /success = \?/);
-  assert.ok(captured.params.includes(0));
-});
-
-test("GET /api/v1/governance/config-changes?block=<n> scopes the feed to one block", async () => {
-  const captured = {};
-  await handleRequest(
-    req("/api/v1/governance/config-changes?block=300"),
-    dbWith([], captured),
-    {},
-  );
-  assert.match(captured.sql, /block_number = \?/);
-  assert.ok(captured.params.includes(300));
-});
-
 test("GET /api/v1/governance/config-changes is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(
     req("/api/v1/governance/config-changes"),
@@ -170,15 +86,43 @@ test("GET /api/v1/governance/config-changes is schema-stable when D1 is cold (ne
   assert.equal(body.data.extrinsic_count, 0);
 });
 
-test("GET /api/v1/governance/config-changes?format=csv downloads the filtered rows as CSV", async () => {
+test("GET /api/v1/governance/config-changes?format=csv exports the filtered rows via the Postgres tier", async () => {
+  const env = {
+    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: null,
+          extrinsics: [
+            {
+              block_number: 300,
+              extrinsic_index: 3,
+              extrinsic_hash: `0x${"c".repeat(64)}`,
+              signer: "5AdminKey",
+              call_module: "AdminUtils",
+              call_function: "sudo_set_tempo",
+              call_args: null,
+              success: true,
+              fee_tao: 0.000123,
+              tip_tao: 0,
+              observed_at: new Date(1750009000000).toISOString(),
+            },
+          ],
+        }),
+    },
+  };
   const res = await handleRequest(
     req("/api/v1/governance/config-changes?format=csv"),
-    dbWith([configChangeRow()]),
+    env,
     {},
   );
   assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type") || "", /text\/csv/);
-  const text = await res.text();
-  assert.match(text, /call_module/);
-  assert.match(text, /AdminUtils,sudo_set_tempo/);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /^300-3,300,5AdminKey,AdminUtils,sudo_set_tempo,true/);
 });

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -1111,56 +1111,6 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     METAGRAPH_HEALTH_DB: neuronsD1([ROW, MINER]),
   };
 
-  test("GET /subnets/{n}/metagraph returns all neurons", async () => {
-    const { res, body } = await getJson("/api/v1/subnets/7/metagraph", env);
-    assert.equal(res.status, 200);
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.neurons[0].validator_permit, true);
-  });
-
-  test("GET /subnets/{n}/metagraph?format=csv exports neuron rows", async () => {
-    const { res, text } = await getText(
-      "/api/v1/subnets/7/metagraph?format=csv",
-      env,
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /^text\/csv/);
-    assert.equal(
-      res.headers.get("content-disposition"),
-      'attachment; filename="subnet-metagraph.csv"',
-    );
-    const lines = text.split("\r\n");
-    assert.equal(lines[0], NEURON_CSV_HEADER);
-    assert.equal(lines.length, 3);
-    assert.equal(
-      lines[1],
-      "0,5Hk1,5Co1,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
-    );
-    assert.match(lines[2], /^5,5Hk5,5Co1,true,false,/);
-  });
-
-  test("?validator_permit=true filters to validators", async () => {
-    const { body } = await getJson(
-      "/api/v1/subnets/7/metagraph?validator_permit=true",
-      env,
-    );
-    assert.equal(body.data.neurons.length, 1);
-    assert.equal(body.data.neurons[0].uid, 0);
-  });
-
-  test("?validator_permit=true&format=csv narrows metagraph CSV to validators", async () => {
-    const { text } = await getText(
-      "/api/v1/subnets/7/metagraph?validator_permit=true&format=csv",
-      env,
-    );
-    const lines = text.split("\r\n");
-    assert.deepEqual(lines, [
-      NEURON_CSV_HEADER,
-      "0,5Hk1,5Co1,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
-    ]);
-  });
-
   test("GET /subnets/{n}/metagraph?format=csv emits a header-only cold export", async () => {
     const coldEnv = {
       ...createLocalArtifactEnv(),
@@ -1172,200 +1122,6 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     );
     assert.equal(res.status, 200);
     assert.equal(text, NEURON_CSV_HEADER);
-  });
-
-  test("GET /subnets/{n}/yield routes to the emission-yield handler", async () => {
-    const { res, body } = await getJson("/api/v1/subnets/7/yield", env);
-    assert.equal(res.status, 200);
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(Array.isArray(body.data.neurons), true);
-    assert.equal(typeof body.data.validator_count, "number");
-    // ranked by yield desc, so the per-UID yields are non-increasing
-    const ys = body.data.neurons.map((n) => n.yield).filter((y) => y != null);
-    assert.deepEqual(
-      ys,
-      [...ys].sort((a, b) => b - a),
-    );
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
-  test("GET /subnets/{n}/concentration computes per-UID, entity, and validator metrics", async () => {
-    const { res, body } = await getJson("/api/v1/subnets/7/concentration", env);
-    assert.equal(res.status, 200);
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.stake.holders, 2); // 2 UIDs
-    assert.equal(body.data.emission.holders, 2);
-    // ROW + MINER share coldkey "5Co1" → one controlling entity.
-    assert.equal(body.data.entity_count, 1);
-    assert.equal(body.data.uids_per_entity, 2);
-    assert.equal(body.data.entity_stake.holders, 1);
-    // Only ROW carries a validator permit.
-    assert.equal(body.data.validator_stake.holders, 1);
-    assert.equal(typeof body.data.stake.gini, "number");
-    assert.equal(typeof body.data.stake.nakamoto_coefficient, "number");
-  });
-
-  test("GET /subnets/{n}/concentration/history routes to the trend handler", async () => {
-    const dailyEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: neuronsD1([
-        { snapshot_date: "2026-06-27", stake_tao: 100, emission_tao: 5 },
-        { snapshot_date: "2026-06-27", stake_tao: 1, emission_tao: 1 },
-      ]),
-    };
-    const { res, body } = await getJson(
-      "/api/v1/subnets/7/concentration/history?window=7d",
-      dailyEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.window, "7d");
-    assert.equal(Array.isArray(body.data.points), true);
-    assert.equal(body.data.point_count, 1); // both rows share one snapshot_date
-  });
-
-  test("GET /subnets/{n}/turnover routes to the turnover handler", async () => {
-    // Two-query handler: a MIN/MAX boundary probe, then the boundary rows.
-    const turnoverEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind() {
-              return {
-                all() {
-                  if (/MIN\(snapshot_date\)/.test(sql)) {
-                    return Promise.resolve({
-                      results: [
-                        { start_date: "2026-05-28", end_date: "2026-06-27" },
-                      ],
-                    });
-                  }
-                  return Promise.resolve({
-                    results: [
-                      {
-                        snapshot_date: "2026-05-28",
-                        uid: 0,
-                        hotkey: "V1",
-                        validator_permit: 1,
-                      },
-                      {
-                        snapshot_date: "2026-06-27",
-                        uid: 0,
-                        hotkey: "V1",
-                        validator_permit: 1,
-                      },
-                    ],
-                  });
-                },
-              };
-            },
-          };
-        },
-      },
-    };
-    const { res, body } = await getJson(
-      "/api/v1/subnets/7/turnover?window=30d",
-      turnoverEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.comparable, true);
-    assert.equal(body.data.validators_start, 1);
-  });
-
-  test("GET /subnets/{n}/stake-flow routes to the stake-flow handler", async () => {
-    const stakeFlowEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind() {
-              return {
-                all() {
-                  if (/SUM\(amount_tao\)/.test(sql)) {
-                    return Promise.resolve({
-                      results: [
-                        {
-                          event_kind: "StakeAdded",
-                          total_tao: 300,
-                          event_count: 6,
-                          last_observed: 1717900000000,
-                        },
-                        {
-                          event_kind: "StakeRemoved",
-                          total_tao: 100,
-                          event_count: 3,
-                          last_observed: 1717800000000,
-                        },
-                      ],
-                    });
-                  }
-                  return Promise.resolve({ results: [] });
-                },
-              };
-            },
-          };
-        },
-      },
-    };
-    const { res, body } = await getJson(
-      "/api/v1/subnets/7/stake-flow?window=30d",
-      stakeFlowEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.netuid, 7);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.total_staked_tao, 300);
-    assert.equal(body.data.total_unstaked_tao, 100);
-    assert.equal(body.data.net_flow_tao, 200);
-    // account_events provenance + newest event timestamp (ISO string) in the window.
-    assert.equal(body.meta.source, "chain-events");
-    assert.equal(body.meta.generated_at, new Date(1717900000000).toISOString());
-  });
-
-  test("GET /subnets/movers routes to the cross-subnet movers handler", async () => {
-    const moversEnv = createMoversEnv();
-    const { res, body } = await getJson(
-      "/api/v1/subnets/movers?window=30d&sort=stake&limit=10",
-      moversEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.sort, "stake");
-    assert.equal(body.data.start_date, "2026-05-31");
-    assert.equal(body.data.end_date, "2026-06-30");
-    assert.equal(body.data.subnet_count, 2);
-    // subnet 1 (+150 stake) ranks above subnet 2 (-20)
-    assert.equal(body.data.movers[0].netuid, 1);
-    assert.equal(body.data.movers[0].stake_delta_tao, 150);
-    assert.equal(body.data.movers[1].netuid, 2);
-    assert.equal(body.data.movers[1].stake_delta_tao, -20);
-    // neuron_daily provenance + end snapshot date as generated_at.
-    assert.equal(body.meta.source, "metagraph-snapshot");
-    assert.equal(body.meta.generated_at, "2026-06-30");
-  });
-
-  test("GET /subnets/movers?format=csv exports ranked mover rows", async () => {
-    const { res, text } = await getText(
-      "/api/v1/subnets/movers?window=30d&sort=emission&limit=10&format=csv",
-      createMoversEnv(),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /^text\/csv/);
-    assert.equal(
-      res.headers.get("content-disposition"),
-      'attachment; filename="subnet-movers.csv"',
-    );
-    const lines = text.split("\r\n");
-    assert.deepEqual(lines, [
-      MOVERS_CSV_HEADER,
-      "1,100,250,150,150,5,9,4,80,3,4,1,10,12,2",
-      "2,50,30,'-20,'-40,4,4,0,0,2,2,0,8,8,0",
-    ]);
   });
 
   test("GET /subnets/movers?format=csv emits a header-only cold export", async () => {
@@ -1381,80 +1137,12 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     assert.equal(res.status, 400);
   });
 
-  test("GET /subnets/{n}/validators returns only validators", async () => {
-    const { body } = await getJson("/api/v1/subnets/7/validators", env);
-    assert.equal(body.data.validator_count, 1);
-    assert.equal(body.data.validators[0].validator_permit, true);
-  });
-
-  test("GET /subnets/{n}/validators?format=csv exports validator rows", async () => {
-    const { res, text } = await getText(
-      "/api/v1/subnets/7/validators?format=csv",
-      env,
-    );
-    assert.equal(res.status, 200);
-    assert.deepEqual(text.split("\r\n"), [
-      NEURON_CSV_HEADER,
-      "0,5Hk1,5Co1,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
-    ]);
-  });
-
   test("GET /subnets/{n}/validators rejects invalid response formats", async () => {
     const { res } = await getJson(
       "/api/v1/subnets/7/validators?format=xml",
       env,
     );
     assert.equal(res.status, 400);
-  });
-
-  test("GET /validators returns the global validator leaderboard", async () => {
-    const globalEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: neuronsD1([
-        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", stake_tao: 10 },
-        { ...ROW, netuid: 2, uid: 1, hotkey: "hk-a", stake_tao: 20 },
-        { ...ROW, netuid: 3, uid: 0, hotkey: "hk-b", stake_tao: 100 },
-        { ...MINER, netuid: 4, uid: 0, hotkey: "hk-miner", stake_tao: 999 },
-      ]),
-    };
-    const { res, body } = await getJson(
-      "/api/v1/validators?sort=subnet_count&limit=2",
-      globalEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.sort, "subnet_count");
-    assert.equal(body.data.limit, 2);
-    assert.equal(body.data.validator_count, 2);
-    assert.equal(body.data.validators[0].hotkey, "hk-a");
-    assert.equal(body.data.validators[0].subnet_count, 2);
-    assert.equal(body.data.validators[0].uid_count, 2);
-    assert.equal(body.data.validators[1].hotkey, "hk-b");
-    assert.equal(body.meta.artifact_path, "/metagraph/validators.json");
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
-  test("GET /validators?format=csv exports the global validator leaderboard", async () => {
-    const globalEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: neuronsD1([
-        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", stake_tao: 10 },
-        { ...ROW, netuid: 2, uid: 1, hotkey: "hk-a", stake_tao: 20 },
-        { ...ROW, netuid: 3, uid: 0, hotkey: "hk-b", stake_tao: 100 },
-        { ...MINER, netuid: 4, uid: 0, hotkey: "hk-miner", stake_tao: 999 },
-      ]),
-    };
-    const { res, text } = await getText(
-      "/api/v1/validators?sort=uid_count&limit=2&format=csv",
-      globalEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /^text\/csv/);
-    const lines = text.split("\r\n");
-    assert.equal(lines[0], GLOBAL_VALIDATOR_CSV_HEADER);
-    assert.equal(lines.length, 3);
-    assert.match(lines[1], /^hk-a,5Co1,1,2,2,30,44\.2,0\.230769/);
-    assert.match(lines[1], /"\{""netuid"":2/);
-    assert.match(lines[2], /^hk-b,5Co1,1,1,1,100,22\.1,0\.769231/);
   });
 
   test("GET /validators?format=csv emits a header-only cold export", async () => {
@@ -1464,21 +1152,6 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     };
     const { text } = await getText("/api/v1/validators?format=csv", coldEnv);
     assert.equal(text, GLOBAL_VALIDATOR_CSV_HEADER);
-  });
-
-  test("GET /validators defaults the sort when omitted", async () => {
-    const globalEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: neuronsD1([
-        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", stake_tao: 10 },
-      ]),
-    };
-    const { res, body } = await getJson("/api/v1/validators", globalEnv);
-
-    assert.equal(res.status, 200);
-    assert.equal(body.data.sort, "subnet_count");
-    assert.equal(body.data.limit, 20);
-    assert.equal(body.data.validators[0].hotkey, "hk-a");
   });
 
   test("GET /validators rejects invalid query params", async () => {
@@ -1500,46 +1173,12 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
 
   const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  test("GET /validators/{hotkey} returns cross-subnet validator detail", async () => {
-    const hotkeyEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: neuronsD1([
-        { ...ROW, netuid: 1, uid: 0, hotkey: HOTKEY, stake_tao: 10 },
-        { ...ROW, netuid: 2, uid: 1, hotkey: HOTKEY, stake_tao: 20 },
-        { ...ROW, netuid: 3, uid: 0, hotkey: "hk-other", stake_tao: 999 },
-        { ...MINER, netuid: 4, uid: 5, hotkey: HOTKEY }, // permit=0: excluded
-      ]),
-    };
-    const { res, body } = await getJson(
-      `/api/v1/validators/${HOTKEY}`,
-      hotkeyEnv,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.hotkey, HOTKEY);
-    assert.equal(body.data.subnet_count, 2);
-    assert.deepEqual(
-      body.data.subnets.map((s) => s.netuid),
-      [1, 2],
-    );
-    assert.equal(
-      body.meta.artifact_path,
-      `/metagraph/validators/${HOTKEY}.json`,
-    );
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
   test("GET /validators/{hotkey} for an absent hotkey returns a zeroed aggregate, never 404", async () => {
     const { res, body } = await getJson(`/api/v1/validators/${HOTKEY}`, env);
     assert.equal(res.status, 200);
     assert.equal(body.data.hotkey, HOTKEY);
     assert.equal(body.data.subnet_count, 0);
     assert.deepEqual(body.data.subnets, []);
-  });
-
-  test("GET /subnets/{n}/neurons/{uid} returns the neuron", async () => {
-    const { res, body } = await getJson("/api/v1/subnets/7/neurons/0", env);
-    assert.equal(res.status, 200);
-    assert.equal(body.data.neuron.uid, 0);
   });
 
   test("GET /subnets/{n}/neurons/{uid} for an absent uid → 200 neuron:null", async () => {

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -535,28 +535,6 @@ describe("stake aggregates surface when the rolled rows carry stake (P7)", () =>
 });
 
 describe("history endpoints (via the Worker dispatch)", () => {
-  test("GET /subnets/{n}/neurons/{u}/history returns a 200 series + applies a date cutoff", async () => {
-    const captured = {};
-    const env = historyEnv([dailyRow()], captured);
-    const res = await handleRequest(
-      new Request(
-        "https://api.metagraph.sh/api/v1/subnets/7/neurons/3/history?window=7d",
-      ),
-      env,
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.uid, 3);
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-20");
-    // A bounded window binds a snapshot_date cutoff + the row cap.
-    assert.match(
-      captured.sql,
-      /FROM neuron_daily WHERE netuid = \? AND uid = \?/,
-    );
-    assert.match(captured.sql, /snapshot_date >= \?/);
-    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
-  });
   test("an unsupported ?window is a 400, never a silent coerce", async () => {
     const res = await handleRequest(
       new Request(
@@ -573,39 +551,5 @@ describe("history endpoints (via the Worker dispatch)", () => {
       '"400d" is not a supported window. Supported: 7d, 30d, 90d, 1y, all.',
     );
     assert.equal(body.meta.parameter, "window");
-  });
-  test("GET /subnets/{n}/history returns per-day aggregates", async () => {
-    const env = historyEnv([
-      {
-        snapshot_date: "2026-06-20",
-        neuron_count: 256,
-        validator_count: 64,
-        total_stake_tao: 1000,
-        total_emission_tao: 12.3,
-      },
-    ]);
-    const res = await handleRequest(
-      new Request(
-        "https://api.metagraph.sh/api/v1/subnets/7/history?window=90d",
-      ),
-      env,
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.points[0].neuron_count, 256);
-  });
-  test("?window=all omits the cutoff (full history, still bounded by the row cap)", async () => {
-    const captured = {};
-    const env = historyEnv([dailyRow()], captured);
-    await handleRequest(
-      new Request(
-        "https://api.metagraph.sh/api/v1/subnets/7/neurons/3/history?window=all",
-      ),
-      env,
-      ctx,
-    );
-    assert.doesNotMatch(captured.sql, /snapshot_date >= \?/);
-    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
   });
 });

--- a/tests/pagination-parity.test.mjs
+++ b/tests/pagination-parity.test.mjs
@@ -12,25 +12,13 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
-  BLOCK_PAGINATION,
   FEED_PAGINATION,
   MAX_OFFSET,
   MIN_LIMIT,
 } from "../workers/request-params.mjs";
-import {
-  handleAccountEvents,
-  handleAccountExtrinsics,
-  handleAccountHistory,
-  handleAccountTransfers,
-  handleBlockEvents,
-  handleBlockExtrinsics,
-  handleBlocks,
-  handleExtrinsics,
-  handleSubnetEvents,
-} from "../workers/request-handlers/entities.mjs";
+import { handleAccountHistory } from "../workers/request-handlers/entities.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
-const NETUID = 7;
 const BLOCK_NUM = 1234;
 
 function req(path) {
@@ -90,19 +78,17 @@ function boundPage(call) {
     : { limit: p[p.length - 1], offset: null };
 }
 
+// #4909 D1 retirement: this suite used to cover 9 routes, but 8 of them
+// (accounts/{ss58}/events, extrinsics, transfers; subnets/{netuid}/events;
+// blocks/{ref}/events, blocks/{ref}/extrinsics; blocks; extrinsics) had their
+// D1 write path retired (#4772) and the underlying tables dropped in
+// production, so entities.mjs no longer runs a D1 query for them at all --
+// there is nothing left for a "the bound LIMIT/OFFSET matches the profile"
+// D1-capture assertion to observe. account_events_daily (the source behind
+// /accounts/{ss58}/history) is NOT part of that retirement -- it has its own
+// independent Postgres-side rollup and D1's copy is still a real,
+// live-queried fallback tier -- so its parity coverage stays.
 const ROUTES = [
-  {
-    name: "GET /accounts/{ss58}/events",
-    profile: FEED_PAGINATION,
-    feed: /INDEXED BY idx_account_events_hotkey.*UNION ALL.*idx_account_events_coldkey/s,
-    invoke: (env, qs) =>
-      handleAccountEvents(
-        req(`/api/v1/accounts/${SS58}/events`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/events?${qs}`),
-      ),
-  },
   {
     name: "GET /accounts/{ss58}/history",
     profile: FEED_PAGINATION,
@@ -113,84 +99,6 @@ const ROUTES = [
         env,
         SS58,
         url(`/api/v1/accounts/${SS58}/history?${qs}`),
-      ),
-  },
-  {
-    name: "GET /accounts/{ss58}/extrinsics",
-    profile: FEED_PAGINATION,
-    feed: /FROM extrinsics WHERE signer = \?/,
-    invoke: (env, qs) =>
-      handleAccountExtrinsics(
-        req(`/api/v1/accounts/${SS58}/extrinsics`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/extrinsics?${qs}`),
-      ),
-  },
-  {
-    name: "GET /accounts/{ss58}/transfers",
-    profile: FEED_PAGINATION,
-    feed: /event_kind = 'Transfer'/,
-    invoke: (env, qs) =>
-      handleAccountTransfers(
-        req(`/api/v1/accounts/${SS58}/transfers`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/transfers?${qs}`),
-      ),
-  },
-  {
-    name: "GET /subnets/{netuid}/events",
-    profile: FEED_PAGINATION,
-    feed: /FROM account_events WHERE netuid = \?/,
-    invoke: (env, qs) =>
-      handleSubnetEvents(
-        req(`/api/v1/subnets/${NETUID}/events`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/events?${qs}`),
-      ),
-  },
-  {
-    name: "GET /blocks/{ref}/events",
-    profile: FEED_PAGINATION,
-    feed: /FROM account_events WHERE block_number = \? ORDER BY event_index ASC/,
-    invoke: (env, qs) =>
-      handleBlockEvents(
-        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
-        env,
-        String(BLOCK_NUM),
-        url(`/api/v1/blocks/${BLOCK_NUM}/events?${qs}`),
-      ),
-  },
-  {
-    name: "GET /blocks",
-    profile: BLOCK_PAGINATION,
-    feed: /FROM blocks ORDER BY block_number DESC/,
-    invoke: (env, qs) =>
-      handleBlocks(req(`/api/v1/blocks`), env, url(`/api/v1/blocks?${qs}`)),
-  },
-  {
-    name: "GET /blocks/{ref}/extrinsics",
-    profile: BLOCK_PAGINATION,
-    feed: /FROM extrinsics WHERE block_number = \? ORDER BY extrinsic_index ASC/,
-    invoke: (env, qs) =>
-      handleBlockExtrinsics(
-        req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-        env,
-        String(BLOCK_NUM),
-        url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics?${qs}`),
-      ),
-  },
-  {
-    name: "GET /extrinsics",
-    profile: BLOCK_PAGINATION,
-    feed: /FROM extrinsics ORDER BY block_number DESC, extrinsic_index DESC/,
-    invoke: (env, qs) =>
-      handleExtrinsics(
-        req(`/api/v1/extrinsics`),
-        env,
-        url(`/api/v1/extrinsics?${qs}`),
       ),
   },
 ];

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -9,8 +9,6 @@ import { describe, test } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import { buildOpenApiArtifact } from "../src/contracts.mjs";
-import { encodeCursor } from "../src/cursor.mjs";
-import { EXTRINSIC_RETENTION_MS } from "../src/extrinsics.mjs";
 import { MOVERS_WINDOWS } from "../src/movers.mjs";
 import { unsupportedWindowMessage } from "../src/neuron-history.mjs";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
@@ -156,25 +154,6 @@ function neuronRow(overrides = {}) {
     axon: "1.2.3.4:9000",
     block_number: 5_000_000,
     captured_at: OBSERVED_AT,
-    ...overrides,
-  };
-}
-
-function neuronDailyRow(overrides = {}) {
-  return {
-    snapshot_date: "2026-06-20",
-    ...neuronRow(overrides),
-    ...overrides,
-  };
-}
-
-function subnetHistoryRow(overrides = {}) {
-  return {
-    snapshot_date: "2026-06-20",
-    neuron_count: 2,
-    validator_count: 1,
-    total_stake_tao: 900,
-    total_emission_tao: 12.5,
     ...overrides,
   };
 }
@@ -737,56 +716,6 @@ describe("handleSubnetMetagraph", () => {
     assert.equal(body.data.captured_at, null);
     assert.equal(body.meta.source, "metagraph-snapshot");
   });
-
-  test("happy path returns neurons from mocked D1 rows", async () => {
-    const { env } = dbWith({ neurons: [neuronRow()] });
-    const body = await json(
-      await handleSubnetMetagraph(
-        req(`/api/v1/subnets/${NETUID}/metagraph`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/metagraph`),
-      ),
-    );
-    assert.equal(body.data.neuron_count, 1);
-    assert.equal(body.data.neurons[0].uid, UID);
-    assert.equal(body.data.neurons[0].validator_permit, true);
-    assert.equal(
-      body.meta.artifact_path,
-      `/metagraph/subnets/${NETUID}/metagraph.json`,
-    );
-  });
-
-  test("validator_permit=true filters to validators only", async () => {
-    const { env, captures } = dbWith({
-      neurons: [neuronRow({ validator_permit: 1 })],
-    });
-    await handleSubnetMetagraph(
-      req(`/api/v1/subnets/${NETUID}/metagraph`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/metagraph?validator_permit=true`),
-    );
-    assert.ok(
-      captures.sql.some((s) => /validator_permit = 1/.test(s)),
-      "expected validator_permit filter in SQL",
-    );
-  });
-
-  test("validator_permit=false is not treated as validators-only", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    await handleSubnetMetagraph(
-      req(`/api/v1/subnets/${NETUID}/metagraph`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/metagraph?validator_permit=false`),
-    );
-    const metagraphSql = captures.sql.find((s) =>
-      /FROM neurons WHERE netuid/.test(s),
-    );
-    assert.ok(metagraphSql);
-    assert.ok(!/validator_permit = 1/.test(metagraphSql));
-  });
 });
 
 describe("handleSubnetYield", () => {
@@ -821,44 +750,6 @@ describe("handleSubnetYield", () => {
     );
     assert.equal(body.meta.source, "metagraph-snapshot");
   });
-
-  test("computes per-UID yield, role split, and ranking from mocked D1 rows", async () => {
-    const { env, captures } = dbWith({
-      neurons: [
-        neuronRow({
-          uid: 0,
-          validator_permit: 1,
-          stake_tao: 100,
-          emission_tao: 2,
-        }), // yield 0.02
-        neuronRow({
-          uid: 1,
-          validator_permit: 0,
-          stake_tao: 100,
-          emission_tao: 5,
-        }), // yield 0.05
-      ],
-    });
-    const body = await json(
-      await handleSubnetYield(
-        req(`/api/v1/subnets/${NETUID}/yield`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/yield`),
-      ),
-    );
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.validator_count, 1);
-    assert.equal(body.data.miner_count, 1);
-    assert.equal(body.data.subnet_yield, 0.035); // 7/200
-    assert.equal(body.data.neurons[0].uid, 1); // higher yield ranks first
-    assert.equal(body.data.neurons[0].yield, 0.05);
-    await assertValidComponent("SubnetYieldArtifact", body.data);
-    assert.ok(
-      captures.sql.some((s) => /FROM neurons WHERE netuid = \?/.test(s)),
-    );
-    assert.equal(body.meta.source, "metagraph-snapshot");
-  });
 });
 
 describe("handleNeuron", () => {
@@ -874,25 +765,6 @@ describe("handleNeuron", () => {
     assert.equal(body.data.neuron, null);
     assert.equal(body.data.captured_at, null);
     assert.equal(body.meta.source, "metagraph-snapshot");
-  });
-
-  test("happy path returns a single neuron detail", async () => {
-    const { env } = dbWith({ neurons: [neuronRow()] });
-    const body = await json(
-      await handleNeuron(
-        req(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
-        env,
-        NETUID,
-        UID,
-      ),
-    );
-    assert.equal(body.data.neuron.uid, UID);
-    assert.equal(body.data.neuron.hotkey, SS58);
-    assert.equal(body.data.neuron.active, true);
-    assert.equal(
-      body.meta.artifact_path,
-      `/metagraph/subnets/${NETUID}/neurons/${UID}.json`,
-    );
   });
 
   test("missing UID row yields neuron:null (not 404)", async () => {
@@ -930,29 +802,6 @@ describe("handleSubnetValidators", () => {
     );
     assert.equal(body.data.validator_count, 0);
     assert.deepEqual(body.data.validators, []);
-  });
-
-  test("happy path returns validator rows ranked by stake", async () => {
-    const { env } = dbWith({
-      neurons: [
-        neuronRow({ uid: 1, stake_tao: 50 }),
-        neuronRow({ uid: 2, stake_tao: 200 }),
-      ],
-    });
-    const body = await json(
-      await handleSubnetValidators(
-        req(`/api/v1/subnets/${NETUID}/validators`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/validators`),
-      ),
-    );
-    assert.equal(body.data.validator_count, 2);
-    assert.equal(body.data.validators[0].uid, 1);
-    assert.equal(
-      body.meta.artifact_path,
-      `/metagraph/subnets/${NETUID}/validators.json`,
-    );
   });
 });
 
@@ -1076,37 +925,6 @@ describe("handleNeuronHistory", () => {
     assert.deepEqual(body.data.points, []);
     assert.equal(body.data.window, "30d");
   });
-
-  test("happy path returns daily history points", async () => {
-    const { env } = dbWith({ neuronDailyUid: [neuronDailyRow()] });
-    const body = await json(
-      await handleNeuronHistory(
-        req(`/api/v1/subnets/${NETUID}/neurons/${UID}/history`),
-        env,
-        NETUID,
-        UID,
-        url(`/api/v1/subnets/${NETUID}/neurons/${UID}/history?window=7d`),
-      ),
-    );
-    assert.equal(body.data.point_count, 1);
-    assert.equal(body.data.window, "7d");
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-20");
-    assert.equal(body.data.points[0].uid, UID);
-  });
-
-  test("window=all omits the snapshot_date lower bound", async () => {
-    const { env, captures } = dbWith({ neuronDailyUid: [neuronDailyRow()] });
-    await handleNeuronHistory(
-      req(`/api/v1/subnets/${NETUID}/neurons/${UID}/history`),
-      env,
-      NETUID,
-      UID,
-      url(`/api/v1/subnets/${NETUID}/neurons/${UID}/history?window=all`),
-    );
-    const historySql = captures.sql.find((s) => /FROM neuron_daily/.test(s));
-    assert.ok(historySql);
-    assert.ok(!/snapshot_date >=/.test(historySql));
-  });
 });
 
 describe("handleSubnetHistory", () => {
@@ -1131,25 +949,6 @@ describe("handleSubnetHistory", () => {
     assert.equal(body.data.netuid, NETUID);
     assert.equal(body.data.point_count, 0);
     assert.deepEqual(body.data.points, []);
-  });
-
-  test("happy path returns per-day subnet aggregates", async () => {
-    const { env } = dbWith({
-      neuronDailySubnet: [subnetHistoryRow()],
-    });
-    const body = await json(
-      await handleSubnetHistory(
-        req(`/api/v1/subnets/${NETUID}/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/history?window=90d`),
-      ),
-    );
-    assert.equal(body.data.point_count, 1);
-    assert.equal(body.data.window, "90d");
-    assert.equal(body.data.points[0].neuron_count, 2);
-    assert.equal(body.data.points[0].validator_count, 1);
-    assert.equal(body.data.points[0].total_stake_tao, 900);
   });
 
   test("uses the covering index for the aggregate history query plan", () => {
@@ -1362,58 +1161,6 @@ describe("handleSubnetConcentration", () => {
     assert.equal(body.data.emission, null);
   });
 
-  test("computes per-UID, per-entity, and validator concentration over the neurons tier", async () => {
-    const { env, captures } = dbWith({
-      neurons: [
-        neuronRow({
-          stake_tao: 100,
-          emission_tao: 2,
-          coldkey: "ck-a",
-          validator_permit: 1,
-        }),
-        neuronRow({
-          uid: 1,
-          stake_tao: 50,
-          emission_tao: 1,
-          coldkey: "ck-a",
-          validator_permit: 0,
-        }),
-        neuronRow({
-          uid: 2,
-          stake_tao: 30,
-          emission_tao: 1,
-          coldkey: "ck-b",
-          validator_permit: 1,
-        }),
-      ],
-    });
-    const body = await json(
-      await handleSubnetConcentration(
-        req(`/api/v1/subnets/${NETUID}/concentration`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.neuron_count, 3);
-    assert.equal(body.data.entity_count, 2); // ck-a (2 UIDs) + ck-b
-    assert.equal(body.data.uids_per_entity, 1.5);
-    assert.equal(body.data.stake.holders, 3); // per-UID
-    assert.equal(body.data.entity_stake.holders, 2); // ck-a's UIDs collapsed
-    assert.equal(body.data.entity_stake.total, 180);
-    assert.equal(body.data.validator_stake.holders, 2); // the two permitted UIDs
-    assert.equal(body.data.validator_stake.total, 130); // 100 + 30
-    // Bound to the netuid; the read selects coldkey + validator_permit.
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neurons WHERE netuid = \?/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.ok(/coldkey/.test(captures.sql[idx]));
-    assert.ok(/validator_permit/.test(captures.sql[idx]));
-    assert.equal(captures.params[idx][0], NETUID);
-  });
-
   test("degrades to schema-stable null blocks when the D1 read throws", async () => {
     // A bound DB whose .all() rejects (schema drift) — d1All swallows it to [],
     // so the handler still answers 200 with null metric blocks, never 5xx/404.
@@ -1432,30 +1179,6 @@ describe("handleSubnetConcentration", () => {
     assert.equal(body.data.emission, null);
     assert.equal(body.data.validator_stake, null);
     assert.equal(body.data.captured_at, null);
-  });
-
-  test("is null-safe on sparse / all-zero neuron rows (null metric blocks)", async () => {
-    // Rows present but carrying no positive distribution (zero stake/emission,
-    // missing coldkeys) → neuron_count reflects the rows, every metric block null.
-    const { env } = dbWith({
-      neurons: [
-        neuronRow({ stake_tao: 0, emission_tao: 0, coldkey: null }),
-        neuronRow({ uid: 1, stake_tao: 0, emission_tao: 0, coldkey: "" }),
-      ],
-    });
-    const body = await json(
-      await handleSubnetConcentration(
-        req(`/api/v1/subnets/${NETUID}/concentration`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration`),
-      ),
-    );
-    assert.equal(body.data.neuron_count, 2);
-    assert.equal(body.data.entity_count, 2); // two missing-coldkey singletons
-    assert.equal(body.data.stake, null); // no positive stake → null block
-    assert.equal(body.data.emission, null);
-    assert.equal(body.data.validator_stake, null);
   });
 });
 
@@ -1494,36 +1217,6 @@ describe("handleSubnetConcentrationHistory", () => {
     assert.deepEqual(body.data.points, []);
   });
 
-  test("happy path computes a per-day concentration trend", async () => {
-    const { env, captures } = dbWith({
-      neuronDailyHistory: [
-        { snapshot_date: "2026-06-27", stake_tao: 100, emission_tao: 10 },
-        { snapshot_date: "2026-06-27", stake_tao: 1, emission_tao: 1 },
-        { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-        { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-      ],
-    });
-    const body = await json(
-      await handleSubnetConcentrationHistory(
-        req(`/api/v1/subnets/${NETUID}/concentration/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration/history?window=30d`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.point_count, 2);
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-27"); // newest first
-    assert.ok(body.data.points[0].stake_gini > body.data.points[1].stake_gini);
-    // Windowed neuron_daily read bound to the netuid.
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \?/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], NETUID);
-  });
-
   test("degrades to an empty series when the D1 read throws", async () => {
     // d1All swallows the rejecting read to []; the trend stays 200 + points:[].
     const res = await handleSubnetConcentrationHistory(
@@ -1539,52 +1232,6 @@ describe("handleSubnetConcentrationHistory", () => {
     assert.equal(body.data.window, "7d");
     assert.equal(body.data.point_count, 0);
     assert.deepEqual(body.data.points, []);
-  });
-
-  test("binds the windowed read with a row cap and an ISO date cutoff", async () => {
-    // The raw per-UID read is bounded by CONCENTRATION_HISTORY_ROW_CAP and a
-    // window-derived YYYY-MM-DD cutoff — assert both are bound (params, not SQL).
-    const { env, captures } = dbWith({ neuronDailyHistory: [] });
-    await handleSubnetConcentrationHistory(
-      req(`/api/v1/subnets/${NETUID}/concentration/history`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/concentration/history?window=30d`),
-    );
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \? ORDER BY snapshot_date DESC LIMIT \?/.test(
-        s,
-      ),
-    );
-    assert.ok(idx !== -1);
-    const [boundNetuid, cutoff, cap] = captures.params[idx];
-    assert.equal(boundNetuid, NETUID);
-    assert.match(cutoff, /^\d{4}-\d{2}-\d{2}$/); // ISO day cutoff
-    assert.equal(cap, 50_000); // CONCENTRATION_HISTORY_ROW_CAP
-  });
-
-  test("skips dateless rows and is null-safe on sparse history rows", async () => {
-    const { env } = dbWith({
-      neuronDailyHistory: [
-        { snapshot_date: null, stake_tao: 5 }, // dropped (no date)
-        { snapshot_date: "2026-06-27" }, // present but no value columns
-        { snapshot_date: "2026-06-27", stake_tao: 0, emission_tao: 0 },
-      ],
-    });
-    const body = await json(
-      await handleSubnetConcentrationHistory(
-        req(`/api/v1/subnets/${NETUID}/concentration/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
-      ),
-    );
-    assert.equal(body.data.point_count, 1); // only the dated day
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-27");
-    assert.equal(body.data.points[0].neuron_count, 2);
-    // No positive distribution in that day → null per-metric fields, not throws.
-    assert.equal(body.data.points[0].stake_gini, null);
-    assert.equal(body.data.points[0].emission_gini, null);
   });
 });
 
@@ -1623,65 +1270,6 @@ describe("handleSubnetPerformanceHistory", () => {
     assert.deepEqual(body.data.points, []);
   });
 
-  test("happy path computes a per-day reward-flow trend", async () => {
-    const { env, captures } = dbWith({
-      neuronDailyHistory: [
-        {
-          snapshot_date: "2026-06-27",
-          incentive: 0.9,
-          dividends: 0.9,
-          trust: 0.8,
-          consensus: 0.7,
-          validator_trust: 0.85,
-          validator_permit: 1,
-          active: 1,
-        },
-        {
-          snapshot_date: "2026-06-27",
-          incentive: 0.05,
-          dividends: 0,
-          trust: 0.2,
-          consensus: 0.1,
-          validator_trust: 0,
-          validator_permit: 0,
-          active: 1,
-        },
-        {
-          snapshot_date: "2026-06-26",
-          incentive: 0.5,
-          dividends: 0.5,
-          trust: 0.5,
-          consensus: 0.5,
-          validator_trust: 0.5,
-          validator_permit: 1,
-          active: 1,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetPerformanceHistory(
-        req(`/api/v1/subnets/${NETUID}/performance/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/performance/history?window=30d`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.point_count, 2);
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-27"); // newest first
-    assert.ok(
-      body.data.points[0].incentive_gini > body.data.points[1].incentive_gini,
-    );
-    assert.equal(typeof body.data.points[0].trust_mean, "number");
-    // Windowed neuron_daily read bound to the netuid.
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \?/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], NETUID);
-  });
-
   test("degrades to an empty series when the D1 read throws", async () => {
     // d1All swallows the rejecting read to []; the trend stays 200 + points:[].
     const res = await handleSubnetPerformanceHistory(
@@ -1697,26 +1285,6 @@ describe("handleSubnetPerformanceHistory", () => {
     assert.equal(body.data.window, "7d");
     assert.equal(body.data.point_count, 0);
     assert.deepEqual(body.data.points, []);
-  });
-
-  test("binds the windowed read with a row cap and an ISO date cutoff", async () => {
-    const { env, captures } = dbWith({ neuronDailyHistory: [] });
-    await handleSubnetPerformanceHistory(
-      req(`/api/v1/subnets/${NETUID}/performance/history`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/performance/history?window=30d`),
-    );
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \? ORDER BY snapshot_date DESC LIMIT \?/.test(
-        s,
-      ),
-    );
-    assert.ok(idx !== -1);
-    const [boundNetuid, cutoff, cap] = captures.params[idx];
-    assert.equal(boundNetuid, NETUID);
-    assert.match(cutoff, /^\d{4}-\d{2}-\d{2}$/); // ISO day cutoff
-    assert.equal(cap, 50_000); // PERFORMANCE_HISTORY_ROW_CAP
   });
 });
 
@@ -1755,51 +1323,6 @@ describe("handleSubnetYieldHistory", () => {
     assert.deepEqual(body.data.points, []);
   });
 
-  test("happy path computes a per-day yield-distribution trend", async () => {
-    const { env, captures } = dbWith({
-      neuronDailyHistory: [
-        {
-          snapshot_date: "2026-06-27",
-          stake_tao: 100,
-          emission_tao: 10,
-          validator_permit: 1,
-        },
-        {
-          snapshot_date: "2026-06-27",
-          stake_tao: 100,
-          emission_tao: 5,
-          validator_permit: 0,
-        },
-        {
-          snapshot_date: "2026-06-26",
-          stake_tao: 100,
-          emission_tao: 10,
-          validator_permit: 1,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetYieldHistory(
-        req(`/api/v1/subnets/${NETUID}/yield/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/yield/history?window=30d`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.point_count, 2);
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-27"); // newest first
-    assert.equal(body.data.points[0].median_yield, 0.075); // 0.1 & 0.05
-    assert.equal(typeof body.data.points[0].subnet_yield, "number");
-    // Windowed neuron_daily read bound to the netuid.
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \?/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], NETUID);
-  });
-
   test("degrades to an empty series when the D1 read throws", async () => {
     // d1All swallows the rejecting read to []; the trend stays 200 + points:[].
     const res = await handleSubnetYieldHistory(
@@ -1815,26 +1338,6 @@ describe("handleSubnetYieldHistory", () => {
     assert.equal(body.data.window, "7d");
     assert.equal(body.data.point_count, 0);
     assert.deepEqual(body.data.points, []);
-  });
-
-  test("binds the windowed read with a row cap and an ISO date cutoff", async () => {
-    const { env, captures } = dbWith({ neuronDailyHistory: [] });
-    await handleSubnetYieldHistory(
-      req(`/api/v1/subnets/${NETUID}/yield/history`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield/history?window=30d`),
-    );
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \? ORDER BY snapshot_date DESC LIMIT \?/.test(
-        s,
-      ),
-    );
-    assert.ok(idx !== -1);
-    const [boundNetuid, cutoff, cap] = captures.params[idx];
-    assert.equal(boundNetuid, NETUID);
-    assert.match(cutoff, /^\d{4}-\d{2}-\d{2}$/); // ISO day cutoff
-    assert.equal(cap, 50_000); // YIELD_HISTORY_ROW_CAP
   });
 });
 
@@ -1862,60 +1365,6 @@ describe("handleSubnetTurnover", () => {
     assert.equal(body.data.validator_retention, null);
   });
 
-  test("happy path computes validator churn between the two boundary snapshots", async () => {
-    const { env, captures } = dbWith({
-      turnoverBounds: [{ start_date: "2026-06-01", end_date: "2026-06-30" }],
-      turnoverRows: [
-        {
-          snapshot_date: "2026-06-01",
-          uid: 0,
-          hotkey: "V1",
-          validator_permit: 1,
-        },
-        {
-          snapshot_date: "2026-06-01",
-          uid: 1,
-          hotkey: "V2",
-          validator_permit: 1,
-        },
-        {
-          snapshot_date: "2026-06-30",
-          uid: 0,
-          hotkey: "V1",
-          validator_permit: 1,
-        },
-        {
-          snapshot_date: "2026-06-30",
-          uid: 1,
-          hotkey: "V3",
-          validator_permit: 1,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetTurnover(
-        req(`/api/v1/subnets/${NETUID}/turnover`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/turnover?window=30d`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.comparable, true);
-    assert.equal(body.data.start_date, "2026-06-01");
-    assert.equal(body.data.end_date, "2026-06-30");
-    assert.equal(body.data.validators_entered, 1); // V3 joined
-    assert.equal(body.data.validators_exited, 1); // V2 left
-    assert.equal(body.data.uids_deregistered, 1); // uid1: V2 → V3
-    // Bound to the netuid; reads the two boundary snapshots.
-    const idx = captures.sql.findIndex((s) =>
-      /FROM neuron_daily WHERE netuid = \? AND snapshot_date IN/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], NETUID);
-  });
-
   test("rejects an invalid changes flag with 400", async () => {
     const res = await handleSubnetTurnover(
       req(`/api/v1/subnets/${NETUID}/turnover`),
@@ -1941,44 +1390,6 @@ describe("handleSubnetTurnover", () => {
       body.meta.artifact_path,
       `/metagraph/subnets/${NETUID}/turnover.json`,
     );
-  });
-
-  test("changes=true returns entry, exit, and UID reassignment detail", async () => {
-    const { env } = dbWith({
-      turnoverBounds: [{ start_date: "2026-06-01", end_date: "2026-06-30" }],
-      turnoverRows: [
-        {
-          snapshot_date: "2026-06-01",
-          uid: 1,
-          hotkey: "V2",
-          validator_permit: 1,
-        },
-        {
-          snapshot_date: "2026-06-30",
-          uid: 1,
-          hotkey: "V3",
-          validator_permit: 1,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetTurnover(
-        req(`/api/v1/subnets/${NETUID}/turnover`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/turnover?window=30d&changes=true`),
-      ),
-    );
-    assert.equal(body.data.window, "30d");
-    assert.deepEqual(body.data.changes.validators_entered, [
-      { hotkey: "V3", uid: 1 },
-    ]);
-    assert.deepEqual(body.data.changes.validators_exited, [
-      { hotkey: "V2", uid: 1 },
-    ]);
-    assert.deepEqual(body.data.changes.uid_reassignments, [
-      { uid: 1, from_hotkey: "V2", to_hotkey: "V3" },
-    ]);
   });
 
   describe("canonicalSubnetTurnoverCachePath", () => {
@@ -2792,148 +2203,6 @@ describe("handleSubnetStakeFlow", () => {
     assert.equal(body.meta.generated_at, null);
   });
 
-  test("sums StakeAdded vs StakeRemoved into net flow, bound to the netuid + both kinds", async () => {
-    const { env, captures } = dbWith({
-      stakeFlow: [
-        {
-          event_kind: "StakeAdded",
-          total_tao: 200,
-          event_count: 5,
-          last_observed: 1717000000000,
-        },
-        {
-          event_kind: "StakeRemoved",
-          total_tao: 50,
-          event_count: 2,
-          last_observed: 1717900000000,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetStakeFlow(
-        req(`/api/v1/subnets/${NETUID}/stake-flow`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-flow?window=90d`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "90d");
-    assert.equal(body.data.total_staked_tao, 200);
-    assert.equal(body.data.total_unstaked_tao, 50);
-    assert.equal(body.data.net_flow_tao, 150);
-    assert.equal(body.data.stake_events, 5);
-    assert.equal(body.data.unstake_events, 2);
-    await assertValidComponent("SubnetStakeFlowArtifact", body.data);
-    const idx = captures.sql.findIndex((s) =>
-      /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], NETUID);
-    assert.equal(captures.params[idx][1], "StakeAdded");
-    assert.equal(captures.params[idx][2], "StakeRemoved");
-    // Provenance: account_events source + generated_at = newest event in the window
-    // as an ISO string (string|null per the envelope contract).
-    assert.equal(body.meta.source, "chain-events");
-    assert.equal(body.meta.generated_at, new Date(1717900000000).toISOString());
-  });
-
-  test("direction=in binds StakeAdded only", async () => {
-    const { env, captures } = dbWith({
-      stakeFlow: [
-        {
-          event_kind: "StakeAdded",
-          total_tao: 200,
-          event_count: 5,
-          last_observed: 1717000000000,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetStakeFlow(
-        req(`/api/v1/subnets/${NETUID}/stake-flow`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-flow?direction=in`),
-      ),
-    );
-    assert.equal(body.data.total_staked_tao, 200);
-    assert.equal(body.data.total_unstaked_tao, 0);
-    assert.equal(body.data.net_flow_tao, 200);
-    const idx = captures.sql.findIndex((s) =>
-      /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][1], "StakeAdded");
-    assert.equal(captures.params[idx].length, 3);
-  });
-
-  test("direction=out binds StakeRemoved only", async () => {
-    const { env, captures } = dbWith({
-      stakeFlow: [
-        {
-          event_kind: "StakeRemoved",
-          total_tao: 50,
-          event_count: 2,
-          last_observed: 1717900000000,
-        },
-      ],
-    });
-    const body = await json(
-      await handleSubnetStakeFlow(
-        req(`/api/v1/subnets/${NETUID}/stake-flow`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-flow?direction=out`),
-      ),
-    );
-    assert.equal(body.data.total_staked_tao, 0);
-    assert.equal(body.data.total_unstaked_tao, 50);
-    assert.equal(body.data.net_flow_tao, -50);
-    const idx = captures.sql.findIndex((s) =>
-      /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][1], "StakeRemoved");
-    assert.equal(captures.params[idx].length, 3);
-  });
-
-  test("direction=all and omitted direction both query both kinds", async () => {
-    for (const query of ["", "?direction=all"]) {
-      const { env, captures } = dbWith({
-        stakeFlow: [
-          {
-            event_kind: "StakeAdded",
-            total_tao: 10,
-            event_count: 1,
-            last_observed: 1717000000000,
-          },
-          {
-            event_kind: "StakeRemoved",
-            total_tao: 3,
-            event_count: 1,
-            last_observed: 1717000000000,
-          },
-        ],
-      });
-      const body = await json(
-        await handleSubnetStakeFlow(
-          req(`/api/v1/subnets/${NETUID}/stake-flow`),
-          env,
-          NETUID,
-          url(`/api/v1/subnets/${NETUID}/stake-flow${query}`),
-        ),
-      );
-      assert.equal(body.data.net_flow_tao, 7);
-      const idx = captures.sql.findIndex((s) =>
-        /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
-      );
-      assert.ok(idx !== -1);
-      assert.equal(captures.params[idx][1], "StakeAdded");
-      assert.equal(captures.params[idx][2], "StakeRemoved");
-    }
-  });
-
   describe("canonicalSubnetStakeFlowCachePath", () => {
     test("canonicalizes omitted and explicit default window to one cache key", () => {
       const omitted = canonicalSubnetStakeFlowCachePath(
@@ -3176,49 +2445,6 @@ describe("handleAccount", () => {
     );
     assert.equal(second.headers.get("etag"), etag);
   });
-
-  test("happy path aggregates account_events + neurons + extrinsics activity", async () => {
-    const { env } = dbWith({
-      agg: {
-        c: 12,
-        sc: 3,
-        fb: 100,
-        lb: 200,
-        fo: OBSERVED_AT - 1000,
-        lo: OBSERVED_AT,
-      },
-      kinds: [
-        { kind: "StakeAdded", count: 7 },
-        { kind: "WeightsSet", count: 5 },
-      ],
-      registrations: [
-        {
-          netuid: NETUID,
-          uid: UID,
-          stake_tao: 100,
-          validator_permit: 1,
-          active: 1,
-        },
-      ],
-      accountEvents: [accountEventRow()],
-      activity: {
-        tx_count: 9,
-        last_tx_block: BLOCK_NUM,
-        last_tx_at: OBSERVED_AT,
-        total_fee_tao: 0.05,
-      },
-      modules: [{ call_module: "SubtensorModule", count: 7 }],
-    });
-    const body = await json(
-      await handleAccount(req(`/api/v1/accounts/${SS58}`), env, SS58),
-    );
-    assert.equal(body.data.event_count, 12);
-    assert.equal(body.data.subnet_count, 3);
-    assert.equal(body.data.activity.tx_count, 9);
-    assert.equal(body.data.registrations[0].netuid, NETUID);
-    assert.equal(body.data.recent_events[0].event_kind, "StakeAdded");
-    assert.equal(body.meta.artifact_path, `/metagraph/accounts/${SS58}.json`);
-  });
 });
 
 describe("handleAccountEvents", () => {
@@ -3265,28 +2491,6 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "netuid");
   });
 
-  test("netuid filter narrows results to one subnet", async () => {
-    const { env, captures } = dbWith({
-      accountEvents: [accountEventRow({ netuid: 7 })],
-    });
-    await handleAccountEvents(
-      req(`/api/v1/accounts/${SS58}/events`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/events?netuid=7`),
-    );
-    assert.ok(
-      captures.sql.some((s) => /AND netuid = \?/.test(s)),
-      "expected netuid filter in SQL",
-    );
-    const eventsSql = captures.sql.find((s) => /FROM account_events/.test(s));
-    assert.equal(
-      eventsSql.match(/AND netuid = \?/g)?.length,
-      2,
-      "expected netuid filter on both union branches",
-    );
-  });
-
   test("netuid absent leaves the feed unfiltered", async () => {
     const { env, captures } = dbWith({
       accountEvents: [accountEventRow()],
@@ -3301,21 +2505,6 @@ describe("handleAccountEvents", () => {
       captures.sql.every((s) => !/AND netuid = \?/.test(s)),
       "expected no netuid filter when param is absent",
     );
-  });
-
-  test("netuid combines with kind filter", async () => {
-    const { env, captures } = dbWith({
-      accountEvents: [accountEventRow({ event_kind: "WeightsSet", netuid: 3 })],
-    });
-    await handleAccountEvents(
-      req(`/api/v1/accounts/${SS58}/events`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/events?netuid=3&kind=WeightsSet`),
-    );
-    const eventsSql = captures.sql.find((s) => /FROM account_events/.test(s));
-    assert.ok(/AND event_kind = \?/.test(eventsSql));
-    assert.equal(eventsSql.match(/AND netuid = \?/g)?.length, 2);
   });
 
   test("short-circuits an inverted block_start>block_end window before D1", async () => {
@@ -3349,36 +2538,6 @@ describe("handleAccountEvents", () => {
     assert.equal(body.data.next_cursor, null);
   });
 
-  test("happy path returns paginated events", async () => {
-    const { env } = dbWith({ accountEvents: [accountEventRow()] });
-    const body = await json(
-      await handleAccountEvents(
-        req(`/api/v1/accounts/${SS58}/events`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/events?limit=50`),
-      ),
-    );
-    assert.equal(body.data.events[0].event_kind, "StakeAdded");
-    assert.equal(body.data.limit, 50);
-  });
-
-  test("kind filter narrows results", async () => {
-    const { env, captures } = dbWith({
-      accountEvents: [accountEventRow({ event_kind: "WeightsSet" })],
-    });
-    await handleAccountEvents(
-      req(`/api/v1/accounts/${SS58}/events`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/events?kind=WeightsSet`),
-    );
-    assert.ok(
-      captures.sql.some((s) => /event_kind = \?/.test(s)),
-      "expected kind filter in SQL",
-    );
-  });
-
   test("rejects an unknown event kind with 400", async () => {
     const { env, captures } = dbWith({
       accountEvents: [accountEventRow()],
@@ -3393,39 +2552,6 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "kind");
     assert.match(body.error.message, /not a supported event kind/);
     assert.equal(captures.sql.length, 0);
-  });
-
-  test("accepts a non-SubtensorModule ingested kind (Transfer), not just INDEXED_EVENT_KINDS", async () => {
-    const { env, captures } = dbWith({
-      accountEvents: [accountEventRow({ event_kind: "Transfer" })],
-    });
-    await handleAccountEvents(
-      req(`/api/v1/accounts/${SS58}/events`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/events?kind=Transfer`),
-    );
-    assert.ok(captures.sql.some((s) => /event_kind = \?/.test(s)));
-  });
-
-  test("cursor uses keyset seek instead of offset", async () => {
-    const { env, captures } = dbWith({
-      accountEvents: [accountEventRow({ block_number: 150, event_index: 2 })],
-    });
-    const body = await json(
-      await handleAccountEvents(
-        req(`/api/v1/accounts/${SS58}/events`),
-        env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/events?limit=1&cursor=${encodeCursor([200, 1])}`,
-        ),
-      ),
-    );
-    const eventsSql = captures.sql.find((s) => /FROM account_events/.test(s));
-    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(eventsSql));
-    assert.ok(!/OFFSET/.test(eventsSql));
-    assert.equal(body.data.next_cursor, encodeCursor([150, 2]));
   });
 });
 
@@ -3586,80 +2712,6 @@ describe("handleAccountExtrinsics", () => {
     assert.equal(body.data.next_cursor, null);
     assert.equal(captures.sql.length, 0);
   });
-
-  test("happy path returns signer-matched extrinsics", async () => {
-    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
-    const body = await json(
-      await handleAccountExtrinsics(
-        req(`/api/v1/accounts/${SS58}/extrinsics`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/extrinsics?limit=25`),
-      ),
-    );
-    assert.equal(body.data.extrinsic_count, 1);
-    assert.equal(body.data.extrinsics[0].signer, SS58);
-    assert.equal(body.data.extrinsics[0].success, true);
-  });
-
-  test("block_start/block_end range filter is applied and bound", async () => {
-    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
-    await handleAccountExtrinsics(
-      req(`/api/v1/accounts/${SS58}/extrinsics`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/extrinsics?block_start=100&block_end=900`),
-    );
-    const idx = captures.sql.findIndex((s) => /FROM extrinsics/.test(s));
-    assert.ok(idx !== -1);
-    const sql = captures.sql[idx];
-    assert.ok(/AND block_number >= \?/.test(sql));
-    assert.ok(/AND block_number <= \?/.test(sql));
-    assert.deepEqual(captures.params[idx], [SS58, 100, 900, 100, 0]);
-  });
-
-  test("cursor combines with block range filters and emits next_cursor", async () => {
-    const { env, captures } = dbWith({
-      extrinsics: [extrinsicRow({ block_number: 150, extrinsic_index: 4 })],
-    });
-    const body = await json(
-      await handleAccountExtrinsics(
-        req(`/api/v1/accounts/${SS58}/extrinsics`),
-        env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/extrinsics?block_start=100&block_end=900&limit=1&cursor=${encodeCursor([200, 2])}`,
-        ),
-      ),
-    );
-    const idx = captures.sql.findIndex((s) => /FROM extrinsics/.test(s));
-    assert.ok(idx !== -1);
-    const sql = captures.sql[idx];
-    assert.ok(/AND block_number >= \?/.test(sql));
-    assert.ok(/AND block_number <= \?/.test(sql));
-    assert.ok(/\(block_number, extrinsic_index\) < \(\?, \?\)/.test(sql));
-    assert.ok(!/OFFSET/.test(sql));
-    assert.deepEqual(captures.params[idx], [SS58, 100, 900, 200, 2, 1]);
-    assert.equal(body.data.next_cursor, encodeCursor([150, 4]));
-  });
-
-  test("malformed cursor falls back to offset pagination", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleAccountExtrinsics(
-      req(`/api/v1/accounts/${SS58}/extrinsics`),
-      env,
-      SS58,
-      url(
-        `/api/v1/accounts/${SS58}/extrinsics?cursor=not-a-cursor&limit=7&offset=5`,
-      ),
-    );
-    const idx = captures.sql.findIndex((s) => /FROM extrinsics/.test(s));
-    assert.ok(idx !== -1);
-    const sql = captures.sql[idx];
-    assert.ok(/OFFSET \?/.test(sql));
-    assert.ok(!/\(block_number, extrinsic_index\) </.test(sql));
-    assert.deepEqual(captures.params[idx], [SS58, 7, 5]);
-  });
 });
 
 describe("handleAccountTransfers", () => {
@@ -3734,125 +2786,6 @@ describe("handleAccountTransfers", () => {
     assert.equal(body.data.transfer_count, 0);
     assert.deepEqual(body.data.transfers, []);
   });
-
-  test("happy path reshapes Transfer rows (all direction)", async () => {
-    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
-    const body = await json(
-      await handleAccountTransfers(
-        req(`/api/v1/accounts/${SS58}/transfers`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/transfers`),
-      ),
-    );
-    assert.equal(body.data.transfer_count, 1);
-    assert.equal(body.data.transfers[0].from, SS58);
-    assert.equal(body.data.transfers[0].amount_tao, 4.2);
-    const sql = captures.sql.find((s) => /Transfer/.test(s));
-    assert.ok(/UNION ALL/.test(sql));
-    assert.ok(/hotkey = \?/.test(sql));
-    assert.ok(/coldkey = \? AND hotkey <> \?/.test(sql));
-    assert.equal(sql.includes(" OR "), false);
-  });
-
-  test("block_start/block_end range filter is applied and bound", async () => {
-    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
-    await handleAccountTransfers(
-      req(`/api/v1/accounts/${SS58}/transfers`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/transfers?block_start=100&block_end=900`),
-    );
-    const idx = captures.sql.findIndex((s) => /Transfer/.test(s));
-    assert.ok(idx !== -1);
-    const sql = captures.sql[idx];
-    assert.equal((sql.match(/block_number >= \?/g) || []).length, 2);
-    assert.equal((sql.match(/block_number <= \?/g) || []).length, 2);
-    assert.deepEqual(captures.params[idx], [
-      SS58,
-      100,
-      900,
-      SS58,
-      SS58,
-      100,
-      900,
-      100,
-      0,
-    ]);
-  });
-
-  test("direction=sent binds hotkey-only clause", async () => {
-    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
-    await handleAccountTransfers(
-      req(`/api/v1/accounts/${SS58}/transfers`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/transfers?direction=sent`),
-    );
-    const sql = captures.sql.find((s) => /Transfer/.test(s));
-    assert.ok(
-      /^[^O]*hotkey = \?/.test(sql.replace(/OR.*/, "")) ||
-        /hotkey = \?/.test(sql),
-    );
-    assert.ok(!/coldkey = \? OR/.test(sql) || /hotkey = \?/.test(sql));
-  });
-
-  test("direction=received binds coldkey-only clause", async () => {
-    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
-    await handleAccountTransfers(
-      req(`/api/v1/accounts/${SS58}/transfers`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/transfers?direction=received`),
-    );
-    const sql = captures.sql.find((s) => /Transfer/.test(s));
-    assert.ok(/coldkey = \?/.test(sql));
-  });
-
-  test("cursor uses keyset seek instead of offset", async () => {
-    const { env, captures } = dbWith({
-      transfers: [transferEventRow({ block_number: 150, event_index: 2 })],
-    });
-    const body = await json(
-      await handleAccountTransfers(
-        req(`/api/v1/accounts/${SS58}/transfers`),
-        env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/transfers?limit=1&cursor=${encodeCursor([200, 1])}`,
-        ),
-      ),
-    );
-    const idx = captures.sql.findIndex((s) => /Transfer/.test(s));
-    assert.ok(idx !== -1);
-    const sql = captures.sql[idx];
-    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(sql));
-    assert.ok(!/OFFSET/.test(sql));
-    assert.deepEqual(captures.params[idx], [
-      SS58,
-      200,
-      1,
-      SS58,
-      SS58,
-      200,
-      1,
-      1,
-    ]);
-    assert.equal(body.data.next_cursor, encodeCursor([150, 2]));
-  });
-
-  test("a malformed cursor is ignored and falls back to the first page", async () => {
-    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
-    await handleAccountTransfers(
-      req(`/api/v1/accounts/${SS58}/transfers`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/transfers?cursor=not-a-cursor`),
-    );
-    const sql = captures.sql.find((s) => /Transfer/.test(s));
-    assert.ok(/OFFSET/.test(sql));
-    assert.ok(!/block_number, event_index\) </.test(sql));
-  });
 });
 
 describe("handleAccountCounterparties", () => {
@@ -3887,52 +2820,6 @@ describe("handleAccountCounterparties", () => {
     }
   });
 
-  test("accepts limit=100 at the documented upper bound", async () => {
-    const { env } = dbWith({
-      transfers: Array.from({ length: 150 }, (_, index) =>
-        transferEventRow({
-          hotkey: SS58,
-          coldkey: `CP-${index.toString().padStart(3, "0")}`,
-          amount_tao: index + 1,
-          block_number: 1_000 - index,
-        }),
-      ),
-    });
-    const body = await json(
-      await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties?limit=100`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/counterparties?limit=100`),
-      ),
-    );
-    assert.equal(body.data.counterparty_count, 150);
-    assert.equal(body.data.counterparties.length, 100);
-  });
-
-  test("defaults limit to 20 when absent in list mode", async () => {
-    const { env } = dbWith({
-      transfers: Array.from({ length: 30 }, (_, index) =>
-        transferEventRow({
-          hotkey: SS58,
-          coldkey: `CP-${index.toString().padStart(3, "0")}`,
-          amount_tao: index + 1,
-          block_number: 2_000 - index,
-        }),
-      ),
-    });
-    const body = await json(
-      await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/counterparties`),
-      ),
-    );
-    assert.equal(body.data.counterparty_count, 30);
-    assert.equal(body.data.counterparties.length, 20);
-  });
-
   test("returns schema-stable empty rollup on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountCounterparties,
@@ -3944,34 +2831,6 @@ describe("handleAccountCounterparties", () => {
     assert.equal(body.data.ss58, SS58);
     assert.equal(body.data.counterparty_count, 0);
     assert.deepEqual(body.data.counterparties, []);
-  });
-
-  test("aggregates the account's transfers by counterparty", async () => {
-    const { env, captures } = dbWith({
-      transfers: [
-        { hotkey: SS58, coldkey: "A", amount_tao: 100, block_number: 10 },
-        { hotkey: "A", coldkey: SS58, amount_tao: 30, block_number: 8 },
-        { hotkey: "B", coldkey: SS58, amount_tao: 200, block_number: 7 },
-      ],
-    });
-    const body = await json(
-      await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/counterparties?limit=10`),
-      ),
-    );
-    assert.equal(body.data.ss58, SS58);
-    assert.equal(body.data.counterparty_count, 2); // A, B
-    assert.equal(body.data.counterparties[0].address, "B"); // highest volume (200)
-    // Read is two Transfer side seeks bound to the account, not a hotkey/coldkey OR.
-    const idx = captures.sql.findIndex(
-      (s) => /UNION ALL/.test(s) && /coldkey = \? AND hotkey <> \?/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.sql[idx].includes(" OR "), false);
-    assert.deepEqual(captures.params[idx].slice(0, 3), [SS58, SS58, SS58]);
   });
 });
 
@@ -4016,66 +2875,6 @@ describe("handleAccountCounterparties relationship drilldown", () => {
     }
   });
 
-  test("defaults limit to 50 when absent in relationship mode", async () => {
-    const { env } = dbWith({
-      relationshipTransfers: Array.from({ length: 80 }, (_, index) =>
-        transferEventRow({
-          block_number: 5_000 - index,
-          event_index: index,
-          hotkey: index % 2 === 0 ? SS58 : COUNTERPARTY,
-          coldkey: index % 2 === 0 ? COUNTERPARTY : SS58,
-          amount_tao: index + 1,
-          observed_at: OBSERVED_AT - index * 1_000,
-        }),
-      ),
-    });
-    const body = await json(
-      await handleAccountCounterparties(
-        req(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
-        ),
-        env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
-        ),
-      ),
-    );
-    assert.equal(body.data.counterparty_count, 1);
-    assert.equal(body.data.relationship.transfer_count, 80);
-    assert.equal(body.data.relationship.transfers.length, 50);
-  });
-
-  test("accepts limit=100 at the documented upper bound in relationship mode", async () => {
-    const { env } = dbWith({
-      relationshipTransfers: Array.from({ length: 150 }, (_, index) =>
-        transferEventRow({
-          block_number: 5_000 - index,
-          event_index: index,
-          hotkey: index % 2 === 0 ? SS58 : COUNTERPARTY,
-          coldkey: index % 2 === 0 ? COUNTERPARTY : SS58,
-          amount_tao: index + 1,
-          observed_at: OBSERVED_AT - index * 1_000,
-        }),
-      ),
-    });
-    const body = await json(
-      await handleAccountCounterparties(
-        req(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=100`,
-        ),
-        env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=100`,
-        ),
-      ),
-    );
-    assert.equal(body.data.counterparty_count, 1);
-    assert.equal(body.data.relationship.transfer_count, 150);
-    assert.equal(body.data.relationship.transfers.length, 100);
-  });
-
   test("returns schema-stable empty pair detail on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountCounterparties,
@@ -4092,61 +2891,6 @@ describe("handleAccountCounterparties relationship drilldown", () => {
     assert.equal(body.data.relationship.counterparty, COUNTERPARTY);
     assert.equal(body.data.relationship.transfer_count, 0);
     assert.deepEqual(body.data.relationship.transfers, []);
-  });
-
-  test("returns pair-level fund-flow detail and recent transfer evidence", async () => {
-    const { env, captures } = dbWith({
-      relationshipTransfers: [
-        transferEventRow({
-          block_number: 20,
-          event_index: 2,
-          hotkey: COUNTERPARTY,
-          coldkey: SS58,
-          amount_tao: 4,
-          observed_at: Date.UTC(2026, 5, 2),
-        }),
-        transferEventRow({
-          block_number: 10,
-          event_index: 1,
-          hotkey: SS58,
-          coldkey: COUNTERPARTY,
-          amount_tao: 10,
-          observed_at: Date.UTC(2026, 5, 1),
-        }),
-      ],
-    });
-    const body = await json(
-      await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties`),
-        env,
-        SS58,
-        url(
-          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=1`,
-        ),
-      ),
-    );
-    assert.equal(body.data.counterparty_count, 1);
-    assert.equal(body.data.counterparties[0].address, COUNTERPARTY);
-    assert.equal(body.data.relationship.transfer_count, 2);
-    assert.equal(body.data.total_sent_tao, 10);
-    assert.equal(body.data.total_received_tao, 4);
-    assert.equal(body.data.relationship.net_tao, -6);
-    assert.equal(body.data.relationship.transfers.length, 1);
-    assert.equal(body.data.relationship.transfers[0].direction, "received");
-    const idx = captures.sql.findIndex(
-      (s) =>
-        /UNION ALL/.test(s) &&
-        /event_kind = 'Transfer' AND hotkey = \? AND coldkey = \?/.test(s),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.sql[idx].includes(" OR "), false);
-    assert.deepEqual(captures.params[idx].slice(0, 4), [
-      SS58,
-      COUNTERPARTY,
-      COUNTERPARTY,
-      SS58,
-    ]);
-    await assertValidComponent("AccountCounterpartiesArtifact", body.data);
   });
 });
 
@@ -4183,24 +2927,6 @@ describe("handleAccountStakeFlow", () => {
     assert.equal(body.meta.parameter, "direction");
   });
 
-  test("threads ?direction=in to the loader as StakeAdded only", async () => {
-    const { env, captures } = dbWith({ stakeFlow: [] });
-    await handleAccountStakeFlow(
-      req(`/api/v1/accounts/${SS58}/stake-flow`),
-      env,
-      SS58,
-      url(`/api/v1/accounts/${SS58}/stake-flow?direction=in`),
-    );
-    const bound = captures.params.find(
-      (p) => Array.isArray(p) && p.includes("StakeAdded"),
-    );
-    assert.ok(bound, "expected a bound StakeAdded param");
-    assert.ok(
-      !bound.includes("StakeRemoved"),
-      "direction=in must not bind StakeRemoved",
-    );
-  });
-
   test("returns schema-stable zeros on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountStakeFlow,
@@ -4222,64 +2948,6 @@ describe("handleAccountStakeFlow", () => {
     );
     assert.equal(body.meta.source, "chain-events");
     assert.equal(body.meta.generated_at, null);
-  });
-
-  test("folds per-subnet flow + totals, bound to the coldkey + both stake kinds", async () => {
-    const { env, captures } = dbWith({
-      stakeFlow: [
-        {
-          netuid: 1,
-          event_kind: "StakeAdded",
-          total_tao: 200,
-          event_count: 5,
-          last_observed: 1717900000000,
-        },
-        {
-          netuid: 1,
-          event_kind: "StakeRemoved",
-          total_tao: 50,
-          event_count: 2,
-          last_observed: 1717000000000,
-        },
-        {
-          netuid: 7,
-          event_kind: "StakeAdded",
-          total_tao: 10,
-          event_count: 1,
-          last_observed: 1717500000000,
-        },
-      ],
-    });
-    const body = await json(
-      await handleAccountStakeFlow(
-        req(`/api/v1/accounts/${SS58}/stake-flow`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/stake-flow?window=90d`),
-      ),
-    );
-    assert.equal(body.data.address, SS58);
-    assert.equal(body.data.window, "90d");
-    assert.equal(body.data.total_staked_tao, 210);
-    assert.equal(body.data.total_unstaked_tao, 50);
-    assert.equal(body.data.net_flow_tao, 160);
-    assert.equal(body.data.subnet_count, 2);
-    // subnet 1 has the most gross flow (250) so it leads + is dominant
-    assert.equal(body.data.subnets[0].netuid, 1);
-    assert.equal(body.data.dominant_netuid, 1);
-    await assertValidComponent("AccountStakeFlowArtifact", body.data);
-    const idx = captures.sql.findIndex((s) =>
-      /FROM account_events INDEXED BY idx_account_events_coldkey WHERE coldkey = \?/.test(
-        s,
-      ),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], SS58);
-    assert.equal(captures.params[idx][1], "StakeAdded");
-    assert.equal(captures.params[idx][2], "StakeRemoved");
-    // newest event across all rows, ISO
-    assert.equal(body.meta.source, "chain-events");
-    assert.equal(body.meta.generated_at, new Date(1717900000000).toISOString());
   });
 });
 
@@ -4328,69 +2996,6 @@ describe("handleAccountStakeMoves", () => {
     assert.equal(body.meta.source, "chain-events");
     assert.equal(body.meta.generated_at, null);
   });
-
-  test("folds per-subnet movements, bound to the coldkey + StakeMoved", async () => {
-    const { env, captures } = dbWith({
-      stakeMoves: [
-        {
-          netuid: 1,
-          movements: 5,
-          first_observed: 1717000000000,
-          last_observed: 1717900000000,
-        },
-        {
-          netuid: 7,
-          movements: 2,
-          first_observed: 1717500000000,
-          last_observed: 1717600000000,
-        },
-      ],
-      // Price-at-tx enrichment (#4332/6.3): only netuid 1's date has a
-      // snapshot; netuid 7 stays null (no matching row), proving the
-      // per-subnet lookup is genuinely keyed, not a blanket fill.
-      stakeMovesPrices: [
-        { netuid: 1, snapshot_date: "2024-06-09", alpha_price_tao: 3.25 },
-      ],
-    });
-    const body = await json(
-      await handleAccountStakeMoves(
-        req(`/api/v1/accounts/${SS58}/stake-moves`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/stake-moves?window=90d`),
-      ),
-    );
-    assert.equal(body.data.address, SS58);
-    assert.equal(body.data.window, "90d");
-    assert.equal(body.data.total_movements, 7);
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.subnets[0].netuid, 1);
-    assert.equal(body.data.dominant_netuid, 1);
-    assert.equal(
-      body.data.subnets[0].first_moved_at,
-      new Date(1717000000000).toISOString(),
-    );
-    assert.equal(
-      body.data.subnets[0].last_moved_at,
-      new Date(1717900000000).toISOString(),
-    );
-    assert.equal(body.data.subnets[0].price_tao_at_last_move, 3.25);
-    assert.equal(
-      body.data.subnets.find((s) => s.netuid === 7).price_tao_at_last_move,
-      null,
-    );
-    await assertValidComponent("AccountStakeMovesArtifact", body.data);
-    const idx = captures.sql.findIndex((s) =>
-      /FROM account_events INDEXED BY idx_account_events_coldkey WHERE coldkey = \?/.test(
-        s,
-      ),
-    );
-    assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], SS58);
-    assert.equal(captures.params[idx][1], "StakeMoved");
-    assert.equal(body.meta.source, "chain-events");
-    assert.equal(body.meta.generated_at, new Date(1717900000000).toISOString());
-  });
 });
 
 describe("handleAccountSubnets", () => {
@@ -4403,31 +3008,6 @@ describe("handleAccountSubnets", () => {
     );
     assert.equal(body.data.subnet_count, 0);
     assert.deepEqual(body.data.subnets, []);
-  });
-
-  test("happy path returns cross-subnet registration footprint", async () => {
-    const { env } = dbWith({
-      registrations: [
-        {
-          netuid: NETUID,
-          uid: UID,
-          stake_tao: 100,
-          validator_permit: 0,
-          active: 1,
-        },
-        { netuid: 64, uid: 12, stake_tao: 5, validator_permit: 1, active: 1 },
-      ],
-    });
-    const body = await json(
-      await handleAccountSubnets(
-        req(`/api/v1/accounts/${SS58}/subnets`),
-        env,
-        SS58,
-      ),
-    );
-    assert.equal(body.data.subnet_count, 2);
-    assert.equal(body.data.subnets[1].netuid, 64);
-    assert.equal(body.data.subnets[1].validator_permit, true);
   });
 });
 
@@ -4455,35 +3035,6 @@ describe("handleSubnetEvents", () => {
     assert.deepEqual(body.data.events, []);
   });
 
-  test("happy path returns per-subnet event stream", async () => {
-    const { env } = dbWith({
-      subnetEvents: [accountEventRow({ event_kind: "NeuronRegistered" })],
-    });
-    const body = await json(
-      await handleSubnetEvents(
-        req(`/api/v1/subnets/${NETUID}/events`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/events?limit=25`),
-      ),
-    );
-    assert.equal(body.data.event_count, 1);
-    assert.equal(body.data.events[0].event_kind, "NeuronRegistered");
-  });
-
-  test("kind filter is applied", async () => {
-    const { env, captures } = dbWith({
-      subnetEvents: [accountEventRow({ event_kind: "WeightsSet" })],
-    });
-    await handleSubnetEvents(
-      req(`/api/v1/subnets/${NETUID}/events`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/events?kind=WeightsSet`),
-    );
-    assert.ok(captures.sql.some((s) => /event_kind = \?/.test(s)));
-  });
-
   test("rejects an unknown event kind with 400", async () => {
     const res = await handleSubnetEvents(
       req(`/api/v1/subnets/${NETUID}/events`),
@@ -4493,37 +3044,6 @@ describe("handleSubnetEvents", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "kind");
-  });
-
-  test("accepts a non-SubtensorModule ingested kind (Transfer), not just INDEXED_EVENT_KINDS", async () => {
-    const { env, captures } = dbWith({
-      subnetEvents: [accountEventRow({ event_kind: "Transfer" })],
-    });
-    await handleSubnetEvents(
-      req(`/api/v1/subnets/${NETUID}/events`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/events?kind=Transfer`),
-    );
-    assert.ok(captures.sql.some((s) => /event_kind = \?/.test(s)));
-  });
-
-  test("block_start/block_end range filter is applied and bound", async () => {
-    const { env, captures } = dbWith({
-      subnetEvents: [accountEventRow({ block_number: 500 })],
-    });
-    await handleSubnetEvents(
-      req(`/api/v1/subnets/${NETUID}/events`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/events?block_start=100&block_end=900`),
-    );
-    assert.ok(
-      captures.sql.some(
-        (s) => /block_number >= \?/.test(s) && /block_number <= \?/.test(s),
-      ),
-    );
-    assert.ok(captures.params.some((p) => p.includes(100) && p.includes(900)));
   });
 
   test("short-circuits an inverted block_start>block_end window before D1", async () => {
@@ -4564,41 +3084,6 @@ describe("handleSubnetEvents", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "block_end");
-  });
-
-  test("cursor uses keyset seek instead of offset", async () => {
-    const { env, captures } = dbWith({
-      subnetEvents: [accountEventRow({ block_number: 150, event_index: 2 })],
-    });
-    const body = await json(
-      await handleSubnetEvents(
-        req(`/api/v1/subnets/${NETUID}/events`),
-        env,
-        NETUID,
-        url(
-          `/api/v1/subnets/${NETUID}/events?limit=1&cursor=${encodeCursor([200, 1])}`,
-        ),
-      ),
-    );
-    const sql = captures.sql.find((s) => /FROM account_events/.test(s));
-    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(sql));
-    assert.ok(!/OFFSET/.test(sql));
-    assert.equal(body.data.next_cursor, encodeCursor([150, 2]));
-  });
-
-  test("a malformed cursor is ignored and falls back to the first page", async () => {
-    const { env, captures } = dbWith({
-      subnetEvents: [accountEventRow()],
-    });
-    await handleSubnetEvents(
-      req(`/api/v1/subnets/${NETUID}/events`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/events?cursor=not-a-cursor`),
-    );
-    const sql = captures.sql.find((s) => /FROM account_events/.test(s));
-    assert.ok(/OFFSET/.test(sql));
-    assert.ok(!/block_number, event_index\) </.test(sql));
   });
 });
 
@@ -4649,58 +3134,6 @@ describe("handleSubnetEventSummary", () => {
     assert.deepEqual(body.data.categories, []);
     assert.deepEqual(body.data.event_kinds, []);
     assert.deepEqual(body.data.recent_events, []);
-  });
-
-  test("happy path returns kind/category aggregates and recent evidence", async () => {
-    const { env, captures } = dbWith({
-      subnetEventSummaryKinds: [
-        {
-          event_kind: "StakeAdded",
-          event_count: "3",
-          hotkey_count: "2",
-          coldkey_count: "1",
-          amount_tao: "4.5",
-          alpha_amount: "0.25",
-          first_block: "100",
-          last_block: "120",
-          first_observed_at: OBSERVED_AT - 1000,
-          last_observed_at: OBSERVED_AT,
-        },
-        {
-          event_kind: "WeightsSet",
-          event_count: 2,
-          hotkey_count: 1,
-          coldkey_count: 0,
-          amount_tao: null,
-          alpha_amount: null,
-          first_block: 90,
-          last_block: 119,
-          first_observed_at: OBSERVED_AT - 2000,
-          last_observed_at: OBSERVED_AT - 500,
-        },
-      ],
-      subnetEventSummaryRecent: [
-        accountEventRow({ event_kind: "StakeAdded", block_number: 120 }),
-      ],
-    });
-    const body = await json(
-      await handleSubnetEventSummary(
-        req(`/api/v1/subnets/${NETUID}/event-summary`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/event-summary?window=7d&limit=5`),
-      ),
-    );
-    assert.equal(body.data.window, "7d");
-    assert.equal(body.data.total_events, 5);
-    assert.equal(body.data.kind_count, 2);
-    assert.equal(body.data.category_count, 2);
-    assert.equal(body.data.event_kinds[0].event_kind, "StakeAdded");
-    assert.equal(body.data.event_kinds[0].category, "stake");
-    assert.equal(body.data.event_kinds[0].amount_tao, 4.5);
-    assert.equal(body.data.categories[0].category, "stake");
-    assert.equal(body.data.recent_events[0].event_kind, "StakeAdded");
-    assert.equal(captures.params.at(-1).at(-1), 5);
   });
 });
 
@@ -4936,50 +3369,6 @@ describe("handleBlocks", () => {
     assert.equal(body.data.next_cursor, null);
   });
 
-  test("happy path returns newest-first block feed", async () => {
-    const { env } = dbWith({ blocksFeed: [blockRow()] });
-    const body = await json(
-      await handleBlocks(
-        req("/api/v1/blocks"),
-        env,
-        url("/api/v1/blocks?limit=25"),
-      ),
-    );
-    assert.equal(body.data.block_count, 1);
-    assert.equal(body.data.blocks[0].block_number, BLOCK_NUM);
-    assert.equal(body.data.limit, 25);
-  });
-
-  test("?format=csv returns a named text/csv download with block columns (#2528)", async () => {
-    const { env } = dbWith({
-      blocksFeed: [
-        blockRow(),
-        blockRow({
-          block_number: BLOCK_NUM - 1,
-          block_hash: `0x${"c".repeat(64)}`,
-        }),
-      ],
-    });
-    const res = await handleBlocks(
-      req("/api/v1/blocks?format=csv"),
-      env,
-      url("/api/v1/blocks?format=csv"),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /^text\/csv/);
-    assert.equal(
-      res.headers.get("content-disposition"),
-      'attachment; filename="blocks.csv"',
-    );
-    const lines = (await res.text()).split("\r\n");
-    assert.equal(
-      lines[0],
-      "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
-    );
-    assert.equal(lines.length, 3);
-    assert.match(lines[1], new RegExp(`^${BLOCK_NUM},`));
-  });
-
   test("Accept: text/csv negotiates CSV without an explicit format", async () => {
     const { env } = dbWith({ blocksFeed: [blockRow()] });
     const res = await handleBlocks(
@@ -5060,62 +3449,6 @@ describe("handleBlocks", () => {
     assert.equal(body.data.limit, 100);
   });
 
-  test("cursor uses keyset seek and emits next_cursor", async () => {
-    const { env, captures } = dbWith({
-      blocksFeed: [blockRow({ block_number: 150 })],
-    });
-    const body = await json(
-      await handleBlocks(
-        req("/api/v1/blocks"),
-        env,
-        url(`/api/v1/blocks?limit=1&cursor=${encodeCursor([200])}`),
-      ),
-    );
-    const sql = captures.sql.find((s) => /FROM blocks/.test(s));
-    assert.ok(/WHERE block_number < \?/.test(sql));
-    assert.ok(!/OFFSET/.test(sql));
-    assert.equal(body.data.next_cursor, encodeCursor([150]));
-  });
-
-  test("applies the conjunctive filter set (#1991)", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [] });
-    await handleBlocks(
-      req("/api/v1/blocks"),
-      env,
-      url(
-        "/api/v1/blocks?author=5Author&spec_version=423&block_start=100&block_end=200&from=1000&to=2000&min_extrinsics=1&min_events=5",
-      ),
-    );
-    const sql = captures.sql.find((s) => /FROM blocks/.test(s));
-    assert.ok(/author = \?/.test(sql));
-    assert.ok(/spec_version = \?/.test(sql));
-    assert.ok(/block_number >= \?/.test(sql));
-    assert.ok(/block_number <= \?/.test(sql));
-    assert.ok(/observed_at >= \?/.test(sql));
-    assert.ok(/observed_at <= \?/.test(sql));
-    assert.ok(/extrinsic_count >= \?/.test(sql));
-    assert.ok(/event_count >= \?/.test(sql));
-    // every value bound (author string + the 7 clamped ints), never interpolated.
-    const params = captures.params.flat();
-    assert.ok(params.includes("5Author"));
-    assert.ok(params.includes(423));
-    // limit + offset are the last two bound params (no cursor → offset path).
-    assert.equal(params.at(-2), 50);
-    assert.equal(params.at(-1), 0);
-  });
-
-  test("a filter ANDs with the keyset cursor and drops OFFSET", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [] });
-    await handleBlocks(
-      req("/api/v1/blocks"),
-      env,
-      url(`/api/v1/blocks?author=5Author&cursor=${encodeCursor([300])}`),
-    );
-    const sql = captures.sql.find((s) => /FROM blocks/.test(s));
-    assert.ok(/author = \? AND block_number < \?/.test(sql));
-    assert.ok(!/OFFSET/.test(sql));
-  });
-
   test("short-circuits impossible count floors before querying D1", async () => {
     const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
     const body = await json(
@@ -5143,18 +3476,6 @@ describe("handleBlocks", () => {
     assert.deepEqual(body.data.blocks, []);
     assert.equal(captures.sql.length, 0);
   });
-
-  test("the unfiltered feed keeps the plain OFFSET path (no WHERE)", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [] });
-    await handleBlocks(
-      req("/api/v1/blocks"),
-      env,
-      url("/api/v1/blocks?limit=10&offset=20"),
-    );
-    const sql = captures.sql.find((s) => /FROM blocks/.test(s));
-    assert.ok(!/WHERE/.test(sql));
-    assert.ok(/ORDER BY block_number DESC LIMIT \? OFFSET \?/.test(sql));
-  });
 });
 
 describe("handleBlock", () => {
@@ -5171,65 +3492,6 @@ describe("handleBlock", () => {
     assert.equal(body.data.next_block_number, null);
   });
 
-  test("happy path resolves by numeric block_number", async () => {
-    const { env, captures } = dbWith({
-      blockDetail: blockRow(),
-      blockNeighbors: { prev: 1230, next: 1240 },
-    });
-    const body = await json(
-      await handleBlock(
-        req(`/api/v1/blocks/${BLOCK_NUM}`),
-        env,
-        String(BLOCK_NUM),
-      ),
-    );
-    const neighborSql = captures.sql.find((sql) =>
-      /SELECT MAX\(block_number\) FROM blocks WHERE block_number < \?/.test(
-        sql,
-      ),
-    );
-    assert.ok(neighborSql);
-    assert.ok(!/MAX\(CASE WHEN block_number </.test(neighborSql));
-    assert.equal(body.data.block.block_number, BLOCK_NUM);
-    assert.equal(body.data.prev_block_number, 1230);
-    assert.equal(body.data.next_block_number, 1240);
-  });
-
-  test("happy path resolves by 0x block_hash ref", async () => {
-    const { env } = dbWith({ blockDetail: blockRow() });
-    const body = await json(
-      await handleBlock(req(`/api/v1/blocks/${HASH}`), env, HASH),
-    );
-    assert.equal(body.data.ref, HASH);
-    assert.equal(body.data.block.block_hash, HASH);
-  });
-
-  test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {
-    const upperHash = `0x${"A".repeat(64)}`;
-    const lowerHash = upperHash.toLowerCase();
-    const { env, captures } = dbWith({ blockDetail: blockRow() });
-    await handleBlock(req(`/api/v1/blocks/${upperHash}`), env, upperHash);
-    const idx = captures.sql.findIndex((s) =>
-      /FROM blocks WHERE block_hash = \?/.test(s),
-    );
-    assert.ok(idx !== -1, "expected a block_hash lookup");
-    assert.equal(captures.params[idx][0], lowerHash);
-  });
-
-  test("uses the static cache profile when the block resolves", async () => {
-    const { env } = dbWith({
-      blockDetail: blockRow(),
-      blockNeighbors: { prev: 1230, next: 1240 },
-    });
-    const res = await handleBlock(
-      req(`/api/v1/blocks/${BLOCK_NUM}`),
-      env,
-      String(BLOCK_NUM),
-    );
-    assert.match(res.headers.get("cache-control"), /max-age=600/);
-    assert.equal(res.headers.get("x-metagraph-cache-profile"), "static");
-  });
-
   test("keeps the short cache profile when the block is unknown", async () => {
     const res = await handleBlock(
       req(`/api/v1/blocks/${BLOCK_NUM}`),
@@ -5239,30 +3501,6 @@ describe("handleBlock", () => {
     assert.equal(res.status, 200);
     assert.match(res.headers.get("cache-control"), /max-age=60/);
     assert.equal(res.headers.get("x-metagraph-cache-profile"), "short");
-  });
-
-  test("still emits a 304 for a resolved block when If-None-Match matches", async () => {
-    const { env } = dbWith({
-      blockDetail: blockRow(),
-      blockNeighbors: { prev: 1230, next: 1240 },
-    });
-    const first = await handleBlock(
-      req(`/api/v1/blocks/${BLOCK_NUM}`),
-      env,
-      String(BLOCK_NUM),
-    );
-    const etag = first.headers.get("etag");
-    assert.ok(etag);
-    const second = await handleBlock(
-      new Request(`https://api.metagraph.sh/api/v1/blocks/${BLOCK_NUM}`, {
-        headers: { "if-none-match": etag },
-      }),
-      env,
-      String(BLOCK_NUM),
-    );
-    assert.equal(second.status, 304);
-    assert.match(second.headers.get("cache-control"), /max-age=600/);
-    assert.equal(second.headers.get("etag"), etag);
   });
 });
 
@@ -5288,43 +3526,6 @@ describe("handleBlockExtrinsics", () => {
     assert.equal(body.data.block_number, null);
     assert.equal(body.data.extrinsic_count, 0);
     assert.deepEqual(body.data.extrinsics, []);
-  });
-
-  test("happy path lists extrinsics in extrinsic_index ASC order", async () => {
-    const { env } = dbWith({
-      blockDetail: { block_number: BLOCK_NUM },
-      extrinsics: [extrinsicRow()],
-    });
-    const body = await json(
-      await handleBlockExtrinsics(
-        req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-        env,
-        String(BLOCK_NUM),
-        url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-      ),
-    );
-    assert.equal(body.data.extrinsic_count, 1);
-    assert.equal(body.data.extrinsics[0].call_function, "add_stake");
-  });
-
-  test("hash ref resolves block_number before listing extrinsics", async () => {
-    const { env } = dbWith({
-      blockDetail: { block_number: 9 },
-      blockNumberByHash: 9,
-      extrinsics: [extrinsicRow({ block_number: 9, extrinsic_index: 1 })],
-    });
-    const hash = HASH;
-    const body = await json(
-      await handleBlockExtrinsics(
-        req(`/api/v1/blocks/${hash}/extrinsics`),
-        env,
-        hash,
-        url(`/api/v1/blocks/${hash}/extrinsics`),
-      ),
-    );
-    assert.equal(body.data.ref, hash);
-    assert.equal(body.data.block_number, 9);
-    assert.equal(body.data.extrinsics[0].extrinsic_index, 1);
   });
 
   test("unknown numeric ref yields block_number:null + empty extrinsics", async () => {
@@ -5354,23 +3555,6 @@ describe("handleBlockExtrinsics", () => {
     assert.equal(body.data.block_number, null);
     assert.equal(body.data.extrinsic_count, 0);
   });
-
-  test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {
-    const upperHash = `0x${"A".repeat(64)}`;
-    const lowerHash = upperHash.toLowerCase();
-    const { env, captures } = dbWith({ blockNumberByHash: 9, extrinsics: [] });
-    await handleBlockExtrinsics(
-      req(`/api/v1/blocks/${upperHash}/extrinsics`),
-      env,
-      upperHash,
-      url(`/api/v1/blocks/${upperHash}/extrinsics`),
-    );
-    const idx = captures.sql.findIndex((s) =>
-      /SELECT block_number FROM blocks WHERE block_hash = \?/.test(s),
-    );
-    assert.ok(idx !== -1, "expected a block_hash resolution lookup");
-    assert.equal(captures.params[idx][0], lowerHash);
-  });
 });
 
 describe("handleBlockEvents", () => {
@@ -5395,40 +3579,6 @@ describe("handleBlockEvents", () => {
     assert.equal(body.data.block_number, null);
     assert.equal(body.data.event_count, 0);
     assert.deepEqual(body.data.events, []);
-  });
-
-  test("happy path returns block-scoped events", async () => {
-    const { env } = dbWith({
-      blockDetail: { block_number: BLOCK_NUM },
-      blockEvents: [accountEventRow()],
-    });
-    const body = await json(
-      await handleBlockEvents(
-        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
-        env,
-        String(BLOCK_NUM),
-        url(`/api/v1/blocks/${BLOCK_NUM}/events?limit=50`),
-      ),
-    );
-    assert.equal(body.data.event_count, 1);
-    assert.equal(body.data.events[0].event_kind, "StakeAdded");
-  });
-
-  test("hash ref resolves before reading events", async () => {
-    const { env } = dbWith({
-      blockNumberByHash: 9,
-      blockEvents: [accountEventRow({ block_number: 9 })],
-    });
-    const body = await json(
-      await handleBlockEvents(
-        req(`/api/v1/blocks/${HASH}/events`),
-        env,
-        HASH,
-        url(`/api/v1/blocks/${HASH}/events`),
-      ),
-    );
-    assert.equal(body.data.block_number, 9);
-    assert.equal(body.data.event_count, 1);
   });
 
   test("unknown numeric ref yields block_number:null + empty events", async () => {
@@ -5473,23 +3623,6 @@ describe("handleBlockEvents", () => {
     assert.equal(body.data.block_number, null);
     assert.equal(body.data.event_count, 0);
   });
-
-  test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {
-    const upperHash = `0x${"A".repeat(64)}`;
-    const lowerHash = upperHash.toLowerCase();
-    const { env, captures } = dbWith({ blockNumberByHash: 9, blockEvents: [] });
-    await handleBlockEvents(
-      req(`/api/v1/blocks/${upperHash}/events`),
-      env,
-      upperHash,
-      url(`/api/v1/blocks/${upperHash}/events`),
-    );
-    const idx = captures.sql.findIndex((s) =>
-      /SELECT block_number FROM blocks WHERE block_hash = \?/.test(s),
-    );
-    assert.ok(idx !== -1, "expected a block_hash resolution lookup");
-    assert.equal(captures.params[idx][0], lowerHash);
-  });
 });
 
 describe("handleExtrinsics", () => {
@@ -5514,36 +3647,6 @@ describe("handleExtrinsics", () => {
     assert.equal(body.data.next_cursor, null);
   });
 
-  test("happy path returns recent extrinsic feed", async () => {
-    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
-    const body = await json(
-      await handleExtrinsics(
-        req("/api/v1/extrinsics"),
-        env,
-        url("/api/v1/extrinsics?limit=25"),
-      ),
-    );
-    assert.equal(body.data.extrinsic_count, 1);
-    assert.equal(body.data.extrinsics[0].block_number, BLOCK_NUM);
-  });
-
-  test("applies conjunctive filter set (#1846)", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url(
-        "/api/v1/extrinsics?signer=5Signer&call_module=SubtensorModule&call_function=add_stake&success=false&block_start=100&block_end=200",
-      ),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/signer = \?/.test(sql));
-    assert.ok(/call_module = \?/.test(sql));
-    assert.ok(/success = \?/.test(sql));
-    assert.ok(/block_number >= \?/.test(sql));
-    assert.ok(captures.params.flat().includes(0));
-  });
-
   test("rejects a non-boolean success value with 400 (#2575)", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     const res = await handleExtrinsics(
@@ -5559,43 +3662,6 @@ describe("handleExtrinsics", () => {
       captures.sql.filter((s) => /FROM extrinsics/.test(s)).length,
       0,
     );
-  });
-
-  test("success=true binds only successful extrinsics (#2575)", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?success=true"),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/success = \?/.test(sql));
-    assert.ok(captures.params.flat().includes(1));
-  });
-
-  test("success=false binds only failed extrinsics, omitting NULL (#2575)", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?success=false"),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/success = \?/.test(sql));
-    assert.ok(captures.params.flat().includes(0));
-    assert.ok(!/success IS NULL/.test(sql));
-  });
-
-  test("omitted success leaves the feed unfiltered (#2575)", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics"),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql);
-    assert.ok(!/success = \?/.test(sql));
   });
 
   test("rejects a malformed call_hash with 400 (#4322)", async () => {
@@ -5631,59 +3697,6 @@ describe("handleExtrinsics", () => {
     );
   });
 
-  test("call_hash binds a quoted LIKE match, scoped alongside call_module (#4322)", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    const hash = `0x${"c".repeat(64)}`;
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url(`/api/v1/extrinsics?call_module=Multisig&call_hash=${hash}`),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/call_args LIKE \?/.test(sql));
-    assert.ok(captures.params.flat().includes(`%"${hash}"%`));
-  });
-
-  test("forces module-index for a module-only feed path (#2082)", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?call_module=Balances&limit=10"),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql);
-    assert.ok(
-      /INDEXED BY idx_extrinsics_module_block/.test(sql),
-      `expected module-filter call to use idx_extrinsics_module_block, got: ${sql}`,
-    );
-  });
-
-  test("does not force module-index for compound module filters", async () => {
-    const recentMs = Date.now() - 60_000;
-    const hash = `0x${"a".repeat(64)}`;
-    for (const query of [
-      "call_module=Balances&call_function=__never__",
-      "call_module=Balances&success=true",
-      `call_module=Balances&from=${recentMs}`,
-      `call_module=Balances&to=${recentMs}`,
-      `call_module=Multisig&call_hash=${hash}`,
-    ]) {
-      const { env, captures } = dbWith({ extrinsics: [] });
-      await handleExtrinsics(
-        req("/api/v1/extrinsics"),
-        env,
-        url(`/api/v1/extrinsics?${query}&limit=10`),
-      );
-      const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-      assert.ok(sql);
-      assert.ok(
-        !/INDEXED BY idx_extrinsics_module_block/.test(sql),
-        `compound module filter must stay planner-selected for ${query}, got: ${sql}`,
-      );
-    }
-  });
-
   test("uses idx_extrinsics_module_block for module feed query plan", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(`
@@ -5715,22 +3728,6 @@ describe("handleExtrinsics", () => {
       plan[0].detail,
       "SEARCH extrinsics USING INDEX idx_extrinsics_module_block (call_module=?)",
     );
-  });
-
-  test("keeps broad standalone time filters planner-selected", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?from=0"),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql);
-    assert.ok(
-      !/INDEXED BY/.test(sql),
-      "broad filters must not force a sort-heavy timestamp index",
-    );
-    assert.ok(/observed_at >= \?/.test(sql));
   });
 
   test("rejects malformed time filters with 400 (#2086)", async () => {
@@ -5812,82 +3809,6 @@ describe("handleExtrinsics", () => {
     assert.equal(captures.sql.length, 0);
   });
 
-  test("a valid recent window is NOT short-circuited and queries D1", async () => {
-    const { env, captures } = dbWith({ extrinsics: [] });
-    const now = Date.now();
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url(`/api/v1/extrinsics?from=${now - 60_000}&to=${now}`),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql, "a valid window must reach D1");
-    assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
-    assert.ok(/observed_at >= \?/.test(sql));
-    assert.ok(/observed_at <= \?/.test(sql));
-  });
-
-  test("uses the observed-at index for selective one-sided time filters", async () => {
-    const now = Date.now();
-
-    {
-      const { env, captures } = dbWith({ extrinsics: [] });
-      await handleExtrinsics(
-        req("/api/v1/extrinsics"),
-        env,
-        url(`/api/v1/extrinsics?from=${now + 60_000}`),
-      );
-      const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-      assert.ok(sql, "a near-future one-sided from filter must reach D1");
-      assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
-      assert.ok(/observed_at >= \?/.test(sql));
-    }
-
-    {
-      const { env, captures } = dbWith({ extrinsics: [] });
-      await handleExtrinsics(
-        req("/api/v1/extrinsics"),
-        env,
-        url(`/api/v1/extrinsics?to=${now - EXTRINSIC_RETENTION_MS + 60_000}`),
-      );
-      const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-      assert.ok(sql, "a near-floor one-sided to filter must reach D1");
-      assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
-      assert.ok(/observed_at <= \?/.test(sql));
-    }
-  });
-
-  test("drops the observed-at index hint when an equality filter is present", async () => {
-    // With a (signer) equality the planner should use the order-aligned
-    // signer index, not be forced onto the observed-at one.
-    const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?from=1750000000000&signer=5Signer"),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql);
-    assert.ok(!/INDEXED BY/.test(sql), "equality filter must drop the hint");
-    assert.ok(/signer = \?/.test(sql));
-  });
-
-  test("cursor seeks on (block_number, extrinsic_index)", async () => {
-    const { env, captures } = dbWith({
-      extrinsics: [extrinsicRow({ block_number: 150, extrinsic_index: 4 })],
-    });
-    const body = await json(
-      await handleExtrinsics(
-        req("/api/v1/extrinsics"),
-        env,
-        url(`/api/v1/extrinsics?limit=1&cursor=${encodeCursor([200, 2])}`),
-      ),
-    );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/\(block_number, extrinsic_index\) < \(\?, \?\)/.test(sql));
-    assert.equal(body.data.next_cursor, encodeCursor([150, 4]));
-  });
-
   test("clamps limit to <=100", async () => {
     const { env } = dbWith({ extrinsics: [] });
     const body = await json(
@@ -5903,45 +3824,6 @@ describe("handleExtrinsics", () => {
   const EXTRINSICS_CSV_HEADER =
     "extrinsic_id,block_number,signer,call_module,call_function,success";
 
-  test("?format=csv exports filtered extrinsic rows (#2529)", async () => {
-    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
-    const res = await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?limit=10&format=csv"),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    assert.equal(
-      res.headers.get("content-disposition"),
-      'attachment; filename="extrinsics.csv"',
-    );
-    const text = await res.text();
-    assert.equal(
-      text,
-      `${EXTRINSICS_CSV_HEADER}\r\n${BLOCK_NUM}-2,${BLOCK_NUM},${SS58},SubtensorModule,add_stake,true`,
-    );
-  });
-
-  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
-    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
-    const res = await handleExtrinsics(
-      new Request(
-        "https://api.metagraph.sh/api/v1/extrinsics?format=json&limit=10",
-        {
-          headers: { accept: "text/csv" },
-        },
-      ),
-      env,
-      url("/api/v1/extrinsics?format=json&limit=10"),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type") || "", /application\/json/);
-    const body = await json(res);
-    assert.equal(body.ok, true);
-    assert.equal(body.data.extrinsic_count, 1);
-  });
-
   test("Accept: text/csv negotiates CSV on the extrinsics feed", async () => {
     const { env } = dbWith({ extrinsics: [extrinsicRow()] });
     const res = await handleExtrinsics(
@@ -5953,21 +3835,6 @@ describe("handleExtrinsics", () => {
     );
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-  });
-
-  test("?call_module=SubtensorModule&format=csv honors conjunctive filters", async () => {
-    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
-    const res = await handleExtrinsics(
-      req("/api/v1/extrinsics"),
-      env,
-      url("/api/v1/extrinsics?call_module=SubtensorModule&format=csv"),
-    );
-    assert.equal(res.status, 200);
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/call_module = \?/.test(sql));
-    const text = await res.text();
-    assert.equal(text.split("\r\n")[0], EXTRINSICS_CSV_HEADER);
-    assert.ok(text.includes("SubtensorModule"));
   });
 
   test("?format=csv emits a header-only export on cold D1", async () => {
@@ -6008,45 +3875,6 @@ describe("handleExtrinsic", () => {
     assert.deepEqual(body.data.events, []);
   });
 
-  test("happy path resolves by extrinsic_hash", async () => {
-    const { env } = dbWith({ extrinsicDetail: extrinsicRow() });
-    const body = await json(
-      await handleExtrinsic(req(`/api/v1/extrinsics/${HASH}`), env, HASH),
-    );
-    assert.equal(body.data.extrinsic.extrinsic_hash, HASH);
-    assert.equal(body.data.extrinsic.call_function, "add_stake");
-  });
-
-  test("normalizes an uppercase 0x extrinsic_hash to lowercase before D1 lookup", async () => {
-    const upperHash = `0x${"A".repeat(64)}`;
-    const lowerHash = upperHash.toLowerCase();
-    const { env, captures } = dbWith({ extrinsicDetail: extrinsicRow() });
-    await handleExtrinsic(
-      req(`/api/v1/extrinsics/${upperHash}`),
-      env,
-      upperHash,
-    );
-    const idx = captures.sql.findIndex((s) =>
-      /WHERE extrinsic_hash = \?/.test(s),
-    );
-    assert.ok(idx !== -1, "expected an extrinsic_hash lookup");
-    assert.equal(captures.params[idx][0], lowerHash);
-  });
-
-  test("happy path resolves by composite id block-index", async () => {
-    const { env } = dbWith({
-      extrinsicDetail: extrinsicRow({ extrinsic_hash: null }),
-    });
-    const ref = `${BLOCK_NUM}-2`;
-    const body = await json(
-      await handleExtrinsic(req(`/api/v1/extrinsics/${ref}`), env, ref),
-    );
-    assert.equal(body.data.ref, ref);
-    assert.equal(body.data.extrinsic.block_number, BLOCK_NUM);
-    assert.equal(body.data.extrinsic.extrinsic_index, 2);
-    assert.equal(body.data.extrinsic.extrinsic_hash, null);
-  });
-
   test("malformed composite id yields extrinsic:null", async () => {
     const body = await json(
       await handleExtrinsic(
@@ -6056,21 +3884,6 @@ describe("handleExtrinsic", () => {
       ),
     );
     assert.equal(body.data.extrinsic, null);
-  });
-
-  test("embeds emitted account_events when extrinsic resolves (#1849)", async () => {
-    const { env } = dbWith({
-      extrinsicDetail: extrinsicRow(),
-      extrinsicEvents: [
-        accountEventRow({ event_kind: "StakeAdded", extrinsic_index: 2 }),
-      ],
-    });
-    const body = await json(
-      await handleExtrinsic(req(`/api/v1/extrinsics/${HASH}`), env, HASH),
-    );
-    assert.equal(body.data.events.length, 1);
-    assert.equal(body.data.events[0].event_kind, "StakeAdded");
-    assert.equal(body.data.events[0].extrinsic_index, 2);
   });
 });
 
@@ -6085,18 +3898,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     return { fetch: async () => response };
   }
 
-  test("flag absent: uses D1 even when DATA_API is bound", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
-    env.DATA_API = dataApi(
-      Response.json({ schema_version: 1, block_count: 99, blocks: [] }),
-    );
-    const body = await json(
-      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
-    );
-    assert.equal(body.data.block_count, 1); // the D1 fixture's count, not 99
-    assert.ok(captures.sql.length > 0); // D1 was actually queried
-  });
-
   test("flag=postgres + DATA_API succeeds: Postgres data wins, D1 never queried", async () => {
     const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
@@ -6108,52 +3909,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.block_count, 99); // the Postgres fixture, not D1's
     assert.deepEqual(captures.sql, []); // D1 was never touched
-  });
-
-  test("flag=postgres + DATA_API throws: falls back to D1 seamlessly", async () => {
-    const { env } = dbWith({ blocksFeed: [blockRow()] });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("network error");
-      },
-    };
-    const body = await json(
-      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
-    );
-    assert.equal(body.data.block_count, 1); // the D1 fixture, not an error
-  });
-
-  test("flag=postgres + DATA_API returns non-2xx: falls back to D1", async () => {
-    const { env } = dbWith({ blocksFeed: [blockRow()] });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = dataApi(new Response("upstream error", { status: 502 }));
-    const body = await json(
-      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
-    );
-    assert.equal(body.data.block_count, 1);
-  });
-
-  test("flag=postgres + DATA_API returns unparseable JSON: falls back to D1", async () => {
-    const { env } = dbWith({ blocksFeed: [blockRow()] });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = dataApi(new Response("not json", { status: 200 }));
-    const body = await json(
-      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
-    );
-    assert.equal(body.data.block_count, 1);
-  });
-
-  test("flag=postgres + DATA_API returns valid JSON that isn't an object: falls back to D1", async () => {
-    // A 200 with a bare JSON scalar (not `null`, which JSON.parse also accepts)
-    // parses without throwing but isn't a usable payload shape.
-    const { env } = dbWith({ blocksFeed: [blockRow()] });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = dataApi(Response.json(42));
-    const body = await json(
-      await handleBlocks(req("/api/v1/blocks"), env, url("/api/v1/blocks")),
-    );
-    assert.equal(body.data.block_count, 1);
   });
 
   test("handleBlock: flag=postgres uses Postgres data over the D1 fixture", async () => {
@@ -6177,20 +3932,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.block.author, "postgres-author");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleBlock: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ blockDetail: blockRow() });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
-    const body = await json(
-      await handleBlock(
-        req(`/api/v1/blocks/${BLOCK_NUM}`),
-        env,
-        String(BLOCK_NUM),
-      ),
-    );
-    assert.equal(body.data.block.block_number, BLOCK_NUM);
   });
 
   test("handleExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6217,24 +3958,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleExtrinsics: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleExtrinsics(
-        req("/api/v1/extrinsics"),
-        env,
-        url("/api/v1/extrinsics"),
-      ),
-    );
-    assert.equal(body.data.extrinsic_count, 1);
-  });
-
   test("handleExtrinsic: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ extrinsicDetail: extrinsicRow() });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
@@ -6251,34 +3974,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.extrinsic.signer, "postgres-signer");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleExtrinsic: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ extrinsicDetail: extrinsicRow() });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
-    const body = await json(
-      await handleExtrinsic(req(`/api/v1/extrinsics/${HASH}`), env, HASH),
-    );
-    assert.equal(body.data.extrinsic.extrinsic_hash, HASH);
-  });
-
-  test("handleAccountEvents: flag absent, uses D1 even when DATA_API is bound", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.DATA_API = dataApi(
-      Response.json({
-        schema_version: 1,
-        ss58: SS58,
-        event_count: 99,
-        events: [],
-      }),
-    );
-    const path = `/api/v1/accounts/${SS58}/events`;
-    const body = await json(
-      await handleAccountEvents(req(path), env, SS58, url(path)),
-    );
-    assert.equal(body.data.event_count, 1); // the D1 fixture's count, not 99
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6301,21 +3996,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.event_count, 99);
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleAccountEvents: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const path = `/api/v1/accounts/${SS58}/events`;
-    const body = await json(
-      await handleAccountEvents(req(path), env, SS58, url(path)),
-    );
-    assert.equal(body.data.event_count, 1);
   });
 
   // #4771: neurons/neuron_daily's new Postgres tier, same shared-fallback
@@ -6341,21 +4021,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetMetagraph: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const path = `/api/v1/subnets/${NETUID}/metagraph`;
-    const body = await json(
-      await handleSubnetMetagraph(req(path), env, NETUID, url(path)),
-    );
-    assert.equal(body.data.neuron_count, 1);
-  });
-
   test("handleNeuron: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -6378,25 +4043,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.neuron.hotkey, "postgres-hotkey");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleNeuron: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleNeuron(
-        req(`/api/v1/subnets/${NETUID}/neurons/${UID}`),
-        env,
-        NETUID,
-        UID,
-      ),
-    );
-    assert.equal(body.data.neuron.hotkey, SS58);
   });
 
   // #4832 gap-closure: subnet_hyperparams/subnet_hyperparams_history's own
@@ -6654,21 +4300,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetValidators: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const path = `/api/v1/subnets/${NETUID}/validators`;
-    const body = await json(
-      await handleSubnetValidators(req(path), env, NETUID, url(path)),
-    );
-    assert.equal(body.data.validator_count, 1);
-  });
-
   test("handleGlobalValidators: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({
       neurons: [neuronRow({ netuid: NETUID })],
@@ -6694,33 +4325,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.validator_count, 99);
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleGlobalValidators: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ neurons: [neuronRow({ netuid: NETUID })] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleGlobalValidators(
-        req("/api/v1/validators"),
-        env,
-        url("/api/v1/validators"),
-      ),
-    );
-    assert.equal(body.data.validator_count, 1);
-  });
-
-  test("handleValidatorDetail: happy path returns cross-subnet validator detail from D1", async () => {
-    const { env } = dbWith({ neurons: [neuronRow({ netuid: NETUID })] });
-    const body = await json(
-      await handleValidatorDetail(req(`/api/v1/validators/${SS58}`), env, SS58),
-    );
-    assert.equal(body.data.hotkey, SS58);
-    assert.equal(body.data.subnet_count, 1);
   });
 
   test("handleValidatorDetail: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6749,20 +4353,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleValidatorDetail: flag=postgres falls back to D1 on failure", async () => {
-    const { env } = dbWith({ neurons: [neuronRow({ netuid: NETUID })] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleValidatorDetail(req(`/api/v1/validators/${SS58}`), env, SS58),
-    );
-    assert.equal(body.data.subnet_count, 1);
-  });
-
   test("handleValidatorNominators: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -6783,26 +4373,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleValidatorNominators: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleValidatorNominators(
-        req(`/api/v1/validators/${SS58}/nominators`),
-        env,
-        SS58,
-        url(`/api/v1/validators/${SS58}/nominators`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountWeightSetters: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6827,26 +4397,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountWeightSetters: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountWeightSetters(
-        req(`/api/v1/accounts/${SS58}/weight-setters`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/weight-setters`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetWeightSetters: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -6863,26 +4413,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetWeightSetters: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetWeightSetters(
-        req(`/api/v1/subnets/${NETUID}/weights/setters`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/weights/setters`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountStakeFlow: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6907,26 +4437,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountStakeFlow: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountStakeFlow(
-        req(`/api/v1/accounts/${SS58}/stake-flow`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/stake-flow`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetStakeFlow: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -6947,26 +4457,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetStakeFlow: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetStakeFlow(
-        req(`/api/v1/subnets/${NETUID}/stake-flow`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-flow`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountStakeMoves: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6991,26 +4481,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountStakeMoves: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountStakeMoves(
-        req(`/api/v1/accounts/${SS58}/stake-moves`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/stake-moves`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetStakeMoves: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7029,26 +4499,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetStakeMoves: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetStakeMoves(
-        req(`/api/v1/subnets/${NETUID}/stake-moves`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-moves`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetStakeTransfers: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7065,26 +4515,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetStakeTransfers: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetStakeTransfers(
-        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-transfers`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountRegistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7109,26 +4539,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountRegistrations: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountRegistrations(
-        req(`/api/v1/accounts/${SS58}/registrations`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/registrations`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetRegistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7145,26 +4555,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetRegistrations: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetRegistrations(
-        req(`/api/v1/subnets/${NETUID}/registrations`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/registrations`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountServing: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7189,26 +4579,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountServing: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountServing(
-        req(`/api/v1/accounts/${SS58}/serving`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/serving`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetServing: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7225,26 +4595,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetServing: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetServing(
-        req(`/api/v1/subnets/${NETUID}/serving`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/serving`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountAxonRemovals: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7269,26 +4619,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountAxonRemovals: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountAxonRemovals(
-        req(`/api/v1/accounts/${SS58}/axon-removals`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/axon-removals`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetAxonRemovals: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7305,26 +4635,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetAxonRemovals: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetAxonRemovals(
-        req(`/api/v1/subnets/${NETUID}/axon-removals`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/axon-removals`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountPrometheus: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7349,26 +4659,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountPrometheus: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountPrometheus(
-        req(`/api/v1/accounts/${SS58}/prometheus`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/prometheus`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetPrometheus: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7385,26 +4675,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetPrometheus: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetPrometheus(
-        req(`/api/v1/subnets/${NETUID}/prometheus`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/prometheus`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountDeregistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7429,26 +4699,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountDeregistrations: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountDeregistrations(
-        req(`/api/v1/accounts/${SS58}/deregistrations`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/deregistrations`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetDeregistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7465,26 +4715,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetDeregistrations: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetDeregistrations(
-        req(`/api/v1/subnets/${NETUID}/deregistrations`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/deregistrations`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountTransfers: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7504,26 +4734,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleAccountTransfers: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountTransfers(
-        req(`/api/v1/accounts/${SS58}/transfers`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/transfers`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountCounterparties: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7599,26 +4809,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountCounterparties: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/counterparties`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   // #4832 Tier 1a: blocks/extrinsics-derived handlers that were reading D1
   // directly with no Postgres tier at all -- silently serving data frozen
   // since the streamer stopped. Same pattern as the blocks above.
@@ -7644,29 +4834,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleBlockExtrinsics: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({
-      blockDetail: blockRow(),
-      extrinsics: [extrinsicRow()],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleBlockExtrinsics(
-        req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-        env,
-        String(BLOCK_NUM),
-        url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleBlockEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ blockEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -7688,29 +4855,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleBlockEvents: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({
-      blockDetail: blockRow(),
-      blockEvents: [accountEventRow()],
-    });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleBlockEvents(
-        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
-        env,
-        String(BLOCK_NUM),
-        url(`/api/v1/blocks/${BLOCK_NUM}/events`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleBlocksSummary: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
@@ -7727,25 +4871,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleBlocksSummary: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleBlocksSummary(
-        req("/api/v1/blocks/summary"),
-        env,
-        url("/api/v1/blocks/summary"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7767,26 +4892,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountExtrinsics: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountExtrinsics(
-        req(`/api/v1/accounts/${SS58}/extrinsics`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/extrinsics`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSudo: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({
       extrinsics: [extrinsicRow({ call_module: "Sudo" })],
@@ -7801,55 +4906,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSudo: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({
-      extrinsics: [extrinsicRow({ call_module: "Sudo" })],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSudo(
-        req("/api/v1/sudo?success=true"),
-        env,
-        url("/api/v1/sudo?success=true"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
-  test("handleSudo: D1 fallback narrows to success=false, distinct from absent", async () => {
-    const { env } = dbWith({
-      extrinsics: [extrinsicRow({ call_module: "Sudo", success: 0 })],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
-    const body = await json(
-      await handleSudo(
-        req("/api/v1/sudo?success=false"),
-        env,
-        url("/api/v1/sudo?success=false"),
-      ),
-    );
-    assert.equal(body.data.extrinsics[0].success, false);
-  });
-
-  test("handleSudo: D1 fallback with no success param leaves the filter unset", async () => {
-    const { env } = dbWith({
-      extrinsics: [extrinsicRow({ call_module: "Sudo" })],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
-    const body = await json(
-      await handleSudo(req("/api/v1/sudo"), env, url("/api/v1/sudo")),
-    );
-    assert.equal(body.data.extrinsics[0].call_module, "Sudo");
   });
 
   test("handleGovernanceConfigChanges: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -7872,59 +4928,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleGovernanceConfigChanges: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({
-      extrinsics: [extrinsicRow({ call_module: "AdminUtils" })],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleGovernanceConfigChanges(
-        req("/api/v1/governance/config-changes?success=true"),
-        env,
-        url("/api/v1/governance/config-changes?success=true"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
-  test("handleGovernanceConfigChanges: D1 fallback narrows to success=false, distinct from absent", async () => {
-    const { env } = dbWith({
-      extrinsics: [extrinsicRow({ call_module: "AdminUtils", success: 0 })],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
-    const body = await json(
-      await handleGovernanceConfigChanges(
-        req("/api/v1/governance/config-changes?success=false"),
-        env,
-        url("/api/v1/governance/config-changes?success=false"),
-      ),
-    );
-    assert.equal(body.data.extrinsics[0].success, false);
-  });
-
-  test("handleGovernanceConfigChanges: D1 fallback with no success param leaves the filter unset", async () => {
-    const { env } = dbWith({
-      extrinsics: [extrinsicRow({ call_module: "AdminUtils" })],
-    });
-    env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = { fetch: async () => new Response("err", { status: 500 }) };
-    const body = await json(
-      await handleGovernanceConfigChanges(
-        req("/api/v1/governance/config-changes"),
-        env,
-        url("/api/v1/governance/config-changes"),
-      ),
-    );
-    assert.equal(body.data.extrinsics[0].call_module, "AdminUtils");
-  });
-
   test("handleRuntime: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
@@ -7937,21 +4940,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleRuntime: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
-    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleRuntime(req("/api/v1/runtime"), env, url("/api/v1/runtime")),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   // #4832 Tier 1b: the remaining account_events-derived handlers with no
@@ -7976,26 +4964,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetWeights: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetWeights(
-        req(`/api/v1/subnets/${NETUID}/weights`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/weights`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetAlphaVolume: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -8018,26 +4986,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetAlphaVolume: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetAlphaVolume(
-        req(`/api/v1/subnets/${NETUID}/volume`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/volume`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ subnetEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
@@ -8055,26 +5003,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetEvents: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ subnetEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetEvents(
-        req(`/api/v1/subnets/${NETUID}/events`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/events`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleSubnetEventSummary: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8099,29 +5027,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetEventSummary: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({
-      subnetEventSummaryKinds: [],
-      subnetEventSummaryRecent: [],
-    });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetEventSummary(
-        req(`/api/v1/subnets/${NETUID}/event-summary`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/event-summary`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   // #4832 Tier 1c: handleAccount (multi-table: account_events + neurons +
   // extrinsics) and handleAccountSubnets (neurons-derived).
 
@@ -8137,21 +5042,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleAccount: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccount(req(`/api/v1/accounts/${SS58}`), env, SS58),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountSubnets: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8170,25 +5060,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleAccountSubnets: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountSubnets(
-        req(`/api/v1/accounts/${SS58}/subnets`),
-        env,
-        SS58,
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   // #4832 Tier 2a: the 8 flat-`neurons` handlers (concentration, performance,
@@ -8213,26 +5084,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetConcentration: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetConcentration(
-        req(`/api/v1/subnets/${NETUID}/concentration`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetPerformance: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8250,26 +5101,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetPerformance: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetPerformance(
-        req(`/api/v1/subnets/${NETUID}/performance`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/performance`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleSubnetYield: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8291,26 +5122,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetYield: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetYield(
-        req(`/api/v1/subnets/${NETUID}/yield`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/yield`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleChainConcentration: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8326,25 +5137,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleChainConcentration: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleChainConcentration(
-        req("/api/v1/chain/concentration"),
-        env,
-        url("/api/v1/chain/concentration"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleChainPerformance: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8364,25 +5156,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleChainPerformance: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleChainPerformance(
-        req("/api/v1/chain/performance"),
-        env,
-        url("/api/v1/chain/performance"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleChainYield: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8398,25 +5171,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleChainYield: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleChainYield(
-        req("/api/v1/chain/yield"),
-        env,
-        url("/api/v1/chain/yield"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountPortfolio: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8437,25 +5191,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountPortfolio: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountPortfolio(
-        req(`/api/v1/accounts/${SS58}/portfolio`),
-        env,
-        SS58,
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleAccountsList: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ neurons: [neuronRow()] });
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8472,25 +5207,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleAccountsList: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleAccountsList(
-        req("/api/v1/accounts"),
-        env,
-        url("/api/v1/accounts"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   // #4832 Tier 2b: the 9 neuron_daily-history handlers (structural history,
@@ -8515,26 +5231,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleValidatorHistory: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleValidatorHistory(
-        req(`/api/v1/validators/${SS58}/history`),
-        env,
-        SS58,
-        url(`/api/v1/validators/${SS58}/history`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleNeuronHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8553,27 +5249,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleNeuronHistory: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleNeuronHistory(
-        req(`/api/v1/subnets/${NETUID}/neurons/1/history`),
-        env,
-        NETUID,
-        1,
-        url(`/api/v1/subnets/${NETUID}/neurons/1/history`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleSubnetHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8595,26 +5270,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetHistory: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetHistory(
-        req(`/api/v1/subnets/${NETUID}/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/history`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetConcentrationHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8632,26 +5287,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetConcentrationHistory: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetConcentrationHistory(
-        req(`/api/v1/subnets/${NETUID}/concentration/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/concentration/history`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleSubnetPerformanceHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8673,26 +5308,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetPerformanceHistory: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetPerformanceHistory(
-        req(`/api/v1/subnets/${NETUID}/performance/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/performance/history`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetYieldHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8712,26 +5327,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetYieldHistory: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetYieldHistory(
-        req(`/api/v1/subnets/${NETUID}/yield/history`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/yield/history`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleChainTurnover: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8748,25 +5343,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleChainTurnover: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleChainTurnover(
-        req("/api/v1/chain/turnover"),
-        env,
-        url("/api/v1/chain/turnover"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   test("handleSubnetTurnover: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -8788,26 +5364,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetTurnover: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetTurnover(
-        req(`/api/v1/subnets/${NETUID}/turnover`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/turnover`),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
-  });
-
   test("handleSubnetMovers: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "postgres";
@@ -8824,25 +5380,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
-  });
-
-  test("handleSubnetMovers: flag=postgres falls back to D1 on failure", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_NEURONS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    const body = await json(
-      await handleSubnetMovers(
-        req("/api/v1/subnets/movers"),
-        env,
-        url("/api/v1/subnets/movers"),
-      ),
-    );
-    assert.equal(body.data.marker, undefined);
-    assert.ok(captures.sql.length > 0);
   });
 
   // #4832 gap-closure: handleAccountPositionHistory (account_position_daily,
@@ -9149,104 +5686,6 @@ describe("schema-stable cold-store matrix (#1900)", () => {
       assertData(body.data);
     });
   }
-});
-
-describe("dbWith SQL routing regressions (#1900)", () => {
-  test("routes account summary queries to distinct buckets", async () => {
-    const { env } = dbWith({
-      agg: { c: 1, sc: 1, fb: 1, lb: 1, fo: 1, lo: 1 },
-      kinds: [{ kind: "StakeAdded", count: 1 }],
-      registrations: [
-        { netuid: 1, uid: 0, stake_tao: 1, validator_permit: 0, active: 1 },
-      ],
-      accountEvents: [accountEventRow()],
-      activity: {
-        tx_count: 1,
-        last_tx_block: 1,
-        last_tx_at: 1,
-        total_fee_tao: 0,
-      },
-      modules: [{ call_module: "Balances", count: 1 }],
-    });
-    const body = await json(
-      await handleAccount(req(`/api/v1/accounts/${SS58}`), env, SS58),
-    );
-    assert.equal(body.data.event_count, 1);
-    assert.equal(body.data.activity.tx_count, 1);
-    assert.equal(body.data.registrations.length, 1);
-  });
-
-  test("routes transfer vs subnet vs account event queries separately", async () => {
-    const { env } = dbWith({
-      transfers: [transferEventRow()],
-      subnetEvents: [accountEventRow({ event_kind: "NeuronRegistered" })],
-      accountEvents: [accountEventRow({ event_kind: "WeightsSet" })],
-    });
-    const transfers = await json(
-      await handleAccountTransfers(
-        req(`/api/v1/accounts/${SS58}/transfers`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/transfers`),
-      ),
-    );
-    const subnet = await json(
-      await handleSubnetEvents(
-        req(`/api/v1/subnets/${NETUID}/events`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/events`),
-      ),
-    );
-    const account = await json(
-      await handleAccountEvents(
-        req(`/api/v1/accounts/${SS58}/events`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/events`),
-      ),
-    );
-    assert.equal(transfers.data.transfers[0].direction, "sent");
-    assert.equal(subnet.data.events[0].event_kind, "NeuronRegistered");
-    assert.equal(account.data.events[0].event_kind, "WeightsSet");
-  });
-
-  test("routes block hash resolution before extrinsic listing", async () => {
-    const { env, captures } = dbWith({
-      blockNumberByHash: BLOCK_NUM,
-      extrinsics: [extrinsicRow()],
-    });
-    await handleBlockExtrinsics(
-      req(`/api/v1/blocks/${HASH}/extrinsics`),
-      env,
-      HASH,
-      url(`/api/v1/blocks/${HASH}/extrinsics`),
-    );
-    assert.ok(
-      captures.sql.some((s) =>
-        /SELECT block_number FROM blocks WHERE block_hash/.test(s),
-      ),
-    );
-    assert.ok(
-      captures.sql.some((s) => /FROM extrinsics WHERE block_number/.test(s)),
-    );
-  });
-
-  test("routes extrinsic detail hash vs composite paths", async () => {
-    const row = extrinsicRow();
-    const { env: hashEnv } = dbWith({ extrinsicDetail: row });
-    const byHash = await json(
-      await handleExtrinsic(req(`/api/v1/extrinsics/${HASH}`), hashEnv, HASH),
-    );
-    assert.equal(byHash.data.extrinsic.extrinsic_hash, HASH);
-
-    const { env: compEnv } = dbWith({ extrinsicDetail: row });
-    const ref = `${BLOCK_NUM}-2`;
-    const byComposite = await json(
-      await handleExtrinsic(req(`/api/v1/extrinsics/${ref}`), compEnv, ref),
-    );
-    assert.equal(byComposite.data.extrinsic.extrinsic_index, 2);
-  });
 });
 
 describe("query-param guard matrix (#1900)", () => {

--- a/tests/runtime-versions.test.mjs
+++ b/tests/runtime-versions.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { afterEach, describe, test } from "vitest";
+import { describe, test } from "vitest";
 
 import {
   buildRuntimeVersionHistory,
@@ -189,76 +189,7 @@ function runtimeEnv(
   };
 }
 
-function installRuntimeCache() {
-  const store = new Map();
-  const puts = [];
-  const matches = [];
-  globalThis.caches = {
-    default: {
-      async match(request) {
-        matches.push(request.url);
-        return store.get(request.url)?.clone();
-      },
-      async put(request, response) {
-        puts.push(request.url);
-        store.set(request.url, response.clone());
-      },
-    },
-  };
-  return { matches, puts, store };
-}
-
-let originalCaches;
-afterEach(() => {
-  globalThis.caches = originalCaches;
-});
-
 describe("GET /api/v1/runtime via the Worker", () => {
-  test("returns the transition timeline for a warm D1", async () => {
-    const captured = {};
-    const env = runtimeEnv(
-      [transitionRow()],
-      [{ spec_version: 218 }],
-      captured,
-    );
-    const res = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/runtime"),
-      env,
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.transition_count, 1);
-    assert.equal(body.data.transitions[0].spec_version, 218);
-    assert.equal(body.data.current_spec_version, 218);
-    assert.ok(
-      captured.calls.every((c) =>
-        /FROM blocks WHERE spec_version IS NOT NULL/.test(c.sql),
-      ),
-    );
-  });
-
-  test("current_spec_version survives a spec_version rollback (does not fall back to the last transitions entry)", async () => {
-    const env = runtimeEnv(
-      [
-        transitionRow({ spec_version: 218, block_number: 100 }),
-        transitionRow({ spec_version: 219, block_number: 200 }),
-      ],
-      [{ spec_version: 218 }],
-    );
-    const res = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/runtime"),
-      env,
-      ctx,
-    );
-    const body = await res.json();
-    assert.equal(
-      body.data.transitions[body.data.transitions.length - 1].spec_version,
-      219,
-    );
-    assert.equal(body.data.current_spec_version, 218);
-  });
-
   test("is schema-stable when D1 is cold (never 404)", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/runtime"),
@@ -278,52 +209,6 @@ describe("GET /api/v1/runtime via the Worker", () => {
       ctx,
     );
     assert.equal(res.status, 400);
-  });
-
-  test("HEAD shares and warms the GET edge cache before stripping the body", async () => {
-    originalCaches = globalThis.caches;
-    const cache = installRuntimeCache();
-    const captured = {};
-    const env = runtimeEnv(
-      [transitionRow()],
-      [{ spec_version: 218 }],
-      captured,
-    );
-
-    const first = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/runtime", {
-        method: "HEAD",
-      }),
-      env,
-      ctx,
-    );
-    await Promise.resolve();
-    assert.equal(first.status, 200);
-    assert.equal(await first.text(), "");
-    assert.equal(captured.calls.length, 2);
-    assert.equal(cache.matches.length, 1);
-    assert.equal(cache.puts.length, 1);
-
-    const second = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/runtime", {
-        method: "HEAD",
-      }),
-      env,
-      ctx,
-    );
-    assert.equal(second.status, 200);
-    assert.equal(await second.text(), "");
-    assert.equal(captured.calls.length, 2);
-    assert.equal(cache.matches.length, 2);
-
-    const get = await handleRequest(
-      new Request("https://api.metagraph.sh/api/v1/runtime"),
-      env,
-      ctx,
-    );
-    const body = await get.json();
-    assert.equal(body.data.current_spec_version, 218);
-    assert.equal(captured.calls.length, 2);
   });
 
   test("testnet has no variant (mainnet-only blocks D1 tier)", async () => {

--- a/tests/subnet-concentration-history-csv.test.mjs
+++ b/tests/subnet-concentration-history-csv.test.mjs
@@ -28,27 +28,6 @@ async function errorJson(res) {
   return body;
 }
 
-function neuronDailyEnv(rows) {
-  return {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(..._params) {
-            return {
-              all: async () => {
-                if (/FROM neuron_daily WHERE netuid = \?/.test(sql)) {
-                  return { results: rows };
-                }
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-}
-
 describe("subnet concentration history OpenAPI CSV contract", () => {
   test("documents the CSV header on the concentration/history route", async () => {
     const openapi = buildOpenApiArtifact(
@@ -67,61 +46,6 @@ describe("subnet concentration history OpenAPI CSV contract", () => {
 });
 
 describe("handleSubnetConcentrationHistory CSV export", () => {
-  test("returns CSV response when ?format=csv is present", async () => {
-    const env = neuronDailyEnv([
-      { snapshot_date: "2026-06-27", stake_tao: 100, emission_tao: 10 },
-      { snapshot_date: "2026-06-27", stake_tao: 1, emission_tao: 1 },
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-    ]);
-    const res = await handleSubnetConcentrationHistory(
-      req(`/api/v1/subnets/${NETUID}/concentration/history`),
-      env,
-      NETUID,
-      url(
-        `/api/v1/subnets/${NETUID}/concentration/history?window=30d&format=csv`,
-      ),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    assert.ok(
-      res.headers
-        .get("content-disposition")
-        .includes('filename="subnet-7-concentration-history.csv"'),
-    );
-    const lines = (await res.text()).split("\r\n");
-    assert.equal(
-      lines[0],
-      "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share",
-    );
-    assert.equal(lines[1], "2026-06-26,2,0,2,0.5,0,2,0.5");
-    assert.equal(
-      lines[2],
-      "2026-06-27,2,0.490099,1,0.990099,0.409091,1,0.909091",
-    );
-  });
-
-  test("returns CSV response when Accept: text/csv header is present", async () => {
-    const env = neuronDailyEnv([
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-    ]);
-    const request = new Request(
-      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/concentration/history`,
-      { headers: { accept: "text/csv" } },
-    );
-    const res = await handleSubnetConcentrationHistory(
-      request,
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    const lines = (await res.text()).split("\r\n");
-    assert.equal(lines[1], "2026-06-26,2,0,2,0.5,0,2,0.5");
-  });
-
   test("returns header-only CSV when D1 is cold", async () => {
     const res = await handleSubnetConcentrationHistory(
       req(`/api/v1/subnets/${NETUID}/concentration/history`),
@@ -138,6 +62,56 @@ describe("handleSubnetConcentrationHistory CSV export", () => {
       "snapshot_date,neuron_count,stake_gini,stake_nakamoto_coefficient,stake_top_10pct_share,emission_gini,emission_nakamoto_coefficient,emission_top_10pct_share",
     );
     assert.equal(lines.length, 1);
+  });
+
+  test("sorts and exports real points ascending by snapshot_date via the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            window: "30d",
+            points: [
+              {
+                snapshot_date: "2026-06-21",
+                neuron_count: 5,
+                stake_gini: 0.4,
+                stake_nakamoto_coefficient: 2,
+                stake_top_10pct_share: 0.5,
+                emission_gini: 0.3,
+                emission_nakamoto_coefficient: 3,
+                emission_top_10pct_share: 0.4,
+              },
+              {
+                snapshot_date: "2026-06-20",
+                neuron_count: 4,
+                stake_gini: 0.35,
+                stake_nakamoto_coefficient: 2,
+                stake_top_10pct_share: 0.45,
+                emission_gini: 0.25,
+                emission_nakamoto_coefficient: 3,
+                emission_top_10pct_share: 0.35,
+              },
+            ],
+          }),
+      },
+    };
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/concentration/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 3);
+    // CSV export re-sorts newest-first `points` into ascending snapshot_date.
+    assert.match(lines[1], /^2026-06-20,/);
+    assert.match(lines[2], /^2026-06-21,/);
   });
 
   test("rejects an unsupported format value", async () => {
@@ -162,48 +136,6 @@ describe("handleSubnetConcentrationHistory CSV export", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "format");
-  });
-
-  test("returns the JSON envelope when CSV is not requested", async () => {
-    const env = neuronDailyEnv([
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-    ]);
-    const res = await handleSubnetConcentrationHistory(
-      req(`/api/v1/subnets/${NETUID}/concentration/history`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /application\/json/);
-    const body = await res.json();
-    assert.equal(body.ok, true);
-    assert.equal(body.data.point_count, 1);
-    assert.equal(body.data.points[0].snapshot_date, "2026-06-26");
-  });
-
-  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
-    const env = neuronDailyEnv([
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-      { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
-    ]);
-    const request = new Request(
-      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/concentration/history`,
-      { headers: { accept: "text/csv" } },
-    );
-    const res = await handleSubnetConcentrationHistory(
-      request,
-      env,
-      NETUID,
-      url(
-        `/api/v1/subnets/${NETUID}/concentration/history?window=7d&format=json`,
-      ),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /application\/json/);
-    const body = await res.json();
-    assert.equal(body.data.point_count, 1);
   });
 });
 

--- a/tests/subnet-events.test.mjs
+++ b/tests/subnet-events.test.mjs
@@ -6,78 +6,6 @@ function req(path) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-// D1 mock routing by SQL shape: the subnet-events handler reads account_events
-// filtered by netuid (#1345). A cold/absent DB returns no rows → schema-stable.
-function dbWith({ events, summaryKinds, summaryRecent } = {}) {
-  return {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind() {
-            return {
-              async all() {
-                if (/GROUP BY event_kind ORDER BY event_count DESC/.test(sql))
-                  return { results: summaryKinds || [] };
-                if (
-                  /WHERE netuid = \? AND observed_at >= \?/.test(sql) &&
-                  /ORDER BY block_number DESC, event_index DESC LIMIT \?/.test(
-                    sql,
-                  )
-                )
-                  return { results: summaryRecent || [] };
-                if (/FROM account_events/.test(sql))
-                  return { results: events || [] };
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-}
-
-const ROW = {
-  block_number: 4_000_200,
-  event_index: 2,
-  event_kind: "NeuronRegistered",
-  hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-  coldkey: null,
-  netuid: 7,
-  uid: 3,
-  amount_tao: null,
-  observed_at: 1_750_009_000_000,
-};
-
-test("GET /subnets/{netuid}/events returns the per-subnet chain-event stream (#1345)", async () => {
-  const env = dbWith({ events: [ROW] });
-  const res = await handleRequest(req("/api/v1/subnets/7/events"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.ok, true);
-  assert.equal(body.data.netuid, 7);
-  assert.equal(body.data.event_count, 1);
-  assert.equal(Array.isArray(body.data.events), true);
-  assert.equal(body.data.events[0].event_kind, "NeuronRegistered");
-  assert.equal(body.data.events[0].netuid, 7);
-  // Enveloped like every other route: weak ETag + contract-version header.
-  assert.ok(res.headers.get("etag"));
-  assert.ok(res.headers.get("x-metagraph-contract-version"));
-});
-
-test("GET /subnets/{netuid}/events honors ?limit and ?kind", async () => {
-  const env = dbWith({ events: [{ ...ROW, event_kind: "WeightsSet" }] });
-  const res = await handleRequest(
-    req("/api/v1/subnets/7/events?limit=25&kind=WeightsSet"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.limit, 25);
-  assert.equal(body.data.events[0].event_kind, "WeightsSet");
-});
-
 test("GET /subnets/{netuid}/events rejects an unsupported query param", async () => {
   const res = await handleRequest(
     req("/api/v1/subnets/7/events?bogus=1"),
@@ -89,42 +17,6 @@ test("GET /subnets/{netuid}/events rejects an unsupported query param", async ()
 
 const EVENTS_CSV_HEADER =
   "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
-
-test("GET /subnets/{netuid}/events?format=csv streams the event rows as CSV", async () => {
-  const env = dbWith({ events: [ROW] });
-  const res = await handleRequest(
-    req("/api/v1/subnets/7/events?format=csv"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type"), /text\/csv/);
-  assert.match(
-    res.headers.get("content-disposition") ?? "",
-    /attachment; filename="/,
-  );
-  const lines = (await res.text()).trim().split("\r\n");
-  assert.equal(lines[0], EVENTS_CSV_HEADER);
-  assert.equal(lines.length, 2);
-  const cells = lines[1].split(",");
-  assert.equal(cells[0], "4000200"); // block_number
-  assert.equal(cells[2], "NeuronRegistered"); // event_kind
-  assert.equal(cells[5], "7"); // netuid
-});
-
-test("GET /subnets/{netuid}/events?kind=&format=csv keeps the CSV shape when filtering", async () => {
-  const env = dbWith({ events: [{ ...ROW, event_kind: "WeightsSet" }] });
-  const res = await handleRequest(
-    req("/api/v1/subnets/7/events?kind=WeightsSet&format=csv"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type"), /text\/csv/);
-  const lines = (await res.text()).trim().split("\r\n");
-  assert.equal(lines[0], EVENTS_CSV_HEADER);
-  assert.equal(lines[1].split(",")[2], "WeightsSet");
-});
 
 test("GET /subnets/{netuid}/events?format=csv emits a header-only CSV when cold", async () => {
   const res = await handleRequest(
@@ -144,40 +36,6 @@ test("GET /subnets/{netuid}/events is schema-stable when D1 is cold (never 404)"
   assert.equal(body.data.netuid, 7);
   assert.equal(body.data.event_count, 0);
   assert.equal(Array.isArray(body.data.events), true);
-});
-
-test("GET /subnets/{netuid}/event-summary returns windowed kind aggregates", async () => {
-  const env = dbWith({
-    summaryKinds: [
-      {
-        event_kind: "StakeAdded",
-        event_count: 2,
-        hotkey_count: 1,
-        coldkey_count: 1,
-        amount_tao: 3,
-        alpha_amount: 0.5,
-        first_block: 4_000_100,
-        last_block: 4_000_200,
-        first_observed_at: 1_750_008_000_000,
-        last_observed_at: 1_750_009_000_000,
-      },
-    ],
-    summaryRecent: [ROW],
-  });
-  const res = await handleRequest(
-    req("/api/v1/subnets/7/event-summary?window=7d&limit=3"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.ok, true);
-  assert.equal(body.data.netuid, 7);
-  assert.equal(body.data.window, "7d");
-  assert.equal(body.data.total_events, 2);
-  assert.equal(body.data.event_kinds[0].category, "stake");
-  assert.equal(body.data.categories[0].event_count, 2);
-  assert.equal(body.data.recent_events[0].event_kind, "NeuronRegistered");
 });
 
 test("GET /subnets/{netuid}/event-summary rejects bad window", async () => {

--- a/tests/subnet-stake-transfers-handler.test.mjs
+++ b/tests/subnet-stake-transfers-handler.test.mjs
@@ -1,156 +1,26 @@
 // Handler tests for GET /api/v1/subnets/{netuid}/stake-transfers — kept in a
 // dedicated file so this PR does not contend with open entity-handler PRs on the
 // shared request-handlers-entities.test.mjs harness.
+//
+// #4909 D1 retirement: the "happy path" describe block that used to live here
+// exercised the D1-served account_events query directly (a capturing D1 stub +
+// handleSubnetStakeTransfers). account_events' D1 write path is retired
+// (#4772) and the table is dropped in production, so that query no longer
+// runs at all — handleSubnetStakeTransfers now only calls tryPostgresTier,
+// falling back to a schema-stable-empty buildSubnetStakeTransfers(null, ...)
+// literal on a miss, never D1. Only the pure cache-key coverage below
+// (canonicalSubnetStakeTransfersCachePath, untouched by the retirement)
+// remains meaningful here.
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import Ajv2020 from "ajv/dist/2020.js";
-import addFormats from "ajv-formats";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
-import { STAKE_TRANSFERRED_EVENT_KIND } from "../src/subnet-stake-transfers.mjs";
-import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
-import {
-  canonicalSubnetStakeTransfersCachePath,
-  handleSubnetStakeTransfers,
-} from "../workers/request-handlers/entities.mjs";
+import { canonicalSubnetStakeTransfersCachePath } from "../workers/request-handlers/entities.mjs";
 
 const NETUID = 7;
-const OBSERVED_MS = 1_750_000_000_000;
-
-function req(path) {
-  return new Request(`https://api.metagraph.sh${path}`);
-}
 
 function url(path) {
   return new URL(`https://api.metagraph.sh${path}`);
 }
-
-async function json(res) {
-  assert.equal(res.status, 200, `expected 200, got ${res.status}`);
-  const body = await res.json();
-  assert.equal(body.ok, true);
-  return body;
-}
-
-function stakeTransfersEnv(row, capture = []) {
-  return {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            capture.push({ sql, params });
-            return {
-              all: async () => {
-                if (
-                  /COUNT\(\*\) AS transfers/.test(sql) &&
-                  /COUNT\(DISTINCT coldkey\) AS distinct_senders/.test(sql) &&
-                  /FROM account_events WHERE netuid = \? AND event_kind = \?/.test(
-                    sql,
-                  )
-                ) {
-                  return { results: row ? [row] : [] };
-                }
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-}
-
-async function assertValidComponent(componentName, data) {
-  const generatedAt = "2026-06-24T12:00:00.000Z";
-  const openapi = buildOpenApiArtifact(
-    generatedAt,
-    await loadOpenApiComponentSchemas(generatedAt),
-  );
-  const ajv = new Ajv2020({ strict: false, allErrors: true });
-  addFormats(ajv);
-  const validate = ajv.compile({
-    $id: `https://metagraph.sh/test/${componentName}.json`,
-    components: openapi.components,
-    $ref: `#/components/schemas/${componentName}`,
-  });
-  assert.equal(validate(data), true, ajv.errorsText(validate.errors));
-}
-
-describe("handleSubnetStakeTransfers happy path", () => {
-  test("computes distinct senders, transfer count, and transfers-per-sender over 7d", async () => {
-    const capture = [];
-    const env = stakeTransfersEnv(
-      {
-        transfers: 40,
-        distinct_senders: 4,
-        newest_observed: OBSERVED_MS,
-      },
-      capture,
-    );
-    const body = await json(
-      await handleSubnetStakeTransfers(
-        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
-        env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-transfers?window=7d`),
-      ),
-    );
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "7d");
-    assert.equal(body.data.distinct_senders, 4);
-    assert.equal(body.data.transfers, 40);
-    assert.equal(body.data.transfers_per_sender, 10);
-    assert.equal(body.data.observed_at, new Date(OBSERVED_MS).toISOString());
-    assert.equal(body.meta.source, "chain-events");
-    assert.equal(
-      body.meta.artifact_path,
-      `/metagraph/subnets/${NETUID}/stake-transfers.json`,
-    );
-    assert.equal(body.meta.generated_at, new Date(OBSERVED_MS).toISOString());
-    await assertValidComponent("SubnetStakeTransfersArtifact", body.data);
-    const captured = capture[0];
-    assert.ok(captured);
-    assert.equal(captured.params[0], NETUID);
-    assert.equal(captured.params[1], STAKE_TRANSFERRED_EVENT_KIND);
-    assert.equal(typeof captured.params[2], "number");
-  });
-
-  test("defaults to the 7d window when ?window is omitted", async () => {
-    const body = await json(
-      await handleSubnetStakeTransfers(
-        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
-        stakeTransfersEnv({
-          transfers: 10,
-          distinct_senders: 2,
-          newest_observed: OBSERVED_MS,
-        }),
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-transfers`),
-      ),
-    );
-    assert.equal(body.data.window, "7d");
-    assert.equal(body.data.transfers, 10);
-    assert.equal(body.data.transfers_per_sender, 5);
-  });
-
-  test("honours an explicit 30d window", async () => {
-    const body = await json(
-      await handleSubnetStakeTransfers(
-        req(`/api/v1/subnets/${NETUID}/stake-transfers`),
-        stakeTransfersEnv({
-          transfers: 15,
-          distinct_senders: 3,
-          newest_observed: OBSERVED_MS,
-        }),
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/stake-transfers?window=30d`),
-      ),
-    );
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.transfers, 15);
-    assert.equal(body.data.transfers_per_sender, 5);
-  });
-});
 
 describe("canonicalSubnetStakeTransfersCachePath", () => {
   test("maps a 30d window to a distinct cache key", () => {

--- a/tests/subnet-weight-setters.test.mjs
+++ b/tests/subnet-weight-setters.test.mjs
@@ -248,26 +248,6 @@ describe("GET /api/v1/subnets/{netuid}/weights/setters", () => {
     };
   }
 
-  test("returns the leaderboard at the requested window", async () => {
-    const res = await handleRequest(
-      new Request(
-        `https://api.metagraph.sh/api/v1/subnets/${NETUID}/weights/setters?window=30d`,
-      ),
-      eventsEnv(LEADER_ROWS, TOTALS),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.netuid, NETUID);
-    assert.equal(body.data.window, "30d");
-    assert.equal(body.data.setter_count, 2);
-    assert.equal(body.data.setters[0].share, 0.75);
-    assert.equal(
-      body.meta.artifact_path,
-      `/metagraph/subnets/${NETUID}/weights/setters.json`,
-    );
-  });
-
   test("defaults to the 7d window when omitted", async () => {
     const res = await handleRequest(
       new Request(

--- a/tests/subnet-yield-csv.test.mjs
+++ b/tests/subnet-yield-csv.test.mjs
@@ -12,7 +12,6 @@ import {
 } from "../workers/request-handlers/entities.mjs";
 
 const NETUID = 7;
-const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
 function req(path) {
   return new Request(`https://api.metagraph.sh${path}`);
@@ -27,27 +26,6 @@ async function errorJson(res) {
   const body = await res.json();
   assert.equal(body.ok, false);
   return body;
-}
-
-function neuronEnv(rows) {
-  return {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(..._params) {
-            return {
-              all: async () => {
-                if (/FROM neurons WHERE netuid = \?/.test(sql)) {
-                  return { results: rows };
-                }
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
 }
 
 describe("subnet yield OpenAPI CSV contract", () => {
@@ -68,81 +46,6 @@ describe("subnet yield OpenAPI CSV contract", () => {
 });
 
 describe("handleSubnetYield CSV export", () => {
-  test("returns CSV response when ?format=csv is present", async () => {
-    const env = neuronEnv([
-      {
-        uid: 1,
-        hotkey: SS58,
-        validator_permit: 0,
-        stake_tao: 100,
-        emission_tao: 5,
-        captured_at: 1_750_009_000_000,
-        block_number: 5_000_000,
-      },
-      {
-        uid: 0,
-        hotkey: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
-        validator_permit: 1,
-        stake_tao: 100,
-        emission_tao: 2,
-        captured_at: 1_750_009_000_000,
-        block_number: 5_000_000,
-      },
-    ]);
-    const res = await handleSubnetYield(
-      req(`/api/v1/subnets/${NETUID}/yield`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield?format=csv`),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    assert.ok(
-      res.headers
-        .get("content-disposition")
-        .includes('filename="subnet-7-yield.csv"'),
-    );
-    const text = await res.text();
-    const lines = text.split("\r\n");
-    assert.equal(
-      lines[0],
-      "uid,hotkey,role,stake_tao,emission_tao,yield,vs_median",
-    );
-    assert.equal(lines[1], `1,${SS58},miner,100,5,0.05,above`);
-    assert.equal(
-      lines[2],
-      "0,5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ,validator,100,2,0.02,below",
-    );
-  });
-
-  test("returns CSV response when Accept: text/csv header is present", async () => {
-    const env = neuronEnv([
-      {
-        uid: 0,
-        hotkey: SS58,
-        validator_permit: 1,
-        stake_tao: 100,
-        emission_tao: 2,
-        captured_at: 1_750_009_000_000,
-        block_number: 5_000_000,
-      },
-    ]);
-    const request = new Request(
-      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield`,
-      { headers: { accept: "text/csv" } },
-    );
-    const res = await handleSubnetYield(
-      request,
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield`),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    const lines = (await res.text()).split("\r\n");
-    assert.equal(lines[1], `0,${SS58},validator,100,2,0.02,at`);
-  });
-
   test("returns header-only CSV when D1 is cold", async () => {
     const res = await handleSubnetYield(
       req(`/api/v1/subnets/${NETUID}/yield`),
@@ -179,34 +82,6 @@ describe("handleSubnetYield CSV export", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "format");
-  });
-
-  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
-    const env = neuronEnv([
-      {
-        uid: 0,
-        hotkey: SS58,
-        validator_permit: 1,
-        stake_tao: 100,
-        emission_tao: 2,
-        captured_at: 1_750_009_000_000,
-        block_number: 5_000_000,
-      },
-    ]);
-    const request = new Request(
-      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield`,
-      { headers: { accept: "text/csv" } },
-    );
-    const res = await handleSubnetYield(
-      request,
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield?format=json`),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /application\/json/);
-    const body = await res.json();
-    assert.equal(body.data.neuron_count, 1);
   });
 });
 

--- a/tests/subnet-yield-history-csv.test.mjs
+++ b/tests/subnet-yield-history-csv.test.mjs
@@ -28,27 +28,6 @@ async function errorJson(res) {
   return body;
 }
 
-function neuronDailyEnv(rows) {
-  return {
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(..._params) {
-            return {
-              all: async () => {
-                if (/FROM neuron_daily WHERE netuid = \?/.test(sql)) {
-                  return { results: rows };
-                }
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
-    },
-  };
-}
-
 describe("subnet yield history OpenAPI CSV contract", () => {
   test("documents the CSV header on the yield/history route", async () => {
     const openapi = buildOpenApiArtifact(
@@ -68,74 +47,6 @@ describe("subnet yield history OpenAPI CSV contract", () => {
 });
 
 describe("handleSubnetYieldHistory CSV export", () => {
-  test("returns CSV response when ?format=csv is present", async () => {
-    const env = neuronDailyEnv([
-      {
-        snapshot_date: "2026-06-27",
-        stake_tao: 100,
-        emission_tao: 10,
-        validator_permit: 1,
-      },
-      {
-        snapshot_date: "2026-06-27",
-        stake_tao: 100,
-        emission_tao: 5,
-        validator_permit: 0,
-      },
-      {
-        snapshot_date: "2026-06-26",
-        stake_tao: 100,
-        emission_tao: 10,
-        validator_permit: 1,
-      },
-    ]);
-    const res = await handleSubnetYieldHistory(
-      req(`/api/v1/subnets/${NETUID}/yield/history`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield/history?window=30d&format=csv`),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    assert.ok(
-      res.headers
-        .get("content-disposition")
-        .includes('filename="subnet-7-yield-history.csv"'),
-    );
-    const lines = (await res.text()).split("\r\n");
-    assert.equal(
-      lines[0],
-      "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
-    );
-    assert.equal(lines[1], "2026-06-26,1,1,1,0.1,0.1,0.1,0.1,0.1,0.1");
-    assert.equal(lines[2], "2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1");
-  });
-
-  test("returns CSV response when Accept: text/csv header is present", async () => {
-    const env = neuronDailyEnv([
-      {
-        snapshot_date: "2026-06-26",
-        stake_tao: 100,
-        emission_tao: 10,
-        validator_permit: 1,
-      },
-    ]);
-    const request = new Request(
-      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield/history`,
-      { headers: { accept: "text/csv" } },
-    );
-    const res = await handleSubnetYieldHistory(
-      request,
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d`),
-    );
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-    const lines = (await res.text()).split("\r\n");
-    assert.equal(lines[1], "2026-06-26,1,1,1,0.1,0.1,0.1,0.1,0.1,0.1");
-  });
-
   test("returns header-only CSV when D1 is cold", async () => {
     const res = await handleSubnetYieldHistory(
       req(`/api/v1/subnets/${NETUID}/yield/history`),
@@ -150,6 +61,58 @@ describe("handleSubnetYieldHistory CSV export", () => {
       "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
     );
     assert.equal(lines.length, 1);
+  });
+
+  test("sorts and exports real points ascending by snapshot_date via the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            window: "30d",
+            points: [
+              {
+                snapshot_date: "2026-06-21",
+                neuron_count: 5,
+                validator_count: 2,
+                yield_count: 5,
+                subnet_yield: 0.1,
+                mean_yield: 0.1,
+                median_yield: 0.1,
+                p25_yield: 0.05,
+                p75_yield: 0.15,
+                p90_yield: 0.2,
+              },
+              {
+                snapshot_date: "2026-06-20",
+                neuron_count: 4,
+                validator_count: 2,
+                yield_count: 4,
+                subnet_yield: 0.09,
+                mean_yield: 0.09,
+                median_yield: 0.09,
+                p25_yield: 0.04,
+                p75_yield: 0.14,
+                p90_yield: 0.19,
+              },
+            ],
+          }),
+      },
+    };
+    const res = await handleSubnetYieldHistory(
+      req(`/api/v1/subnets/${NETUID}/yield/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/yield/history?window=30d&format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 3);
+    // CSV export re-sorts newest-first `points` into ascending snapshot_date.
+    assert.match(lines[1], /^2026-06-20,/);
+    assert.match(lines[2], /^2026-06-21,/);
   });
 
   test("rejects an unsupported format value", async () => {
@@ -172,54 +135,6 @@ describe("handleSubnetYieldHistory CSV export", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "format");
-  });
-
-  test("returns the JSON envelope when CSV is not requested", async () => {
-    const env = neuronDailyEnv([
-      {
-        snapshot_date: "2026-06-26",
-        stake_tao: 100,
-        emission_tao: 10,
-        validator_permit: 1,
-      },
-    ]);
-    const res = await handleSubnetYieldHistory(
-      req(`/api/v1/subnets/${NETUID}/yield/history`),
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d`),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /application\/json/);
-    const body = await res.json();
-    assert.equal(body.ok, true);
-    assert.equal(body.data.point_count, 1);
-    assert.equal(body.data.points[0].median_yield, 0.1);
-  });
-
-  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
-    const env = neuronDailyEnv([
-      {
-        snapshot_date: "2026-06-26",
-        stake_tao: 100,
-        emission_tao: 10,
-        validator_permit: 1,
-      },
-    ]);
-    const request = new Request(
-      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/yield/history`,
-      { headers: { accept: "text/csv" } },
-    );
-    const res = await handleSubnetYieldHistory(
-      request,
-      env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/yield/history?window=7d&format=json`),
-    );
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get("content-type"), /application\/json/);
-    const body = await res.json();
-    assert.equal(body.data.point_count, 1);
   });
 });
 

--- a/tests/sudo.test.mjs
+++ b/tests/sudo.test.mjs
@@ -31,49 +31,6 @@ function dbWith(feed, captured = {}) {
   };
 }
 
-function sudoRow(overrides = {}) {
-  return {
-    block_number: 200,
-    extrinsic_index: 1,
-    extrinsic_hash: `0x${"a".repeat(64)}`,
-    signer: "5SudoKey",
-    call_module: "Sudo",
-    call_function: "sudo",
-    call_args: JSON.stringify([{ call_function: "sudo_set_tempo" }]),
-    success: 1,
-    fee_tao: 0.000123,
-    tip_tao: 0,
-    observed_at: 1750009000000,
-    ...overrides,
-  };
-}
-
-test("GET /api/v1/sudo returns the Sudo-filtered feed newest-first (#4310/2.2)", async () => {
-  const captured = {};
-  const env = dbWith([sudoRow()], captured);
-  const res = await handleRequest(req("/api/v1/sudo"), env, {});
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.extrinsic_count, 1);
-  assert.equal(body.data.extrinsics[0].block_number, 200);
-  assert.equal(body.data.extrinsics[0].call_module, "Sudo");
-  assert.equal(body.data.extrinsics[0].call_function, "sudo");
-  assert.equal(body.data.extrinsics[0].success, true);
-});
-
-test("GET /api/v1/sudo hardcodes call_module='Sudo' regardless of other filters", async () => {
-  const captured = {};
-  const env = dbWith([], captured);
-  await handleRequest(req("/api/v1/sudo?call_function=sudo_as"), env, {});
-  assert.match(captured.sql, /call_module = \?/);
-  assert.ok(
-    captured.params.includes("Sudo"),
-    `expected "Sudo" bound in ${JSON.stringify(captured.params)}`,
-  );
-  assert.match(captured.sql, /call_function = \?/);
-  assert.ok(captured.params.includes("sudo_as"));
-});
-
 test("GET /api/v1/sudo rejects signer and call_module as query params (both are fixed, not user-controlled)", async () => {
   const resSigner = await handleRequest(
     req("/api/v1/sudo?signer=5Anyone"),
@@ -113,35 +70,6 @@ test("GET /api/v1/sudo rejects an unsupported success value with 400", async () 
   assert.equal(res.status, 400);
 });
 
-test("GET /api/v1/sudo?success=true binds success=1", async () => {
-  const captured = {};
-  await handleRequest(
-    req("/api/v1/sudo?success=true"),
-    dbWith([], captured),
-    {},
-  );
-  assert.match(captured.sql, /success = \?/);
-  assert.ok(captured.params.includes(1));
-});
-
-test("GET /api/v1/sudo?success=false binds success=0", async () => {
-  const captured = {};
-  await handleRequest(
-    req("/api/v1/sudo?success=false"),
-    dbWith([], captured),
-    {},
-  );
-  assert.match(captured.sql, /success = \?/);
-  assert.ok(captured.params.includes(0));
-});
-
-test("GET /api/v1/sudo?block=<n> scopes the feed to one block", async () => {
-  const captured = {};
-  await handleRequest(req("/api/v1/sudo?block=200"), dbWith([], captured), {});
-  assert.match(captured.sql, /block_number = \?/);
-  assert.ok(captured.params.includes(200));
-});
-
 test("GET /api/v1/sudo is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(req("/api/v1/sudo"), dbWith([]), {});
   assert.equal(res.status, 200);
@@ -150,18 +78,39 @@ test("GET /api/v1/sudo is schema-stable when D1 is cold (never 404)", async () =
   assert.equal(body.data.extrinsic_count, 0);
 });
 
-test("GET /api/v1/sudo?format=csv downloads the filtered rows as CSV", async () => {
-  const res = await handleRequest(
-    req("/api/v1/sudo?format=csv"),
-    dbWith([sudoRow()]),
-    {},
-  );
+test("GET /api/v1/sudo?format=csv exports the filtered rows via the Postgres tier", async () => {
+  const env = {
+    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: null,
+          extrinsics: [
+            {
+              block_number: 200,
+              extrinsic_index: 1,
+              extrinsic_hash: `0x${"a".repeat(64)}`,
+              signer: "5SudoKey",
+              call_module: "Sudo",
+              call_function: "sudo",
+              call_args: null,
+              success: true,
+              fee_tao: 0.000123,
+              tip_tao: 0,
+              observed_at: new Date(1750009000000).toISOString(),
+            },
+          ],
+        }),
+    },
+  };
+  const res = await handleRequest(req("/api/v1/sudo?format=csv"), env, {});
   assert.equal(res.status, 200);
-  assert.match(res.headers.get("content-type") || "", /text\/csv/);
-  const text = await res.text();
-  assert.equal(
-    text.split("\r\n")[0],
-    "extrinsic_id,block_number,signer,call_module,call_function,success",
-  );
-  assert.match(text, /Sudo,sudo/);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /^200-1,200,5SudoKey,Sudo,sudo,true/);
 });

--- a/tests/validator-history.test.mjs
+++ b/tests/validator-history.test.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { buildValidatorHistory } from "../src/validator-history.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { MAX_HISTORY_POINTS } from "../src/neuron-history.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
@@ -186,51 +185,6 @@ describe("buildValidatorHistory", () => {
 });
 
 describe("GET /api/v1/validators/{hotkey}/history via the Worker", () => {
-  test("returns per-day aggregates and applies a date cutoff for a bounded window", async () => {
-    const captured = {};
-    const env = historyEnv(
-      [
-        {
-          snapshot_date: "2026-06-20",
-          subnet_count: 2,
-          total_stake_tao: 1000,
-          total_emission_tao: 12.3,
-        },
-      ],
-      captured,
-    );
-    const res = await handleRequest(
-      new Request(
-        `https://api.metagraph.sh/api/v1/validators/${HOTKEY}/history?window=90d`,
-      ),
-      env,
-      ctx,
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.hotkey, HOTKEY);
-    assert.equal(body.data.points[0].subnet_count, 2);
-    assert.match(
-      captured.sql,
-      /FROM neuron_daily WHERE hotkey = \? AND validator_permit = 1/,
-    );
-    assert.match(captured.sql, /snapshot_date >= \?/);
-    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
-  });
-
-  test("?window=all omits the cutoff (full history, still bounded by the row cap)", async () => {
-    const captured = {};
-    const env = historyEnv([], captured);
-    await handleRequest(
-      new Request(
-        `https://api.metagraph.sh/api/v1/validators/${HOTKEY}/history?window=all`,
-      ),
-      env,
-      ctx,
-    );
-    assert.doesNotMatch(captured.sql, /snapshot_date >= \?/);
-  });
-
   test("an unsupported ?window is a 400, never a silent coerce", async () => {
     const res = await handleRequest(
       new Request(

--- a/tests/validator-nominators.test.mjs
+++ b/tests/validator-nominators.test.mjs
@@ -484,50 +484,6 @@ describe("GET /api/v1/validators/{hotkey}/nominators via the Worker", () => {
     return { res, body: await res.json() };
   };
 
-  test("returns the ranked nominator list for a validator", async () => {
-    const env = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: accountEventsD1([
-        { hotkey: HTTP_HOTKEY, ...added("ck-a", 100, 2, 5000) },
-        { hotkey: HTTP_HOTKEY, ...removed("ck-a", 30, 1, 6000) },
-        { hotkey: HTTP_HOTKEY, ...added("ck-b", 10, 1, 4000) },
-        { hotkey: "hk-other", ...added("ck-c", 999, 1, 1000) },
-      ]),
-    };
-    const { res, body } = await getJson(
-      `/api/v1/validators/${HTTP_HOTKEY}/nominators?window=30d`,
-      env,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.hotkey, HTTP_HOTKEY);
-    assert.equal(body.data.nominator_count, 2);
-    assert.equal(body.data.nominators[0].coldkey, "ck-a");
-    assert.equal(body.data.nominators[0].net_staked_tao, 70);
-    assert.equal(body.meta.source, "chain-events");
-  });
-
-  test("?coldkey= narrows to one nominator's own flow", async () => {
-    // The handler validates ?coldkey= as a real SS58 shape, so both the query
-    // param and the mock rows' coldkey must be SS58-shaped here (unlike the
-    // other tests above, which only exercise the unvalidated request path).
-    const coldkeyA = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-    const coldkeyB = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";
-    const env = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: accountEventsD1([
-        { hotkey: HTTP_HOTKEY, ...added(coldkeyA, 100, 2, 5000) },
-        { hotkey: HTTP_HOTKEY, ...added(coldkeyB, 10, 1, 4000) },
-      ]),
-    };
-    const { res, body } = await getJson(
-      `/api/v1/validators/${HTTP_HOTKEY}/nominators?coldkey=${coldkeyB}`,
-      env,
-    );
-    assert.equal(res.status, 200);
-    assert.equal(body.data.nominator_count, 1);
-    assert.equal(body.data.nominators[0].coldkey, coldkeyB);
-  });
-
   test("is schema-stable when D1 is cold (never 404)", async () => {
     const env = {
       ...createLocalArtifactEnv(),

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -17,7 +17,7 @@
 // imported straight from the src/* leaf modules + config. api.mjs imports the
 // handlers back and dispatches them from the router.
 
-import { DAY_MS, SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.mjs";
+import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.mjs";
 import {
   BLOCK_PAGINATION,
   DAY_PATTERN,
@@ -43,18 +43,18 @@ import {
   validateQueryParams,
 } from "./analytics.mjs";
 import {
-  loadGlobalValidators,
-  loadSubnetMetagraph,
-  loadSubnetValidators,
-  loadNeuron,
-  loadValidatorDetail,
+  buildGlobalValidators,
+  buildSubnetMetagraph,
+  buildSubnetValidators,
+  buildNeuronDetail,
+  buildValidatorDetail,
   GLOBAL_VALIDATOR_SORTS,
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
 } from "../../src/metagraph-neurons.mjs";
 import {
-  loadAccountsList,
+  buildAccountsList,
   ACCOUNTS_LIST_SORTS,
   DEFAULT_ACCOUNTS_LIST_SORT,
   ACCOUNTS_LIST_LIMIT_DEFAULT,
@@ -63,9 +63,7 @@ import {
 import { buildSubnetHyperparams } from "../../src/subnet-hyperparams.mjs";
 import { buildSubnetHyperparamsHistory } from "../../src/subnet-hyperparams-history.mjs";
 import {
-  loadSubnetYield,
-  YIELD_HISTORY_READ_COLUMNS,
-  YIELD_HISTORY_ROW_CAP,
+  buildSubnetYield,
   buildSubnetYieldHistory,
   parseSubnetYieldHistoryWindow,
 } from "../../src/subnet-yield.mjs";
@@ -74,8 +72,6 @@ import {
   buildSubnetHistory,
   parseHistoryWindow,
   unsupportedWindowMessage,
-  NEURON_DAILY_READ_COLUMNS,
-  MAX_HISTORY_POINTS,
 } from "../../src/neuron-history.mjs";
 import {
   INGESTED_EVENT_KINDS,
@@ -84,15 +80,15 @@ import {
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   SUBNET_EVENT_SUMMARY_WINDOWS,
   buildAccountHistory,
-  loadAccountSummary,
-  loadAccountEvents,
-  loadSubnetEvents,
-  loadSubnetEventSummary,
-  loadAccountExtrinsics,
-  loadAccountTransfers,
-  loadAccountSubnets,
+  buildAccountSummary,
+  buildAccountEvents,
+  buildSubnetEvents,
+  buildSubnetEventSummary,
+  buildAccountTransfers,
+  buildAccountSubnets,
+  buildBlockEvents,
 } from "../../src/account-events.mjs";
-import { loadAccountPortfolio } from "../../src/account-portfolio.mjs";
+import { buildAccountPortfolio } from "../../src/account-portfolio.mjs";
 import { buildAccountPositionHistory } from "../../src/account-position-history.mjs";
 import { loadAccountIdentity } from "../../src/account-identity.mjs";
 import { loadAccountIdentityHistory } from "../../src/account-identity-history.mjs";
@@ -102,153 +98,145 @@ import {
 } from "../../src/account-balance.mjs";
 import { loadSudoKey } from "../../src/sudo-key.mjs";
 import { isU16Netuid, loadSubnetRecycled } from "../../src/subnet-recycled.mjs";
-import { loadRuntimeVersionHistory } from "../../src/runtime-versions.mjs";
+import { buildRuntimeVersionHistory } from "../../src/runtime-versions.mjs";
 import { decodeCursor, encodeCursor } from "../../src/cursor.mjs";
-import {
-  BLOCK_READ_COLUMNS,
-  buildBlock,
-  loadBlocks,
-} from "../../src/blocks.mjs";
-import { loadBlocksSummary } from "../../src/blocks-summary.mjs";
+import { buildBlock, buildBlockFeed } from "../../src/blocks.mjs";
+import { buildBlocksSummary } from "../../src/blocks-summary.mjs";
 import {
   EXTRINSICS_CSV_COLUMNS,
   extrinsicsToCsvRows,
-  loadExtrinsics,
+  buildExtrinsic,
+  buildExtrinsicFeed,
+  buildAccountExtrinsics,
+  buildBlockExtrinsics,
 } from "../../src/extrinsics.mjs";
 import {
-  loadBlockEvents,
-  loadBlockExtrinsics,
-} from "../../src/block-subresources.mjs";
-import { loadExtrinsicDetail } from "../../src/extrinsic-detail.mjs";
-import {
-  CONCENTRATION_HISTORY_ROW_CAP,
-  CONCENTRATION_READ_COLUMNS,
   buildConcentration,
+  buildChainConcentration,
   buildConcentrationHistory,
-  loadChainConcentration,
   parseConcentrationHistoryWindow,
 } from "../../src/concentration.mjs";
-import { loadChainPerformance } from "../../src/chain-performance.mjs";
-import { loadChainYield } from "../../src/chain-yield.mjs";
+import { buildChainPerformance } from "../../src/chain-performance.mjs";
+import { buildChainYield } from "../../src/chain-yield.mjs";
 import {
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
   loadChainIdentityHistory,
 } from "../../src/chain-identity-history.mjs";
 import {
-  PERFORMANCE_READ_COLUMNS,
   buildSubnetPerformance,
-  PERFORMANCE_HISTORY_READ_COLUMNS,
-  PERFORMANCE_HISTORY_ROW_CAP,
   buildSubnetPerformanceHistory,
   parseSubnetPerformanceHistoryWindow,
 } from "../../src/subnet-performance.mjs";
 import {
-  loadCounterparties,
-  loadCounterpartyRelationship,
+  buildCounterparties,
+  buildCounterpartyRelationship,
 } from "../../src/counterparties.mjs";
-import { loadSubnetTurnover } from "../../src/turnover.mjs";
 import {
-  loadSubnetWeights,
+  buildTurnover,
+  buildTurnoverChanges,
+  turnoverChangeDetail,
+} from "../../src/turnover.mjs";
+import {
+  buildSubnetWeights,
   SUBNET_WEIGHTS_WINDOWS,
   DEFAULT_SUBNET_WEIGHTS_WINDOW,
 } from "../../src/subnet-weights.mjs";
 import {
-  loadSubnetWeightSetters,
+  buildSubnetWeightSetters,
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
 } from "../../src/subnet-weight-setters.mjs";
 import {
-  loadSubnetServing,
+  buildSubnetServing,
   SUBNET_SERVING_WINDOWS,
   DEFAULT_SUBNET_SERVING_WINDOW,
 } from "../../src/subnet-serving.mjs";
 import {
-  loadSubnetPrometheus,
+  buildSubnetPrometheus,
   SUBNET_PROMETHEUS_WINDOWS,
   DEFAULT_SUBNET_PROMETHEUS_WINDOW,
 } from "../../src/subnet-prometheus.mjs";
 import {
-  loadSubnetStakeMoves,
+  buildSubnetStakeMoves,
   SUBNET_STAKE_MOVES_WINDOWS,
   DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
 } from "../../src/subnet-stake-moves.mjs";
 import {
-  loadSubnetStakeTransfers,
+  buildSubnetStakeTransfers,
   SUBNET_STAKE_TRANSFERS_WINDOWS,
   DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
 } from "../../src/subnet-stake-transfers.mjs";
 import {
-  loadSubnetRegistrations,
+  buildSubnetRegistrations,
   SUBNET_REGISTRATIONS_WINDOWS,
   DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
 } from "../../src/subnet-registrations.mjs";
 import {
-  loadSubnetAxonRemovals,
+  buildSubnetAxonRemovals,
   SUBNET_AXON_REMOVALS_WINDOWS,
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
 } from "../../src/subnet-axon-removals.mjs";
 import {
-  loadSubnetDeregistrations,
+  buildSubnetDeregistrations,
   SUBNET_DEREGISTRATIONS_WINDOWS,
   DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
 } from "../../src/subnet-deregistrations.mjs";
 import {
-  loadSubnetStakeFlow,
+  buildStakeFlow,
   STAKE_FLOW_WINDOWS,
   DEFAULT_STAKE_FLOW_WINDOW,
-  DEFAULT_STAKE_FLOW_DIRECTION,
   STAKE_FLOW_DIRECTIONS,
 } from "../../src/stake-flow.mjs";
-import { loadSubnetAlphaVolume } from "../../src/alpha-volume.mjs";
+import { buildAlphaVolume } from "../../src/alpha-volume.mjs";
 import { resolveLiveEconomics } from "../../src/health-serving.mjs";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.mjs";
 import { readArtifact, readHealthKv } from "../storage.mjs";
-import { loadAccountStakeFlow } from "../../src/account-stake-flow.mjs";
+import { buildAccountStakeFlow } from "../../src/account-stake-flow.mjs";
 import {
-  loadValidatorNominators,
+  buildValidatorNominators,
   NOMINATOR_WINDOWS,
   DEFAULT_NOMINATOR_WINDOW,
   NOMINATOR_SORTS,
 } from "../../src/validator-nominators.mjs";
 import { buildValidatorHistory } from "../../src/validator-history.mjs";
 import {
-  loadAccountStakeMoves,
+  buildAccountStakeMoves,
   ACCOUNT_STAKE_MOVES_WINDOWS,
   DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
 } from "../../src/account-stake-moves.mjs";
 import {
-  loadAccountWeightSetters,
+  buildAccountWeightSetters,
   ACCOUNT_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
 } from "../../src/account-weight-setters.mjs";
 import {
-  loadAccountRegistrations,
+  buildAccountRegistrations,
   REGISTRATION_WINDOWS,
   DEFAULT_REGISTRATION_WINDOW,
 } from "../../src/account-registrations.mjs";
 import {
-  loadAccountServing,
+  buildAccountServing,
   SERVING_WINDOWS,
   DEFAULT_SERVING_WINDOW,
 } from "../../src/account-serving.mjs";
 import {
-  loadAccountAxonRemovals,
+  buildAccountAxonRemovals,
   AXON_REMOVAL_WINDOWS,
   DEFAULT_AXON_REMOVAL_WINDOW,
 } from "../../src/account-axon-removals.mjs";
 import {
-  loadAccountPrometheus,
+  buildAccountPrometheus,
   PROMETHEUS_WINDOWS,
   DEFAULT_PROMETHEUS_WINDOW,
 } from "../../src/account-prometheus.mjs";
 import {
-  loadAccountDeregistrations,
+  buildAccountDeregistrations,
   DEREGISTRATION_WINDOWS,
   DEFAULT_DEREGISTRATION_WINDOW,
 } from "../../src/account-deregistrations.mjs";
 import {
-  loadSubnetMovers,
+  buildMovers,
   MOVERS_WINDOWS,
   DEFAULT_MOVERS_WINDOW,
   MOVERS_SORTS,
@@ -257,7 +245,7 @@ import {
   MOVERS_LIMIT_MAX,
 } from "../../src/movers.mjs";
 import {
-  loadChainTurnover,
+  buildChainTurnover,
   CHAIN_TURNOVER_WINDOWS,
   DEFAULT_CHAIN_TURNOVER_WINDOW,
   CHAIN_TURNOVER_LIMIT_DEFAULT,
@@ -473,19 +461,6 @@ function parseBoundedIntParam(url, parameter, { def, min, max }) {
   return { value };
 }
 
-// Strict path-ref parsers: Number()/split("-") coerce a malformed ref (hex,
-// 1e3, empty/extra halves) into a wrong-but-valid lookup; require bare decimal
-// segments + Number.isSafeInteger (same convention as parseBoundedIntParam).
-const STRICT_UINT_RE = /^\d+$/;
-
-// A strict non-negative block_number, or null for a non-decimal ref (so the
-// caller skips the lookup and serves the schema-stable miss).
-function strictBlockNumber(ref) {
-  if (!STRICT_UINT_RE.test(ref)) return null;
-  const value = Number(ref);
-  return Number.isSafeInteger(value) ? value : null;
-}
-
 // --- Per-UID metagraph (#1304/#1305): served live from the neurons D1 tier ---
 // (migration 0007, populated by the refresh-metagraph cron). Null-safe: an
 // unbound/cold D1 returns a schema-stable empty payload, like the other
@@ -507,12 +482,15 @@ export async function handleSubnetMetagraph(request, env, netuid, url) {
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const validatorsOnly = url.searchParams.get("validator_permit") === "true";
+  // #4909 D1 retirement: neurons' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
+  // Mirrors handleSubnetHyperparams's pattern below (a schema-stable literal,
+  // not a live D1 query) rather than querying a table that no longer exists.
+  // validator_permit is still validated above and forwarded to Postgres via
+  // the proxied request (tryPostgresTier passes the request through unchanged).
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadSubnetMetagraph(d1Runner(env), netuid, {
-      validatorsOnly,
-    }));
+    buildSubnetMetagraph([], netuid);
   if (csvRequested(url, request)) {
     return csvResponse(
       data.neurons,
@@ -545,7 +523,7 @@ export async function handleSubnetYield(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadSubnetYield(d1Runner(env), netuid));
+    buildSubnetYield([], netuid);
   if (csvRequested(url, request)) {
     return csvResponse(
       data.neurons,
@@ -574,7 +552,7 @@ export async function handleNeuron(request, env, netuid, uid) {
   // tiers (health/economics never 404 on a cold store).
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadNeuron(d1Runner(env), netuid, uid));
+    buildNeuronDetail(null, netuid);
   return envelopeResponse(
     request,
     {
@@ -678,7 +656,7 @@ export async function handleSubnetValidators(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadSubnetValidators(d1Runner(env), netuid));
+    buildSubnetValidators([], netuid);
   if (csvRequested(url, request)) {
     return csvResponse(
       data.validators,
@@ -754,10 +732,10 @@ export async function handleGlobalValidators(request, env, url) {
   if (parsed.error) return analyticsQueryError(parsed.error);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadGlobalValidators(d1Runner(env), {
+    buildGlobalValidators([], {
       sort: parsed.sort,
       limit: parsed.limit,
-    }));
+    });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.validators,
@@ -836,10 +814,10 @@ export async function handleAccountsList(request, env, url) {
   if (parsed.error) return analyticsQueryError(parsed.error);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadAccountsList(d1Runner(env), {
+    buildAccountsList([], {
       sort: parsed.sort,
       limit: parsed.limit,
-    }));
+    });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.accounts,
@@ -872,7 +850,7 @@ export async function handleAccountsList(request, env, url) {
 export async function handleValidatorDetail(request, env, hotkey) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadValidatorDetail(d1Runner(env), hotkey));
+    buildValidatorDetail([], hotkey);
   return envelopeResponse(
     request,
     {
@@ -938,15 +916,19 @@ export async function handleValidatorNominators(request, env, hotkey, url) {
       message: `"coldkey" must be a valid SS58 address.`,
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadValidatorNominators(d1Runner(env), hotkey, {
-      windowLabel: windowParam,
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildValidatorNominators([], hotkey, {
+      window: windowParam,
       sort: sort ?? undefined,
       limit: limit.value,
       offset: offset.value,
-      coldkey: coldkeyParam ?? undefined,
-    }));
+    }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -969,27 +951,13 @@ export async function handleValidatorNominators(request, env, hotkey, url) {
 export async function handleValidatorHistory(request, env, hotkey, url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return analyticsQueryError(error);
-  const params = [hotkey];
-  let sql =
-    "SELECT snapshot_date, COUNT(DISTINCT netuid) AS subnet_count, " +
-    "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
-    "FROM neuron_daily WHERE hotkey = ? AND validator_permit = 1";
-  if (days != null) {
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    sql += " AND snapshot_date >= ?";
-    params.push(cutoff);
-  }
-  sql += " GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ?";
-  params.push(MAX_HISTORY_POINTS);
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildValidatorHistory(await d1All(env, sql, params), hotkey, {
+    buildValidatorHistory([], hotkey, {
       window: label,
     });
   return envelopeResponse(
@@ -1015,25 +983,13 @@ export async function handleValidatorHistory(request, env, hotkey, url) {
 export async function handleNeuronHistory(request, env, netuid, uid, url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return analyticsQueryError(error);
-  const params = [netuid, uid];
-  let sql = `SELECT ${NEURON_DAILY_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND uid = ?`;
-  if (days != null) {
-    // Cutoff computed in JS and bound as a plain YYYY-MM-DD (idx_neuron_daily_uid_date covers it).
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    sql += " AND snapshot_date >= ?";
-    params.push(cutoff);
-  }
-  sql += " ORDER BY snapshot_date DESC LIMIT ?";
-  params.push(MAX_HISTORY_POINTS);
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildNeuronHistory(await d1All(env, sql, params), netuid, uid, {
+    buildNeuronHistory([], netuid, uid, {
       window: label,
     });
   return envelopeResponse(
@@ -1056,28 +1012,13 @@ export async function handleNeuronHistory(request, env, netuid, uid, url) {
 export async function handleSubnetHistory(request, env, netuid, url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return analyticsQueryError(error);
-  const params = [netuid];
-  let sql =
-    "SELECT snapshot_date, COUNT(*) AS neuron_count, " +
-    "SUM(validator_permit) AS validator_count, " +
-    "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
-    "FROM neuron_daily WHERE netuid = ?";
-  if (days != null) {
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    sql += " AND snapshot_date >= ?";
-    params.push(cutoff);
-  }
-  sql += " GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ?";
-  params.push(MAX_HISTORY_POINTS);
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildSubnetHistory(await d1All(env, sql, params), netuid, {
+    buildSubnetHistory([], netuid, {
       window: label,
     });
   return envelopeResponse(
@@ -1140,14 +1081,7 @@ export async function handleSubnetConcentration(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildConcentration(
-      await d1All(
-        env,
-        `SELECT ${CONCENTRATION_READ_COLUMNS} FROM neurons WHERE netuid = ?`,
-        [netuid],
-      ),
-      netuid,
-    );
+    buildConcentration([], netuid);
   return envelopeResponse(
     request,
     {
@@ -1174,14 +1108,7 @@ export async function handleSubnetPerformance(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildSubnetPerformance(
-      await d1All(
-        env,
-        `SELECT ${PERFORMANCE_READ_COLUMNS} FROM neurons WHERE netuid = ?`,
-        [netuid],
-      ),
-      netuid,
-    );
+    buildSubnetPerformance([], netuid);
   return envelopeResponse(
     request,
     {
@@ -1206,7 +1133,7 @@ export async function handleChainConcentration(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadChainConcentration(d1Runner(env)));
+    buildChainConcentration([]);
   return envelopeResponse(
     request,
     {
@@ -1232,7 +1159,7 @@ export async function handleChainPerformance(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadChainPerformance(d1Runner(env)));
+    buildChainPerformance([]);
   return envelopeResponse(
     request,
     {
@@ -1291,7 +1218,7 @@ export async function handleChainYield(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadChainYield(d1Runner(env)));
+    buildChainYield([]);
   return envelopeResponse(
     request,
     {
@@ -1504,10 +1431,12 @@ export async function handleChainTurnover(request, env, url) {
   if (limit.error) return analyticsQueryError(limit.error);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadChainTurnover(d1Runner(env), {
-      windowLabel: windowParam,
+    buildChainTurnover([], {
+      window: windowParam,
+      startDate: null,
+      endDate: null,
       limit: limit.value,
-    }));
+    });
   // CSV exports the row-shaped per-subnet churn leaderboard; the network rollup +
   // stability distribution stay JSON-only (mirrors the chain-analytics exports).
   if (csvRequested(url, request)) {
@@ -1581,27 +1510,18 @@ export async function handleSubnetConcentrationHistory(
   if (validationError) return analyticsQueryError(validationError);
   const formatError = validateResponseFormat(url);
   if (formatError) return analyticsQueryError(formatError);
-  const { label, days, error } = parseConcentrationHistoryWindow(
+  const { label, error } = parseConcentrationHistoryWindow(
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  const cutoff = new Date(Date.now() - days * DAY_MS)
-    .toISOString()
-    .slice(0, 10);
-  async function fromD1() {
-    const rows = await d1All(
-      env,
-      "SELECT snapshot_date, stake_tao, emission_tao FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC LIMIT ?",
-      [netuid, cutoff, CONCENTRATION_HISTORY_ROW_CAP],
-    );
-    return buildConcentrationHistory(rows, netuid, {
-      window: label,
-      capped: rows.length >= CONCENTRATION_HISTORY_ROW_CAP,
-    });
-  }
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await fromD1());
+    buildConcentrationHistory([], netuid, {
+      window: label,
+      capped: false,
+    });
   if (csvRequested(url, request)) {
     const points = [...data.points].sort((a, b) =>
       String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
@@ -1643,27 +1563,18 @@ export async function handleSubnetPerformanceHistory(
 ) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseSubnetPerformanceHistoryWindow(
+  const { label, error } = parseSubnetPerformanceHistoryWindow(
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  const cutoff = new Date(Date.now() - days * DAY_MS)
-    .toISOString()
-    .slice(0, 10);
-  async function fromD1() {
-    const rows = await d1All(
-      env,
-      `SELECT ${PERFORMANCE_HISTORY_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC LIMIT ?`,
-      [netuid, cutoff, PERFORMANCE_HISTORY_ROW_CAP],
-    );
-    return buildSubnetPerformanceHistory(rows, netuid, {
-      window: label,
-      capped: rows.length >= PERFORMANCE_HISTORY_ROW_CAP,
-    });
-  }
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await fromD1());
+    buildSubnetPerformanceHistory([], netuid, {
+      window: label,
+      capped: false,
+    });
   return envelopeResponse(
     request,
     {
@@ -1690,27 +1601,18 @@ export async function handleSubnetYieldHistory(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const formatError = validateResponseFormat(url);
   if (formatError) return analyticsQueryError(formatError);
-  const { label, days, error } = parseSubnetYieldHistoryWindow(
+  const { label, error } = parseSubnetYieldHistoryWindow(
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  const cutoff = new Date(Date.now() - days * DAY_MS)
-    .toISOString()
-    .slice(0, 10);
-  async function fromD1() {
-    const rows = await d1All(
-      env,
-      `SELECT ${YIELD_HISTORY_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC LIMIT ?`,
-      [netuid, cutoff, YIELD_HISTORY_ROW_CAP],
-    );
-    return buildSubnetYieldHistory(rows, netuid, {
-      window: label,
-      capped: rows.length >= YIELD_HISTORY_ROW_CAP,
-    });
-  }
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await fromD1());
+    buildSubnetYieldHistory([], netuid, {
+      window: label,
+      capped: false,
+    });
   if (csvRequested(url, request)) {
     const points = [...data.points].sort((a, b) =>
       String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
@@ -1745,9 +1647,7 @@ export async function handleSubnetYieldHistory(request, env, netuid, url) {
 export async function handleSubnetTurnover(request, env, netuid, url) {
   const validationError = validateQueryParams(url, ["window", "changes"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return analyticsQueryError(error);
   const changes = url.searchParams.get("changes");
   if (changes != null && changes !== "true") {
@@ -1756,13 +1656,19 @@ export async function handleSubnetTurnover(request, env, netuid, url) {
       message: `"${changes}" is not a valid changes flag. Supported: true.`,
     });
   }
+  // #4909 D1 retirement: neuron_daily's D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
+  const turnoverOptions = { window: label, startDate: null, endDate: null };
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadSubnetTurnover(d1Runner(env), netuid, {
-      windowLabel: label,
-      windowDays: days,
-      includeChanges: changes === "true",
-    }));
+    (changes === "true"
+      ? {
+          ...buildTurnover([], netuid, turnoverOptions),
+          changes: turnoverChangeDetail(
+            buildTurnoverChanges([], netuid, turnoverOptions),
+          ),
+        }
+      : buildTurnover([], netuid, turnoverOptions));
   return envelopeResponse(
     request,
     {
@@ -1807,10 +1713,7 @@ export async function handleSubnetWeights(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetWeights(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam],
-    }));
+    buildSubnetWeights(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -1860,10 +1763,7 @@ export async function handleSubnetWeightSetters(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetWeightSetters(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam],
-    }));
+    buildSubnetWeightSetters([], null, netuid, { window: windowParam });
   // account_events-derived: the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling /weights route.
   return envelopeResponse(
@@ -1910,10 +1810,7 @@ export async function handleSubnetServing(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetServing(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_SERVING_WINDOWS[windowParam],
-    }));
+    buildSubnetServing(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonServed event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -1961,10 +1858,7 @@ export async function handleSubnetPrometheus(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetPrometheus(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_PROMETHEUS_WINDOWS[windowParam],
-    }));
+    buildSubnetPrometheus(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed PrometheusServed event, mirroring the sibling serving route.
   return envelopeResponse(
@@ -2015,10 +1909,7 @@ export async function handleSubnetStakeMoves(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetStakeMoves(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam],
-    }));
+    buildSubnetStakeMoves(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeMoved event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2069,10 +1960,7 @@ export async function handleSubnetStakeTransfers(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetStakeTransfers(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam],
-    }));
+    buildSubnetStakeTransfers(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeTransferred event, mirroring the sibling stake-moves route.
   return envelopeResponse(
@@ -2122,10 +2010,7 @@ export async function handleSubnetRegistrations(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetRegistrations(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam],
-    }));
+    buildSubnetRegistrations(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed NeuronRegistered event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2175,10 +2060,7 @@ export async function handleSubnetAxonRemovals(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetAxonRemovals(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_AXON_REMOVALS_WINDOWS[windowParam],
-    }));
+    buildSubnetAxonRemovals(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonInfoRemoved event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2228,10 +2110,7 @@ export async function handleSubnetDeregistrations(request, env, netuid, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetDeregistrations(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      windowDays: SUBNET_DEREGISTRATIONS_WINDOWS[windowParam],
-    }));
+    buildSubnetDeregistrations(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed NeuronDeregistered event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2273,14 +2152,14 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
       message: `"${direction}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
     });
   }
-  const normalizedDirection =
-    direction === "in" || direction === "out" ? direction : undefined;
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetStakeFlow(d1Runner(env), netuid, {
-      windowLabel: windowParam,
-      direction: normalizedDirection ?? DEFAULT_STAKE_FLOW_DIRECTION,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildStakeFlow([], netuid, { window: windowParam }),
+    generatedAt: null,
+  };
   // account_events-derived, so the meta reports source "chain-events" (via
   // accountMeta), not the metagraph snapshot; generated_at is the newest event in
   // the window.
@@ -2338,11 +2217,14 @@ export async function handleSubnetAlphaVolume(request, env, netuid, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
   const marketCapTao = await resolveSubnetMarketCapTao(env, netuid);
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetAlphaVolume(d1Runner(env), netuid, {
-      marketCapTao,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAlphaVolume([], netuid, { marketCapTao }),
+    generatedAt: null,
+  };
   return envelopeResponse(
     request,
     {
@@ -2395,11 +2277,13 @@ export async function handleSubnetMovers(request, env, url) {
   if (limit.error) return analyticsQueryError(limit.error);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadSubnetMovers(d1Runner(env), {
-      windowLabel: windowParam,
+    buildMovers([], [], {
+      window: windowParam,
+      startDate: null,
+      endDate: null,
       sort: sortParam,
       limit: limit.value,
-    }));
+    });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.movers,
@@ -2476,14 +2360,14 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
       message: `"${direction}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
     });
   }
-  const normalizedDirection =
-    direction === "in" || direction === "out" ? direction : undefined;
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountStakeFlow(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-      direction: normalizedDirection,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountStakeFlow([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2516,11 +2400,14 @@ export async function handleAccountStakeMoves(request, env, ss58, url) {
       ),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountStakeMoves(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountStakeMoves([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2553,11 +2440,14 @@ export async function handleAccountWeightSetters(request, env, ss58, url) {
       ),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountWeightSetters(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountWeightSetters([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2587,11 +2477,14 @@ export async function handleAccountRegistrations(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, REGISTRATION_WINDOWS),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountRegistrations(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountRegistrations([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2620,11 +2513,14 @@ export async function handleAccountServing(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, SERVING_WINDOWS),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountServing(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountServing([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2654,11 +2550,14 @@ export async function handleAccountAxonRemovals(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, AXON_REMOVAL_WINDOWS),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountAxonRemovals(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountAxonRemovals([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2688,11 +2587,14 @@ export async function handleAccountPrometheus(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, PROMETHEUS_WINDOWS),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountPrometheus(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountPrometheus([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2722,11 +2624,14 @@ export async function handleAccountDeregistrations(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, DEREGISTRATION_WINDOWS),
     });
   }
-  const { data, generatedAt } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountDeregistrations(d1Runner(env), ss58, {
-      windowLabel: windowParam,
-    }));
+  const { data, generatedAt } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? {
+    data: buildAccountDeregistrations([], ss58, { window: windowParam }),
+    generatedAt: null,
+  };
   return accountEnvelopeResponse(
     request,
     {
@@ -2747,7 +2652,7 @@ export async function handleAccountDeregistrations(request, env, ss58, url) {
 export async function handleAccount(request, env, ss58) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountSummary(d1Runner(env), ss58));
+    buildAccountSummary(ss58, {});
   return accountEnvelopeResponse(
     request,
     {
@@ -2807,17 +2712,19 @@ export async function handleAccountEvents(request, env, ss58, url) {
       message: `"${kind}" is not a supported event kind. Supported: ${INGESTED_EVENT_KINDS.join(", ")}.`,
     });
   }
+  // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
+  const { limit: parsedLimit, offset: parsedOffset } = parsePagination(
+    url,
+    FEED_PAGINATION,
+  );
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountEvents(d1Runner(env), ss58, {
-      limit: url.searchParams.get("limit"),
-      offset: url.searchParams.get("offset"),
-      kind,
-      netuid: netuid.value,
-      cursor: url.searchParams.get("cursor"),
-      blockStart: blockStart.value,
-      blockEnd: blockEnd.value,
-    }));
+    buildAccountEvents([], ss58, {
+      limit: parsedLimit,
+      offset: parsedOffset,
+      nextCursor: null,
+    });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.events,
@@ -2997,15 +2904,19 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
+  const { limit: parsedLimit, offset: parsedOffset } = parsePagination(
+    url,
+    FEED_PAGINATION,
+  );
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
-    (await loadAccountExtrinsics(d1Runner(env), ss58, {
-      limit: url.searchParams.get("limit"),
-      offset: url.searchParams.get("offset"),
-      cursor: url.searchParams.get("cursor"),
-      blockStart: blockStart.value,
-      blockEnd: blockEnd.value,
-    }));
+    buildAccountExtrinsics([], ss58, {
+      limit: parsedLimit,
+      offset: parsedOffset,
+      nextCursor: null,
+    });
   if (csvRequested(url, request)) {
     const csvRows = data.extrinsics.map((extrinsic) => ({
       ...extrinsic,
@@ -3064,7 +2975,7 @@ export async function handleAccountTransfers(request, env, ss58, url) {
       message: `"${direction}" is not a valid direction. Supported: all, sent, received.`,
     });
   }
-  const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
+  const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   const blockStart = parseNonNegativeIntParam(
     url.searchParams.get("block_start"),
     "block_start",
@@ -3075,18 +2986,16 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
-  const normalizedDirection =
-    direction === "sent" || direction === "received" ? direction : undefined;
+  // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadAccountTransfers(d1Runner(env), ss58, {
-      direction: normalizedDirection,
+    buildAccountTransfers([], ss58, {
       limit,
       offset,
-      cursor,
-      blockStart: blockStart.value,
-      blockEnd: blockEnd.value,
-    }));
+      nextCursor: null,
+      direction: undefined,
+    });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.transfers,
@@ -3138,15 +3047,32 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
         message: "counterparty must differ from ss58.",
       });
     }
-    const data =
-      (await tryPostgresTier(
-        env,
-        request,
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
-      (await loadCounterpartyRelationship(d1Runner(env), ss58, counterparty, {
-        limit,
-      }));
+    // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
+    // and the table is dropped in production, so a D1 query here would
+    // always miss. An empty rows input always yields transfer_count: 0, so
+    // this mirrors loadCounterpartyRelationship's composite shape with an
+    // always-empty counterparties list, without querying D1 at all.
+    const emptyRelationship = buildCounterpartyRelationship(
+      [],
+      ss58,
+      counterparty,
+      { limit },
+    );
+    const data = (await tryPostgresTier(
+      env,
+      request,
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    )) ?? {
+      schema_version: 1,
+      ss58,
+      counterparty_count: 0,
+      transfers_scanned: emptyRelationship.transfers_scanned,
+      scan_capped: emptyRelationship.scan_capped,
+      total_sent_tao: emptyRelationship.total_sent_tao,
+      total_received_tao: emptyRelationship.total_received_tao,
+      counterparties: [],
+      relationship: emptyRelationship,
+    };
     return accountEnvelopeResponse(
       request,
       {
@@ -3162,7 +3088,7 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
   }
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadCounterparties(d1Runner(env), ss58, { limit }));
+    buildCounterparties([], ss58, { limit });
   return accountEnvelopeResponse(
     request,
     {
@@ -3182,7 +3108,7 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
 export async function handleAccountSubnets(request, env, ss58) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadAccountSubnets(d1Runner(env), ss58));
+    buildAccountSubnets([], ss58);
   return accountEnvelopeResponse(
     request,
     {
@@ -3204,7 +3130,7 @@ export async function handleAccountSubnets(request, env, ss58) {
 export async function handleAccountPortfolio(request, env, ss58) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    (await loadAccountPortfolio(d1Runner(env), ss58));
+    buildAccountPortfolio([], ss58);
   return accountEnvelopeResponse(
     request,
     {
@@ -3371,16 +3297,19 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
+  const { limit: parsedLimit, offset: parsedOffset } = parsePagination(
+    url,
+    FEED_PAGINATION,
+  );
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetEvents(d1Runner(env), netuid, {
-      limit: url.searchParams.get("limit"),
-      offset: url.searchParams.get("offset"),
-      kind: url.searchParams.get("kind"),
-      cursor: url.searchParams.get("cursor"),
-      blockStart: blockStart.value,
-      blockEnd: blockEnd.value,
-    }));
+    buildSubnetEvents([], netuid, {
+      limit: parsedLimit,
+      offset: parsedOffset,
+      nextCursor: null,
+    });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.events,
@@ -3430,10 +3359,10 @@ export async function handleSubnetEventSummary(request, env, netuid, url) {
   if (parsedLimit.error) return analyticsQueryError(parsedLimit.error);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadSubnetEventSummary(d1Runner(env), netuid, {
-      windowLabel,
+    buildSubnetEventSummary([], [], netuid, {
+      window: windowLabel,
       limit: parsedLimit.limit,
-    }));
+    });
   return envelopeResponse(
     request,
     {
@@ -3559,10 +3488,9 @@ export async function handleBlocks(request, env, url) {
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
+  const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
   // Reject non-integer numeric filters with 400 (mirrors handleExtrinsics / #2274).
-  const numericFilters = {};
   for (const param of [
     "block_start",
     "block_end",
@@ -3576,30 +3504,12 @@ export async function handleBlocks(request, env, url) {
     if (raw === null) continue;
     const parsed = parseNonNegativeIntParam(raw, param);
     if (parsed.error) return analyticsQueryError(parsed.error);
-    numericFilters[param] = parsed.value;
   }
-  const blockStart = numericFilters.block_start ?? null;
-  const blockEnd = numericFilters.block_end ?? null;
-  const from = numericFilters.from ?? null;
-  const to = numericFilters.to ?? null;
-  const minExtrinsics = numericFilters.min_extrinsics ?? null;
-  const minEvents = numericFilters.min_events ?? null;
-
+  // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
-    (await loadBlocks(d1Runner(env), {
-      limit,
-      offset,
-      cursor,
-      author: sp.get("author") || undefined,
-      specVersion: numericFilters.spec_version ?? undefined,
-      blockStart,
-      blockEnd,
-      from,
-      to,
-      minExtrinsics,
-      minEvents,
-    }));
+    buildBlockFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.blocks,
@@ -3634,7 +3544,7 @@ export async function handleBlocksSummary(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
-    (await loadBlocksSummary(d1Runner(env)));
+    buildBlocksSummary([]);
   return envelopeResponse(
     request,
     {
@@ -3654,55 +3564,13 @@ export async function handleBlocksSummary(request, env, url) {
 // unknown ref / cold store → 200 with block:null (schema-stable, mirrors the
 // neuron detail route — NEVER 404/throw).
 export async function handleBlock(request, env, ref) {
-  const pg = await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE");
-  let data = pg;
-  if (!data) {
-    const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-    // A non-hash ref must be a strict decimal block_number; anything else (0x-short,
-    // 1e3, signs, empty) is a guaranteed miss, never a Number()-coerced wrong row.
-    const blockNumber = isHash ? null : strictBlockNumber(ref);
-    const sql = isHash
-      ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
-      : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
-    // The poller stores hashes lowercase (substrateinterface emits `0x` lowercase)
-    // and D1 text columns are BINARY-collated, so a mixed/upper-case 0x ref would
-    // miss. Normalize the hash ref to lowercase before binding (same for the block-
-    // extrinsics, block-events, and extrinsic handlers below).
-    const rows =
-      isHash || blockNumber !== null
-        ? await d1All(env, sql, [isHash ? ref.toLowerCase() : blockNumber])
-        : [];
-    // prev/next chain-walk neighbors (#1853): indexed scalar lookups for the
-    // nearest STORED block numbers around the resolved height (skips pruned gaps;
-    // null at the window edges). Derived from the resolved row's number (works for
-    // the hash path too). Only when the block resolved — a cold/unknown ref has no
-    // anchor. Keep these as WHERE-bounded subqueries so public detail requests use
-    // the block_number primary key instead of scanning the retained blocks table.
-    let prev = null;
-    let next = null;
-    // D1 can return the INTEGER block_number as a numeric string, and a bare
-    // Number.isInteger(rows[0]?.block_number) guard is false for "1234" — which
-    // would skip the neighbor query and make a resolved block wrongly report
-    // prev/next_block_number: null. Coerce the anchor first (mirrors formatBlock's
-    // toBlockNumber, and the string-cell fix applied to account-events #2489).
-    const resolvedRaw = Number(rows[0]?.block_number);
-    const resolvedNumber =
-      Number.isInteger(resolvedRaw) && resolvedRaw >= 0 ? resolvedRaw : null;
-    if (resolvedNumber !== null) {
-      const nbr = await d1All(
-        env,
-        `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next`,
-        [resolvedNumber, resolvedNumber],
-      );
-      prev = nbr[0]?.prev ?? null;
-      next = nbr[0]?.next ?? null;
-    }
-    data = buildBlock(rows[0], ref, { prev, next });
-  }
+  // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
+  const data =
+    (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
+    buildBlock(undefined, ref);
   // Finalized block detail is immutable once resolved; a cold/unknown ref stays
-  // on the short profile so clients re-check when the block lands. Checked on
-  // `data.block` (not the D1-only `rows[0]` var, now scoped to the D1 branch)
-  // so this works whether the row resolved via Postgres or D1.
+  // on the short profile so clients re-check when the block lands.
   const cacheProfile = data.block ? "static" : "short";
   return envelopeResponse(
     request,
@@ -3728,12 +3596,13 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
-  const { data } =
-    (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
-    (await loadBlockExtrinsics(d1Runner(env), ref, {
-      limit,
-      offset,
-    }));
+  // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
+  const { data } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_EXTRINSICS_SOURCE",
+  )) ?? { data: buildBlockExtrinsics([], ref, null, { limit, offset }) };
   return envelopeResponse(
     request,
     {
@@ -3758,12 +3627,13 @@ export async function handleBlockEvents(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
-  const { data } =
-    (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
-    (await loadBlockEvents(d1Runner(env), ref, {
-      limit,
-      offset,
-    }));
+  // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
+  // the table is dropped in production, so a D1 query here would always miss.
+  const { data } = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+  )) ?? { data: buildBlockEvents([], ref, null, { limit, offset }) };
   return envelopeResponse(
     request,
     {
@@ -3809,18 +3679,14 @@ export async function handleExtrinsics(request, env, url) {
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
+  const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
-  const numericFilters = {};
   for (const param of ["block", "block_start", "block_end", "from", "to"]) {
     const raw = sp.get(param);
     if (raw === null) continue;
     const parsed = parseNonNegativeIntParam(raw, param);
     if (parsed.error) return analyticsQueryError(parsed.error);
-    numericFilters[param] = parsed.value;
   }
-  const fromMs = numericFilters.from ?? null;
-  const toMs = numericFilters.to ?? null;
   const successRaw = sp.get("success");
   if (successRaw !== null && successRaw !== "true" && successRaw !== "false") {
     return analyticsQueryError({
@@ -3842,28 +3708,11 @@ export async function handleExtrinsics(request, env, url) {
       message: "call_module is required when call_hash is provided.",
     });
   }
+  // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
-    (await loadExtrinsics(d1Runner(env), {
-      block: numericFilters.block ?? undefined,
-      signer: sp.get("signer") || undefined,
-      callModule,
-      callFunction: sp.get("call_function") || undefined,
-      callHash: callHashRaw || undefined,
-      success:
-        successRaw === "true"
-          ? true
-          : successRaw === "false"
-            ? false
-            : undefined,
-      blockStart: numericFilters.block_start ?? undefined,
-      blockEnd: numericFilters.block_end ?? undefined,
-      from: fromMs ?? undefined,
-      to: toMs ?? undefined,
-      limit,
-      offset,
-      cursor,
-    }));
+    buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(data.extrinsics),
@@ -3909,15 +3758,13 @@ export async function handleSudo(request, env, url) {
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
+  const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
-  const numericFilters = {};
   for (const param of ["block", "block_start", "block_end", "from", "to"]) {
     const raw = sp.get(param);
     if (raw === null) continue;
     const parsed = parseNonNegativeIntParam(raw, param);
     if (parsed.error) return analyticsQueryError(parsed.error);
-    numericFilters[param] = parsed.value;
   }
   const successRaw = sp.get("success");
   if (successRaw !== null && successRaw !== "true" && successRaw !== "false") {
@@ -3926,26 +3773,11 @@ export async function handleSudo(request, env, url) {
       message: "success must be one of: true, false.",
     });
   }
+  // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
-    (await loadExtrinsics(d1Runner(env), {
-      callModule: "Sudo",
-      block: numericFilters.block ?? undefined,
-      callFunction: sp.get("call_function") || undefined,
-      success:
-        successRaw === "true"
-          ? true
-          : successRaw === "false"
-            ? false
-            : undefined,
-      blockStart: numericFilters.block_start ?? undefined,
-      blockEnd: numericFilters.block_end ?? undefined,
-      from: numericFilters.from ?? undefined,
-      to: numericFilters.to ?? undefined,
-      limit,
-      offset,
-      cursor,
-    }));
+    buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(data.extrinsics),
@@ -3990,15 +3822,13 @@ export async function handleGovernanceConfigChanges(request, env, url) {
     "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
+  const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
-  const numericFilters = {};
   for (const param of ["block", "block_start", "block_end", "from", "to"]) {
     const raw = sp.get(param);
     if (raw === null) continue;
     const parsed = parseNonNegativeIntParam(raw, param);
     if (parsed.error) return analyticsQueryError(parsed.error);
-    numericFilters[param] = parsed.value;
   }
   const successRaw = sp.get("success");
   if (successRaw !== null && successRaw !== "true" && successRaw !== "false") {
@@ -4007,26 +3837,11 @@ export async function handleGovernanceConfigChanges(request, env, url) {
       message: "success must be one of: true, false.",
     });
   }
+  // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
-    (await loadExtrinsics(d1Runner(env), {
-      callModule: "AdminUtils",
-      block: numericFilters.block ?? undefined,
-      callFunction: sp.get("call_function") || undefined,
-      success:
-        successRaw === "true"
-          ? true
-          : successRaw === "false"
-            ? false
-            : undefined,
-      blockStart: numericFilters.block_start ?? undefined,
-      blockEnd: numericFilters.block_end ?? undefined,
-      from: numericFilters.from ?? undefined,
-      to: numericFilters.to ?? undefined,
-      limit,
-      offset,
-      cursor,
-    }));
+    buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(data.extrinsics),
@@ -4059,9 +3874,11 @@ export async function handleGovernanceConfigChanges(request, env, url) {
 export async function handleRuntime(request, env, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
+  // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
-    (await loadRuntimeVersionHistory(d1Runner(env)));
+    buildRuntimeVersionHistory([]);
   return envelopeResponse(
     request,
     {
@@ -4106,9 +3923,11 @@ export async function handleSudoKey(request, env) {
 // embedded via a second lookup on (block_number, extrinsic_index) — bounded to 50.
 // Empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store.
 export async function handleExtrinsic(request, env, ref) {
+  // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
+  // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_EXTRINSICS_SOURCE")) ??
-    (await loadExtrinsicDetail(d1Runner(env), ref));
+    buildExtrinsic(undefined, ref);
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Closes #4909. PR #4772 retired D1's write/prune/ingest path for `blocks`, `extrinsics`, `account_events`, `neurons`, and `neuron_daily`; those tables are now fully dropped in production, so every `(await tryPostgresTier(...)) ?? (await loadXFromD1(...))` branch for these five tiers in `workers/request-handlers/entities.mjs` was unreachable dead code -- a live D1 query would always miss the dropped table (`d1All` already catches "no such table" and degrades gracefully, so this was provably safe but not yet cleaned up).

**One deliberate deviation from the issue's literal wording**, flagged for visibility: the issue described leaving a bare `tryPostgresTier(...)` call with no fallback at all. Doing that literally would have made every one of these ~50 routes throw an unhandled error on any transient Postgres/DATA_API miss, directly contradicting this file's own "null-safe by design, never a 404 or a throw" contract -- and empirically broke 554 tests when tried. Implemented instead with the same schema-stable-empty-literal fallback already established for `subnet_hyperparams`'s own earlier D1 retirement (e.g. `buildSubnetMetagraph([], netuid)` calling the paired pure `buildX` function each `src/*.mjs` module already exports, instead of the D1-querying `loadX`). Net production behavior is identical either way on the Postgres-success path; the difference only matters on a cold/failed Postgres call, where this version degrades to an empty-but-valid response instead of a 500.

Left untouched (not part of this retirement): `subnet_hyperparams`/`subnet_identity`/`account_identity` call sites, `handleAccountPositionHistory` (`account_position_daily`, already D1-free), and `handleAccountHistory` (`account_events_daily` has its own independent Postgres rollup, distinct from the five genuinely-dropped tables).

Removed now-fully-unused D1 loader imports and two helper functions (`strictBlockNumber`/`STRICT_UINT_RE`) this file no longer needs, and updated/removed tests across 29 files that exercised the removed D1-query behavior, adding a few targeted tests to close coverage gaps the removal left on genuine CSV-export branches.

Independently adversarially reviewed (approved) before landing. The review surfaced one follow-up, filed separately as #5047: `src/mcp-server.mjs` has the identical dead-D1-fallback pattern for the same five tables, on the MCP tool-call surface rather than REST routes -- explicitly out of scope here (this PR only touches `entities.mjs`).

## Test plan

- [x] `npx vitest run` -- 265 files / 7680 tests pass
- [x] `npm run test:coverage` -- unsharded; `entities.mjs` at 99.44%/98.52%/98.24%/99.87%, the one uncovered line (1320) is a pre-existing, unrelated gap in `canonicalSubnetTurnoverCachePath`
- [x] `npm run lint` / `npx prettier --check`

Note: hit a known, pre-existing, unrelated test flake during verification (`tests/artifacts.test.mjs`'s `registry validates`, filed as #5048 -- a test-isolation race between two test files sharing the real `public/` directory under parallel vitest workers) on one run; a clean re-run confirms it's unrelated to this diff.