### PR TITLE
fix(data-api): preserve chain yield postgres captured_at

### DIFF
--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -70,6 +70,13 @@ function captureStamp(value) {
     }
   }
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) {
+      const ms = Number(value);
+      const date = new Date(ms);
+      if (Number.isFinite(ms) && Number.isFinite(date.getTime())) {
+        return { ms, value: date.toISOString() };
+      }
+    }
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
   }

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -135,6 +135,26 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, new Date(newest).toISOString());
   });
 
+  test("ignores an all-digit captured_at string outside Date's representable range", () => {
+    // A digit string so large it represents a date beyond JS Date's
+    // +/-8.64e15ms range -- Number(value) stays finite, but
+    // new Date(ms).getTime() is NaN, so this must fall through rather
+    // than return an invalid timestamp.
+    const out = buildChainYield([
+      {
+        stake_tao: 1,
+        emission_tao: 0,
+        captured_at: "100000000000000000000",
+      },
+      {
+        stake_tao: 1,
+        emission_tao: 0,
+        captured_at: "1750000000000",
+      },
+    ]);
+    assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
+  });
+
   test("ignores out-of-range numeric captured_at values", () => {
     const out = buildChainYield([
       {

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -126,6 +126,15 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("accepts epoch-millisecond string captured_at values from Postgres", () => {
+    const newest = 1_750_000_000_000;
+    const out = buildChainYield([
+      { stake_tao: 1, emission_tao: 0, captured_at: "1700000000000" },
+      { stake_tao: 1, emission_tao: 0, captured_at: String(newest) },
+    ]);
+    assert.equal(out.captured_at, new Date(newest).toISOString());
+  });
+
   test("ignores out-of-range numeric captured_at values", () => {
     const out = buildChainYield([
       {


### PR DESCRIPTION
### Motivation
- Postgres returns BIGINT timestamp columns as all-digit strings, and the existing `captureStamp()` only accepted numbers or Date.parse()-parsable strings, causing Postgres-backed `/api/v1/chain/yield` responses to lose `captured_at` (and thus `meta.generated_at`).

### Description
- Accept all-digit epoch-millisecond strings in `captureStamp()` by coercing them to `Number`, validating the resulting `Date`, and returning the ISO timestamp when valid (`src/chain-yield.mjs`).
- Add a regression test that supplies Postgres-style epoch-millisecond strings and asserts the newest stamp is preserved (`tests/chain-yield.test.mjs`).
- This change preserves existing behavior for numeric and ISO-string stamps while ensuring Postgres BIGINT snapshots propagate freshness metadata.

### Testing
- Ran the unit tests for the affected module with `npx vitest run tests/chain-yield.test.mjs`, and the test file passed (1 file, 21 tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546680a100832c88e0136578bdfe1e)