### PR TITLE
feat(registry): add SN77 Liquidity dashboard surface

### DIFF
--- a/registry/subnets/liquidity.json
+++ b/registry/subnets/liquidity.json
@@ -45,6 +45,25 @@
         "https://github.com/creativebuilds/sn77/blob/master/README.md"
       ],
       "url": "https://77.creativebuilds.io/weights"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-77-liquidity-dashboard",
+      "kind": "dashboard",
+      "name": "SN77 Liquidity dashboard",
+      "notes": "Public no-auth web dashboard for SN77 Liquidity at sn77.xyz (page title \"SN77 - Liquidity\", author \"SN77 Team\") showing the subnet's live total active liquidity, Uniswap V3 pools, unique voters, and LP positions. It visualizes the data served by the subnet's public creativebuilds/sn77 API (77.creativebuilds.io). This is the subnet's official website and product dashboard; distinct host from the 77.creativebuilds.io API surfaces.",
+      "provider": "liquidity",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/creativebuilds/sn77/blob/master/README.md",
+        "https://sn77.xyz/"
+      ],
+      "url": "https://sn77.xyz/"
     }
   ],
   "source_repo": "https://github.com/creativebuilds/sn77",


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN77 Liquidity** — the subnet's public liquidity dashboard, a surface kind the file did not yet have.

- **url:** https://sn77.xyz/ (public, no-auth; title "SN77 - Liquidity", author "SN77 Team")
- **source_urls (proof):** https://github.com/creativebuilds/sn77/blob/master/README.md (official SN77 repo) + https://sn77.xyz/ (the subnet's official website + product dashboard)
- **kind:** dashboard (new kind; existing surfaces are subnet-api / data-artifact)
- **host:** sn77.xyz — distinct from the 77.creativebuilds.io API surfaces

Verified live: HTTP 200; renders the subnet's live total active liquidity, Uniswap V3 pools, unique voters, and LP positions (the page's meta description carries the live on-chain liquidity total).

## Validation
- `npm run validate:surface -- registry/subnets/liquidity.json` → passed (3 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #4093