### PR TITLE
feat(ui): wire Download CSV into the Accounts detail page tabs

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import type { HTMLAttributes } from "react";
-import { ArrowUp, ArrowDown, X } from "lucide-react";
+import { ArrowUp, ArrowDown, X, Filter } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 
 /**
@@ -133,6 +133,52 @@ export function SelectFilter({
         )}
       >
         {allowEmpty ? <option value="">all</option> : null}
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * Pill-shaped filter chip matching the EndpointKindTabs / window-toggle idiom
+ * used elsewhere for compact filters, rather than the generic bordered-box
+ * label+select pattern (SelectFilter) — a native <select> still drives it for
+ * a11y and mobile-native option picking, the Filter icon carries the label so
+ * the chip stays narrow enough that it never pushes a section title onto
+ * multiple lines.
+ */
+export function FilterChip({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+  placeholder = "All",
+  className,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Array<{ value: string; label: string }>;
+  ariaLabel: string;
+  placeholder?: string;
+  className?: string;
+}) {
+  return (
+    <label className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2 py-1 text-ink-muted hover:border-ink/30 transition-colors">
+      <Filter className="size-3 shrink-0" aria-hidden />
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={ariaLabel}
+        className={classNames(
+          "min-w-0 max-w-[85px] truncate bg-transparent font-mono text-[11px] uppercase tracking-widest text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded",
+          className,
+        )}
+      >
+        <option value="">{placeholder}</option>
         {options.map((o) => (
           <option key={o.value} value={o.value}>
             {o.label}

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -26,7 +26,7 @@ import {
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
-import { SelectFilter } from "@/components/metagraphed/table-controls";
+import { SelectFilter, FilterChip } from "@/components/metagraphed/table-controls";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CopyableCode,
@@ -37,6 +37,7 @@ import {
   SectionAnchor,
   StatTile,
   BarMini,
+  DownloadCsvButton,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
@@ -60,6 +61,7 @@ import {
   accountTransfersQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
@@ -338,6 +340,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
 
       <AccountExtrinsicsSection
+        ss58={ss58}
         rows={signedExtrinsics}
         isPending={extrinsicsResult.isPending}
         isError={extrinsicsResult.isError}
@@ -442,25 +445,29 @@ function AccountFeedSectionSkeleton({
   id,
   title,
   subtitle,
+  info,
 }: {
   id: string;
   title: string;
-  subtitle: string;
+  subtitle?: string;
+  info?: string;
 }) {
   return (
-    <SectionAnchor id={id} title={title} subtitle={subtitle} tone="accent">
+    <SectionAnchor id={id} title={title} subtitle={subtitle} info={info} tone="accent">
       <Skeleton className="h-64 w-full" />
     </SectionAnchor>
   );
 }
 
 function AccountExtrinsicsSection({
+  ss58,
   rows,
   isPending,
   isError,
   error,
   onRetry,
 }: {
+  ss58: string;
   rows: Extrinsic[];
   isPending?: boolean;
   isError?: boolean;
@@ -477,7 +484,7 @@ function AccountExtrinsicsSection({
       <AccountFeedSectionSkeleton
         id="extrinsics"
         title="Signed extrinsics"
-        subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
+        info="The newest transactions this account signed, from the chain-direct extrinsics tier."
       />
     );
   }
@@ -486,7 +493,7 @@ function AccountExtrinsicsSection({
       <SectionAnchor
         id="extrinsics"
         title="Signed extrinsics"
-        subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
+        info="The newest transactions this account signed, from the chain-direct extrinsics tier."
         tone="accent"
       >
         <TableState
@@ -504,9 +511,14 @@ function AccountExtrinsicsSection({
     <SectionAnchor
       id="extrinsics"
       title="Signed extrinsics"
-      subtitle="The newest transactions this account signed, from the chain-direct extrinsics tier."
+      info="The newest transactions this account signed, from the chain-direct extrinsics tier."
       tone="accent"
-      right={<SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>}
+      right={
+        <div className="flex items-center gap-2">
+          <SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>
+          <DownloadCsvButton url={buildUrl(`/api/v1/accounts/${ss58}/extrinsics`)} />
+        </div>
+      }
     >
       <DataPanel>
         <table className="w-full text-left text-sm">
@@ -599,7 +611,7 @@ function AccountTransfersSection({
       <AccountFeedSectionSkeleton
         id="transfers"
         title="Transfers"
-        subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
+        info="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
       />
     );
   }
@@ -608,7 +620,7 @@ function AccountTransfersSection({
       <SectionAnchor
         id="transfers"
         title="Transfers"
-        subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
+        info="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
         tone="accent"
       >
         <TableState
@@ -626,9 +638,14 @@ function AccountTransfersSection({
     <SectionAnchor
       id="transfers"
       title="Transfers"
-      subtitle="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
+      info="Native-TAO Balances.Transfer activity for this account, directional (sent / received)."
       tone="accent"
-      right={<SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>}
+      right={
+        <div className="flex items-center gap-2">
+          <SectionBadge>{formatNumber(rows.length)} rows</SectionBadge>
+          <DownloadCsvButton url={buildUrl(`/api/v1/accounts/${ss58}/transfers`)} />
+        </div>
+      }
     >
       <DataPanel>
         <table className="w-full text-left text-sm">
@@ -1974,7 +1991,7 @@ function AccountEventsSection({
       <AccountFeedSectionSkeleton
         id="events"
         title="Chain events"
-        subtitle="Full first-party event feed for this account, newest first."
+        info="Full first-party event feed for this account, newest first — filter by kind, page through history."
       />
     );
   }
@@ -1984,7 +2001,7 @@ function AccountEventsSection({
       <SectionAnchor
         id="events"
         title="Chain events"
-        subtitle="Full first-party event feed for this account, newest first — filter by kind, page through history."
+        info="Full first-party event feed for this account, newest first — filter by kind, page through history."
         tone="accent"
       >
         <TableState
@@ -2002,17 +2019,22 @@ function AccountEventsSection({
     <SectionAnchor
       id="events"
       title="Chain events"
-      subtitle="Full first-party event feed for this account, newest first — filter by kind, page through history."
+      info="Full first-party event feed for this account, newest first — filter by kind, page through history."
       tone="accent"
       right={
-        kindOptions.length > 0 ? (
-          <SelectFilter
-            label="Kind"
-            value={search.ev_kind ?? ""}
-            onChange={(v) => setSearch({ ev_kind: v || undefined, ev_offset: undefined })}
-            options={kindOptions.map((k) => ({ value: k.kind, label: k.kind }))}
+        <div className="flex items-center gap-2">
+          {kindOptions.length > 0 ? (
+            <FilterChip
+              ariaLabel="Filter by event kind"
+              value={search.ev_kind ?? ""}
+              onChange={(v) => setSearch({ ev_kind: v || undefined, ev_offset: undefined })}
+              options={kindOptions.map((k) => ({ value: k.kind, label: k.kind }))}
+            />
+          ) : null}
+          <DownloadCsvButton
+            url={buildUrl(`/api/v1/accounts/${ss58}/events`, { kind: search.ev_kind })}
           />
-        ) : undefined
+        </div>
       }
     >
       {events.length > 0 ? (

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1565,12 +1565,15 @@ function DownloadCsvButton({
       "aria-label": label,
       title: label,
       className: classNames(
-        "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
+        // other compact header controls it commonly sits next to — a plain
+        // `rounded` rectangle reads as a mismatched shape beside a pill.
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
         className
       ),
       children: [
         /* @__PURE__ */ jsxRuntime.jsx(lucideReact.Download, { className: "size-3 text-ink-muted", "aria-hidden": true }),
-        label
+        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: label })
       ]
     }
   );
@@ -2267,7 +2270,7 @@ function SectionAnchor({
         )
       ),
       children: [
-        /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-3 flex items-baseline gap-3", children: [
+        /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-3 flex items-center gap-3", children: [
           /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0 flex-1", children: [
             /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center gap-1.5", children: [
               /* @__PURE__ */ jsxRuntime.jsx("h2", { className: "font-display text-sm font-semibold uppercase tracking-wider text-ink-strong", children: title }),

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1536,12 +1536,15 @@ function DownloadCsvButton({
       "aria-label": label,
       title: label,
       className: classNames(
-        "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
+        // other compact header controls it commonly sits next to — a plain
+        // `rounded` rectangle reads as a mismatched shape beside a pill.
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
         className
       ),
       children: [
         /* @__PURE__ */ jsx(Download, { className: "size-3 text-ink-muted", "aria-hidden": true }),
-        label
+        /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: label })
       ]
     }
   );
@@ -2238,7 +2241,7 @@ function SectionAnchor({
         )
       ),
       children: [
-        /* @__PURE__ */ jsxs("div", { className: "mb-3 flex items-baseline gap-3", children: [
+        /* @__PURE__ */ jsxs("div", { className: "mb-3 flex items-center gap-3", children: [
           /* @__PURE__ */ jsxs("div", { className: "min-w-0 flex-1", children: [
             /* @__PURE__ */ jsxs("div", { className: "flex items-center gap-1.5", children: [
               /* @__PURE__ */ jsx("h2", { className: "font-display text-sm font-semibold uppercase tracking-wider text-ink-strong", children: title }),

--- a/packages/ui-kit/src/components/metagraphed/download-csv-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/download-csv-button.tsx
@@ -35,12 +35,18 @@ export function DownloadCsvButton({
       aria-label={label}
       title={label}
       className={classNames(
-        "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
+        // other compact header controls it commonly sits next to — a plain
+        // `rounded` rectangle reads as a mismatched shape beside a pill.
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
         className,
       )}
     >
       <Download className="size-3 text-ink-muted" aria-hidden />
-      {label}
+      {/* Icon-only below `sm` — a text label is the first thing to drop when a
+          button shares a header row with other controls on a narrow viewport;
+          the icon + aria-label/title keep it identifiable either way. */}
+      <span className="hidden sm:inline">{label}</span>
     </button>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/section-anchor.tsx
+++ b/packages/ui-kit/src/components/metagraphed/section-anchor.tsx
@@ -66,7 +66,7 @@ export function SectionAnchor({
           ),
       )}
     >
-      <div className="mb-3 flex items-baseline gap-3">
+      <div className="mb-3 flex items-center gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <h2 className="font-display text-sm font-semibold uppercase tracking-wider text-ink-strong">


### PR DESCRIPTION
## Summary

`AccountDetail` (`apps/ui/src/routes/accounts.$ss58.tsx`) renders three tables — Chain events (`#events`), Signed extrinsics (`#extrinsics`), Transfers (`#transfers`) — whose backing routes already accept `?format=csv`, but had no export affordance. This wires the `DownloadCsvButton` component (landed via #3402, already in `@jsonbored/ui-kit`) into all three section headers.

- `AccountEventsSection`: `DownloadCsvButton` added to the `right` slot alongside the existing Kind filter. Its URL is built via `buildUrl(\`/api/v1/accounts/${ss58}/events\`, { kind: search.ev_kind })` — `buildUrl` skips `undefined`/`null`/`""` params, so the active `ev_kind` filter is included in the export when set and omitted otherwise. `DownloadCsvButton` itself appends `format=csv`.
- `AccountExtrinsicsSection`: gained an `ss58` prop (previously only received pre-fetched `rows`), passed from `ValidAccountDetail`, used to build `buildUrl(\`/api/v1/accounts/${ss58}/extrinsics\`)`. Rendered next to the existing row-count `SectionBadge`.
- `AccountTransfersSection`: already had `ss58` in scope; same treatment, `buildUrl(\`/api/v1/accounts/${ss58}/transfers\`)`.
- No changes to `queries.ts`, `client.ts`, or any backend file — reuses the existing `buildUrl` helper and the already-shipped `?format=csv` support, per the issue's explicit scope.

**Update:** the first version of this PR added the button as-is, which crowded the section headers and wrapped "Chain events" / "Signed extrinsics" onto two lines at mobile width. Fixed with the same treatment already established for the subnet page's Activity panel (#3369/#3376):

- Extracted the pill-shaped `EventKindFilterChip` pattern into a new, generic **`FilterChip`** component (`apps/ui/src/components/metagraphed/table-controls.tsx`) and used it in place of the generic `SelectFilter` for the Events tab's Kind filter — a narrow `rounded-full` chip with a `Filter` icon instead of a labeled bordered box.
- Swapped each section's long descriptive `subtitle` paragraph for a compact `info` tooltip on `SectionAnchor` (same "drop the subtitle, keep an (i) tooltip" pattern used for "On-chain activity" on the subnet page), for all three render phases (skeleton/error/loaded) of Events, Extrinsics, and Transfers.
- Made **`DownloadCsvButton`** itself responsive: the text label is now `hidden` below the `sm` breakpoint and `sm:inline` above it, so it's icon-only on mobile (where a header row sharing space with other controls has the least room to spare) and shows the full "Download CSV" label from tablet up. This is a shared `packages/ui-kit` component used by many other pages (blocks, subnets, endpoints, surfaces, extrinsics, sudo, admin-changes) — the change is purely additive (existing consumers get the same icon-only-on-mobile treatment automatically) and preserves the full accessible name via `aria-label`/`title` regardless of viewport.

Net effect: all three section headings now render on a single line at every mandated viewport, with no loss of functionality — the CSV export, the Kind filter, and the descriptive copy (now in a tooltip) are all still one interaction away.

**Second update:** the icon-only mobile button above still used `DownloadCsvButton`'s original `rounded` (plain rectangle) corners, which sat awkwardly next to the fully-`rounded-full` `SectionBadge`/`FilterChip` pills beside it — two different shape languages in the same row, with mismatched height (22px vs 25px) and padding on top of it. Fixed by changing `DownloadCsvButton` to `rounded-full` with matched padding (`p-1.5` icon-only, `sm:px-2.5 sm:py-1` once the label shows), so it now reads as the same family of compact pill control as everything else in these header rows, at every breakpoint — not just an icon bolted onto a box.

**Third update:** even with matching shapes, the row still looked unevenly spaced — measured it directly (`getBoundingClientRect()`), and `SectionAnchor`'s header row was `flex items-baseline`, which aligns flex items by their text baseline. The title `<h2>` has a real text baseline; the `right` slot (FilterChip + button, no text) falls back to using its own bottom margin edge as a synthetic baseline, so the button was pinned flush to the row's top with zero gap while the title sat baseline-aligned a few px lower — an asymmetric, "off" look even with matching pill shapes. Changed the row to `items-center` in `packages/ui-kit/src/components/metagraphed/section-anchor.tsx` (confirmed via measurement: h2 now sits with an equal ~3px gap top and bottom). This is a shared component used by 9 other route/component files — checked every one of them for regressions (screenshots taken before/after at 375px for `/subnets/1` Activity/Metagraph/Validators panels, plus the one other real `subtitle`+`right` combo in the app, the `PanelShell`-wrapped Operational Status panel). No regression: `align-items` only affects cross-axis (vertical) position, never width/wrapping, so it can't be the cause of any horizontal layout issue. The Operational Status panel does have a severe, pre-existing text-wrap bug on narrow viewports (confirmed present identically with the original `items-baseline`, unrelated to this change) — filed separately, out of scope here.

## Screenshots

| Viewport · Theme | Before                                                                | After                                                              |
| ----------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-light-after-v4.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-dark-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-dark-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-dark-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-desktop-dark-after-v4.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-light-after-v4.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-dark-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-dark-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-dark-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-tablet-dark-after-v4.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-light-after-v4.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-dark-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-dark-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-dark-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-mobile-dark-after-v4.png)<br><sub>after</sub> |

All rows above scrolled to the "Chain events" section (has both the Kind filter and the button — the tightest layout of the three changed sections, and the clearest before/after demonstration of the heading-wrap fix). Supplementary evidence for the other two sections — desktop AND mobile, since mobile is exactly where the original wrap bug showed up:

| Section · Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| Signed extrinsics · Desktop | Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-desktop-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-desktop-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-desktop-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-desktop-light-after-v4.png)<br><sub>after</sub> |
| Signed extrinsics · Mobile | Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-mobile-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-mobile-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-mobile-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-extrinsics-mobile-light-after-v4.png)<br><sub>after</sub> |
| Transfers · Desktop | Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-desktop-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-desktop-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-desktop-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-desktop-light-after-v4.png)<br><sub>after</sub> |
| Transfers · Mobile | Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-mobile-light-before-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-mobile-light-before-v4.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-mobile-light-after-v4.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3407-transfers-mobile-light-after-v4.png)<br><sub>after</sub> |

## Validation

```
npm run lint --workspace=apps/ui
npm run lint --workspace=packages/ui-kit
npm run format:check --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm run typecheck --workspace=packages/ui-kit
npm test --workspace=apps/ui
npm test --workspace=packages/ui-kit
npm run test:e2e --workspace=apps/ui
npm run build --workspace=packages/ui-kit
npm run build --workspace=apps/ui
```

All green.

Closes #3407