### PR TITLE
fix(ui): restore the newest-first indicator on the blocks controls row

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -232,6 +232,12 @@ function BlocksTable() {
 
   const filters = (
     <>
+      <span
+        className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
+        title="Blocks are listed newest first"
+      >
+        <span aria-hidden="true">↓ </span>Newest first
+      </span>
       <SearchInput
         value={search.author}
         onChange={(v) => setSearch({ author: v, offset: 0 })}


### PR DESCRIPTION
Closes #3988

## What

#3699 ("add author/range filters to Blocks list") added the six-input filter bar to `/blocks`' controls row and, in the same diff, deleted the sort-order label that used to sit there — `git show 8eb7b8e2 -- apps/ui/src/routes/blocks.index.tsx` shows exactly one line removed:

```diff
-      <span className="font-mono text-[11px] text-ink-muted">Newest first</span>
```

The feed still sorts newest-first (`/api/v1/blocks` always returns newest-first pages — the comment right above `BlocksTable`'s pagination logic still says so, and that behavior itself never changed), but nothing on screen communicated it anymore.

## Fix

Restores a `↓ Newest first` indicator at the start of the controls row, reusing the existing `font-mono text-[11px] text-ink-muted` token. The down-arrow glyph is wrapped in its own `aria-hidden="true"` span so a screen reader announces only "Newest first," not a bare arrow character. The six filter inputs and `ResetFiltersButton` are untouched.

## On the "empty gap" also reported in the issue

Traced this before touching anything: `git show 8eb7b8e2` above shows #3699 changed only the label span and the query-params construction — it introduced no margin/padding class anywhere in the file. The space above the filter bar is `BlockProductionHeader`'s own `mb-8` (added later, by #3488, on its stat-tile grid) plus `BlockThroughputCard`'s `mb-3` — the same section-spacing rhythm used elsewhere on this page, not a `/blocks`-specific artifact. Measured it directly: 32px between the stat-grid's bottom edge and the filter bar's top edge, exactly matching the intentional `mb-8`. There's nothing anomalous to correct, so this PR only fixes the one concrete, git-traceable regression — the missing indicator — rather than "fixing" spacing that already matches the page's convention.

## Screenshots

3 viewports × 2 themes, before/after, full page (controls row visible in all):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-blocks-newest-first-3988/after-mobile-dark.png)<br><sub>after</sub> |

Both servers ran against the same live data (a real `mainnet` snapshot with indexed blocks) so the before/after comparison is on identical content, isolating just the controls-row change.

## Acceptance criteria

- [x] `blocks.index.tsx` appears in the diff
- [x] A sort-order indicator ("Newest first" or equivalent) is visible in the controls row again
- [x] The reported spacing gap is confirmed, by direct measurement, to already match the page's normal section spacing — no change needed there
- [x] All six filter inputs continue to work exactly as before (untouched in the diff)
- [x] Before/after screenshot table across all 3 viewports × 2 themes

## Testing

```
npx tsc --noEmit         # no new errors (pre-existing unrelated errors reproduce identically on a clean checkout)
npx eslint src/routes/blocks.index.tsx    # clean aside from pre-existing CRLF line-ending noise (core.autocrlf), confirmed via `git diff --check` on the actual diff
npx prettier --check src/routes/blocks.index.tsx   # same CRLF-only noise, diff itself is clean
```

Diff is 6 insertions, 0 deletions, in the one file the issue names.
