### PR TITLE
fix(ui): redesign the incident strip to lead with the affected subnet (#3951)

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -54,8 +54,8 @@ export function IncidentStrip() {
   if (!onOperationalRoute || active.length === 0) return null;
 
   const top = active[0]!;
-  const more = active.length - 1;
   const isDown = (top.state ?? "").toLowerCase() === "down";
+  const severity = isDown ? "Incident" : "Degraded";
 
   return (
     <div
@@ -67,44 +67,40 @@ export function IncidentStrip() {
           : "bg-health-warn/10 border-health-warn/30 text-ink-strong",
       )}
     >
-      <div className="max-w-shell-max mx-auto px-4 md:px-8 py-1.5 flex items-center gap-3">
+      <div className="max-w-shell-max mx-auto px-4 md:px-8 py-1.5 flex items-center gap-2.5">
         <AlertTriangle
           className={classNames(
             "size-3.5 shrink-0",
             isDown ? "text-health-down" : "text-health-warn",
           )}
         />
-        <span className="font-mono text-[10px] uppercase tracking-widest shrink-0">
-          {isDown ? "Incident" : "Degraded"}
-        </span>
-        <span className="min-w-0 flex-1 truncate">
-          {top.message ?? `Endpoint ${top.endpoint_id ?? top.id} reported ${top.state ?? "issue"}.`}
+        {/* #3951 redesign: lead with the AFFECTED entity + severity as one token,
+            so the banner always reads as that subnet's status — never the current
+            page's — and the old standalone label + trailing subnet link collapse
+            into it. A net simplification (fewer elements), not another chip. */}
+        <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest">
           {top.netuid != null ? (
-            <>
-              {" · "}
-              <Link
-                to="/subnets/$netuid"
-                params={{ netuid: top.netuid }}
-                className="underline hover:text-accent"
-              >
-                SN{top.netuid}
-              </Link>
-            </>
-          ) : null}
+            <Link
+              to="/subnets/$netuid"
+              params={{ netuid: top.netuid }}
+              className="text-ink-strong underline decoration-dotted underline-offset-2 hover:text-accent"
+            >
+              SN{top.netuid}
+            </Link>
+          ) : (
+            <span className="text-ink-strong">Network</span>
+          )}{" "}
+          <span className={isDown ? "text-health-down" : "text-health-warn"}>{severity}</span>
         </span>
-        {more > 0 ? (
-          <Link
-            to="/health"
-            className="hidden sm:inline-flex shrink-0 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
-          >
-            +{more} more
-          </Link>
-        ) : null}
+        <span className="min-w-0 flex-1 truncate text-ink-muted">
+          {top.message ?? `Endpoint ${top.endpoint_id ?? top.id} reported ${top.state ?? "issue"}.`}
+        </span>
         <Link
           to="/health"
           className="shrink-0 inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest hover:text-accent"
         >
-          View <ArrowRight className="size-3" />
+          {active.length > 1 ? `All ${active.length}` : "View"}
+          <ArrowRight className="size-3" />
         </Link>
         <button
           type="button"


### PR DESCRIPTION
## Summary

Closes #3951

The global incident strip led with a generic severity word ("Degraded") and buried the affected subnet in a trailing `· SNx` link, so on a subnet detail page the banner read as the **current** subnet's own status even when the incident was about a *different* subnet (#3951).

Rather than bolt a scope label onto an already-dense row, this **redesigns the strip around the affected entity**:
- **Lead with the subnet** (or "Network") + severity as one token, so the banner  is self-scoping at a glance and can't be misread as the current page's status.
- **Fold** the old standalone severity label *and* the trailing subnet link into  that leading token.
- **Merge** the separate "+N more" and "View" controls into one.

Net result is **fewer elements** (−4 lines) — a tighter, less-cluttered strip, not more text pushed across the bar.

## Changes
- `components/metagraphed/incident-strip.tsx` — restructured the strip header
  (affected-entity-first lead token; consolidated controls). No data/query changes.

## Screenshots

Incident strip on `/subnets/1` while the top active incident concerns SN10
(mocked for a deterministic capture). Captured from a single dev server with the
file toggled between base and redesign, so before/after share an identical
render environment.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3951-redesign/after-mobile-dark.png) |

## Validation
- `tsc --noEmit` ✓ · `prettier --check` (3.9.4) ✓ · `eslint` (0 errors) ✓ · `vitest` ✓ · `build` ✓
- 0-behind `main`; no new API call → no HAR re-record


