### PR TITLE
fix(ui): URL-back the 7d/30d window toggle on /status and /endpoints

### DIFF
--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Zap, GitBranch, Database, ShieldCheck, Gauge, ArrowUpDown } from "lucide-react";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { useNetwork } from "@/hooks/use-api-base";
@@ -155,7 +155,10 @@ function UsageStat({
 }
 
 export function ProxyUsagePanel() {
-  const [window, setWindow] = useState<"7d" | "30d">("7d");
+  // #3976: window is URL-backed on /endpoints (this panel's only host) so a
+  // shared link restores the same 7d/30d view and back/forward works.
+  const window = useSearch({ from: "/endpoints", select: (s) => s.window });
+  const navigate = useNavigate({ from: "/endpoints" });
   const { data } = useSuspenseQuery(rpcUsageQuery(window));
   const usage = data.data as RpcUsage;
   const s = usage.summary;
@@ -179,7 +182,7 @@ export function ProxyUsagePanel() {
             <button
               key={w}
               type="button"
-              onClick={() => setWindow(w)}
+              onClick={() => navigate({ search: (prev) => ({ ...prev, window: w }) })}
               className={classNames(
                 "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
                 window === w ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -84,6 +84,9 @@ const endpointsSearchSchema = z.object({
   page: fallback(z.number().int().min(1), 1).default(1),
   pageSize: fallback(z.number().int().min(10).max(200), 25).default(25),
   view: fallback(z.enum(["table", "grid"]), "table").default("table"),
+  // #3976: ProxyUsagePanel's 7d/30d window is URL-backed (like /explorer) so a
+  // shared /endpoints link restores the same window and back/forward works.
+  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
 });
 
 type EndpointsSearch = z.infer<typeof endpointsSearchSchema>;

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -66,6 +66,9 @@ const statusSearchSchema = z.object({
   status: fallback(z.string(), "").default(""),
   sort: fallback(z.enum(SURFACE_SORT_FIELDS), "status").default("status"),
   order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+  // #3976: RecentIncidents' 7d/30d window is URL-backed (like /explorer) so a
+  // shared /status link restores the same window and back/forward works.
+  window: fallback(z.enum(WINDOWS), "7d").default("7d"),
 });
 
 export const Route = createFileRoute("/status")({
@@ -324,7 +327,8 @@ function Kpi({
 
 /** Global, cross-subnet incident ledger from /api/v1/incidents (7d / 30d window). */
 function RecentIncidents() {
-  const [window, setWindow] = useState<IncidentWindow>("7d");
+  const window = Route.useSearch({ select: (s) => s.window });
+  const navigate = useNavigate({ from: Route.fullPath });
   const [showAll, setShowAll] = useState(false);
   const refetchInterval = useRefetchInterval(60_000);
   const { data } = useSuspenseQuery({
@@ -380,7 +384,7 @@ function RecentIncidents() {
               key={w}
               type="button"
               onClick={() => {
-                setWindow(w);
+                navigate({ search: (prev) => ({ ...prev, window: w }) });
                 setShowAll(false);
               }}
               className={classNames(


### PR DESCRIPTION
## Summary
The `7d | 30d` window toggle is correctly URL-backed on `/explorer`, but `RecentIncidents` (`/status`) and `ProxyUsagePanel` (`/endpoints`) each kept their window in a local `useState` — so the selection reset to 7d on every reload and was invisible to back/forward and link-sharing. A user could share a 30d `/explorer` link, but not an equivalent `/status` or `/endpoints` one (**#3976**).

## Change
Wire both toggles to the URL using the exact pattern `/explorer` already demonstrates — no new mechanism.

- Add a `window: fallback(z.enum(["7d","30d"]), "7d")` param to each route's **existing** search schema (`statusSearchSchema`, `endpointsSearchSchema`).
- Replace the local `useState` in `RecentIncidents` and `ProxyUsagePanel` with `Route.useSearch()` / `useSearch({ from: "/endpoints" })` for the value and `navigate({ search: (prev) => ({ ...prev, window: w }) })` for the toggle — the functional merge preserves every other param already in the URL.
- No change to the window options (still 7d/30d), the toggle markup, or the data-fetching paths (`globalIncidentsQuery`/`rpcUsageQuery`).

Toggling now updates the URL; reloading or sharing that URL restores the window; back/forward works. `tsc` / `prettier` clean. Verified locally: toggling on both pages produces `…&window=30d` (all sibling params intact) and survives a reload.

Closes #3976

## Screenshots
Same shared link in every cell — `/status?window=30d` and `/endpoints?window=30d`. **Before** ignores the param (toggle falls back to **7d**, summary reads "· 7d ·"); **after** restores it (toggle shows **30d**, summary reads "· 30d ·"). Theme forced via `localStorage`.

### `/status` — RecentIncidents (`?window=30d`)
| Viewport · Theme | Before (window dropped) | After (window restored) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-status-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-status-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-status-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-status-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-status-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-status-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-status-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-status-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-status-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-status-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-status-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-status-mobile-dark.png) |

### `/endpoints` — ProxyUsagePanel (`?window=30d`)
| Viewport · Theme | Before (window dropped) | After (window restored) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-endpoints-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-endpoints-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-endpoints-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-endpoints-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-endpoints-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-endpoints-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-endpoints-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-endpoints-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-endpoints-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-endpoints-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/before-endpoints-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3976-assets/3976/after-endpoints-mobile-dark.png) |
