### PR TITLE
fix(data-api): preserve typed scalar call arg wrappers

### DIFF
--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -89,6 +89,16 @@ function isByteBlobCollectionType(type) {
   return BYTE_BLOB_COLLECTION_RE.test(type);
 }
 
+// True when a descriptor's own non-collection type string names an opaque
+// byte/hash scalar. This intentionally does NOT treat arbitrary scalar
+// newtypes (Rate, u32, Compact<u64>, etc.) as byte blobs: single-field
+// scalar wrappers such as [0] must survive until normalizePostgresValue can
+// unwrap them to 0.
+const BYTE_BLOB_SCALAR_RE = /^(?:H\d+|Hash|Bytes|\[u8;\s*\d+\])$/;
+function isByteBlobScalarType(type) {
+  return BYTE_BLOB_SCALAR_RE.test(type);
+}
+
 // Decodes a byte-blob-typed descriptor's value, which may either be a bare
 // (possibly newtype-wrapped) byte array (BoundedVec<u8,_>) or an Option-
 // wrapped one (Option<BoundedVec<u8,_>> -- confirmed live: announce_next_key's
@@ -426,22 +436,12 @@ function walk(value, keyHint, nestedCall, topCall) {
         };
       }
     }
-    // U256 excluded from the generic byte-blob-unwrap attempt below: its
-    // 4-limb little-endian u64 array ([[limb0..limb3]]) is shape-identical
-    // to a genuine 1-4-byte blob whenever every limb happens to be small
-    // (0-255) -- the same #4693/#4915 collection-vs-blob ambiguity class,
-    // just for U256 instead of a BTreeSet. Confirmed live 2026-07-12:
-    // DynamicFee.note_min_gas_price_target's `target` (real value 1, raw
-    // limbs [1,0,0,0]) was silently misinterpreted as 4 raw bytes and
-    // hex-encoded to "0x01000000" (16,777,216) -- actively WRONG, not just
-    // undecoded -- before decodeEthereumEvmCallArgs (indexer-rs-ethereum-
-    // decode.mjs, which runs AFTER this module and knows the real 4-limb
-    // encoding) ever got a chance to correctly decode it via decodeU256Limbs.
-    // Every OTHER U256 field (Ethereum.transact's nonce/value/gas_limit/...)
-    // already survived this unscathed only because those arrive nested
-    // inside the `transaction` descriptor's untyped struct body, never
-    // themselves a separate top-level typed descriptor the way `target` is.
-    if (!isCollectionType(value.type) && value.type !== "U256") {
+    // Only descriptor types that are semantically byte/hash scalars take this
+    // typed byte-blob path. Other scalar/newtype wrappers (Rate/u32/U256/etc.)
+    // can be shape-identical to a one-byte blob while carrying numeric data,
+    // so they must fall through for normalizePostgresValue or the later
+    // type-specific decoders to unwrap them without corrupting [0] -> "0x00".
+    if (isByteBlobScalarType(value.type)) {
       const bytes = unwrapByteArray(value.value);
       if (bytes && bytes.length > 0) {
         const ctx = nestedCall ?? topCall;

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -380,6 +380,17 @@ describe("decodePostgresCallArgs", () => {
       assert.deepEqual(out[0].value, [104]);
     });
 
+    test("typed scalar newtype wrappers survive for normalizePostgresValue instead of being hex-encoded", () => {
+      const out = decode([
+        { name: "fee_rate", type: "Rate", value: [0] },
+        { name: "small_count", type: "u32", value: [5] },
+        { name: "large_count", type: "u32", value: [256] },
+      ]);
+      assert.equal(out[0].value, 0);
+      assert.equal(out[1].value, 5);
+      assert.equal(out[2].value, 256);
+    });
+
     test("SubtensorModule.commit_weights' top-level commit_hash, an H256 (real, block 8602444/9)", () => {
       // A non-account, non-collection typed byte-blob field: `type` rules
       // out both AccountId32/MultiAddress (isAccountId32Type) and a


### PR DESCRIPTION
### Motivation
- A recent change decoded any typed `{name,type,value}` whose `value` looked like a flat integer byte array as a byte blob before scalar normalization ran, causing scalar newtype wrappers like `[0]` to be emitted as `"0x00"` instead of numeric `0`.
- The intent is to keep decoding byte/blob fields (hashes, H256, Vec<u8>) while preserving numeric/newtype wrappers for `normalizePostgresValue` to unwrap correctly.

### Description
- Add a new explicit byte/hash scalar predicate `isByteBlobScalarType` (regex matching `H*`, `Hash`, `Bytes`, and `[u8; N]`) and use it to gate the typed-descriptor byte-blob path so only true byte/hash scalar types are decoded early.
- Keep the existing `isByteBlobCollectionType` branch for `Vec<u8>`-style collections unchanged so byte-vector collections still decode to hex/text as before.
- Change the previously-broad typed-descriptor condition to only take the byte-decoding branch when `isByteBlobScalarType(type)` (instead of `!isCollectionType && type !== 'U256'`), preventing numeric/newtype wrappers (e.g. `Rate`, `u32`) from being preemptively hex-encoded.
- Add a regression test that asserts typed scalar wrappers (`Rate: [0]`, `u32: [5]`, `u32: [256]`) normalize to `0`, `5`, and `256` respectively, and leave existing byte/hash decoding tests in place.

### Testing
- Ran the focused test file with `npm test -- tests/postgres-call-args.test.mjs` and observed all tests pass (`56 passed / 56`).
- Ran formatting and lint checks with `npm run format:check -- src/postgres-call-args.mjs tests/postgres-call-args.test.mjs` and `npm run lint`, both succeeded.
- Verified the new regression proves the previous `[0]` -> `"0x00"` regression is fixed and that genuine byte/hash fields (e.g. `H256`, `Bytes`, `Vec<u8>`) continue to decode to hex/text as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54667f1bf0832c90cd28cb5c0497a9)