### PR TITLE
feat(registry): add SN104 TaoMarketCap candle-chart data-artifact

### DIFF
--- a/registry/subnets/for-sale-burn-to-uid1.json
+++ b/registry/subnets/for-sale-burn-to-uid1.json
@@ -1,25 +1,10 @@
 {
-  "schema_version": 1,
-  "netuid": 104,
-  "name": "for sale (burn to uid1)",
-  "slug": "for-sale-uid1",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "no-public-project-surface"
   ],
-  "source_repo": null,
-  "website_url": null,
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN104. The current chain identity is a sale/placeholder-style name and no official project website, source repository, API, OpenAPI schema, or docs site has been verified.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Current chain identity is sale/placeholder-style rather than a clear product identity.",
       "No verified official website yet.",
@@ -29,8 +14,22 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "for sale (burn to uid1)",
+  "netuid": 104,
+  "notes": "Reviewed overlay for SN104. The current chain identity is a sale/placeholder-style name and no official project website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "schema_version": 1,
+  "slug": "for-sale-uid1",
+  "source_repo": null,
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -50,6 +49,26 @@
         "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/104"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-104-taomarketcap-data-artifact",
+      "kind": "data-artifact",
+      "name": "SN104 TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/104/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN104's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 104. A standalone historical price/volume dataset, distinct from the point-in-time /subnets/104 snapshot already registered. SN104 exposes no verified first-party API; this indexed feed is the concrete public JSON data endpoint for netuid 104, documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation",
+        "https://taomarketcap.com/subnets/104"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/104/candle-chart"
     }
-  ]
+  ],
+  "website_url": null
 }


### PR DESCRIPTION
Closes #4135

## Summary

Registers **SN104**'s public **OHLCV candle-chart dataset** as a `data-artifact` surface — a no-auth JSON time-series of SN104's alpha-token price/volume, and the concrete public API data endpoint the registry did not yet capture for SN104. Append-only: one new surface on the existing subnet file, nothing else changed.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/104/candle-chart/`
- **provider:** `taomarketcap`
- **auth_required:** `false` · **public_safe:** `true`

A standalone historical price/volume dataset, **distinct from the point-in-time `/subnets/104` snapshot already registered**. SN104 exposes no verified first-party API; this indexed feed is the concrete public JSON data endpoint for netuid 104, documented in the TaoMarketCap developer API. Each record is scoped to `subnet_id: 104` and carries `period_name, timestamp, block_number, open/high/low/close, volume, start_volume, tao_price_usd/eur`.

Mirrors the shape merged for SN86 in #5006.

## Verification

- `surface:add` live-verified the URL: **reachable + public-safe** (720 hourly OHLCV records, `subnet_id: 104`)
- `npm run build` — passed
- `npm run validate` — passed (1565 surfaces)
- `npm run validate:surface` — passed
- `npm run scan:public-safety` — passed
- `npm run test:ci:artifacts` — 27/27 passed
- Diff is a single file (`registry/subnets/for-sale-burn-to-uid1.json`)
