### PR TITLE
feat(registry): add SN46 Zipcode dashboard surface

### DIFF
--- a/registry/subnets/zipcode.json
+++ b/registry/subnets/zipcode.json
@@ -90,6 +90,25 @@
         "https://zipcode.ai/api/dashboard/docs"
       ],
       "url": "https://zipcode.ai/api/dashboard/stats/emissions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-wandb",
+      "kind": "dashboard",
+      "name": "Zipcode (SN46) validator Weights & Biases dashboard",
+      "notes": "Public Weights & Biases project the SN46 Zipcode (RESI) validators log evaluation runs to (wandb.ai/resi-labs/subnet-46-evaluations-main). Project 'subnet-46-evaluations-main' and entity 'resi-labs' are the validator defaults in the official resi-labs-ai/RESI-models config (real_estate/validator/config.py), and docs/VALIDATOR.md documents that validators log to this team project. Publicly readable via the W&B API. Distinct host from the zipcode.ai API surfaces.",
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/resi-labs-ai/RESI-models/blob/main/real_estate/validator/config.py",
+        "https://github.com/resi-labs-ai/RESI-models/blob/main/docs/VALIDATOR.md"
+      ],
+      "url": "https://wandb.ai/resi-labs/subnet-46-evaluations-main"
     }
   ],
   "source_repo": "https://github.com/resi-labs-ai/RESI-models",


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN46 Zipcode (RESI)** — the public Weights & Biases project the subnet's validators log evaluation runs to, a surface kind the file did not yet have.

- **url:** https://wandb.ai/resi-labs/subnet-46-evaluations-main (public W&B project)
- **source_urls (proof):** https://github.com/resi-labs-ai/RESI-models/blob/main/real_estate/validator/config.py sets W&B project default `subnet-46-evaluations-main` and entity default `resi-labs`; https://github.com/resi-labs-ai/RESI-models/blob/main/docs/VALIDATOR.md documents validators logging to this team project
- **kind:** dashboard (new kind; existing surfaces are openapi / subnet-api / data-artifact)
- **host:** wandb.ai — distinct from the zipcode.ai surfaces

Verified: unauthenticated `api.wandb.ai/graphql` returns the project with `access USER_READ` and live runs (publicly readable).

## Validation
- `npm run validate:surface -- registry/subnets/zipcode.json` → passed (5 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean