### PR TITLE
fix(ui): stop the block-production Throughput tile wrapping on mobile

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -177,9 +177,15 @@ function BlockProductionHeader() {
       <StatTile
         icon={Activity}
         eyebrow="Throughput"
-        value={throughput ? `${formatNumber(throughput.mean_extrinsics_per_block)} ext/block` : "—"}
+        // #3940: keep the value a bare number like the sibling tiles -- baking
+        // "ext/block" into it made the value wrap mid-word on narrow tiles.
+        // The unit + secondary metric both live in the (already truncating)
+        // hint instead.
+        value={throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
         hint={
-          throughput ? `${formatNumber(throughput.mean_events_per_block)} events/block` : undefined
+          throughput
+            ? `ext/block · ${formatNumber(throughput.mean_events_per_block)} events/block`
+            : undefined
         }
       />
       <StatTile

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3396,7 +3396,7 @@ function StatTile({
                 truncate ? "items-baseline" : "flex-wrap items-baseline"
               ),
               children: [
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
                 hint ? /* @__PURE__ */ jsxRuntime.jsx(
                   "span",
                   {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3367,7 +3367,7 @@ function StatTile({
                 truncate ? "items-baseline" : "flex-wrap items-baseline"
               ),
               children: [
-                /* @__PURE__ */ jsx("span", { className: "min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
+                /* @__PURE__ */ jsx("span", { className: "shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl", children: value }),
                 hint ? /* @__PURE__ */ jsx(
                   "span",
                   {

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -77,7 +77,12 @@ export function StatTile({
             truncate ? "items-baseline" : "flex-wrap items-baseline",
           )}
         >
-          <span className="min-w-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
+          {/* #3940: shrink-0 so a long hint can't flex-shrink the value box
+              below its own content width -- without it, an unbreakable short
+              value (e.g. "24.85") still visibly overflows/wraps once the
+              combined width exceeds the tile, since only the hint (not the
+              value) is truncate-clipped. */}
+          <span className="shrink-0 font-display text-base font-semibold tabular-nums leading-none text-ink-strong sm:text-xl md:text-2xl">
             {value}
           </span>
           {hint ? (


### PR DESCRIPTION
Closes #3940

## Verification

Confirmed at mobile (375px): the `BlockProductionHeader`'s Throughput tile's value (`"24.14 ext/block"`) wraps onto a second line inside the tile, since the unit text was baked directly into the `value` prop rather than the `hint`. Screenshotted before making any change to establish the baseline.

## Root cause

`StatTile` (`packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx`) lays the value and hint out in a flex row with `min-w-0` on the value span — `min-w-0` lets a flex item shrink below its own content width, so once the tile's available width is exceeded (unavoidable in the 2-column mobile grid), the value itself gets squeezed and its text wraps instead of the (already-truncating) hint absorbing the overflow.

`blocks.index.tsx`'s Throughput tile compounded this by baking the unit into the value string (`` `${formatNumber(...)} ext/block` ``) instead of the hint, unlike its sibling tiles in the same row (Inter-block time, Author decentralization), which both keep the value a bare number and put units/secondary text in the hint.

## Fix

- **`stat-tile.tsx`**: value span `min-w-0` → `shrink-0`, so the value can never shrink below its own content width — it's the hint (already `truncate`-clipped) that absorbs constrained space, matching every sibling StatTile's actual behavior.
- **`blocks.index.tsx`**: Throughput tile's value is now a bare number (`formatNumber(throughput.mean_extrinsics_per_block)`), matching its siblings; `ext/block` moves into the hint alongside the existing `events/block` secondary metric.

`StatTile` is a shared component (19 call sites across `apps/ui`) — checked `/`, `/endpoints`, and `/leaderboards` at 375px after the change; every value across all three renders on a single line with no overflow or regression.

## Screenshots

3 viewports × 2 themes, before/after:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-bph-throughput-wrap-3940/after-mobile-dark.png)<br><sub>after</sub> |

Mobile is where the bug is most visible: "before" shows `24.14` wrapping onto its own line above `419.72…`; "after" shows a clean single-line `24.15` with the hint (`ext/block · ...`) truncating instead. Desktop/tablet are visually unaffected (already had enough room) — included per the repo's full-matrix requirement.

## Acceptance criteria

- [x] `blocks.index.tsx` appears in the diff
- [x] Before/after screenshots exist at mobile (375px) and tablet (768px), both themes (plus desktop, unaffected)
- [x] A real wrapping bug was found and fixed; the throughput tile's secondary value is fully legible at all tested widths
- [x] Desktop rendering (already correct) is unaffected

## Testing

```
npx tsc --noEmit            # 2 pre-existing unrelated errors reproduce identically on a clean checkout
npx eslint <changed files>  # clean aside from pre-existing CRLF line-ending noise (core.autocrlf), confirmed via `git diff --check`
npx prettier --check <changed files>   # same CRLF-only noise, diff itself is clean
```

`packages/ui-kit` rebuilt (`npm run build`) and `dist/index.js` + `dist/index.cjs` committed alongside the source change, per the workspace's dist-commit convention (`apps/ui`'s build must never depend on rebuilding a sibling workspace package). `dist/index.css` unaffected — checked, no diff.
