### PR TITLE
fix(ui): stop truncating the Yield tab's Validators/miners KPI tile

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -104,6 +104,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
           eyebrow="Validators / miners"
           value={`${y.validator_count ?? "—"} / ${y.miner_count ?? "—"}`}
           hint={`${y.neuron_count ?? neurons.length} UIDs`}
+          truncate={false}
         />
       </div>
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3326,7 +3326,8 @@ function StatTile({
   hint,
   chart,
   tone = "default",
-  className
+  className,
+  truncate = true
 }) {
   return /* @__PURE__ */ jsxRuntime.jsxs(
     "div",
@@ -3352,11 +3353,38 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate", children: eyebrow }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 flex min-w-0 items-baseline gap-1.5", children: [
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
-            hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 font-mono text-[10px] text-ink-muted truncate", children: hint }) : null
-          ] })
+          /* @__PURE__ */ jsxRuntime.jsx(
+            "div",
+            {
+              className: classNames(
+                "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+                truncate ? "truncate" : "leading-tight"
+              ),
+              children: eyebrow
+            }
+          ),
+          /* @__PURE__ */ jsxRuntime.jsxs(
+            "div",
+            {
+              className: classNames(
+                "mt-1 flex min-w-0 gap-1.5",
+                truncate ? "items-baseline" : "flex-wrap items-baseline"
+              ),
+              children: [
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
+                hint ? /* @__PURE__ */ jsxRuntime.jsx(
+                  "span",
+                  {
+                    className: classNames(
+                      "min-w-0 font-mono text-[10px] text-ink-muted",
+                      truncate ? "truncate" : ""
+                    ),
+                    children: hint
+                  }
+                ) : null
+              ]
+            }
+          )
         ] }),
         chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "shrink-0 opacity-80", children: chart }) : null
       ]

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3297,7 +3297,8 @@ function StatTile({
   hint,
   chart,
   tone = "default",
-  className
+  className,
+  truncate = true
 }) {
   return /* @__PURE__ */ jsxs(
     "div",
@@ -3323,11 +3324,38 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate", children: eyebrow }),
-          /* @__PURE__ */ jsxs("div", { className: "mt-1 flex min-w-0 items-baseline gap-1.5", children: [
-            /* @__PURE__ */ jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
-            hint ? /* @__PURE__ */ jsx("span", { className: "min-w-0 font-mono text-[10px] text-ink-muted truncate", children: hint }) : null
-          ] })
+          /* @__PURE__ */ jsx(
+            "div",
+            {
+              className: classNames(
+                "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+                truncate ? "truncate" : "leading-tight"
+              ),
+              children: eyebrow
+            }
+          ),
+          /* @__PURE__ */ jsxs(
+            "div",
+            {
+              className: classNames(
+                "mt-1 flex min-w-0 gap-1.5",
+                truncate ? "items-baseline" : "flex-wrap items-baseline"
+              ),
+              children: [
+                /* @__PURE__ */ jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
+                hint ? /* @__PURE__ */ jsx(
+                  "span",
+                  {
+                    className: classNames(
+                      "min-w-0 font-mono text-[10px] text-ink-muted",
+                      truncate ? "truncate" : ""
+                    ),
+                    children: hint
+                  }
+                ) : null
+              ]
+            }
+          )
         ] }),
         chart ? /* @__PURE__ */ jsx("div", { className: "shrink-0 opacity-80", children: chart }) : null
       ]

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -10,6 +10,13 @@ interface Props {
   chart?: ReactNode;
   tone?: "default" | "accent" | "ok" | "warn" | "down";
   className?: string;
+  /**
+   * When false, the eyebrow/hint wrap instead of truncating with an
+   * ellipsis — for a label too long to reliably fit one line at every
+   * breakpoint (e.g. "Validators / miners" in a 2-column mobile grid).
+   * Defaults to true, unchanged for every other consumer.
+   */
+  truncate?: boolean;
 }
 
 /**
@@ -24,6 +31,7 @@ export function StatTile({
   chart,
   tone = "default",
   className,
+  truncate = true,
 }: Props) {
   return (
     <div
@@ -55,15 +63,30 @@ export function StatTile({
         />
       ) : null}
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate">
+        <div
+          className={classNames(
+            "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
+            truncate ? "truncate" : "leading-tight",
+          )}
+        >
           {eyebrow}
         </div>
-        <div className="mt-1 flex min-w-0 items-baseline gap-1.5">
+        <div
+          className={classNames(
+            "mt-1 flex min-w-0 gap-1.5",
+            truncate ? "items-baseline" : "flex-wrap items-baseline",
+          )}
+        >
           <span className="min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
             {value}
           </span>
           {hint ? (
-            <span className="min-w-0 font-mono text-[10px] text-ink-muted truncate">
+            <span
+              className={classNames(
+                "min-w-0 font-mono text-[10px] text-ink-muted",
+                truncate ? "truncate" : "",
+              )}
+            >
               {hint}
             </span>
           ) : null}


### PR DESCRIPTION
## Summary

- `StatTile` (`packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx`) always truncated its eyebrow label and hint with an ellipsis on one line. On the Yield tab's KPI row, "Validators / miners" is longer than its two siblings ("Subnet yield", "Median yield") and was the only one that clipped mid-word at mobile/narrow-two-column widths.
- Added an opt-in `truncate?: boolean` prop (default `true`, so every other `StatTile` consumer is unaffected). When `false`, the eyebrow/hint wrap onto a second line instead of truncating.
- Set `truncate={false}` on the "Validators / miners" tile only (`apps/ui/src/components/metagraphed/yield-panel.tsx`). The two sibling tiles are untouched, per the issue's non-goals.
- Border/icon treatment was already shared across all three tiles via the same `StatTile` component — no separate fix needed there; it "looked broken" only because the truncated label made the tile read as cut off, not because the container itself differed.

## Note on repro width

The issue reports the bug at 375–390px. The KPI row (`PROFILE_KPI_GRID_CLASS`) is single-column below 400px, so at a literal 375px viewport all three tiles are already full-width and the label fits without truncating. The truncation reproduces in the row's 2-column range (~400–460px, e.g. 430px), and — more importantly — the same `StatTile` is reused at other call sites/viewports where 2-up or 3-up layouts do compress the label, so the fix is general rather than viewport-specific. Screenshots below include the mandated 375/768/1280 set plus a 430px close-up that concretely demonstrates the before/after.

## Screenshots

All captured via a local Playwright script against a synced dev server, both themes, before (`upstream/main` @ `34554690`) vs. after.

| Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| 375×812 (mobile) | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-mobile-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-mobile-light-after.png) |
| 375×812 (mobile) | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-mobile-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-mobile-dark-after.png) |
| 768×1024 (tablet) | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-tablet-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-tablet-light-after.png) |
| 768×1024 (tablet) | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-tablet-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-tablet-dark-after.png) |
| 1280×800 (desktop) | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-desktop-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-desktop-light-after.png) |
| 1280×800 (desktop) | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-desktop-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-desktop-dark-after.png) |
| 430×500 (close-up, demonstrates the bug) | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-430w-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-430w-light-after.png) |
| 430×500 (close-up, demonstrates the bug) | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-430w-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3936-430w-dark-after.png) |

## Validation

```
npm run lint
npm run format:check
npm run typecheck --workspace=apps/ui
npm run typecheck --workspace=packages/ui-kit
npm test --workspace=apps/ui
npm run test:e2e --workspace=apps/ui
npm run build --workspace=apps/ui
```

All green.

Closes #3936
