### PR TITLE
feat(ui): add a kind filter to the subnet on-chain-activity table

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -124,8 +124,11 @@ export function SelectFilter({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        // Native <select> doesn't inherit the surrounding font by default — pin it
+        // to font-mono so the value matches the label instead of falling back to
+        // the sans body font, which reads as unstyled next to the mono label.
         className={classNames(
-          "min-w-0 truncate bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           fill ? "flex-1" : "",
         )}
       >

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -93,6 +93,7 @@ export function SelectFilter({
   label,
   allowEmpty = true,
   fill = false,
+  className,
 }: {
   value: string;
   onChange: (v: string) => void;
@@ -104,22 +105,29 @@ export function SelectFilter({
   // When true, the control stretches to fill its flex track (label stays fixed,
   // the select grows) so a row of filters can be justified edge-to-edge.
   fill?: boolean;
+  // Extra classes on the wrapping <label> — e.g. a max-w-[...] cap for option
+  // lists with a few long entries, so the closed control doesn't size itself
+  // to its widest option (native <select> sizing behavior).
+  className?: string;
 }) {
   return (
     <label
-      className={`items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs ${
-        fill ? "flex w-full min-w-0" : "inline-flex"
-      }`}
+      className={classNames(
+        "items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs",
+        fill ? "flex w-full min-w-0" : "inline-flex",
+        className,
+      )}
     >
-      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+      <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
         {label}
       </span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-          fill ? "min-w-0 flex-1" : ""
-        }`}
+        className={classNames(
+          "min-w-0 truncate bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          fill ? "flex-1" : "",
+        )}
       >
         {allowEmpty ? <option value="">all</option> : null}
         {options.map((o) => (

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4488,14 +4488,19 @@ export const subnetStakeFlowQuery = (netuid: number, window = "30d") =>
     staleTime: STALE_MED,
   });
 
-export const subnetEventsQuery = (netuid: number) =>
+export interface SubnetEventsParams {
+  /** Filter to one event_kind (e.g. "StakeAdded"). */
+  kind?: string;
+}
+
+export const subnetEventsQuery = (netuid: number, params: SubnetEventsParams = {}) =>
   queryOptions({
-    queryKey: k("subnet-events", netuid),
+    queryKey: k("subnet-events", netuid, params.kind ?? null),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Record<string, unknown>>(
-        `/api/v1/subnets/${netuid}/events?limit=100`,
-        { signal },
-      );
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/subnets/${netuid}/events`, {
+        params: { limit: 100, kind: params.kind },
+        signal,
+      });
       const d = (res.data ?? {}) as Record<string, unknown>;
       const events = normalizeAccountEvents(d.events);
       return {

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -44,6 +44,7 @@ import { TurnoverLoader } from "@/components/metagraphed/turnover-panel";
 import { NeuronDetailCard } from "@/components/metagraphed/neuron-detail-card";
 import { NeuronHistoryChart } from "@/components/metagraphed/neuron-history-chart";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
+import { SelectFilter } from "@/components/metagraphed/table-controls";
 import {
   subnetProfileQuery,
   subnetSurfacesQuery,
@@ -68,6 +69,7 @@ import {
   eventKindCategory,
   eventKindCategoryLabel,
   eventKindLabel,
+  EVENT_KIND_LABELS,
   type EventKindCategory,
 } from "@/lib/metagraphed/event-kinds";
 import type {
@@ -95,6 +97,7 @@ type SearchParams = {
   tab?: string;
   sev?: string;
   uid?: number;
+  ev_kind?: string;
 };
 
 export const Route = createFileRoute("/subnets/$netuid")({
@@ -104,6 +107,7 @@ export const Route = createFileRoute("/subnets/$netuid")({
       tab: typeof s.tab === "string" ? s.tab : undefined,
       sev: typeof s.sev === "string" ? s.sev : undefined,
       uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined,
+      ev_kind: typeof s.ev_kind === "string" && s.ev_kind ? s.ev_kind : undefined,
     };
   },
   parseParams: ({ netuid }) => {
@@ -670,22 +674,46 @@ function StakeFlowScorecard({ netuid }: { netuid: number }) {
 }
 
 function ActivityPanel({ netuid }: { netuid: number }) {
+  const { ev_kind } = Route.useSearch();
+  const navigate = Route.useNavigate();
   return (
     <SectionAnchor
       id="activity"
       title="On-chain activity"
       subtitle="First-party chain events for this subnet, newest first."
       info="Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
+      right={
+        <SelectFilter
+          label="Kind"
+          value={ev_kind ?? ""}
+          onChange={(v) =>
+            navigate({
+              to: ".",
+              search: (prev: SearchParams) => ({ ...prev, ev_kind: v || undefined }),
+              replace: true,
+            })
+          }
+          options={EVENT_KIND_OPTIONS}
+        />
+      }
     >
       <StakeFlowScorecard netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <ActivityTableLoader netuid={netuid} />
+          <ActivityTableLoader netuid={netuid} kind={ev_kind} />
         </Suspense>
       </QueryErrorBoundary>
     </SectionAnchor>
   );
 }
+
+// Subnets have no per-subnet event_kinds summary to source filter options from
+// (unlike AccountSummary.event_kinds on the account page) — use the full
+// shared label map instead.
+const EVENT_KIND_OPTIONS = Object.entries(EVENT_KIND_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}));
 
 const EVENT_KIND_CATEGORY_DOT: Record<EventKindCategory, string> = {
   registration: "var(--chart-1)",
@@ -723,17 +751,41 @@ function EventKindCell({ kind }: { kind: string | null | undefined }) {
   );
 }
 
-function ActivityTableLoader({ netuid }: { netuid: number }) {
-  const { data } = useSuspenseQuery(subnetEventsQuery(netuid));
+function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }) {
+  const navigate = Route.useNavigate();
+  const { data } = useSuspenseQuery(subnetEventsQuery(netuid, { kind }));
   const events = (data.data.events ?? []) as AccountEvent[];
   if (events.length === 0) {
     return (
-      <TableState
-        variant="empty"
-        title="No recent on-chain activity"
-        description="No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
-        generatedAt={data.meta?.generated_at}
-      />
+      <div className="space-y-3">
+        <TableState
+          variant="empty"
+          title={kind ? `No ${kind} events` : "No recent on-chain activity"}
+          description={
+            kind
+              ? "Try clearing the kind filter — this subnet may not have emitted that event recently."
+              : "No first-party chain events are indexed for this subnet in the current window — a quiet or newly-added subnet may have none yet. Registrations, stake, weights, delegation, and transfers will appear here as they're decoded."
+          }
+          generatedAt={data.meta?.generated_at}
+        />
+        {kind ? (
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={() =>
+                navigate({
+                  to: ".",
+                  search: (prev: SearchParams) => ({ ...prev, ev_kind: undefined }),
+                  replace: true,
+                })
+              }
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+            >
+              Clear filter
+            </button>
+          </div>
+        ) : null}
+      </div>
     );
   }
   return (

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
-import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, Waves, Activity } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Waves,
+  Activity,
+  Filter,
+} from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   EmptyState,
@@ -44,7 +51,6 @@ import { TurnoverLoader } from "@/components/metagraphed/turnover-panel";
 import { NeuronDetailCard } from "@/components/metagraphed/neuron-detail-card";
 import { NeuronHistoryChart } from "@/components/metagraphed/neuron-history-chart";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
-import { SelectFilter } from "@/components/metagraphed/table-controls";
 import {
   subnetProfileQuery,
   subnetSurfacesQuery,
@@ -682,8 +688,7 @@ function ActivityPanel({ netuid }: { netuid: number }) {
       title="On-chain activity"
       info="First-party chain events for this subnet, newest first. Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
       right={
-        <SelectFilter
-          label="Kind"
+        <EventKindFilterChip
           value={ev_kind ?? ""}
           onChange={(v) =>
             navigate({
@@ -692,8 +697,6 @@ function ActivityPanel({ netuid }: { netuid: number }) {
               replace: true,
             })
           }
-          options={EVENT_KIND_OPTIONS}
-          className="max-w-[130px]"
         />
       }
     >
@@ -714,6 +717,39 @@ const EVENT_KIND_OPTIONS = Object.entries(EVENT_KIND_LABELS).map(([value, label]
   value,
   label,
 }));
+
+// Pill-shaped filter chip matching the EndpointKindTabs / window-toggle idiom
+// used elsewhere for compact filters, rather than the generic bordered-box
+// label+select pattern — a native <select> still drives it for a11y and
+// mobile-native option picking, the Filter icon carries the "Kind" label so
+// the chip stays narrow enough that it never pushes the section title onto
+// multiple lines.
+function EventKindFilterChip({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2 py-1 text-ink-muted hover:border-ink/30 transition-colors">
+      <Filter className="size-3 shrink-0" aria-hidden />
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Filter by event kind"
+        className="min-w-0 max-w-[85px] truncate bg-transparent font-mono text-[11px] uppercase tracking-widest text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+      >
+        <option value="">All</option>
+        {EVENT_KIND_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
 
 const EVENT_KIND_CATEGORY_DOT: Record<EventKindCategory, string> = {
   registration: "var(--chart-1)",

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -680,8 +680,7 @@ function ActivityPanel({ netuid }: { netuid: number }) {
     <SectionAnchor
       id="activity"
       title="On-chain activity"
-      subtitle="First-party chain events for this subnet, newest first."
-      info="Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
+      info="First-party chain events for this subnet, newest first. Registrations, stake, weights, axon, delegation, lifecycle, and transfers decoded directly from finney System.Events for recent finalized blocks (the rolling first-party event window) — not Taostats."
       right={
         <SelectFilter
           label="Kind"
@@ -694,6 +693,7 @@ function ActivityPanel({ netuid }: { netuid: number }) {
             })
           }
           options={EVENT_KIND_OPTIONS}
+          className="max-w-[130px]"
         />
       }
     >
@@ -734,7 +734,7 @@ function EventKindCell({ kind }: { kind: string | null | undefined }) {
 
   return (
     <span
-      className="inline-flex flex-wrap items-center gap-1.5"
+      className="inline-flex items-center gap-1.5 whitespace-nowrap"
       title={`${label} · ${categoryLabel}`}
     >
       <span
@@ -790,20 +790,20 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   }
   return (
     <div className="overflow-x-auto rounded border border-border bg-card">
-      <table className="w-full text-left text-sm">
+      <table className="w-full min-w-[720px] text-left text-sm">
         <thead className="bg-surface/40">
           <tr>
-            <th className="px-4 py-2.5">Block</th>
-            <th className="px-4 py-2.5">Kind</th>
-            <th className="px-4 py-2.5">Hotkey</th>
-            <th className="px-4 py-2.5 text-right">Amount</th>
-            <th className="px-4 py-2.5 text-right">Observed</th>
+            <th className="px-4 py-2.5 whitespace-nowrap">Block</th>
+            <th className="px-4 py-2.5 whitespace-nowrap">Kind</th>
+            <th className="px-4 py-2.5 whitespace-nowrap">Hotkey</th>
+            <th className="px-4 py-2.5 text-right whitespace-nowrap">Amount</th>
+            <th className="px-4 py-2.5 text-right whitespace-nowrap">Observed</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-border">
           {events.map((ev, i) => (
             <tr key={`${ev.block_number}-${ev.event_index}-${i}`} className="hover:bg-surface/40">
-              <td className="px-4 py-2.5 font-mono text-[12px]">
+              <td className="px-4 py-2.5 font-mono text-[12px] whitespace-nowrap">
                 {ev.block_number != null ? (
                   <Link
                     to="/blocks/$ref"
@@ -816,10 +816,10 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
                   "—"
                 )}
               </td>
-              <td className="px-4 py-2.5">
+              <td className="px-4 py-2.5 whitespace-nowrap">
                 <EventKindCell kind={ev.event_kind} />
               </td>
-              <td className="px-4 py-2.5 font-mono text-[11px]">
+              <td className="px-4 py-2.5 font-mono text-[11px] whitespace-nowrap">
                 {ev.hotkey ? (
                   <Link
                     to="/accounts/$ss58"
@@ -832,10 +832,10 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
                   "—"
                 )}
               </td>
-              <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+              <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink whitespace-nowrap">
                 {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
               </td>
-              <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+              <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted whitespace-nowrap">
                 <TimeAgo at={ev.observed_at} />
               </td>
             </tr>


### PR DESCRIPTION
## Summary

Adds a `?kind=` filter dropdown to the subnet "On-chain activity" table, mirroring the account page's `AccountEventsSection` kind-filter UX and wiring it through to the existing server-side `?kind=` support in `handleSubnetEvents` (already live — no backend changes).

Subnets have no per-subnet `event_kinds` summary field to source dropdown options from (unlike `AccountSummary.event_kinds` on the account page), so options are sourced from the shared `EVENT_KIND_LABELS` map instead.

**Two follow-up fixes beyond the original issue scope, found and addressed while verifying the mobile screenshots:**

1. **Mobile table layout.** `ActivityTableLoader`'s `<table>` had no `min-width`, so on narrow viewports the browser squeezed columns instead of letting `overflow-x-auto` scroll — `EventKindCell`'s label+category-badge wrapped across multiple lines (it had `flex-wrap`), ballooning row height ~3x and pushing the section to over 10,000px tall on a 100-row page. Gave the table a `min-w-[720px]` and `whitespace-nowrap` cells so it scrolls horizontally like every other table in this app, and removed `EventKindCell`'s `flex-wrap`.
2. **Filter control design.** The stock `SelectFilter` (a bordered box with a separate "KIND" text label) sized itself to its widest *option* — `EVENT_KIND_LABELS` has several long entries ("PoW registration allowed") — wide enough to push "On-chain activity" onto 3 lines on mobile, and its own value text silently fell back to the sans body font instead of matching the label's monospace, which read as unstyled. Replaced it with a purpose-built `EventKindFilterChip`: a pill (`rounded-full`, `bg-card`, `border-border`) matching the chip idiom already used elsewhere in this app (`EndpointKindTabs`, the explorer window toggle), with a `Filter` icon carrying what "Kind" used to spell out and `font-mono` value text. Also dropped the section's redundant `subtitle` line in favor of the `info` tooltip already present, so the header collapses to one line at any width. Kept `SelectFilter` itself untouched aside from the font-mono fix (still used by several other pages) rather than reshaping its shared markup.

## What Changed

- `apps/ui/src/lib/metagraphed/queries.ts`: `subnetEventsQuery` now accepts an optional `{ kind }` param, forwarded to `/api/v1/subnets/{netuid}/events` alongside the existing `limit=100` (same pattern as `accountEventsQuery`).
- `apps/ui/src/routes/subnets.$netuid.tsx`: extend `SearchParams`/`validateSearch` with `ev_kind`; add a new `EventKindFilterChip` pill component and wire it into `ActivityPanel`'s header; `ActivityTableLoader` takes the selected kind, forwards it to the query, and its empty state gets a kind-aware title/description with a "Clear filter" affordance; `ActivityTableLoader`'s table gets `min-w-[720px]` + `whitespace-nowrap` cells; `EventKindCell` drops `flex-wrap`; dropped the section's `subtitle` line.
- `apps/ui/src/components/metagraphed/table-controls.tsx`: `SelectFilter` gains an optional `className` passthrough (mirrors `SearchInput`'s existing convention) and its `<select>` is now pinned to `font-mono` so the value matches the label — both fixes benefit its other existing consumers too, not just this page.

## Validation

- `npm run lint` / `typecheck` / `test` (678 passing) / `build` — `--workspace=apps/ui`
- `npm run test:e2e --workspace=apps/ui` — 24/24 passing, including `/subnets/1` and `/endpoints` (another `SelectFilter` consumer, confirming no regression there)
- **Manually drove the full flow in a local preview**: selected a kind → URL updated to `?ev_kind=<Kind>` and the table re-fetched, filtered to only that kind; selected "all" → `ev_kind` removed from the URL, full feed restored; selected a kind with zero matches → empty state read "No `<Kind>` events" with a working "Clear filter" button

## Screenshots

"On-chain activity" section on `/subnets/1`:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-light-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-light-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-dark-before.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-dark-after.png" width="200">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-tablet-dark-after.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-desktop-dark-after.png)<br><sub>after</sub> |

Mobile, scrolled to the table body specifically — the row-wrapping fix:

| Before | After |
| --- | --- |
| [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-table-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-table-light-before.png) | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-table-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3369-mobile-table-light-after.png) |

Closes #3369