### PR TITLE
fix(ui): route the #activity hash link to the Activity tab (#3978)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -200,6 +200,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   yield: "metagraph",
   turnover: "metagraph",
   validators: "validators",
+  activity: "activity",
   identity: "identity",
   hyperparameters: "hyperparameters",
   services: "services",


### PR DESCRIPTION
Closes #3978

The `activity` tab was the only tab missing from `SECTION_TO_TAB`, so a `#activity` hash link — including the one the Activity section's own **copy-link** button generates — silently failed to switch tabs. `useHashScroll` had no mapping to resolve `#activity` to its owning tab.

**Fix:** one line — add `activity: "activity"` to the map, matching the 22 existing entries. `subnets.$netuid.tsx` only, **+1 line**. No new files, no refactor (per the issue's "one-entry map fix" + non-goals). typecheck ✓ · eslint ✓ · 678 tests ✓ · verified: `/subnets/7#activity` now sets `?tab=activity` and renders the Activity panel.

### Activity hash-link (animated)

Static images can't show this — the at-rest `/subnets/{netuid}` layout is **byte-identical** before/after (a 1-line map entry), so the standard 3-viewport × 2-theme matrix is provably unaffected and skipped; the change is only observable when *following* a `#activity` link:

| Target | Before (bug) | After (fix) |
| --- | --- | --- |
| Follow `/subnets/7#activity` | [<img src="https://raw.githubusercontent.com/madeline-coder/metagraphed/screenshots/ht-before.gif" width="380">](https://raw.githubusercontent.com/madeline-coder/metagraphed/screenshots/ht-before.gif)<br><sub>stays on Overview</sub> | [<img src="https://raw.githubusercontent.com/madeline-coder/metagraphed/screenshots/ht-after.gif" width="380">](https://raw.githubusercontent.com/madeline-coder/metagraphed/screenshots/ht-after.gif)<br><sub>switches to Activity</sub> |
