### PR TITLE
fix(data-api): normalize HEAD probes to GET for Postgres DATA_API tier

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -8868,6 +8868,37 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
+  test("handleAccountPositionHistory: HEAD uses the Postgres GET representation", async () => {
+    const { env, captures } = dbWith({});
+    let forwardedMethod;
+    env.METAGRAPH_NEURONS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async (request) => {
+        forwardedMethod = request.method;
+        return Response.json({
+          schema_version: 1,
+          marker: "pg",
+          points: [{ captured_at: "2026-07-13T00:00:00.000Z" }],
+        });
+      },
+    };
+    const res = await handleAccountPositionHistory(
+      new Request(
+        `https://api.metagraph.sh/api/v1/accounts/${SS58}/subnets/${NETUID}/history`,
+        { method: "HEAD" },
+      ),
+      env,
+      SS58,
+      NETUID,
+      url(`/api/v1/accounts/${SS58}/subnets/${NETUID}/history`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "");
+    assert.equal(forwardedMethod, "GET");
+    assert.notEqual(res.headers.get("etag"), null);
+    assert.deepEqual(captures.sql, []);
+  });
+
   // No D1 fallback here (unlike the ~40 branches #4909 tracks separately):
   // D1's own account_position_daily rollup has been permanently broken since
   // #4908 dropped D1's `neurons` table, so a Postgres failure degrades to the

--- a/workers/postgres-tier.mjs
+++ b/workers/postgres-tier.mjs
@@ -2,13 +2,15 @@
 // deploy/README.md "Serving cutover" runbook: "if FLAG[tier] == postgres: try
 // Postgres; on error -> D1"). Each tier has its own env flag so a rollback is a
 // single-flag flip, never a code change or redeploy of the fallback path.
-// `request` is forwarded UNCHANGED to the DATA_API service binding -- the caller
-// has already run the SAME validation the D1 path runs (or, for an MCP tool
-// caller, has already validated via its own inputSchema), so this trusts
-// well-formed params and treats ANY failure (binding absent, network error,
-// non-2xx, unparseable/malformed body) as "fall back to D1", never as a
-// client-facing error. Postgres never gets to independently fail a request the
-// D1 path would have served.
+// `request` is forwarded to the DATA_API service binding after normalizing HEAD
+// probes to GET: DATA_API is GET-only, while the public API computes HEAD
+// metadata from the GET representation and strips the body later. The caller has
+// already run the SAME validation the D1 path runs (or, for an MCP tool caller,
+// has already validated via its own inputSchema), so this trusts well-formed
+// params and treats ANY failure (binding absent, network error, non-2xx,
+// unparseable/malformed body) as "fall back to D1", never as a client-facing
+// error. Postgres never gets to independently fail a request the D1 path would
+// have served.
 //
 // Extracted from workers/request-handlers/entities.mjs (#4668/#4686) into this
 // neutral module so src/mcp-server.mjs (#4694) can share the identical
@@ -26,9 +28,13 @@
 // before a wider live-testing pass happened to notice).
 export async function tryPostgresTier(env, request, flagName) {
   if (env[flagName] !== "postgres" || !env.DATA_API) return null;
+  const upstreamRequest =
+    request.method === "HEAD"
+      ? new Request(request, { method: "GET" })
+      : request;
   let upstream;
   try {
-    upstream = await env.DATA_API.fetch(request);
+    upstream = await env.DATA_API.fetch(upstreamRequest);
   } catch (err) {
     console.error(
       `tryPostgresTier(${flagName}): DATA_API fetch failed, falling back to D1:`,


### PR DESCRIPTION
### Motivation

- Public read routes compute HEAD metadata from the GET representation, but the Postgres helper forwarded the caller's `HEAD` unchanged to the DATA_API service which rejects non-GET, causing HEAD to fall back to an empty schema-stable response instead of matching GET metadata. This broke conditional/monitoring semantics for the account position history route.

### Description

- Normalize `HEAD` probes to `GET` inside the shared Postgres helper so DATA_API-backed reads are requested as `GET` and the public layer can still strip the body for HEAD responses (`workers/postgres-tier.mjs`).
- Add a regression unit test that verifies a `HEAD` to `handleAccountPositionHistory` is forwarded upstream as `GET`, returns a bodyless 200 with an `ETag`, and does not query the retired D1 store (`tests/request-handlers-entities.test.mjs`).
- Minor comment updates documenting the HEAD normalization and the intended contract (no behavior changes to envelope stripping or D1 fallback semantics beyond the HEAD normalization).

### Testing

- Ran `npx prettier --check workers/postgres-tier.mjs tests/request-handlers-entities.test.mjs` after formatting fixes and it passed.
- Ran the focused unit suite with `npm test -- tests/request-handlers-entities.test.mjs` and all tests passed (`505 tests` passed).
- Verified there are no `git diff --check` style issues and Prettier code-style warnings were addressed prior to the final test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54667fa2b4832cab36cf2737171583)