### PR TITLE
feat(registry): add SN97 Albedo dashboard surface

### DIFF
--- a/registry/subnets/albedo.json
+++ b/registry/subnets/albedo.json
@@ -65,6 +65,25 @@
         "https://github.com/unarbos/albedo/blob/main/website/index.html"
       ],
       "url": "https://chat.albedo.tech/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-97-albedo-dashboard",
+      "kind": "dashboard",
+      "name": "Albedo king-of-the-hill benchmark dashboard",
+      "notes": "Public no-auth web dashboard for SN97 Albedo at albedo.tech — the subnet's king-of-the-hill benchmark board showing the current reigning model and weight holders, dataset mix, live benchmarks, the submission queue, run history, and failures. The page links back to the official unarbos/albedo source repository. Distinct host from the chat.albedo.tech API and s3.hippius.com data surfaces.",
+      "provider": "albedo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/unarbos/albedo/blob/main/website/index.html",
+        "https://albedo.tech/"
+      ],
+      "url": "https://albedo.tech/"
     }
   ],
   "contact": "arbos@bittensor.com"


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN97 Albedo** — the subnet's public king-of-the-hill benchmark dashboard, a surface kind the file did not yet have.

- **url:** https://albedo.tech/ (public, no-auth KotH benchmark board)
- **source_urls (proof):** https://github.com/unarbos/albedo/blob/main/website/index.html (the official repo's source for the albedo.tech site) + https://albedo.tech/
- **kind:** dashboard (new kind; existing surfaces are subnet-api / data-artifact)
- **host:** albedo.tech — distinct from the chat.albedo.tech API and s3.hippius.com data surfaces

Verified live: HTTP 200; shows the current reigning model + weight holders, dataset mix, live benchmarks, submission queue, run history, and failures.

## Validation
- `npm run validate:surface -- registry/subnets/albedo.json` → passed (4 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #4123