### PR TITLE
feat(registry): add SN47 EvolAI dashboard surface

### DIFF
--- a/registry/subnets/evolai.json
+++ b/registry/subnets/evolai.json
@@ -114,6 +114,24 @@
         "https://huggingface.co/spaces/evolai/gate"
       ],
       "url": "https://evolai-gate.hf.space/datasets"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-47-evolai-dashboard",
+      "kind": "dashboard",
+      "name": "EvolAI validator Weights & Biases dashboard",
+      "notes": "Public Weights & Biases project the SN47 EvolAI validators log to (wandb.ai/open-evolai/evol-validator) — live validator run logs and loss-eval scoring metrics. Default entity open-evolai and project evol-validator are set in the official openevolai/evolai validator CLI (evolai/cli/commands/validator.py) via wandb.init. Publicly readable via the W&B API (observed runCount 92). Distinct host from the evolai.ai website and evolai-gate.hf.space API.",
+      "provider": "evolai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://github.com/openevolai/evolai/blob/main/evolai/cli/commands/validator.py"
+      ],
+      "url": "https://wandb.ai/open-evolai/evol-validator"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a **dashboard** surface for **SN47 EvolAI** — the public Weights & Biases project the subnet's validators log to, a surface kind the file did not yet have.

- **url:** https://wandb.ai/open-evolai/evol-validator (public W&B project, 92 runs)
- **source_url (proof):** https://github.com/openevolai/evolai/blob/main/evolai/cli/commands/validator.py — validators `wandb.init` under entity `open-evolai` / project `evol-validator`
- **kind:** dashboard (new kind; existing surfaces are source-repo / data-artifact / website / subnet-api)
- **host:** wandb.ai — distinct from evolai.ai and evolai-gate.hf.space

Verified: unauthenticated `api.wandb.ai/graphql` returns the project with `access USER_WRITE` and `runCount 92` (publicly readable).

## Validation
- `npm run validate:surface -- --file registry/subnets/evolai.json` → passed
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean

Closes #4051
