### PR TITLE
fix(data-api): use repeatable-read snapshots for Data API read transactions

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -14,6 +14,7 @@ import {
 } from "../src/subnet-identity-history.mjs";
 
 const sqlCalls = vi.hoisted(() => []);
+const sqlBeginOptions = vi.hoisted(() => []);
 const mockRows = vi.hoisted(() => ({
   current: [
     {
@@ -202,6 +203,7 @@ vi.mock("postgres", () => ({
     // sees the identical call stream, and resolves to whatever cb returns.
     sql.begin = (optionsOrCb, maybeCb) => {
       const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+      sqlBeginOptions.push(typeof optionsOrCb === "string" ? optionsOrCb : "");
       return cb(sql);
     };
     return sql;
@@ -235,6 +237,7 @@ const queryText = () => sqlCalls.map((call) => call.text).join("\n");
 
 beforeEach(() => {
   sqlCalls.length = 0;
+  sqlBeginOptions.length = 0;
   mockQueue.current = [];
   neuronsSyncFailure.error = null;
   neuronsSyncPruneRows.current = [];
@@ -4497,6 +4500,9 @@ test("GET /api/v1/chain/transfers: totals + distinct counts + senders + receiver
   ];
   const res = await req("/api/v1/chain/transfers?window=7d&limit=5");
   expect(res.status).toBe(200);
+  expect(sqlBeginOptions).toContain(
+    "isolation level repeatable read read only",
+  );
   const body = await res.json();
   expect(body.total_volume_tao).toBe(100);
   expect(body.unique_senders).toBe(2);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -7,7 +7,7 @@
 // tiers (chain_events / deep history); this exposes them to the public API.
 //
 // Mostly read-only, parameterized (postgres.js tagged templates), one request one
-// sql.begin("read only", ...) transaction (#4686 connection-affinity). The ONE
+// sql.begin(DATA_API_READ_TRANSACTION, ...) transaction (#4686 connection-affinity). The ONE
 // exception is POST /api/v1/internal/neurons-sync (#4771): the write path into
 // this SAME Postgres instance's neurons/neuron_daily tables. It does NOT get its
 // own dedicated Worker the way registry-sync-api.mjs does -- that split is
@@ -322,6 +322,7 @@ import {
   buildChainSigners,
 } from "../src/chain-analytics.mjs";
 import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.mjs";
+const DATA_API_READ_TRANSACTION = "isolation level repeatable read read only";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
@@ -2548,8 +2549,10 @@ export default {
       // queries, so a bare SET (no transaction) has no guarantee it applies
       // to the query that follows it (Hyperdrive's connection-lifecycle
       // docs; #4686's root cause). "read only" matches this Worker's own
-      // READ-ONLY invariant (top of file) at the database level too.
-      return await sql.begin("read only", async (sql) => {
+      // READ-ONLY invariant (top of file) at the database level too, and
+      // repeatable read keeps multi-statement analytics responses on one
+      // stable snapshot while preserving each route's bounded timeouts.
+      return await sql.begin(DATA_API_READ_TRANSACTION, async (sql) => {
         await sql`SET statement_timeout = '3000ms'`;
 
         // GET /api/v1/blocks (D1 serving-cutover, #4656 followup): the recent-block


### PR DESCRIPTION
### Motivation

- Prevent inconsistent multi-statement analytics responses by ensuring multi-query routes (notably `/api/v1/chain/transfers`) observe a single stable PostgreSQL snapshot instead of per-statement READ COMMITTED snapshots. 

### Description

- Change the Data API's per-request transaction from plain `read only` to a named constant `DATA_API_READ_TRANSACTION = "isolation level repeatable read read only"` and use it in `sql.begin(...)` so read routes run under REPEATABLE READ while remaining read-only and bounded by the existing `SET statement_timeout` logic. 
- Keep existing per-route `SET LOCAL statement_timeout` behavior so slow analytics still have a widened per-route budget without altering the global default. 
- Update the Postgres mock in `tests/data-api.test.mjs` to record `sql.begin(...)` options and assert that `/api/v1/chain/transfers` uses the repeatable-read read-only transaction mode.

### Testing

- Ran syntax checks with `node --check workers/data-api.mjs` and `node --check tests/data-api.test.mjs`, which succeeded. 
- Verified formatting with `npx prettier --check workers/data-api.mjs tests/data-api.test.mjs`, which passed. 
- Executed the relevant unit test file with `npm test -- tests/data-api.test.mjs`, and all tests in that file passed (`377` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54667f406c832c92944db9fb64b4a4)