### PR TITLE
fix(realtime): rebuild WebSocket per-IP quota across Durable Object hibernation

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -157,16 +157,19 @@ socket upgrades per IP -- well under the global caps, tracked via
 `sseClientsByIp`/`wsClientsByIp` and released on the same
 connect/disconnect lifecycle hooks the underlying `sseClients`/
 `state.getWebSockets()` bookkeeping already uses, so the two can never
-drift apart. A WS-connection cap alone doesn't bound how many `chainEvents`
+drift apart. Because hibernatable WebSockets survive Durable Object
+reconstruction while in-memory Maps do not, the WS per-IP count is rebuilt
+from each surviving socket's serialized `{ ip }` attachment before every WS
+admission check. A WS-connection cap alone doesn't bound how many `chainEvents`
 subscriptions get multiplexed onto one already-open graphql-ws socket
 (graphql-ws itself imposes no per-socket subscription limit), so
 `CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP` (20) is a second,
 independent sub-quota on subscription count, with the connecting IP
 threaded from the WS upgrade through graphql-ws's own `opened()`/`context()`
 extension point (`ctx.extra.ip` -> `context.clientIp`) into
-`subscribeChainEvents`. All four per-IP Maps are in-memory only and reset
-to empty on every Durable Object reconstruction, the same hibernation-reset
-convention every other in-memory Map on this class already follows.
+`subscribeChainEvents`. The SSE and GraphQL-subscription per-IP Maps remain
+in-memory only; unlike accepted WebSockets, those live stream/subscription
+objects do not survive Durable Object reconstruction.
 
 Testability: this repo has no Durable Object-capable test harness (no
 `@cloudflare/vitest-pool-workers`/Miniflare). Every actual decision the hub

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -914,6 +914,44 @@ test("ChainFirehoseHub.releaseWsIpSlot: a no-op when this DO instance never reco
   assert.equal(hub.wsClientsByIp.has("203.0.113.9"), false);
 });
 
+test("ChainFirehoseHub.rebuildWsClientsByIp: reconstructs per-IP counts from surviving hibernatable WebSocket attachments", () => {
+  const hub = new ChainFirehoseHub(
+    stubState([
+      { deserializeAttachment: () => ({ ip: "203.0.113.9" }) },
+      { deserializeAttachment: () => ({ ip: "203.0.113.9", topics: null }) },
+      { deserializeAttachment: () => ({ ip: "198.51.100.4" }) },
+    ]),
+    {},
+  );
+
+  hub.wsClientsByIp.set("stale-before-rebuild", 99);
+  hub.rebuildWsClientsByIp();
+
+  assert.equal(hub.wsClientsByIp.get("203.0.113.9"), 2);
+  assert.equal(hub.wsClientsByIp.get("198.51.100.4"), 1);
+  assert.equal(hub.wsClientsByIp.has("stale-before-rebuild"), false);
+});
+
+test("ChainFirehoseHub.rebuildWsClientsByIp: ignores malformed attachments while preserving valid counts", () => {
+  const hub = new ChainFirehoseHub(
+    stubState([
+      { deserializeAttachment: () => ({ ip: "203.0.113.9" }) },
+      { deserializeAttachment: () => ({ topics: null }) },
+      { deserializeAttachment: () => null },
+      {
+        deserializeAttachment: () => {
+          throw new Error("bad attachment");
+        },
+      },
+    ]),
+    {},
+  );
+
+  assert.doesNotThrow(() => hub.rebuildWsClientsByIp());
+  assert.equal(hub.wsClientsByIp.size, 1);
+  assert.equal(hub.wsClientsByIp.get("203.0.113.9"), 1);
+});
+
 // --- subscribeChainEvents / unsubscribeChainEvents / broadcast (#4983) ----------
 
 test("ChainFirehoseHub.subscribeChainEvents: broadcast delivers matching payloads to the returned repeater", async () => {

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -347,13 +347,10 @@ export class ChainFirehoseHub {
     // (plain firehose and graphql-ws) share wsClientsByIp: they both accept a
     // WebSocketPair from the SAME handleSubscribe entry point and both count
     // against the same per-IP WS budget (see handleSubscribe's WS-upgrade
-    // branch). Like every other piece of this class's in-memory state, these
-    // reset to empty on a fresh DO reconstruction (hibernation wake, idle
-    // eviction, or a code deploy) -- see the class header comment and
-    // closeStaleGraphqlWsSocket's comment for this class's own established
-    // hibernation-survival convention; the bar here is the same one: keep
-    // increment/decrement paired within a single DO lifetime, not survive
-    // reconstruction.
+    // branch). WebSockets are hibernatable and survive fresh DO
+    // reconstruction, so wsClientsByIp must be rebuilt from
+    // state.getWebSockets() attachments before each WS admission check rather
+    // than trusting this constructor-fresh Map alone.
     this.sseClientsByIp = new Map();
     this.wsClientsByIp = new Map();
     // #4983: GraphQL subscriptions over WS, negotiated via
@@ -566,6 +563,7 @@ export class ChainFirehoseHub {
       // shape as the global-cap response above; no need for a distinct error
       // -- a client can't act on the difference and both mean "try later".
       const clientIp = resolveClientIp(request);
+      this.rebuildWsClientsByIp();
       if (
         (this.wsClientsByIp.get(clientIp) || 0) >=
         CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
@@ -724,6 +722,28 @@ export class ChainFirehoseHub {
     }
   }
 
+  // Rebuilds the per-IP WS quota from the Durable Object runtime's durable
+  // hibernatable WebSocket list. Accepted sockets persist their IP in
+  // serializeAttachment() in both WS branches below; after a hibernation
+  // wake, idle eviction, or deploy, this in-memory Map starts empty while
+  // state.getWebSockets() still includes those sockets. Recounting from the
+  // durable socket attachments before admission keeps the per-IP quota
+  // aligned with the same socket population used by the global cap.
+  rebuildWsClientsByIp() {
+    const counts = new Map();
+    for (const ws of this.state.getWebSockets()) {
+      let ip;
+      try {
+        ip = ws.deserializeAttachment()?.ip;
+      } catch {
+        continue;
+      }
+      if (!ip) continue;
+      counts.set(ip, (counts.get(ip) || 0) + 1);
+    }
+    this.wsClientsByIp = counts;
+  }
+
   // #5004 item 1: releases a closed/errored WS connection's per-IP slot,
   // reversing the increment made at accept time in handleSubscribe's
   // WS-upgrade branch (both the plain-firehose and graphql-ws sub-branches
@@ -733,10 +753,10 @@ export class ChainFirehoseHub {
   // disconnect path -- clean close or the runtime reporting an error --
   // releases the slot; an unreleased slot would let a client ratchet down
   // its own remaining budget forever across repeated reconnects. A socket
-  // accepted by a PRIOR (now-replaced) DO instance has no entry in THIS
-  // instance's in-memory wsClientsByIp -- fresh per this class's own
-  // hibernation-survival convention (see closeStaleGraphqlWsSocket's
-  // comment) -- so this is a safe no-op for it, not an underflow.
+  // accepted by a PRIOR (now-replaced) DO instance is counted after
+  // rebuildWsClientsByIp() scans its durable attachment; if the close/error
+  // event arrives before any admission-triggered rebuild, missing counts
+  // still remain a safe no-op rather than an underflow.
   releaseWsIpSlot(ws) {
     let ip;
     try {


### PR DESCRIPTION
### Motivation
- The per-IP WebSocket quota used an in-memory `wsClientsByIp` Map that was reset on Durable Object reconstruction while hibernatable WebSockets survived, allowing an attacker to bypass the per-IP cap by waiting for a DO restart and opening more sockets.

### Description
- Add `rebuildWsClientsByIp()` which scans `state.getWebSockets()` and tallies `ip` values from each socket's serialized attachment to reconstruct per-IP counts from durable socket attachments.
- Call `rebuildWsClientsByIp()` in the WS admission path (`handleSubscribe`) before checking `wsClientsByIp` so the per-IP check reflects surviving sockets.
- Add two unit tests: `rebuildWsClientsByIp: reconstructs per-IP counts from surviving hibernatable WebSocket attachments` and `rebuildWsClientsByIp: ignores malformed attachments while preserving valid counts` in `tests/chain-firehose-hub.test.mjs` to cover the regression.
- Update `docs/realtime-firehose.md` and inline comments to document the hibernation-safe behavior and to clarify the lifecycle reasoning for per-IP counters and release logic.

### Testing
- Ran `git diff --check` and `npm run format:check` against modified files and they succeeded (`prettier` check passed). 
- Added unit tests in `tests/chain-firehose-hub.test.mjs`; running `npm test -- tests/chain-firehose-hub.test.mjs` in the local environment failed due to a local runtime/dependency mismatch (`Vitest` imports `disableDefaultColors` from `tinyrainbow`, which is not exported in the installed package under the local Node runtime), so full test execution was blocked locally but the new tests are included and expected to run in CI.
- `npm run lint` could not be completed locally due to an ESLint/runtime mismatch (`scopeManager.addGlobals is not a function`), so lint was not verified locally but file formatting and added tests are ready for CI validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a548c5c004c832cb9c5f9cae91e0dcd)