### PR TITLE
fix(ui): label subnet freshness by tier — daily rollup vs live chain read

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -10,6 +10,7 @@ import {
   MiniStack,
   SparkLegend,
   Sparkline,
+  RealtimeFreshness,
   type SparklinePoint,
 } from "@jsonbored/ui-kit";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
@@ -129,56 +130,61 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
   if (!e) return <Notice>No on-chain economic data for this subnet.</Notice>;
 
   return (
-    // Flex-wrap (not grid) so a trailing partial row's tiles stretch to fill
-    // the row instead of leaving empty column slots — grid tracks are shared
-    // across every row, but flex lines size independently (same pattern as
-    // the stat spine in subnet-masthead.tsx / operational-panel.tsx).
-    <div className="flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[200px]">
-      <StatTile
-        eyebrow="Emission share"
-        tone="accent"
-        value={e.emission_share != null ? `${(e.emission_share * 100).toFixed(3)}%` : "—"}
-      />
-      <StatTile
-        eyebrow="Alpha price"
-        value={e.alpha_price_tao != null ? `${e.alpha_price_tao.toFixed(4)} τ` : "—"}
-        chart={
-          <Sparkline
-            values={priceValues}
-            points={pricePoints}
-            width={72}
-            height={28}
-            formatValue={(v) => `${v.toFixed(4)} τ`}
-            ariaLabel="Alpha price trend"
-          />
-        }
-      />
-      <StatTile
-        eyebrow="Validators"
-        value={
-          e.validator_count != null
-            ? `${e.validator_count}${e.max_validators ? ` / ${e.max_validators}` : ""}`
-            : "—"
-        }
-      />
-      <StatTile
-        eyebrow="Miners"
-        value={formatNumber(e.miner_count)}
-        hint={e.max_uids ? `${e.max_uids} max UIDs` : undefined}
-      />
-      <StatTile eyebrow="Total stake" value={formatTao(e.total_stake_tao)} />
-      <StatTile eyebrow="Volume" value={formatTao(e.subnet_volume_tao)} />
-      <StatTile eyebrow="Max stake" value={formatTao(e.max_stake_tao)} />
-      <StatTile eyebrow="Market cap" value={formatTao(e.alpha_market_cap_tao)} hint="proxy" />
-      <StatTile eyebrow="FDV" value={formatTao(e.alpha_fdv_tao)} hint="proxy" />
-      <StatTile
-        eyebrow="Registration"
-        tone={e.registration_allowed === false ? "down" : "default"}
-        value={e.registration_cost_tao != null ? `${e.registration_cost_tao} τ` : "—"}
-        hint={e.registration_allowed === false ? "closed" : "open"}
-      />
-      <StakeMovesTile netuid={netuid} />
-      <StakeTransfersTile netuid={netuid} />
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <RealtimeFreshness at={res?.meta?.generated_at} />
+      </div>
+      {/* Flex-wrap (not grid) so a trailing partial row's tiles stretch to fill
+          the row instead of leaving empty column slots — grid tracks are shared
+          across every row, but flex lines size independently (same pattern as
+          the stat spine in subnet-masthead.tsx / operational-panel.tsx). */}
+      <div className="flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[200px]">
+        <StatTile
+          eyebrow="Emission share"
+          tone="accent"
+          value={e.emission_share != null ? `${(e.emission_share * 100).toFixed(3)}%` : "—"}
+        />
+        <StatTile
+          eyebrow="Alpha price"
+          value={e.alpha_price_tao != null ? `${e.alpha_price_tao.toFixed(4)} τ` : "—"}
+          chart={
+            <Sparkline
+              values={priceValues}
+              points={pricePoints}
+              width={72}
+              height={28}
+              formatValue={(v) => `${v.toFixed(4)} τ`}
+              ariaLabel="Alpha price trend"
+            />
+          }
+        />
+        <StatTile
+          eyebrow="Validators"
+          value={
+            e.validator_count != null
+              ? `${e.validator_count}${e.max_validators ? ` / ${e.max_validators}` : ""}`
+              : "—"
+          }
+        />
+        <StatTile
+          eyebrow="Miners"
+          value={formatNumber(e.miner_count)}
+          hint={e.max_uids ? `${e.max_uids} max UIDs` : undefined}
+        />
+        <StatTile eyebrow="Total stake" value={formatTao(e.total_stake_tao)} />
+        <StatTile eyebrow="Volume" value={formatTao(e.subnet_volume_tao)} />
+        <StatTile eyebrow="Max stake" value={formatTao(e.max_stake_tao)} />
+        <StatTile eyebrow="Market cap" value={formatTao(e.alpha_market_cap_tao)} hint="proxy" />
+        <StatTile eyebrow="FDV" value={formatTao(e.alpha_fdv_tao)} hint="proxy" />
+        <StatTile
+          eyebrow="Registration"
+          tone={e.registration_allowed === false ? "down" : "default"}
+          value={e.registration_cost_tao != null ? `${e.registration_cost_tao} τ` : "—"}
+          hint={e.registration_allowed === false ? "closed" : "open"}
+        />
+        <StakeMovesTile netuid={netuid} />
+        <StakeTransfersTile netuid={netuid} />
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Boxes, Layers, ShieldCheck } from "lucide-react";
 import { subnetMetagraphQuery } from "@/lib/metagraphed/queries";
-import { TableState, DailyRollupFreshness, StatTile, BarMini } from "@jsonbored/ui-kit";
+import { TableState, RealtimeFreshness, StatTile, BarMini } from "@jsonbored/ui-kit";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
@@ -60,7 +60,7 @@ export function MetagraphTableLoader({
     );
   }
 
-  const freshness = <DailyRollupFreshness at={meta?.generated_at} />;
+  const freshness = <RealtimeFreshness at={meta?.generated_at} />;
 
   return (
     <div className="space-y-4">

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Coins, Flame, Award, Server, X } from "lucide-react";
 import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
-import { TableState, DailyRollupFreshness, StatTile } from "@jsonbored/ui-kit";
+import { TableState, RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -64,7 +64,7 @@ export function NeuronDetailCard({
           ) : null}
         </div>
         <div className="ml-auto flex items-center gap-2">
-          <DailyRollupFreshness at={meta?.generated_at} />
+          <RealtimeFreshness at={meta?.generated_at} />
           {onClose ? (
             <button
               type="button"

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -20,7 +20,7 @@ import {
   safeExternalUrl,
   CurationChip,
   HealthPill,
-  FreshnessIndicator,
+  DailyRollupFreshness,
   StatWithSpark,
   MiniStack,
   MiniRadial,
@@ -300,7 +300,7 @@ export function SubnetMasthead({
         <span aria-hidden className="opacity-50">
           ·
         </span>
-        <FreshnessIndicator at={generatedAt} />
+        <DailyRollupFreshness at={generatedAt} />
         {stale ? (
           <span className="inline-flex items-center gap-1 rounded border border-health-warn/40 bg-health-warn/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-health-warn">
             stale

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { subnetValidatorsQuery } from "@/lib/metagraphed/queries";
 import {
   TableState,
-  DailyRollupFreshness,
+  RealtimeFreshness,
   BarMini,
   TreemapMini,
   type TreemapMiniDatum,
@@ -63,7 +63,7 @@ export function ValidatorsTableLoader({
     );
   }
 
-  const freshness = <DailyRollupFreshness at={meta?.generated_at} />;
+  const freshness = <RealtimeFreshness at={meta?.generated_at} />;
 
   return (
     <div className="space-y-4">

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -33,6 +33,7 @@ import {
   CopyableCode,
   MethodologyCallout,
   StatTile,
+  RealtimeFreshness,
 } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
@@ -825,59 +826,67 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
     );
   }
   return (
-    <div className="overflow-x-auto rounded border border-border bg-card">
-      <table className="w-full min-w-[720px] text-left text-sm">
-        <thead className="bg-surface/40">
-          <tr>
-            <th className="px-4 py-2.5 whitespace-nowrap">Block</th>
-            <th className="px-4 py-2.5 whitespace-nowrap">Kind</th>
-            <th className="px-4 py-2.5 whitespace-nowrap">Hotkey</th>
-            <th className="px-4 py-2.5 text-right whitespace-nowrap">Amount</th>
-            <th className="px-4 py-2.5 text-right whitespace-nowrap">Observed</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {events.map((ev, i) => (
-            <tr key={`${ev.block_number}-${ev.event_index}-${i}`} className="hover:bg-surface/40">
-              <td className="px-4 py-2.5 font-mono text-[12px] whitespace-nowrap">
-                {ev.block_number != null ? (
-                  <Link
-                    to="/blocks/$ref"
-                    params={{ ref: String(ev.block_number) }}
-                    className="text-ink hover:underline"
-                  >
-                    #{formatNumber(ev.block_number)}
-                  </Link>
-                ) : (
-                  "—"
-                )}
-              </td>
-              <td className="px-4 py-2.5 whitespace-nowrap">
-                <EventKindCell kind={ev.event_kind} />
-              </td>
-              <td className="px-4 py-2.5 font-mono text-[11px] whitespace-nowrap">
-                {ev.hotkey ? (
-                  <Link
-                    to="/accounts/$ss58"
-                    params={{ ss58: ev.hotkey }}
-                    className="text-ink-muted hover:text-ink hover:underline"
-                  >
-                    {shortHash(ev.hotkey) ?? ev.hotkey}
-                  </Link>
-                ) : (
-                  "—"
-                )}
-              </td>
-              <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink whitespace-nowrap">
-                {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
-              </td>
-              <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted whitespace-nowrap">
-                <TimeAgo at={ev.observed_at} />
-              </td>
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          {events.length} event{events.length === 1 ? "" : "s"}
+        </span>
+        <RealtimeFreshness at={data.meta?.generated_at} />
+      </div>
+      <div className="overflow-x-auto rounded border border-border bg-card">
+        <table className="w-full min-w-[720px] text-left text-sm">
+          <thead className="bg-surface/40">
+            <tr>
+              <th className="px-4 py-2.5 whitespace-nowrap">Block</th>
+              <th className="px-4 py-2.5 whitespace-nowrap">Kind</th>
+              <th className="px-4 py-2.5 whitespace-nowrap">Hotkey</th>
+              <th className="px-4 py-2.5 text-right whitespace-nowrap">Amount</th>
+              <th className="px-4 py-2.5 text-right whitespace-nowrap">Observed</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {events.map((ev, i) => (
+              <tr key={`${ev.block_number}-${ev.event_index}-${i}`} className="hover:bg-surface/40">
+                <td className="px-4 py-2.5 font-mono text-[12px] whitespace-nowrap">
+                  {ev.block_number != null ? (
+                    <Link
+                      to="/blocks/$ref"
+                      params={{ ref: String(ev.block_number) }}
+                      className="text-ink hover:underline"
+                    >
+                      #{formatNumber(ev.block_number)}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 whitespace-nowrap">
+                  <EventKindCell kind={ev.event_kind} />
+                </td>
+                <td className="px-4 py-2.5 font-mono text-[11px] whitespace-nowrap">
+                  {ev.hotkey ? (
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: ev.hotkey }}
+                      className="text-ink-muted hover:text-ink hover:underline"
+                    >
+                      {shortHash(ev.hotkey) ?? ev.hotkey}
+                    </Link>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink whitespace-nowrap">
+                  {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
+                </td>
+                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted whitespace-nowrap">
+                  <TimeAgo at={ev.observed_at} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1844,14 +1844,27 @@ function FreshnessIndicator({
     }
   );
 }
+function tierFreshnessLabel(tier, at) {
+  if (at == null) return "No freshness data";
+  const prefix = tier === "realtime" ? "Live chain read" : "Daily rollup snapshot";
+  return `${prefix} \u2014 updated ${formatRelative(at)}`;
+}
 function DailyRollupFreshness({
   at,
   className
 }) {
-  const label = at == null ? "No freshness data" : `Daily rollup snapshot \u2014 updated ${formatRelative(at)}`;
   return /* @__PURE__ */ jsxRuntime.jsxs("span", { className: classNames("inline-flex items-center gap-1", className), children: [
     /* @__PURE__ */ jsxRuntime.jsx(FreshnessIndicator, { at, dotOnly: true }),
-    /* @__PURE__ */ jsxRuntime.jsx(InfoTooltip, { label })
+    /* @__PURE__ */ jsxRuntime.jsx(InfoTooltip, { label: tierFreshnessLabel("daily", at) })
+  ] });
+}
+function RealtimeFreshness({
+  at,
+  className
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsxs("span", { className: classNames("inline-flex items-center gap-1", className), children: [
+    /* @__PURE__ */ jsxRuntime.jsx(FreshnessIndicator, { at, dotOnly: true }),
+    /* @__PURE__ */ jsxRuntime.jsx(InfoTooltip, { label: tierFreshnessLabel("realtime", at) })
   ] });
 }
 function HoverPreview({
@@ -3764,6 +3777,7 @@ exports.PopoverContent = PopoverContent;
 exports.PopoverTrigger = PopoverTrigger;
 exports.PrimaryLinksRail = PrimaryLinksRail;
 exports.ProfileHero = ProfileHero;
+exports.RealtimeFreshness = RealtimeFreshness;
 exports.ReviewChip = ReviewChip;
 exports.SCOPES = SCOPES;
 exports.ScrollReveal = ScrollReveal;
@@ -3805,5 +3819,6 @@ exports.freshnessDotClass = freshnessDotClass;
 exports.freshnessTierLabel = freshnessTierLabel;
 exports.prefetchBrandIcon = prefetchBrandIcon;
 exports.safeExternalUrl = safeExternalUrl;
+exports.tierFreshnessLabel = tierFreshnessLabel;
 exports.timeAgoAbsoluteTitle = timeAgoAbsoluteTitle;
 exports.visibleTools = visibleTools;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1815,14 +1815,27 @@ function FreshnessIndicator({
     }
   );
 }
+function tierFreshnessLabel(tier, at) {
+  if (at == null) return "No freshness data";
+  const prefix = tier === "realtime" ? "Live chain read" : "Daily rollup snapshot";
+  return `${prefix} \u2014 updated ${formatRelative(at)}`;
+}
 function DailyRollupFreshness({
   at,
   className
 }) {
-  const label = at == null ? "No freshness data" : `Daily rollup snapshot \u2014 updated ${formatRelative(at)}`;
   return /* @__PURE__ */ jsxs("span", { className: classNames("inline-flex items-center gap-1", className), children: [
     /* @__PURE__ */ jsx(FreshnessIndicator, { at, dotOnly: true }),
-    /* @__PURE__ */ jsx(InfoTooltip, { label })
+    /* @__PURE__ */ jsx(InfoTooltip, { label: tierFreshnessLabel("daily", at) })
+  ] });
+}
+function RealtimeFreshness({
+  at,
+  className
+}) {
+  return /* @__PURE__ */ jsxs("span", { className: classNames("inline-flex items-center gap-1", className), children: [
+    /* @__PURE__ */ jsx(FreshnessIndicator, { at, dotOnly: true }),
+    /* @__PURE__ */ jsx(InfoTooltip, { label: tierFreshnessLabel("realtime", at) })
   ] });
 }
 function HoverPreview({
@@ -3666,4 +3679,4 @@ function TreemapMini({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProfileHero, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, timeAgoAbsoluteTitle, visibleTools };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProfileHero, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };

--- a/packages/ui-kit/src/components/metagraphed/freshness.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/freshness.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tierFreshnessLabel } from "./freshness";
+
+describe("tierFreshnessLabel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T18:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'No freshness data' when at is missing, for either tier", () => {
+    expect(tierFreshnessLabel("realtime", null)).toBe("No freshness data");
+    expect(tierFreshnessLabel("daily", undefined)).toBe("No freshness data");
+  });
+
+  it("frames realtime data as a live chain read", () => {
+    const at = new Date("2026-07-09T17:00:00.000Z").toISOString();
+    expect(tierFreshnessLabel("realtime", at)).toMatch(
+      /^Live chain read — updated 1h ago$/,
+    );
+  });
+
+  it("frames daily data as a daily rollup snapshot", () => {
+    const at = new Date("2026-07-09T17:00:00.000Z").toISOString();
+    expect(tierFreshnessLabel("daily", at)).toMatch(
+      /^Daily rollup snapshot — updated 1h ago$/,
+    );
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/freshness.tsx
+++ b/packages/ui-kit/src/components/metagraphed/freshness.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { classNames, formatRelative, isStaleFreshness } from "@/lib/format";
 import { InfoTooltip } from "@/components/metagraphed/info-tooltip";
+import type { FreshnessTier } from "./freshness-badge";
 
 interface Props {
   at?: string | null;
@@ -58,6 +59,17 @@ export function FreshnessIndicator({
   );
 }
 
+/** Tooltip copy shared by the compact tier-freshness indicators below. */
+export function tierFreshnessLabel(
+  tier: FreshnessTier,
+  at?: string | null,
+): string {
+  if (at == null) return "No freshness data";
+  const prefix =
+    tier === "realtime" ? "Live chain read" : "Daily rollup snapshot";
+  return `${prefix} — updated ${formatRelative(at)}`;
+}
+
 /**
  * Minimal daily-rollup freshness signal — a staleness dot plus an info icon
  * whose tooltip carries the tier + relative time, instead of always-visible
@@ -71,14 +83,33 @@ export function DailyRollupFreshness({
   at?: string | null;
   className?: string;
 }) {
-  const label =
-    at == null
-      ? "No freshness data"
-      : `Daily rollup snapshot — updated ${formatRelative(at)}`;
   return (
     <span className={classNames("inline-flex items-center gap-1", className)}>
       <FreshnessIndicator at={at} dotOnly />
-      <InfoTooltip label={label} />
+      <InfoTooltip label={tierFreshnessLabel("daily", at)} />
+    </span>
+  );
+}
+
+/**
+ * Realtime/chain-derived twin of {@link DailyRollupFreshness} — same compact
+ * dot + info-tooltip shape, but "Live chain read" framing for data sourced
+ * from a live/near-realtime chain read (metagraph snapshot, validators,
+ * on-chain activity, live economics) rather than the daily registry-build
+ * snapshot. Use this, not DailyRollupFreshness, for anything backed by a
+ * query that isn't the daily subnetProfileQuery/registry-artifact family.
+ */
+export function RealtimeFreshness({
+  at,
+  className,
+}: {
+  at?: string | null;
+  className?: string;
+}) {
+  return (
+    <span className={classNames("inline-flex items-center gap-1", className)}>
+      <FreshnessIndicator at={at} dotOnly />
+      <InfoTooltip label={tierFreshnessLabel("realtime", at)} />
     </span>
   );
 }

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -107,6 +107,8 @@ export {
 export {
   FreshnessIndicator,
   DailyRollupFreshness,
+  RealtimeFreshness,
+  tierFreshnessLabel,
 } from "@/components/metagraphed/freshness";
 export { HoverPreview } from "@/components/metagraphed/hover-preview";
 export { InfoTooltip } from "@/components/metagraphed/info-tooltip";


### PR DESCRIPTION
## Summary

The subnet detail page's masthead showed exactly one freshness dot (`meta?.generated_at` from the daily profile snapshot) regardless of which tab was open, even though the Activity, Metagraph, Validators, and Economics tabs each pull from their own chain-derived queries that are materially fresher than the daily registry build. There was no way for a viewer to tell "this timestamp is a live chain read" from "this timestamp is a ~daily snapshot."

- Added `tierFreshnessLabel(tier, at)` and a new `RealtimeFreshness` component (`packages/ui-kit/src/components/metagraphed/freshness.tsx`), a twin of the existing `DailyRollupFreshness` — same compact dot + `InfoTooltip` pattern, different copy ("Live chain read — updated …" vs. "Daily rollup snapshot — updated …").
- Traced each panel's `meta.generated_at` back to its actual query to classify it correctly:
  - **Realtime tier** (now `RealtimeFreshness`): `MetagraphTableLoader`/`ValidatorsTableLoader` (live metagraph snapshot), `NeuronDetailCard`, `EconomicsPanel` (live KV-tier economics — previously had **no** freshness indicator at all), and the new Activity-tab event stream freshness row.
  - **Daily tier** (kept as `DailyRollupFreshness`, now with explicit "Daily rollup" framing instead of the generic dot): the masthead's `subnetProfileQuery`-backed indicator.
- This directly fixes a pre-existing mislabeling: several genuinely-realtime panels were using the daily-rollup component (or no indicator at all), silently implying they were as stale as the profile snapshot.
- Added `packages/ui-kit/src/components/metagraphed/freshness.test.ts` covering `tierFreshnessLabel`'s missing-data fallback and both tier copies.

## Files changed

- `packages/ui-kit/src/components/metagraphed/freshness.tsx` — new `tierFreshnessLabel` helper + `RealtimeFreshness` component
- `packages/ui-kit/src/components/metagraphed/freshness.test.ts` — new unit tests
- `packages/ui-kit/src/index.ts` — export `RealtimeFreshness`, `tierFreshnessLabel`
- `apps/ui/src/components/metagraphed/metagraph-panel.tsx`, `validators-panel.tsx`, `neuron-detail-card.tsx` — swapped `DailyRollupFreshness` → `RealtimeFreshness` (backed by live snapshot queries, not daily rollups)
- `apps/ui/src/components/metagraphed/economics-panel.tsx` — added a `RealtimeFreshness` indicator (previously had none)
- `apps/ui/src/components/metagraphed/subnet-masthead.tsx` — masthead indicator now explicitly `DailyRollupFreshness` instead of the generic `FreshnessIndicator`
- `apps/ui/src/routes/subnets.$netuid.tsx` — Activity tab freshness row wiring (kept in sync with the mobile-table fix already merged in #3369)

## Screenshots

Captured via a local Playwright script, both themes, before (`upstream/main` @ `34554690`) vs. after, across the masthead and all four affected panels.

| Panel | Theme | Before | After |
| --- | --- | --- | --- |
| Masthead | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-masthead-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-masthead-light-after.png) |
| Masthead | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-masthead-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-masthead-dark-after.png) |
| Activity | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-activity-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-activity-light-after.png) |
| Activity | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-activity-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-activity-dark-after.png) |
| Metagraph | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-metagraph-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-metagraph-light-after.png) |
| Metagraph | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-metagraph-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-metagraph-dark-after.png) |
| Validators | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-validators-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-validators-light-after.png) |
| Validators | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-validators-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-validators-dark-after.png) |
| Economics | Light | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-economics-light-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-economics-light-after.png) |
| Economics | Dark | ![before](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-economics-dark-before.png) | ![after](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3376-economics-dark-after.png) |

All shots taken at 1280×800 (the width where the panel content in question is fully visible without scrolling to a narrow-viewport-only layout).

## Validation

```
npm run lint
npm run format:check
npm run typecheck --workspace=apps/ui
npm run typecheck --workspace=packages/ui-kit
npm test --workspace=apps/ui
npm test --workspace=packages/ui-kit
npm run test:e2e --workspace=apps/ui
npm run build --workspace=packages/ui-kit
npm run build --workspace=apps/ui
```

All green.

Closes #3376
