### PR TITLE
fix(ui): keep the account Endpoint announcements heading on one line on mobile

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -448,7 +448,7 @@ function AccountFeedSectionSkeleton({
   info,
 }: {
   id: string;
-  title: string;
+  title: ReactNode;
   subtitle?: string;
   info?: string;
 }) {
@@ -1711,6 +1711,15 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
  * Non-blocking: shows a graceful empty state when the account announced no
  * endpoints (typical for non-miner accounts).
  */
+// #3938: the "Endpoint announcements" heading is a few characters longer than
+// its "Teardown activity" sibling and, with the section header's wide tracking,
+// wrapped to two lines at the 375px mobile width. Tighten the tracking a step on
+// mobile so it stays on one line, restoring the default wider tracking from the
+// sm breakpoint up (tablet/desktop are unchanged).
+const endpointAnnouncementsTitle = (
+  <span className="tracking-normal sm:tracking-wider">Endpoint announcements</span>
+);
+
 function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
   const servingResult = useQuery(accountServingQuery(ss58));
   const prometheusResult = useQuery(accountPrometheusQuery(ss58));
@@ -1726,7 +1735,7 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
     return (
       <AccountFeedSectionSkeleton
         id="endpoint-announcements"
-        title="Endpoint announcements"
+        title={endpointAnnouncementsTitle}
         subtitle={`Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing ${windowLabel} window.`}
       />
     );
@@ -1736,7 +1745,7 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
     return (
       <SectionAnchor
         id="endpoint-announcements"
-        title="Endpoint announcements"
+        title={endpointAnnouncementsTitle}
         subtitle={`Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing ${windowLabel} window.`}
         tone="accent"
       >
@@ -1767,7 +1776,7 @@ function AccountEndpointAnnouncementSection({ ss58 }: { ss58: string }) {
   return (
     <SectionAnchor
       id="endpoint-announcements"
-      title="Endpoint announcements"
+      title={endpointAnnouncementsTitle}
       subtitle={`Axon endpoint (AxonServed) and Prometheus telemetry (PrometheusServed) announcements for this account over the trailing ${windowLabel} window.`}
       tone="accent"
       info="The account-level companion to subnet serving + prometheus activity — counts how often this hotkey announced axon and Prometheus endpoints."


### PR DESCRIPTION
Closes #3938

## What

Tightens the account detail page's **"Endpoint announcements"** section heading tracking a step on mobile so it stays on one line at 375px — consistent with its shorter **"Teardown activity"** sibling. The heading is passed with `tracking-normal sm:tracking-wider` (shared across the loading / error / loaded states), narrowing it **~16px** at mobile width (measured **203px → 187px**) so the title, info icon, and 30D freshness badge sit on a single line. Tablet/desktop are unchanged (they restore the default wider tracking from the `sm` breakpoint up — so their before/after are identical, included for completeness).

**File:** `apps/ui/src/routes/accounts.$ss58.tsx` — the `AccountEndpointAnnouncementSection` heading (all three render states) + a one-line widening of `AccountFeedSectionSkeleton`'s `title` prop to `ReactNode` so the styled heading can be shared.

## Verify

- `npm run lint` (0 errors) · `format:check` · `typecheck` · `npm test` (679 pass) · `npm run build` — all green
- Measured at 375px (Space Grotesk loaded): heading renders on 1 line in both themes; width 203px → 187px

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-before-mobile-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-after-mobile-light.png" width="300"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-before-mobile-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-after-mobile-dark.png" width="300"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-before-tablet-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-after-tablet-light.png" width="300"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-before-tablet-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-after-tablet-dark.png" width="300"> |
| Desktop · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-before-desktop-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-after-desktop-light.png" width="300"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-before-desktop-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn3938-after-desktop-dark.png" width="300"> |
