### PR TITLE
fix(ui): map #activity hash to the Activity tab (#3978)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -200,6 +200,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   yield: "metagraph",
   turnover: "metagraph",
   validators: "validators",
+  activity: "activity",
   identity: "identity",
   hyperparameters: "hyperparameters",
   services: "services",


### PR DESCRIPTION
## Summary

`/subnets/<n>#activity` deep links — including the one the Activity section's own **copy-link** button generates — silently failed to switch the page to the **Activity** tab.

`subnets.$netuid.tsx` drives cross-tab deep links through `useHashScroll(tab, SECTION_TO_TAB)`: when an incoming hash's id maps to a tab in `SECTION_TO_TAB`, the hook switches the `?tab=` search param to that tab and scrolls the anchor into view. Every tab section had an entry **except** the `activity` section anchor (`<SectionAnchor id="activity">`), so `SECTION_TO_TAB["activity"]` was `undefined`, the hook's `if (expectedTab && expectedTab !== activeTab)` guard was never satisfied, and the tab never switched. The page produced a link to itself that didn't work.

## Fix

One line — add the missing `activity: "activity"` mapping, matching the pattern every sibling tab already has:

```diff
   validators: "validators",
+  activity: "activity",
   identity: "identity",
```

## Verification (before / after, same interaction)

Followed `/subnets/1?tab=overview#activity` on both the base commit and this branch, driven with Playwright:

| State | Result |
| --- | --- |
| **before** (no mapping) | `?tab` stays `overview` — page remains on the **Overview** tab (bug) |
| **after** (this PR) | `?tab` becomes `activity` — page switches to the **Activity** tab (fixed) |

This navigation behavior isn't captured by a static screenshot, so per the repo's animated-evidence requirement here is the before/after recording of following the `#activity` link:

### Hash-link navigation (animated)

| Target | Before | After |
| --- | --- | --- |
| Follow `/subnets/1#activity` (Activity section copy-link) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3978/before.gif" width="380">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3978/before.gif) | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3978/after.gif" width="380">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/3978/after.gif) |

In **before**, the view stays on the Overview masthead/KPI tiles after the hash navigation; in **after**, the same navigation lands on the Activity tab's on-chain event stream.

## Scope / gates

- One file, one line: `apps/ui/src/routes/subnets.$netuid.tsx`.
- Behavioral navigation-logic fix — no at-rest visual change to any tab or section.
- Local gates green: `lint`, `format:check`, `typecheck`, `test`, `test:e2e` (responsive-overflow HAR replay), `build` — all `--workspace=apps/ui`. No `packages/*/dist` drift.
- Branch rebased on current `main`.

Closes #3978
