### PR TITLE
feat(registry): add SN62 Ridges sample-benchmark data-artifact surface (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -1,25 +1,12 @@
 {
-  "schema_version": 1,
-  "netuid": 62,
-  "name": "Ridges",
-  "slug": "sn-62",
-  "status": "active",
   "categories": [
     "agents",
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/ridgesai/ridges",
-  "dashboard_url": "https://taomarketcap.com/subnets/62",
-  "website_url": "https://www.ridges.ai/",
-  "notes": "Reviewed overlay for SN62 using the official Ridges source repository and public website identity. The website and common API/docs paths currently rate-limit simple probes, so they are not promoted as monitored operational surfaces.",
+  "contact": "hello@ridges.ai",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
-    "verified_at": "2026-06-08T09:25:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "Website exists but currently rate-limits simple probes.",
       "No verified docs site yet.",
@@ -27,49 +14,62 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T09:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/62",
+  "name": "Ridges",
+  "netuid": 62,
+  "notes": "Reviewed overlay for SN62 using the official Ridges source repository and public website identity. The website and common API/docs paths currently rate-limit simple probes, so they are not promoted as monitored operational surfaces.",
+  "schema_version": 1,
+  "slug": "sn-62",
+  "source_repo": "https://github.com/ridgesai/ridges",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-62-ridges-source",
-      "name": "Ridges source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/ridgesai/ridges",
-      "provider": "ridges",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/ridgesai/ridges"],
+      "id": "sn-62-ridges-source",
+      "kind": "source-repo",
+      "name": "Ridges source repository",
+      "notes": "Official Ridges source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Ridges source repository."
+      "provider": "ridges",
+      "public_safe": true,
+      "source_urls": ["https://github.com/ridgesai/ridges"],
+      "url": "https://github.com/ridgesai/ridges"
     },
     {
-      "id": "sn-62-ridges-subnet-api",
-      "name": "Ridges API — top agents leaderboard (retrieval)",
-      "kind": "subnet-api",
-      "url": "https://agent-upload.ridges.ai/retrieval/top-agents",
-      "provider": "ridges",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-62-ridges-subnet-api",
+      "kind": "subnet-api",
+      "name": "Ridges API — top agents leaderboard (retrieval)",
+      "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json.",
+      "provider": "ridges",
       "public_safe": true,
-      "schema_url": "https://agent-upload.ridges.ai/openapi.json",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dexterity104"
+      },
       "schema_status": "machine-readable",
+      "schema_url": "https://agent-upload.ridges.ai/openapi.json",
       "source_urls": [
         "https://github.com/ridgesai/ridges/blob/main/miners/cli/commands/upload.py",
         "https://raw.githubusercontent.com/ridgesai/ridges/main/miners/cli/commands/upload.py",
         "https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py",
         "https://raw.githubusercontent.com/ridgesai/ridges/main/api/endpoints/retrieval.py"
       ],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "dexterity104"
-      },
-      "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json."
+      "url": "https://agent-upload.ridges.ai/retrieval/top-agents"
     },
     {
       "auth_required": false,
@@ -91,7 +91,26 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-data-artifact",
+      "kind": "data-artifact",
+      "name": "Ridges sample benchmark tasks (ridges-bench)",
+      "notes": "Public GitHub repository of synthetic sample SWE benchmark tasks (Harbor-format: instruction.md, task.toml, environment, tests, solution) that Ridges miners can run their agent against locally before competing on-chain. Owned by the ridgesai GitHub org, whose profile self-identifies as \"Ridges | SN62\" (website ridges.ai) -- the same org that owns the already-registered official source repository. Distinct from the already-registered leaderboard subnet-api/openapi surfaces (agent-upload.ridges.ai).",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai",
+        "https://github.com/ridgesai/ridges-bench/blob/main/README.md"
+      ],
+      "url": "https://github.com/ridgesai/ridges-bench"
     }
   ],
-  "contact": "hello@ridges.ai"
+  "website_url": "https://www.ridges.ai/"
 }


### PR DESCRIPTION
## Summary

Issue #4069 asks to find and register SN62 Ridges' public **data artifact**. Several prior attempts at this issue were closed:

- Mirrors of third-party academic benchmarks (SWE-Bench Verified, Aider Polyglot) hosted under `ridgesai/abstract-agent-runner` — thin ownership evidence and raw dataset content risked secret-scanner false positives.
- Repeated `data-artifact` entries pointed at `agent-upload.ridges.ai/*` paths — the same host already registered as the `subnet-api`/`openapi` surfaces, making the evidence redundant/thin.

This PR registers a different, previously-untried surface: **[`ridgesai/ridges-bench`](https://github.com/ridgesai/ridges-bench)** — a public GitHub repository, in the same `ridgesai` org as the already-registered official source repo, containing synthetic sample SWE benchmark tasks (Harbor-format: `instruction.md`, `task.toml`, `environment/`, `tests/`, `solution/`) that Ridges miners run their `agent.py` against locally to iterate before competing on-chain. Its own README states it is "for Ridges" and links to the official `ridgesai/ridges` repo.

### Ownership proof

- `https://github.com/ridgesai` — the org's GitHub profile self-identifies as **"Ridges | SN62"** with website `ridges.ai`, matching the subnet's already-registered `website_url`.
- `https://github.com/ridgesai/ridges-bench/blob/main/README.md` — the repo's own README names Ridges and links to the official source repo.

### Change

Appended exactly one community surface to `registry/subnets/ridges.json` (no other fields touched):

```jsonc
{
  "id": "sn-62-ridges-data-artifact",
  "kind": "data-artifact",
  "name": "Ridges sample benchmark tasks (ridges-bench)",
  "url": "https://github.com/ridgesai/ridges-bench",
  "provider": "ridges",
  "authority": "community",
  "auth_required": false,
  "public_safe": true,
  "source_urls": ["https://github.com/ridgesai", "https://github.com/ridgesai/ridges-bench/blob/main/README.md"],
  "review": { "state": "community-submitted", "submitted_by": "claytonlin1110" }
}
```

## Validation

- [x] `npm run surface:add` — live-verified reachable + public-safe
- [x] `npm run validate:surface -- registry/subnets/ridges.json` — passed (4 surfaces across 1 subnet file)
- [x] `npm run scan:public-safety` — passed
- [x] `git diff --stat` — exactly one file changed: `registry/subnets/ridges.json`

Closes #4069
