### PR TITLE
fix(registry-sync): stop binding a JS array to ANY() in the surfaces prune

### DIFF
--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -29,6 +29,18 @@ vi.mock("postgres", () => ({
     };
     sql.json = (value) => value;
     sql.end = () => Promise.resolve();
+    // sql.unsafe(text, params) -- the surfaces-prune's (kind, url) VALUES
+    // join (a bound JS array broke under this Worker's real Hyperdrive
+    // fetch_types:false setting, see the prune's own comment). Recorded into
+    // the SAME sqlCalls list so existing assertions work unchanged
+    // regardless of which call form produced them.
+    sql.unsafe = (text, params = []) => {
+      sqlCalls.push({ text, values: params });
+      if (/DELETE FROM surfaces/.test(text)) {
+        return Promise.resolve(deleteResult.surfaces);
+      }
+      return Promise.resolve([]);
+    };
     // sql.begin(cb) reserves a connection for cb in real postgres.js; the
     // mock just invokes cb with this same sql function so every existing
     // tagged-template assertion (sqlCalls) still sees the identical call
@@ -336,10 +348,9 @@ test("REGRESSION: prune_surfaces with authority_scope 'community' passes a true 
 
   expect(res.status).toBe(200);
   const deleteCall = sqlCalls.find((c) => /DELETE FROM surfaces/.test(c.text));
-  expect(deleteCall.text).toMatch(/authority = /);
+  expect(deleteCall.text).toMatch(/authority = 'community'/);
   // The scope flag is bound as a real parameter (true), not spliced into the query text.
   expect(deleteCall.values).toContain(true);
-  expect(deleteCall.values).toContain("community");
 });
 
 test("does not scope by authority when authority_scope is absent (the scheduled full-resync path)", async () => {
@@ -369,6 +380,55 @@ test("does not scope by authority when authority_scope is absent (the scheduled 
   // The scope flag is still present in the query shape (always-composed OR clause),
   // but bound to false so it never actually filters by authority.
   expect(deleteCall.values).toContain(false);
+});
+
+test("REGRESSION: prunes with a non-empty current_surfaces list via scalar positional binds, not a bound array", async () => {
+  // Hyperdrive's fetch_types:false breaks postgres.js's ANY($1)/array
+  // serialization (confirmed live 2026-07-10, #4771) -- a bound JS array
+  // parameter here sends Postgres a malformed literal with no braces and
+  // every write that pruned against a non-empty current_surfaces list
+  // 502'd. This mock can't reproduce the real Postgres-side failure, but it
+  // pins the query shape that avoids it: every bound value must be a
+  // scalar (never an array), and the (kind, url) pairs must appear as
+  // explicit $N::text placeholders in the query text instead.
+  deleteResult.surfaces = [];
+
+  const res = await worker.fetch(
+    post(
+      {
+        prune_surfaces: [
+          {
+            subnet_netuid: 8,
+            current_surfaces: [
+              { kind: "docs", url: "https://example.com/docs" },
+              { kind: "website", url: "https://example.com" },
+            ],
+            source_commit: "def456",
+          },
+        ],
+      },
+      { secret: SECRET },
+    ),
+    baseEnv(),
+    {},
+  );
+
+  expect(res.status).toBe(200);
+  const deleteCall = sqlCalls.find((c) => /DELETE FROM surfaces/.test(c.text));
+  for (const value of deleteCall.values) {
+    expect(Array.isArray(value)).toBe(false);
+  }
+  expect(deleteCall.values).toEqual([
+    false,
+    8,
+    "docs",
+    "https://example.com/docs",
+    "website",
+    "https://example.com",
+  ]);
+  expect(deleteCall.text).toMatch(/\$3::text, \$4::text/);
+  expect(deleteCall.text).toMatch(/\$5::text, \$6::text/);
+  expect(deleteCall.text).not.toMatch(/ANY\(/);
 });
 
 test("skips a prune_surfaces entry missing subnet_netuid/current_surfaces/source_commit instead of failing the request", async () => {

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -172,9 +172,9 @@ export default {
             !prune.source_commit
           )
             continue;
-          const keepKeys = prune.current_surfaces
+          const keepPairs = prune.current_surfaces
             .filter((surface) => surface?.kind && surface?.url)
-            .map((surface) => `${surface.kind}\u001f${surface.url}`);
+            .map((surface) => [surface.kind, surface.url]);
           // `authority_scope: "community"` (set by the merge-triggered fast path,
           // scripts/sync-registry-to-postgres.mjs) bounds this prune to ONLY the
           // community-authority rows for the subnet -- the fast path's
@@ -185,22 +185,41 @@ export default {
           // merge that touches the file. The scheduled full resync
           // (scripts/backfill-registry-postgres.mjs) computes current_surfaces
           // from the complete baseline-augmented view and omits authority_scope,
-          // so it keeps pruning across every authority as before. Passed as a
-          // plain boolean parameter (not spliced SQL) so the condition is a
-          // no-op OR branch when unscoped, rather than composing raw fragments.
+          // so it keeps pruning across every authority as before.
           const scopeToCommunity = prune.authority_scope === "community";
-          const deleted = keepKeys.length
-            ? await sql`
-              DELETE FROM surfaces
-              WHERE subnet_netuid = ${prune.subnet_netuid}
-                AND (NOT ${scopeToCommunity} OR authority = ${"community"})
-                AND NOT (kind || ${"\u001f"} || url = ANY(${keepKeys}))
-              RETURNING id, subnet_netuid, overlay`
-            : await sql`
+          let deleted;
+          if (keepPairs.length) {
+            // Plain scalar positional binds via sql.unsafe, NOT a bound JS
+            // array -- Hyperdrive's fetch_types:false breaks postgres.js's
+            // ANY($1)/array serialization (confirmed live 2026-07-10, #4771's
+            // identical fix to data-api.mjs's neurons-sync prune; this query
+            // shipped the same broken ANY(${keepKeys}) pattern in #3892 three
+            // days earlier and was never ported). A bound array here sends a
+            // malformed literal with no braces, 502'ing every write that
+            // pruned against a non-empty current_surfaces list. Matches
+            // (kind, url) pairs directly via a VALUES join instead of a
+            // synthetic separator-joined key.
+            const valuesSql = keepPairs
+              .map((_, i) => `($${i * 2 + 3}::text, $${i * 2 + 4}::text)`)
+              .join(", ");
+            deleted = await sql.unsafe(
+              `DELETE FROM surfaces
+              WHERE subnet_netuid = $2::int
+                AND (NOT $1::boolean OR authority = 'community')
+                AND NOT EXISTS (
+                  SELECT 1 FROM (VALUES ${valuesSql}) AS keep(kind, url)
+                  WHERE keep.kind = surfaces.kind AND keep.url = surfaces.url
+                )
+              RETURNING id, subnet_netuid, overlay`,
+              [scopeToCommunity, prune.subnet_netuid, ...keepPairs.flat()],
+            );
+          } else {
+            deleted = await sql`
               DELETE FROM surfaces
               WHERE subnet_netuid = ${prune.subnet_netuid}
                 AND (NOT ${scopeToCommunity} OR authority = ${"community"})
               RETURNING id, subnet_netuid, overlay`;
+          }
           for (const row of deleted) {
             await sql`
             INSERT INTO surface_history (surface_id, subnet_netuid, action, overlay, source_commit)

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -13,16 +13,16 @@
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
   // Deliberately NOT smart-placed, unlike wrangler.data.jsonc's read-only
-  // sibling: #4767 added `placement: {mode: "smart"}` here, and every
-  // registry-sync write has 502'd ("write failed") since that reached
-  // production -- both the merge-triggered fast path and the 6h full resync
-  // went dark for ~3 days as a result. wrangler.data.jsonc's smart-placed
-  // Worker keeps serving reads fine over a comparable Tunnel+Hyperdrive path
-  // on a different box, so this is specific to this Worker/origin pairing,
-  // not a blanket incompatibility. Reverted to restore the last known-good
-  // state; re-investigate smart placement (e.g. an explicit `placement.host`
-  // pointed at the tunnel origin instead of `mode: "smart"`'s auto-detection)
-  // as deliberate follow-up, not a blind re-add.
+  // sibling. #4767 added `placement: {mode: "smart"}` here on a latency
+  // rationale and was reverted the same day every registry-sync write was
+  // observed 502ing -- but that was a false lead: the writes had actually
+  // been broken since #3892 (2026-07-06/07), three days before #4767 even
+  // merged, by an unrelated bug in the prune query's array parameter
+  // binding (see the fix below). #4767's revert landed first (before the
+  // real bug was found) and turned out to be a no-op fix for the live
+  // incident, but there's no live evidence either way on whether smart
+  // placement itself is safe here -- leave it off until it's deliberately
+  // re-evaluated on its own, not re-added blind.
   // This is a write path into a database, unlike wrangler.data.jsonc's
   // read-only sibling -- explicitly disabled (wrangler otherwise defaults
   // workers.dev to enabled) so the shared-secret check is the only way in,


### PR DESCRIPTION
## Summary

- Fixes the real cause of every registry-sync write failure: the surfaces-prune query bound a JS array directly to `ANY($1)`, which Hyperdrive's `fetch_types: false` setting breaks. #5050 (merged) reverted Smart Placement as the presumed cause; it wasn't — this was.

## What Changed

- `workers/registry-sync-api.mjs`: the prune query's `keepKeys`/`ANY(${keepKeys})` (a bound JS array) is replaced with `keepPairs` matched via a `VALUES (...)` join and scalar positional binds through `sql.unsafe`, mirroring the identical fix already shipped in `data-api.mjs`'s neurons-sync prune (#4771).
- `tests/registry-sync-api.test.mjs`: adds a `sql.unsafe` mock (matching `data-api.test.mjs`'s pattern), fixes two assertions that expected `"community"` as a bound value (it's now a query-text literal), and adds a regression test pinning the new query shape (all-scalar binds, explicit `$N::text` placeholders, no `ANY(`).
- `wrangler.registry.jsonc`: corrects the comment #5050 left, which misattributed the outage to smart placement.

## Root cause (confirmed live)

Ran `wrangler tail metagraphed-registry-sync-api` against production and triggered a manual full resync to capture the real error the client only ever sees as a generic `502 write failed`. The Worker's own `console.error` logged a `PostgresError: malformed array literal`, showing a comma-joined string with no surrounding braces — the surfaces-prune query's `ANY(${keepKeys})` was binding a bare JS array of `kind`+separator+`url` strings, and postgres.js fell back to naive `.join(",")` stringification instead of a real Postgres array literal, because this Worker's Hyperdrive connection sets `fetch_types: false` (Cloudflare's own recommended Hyperdrive setting), which disables the type-OID introspection postgres.js needs to bind arrays correctly.

This exact landmine was already found and fixed once in this codebase — `workers/data-api.mjs`'s neurons-sync prune hit it and was patched in #4771 (2026-07-10), with extensive comments documenting it ("confirmed live 2026-07-10 that Hyperdrive's recommended `fetch_types: false`... breaks postgres.js's automatic ARRAY-literal serialization"). `registry-sync-api.mjs`'s own prune query shipped the same broken `ANY(${keepKeys})` pattern independently in #3892 (2026-07-06/07) and was never updated to match.

Timeline this establishes:

- **2026-07-06/07 ~02:34 UTC** (#3892 merges): the prune query starts failing for any subnet with a non-empty `current_surfaces` list — which is most subnets. The scheduled full resync (`resync-registry-postgres.yml`, always a large batch) has failed on **every single run since**, ~6 days straight.
- **2026-07-10 09:31 UTC**: last real fast-path write succeeds (small/no-prune batch). Fast-path incremental syncs then start failing consistently too.
- **2026-07-10 10:08 UTC**: #4767 (smart placement) merges — coincidentally timed, unrelated.
- **2026-07-13 (today)**: #5050 reverts smart placement based on the correlation above. Doesn't fix it — confirmed via a fresh `wrangler tail` capture after #5050's deploy, plus the `niome.json` fast-path sync still failing post-merge.

## Validation

- [x] `npm run lint`
- [x] `npx prettier --check wrangler.registry.jsonc workers/registry-sync-api.mjs tests/registry-sync-api.test.mjs`
- [x] `npx vitest run tests/registry-sync-api.test.mjs tests/registry-sync-client.test.mjs` — 34/34 pass
- [x] `git diff --check`
- [ ] Live end-to-end verification (trigger `resync-registry-postgres.yml` and confirm no `write failed`) — pending this PR's merge + Worker redeploy, since the bug only reproduces against real Hyperdrive/Postgres (the mocked test suite can't catch this class of serialization bug by construction).

## Registry Safety

- [x] No linked issue — direct production-infra fix by the repo owner, following up on #5050 which turned out to target the wrong cause; see the live-tail evidence above in place of an issue.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none touched).
- [x] R2-only/high-churn detail artifacts are not committed.
- [ ] Public API/OpenAPI/schema changes are intentional and documented. — N/A, no schema/API change.

## Follow-up (not in this PR)

Once merged and deployed, re-trigger `resync-registry-postgres.yml` to confirm the fix and backfill the ~6 days of missed writes (full resync) / ~3 days (fast path).
