### PR TITLE
fix(data-api): fall back on postgres block misses

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -6193,6 +6193,33 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.equal(body.data.block.block_number, BLOCK_NUM);
   });
 
+  test("handleBlock: flag=postgres falls back to D1 on block:null miss", async () => {
+    const { env, captures } = dbWith({ blockDetail: blockRow() });
+    env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+    env.DATA_API = dataApi(
+      Response.json({
+        schema_version: 1,
+        ref: String(BLOCK_NUM),
+        block: null,
+        prev_block_number: null,
+        next_block_number: null,
+      }),
+    );
+    const body = await json(
+      await handleBlock(
+        req(`/api/v1/blocks/${BLOCK_NUM}`),
+        env,
+        String(BLOCK_NUM),
+      ),
+    );
+    assert.equal(body.data.block.block_number, BLOCK_NUM);
+    assert.ok(
+      captures.sql.some((sql) =>
+        /FROM blocks WHERE block_number = \?/.test(sql),
+      ),
+    );
+  });
+
   test("handleExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
     const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -3655,7 +3655,11 @@ export async function handleBlocksSummary(request, env, url) {
 // neuron detail route — NEVER 404/throw).
 export async function handleBlock(request, env, ref) {
   const pg = await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE");
-  let data = pg;
+  // A Postgres block:null is a semantic miss, not authoritative data: during
+  // staged backfills Postgres can have known coverage gaps that D1 still has.
+  // Fall through to D1 so a successful empty DATA_API response cannot mask
+  // retained block rows in the fallback store.
+  let data = pg?.block === null ? null : pg;
   if (!data) {
     const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
     // A non-hash ref must be a strict decimal block_number; anything else (0x-short,


### PR DESCRIPTION
### Motivation

- Postgres was flipped on for block detail serving but a successful Postgres response with `block:null` suppressed the D1 fallback, causing a correctness regression for known Postgres coverage gaps (e.g. 8471001-8479999). 
- The intent is to treat a Postgres `block:null` as a semantic miss so the existing D1 fallback can still return retained rows when Postgres is incomplete.

### Description

- Change `handleBlock` in `workers/request-handlers/entities.mjs` to treat a Postgres response whose `block` is `null` as a miss by setting `data = pg?.block === null ? null : pg;` so the D1 branch executes when appropriate.
- Add a regression test in `tests/request-handlers-entities.test.mjs` (`handleBlock: flag=postgres falls back to D1 on block:null miss`) which verifies that a successful DATA_API `block:null` response does not suppress the D1 query and that D1 is queried and returns the block row.
- Run code formatting on the modified files to satisfy the repo style rules.

### Testing

- Ran `npm install` successfully to prepare the environment.
- Ran the focused test file with `npm test -- tests/request-handlers-entities.test.mjs` and observed all tests in that file pass (`505 tests` passed).
- Ran formatting checks (`npx prettier --write` and `npm run format:check`) and confirmed files now match Prettier style.
- The added regression test verifies the specific previously-broken behavior and passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54667f902c832cbd340ac142ba2124)