### PR TITLE
fix(ui): clamp NetworkSwitcher and SettingsPopover panels to the viewport

### DIFF
--- a/apps/ui/src/components/metagraphed/clamped-popover-content.tsx
+++ b/apps/ui/src/components/metagraphed/clamped-popover-content.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { PopoverContent } from "@jsonbored/ui-kit";
+import { classNames } from "@/lib/metagraphed/format";
+
+/** Viewport gutter kept on every side (px). Matches the `max-w` inset below so
+ * a clamped panel is centred within the gutter rather than flush to one edge. */
+const VIEWPORT_GUTTER = 12;
+
+/**
+ * A `PopoverContent` that never renders wider than the viewport, with a small
+ * gutter on every side. Radix's collision-avoidance repositions a panel to keep
+ * it on-screen but does not shrink its fixed width — so a `w-80` (320px) /
+ * `w-72` (288px) panel is pinned flush against (and on the narrowest devices
+ * spills past) the screen edge, with no breathing room (#3945). Two things fix
+ * that together: a `max-w` of the viewport minus the gutters turns the caller's
+ * fixed width into a *maximum* (so it can shrink to fit), and a matching
+ * `collisionPadding` keeps Radix from pinning that width flush to an edge. The
+ * panel is unchanged where it already fits with room to spare; on narrow
+ * viewports it shrinks and sits inside a consistent gutter instead of bleeding
+ * to the device edge. Callers keep passing their usual width class.
+ */
+export const ClampedPopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverContent>,
+  React.ComponentPropsWithoutRef<typeof PopoverContent>
+>(({ className, collisionPadding = VIEWPORT_GUTTER, ...props }, ref) => (
+  <PopoverContent
+    ref={ref}
+    collisionPadding={collisionPadding}
+    className={classNames("max-w-[calc(100vw-1.5rem)]", className)}
+    {...props}
+  />
+));
+ClampedPopoverContent.displayName = "ClampedPopoverContent";

--- a/apps/ui/src/components/metagraphed/clamped-popover-content.tsx
+++ b/apps/ui/src/components/metagraphed/clamped-popover-content.tsx
@@ -7,17 +7,24 @@ import { classNames } from "@/lib/metagraphed/format";
 const VIEWPORT_GUTTER = 12;
 
 /**
- * A `PopoverContent` that never renders wider than the viewport, with a small
- * gutter on every side. Radix's collision-avoidance repositions a panel to keep
- * it on-screen but does not shrink its fixed width — so a `w-80` (320px) /
- * `w-72` (288px) panel is pinned flush against (and on the narrowest devices
- * spills past) the screen edge, with no breathing room (#3945). Two things fix
- * that together: a `max-w` of the viewport minus the gutters turns the caller's
- * fixed width into a *maximum* (so it can shrink to fit), and a matching
- * `collisionPadding` keeps Radix from pinning that width flush to an edge. The
- * panel is unchanged where it already fits with room to spare; on narrow
- * viewports it shrinks and sits inside a consistent gutter instead of bleeding
- * to the device edge. Callers keep passing their usual width class.
+ * A drop-in `PopoverContent` that always fits — and is legible — inside the
+ * viewport, on every screen size. The base primitive has three gaps that make
+ * these fixed-width header panels (`w-80` / `w-72`) read as broken on small
+ * screens (#3945):
+ *
+ *  - **Width:** Radix keeps a panel on-screen but never shrinks its fixed
+ *    width, so it pins flush to (or spills past) the edge. `max-w` of the
+ *    viewport-minus-gutters makes the caller's width a *maximum*, and a matching
+ *    `collisionPadding` stops Radix pinning it flush.
+ *  - **Height:** a tall panel (network list, settings sections) ran off the
+ *    bottom of short viewports with no way to reach the cut-off content. Cap the
+ *    height to Radix's collision-aware available height and let it scroll.
+ *  - **Surface:** the base `bg-popover` token renders transparent in this app's
+ *    theme, so page content showed straight through the panel. Paint an explicit
+ *    solid card surface so the panel is always opaque.
+ *
+ * Panels that already fit with room to spare are visually unchanged; only the
+ * constrained cases are corrected. Callers keep passing their usual width class.
  */
 export const ClampedPopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverContent>,
@@ -26,7 +33,12 @@ export const ClampedPopoverContent = React.forwardRef<
   <PopoverContent
     ref={ref}
     collisionPadding={collisionPadding}
-    className={classNames("max-w-[calc(100vw-1.5rem)]", className)}
+    className={classNames(
+      "max-w-[calc(100vw-1.5rem)]",
+      "max-h-[min(var(--radix-popover-content-available-height),calc(100dvh-1.5rem))] overflow-y-auto",
+      "bg-card text-ink",
+      className,
+    )}
     {...props}
   />
 ));

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Check, ChevronDown, Globe2, Pencil, TerminalSquare } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@jsonbored/ui-kit";
+import { Popover, PopoverTrigger } from "@jsonbored/ui-kit";
+import { ClampedPopoverContent } from "./clamped-popover-content";
 import { useApiBase, useNetwork } from "@/hooks/use-api-base";
 import { CHAIN_NETWORKS, LOCAL_DEV, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
@@ -81,7 +82,7 @@ export function NetworkSwitcher() {
           <ChevronDown className="size-3 text-ink-muted" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-80 p-3 space-y-3">
+      <ClampedPopoverContent align="end" className="w-80 p-3 space-y-3">
         <div>
           <div className="mg-label mb-1.5">Network</div>
           <ul className="space-y-1">
@@ -218,7 +219,7 @@ export function NetworkSwitcher() {
         <p className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
           Unofficial registry · public read-only data
         </p>
-      </PopoverContent>
+      </ClampedPopoverContent>
     </Popover>
   );
 }

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -1,5 +1,6 @@
 import { Settings, Sun, Moon, Monitor, Rows3, Rows4 } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@jsonbored/ui-kit";
+import { Popover, PopoverTrigger } from "@jsonbored/ui-kit";
+import { ClampedPopoverContent } from "./clamped-popover-content";
 import { useTheme, type ThemeChoice } from "@/lib/theme";
 import { useDensity, type Density } from "@/lib/density";
 import { useHealthPalette, HEALTH_PALETTES, type HealthPaletteId } from "@/lib/health-palette";
@@ -33,9 +34,9 @@ export function SettingsPopover() {
           <Settings className="size-3.5" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-72 p-3">
+      <ClampedPopoverContent align="end" className="w-72 p-3">
         <SettingsPanel />
-      </PopoverContent>
+      </ClampedPopoverContent>
     </Popover>
   );
 }


### PR DESCRIPTION
## Summary
Make the `NetworkSwitcher` and `SettingsPopover` header panels display correctly at every viewport. Both render a fixed-width Radix `PopoverContent`; three separate problems made them read as broken on smaller screens. All three are fixed once, in a shared `ClampedPopoverContent` wrapper that both popovers route through.

## The three fixes
1. **Opaque surface.** The base `bg-popover` token renders **transparent** in this app's theme (computed `rgba(0,0,0,0)`), so page content showed straight through the panels — the biggest "broken" tell. Paint an explicit solid card surface (`bg-card text-ink`).
2. **Height + scroll.** A tall panel (the network list, the settings sections) ran off the bottom of short viewports with the cut-off content unreachable. Cap the height to Radix's collision-aware available height (bounded by the viewport minus a gutter) and let it scroll.
3. **Width (the original #3945).** Radix keeps a panel on-screen but never shrinks its fixed width, so a `w-80`/`w-72` panel pinned flush to (or past) the edge. `max-w` of the viewport-minus-gutters makes the width a *maximum*, and a matching `collisionPadding` keeps it off the edge.

Panels that already fit are visually unchanged. `tsc` / `prettier` clean; verified opaque, fully reachable, and within the viewport at 375 / 768 / 1280 in both themes for both popovers.

Closes #3945

## Screenshots — before (this PR's prior revision) → after
Both popovers opened. **Before**: transparent panel (page bleeds through) and, on mobile, content running past the viewport. **After**: solid panel, clamped to the viewport, scrolls if tall.

### NetworkSwitcher
| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-net-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-net-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-net-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-net-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-net-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-net-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-net-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-net-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-net-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-net-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-net-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-net-mobile-dark.png) |

### SettingsPopover
| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-set-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-set-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-set-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-set-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-set-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-set-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-set-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-set-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-set-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-set-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/before-set-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3945-assets/3945-fix/after-set-mobile-dark.png) |