### PR TITLE
fix(ui): show yield and vs-median per row on the mobile Yield leaderboard

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -132,7 +132,53 @@ export function YieldLoader({ netuid }: { netuid: number }) {
 
       {/* Per-UID yield leaderboard (top yielders). */}
       <div className="rounded-xl border border-border bg-card overflow-hidden">
-        <div className="overflow-x-auto">
+        {/* < md: a 7-column table squeezes Yield/vs-median off an undiscoverable
+            horizontal scroll, so narrow viewports get a stacked card per UID
+            instead — mirrors the cards/table split the explorer stake-transfer
+            leaderboard uses (explorer.tsx) and ListShell uses for paginated lists. */}
+        <div className="md:hidden divide-y divide-border/60">
+          {ranked.map((n) => (
+            <div key={n.uid} className="p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                    #{n.uid}
+                  </span>
+                  {n.hotkey ? (
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: n.hotkey }}
+                      className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+                      title={n.hotkey}
+                    >
+                      {shortHash(n.hotkey) ?? n.hotkey}
+                    </Link>
+                  ) : (
+                    <span className="font-mono text-[12px] text-ink-muted">—</span>
+                  )}
+                </div>
+                {n.role === "validator" ? (
+                  <span className="shrink-0 inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                    Validator
+                  </span>
+                ) : (
+                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                    Miner
+                  </span>
+                )}
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-2 font-mono text-[11px] tabular-nums">
+                <span className="text-ink-muted">{taoCompact(n.stake_tao)} τ stake</span>
+                <span className="text-ink-muted">{taoCompact(n.emission_tao)} τ emission</span>
+                <span className="flex items-center gap-1 text-ink-strong">
+                  {fmtYield(n.yield)}
+                  <VsMedian vs={n.vs_median} />
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
               <tr>


### PR DESCRIPTION
## Summary

The per-UID Yield leaderboard (`YieldLoader` in `apps/ui/src/components/metagraphed/yield-panel.tsx`) is a 7-column table (UID, Hotkey, Role, Stake τ, Emission τ, Yield, vs median) wrapped only in `overflow-x-auto` with no `min-w` on the table. Below `md`, the browser squeezed columns to fit the viewport instead of triggering a discoverable horizontal scroll, so the Yield and vs-median columns — the entire point of a *ranked* leaderboard — were effectively invisible on mobile.

Rather than force horizontal scroll on a 7-column table, this reuses the pattern already established in this app for exactly this situation: the explorer stake-transfer leaderboard (`apps/ui/src/routes/explorer.tsx`) shows a stacked mobile card per row below `md` and the full table only from `md` up, mirroring `ListShell`'s cards/table split for paginated lists.

- Added a `md:hidden` stacked-card list: each card shows UID, hotkey (linked), role badge, stake, emission, and — critically — yield % with its vs-median directional indicator, all on-screen with no scrolling.
- Wrapped the existing table in `hidden md:block overflow-x-auto` — unchanged desktop/tablet rendering, just now gated to `md` and up.
- No changes to data fetching, sorting, or the yield calculation itself (out of scope per the issue's non-goals).

## Screenshots

| Viewport · Theme | Before                                                                | After                                                              |
| ----------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3935-mobile-dark-after.png)<br><sub>after</sub> |

All shots scrolled to the per-UID leaderboard within the Yield tab (`/subnets/1?tab=metagraph`, `#yield`). Mobile before clearly shows Stake/Emission as the last visible columns with Yield/vs-median cut off past the viewport edge; mobile after shows every row's yield % and directional indicator directly, via the stacked-card layout. Desktop/tablet are pixel-identical before vs. after (table gains a `hidden md:block` wrapper only, no visual change at ≥768px).

## Validation

```
npm run lint --workspace=apps/ui
npm run format:check --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui
npm run test:e2e --workspace=apps/ui
npm run build --workspace=apps/ui
```

All green.

Closes #3935
