### PR TITLE
fix(ui): wire the Subnets mega-menu's kind/stale filter links into the actual predicate

### DIFF
--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -16,6 +16,7 @@ export const tableSearchSchema = z.object({
   curation: fallback(z.string(), "").default(""),
   health: fallback(z.string(), "").default(""),
   kind: fallback(z.string(), "").default(""),
+  stale: fallback(z.string(), "").default(""),
   provider: fallback(z.string(), "").default(""),
   netuid: fallback(z.string(), "").default(""),
   // #9: agent-catalog capability filters (applied client-side over joined rows).

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -49,7 +49,7 @@ import {
   agentCatalogMapQuery,
   economicsQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import {
   joinEconomics,
@@ -136,6 +136,8 @@ function SubnetsPage() {
     !!search.health ||
     !!search.serviceKind ||
     !!search.readiness ||
+    !!search.kind ||
+    !!search.stale ||
     !!search.cursor;
   const onReset = () =>
     navigate({
@@ -354,6 +356,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     search.health ||
     search.serviceKind ||
     search.readiness ||
+    search.kind ||
+    search.stale ||
     search.sort
   );
 
@@ -372,9 +376,31 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         if (search.serviceKind && !(s.service_kinds ?? []).includes(search.serviceKind))
           return false;
         if (search.readiness && s.readiness_tier !== search.readiness) return false;
+        // Mega-menu "Has APIs/docs/SSE" links (nav-mega-menu-data.ts). "api"/"sse"
+        // are agent-catalog service_kinds; "docs" has no service_kinds entry (a
+        // docs page isn't a callable service) so it checks the row's own
+        // docs_url instead — this is the one case service_kinds can't answer.
+        if (search.kind === "api" && !(s.service_kinds ?? []).includes("subnet-api"))
+          return false;
+        if (search.kind === "sse" && !(s.service_kinds ?? []).includes("sse")) return false;
+        if (search.kind === "docs" && !s.docs_url) return false;
+        // Mega-menu "Stale > 24h" link: same threshold as the label, using the
+        // same isStaleFreshness convention as the rest of the app. The list API
+        // doesn't emit a `freshness` field on these rows — `updated_at` is what's
+        // actually populated (confirmed against the live response).
+        if (search.stale && !isStaleFreshness(s.updated_at, 24 * 60 * 60_000)) return false;
         return true;
       }),
-    [all, search.q, search.curation, search.health, search.serviceKind, search.readiness],
+    [
+      all,
+      search.q,
+      search.curation,
+      search.health,
+      search.serviceKind,
+      search.readiness,
+      search.kind,
+      search.stale,
+    ],
   );
   const rows = useMemo(
     () =>

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -380,8 +380,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         // are agent-catalog service_kinds; "docs" has no service_kinds entry (a
         // docs page isn't a callable service) so it checks the row's own
         // docs_url instead — this is the one case service_kinds can't answer.
-        if (search.kind === "api" && !(s.service_kinds ?? []).includes("subnet-api"))
-          return false;
+        if (search.kind === "api" && !(s.service_kinds ?? []).includes("subnet-api")) return false;
         if (search.kind === "sse" && !(s.service_kinds ?? []).includes("sse")) return false;
         if (search.kind === "docs" && !s.docs_url) return false;
         // Mega-menu "Stale > 24h" link: same threshold as the label, using the


### PR DESCRIPTION
Closes #3973

## What
The primary nav mega-menu's Subnets filters build links to `/subnets?kind=api`, `?kind=docs`, `?kind=sse`, and `?stale=1` (`nav-mega-menu-data.ts:49-52`). `subnets.index.tsx`'s filter predicate never read `search.kind` or `search.stale` at all — confirmed by grepping every `search.` reference in the file before this change: only `q`/`curation`/`health`/`serviceKind`/`readiness`/`sort`/`order`/`cursor`/`limit`/`view`/`density` were consumed. Clicking any of the four mega-menu links landed on an unfiltered `/subnets` list with no visible indication the filter had silently done nothing.

## Why not just repoint `kind` at the existing `serviceKind` filter
`serviceKind` already filters correctly by agent-catalog capability (`subnet-api`/`openapi`/`sse`/`data-artifact`), and at first glance `kind: "api"`/`"sse"` look like they should just become `serviceKind: "subnet-api"`/`"sse"`. But `"docs"` is **not** a valid `service_kinds` value — confirmed by querying the live `/api/v1/agent-catalog` response, whose `service_kinds` only ever contains `data-artifact`, `openapi`, `subnet-api`, `sse` (docs pages aren't callable agent services). Repointing `kind: "docs"` at `serviceKind: "docs"` would have created a **new** permanently-empty filter — the exact bug this issue is about, just relocated. So this PR wires `search.kind` (already in the shared `tableSearchSchema` — it's actively used by `/surfaces`, just never consumed here) directly into the predicate instead, handling `docs` against the row's own `docs_url` field (confirmed present on every `/api/v1/subnets` list row) rather than forcing it through a capability field that structurally can't represent it.

## Changes
- **`apps/ui/src/lib/metagraphed/url-state.ts`** — adds `stale` to the shared `tableSearchSchema` (previously absent entirely, so `?stale=1` had nowhere to go).
- **`apps/ui/src/routes/subnets.index.tsx`**:
  - Filter predicate now handles `search.kind === "api"` (checks `service_kinds` includes `subnet-api`), `search.kind === "sse"` (checks `service_kinds` includes `sse`), and `search.kind === "docs"` (checks the row's own `docs_url`).
  - `search.stale` filters via the existing `isStaleFreshness` utility (same convention used elsewhere in the app) against `updated_at` at a 24h threshold, matching the mega-menu's own "Stale > 24h" label. (The list rows carry `updated_at`, not `freshness` — confirmed against the live response — so `updated_at` is what's checked.)
  - Both new params added to `filtersActive` (both the header-level and table-level computations) and the `filtered` `useMemo`'s dependency array, so the "Reset filters" affordance and re-filtering behave consistently with every other filter already on this page.
- **`nav-mega-menu-data.ts`** needed **no changes** — its existing `kind`/`stale` links were already correct; the bug was entirely on the consuming end.

## Screenshots

Using `?kind=sse` as the clearest illustration (the rarest, most visibly-filtered case — only one subnet in the registry currently exposes an SSE surface):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnets-mega-menu-filters-3973/after-mobile-dark.png)<br><sub>after</sub> |

Before: `?kind=sse` renders the full unfiltered list (root, DSperse, Templar, Targon...) with no "Reset filters" affordance. After: the list correctly narrows to the one matching subnet, and "Reset filters" appears — both proving `filtersActive` now recognizes the param too.

## Verification (all four links, against live data)
- `?kind=api` (unquoted or quoted — both round-trip identically for non-numeric strings): 25 → 24 rows.
- `?kind=docs`: 25 → 18 rows.
- `?kind=sse`: 25 → 1 row (screenshotted above).
- `?stale=1`: 25 → 0 rows — genuinely correct, not a bug: every currently-loaded subnet's `updated_at` is ~1.3h old (the registry refreshed recently), so nothing currently qualifies as ">24h stale". Verified the mechanism itself is sound by checking `isStaleFreshness` directly against real `updated_at` values from the live API.
- The adjacent, already-working "Machine-verified" mega-menu link (`curation=machine-verified`) is untouched and unaffected — confirmed no changes to the `curation` handling.

## Acceptance criteria
- [x] All cited files appear in the diff (`nav-mega-menu-data.ts` needed no change, since its links were already correct)
- [x] The three `kind=` mega-menu links now visibly filter the `/subnets` list to the matching surface kind
- [x] The `stale=1` link produces a correct filtered result (verified against live timestamps; screenshots use `kind=sse` since it's the more visually compelling proof against current data)
- [x] The "Machine-verified" link is unaffected
- [x] Before/after screenshot table across all 3 viewports × 2 themes

## Testing
- `npx tsc --noEmit`: no new errors (2 pre-existing, unrelated errors reproduce identically on a clean `main` checkout).
- `npx prettier --check` and `npx eslint` on both changed files: clean aside from pre-existing CRLF noise unrelated to this change.
- Diff is 29 insertions / 2 deletions across exactly the two files where the actual bug lived.
