### PR TITLE
fix(ui): give GapsPanel the shared ErrorState on fetch failure (#3961)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -12,6 +12,7 @@ import {
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   EmptyState,
+  ErrorState,
   PageHeading,
   Skeleton,
   StaleBanner,
@@ -1397,7 +1398,7 @@ function CandidatesPanel({ netuid }: { netuid: number }) {
 }
 
 function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
-  const { data: gapsResult, isLoading, error } = useQuery(subnetGapsQuery(netuid));
+  const { data: gapsResult, isLoading, error, refetch } = useQuery(subnetGapsQuery(netuid));
   const gaps = gapsResult?.data;
   const missing = gaps?.missing_kinds ?? [];
   const notes = gaps?.gap_notes ?? [];
@@ -1411,11 +1412,7 @@ function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
   if (error) {
     return (
       <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
-        <EmptyState
-          title="Gaps unavailable"
-          description="The subnet gaps endpoint did not respond."
-          action={RECOVERY.gaps}
-        />
+        <ErrorState error={error} onRetry={() => void refetch()} context="gaps" />
       </SectionAnchor>
     );
   }


### PR DESCRIPTION
## Summary

`GapsPanel` (`apps/ui/src/routes/subnets.$netuid.tsx`) is the one tab-panel on the subnet detail page that manages its own `useQuery` loading/error instead of the `QueryErrorBoundary` + `Suspense` pattern every sibling tab uses. On a genuine fetch error it rendered the **same `EmptyState`** component/style used for the legitimate "No outstanding gaps" success case — just different copy ("Gaps unavailable"). There was no visually distinct error treatment: no red border, no retry, indistinguishable from success.

This makes it use the shared **`ErrorState`** — the same red-bordered `role="alert"` with a **Retry** button that every sibling tab (Surfaces, Endpoints, Callable services, Schemas, Metagraph, Validators, Activity) already gets via `QueryErrorBoundary`.

Closes #3961

## Change

Minimal, matches the existing shared component:
- Import `ErrorState` from `@/components/metagraphed/states` (same module `EmptyState` already comes from).
- Pull `refetch` off the existing `useQuery`.
- In the error branch, render `<ErrorState error={error} onRetry={() => void refetch()} context="gaps" />` instead of the success-styled `EmptyState`.

The success ("No outstanding gaps") and loading (`Skeleton`) branches are unchanged, and `ErrorState` surfaces the real HTTP status + message and wires Retry to the query's own `refetch`.

## Screenshots

Subnet detail → **Gaps** tab with the `/gaps` endpoint forced to `HTTP 500`. **Before** = the muted `EmptyState` that looks identical to the success empty state (no retry). **After** = the shared red `ErrorState` ("Couldn't load gaps · HTTP 500") with a Retry button. Mobile (375) / tablet (768) / desktop (1280), light + dark.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/before-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/after-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/after-desktop-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/before-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/after-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/after-tablet-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/before-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/after-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/3961/3961/after-mobile-dark.png) |

## Validation

- `npx tsc --noEmit` (apps/ui) → clean
- `npm test` (apps/ui) → 679 tests passed (97 files)
- Scoped to the `GapsPanel` error branch; loading/success/populated states unchanged.
