### PR TITLE
test(webhooks): cover the missing-data DoH answer-entry branch

### DIFF
--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -264,6 +264,23 @@ describe("resolveWebhookHostnamesWithDoh", () => {
     assert.deepEqual(addresses, ["8.8.8.8", "8.8.8.8"]);
   });
 
+  test("drops an Answer entry with no data field instead of throwing", async () => {
+    const fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          Answer: [{ TTL: 300 }, { data: "8.8.8.8" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    const addresses = await resolveWebhookHostnamesWithDoh("example.com", {
+      fetchImpl,
+      dnsJsonEndpoint: "https://dns.test/query",
+    });
+
+    assert.deepEqual(addresses, ["8.8.8.8", "8.8.8.8"]);
+  });
+
   test("a thrown/timed-out lookup for one record type doesn't discard a public answer from the other", async () => {
     const fetchImpl = async (url) => {
       const type = new URL(url).searchParams.get("type");


### PR DESCRIPTION
## Summary
- #5087 merged with `codecov/patch` at 96.15% (target 99%): `dnsJsonAddressAnswers`' `answer?.data || ""` fallback branch in `src/webhooks.mjs` (an `Answer` entry with no `data` field) was never exercised by a test.
- Adds a `resolveWebhookHostnamesWithDoh` test with an `Answer` entry missing `data`, confirming it's dropped instead of throwing.

## Test plan
- `npx vitest run tests/webhooks-core.test.mjs tests/alerter-hub.test.mjs tests/webhooks.test.mjs` — 160 passed
- Verified via v8 branch coverage that the target branch (`src/webhooks.mjs:159`, both sides) is now hit
- `npx prettier --check tests/webhooks-core.test.mjs`