### PR TITLE
fix(ui): document the empty-state rule and align mismatched call sites (#3962)

### DIFF
--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -7,7 +7,7 @@ import {
   subnetPerformanceQuery,
   subnetPerformanceHistoryQuery,
 } from "@/lib/metagraphed/queries";
-import { TableState, StatTile, BarMini, Sparkline } from "@jsonbored/ui-kit";
+import { StatTile, BarMini, Sparkline } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
@@ -55,11 +55,9 @@ export function ConcentrationLoader({ netuid }: { netuid: number }) {
   const hasMetrics = Boolean(stake?.gini != null || emission?.gini != null);
   if (!hasMetrics) {
     return (
-      <TableState
-        variant="empty"
+      <EmptyState
         title="No concentration metrics"
         description="Stake- and emission-distribution metrics (Gini, HHI, Nakamoto coefficient) are computed from the metagraph snapshot and will appear here once captured."
-        generatedAt={meta?.generated_at}
       />
     );
   }
@@ -326,11 +324,9 @@ function PerformanceLoader({ netuid }: { netuid: number }) {
   const hasMetrics = Boolean(incentive?.gini != null || dividends?.gini != null);
   if (!hasMetrics) {
     return (
-      <TableState
-        variant="empty"
+      <EmptyState
         title="No reward-distribution metrics"
         description="Incentive- and dividend-distribution metrics (Gini, HHI, Nakamoto coefficient) plus the 0-1 trust/consensus score spread are computed from the metagraph snapshot and will appear here once captured."
-        generatedAt={meta?.generated_at}
       />
     );
   }

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -2,7 +2,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Coins, Flame, Award, Server, X } from "lucide-react";
 import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
-import { TableState, RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
+import { RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
+import { EmptyState } from "@/components/metagraphed/states";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -33,11 +34,9 @@ export function NeuronDetailCard({
 
   if (!n) {
     return (
-      <TableState
-        variant="empty"
+      <EmptyState
         title={`No snapshot for UID ${uid}`}
         description="This UID is not present in the current metagraph snapshot for this subnet."
-        generatedAt={meta?.generated_at}
       />
     );
   }

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -98,6 +98,26 @@ export function ErrorState({
   );
 }
 
+/**
+ * Empty-state component decision rule (#3962).
+ *
+ * The app has three empty-state primitives; use exactly one per context so a
+ * single route never shows two visually different "empty" treatments for no
+ * functional reason:
+ *
+ * - `EmptyState` (this component) — the DEFAULT for general list / card-grid /
+ *   section emptiness: a subtle dashed card with an optional last-checked line
+ *   and action link. Reach for this whenever a slice is simply empty and there
+ *   is no paginated-table retry wiring or registry-provenance story to tell.
+ * - `TableState` (`@jsonbored/ui-kit`) — paginated / query-backed TABLE
+ *   emptiness that shares empty / stale / error states and a retry CTA with the
+ *   table it belongs to (the registry tables on /endpoints, /surfaces,
+ *   /providers, subnet detail, …). Not for plain card grids or single sections.
+ * - `RegistryEmpty` (`./states/registry-empty`) — registry-PROVENANCE content
+ *   specifically: carries a variant badge, a freshness/staleness row, and an
+ *   evidence link. Keep it for surfaces/gaps-style panels where provenance is
+ *   part of the empty message; it is not a general-purpose empty state.
+ */
 export function EmptyState({
   title = "Nothing here yet",
   description,

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -60,6 +60,11 @@ const TONE = {
  * Unified empty/error/stale state for registry surfaces. Surfaces a clear
  * headline, a plain-language explainer, an optional freshness hint, and a
  * compact row of "next actions" so users always know what to do next.
+ *
+ * Scope: registry-PROVENANCE content specifically — the badge + freshness +
+ * evidence rows are the point. For plain list/grid emptiness use `EmptyState`,
+ * and for paginated-table emptiness use `TableState`; see the empty-state
+ * decision rule above `EmptyState` in `../states.tsx` (#3962).
  */
 export function RegistryEmpty({
   variant,

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -9,7 +9,6 @@ import {
   TimeAgo,
   CopyableCode,
   ExternalLink,
-  TableState,
   PageHero,
   PageSection,
   AnimatedNumber,
@@ -236,8 +235,7 @@ function ContractsList() {
   const rows = data.data ?? [];
   if (rows.length === 0) {
     return (
-      <TableState
-        variant="empty"
+      <EmptyState
         title="No contracts published"
         description="Versioned contracts will appear here once the registry ships its first envelope."
       />


### PR DESCRIPTION
## Summary

Closes #3962

The app grew three visually-distinct "this is empty" components — `EmptyState` (dashed card), `TableState variant="empty"` (solid rounded-xl block with an icon circle, `@jsonbored/ui-kit`), and `RegistryEmpty` (badge + freshness + evidence
rows) — used interchangeably, so one route could show two or three different empty treatments for no functional reason (#3962).

This **establishes and documents one decision rule**, then **applies it to the call sites that were demonstrably using the wrong component** — specifically `TableState` (whose own contract is "unified empty block for every registry **table**") used for **non-table** content (a card grid, chart/metrics panels, a per-UID detail card).

## The documented rule (added at each component definition)

- **`EmptyState`** — the default for general list / card-grid / section emptiness.
- **`TableState`** — paginated / query-backed **table** emptiness that shares  empty/stale/error + retry with its table. Not for card grids or single panels.
- **`RegistryEmpty`** — registry-**provenance** content only (badge + freshness +  evidence rows). Not a general-purpose empty state.

`RegistryEmpty`'s badge/freshness/evidence rows are genuinely distinct, so per the issue's non-goal it is **kept separate**, not collapsed.

## Call sites migrated (TableState → EmptyState, non-table content)

- `routes/schemas.tsx` — `ContractsList` is a **card grid**, and its sibling  `SchemaExplorer` on the same route already uses `EmptyState`; aligned for  same-route consistency.
- `components/metagraphed/concentration-panel.tsx` — two **metrics/chart** panels  ("No concentration metrics", "No reward-distribution metrics").
- `components/metagraphed/neuron-detail-card.tsx` — a per-UID **detail card**.

All were `variant="empty"` with no retry/error wiring, so nothing functional is lost. Broader app-wide review of ambiguous cases is left to a follow-up per the issue's "split into follow-up issues" allowance; this PR keeps to the Size-M cap (5 files).

## Screenshots

Captured with the repo's Playwright harness (fixed viewport, both themes) via a single dev server toggled between base and change, so before/after share an identical render environment.

### Concentration panel (`/subnets/1` → Metagraph tab)

| Viewport · Theme | Before (TableState) | After (EmptyState) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/concentration/after-mobile-dark.png) |

### Schemas · Contracts (`/schemas`)

| Viewport · Theme | Before (TableState) | After (EmptyState) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/schemas/after-mobile-dark.png) |

### Neuron detail card (`/subnets/1` → Metagraph tab, UID drill-in)

| Viewport · Theme | Before (TableState) | After (EmptyState) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3962-empty-state/neuron/after-mobile-dark.png) |

## Validation
- `tsc --noEmit` ✓ · `eslint` (0 errors) ✓ · `prettier --check` (3.9.4) ✓ · `vitest` (679 passed) ✓ · `build` ✓
- 5 files, +32/−14; 0-behind `main`


