### PR TITLE
fix(data-api): preserve scalar arrays in chain event args

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -28,7 +28,6 @@
 // hex, or a Result<(),E>::Ok(()) down to bare "Ok"). Everything else is
 // untouched.
 import { encodeAccountId32 } from "./ss58.mjs";
-import { normalizePostgresValue } from "./scale-normalize.mjs";
 
 const ACCOUNT_KEYS = new Set([
   "who",
@@ -166,23 +165,41 @@ const ENUM_PAYLOAD_FIELDS = new Map([
   ["Sudo.Sudid.sudo_result", "unit-or-passthrough"],
 ]);
 
-// Known genuine Vec<T>/collection fields that must stay arrays regardless of
-// element count, mirroring TEXTUAL_FIELDS/HEX_BLOB_FIELDS/ENUM_PAYLOAD_FIELDS'
-// narrow-allowlist discipline for the identical reason (chain_events.args
-// has no per-field type string to consult -- see #4724's COLLECTION_TYPE_RE
-// note in scale-normalize.mjs, which explicitly scopes ITS fix to the
-// `{name,type,value}` D1/extrinsics shape only and punts this untyped side
-// to a narrow allowlist here). normalizePostgresValue's generic newtype-
-// scalar rule runs BEFORE decode() ever sees this tree and has no ctx to
-// consult, so a genuine single-element Vec (e.g. Drand.NewPulse's `rounds`
-// on a pulse carrying exactly one round -- the common case at current block
-// heights, confirmed live 2026-07-12: block 8606141 event_index 148 served
-// `"rounds": 30355357` instead of `[30355357]`, while a multi-round pulse a
-// few million blocks earlier correctly stayed an array) has already been
-// collapsed to a bare scalar by the time this file's own decode() runs.
-// Restored below in decode()'s object branch, the one place ctx + the
-// collapsed value are both in scope together.
-const COLLECTION_FIELDS = new Set(["Drand.NewPulse.rounds"]);
+function normalizeChainEventValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeChainEventValue);
+  }
+  if (value && typeof value === "object") {
+    const keys = Object.keys(value);
+    if (
+      keys.length === 2 &&
+      keys.includes("name") &&
+      keys.includes("values") &&
+      typeof value.name === "string" &&
+      Array.isArray(value.values)
+    ) {
+      if (value.name === "Some" && value.values.length === 1) {
+        return normalizeChainEventValue(value.values[0]);
+      }
+      if (value.name === "None" && value.values.length === 0) {
+        return null;
+      }
+      if (value.values.length === 0) {
+        return value.name;
+      }
+      return {
+        name: value.name,
+        values: value.values.map(normalizeChainEventValue),
+      };
+    }
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = normalizeChainEventValue(val);
+    }
+    return out;
+  }
+  return value;
+}
 
 function decodeTextualField(bytes) {
   try {
@@ -279,39 +296,19 @@ function decode(value, keyHint, ctx) {
     }
     const out = {};
     for (const [k, val] of Object.entries(value)) {
-      // Restore a COLLECTION_FIELDS field's array-ness before recursing --
-      // see that allowlist's own comment for why normalizePostgresValue can
-      // collapse a genuine single-element Vec<T> to a bare scalar upstream.
-      // Never fires on an already-multi-element array (Array.isArray(val)
-      // is already true, so there is nothing to restore).
-      const key = ctx ? `${ctx.pallet ?? ""}.${ctx.method ?? ""}.${k}` : "";
-      const restored =
-        COLLECTION_FIELDS.has(key) && !Array.isArray(val) ? [val] : val;
-      out[k] = decode(restored, k, ctx);
+      out[k] = decode(val, k, ctx);
     }
     return out;
   }
   return value;
 }
 
-/** Unwraps Option<T>/C-like unit-variant enum tags via normalizePostgresValue
- * (#4690's generic pass) FIRST, then decodes account ids and H160 addresses
- * in the result. This order (opposite of src/extrinsics.mjs's
- * formatExtrinsic, which runs its nested-call reconstruction before
- * normalizePostgresValue for an unrelated reason specific to that pass --
- * see its own header) is required here, not merely conventional: running
- * the byte-array decode FIRST turns each element of a single-entry
- * Vec<H256>-shaped field (e.g. EVM.Log's `topics` with exactly one topic)
- * into a plain hex STRING, which normalizePostgresValue's newtype-scalar
- * rule would then wrongly collapse from `["0x...hash"]` down to a bare
- * `"0x...hash"` -- silently changing the field's JSON type from array to
- * scalar (confirmed live 2026-07-12: a real single-topic EVM.Log). Running
- * normalizePostgresValue first avoids this: at that point every byte-array
- * field's elements are still raw integers (0-255), never scalar-shaped
- * wrapped values, so its newtype-scalar rule can never fire on a pristine
- * byte array or its 1-element newtype wrapper -- confirmed safe against
- * every existing fixture in this file's own test suite, including the
- * single-element Vec<AccountId32> case.
+/** Unwraps only Option<T>/C-like unit-variant enum tags first, then decodes
+ * account ids and H160 addresses in the result. This intentionally does not
+ * use normalizePostgresValue's generic scalar-newtype rule: chain_events.args
+ * has no per-field type string, so a legitimate one-element collection like
+ * `[78]` or `{uids:[1]}` is indistinguishable from a scalar newtype wrapper by
+ * shape alone and must remain an array.
  *
  * Confirmed live 2026-07-11: System.ExtrinsicSuccess's
  * `dispatch_info.class`/`pays_fee` rendered as `{"name":"Normal","values":[]}`
@@ -340,5 +337,5 @@ function decode(value, keyHint, ctx) {
  * #4693/#4915 avoid elsewhere by consulting a typed descriptor's own `type`
  * first. */
 export function decodeChainEventArgs(args, ctx = null) {
-  return decode(normalizePostgresValue(args), undefined, ctx);
+  return decode(normalizeChainEventValue(args), undefined, ctx);
 }

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -207,13 +207,10 @@ describe("decodeChainEventArgs", () => {
   test("keeps a single-element Vec<H256> as an array, not collapsed to a bare string (real EVM.Log.log.topics, fixed 2026-07-12)", () => {
     // Found live 2026-07-12 while fixing the H160 gap above: a single-topic
     // EVM.Log collapsed `topics` from `["0x...hash"]` down to a bare
-    // `"0x...hash"` -- normalizePostgresValue's newtype-scalar rule fired
-    // because, by the time it ran, the account/hash decode had already
-    // turned the sole topic into a plain hex STRING (a scalar), making the
-    // outer single-element array indistinguishable from a genuine
-    // newtype-scalar wrap. Fixed by running normalizePostgresValue BEFORE
-    // the byte-array decode instead of after (see decodeChainEventArgs'
-    // own header for why this reordering is safe).
+    // `"0x...hash"` when generic scalar-newtype normalization ran after
+    // account/hash decoding. The chain-event normalizer now avoids that
+    // ambiguous scalar-array collapse entirely because args have no type
+    // descriptor to distinguish a wrapper from a one-element collection.
     const hash = new Array(32).fill(3);
     const args = { log: { topics: [[hash]] } };
     const decoded = decodeChainEventArgs(args, {
@@ -641,14 +638,11 @@ describe("decodeChainEventArgs", () => {
     );
   });
 
-  test("a single-element Vec field NOT in COLLECTION_FIELDS still collapses via normalizePostgresValue (baseline, unaffected)", () => {
-    const args = { fee_rate: [0] };
-    assert.deepEqual(
-      decodeChainEventArgs(args, {
-        pallet: "LimitOrders",
-        method: "SomeOtherEvent",
-      }),
-      { fee_rate: 0 },
-    );
+  test("preserves untyped single-element scalar arrays because chain_events args lack type context", () => {
+    assert.deepEqual(decodeChainEventArgs([78]), [78]);
+    assert.deepEqual(decodeChainEventArgs({ uids: [1] }), { uids: [1] });
+    assert.deepEqual(decodeChainEventArgs({ outer: [[1], [2, 3]] }), {
+      outer: [[1], [2, 3]],
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- A recent change applied `normalizePostgresValue` to `chain_events.args` and its generic single-element scalar-array collapse corrupted legitimate one-element collections because `chain_events.args` lacks per-field type context.

### Description
- Replace the global `normalizePostgresValue` use with a narrow `normalizeChainEventValue` that only unwraps `Option<T>` and C-like unit enum tags and does not collapse untyped single-element scalar arrays.
- Keep the existing account/H160/text/blob decoding and enum-payload allowlists intact while removing the restored-collection heuristic that attempted to reverse upstream collapses.
- Remove the `scale-normalize.mjs` import from the chain-event path and route `decodeChainEventArgs` through `normalizeChainEventValue` instead.
- Add/adjust regression tests asserting positional, named, and nested single-element scalar arrays remain arrays and update related test documentation.

### Testing
- Ran `npm test -- tests/chain-event-args.test.mjs` and the suite passed (`36 tests, 36 passed`).
- Ran linter via `npm run lint -- --max-warnings=0 src/chain-event-args.mjs tests/chain-event-args.test.mjs` which reported no warnings/failures.
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546680e634832c8773aea872377cbc)