### PR TITLE
fix(ui): keep header actions from overflowing at mid-desktop widths

### DIFF
--- a/apps/ui/src/components/metagraphed/api-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/api-drawer.tsx
@@ -45,7 +45,7 @@ export function ApiDrawerTrigger() {
           type="button"
           onClick={open}
           aria-label="View API source for this page"
-          className="hidden md:inline-flex items-center justify-center rounded-md size-9 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+          className="hidden md:inline-flex lg:hidden xl:inline-flex items-center justify-center rounded-md size-9 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
         >
           <Code2 className="size-4" />
         </button>

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -34,6 +34,7 @@ import { ShortcutsPopover } from "./shortcuts-popover";
 import { CommandPalette } from "./command-palette";
 import { NavOmnibox } from "./nav-omnibox";
 import { ApiDrawer, ApiDrawerTrigger } from "./api-drawer";
+import { HeaderActionsMenu } from "./header-actions-menu";
 import { ApiSourceProvider } from "@/lib/metagraphed/api-source-context";
 import { IncidentStrip } from "./incident-strip";
 import { pushRecentVisit, visitFromPath } from "@/lib/metagraphed/recent-visits";
@@ -155,7 +156,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                     <Link
                       to="/settings"
                       aria-label="Developer settings"
-                      className="hidden md:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                      className="hidden md:inline-flex lg:hidden xl:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
                     >
                       <Webhook className="size-3.5" aria-hidden="true" />
                     </Link>
@@ -164,8 +165,14 @@ export function AppShell({ children }: { children: ReactNode }) {
                     Developer settings — webhook subscriptions
                   </TooltipContent>
                 </Tooltip>
-                <div className="hidden md:inline-flex">
+                <div className="hidden md:inline-flex lg:hidden xl:inline-flex">
                   <SettingsPopover />
+                </div>
+                {/* At lg the mega-menu appears and the trailing icons no longer
+                    fit; fold the secondary actions into one popover until xl
+                    restores the room (#3985). */}
+                <div className="hidden lg:inline-flex xl:hidden">
+                  <HeaderActionsMenu />
                 </div>
               </div>
             </div>

--- a/apps/ui/src/components/metagraphed/header-actions-menu.tsx
+++ b/apps/ui/src/components/metagraphed/header-actions-menu.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Code2, MoreHorizontal, Webhook } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@jsonbored/ui-kit";
+import { useApiSourceCtx } from "@/lib/metagraphed/api-source-context";
+import { SettingsPanel } from "./settings-popover";
+
+/**
+ * Consolidated header actions for the mid-desktop range (lg–xl). Once the
+ * mega-menu appears at `lg` there is no longer room to keep every trailing
+ * icon inline without one escaping the viewport (#3985), so the secondary
+ * actions — the API-source drawer, the developer-settings link, and the
+ * theme / density / health controls — fold into this single "more" popover.
+ * At `xl` and up the header has room again and the standalone icons return,
+ * so this is rendered only in the `lg:inline-flex xl:hidden` window.
+ */
+export function HeaderActionsMenu() {
+  const { sources, open } = useApiSourceCtx();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="More header actions"
+          title="More"
+          className="inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+        >
+          <MoreHorizontal className="size-3.5" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-3 space-y-3">
+        <div className="space-y-1">
+          {sources.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => {
+                setMenuOpen(false);
+                open();
+              }}
+              className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-2 text-left text-[12px] text-ink hover:border-ink/30 hover:text-ink-strong transition-colors min-h-9"
+            >
+              <Code2 className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
+              <span>View API source</span>
+            </button>
+          ) : null}
+          <Link
+            to="/settings"
+            onClick={() => setMenuOpen(false)}
+            className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-2 text-left text-[12px] text-ink hover:border-ink/30 hover:text-ink-strong transition-colors min-h-9"
+          >
+            <Webhook className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
+            <span>Developer settings</span>
+          </Link>
+        </div>
+        <SettingsPanel />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -21,10 +21,6 @@ const DENSITIES: Array<{ id: Density; label: string; Icon: typeof Rows3; hint: s
  * color preset. State persists to localStorage via the underlying hooks.
  */
 export function SettingsPopover() {
-  const { choice, setChoice } = useTheme();
-  const { density, setDensity } = useDensity();
-  const { paletteId, setPalette } = useHealthPalette();
-
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -37,61 +33,79 @@ export function SettingsPopover() {
           <Settings className="size-3.5" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-72 p-3 space-y-4">
-        <Section label="Theme">
-          <SegmentedRow>
-            {THEMES.map(({ id, label, Icon }) => (
-              <SegmentBtn
-                key={id}
-                active={choice === id}
-                onClick={() => setChoice(id)}
-                label={label}
-                title={`${label} theme`}
-              >
-                <Icon className="size-3.5" aria-hidden="true" />
-                <span>{label}</span>
-              </SegmentBtn>
-            ))}
-          </SegmentedRow>
-        </Section>
-
-        <Section label="Density" sub="Affects health KPIs and list tables.">
-          <SegmentedRow>
-            {DENSITIES.map(({ id, label, Icon, hint }) => (
-              <SegmentBtn
-                key={id}
-                active={density === id}
-                onClick={() => setDensity(id)}
-                label={hint}
-                title={hint}
-              >
-                <Icon className="size-3.5" aria-hidden="true" />
-                <span>{label}</span>
-              </SegmentBtn>
-            ))}
-          </SegmentedRow>
-        </Section>
-
-        <Section label="Health colors" sub="Preset for ok / warn / down / unknown dots.">
-          <ul className="space-y-1">
-            {HEALTH_PALETTES.map((p) => (
-              <PaletteRow
-                key={p.id}
-                id={p.id}
-                label={p.label}
-                description={p.description}
-                swatches={[p.swatch.ok, p.swatch.warn, p.swatch.down, p.swatch.unknown]}
-                active={paletteId === p.id}
-                onSelect={() => setPalette(p.id)}
-              />
-            ))}
-          </ul>
-          <p className="mt-2 text-[10px] text-ink-muted">
-            All presets verified for perceptible contrast in light and dark.
-          </p>
-        </Section>
+      <PopoverContent align="end" className="w-72 p-3">
+        <SettingsPanel />
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * The theme + density + health-color controls, without the popover chrome, so
+ * they can be reused wherever settings need to be surfaced — the header gear
+ * popover on wide viewports, and the consolidated overflow menu on the mid
+ * desktop range where the standalone gear is folded away to fit the header.
+ */
+export function SettingsPanel() {
+  const { choice, setChoice } = useTheme();
+  const { density, setDensity } = useDensity();
+  const { paletteId, setPalette } = useHealthPalette();
+
+  return (
+    <div className="space-y-4">
+      <Section label="Theme">
+        <SegmentedRow>
+          {THEMES.map(({ id, label, Icon }) => (
+            <SegmentBtn
+              key={id}
+              active={choice === id}
+              onClick={() => setChoice(id)}
+              label={label}
+              title={`${label} theme`}
+            >
+              <Icon className="size-3.5" aria-hidden="true" />
+              <span>{label}</span>
+            </SegmentBtn>
+          ))}
+        </SegmentedRow>
+      </Section>
+
+      <Section label="Density" sub="Affects health KPIs and list tables.">
+        <SegmentedRow>
+          {DENSITIES.map(({ id, label, Icon, hint }) => (
+            <SegmentBtn
+              key={id}
+              active={density === id}
+              onClick={() => setDensity(id)}
+              label={hint}
+              title={hint}
+            >
+              <Icon className="size-3.5" aria-hidden="true" />
+              <span>{label}</span>
+            </SegmentBtn>
+          ))}
+        </SegmentedRow>
+      </Section>
+
+      <Section label="Health colors" sub="Preset for ok / warn / down / unknown dots.">
+        <ul className="space-y-1">
+          {HEALTH_PALETTES.map((p) => (
+            <PaletteRow
+              key={p.id}
+              id={p.id}
+              label={p.label}
+              description={p.description}
+              swatches={[p.swatch.ok, p.swatch.warn, p.swatch.down, p.swatch.unknown]}
+              active={paletteId === p.id}
+              onSelect={() => setPalette(p.id)}
+            />
+          ))}
+        </ul>
+        <p className="mt-2 text-[10px] text-ink-muted">
+          All presets verified for perceptible contrast in light and dark.
+        </p>
+      </Section>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
On viewports where the mega-menu is shown (`lg`, 1024px) but the header hasn't yet reached the roomier `xl` (1280px) layout, the trailing header actions — the API-source `</>` drawer, the developer-settings link, and the settings gear — no longer fit alongside the mega-menu, and the right-most icon is pushed off the edge of the viewport (**#3985**). The `/settings` page makes it most visible because it registers an API source, so it carries the extra `</>` icon.

## Change
One focused change: fold the secondary header actions into a single **"more" popover** for the `lg`–`xl` window, keeping the network switcher inline.

- New `HeaderActionsMenu` (`⋯`) is shown only at `hidden lg:inline-flex xl:hidden`. It contains **View API source** (opens the existing drawer via `useApiSourceCtx`), **Developer settings** (link to `/settings`), and the full **theme / density / health** controls.
- Those controls are extracted from `SettingsPopover` into a reusable **`SettingsPanel`**, so the gear popover (at `xl`+) and the overflow menu share one implementation — no duplication, no behaviour change.
- The standalone `</>`, developer-settings link, and gear now gate to `hidden md:inline-flex lg:hidden xl:inline-flex` — inline below `lg` and again at `xl` (where there's room), folded into the menu only in the tight `lg`–`xl` band.

Net: nothing is removed — every action stays reachable at every width — and no icon escapes the viewport at any breakpoint. `tsc` / `prettier` clean; the repo's `responsive-overflow` e2e check reports zero escaping elements at 375 / 768 / 1024 / 1280 after the change (the `flex items-center gap-1` violation is gone).

Closes #3985

## Screenshots
`/settings` header, **before** = current (right-most icon clipped at the viewport edge in the 1024px band) → **after** = actions folded into the `⋯` menu, nothing clipped. Desktop (1280) / tablet (768) / mobile (375) are visually unchanged (they already fit) and shown for no-regression; the **1024px** rows are where the fix applies.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-1280-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-1280-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-1280-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-1280-dark.png) |
| **Mid-desktop 1024 · Light** (the fix) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-1024-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-1024-light.png) |
| **Mid-desktop 1024 · Dark** (the fix) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-1024-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-1024-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-768-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-768-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-768-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-768-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-375-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-375-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/before-375-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/after-375-dark.png) |

The `⋯` menu open at 1024 (nothing lost — API source, developer settings, theme, density, health all present):

| Light | Dark |
| --- | --- |
| ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/menu-open-1024-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3985-assets/3985/menu-open-1024-dark.png) |
