### PR TITLE
fix(ui): scan packages/ui-kit for Tailwind classes

### DIFF
--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -1,5 +1,6 @@
 @import "tailwindcss" source(none);
 @source "../src";
+@source "../../../packages/ui-kit/src";
 @import "tw-animate-css";
 
 @import "@jsonbored/ui-kit/styles.css";


### PR DESCRIPTION
## Summary

Issue #3994 asked to backfill genuine before/after screenshots for the semantic-search command palette (desktop + tablet, light + dark) after the original PR (#3847) shipped with invalid "before" evidence, and to confirm no real defect was hiding behind that gap.

While capturing genuine before (pre-feature, commit `cb1e76c6`) vs after (current `main`) screenshots, a real defect surfaced: **the command palette dialog rendered completely off-screen on the "after" build.**

### Root cause

`apps/ui/src/styles.css` only Tailwind `@source`-scans `apps/ui/src`:

```css
@source "../src";
```

The Command Palette's `CommandDialog` (and every other `Dialog` primitive) lives in `@jsonbored/ui-kit`, and `packages/ui-kit/src/styles.css` intentionally does **not** run Tailwind itself — the actual compile happens once, in `apps/ui`. So any utility class used exclusively inside ui-kit's component source (`top-[50%]`, `translate-x-[-50%]`, `translate-y-[-50%]`, `zoom-in-95`, the `[&_[cmdk-group-heading]]:...` selectors, etc.) never gets picked up by the scanner and is silently dropped from the compiled CSS.

Confirmed this is a real, currently-shipping bug — not a dev-server artifact — by running a full `npm run build --workspace=apps/ui` and grepping the emitted CSS: zero occurrences of `top-[50%]` / `translate-x-[-50%]` / `zoom-in-95` in the production bundle. In the browser, the dialog's computed style showed `position: fixed; top: 7372.75px; transform: none` — miscentered near the bottom of the ~9000px-tall homepage instead of the viewport center, because the classes controlling its position and centering transform were never generated.

### Fix

Add `packages/ui-kit/src` as a second Tailwind `@source` so its component source is scanned too:

```css
@source "../src";
@source "../../../packages/ui-kit/src";
```

Rebuilt and confirmed the previously-missing classes now compile into the CSS bundle, and the dialog now centers correctly (`top: 400px` on an 800px-tall viewport, `transform: matrix3d(...)` applying the intended scale/translate).

### Screenshot backfill

With the fix applied, recaptured all 6 viewport × theme combinations. The semantic-search "Semantic matches" group renders cleanly — no clipping, overlap, or contrast issues — everywhere, including the dialog centering fix itself (most visible on Desktop/Tablet, where the dialog was previously off-screen entirely).

| Viewport · Theme | Before | After |
| ---------------- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/semantic-search-3994-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run test --workspace=apps/ui -- --run` (678 tests passed)
- [x] `npm run build --workspace=apps/ui` — verified the previously-missing Tailwind classes now compile into the production CSS bundle
- [x] Manual verification: command palette opens centered and visible at desktop/tablet × light/dark, both on the broken baseline and with the fix applied

Closes #3994
