### PR TITLE
fix(data-api): bound chain firehose outbox backlog

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -590,7 +590,10 @@ CREATE TABLE IF NOT EXISTS indexer_cursor (
 -- database failures (for example disk exhaustion) remain database failures;
 -- downstream firehose delivery state does not participate in commits. The
 -- relay claims rows from this outbox, forwards them, and may delete or mark
--- delivered rows according to its retention policy.
+-- delivered rows according to its retention policy. To keep relay downtime
+-- from turning this best-effort stream into unbounded database growth, the
+-- enqueue trigger prunes stale pending rows and keeps only the newest 5,000
+-- pending rows before appending another one.
 CREATE TABLE IF NOT EXISTS chain_firehose_outbox (
   id          BIGSERIAL PRIMARY KEY,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -679,6 +682,21 @@ BEGIN
   ELSE
     RETURN NEW;
   END IF;
+
+  DELETE FROM chain_firehose_outbox
+  WHERE delivered_at IS NULL
+    AND created_at < now() - INTERVAL '1 hour';
+
+  WITH overflow AS (
+    SELECT id
+    FROM chain_firehose_outbox
+    WHERE delivered_at IS NULL
+    ORDER BY id DESC
+    OFFSET 4999
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM chain_firehose_outbox
+  WHERE id IN (SELECT id FROM overflow);
 
   INSERT INTO chain_firehose_outbox (table_name, payload)
   VALUES (TG_ARGV[0], payload);

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -53,10 +53,10 @@ export const CHAIN_FIREHOSE_POLL_BATCH_SIZE = 200;
 // interval between every batch.
 export const CHAIN_FIREHOSE_POLL_INTERVAL_MS = 250;
 
-// How long a delivered (or dropped -- see forwardBatch's own comment) row
-// stays in the outbox before cleanup deletes it. Generous over any plausible
-// relay restart/redeploy window while still bounding table growth (the #5027
-// review's own nit: nothing else prunes this table).
+// How long a row stays in the outbox before cleanup deletes it. Delivered
+// rows are only retained for observability, while pending rows older than
+// this have exceeded the firehose's best-effort window and are pruned so a
+// wedged relay/downstream cannot accumulate unbounded durable backlog.
 export const CHAIN_FIREHOSE_OUTBOX_RETENTION_MS = 60 * 60 * 1000;
 
 // Cleanup runs on its own cadence, independent of the poll loop's busy/idle
@@ -262,7 +262,8 @@ async function main() {
     const cutoff = new Date(Date.now() - CHAIN_FIREHOSE_OUTBOX_RETENTION_MS);
     await sql`
       DELETE FROM chain_firehose_outbox
-      WHERE delivered_at IS NOT NULL AND delivered_at < ${cutoff}`;
+      WHERE (delivered_at IS NOT NULL AND delivered_at < ${cutoff})
+         OR (delivered_at IS NULL AND created_at < ${cutoff})`;
   }
 
   let lastCleanupAt = Date.now();

--- a/tests/chain-firehose-outbox-schema.test.mjs
+++ b/tests/chain-firehose-outbox-schema.test.mjs
@@ -54,3 +54,36 @@ test("chain_firehose_outbox's table_name CHECK constraint matches every enqueue_
     "chain_firehose_outbox's CHECK constraint and enqueue_chain_firehose()'s TG_ARGV branches have drifted apart",
   );
 });
+
+test("enqueue_chain_firehose() bounds the pending outbox backlog before inserting", async () => {
+  const schema = await readFile(
+    path.join(repoRoot, "deploy/postgres/schema.sql"),
+    "utf8",
+  );
+  const functionMatch = schema.match(
+    /CREATE (?:OR REPLACE )?FUNCTION enqueue_chain_firehose\(\)[\s\S]*?\$\$ LANGUAGE plpgsql;/,
+  );
+  assert.ok(functionMatch, "enqueue_chain_firehose() body not found");
+  const functionBody = functionMatch[0];
+
+  assert.match(
+    functionBody,
+    /DELETE FROM chain_firehose_outbox\s+WHERE delivered_at IS NULL\s+AND created_at < now\(\) - INTERVAL '1 hour'/,
+    "enqueue_chain_firehose() must prune stale pending rows so relay downtime cannot retain them indefinitely",
+  );
+  assert.match(
+    functionBody,
+    /ORDER BY id DESC\s+OFFSET 4999\s+FOR UPDATE SKIP LOCKED/,
+    "enqueue_chain_firehose() must drop oldest pending overflow while preserving room for the new row",
+  );
+  assert.match(
+    functionBody,
+    /INSERT INTO chain_firehose_outbox \(table_name, payload\)/,
+    "enqueue_chain_firehose() must still append the current payload after pruning",
+  );
+  assert.ok(
+    functionBody.indexOf("OFFSET 4999") <
+      functionBody.indexOf("INSERT INTO chain_firehose_outbox"),
+    "pending backlog pruning must happen before inserting the next row",
+  );
+});


### PR DESCRIPTION
### Motivation
- Replacing the NOTIFY-based relay with a durable `chain_firehose_outbox` introduced an unbounded pending-row backlog that can exhaust Postgres storage during relay downtime or downstream slowdowns. 
- The enqueue path must therefore prune stale pending rows and bound pending-row count so a wedged relay cannot turn into an indexer availability failure.

### Description
- Modified `deploy/postgres/schema.sql` to have `enqueue_chain_firehose()` delete pending rows older than one hour and drop oldest pending overflow so only the newest 5,000 pending rows are retained before inserting the new row. 
- Updated `scripts/chain-firehose-relay.mjs` `cleanupOnce()` to also remove pending (`delivered_at IS NULL`) rows older than the retention cutoff so pending rows are pruned by the relay's cleanup pass. 
- Added a regression test in `tests/chain-firehose-outbox-schema.test.mjs` that asserts the trigger body contains the stale-pending prune, overflow drop (OFFSET 4999), and that pruning happens before the `INSERT`. 
- Preserved the relay's forwarding semantics (bounded concurrency and bounded retries) and retained delivered-row retention for observability.

### Testing
- Ran `npm test -- tests/chain-firehose-outbox-schema.test.mjs tests/chain-firehose-relay.test.mjs` and both test files passed (22 tests total passed). 
- Ran `npm run format:check` on the modified files and the Prettier check succeeded. 
- Ran `npm run lint` against the changed JS test/script files and the linter passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54a53c49c8832c8e348613a9fb2198)