### PR TITLE
fix(data-api): ignore null account event netuids

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -970,6 +970,22 @@ test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from one bounde
   expect(queryText()).toContain("OR coldkey =");
 });
 
+test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", async () => {
+  mockQueue.current = [
+    [], // SET
+    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: null }], // scanRows
+    [], // regRows
+    [], // activityRows
+    [], // moduleRows
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.event_count).toBe(2);
+  expect(body.subnet_count).toBe(1);
+  expect(body.recent_events.map((event) => event.netuid)).toEqual([4, null]);
+});
+
 test("GET /api/v1/accounts/:ss58 with no matching rows returns a schema-stable empty summary", async () => {
   mockRows.current = [];
   const res = await req(`/api/v1/accounts/${SS58}`);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2947,7 +2947,8 @@ export default {
           let lo = null;
           const kindCounts = new Map();
           for (const row of capped) {
-            netuids.add(row.netuid);
+            const netuid = numberOrNull(row.netuid);
+            if (netuid != null) netuids.add(netuid);
             const bn = numberOrNull(row.block_number);
             if (bn != null && (fb == null || bn < fb)) fb = bn;
             if (bn != null && (lb == null || bn > lb)) lb = bn;


### PR DESCRIPTION
### Motivation
- Fix a data-correctness regression in the Postgres account summary where null `netuid` values were being counted as a distinct subnet, inflating the public `subnet_count` compared to the legacy D1 `COUNT(DISTINCT netuid)` semantics.

### Description
- In `workers/data-api.mjs` coerce `row.netuid` with `numberOrNull()` and only add non-null numeric netuids to the `Set` used for the `agg.sc` (`subnet_count`) calculation so it matches SQL `COUNT(DISTINCT netuid)` behavior.
- Add a regression test in `tests/data-api.test.mjs` that verifies a bounded event window containing one real `netuid` and one `null` returns `subnet_count: 1` while still returning the null-valued event in `recent_events`.
- Files changed: `workers/data-api.mjs`, `tests/data-api.test.mjs`.

### Testing
- Ran the focused Vitest suite with `npm test -- tests/data-api.test.mjs` and the tests in that file passed (378 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54667f4c84832c90fa9793426e02ac)