### PR TITLE
fix(alerts): prevent ID enumeration by hiding private trigger existence

### DIFF
--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -246,20 +246,22 @@ test("get: 404 when no such trigger exists", async () => {
   assert.equal(res.status, 404);
 });
 
-test("get: 403 when the owner token header is entirely absent", async () => {
+test("get: 404 when the owner token header is entirely absent", async () => {
   mockQueue.current.push([row()]);
   const res = await fetch(req("/api/v1/alerts/triggers/1"));
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
-test("get: 403 when the owner token is present but wrong", async () => {
+test("get: 404 when the owner token is present but wrong", async () => {
   mockQueue.current.push([row()]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
       headers: { "x-alert-trigger-owner-token": "wrong" },
     }),
   );
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
 test("get: 200 with the owner view (owner_token stripped) when the token matches", async () => {
@@ -320,7 +322,7 @@ test("update: 404 when no such trigger exists", async () => {
   assert.equal(res.status, 404);
 });
 
-test("update: 403 when the owner token is missing or wrong", async () => {
+test("update: 404 when the owner token is missing or wrong", async () => {
   mockQueue.current.push([{ owner_token: "correct-token" }]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
@@ -329,7 +331,8 @@ test("update: 403 when the owner token is missing or wrong", async () => {
       body: { channel: "email", destination: "a@b.com", netuid: 1 },
     }),
   );
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
 test("update: 200 on success, sends the new validated fields to the UPDATE", async () => {
@@ -378,7 +381,7 @@ test("delete: 404 when no such trigger exists", async () => {
   assert.equal(res.status, 404);
 });
 
-test("delete: 403 when the owner token is missing or wrong", async () => {
+test("delete: 404 when the owner token is missing or wrong", async () => {
   mockQueue.current.push([{ owner_token: "correct-token" }]);
   const res = await fetch(
     req("/api/v1/alerts/triggers/1", {
@@ -386,7 +389,8 @@ test("delete: 403 when the owner token is missing or wrong", async () => {
       headers: { "x-alert-trigger-owner-token": "wrong" },
     }),
   );
-  assert.equal(res.status, 403);
+  assert.equal(res.status, 404);
+  assert.deepEqual(await res.json(), { error: "no such trigger" });
 });
 
 test("delete: 200 with {id, deleted:true} on success, and actually issues the DELETE", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2244,15 +2244,19 @@ async function readAlertTriggerBody(request) {
   }
 }
 
+function alertTriggerNotFoundResponse() {
+  return writeJson({ error: "no such trigger" }, 404);
+}
+
 function requireAlertTriggerOwner(request, storedOwnerToken) {
   const provided = request.headers.get(ALERT_TRIGGER_OWNER_TOKEN_HEADER) || "";
   if (isValidAlertOwnerToken(provided, storedOwnerToken)) return null;
-  return writeJson(
-    {
-      error: `provide the trigger's ${ALERT_TRIGGER_OWNER_TOKEN_HEADER} header`,
-    },
-    403,
-  );
+  // Single-trigger routes intentionally use the same response for absent
+  // rows and failed owner-token checks. Trigger ids are sequential database
+  // ids, and the trigger body can hold capability credentials such as
+  // Discord webhook URLs, so unauthenticated callers must not be able to
+  // distinguish "missing" from "exists but private" by probing ids.
+  return alertTriggerNotFoundResponse();
 }
 
 async function handleAlertTriggerCreate(request, env) {
@@ -2314,7 +2318,7 @@ async function handleAlertTriggerGet(request, env, id) {
   return withAlertTriggersSql(env, async (sql) => {
     const [row] =
       await sql`SELECT * FROM chain_alert_triggers WHERE id = ${id}`;
-    if (!row) return writeJson({ error: "no such trigger" }, 404);
+    if (!row) return alertTriggerNotFoundResponse();
     const authError = requireAlertTriggerOwner(request, row.owner_token);
     if (authError) return authError;
     return writeJson(ownerAlertTriggerView(row));
@@ -2334,7 +2338,7 @@ async function handleAlertTriggerUpdate(request, env, id) {
   return withAlertTriggersSql(env, async (sql) => {
     const [existing] =
       await sql`SELECT owner_token FROM chain_alert_triggers WHERE id = ${id}`;
-    if (!existing) return writeJson({ error: "no such trigger" }, 404);
+    if (!existing) return alertTriggerNotFoundResponse();
     const authError = requireAlertTriggerOwner(request, existing.owner_token);
     if (authError) return authError;
 
@@ -2364,7 +2368,7 @@ async function handleAlertTriggerDelete(request, env, id) {
   return withAlertTriggersSql(env, async (sql) => {
     const [existing] =
       await sql`SELECT owner_token FROM chain_alert_triggers WHERE id = ${id}`;
-    if (!existing) return writeJson({ error: "no such trigger" }, 404);
+    if (!existing) return alertTriggerNotFoundResponse();
     const authError = requireAlertTriggerOwner(request, existing.owner_token);
     if (authError) return authError;
     await sql`DELETE FROM chain_alert_triggers WHERE id = ${id}`;


### PR DESCRIPTION
### Motivation
- Single-trigger alert routes used sequential BIGSERIAL IDs and returned `404` for nonexistent IDs but `403` for rows that exist with a missing/wrong owner token, allowing unauthenticated enumeration of private trigger existence.

### Description
- Add a shared `alertTriggerNotFoundResponse()` helper and change `requireAlertTriggerOwner` to return that indistinguishable `404` response for failed owner-token checks.
- Replace the previous direct `writeJson({ error: "no such trigger" }, 404)` checks in the GET/PATCH/DELETE handlers with the helper so missing rows and failed auth yield the same response.
- Update `tests/alert-triggers-route.test.mjs` to assert that missing or incorrect owner tokens produce `404` with body `{ error: "no such trigger" }` while authorized requests still return `200` with the owner view.

### Testing
- Ran `npm test -- tests/alert-triggers-route.test.mjs` and all tests passed (32 tests). 
- Ran `npm run lint` and `npm run format:check`, and both completed successfully. 
- Ran `git diff --check` to validate whitespace/checks and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5464708368832ca8048451aa9050e1)