### PR TITLE
fix(ui): clamp NetworkSwitcher and SettingsPopover panels to the viewport

### DIFF
--- a/apps/ui/src/components/metagraphed/clamped-popover-content.tsx
+++ b/apps/ui/src/components/metagraphed/clamped-popover-content.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { PopoverContent } from "@jsonbored/ui-kit";
+import { classNames } from "@/lib/metagraphed/format";
+
+/** Viewport gutter kept on every side (px). Matches the `max-w` inset below so
+ * a clamped panel is centred within the gutter rather than flush to one edge. */
+const VIEWPORT_GUTTER = 12;
+
+/**
+ * A `PopoverContent` that never renders wider than the viewport, with a small
+ * gutter on every side. Radix's collision-avoidance repositions a panel to keep
+ * it on-screen but does not shrink its fixed width — so a `w-80` (320px) /
+ * `w-72` (288px) panel is pinned flush against (and on the narrowest devices
+ * spills past) the screen edge, with no breathing room (#3945). Two things fix
+ * that together: a `max-w` of the viewport minus the gutters turns the caller's
+ * fixed width into a *maximum* (so it can shrink to fit), and a matching
+ * `collisionPadding` keeps Radix from pinning that width flush to an edge. The
+ * panel is unchanged where it already fits with room to spare; on narrow
+ * viewports it shrinks and sits inside a consistent gutter instead of bleeding
+ * to the device edge. Callers keep passing their usual width class.
+ */
+export const ClampedPopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverContent>,
+  React.ComponentPropsWithoutRef<typeof PopoverContent>
+>(({ className, collisionPadding = VIEWPORT_GUTTER, ...props }, ref) => (
+  <PopoverContent
+    ref={ref}
+    collisionPadding={collisionPadding}
+    className={classNames("max-w-[calc(100vw-1.5rem)]", className)}
+    {...props}
+  />
+));
+ClampedPopoverContent.displayName = "ClampedPopoverContent";

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Check, ChevronDown, Globe2, Pencil, TerminalSquare } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@jsonbored/ui-kit";
+import { Popover, PopoverTrigger } from "@jsonbored/ui-kit";
+import { ClampedPopoverContent } from "./clamped-popover-content";
 import { useApiBase, useNetwork } from "@/hooks/use-api-base";
 import { CHAIN_NETWORKS, LOCAL_DEV, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
@@ -81,7 +82,7 @@ export function NetworkSwitcher() {
           <ChevronDown className="size-3 text-ink-muted" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-80 p-3 space-y-3">
+      <ClampedPopoverContent align="end" className="w-80 p-3 space-y-3">
         <div>
           <div className="mg-label mb-1.5">Network</div>
           <ul className="space-y-1">
@@ -218,7 +219,7 @@ export function NetworkSwitcher() {
         <p className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
           Unofficial registry · public read-only data
         </p>
-      </PopoverContent>
+      </ClampedPopoverContent>
     </Popover>
   );
 }

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -1,5 +1,6 @@
 import { Settings, Sun, Moon, Monitor, Rows3, Rows4 } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@jsonbored/ui-kit";
+import { Popover, PopoverTrigger } from "@jsonbored/ui-kit";
+import { ClampedPopoverContent } from "./clamped-popover-content";
 import { useTheme, type ThemeChoice } from "@/lib/theme";
 import { useDensity, type Density } from "@/lib/density";
 import { useHealthPalette, HEALTH_PALETTES, type HealthPaletteId } from "@/lib/health-palette";
@@ -33,9 +34,9 @@ export function SettingsPopover() {
           <Settings className="size-3.5" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-72 p-3">
+      <ClampedPopoverContent align="end" className="w-72 p-3">
         <SettingsPanel />
-      </PopoverContent>
+      </ClampedPopoverContent>
     </Popover>
   );
 }


### PR DESCRIPTION
## Summary
`NetworkSwitcher` (`w-80` = 320px) and `SettingsPopover` (`w-72` = 288px) each render a fixed-width Radix `PopoverContent` with no viewport clamp. Radix's collision-avoidance keeps a panel on-screen but does **not** shrink its fixed width, so on narrow devices the panel is pinned **flush against the screen edge** with no gutter — and at 320px the 320px NetworkSwitcher panel spans edge-to-edge (**#3945**).

## Change
Rather than copy-paste a clamp into each call site, extract **one shared `ClampedPopoverContent`** — a thin pass-through over the ui-kit `PopoverContent` — and route both popovers through it. It combines two things so the panel both fits *and* keeps a gutter:

- **`max-w-[calc(100vw-1.5rem)]`** — turns the caller's fixed width into a *maximum*, so it can shrink below `w-80`/`w-72` on narrow viewports.
- **`collisionPadding: 12`** — stops Radix from pinning that width flush to an edge, so the (possibly shrunk) panel sits inside a consistent gutter instead of bleeding to the device edge.

Callers keep passing their usual width class; the wrapper only ever caps + insets it. No change to popover **content**, and desktop/tablet rendering is unchanged (the panels already fit there with room to spare, so the clamp is a no-op). `tsc` / `prettier` clean.

Measured panel bounds (viewport `vw`, panel left→right px):

| Popover · width | Before | After |
| --- | --- | --- |
| NetworkSwitcher @ 320 | `0 → 320` (flush both edges) | `12 → 308` (12px gutter, shrunk to 296) |
| NetworkSwitcher @ 375 | `55 → 375` (flush right edge) | `43 → 363` (12px right gutter) |

Closes #3945

## Screenshots
Each popover opened at 320 / 375 / 768px, both themes. Before = panel flush to the screen edge; after = panel inside a consistent gutter (unchanged at 768px, where it already fits). NetworkSwitcher is always in the header; SettingsPopover is opened from the mobile menu below `md` and the header gear at `md+`.

### NetworkSwitcher (`w-80`)
| Viewport · Theme | Before | After |
| --- | --- | --- |
| 320 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-network-320-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-network-320-light.png) |
| 320 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-network-320-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-network-320-dark.png) |
| 375 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-network-375-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-network-375-light.png) |
| 375 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-network-375-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-network-375-dark.png) |
| 768 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-network-768-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-network-768-light.png) |
| 768 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-network-768-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-network-768-dark.png) |

### SettingsPopover (`w-72`)
| Viewport · Theme | Before | After |
| --- | --- | --- |
| 320 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-settings-320-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-settings-320-light.png) |
| 320 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-settings-320-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-settings-320-dark.png) |
| 375 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-settings-375-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-settings-375-light.png) |
| 375 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-settings-375-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-settings-375-dark.png) |
| 768 · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-settings-768-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-settings-768-light.png) |
| 768 · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/before-settings-768-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/after-settings-768-dark.png) |

### Screen recordings (each popover opening at 375px, after)
Click-triggered reveals, so a page-load screenshot can't show them opening:
- NetworkSwitcher: https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/network-open-375.webm
- SettingsPopover: https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945/settings-open-375.webm
