### PR TITLE
feat(registry): add SN57 Sparket dashboard surface

### DIFF
--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -113,6 +113,25 @@
         "submitted_by": "nickmopen"
       },
       "notes": "Public no-auth GET returning the Sparket (SN57) miner leaderboard as JSON — per-miner rank, uid, component scores (skill/accuracy/edge/timeliness/uniqueness), incentive, and weight (25 ranked rows plus a meta block). Served on the subnet's own registered domain sparket.ai under /api/v1/; all fields are public scoreboard and ranking data. Fills the file's noted missing standalone-data-artifact gap."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-57-sparket-leaderboard-dashboard",
+      "kind": "dashboard",
+      "name": "Sparket miner leaderboard dashboard",
+      "notes": "Public no-auth web leaderboard for SN57 Sparket at dashboard.sparket.ai/leaderboard — the Sparket prediction-markets app's live miner leaderboard view, rendering the same rankings exposed by the subnet's public /api/v1/leaderboard endpoint. Served on the official sparket.ai domain (app subdomain); distinct host from the sparket.ai API surfaces.",
+      "provider": "sparket",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/sparket-ai/sparket-ai/blob/main/README.md",
+        "https://sparket.ai/"
+      ],
+      "url": "https://dashboard.sparket.ai/leaderboard"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN57 Sparket** — the subnet's public web leaderboard view, a surface kind the file did not yet have.

- **url:** https://dashboard.sparket.ai/leaderboard (public, no-auth leaderboard page in the Sparket app)
- **source_urls (proof):** https://github.com/sparket-ai/sparket-ai/blob/main/README.md (official SN57 repo) + https://sparket.ai/ — the app renders the same rankings served by the subnet's public `/api/v1/leaderboard` endpoint
- **kind:** dashboard (new kind; existing surfaces are website / source-repo / subnet-api / data-artifact)
- **host:** dashboard.sparket.ai — distinct from the sparket.ai surfaces

Verified live: https://dashboard.sparket.ai/leaderboard returns HTTP 200 with no login redirect.

## Validation
- `npm run validate:surface -- registry/subnets/sparket.json` → passed (5 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #4063