### PR TITLE
fix(health): preserve postgres incident surface keys

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4992,11 +4992,18 @@ test("GET /api/v1/subnets/:netuid/health/percentiles on a cold store returns sur
 test("GET /api/v1/subnets/:netuid/health/incidents: SLA rollup + gap-island incidents", async () => {
   mockQueue.current = [
     [],
-    [{ surface_id: "sn-7-api", total: 100, ok_count: 92 }],
     [
       {
         surface_id: "sn-7-api",
-        surface_key: "sn-7-api",
+        surface_key: "stable-sn-7-api",
+        total: 100,
+        ok_count: 92,
+      },
+    ],
+    [
+      {
+        surface_id: "sn-7-api",
+        surface_key: "stable-sn-7-api",
         started_at: "1780000000000",
         ended_at: "1780000600000",
         failed_samples: 3,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -4295,6 +4295,7 @@ export default {
           );
           const slaRows = await sql`
           SELECT MAX(surface_id) AS surface_id,
+                 COALESCE(surface_key, surface_id) AS surface_key,
                  COUNT(*) AS total,
                  SUM(CASE WHEN ok THEN 1 ELSE 0 END) AS ok_count
           FROM surface_checks WHERE netuid = ${netuid} AND checked_at >= ${since}


### PR DESCRIPTION
### Motivation

- Fix a Postgres migration regression where SLA rollup rows for the subnet health incidents route did not expose the stable `surface_key`, causing reconstructed incidents to be looked up under the wrong key and thus under-report downtime and incident lists.

### Description

- Add `COALESCE(surface_key, surface_id) AS surface_key` to the SLA aggregate query used by the Postgres-backed `/api/v1/subnets/:netuid/health/incidents` handler in `workers/data-api.mjs` so SLA rows and incident rows share the same lookup key. 
- Update the incident-route unit test in `tests/data-api.test.mjs` to exercise the case where `surface_key` differs from `surface_id` (a stable `surface_key` is provided), preserving coverage for the regression scenario. 
- Ensure formatting remains consistent via the project's Prettier configuration.

### Testing

- Ran the targeted Vitest tests: `npx vitest run tests/data-api.test.mjs -t "health/incidents" --reporter=verbose`, which passed the incident-route test (test file run succeeded). 
- Ran formatting check with `npm run format:check -- --ignore-unknown workers/data-api.mjs tests/data-api.test.mjs`, which reported all matched files use Prettier style.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546680adc0832c8524ddd8b821a5e6)