### PR TITLE
fix(ui): route the #activity hash link to the Activity tab (#3978)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -200,6 +200,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   yield: "metagraph",
   turnover: "metagraph",
   validators: "validators",
+  activity: "activity",
   identity: "identity",
   hyperparameters: "hyperparameters",
   services: "services",


### PR DESCRIPTION
## Summary

`SECTION_TO_TAB` in `apps/ui/src/routes/subnets.$netuid.tsx` maps each section-anchor id to the tab that owns it, and `useHashScroll` uses it to switch tabs when a hash deep-link points at a section under a non-active tab. Every tab's section was mapped **except `activity`** — even though `ActivityPanel` renders inside `<SectionAnchor id="activity">` and only when `tab === "activity"`.

As a result, following `/subnets/<n>#activity` — including the link this page's own `SectionAnchor` "copy link" button generates (`section-anchor.tsx` writes `url.hash = id`) — did **not** switch to the Activity tab. `useHashScroll` looked up `sectionToTab["activity"]`, got `undefined`, and no-op'd; the page stayed on the default Overview tab. The page produced a self-link that didn't work.

Closes #3978

## Change

One line: add `activity: "activity"` to `SECTION_TO_TAB`, placed in tab order (right after `validators`). Now `useHashScroll` resolves `#activity` to the Activity tab, switches `?tab=activity`, and scrolls the anchor into view — exactly the path every other tab's hash link already takes. No other behavior changes.

## Screenshots

Following `/subnets/1#activity` (the copied deep link). **Before** = current: lands on the default **Overview** masthead, Activity tab never selected. **After** = fix: switches to the **Activity** tab (on-chain activity panel) and scrolls to the anchor. Mobile (375) / tablet (768) / desktop (1280), light + dark.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/before-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/after-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/after-desktop-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/before-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/after-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/after-tablet-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/before-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/after-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3978/3978/after-mobile-dark.png) |

## Validation

- `npx tsc --noEmit` (apps/ui) → clean
- `npm test` (apps/ui) → 679 tests passed (97 files)
- Change is a single map entry; no data-fetch, routing, or layout changes.
