### PR TITLE
feat(registry): add SN107 Minos dashboard surface

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -57,6 +57,25 @@
         "https://taomarketcap.com/subnets/107"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/107"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-dashboard",
+      "kind": "dashboard",
+      "name": "Minos live subnet intelligence dashboard",
+      "notes": "Public no-auth web dashboard for SN107 Minos at theminos.ai/dashboard (page title \"Dashboard | <n>/<N> Miners Active | Minos\") showing live subnet intelligence: active miner count, network score, genomes analyzed, a top-miners leaderboard, network stats, and live activity. Linked as the \"ENTER_DASHBOARD\" action from the official theminos.ai homepage (the site named in the minos-protocol/minos_subnet README). Distinct host from the api.theminos.ai API surfaces.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
+        "https://theminos.ai/"
+      ],
+      "url": "https://theminos.ai/dashboard"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN107 Minos** — the subnet's public live-intelligence dashboard, a surface kind the file did not yet have.

- **url:** https://theminos.ai/dashboard (public, no-auth; title "Dashboard | <n>/<N> Miners Active | Minos")
- **source_urls (proof):** https://github.com/minos-protocol/minos_subnet/blob/main/README.md (official SN107 repo, references theminos.ai) + https://theminos.ai/ (homepage links this via its "ENTER_DASHBOARD" action)
- **kind:** dashboard (new kind; existing surfaces are subnet-api)
- **host:** theminos.ai — distinct from the api.theminos.ai API surfaces

Verified live: HTTP 200, ~32 KB rendered page showing active miner count, network score, genomes analyzed, a top-miners leaderboard, network stats, and live activity.

## Validation
- `npm run validate:surface -- registry/subnets/minos.json` → passed (3 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #463