### PR TITLE
feat(registry): add SN62 Ridges evaluation-set problem suite data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,26 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-data-artifact",
+      "kind": "data-artifact",
+      "name": "Ridges evaluation-set problem suite",
+      "notes": "Public, unauthenticated GET /evaluation-sets/all-latest-set-problems on the Ridges backend API returning the full machine-readable problem suite (set_id, problem_name, benchmark_family swe-bench, problem_suite_name, execution_spec) the subnet currently evaluates SWE agents against. agent-upload.ridges.ai is the DEFAULT_API_BASE_URL used by the official ridgesai/ridges miner CLI; the route is defined without auth in api/endpoints/evaluation_sets.py and mounted at the /evaluation-sets prefix in api/src/main.py.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/endpoints/evaluation_sets.py",
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/src/main.py",
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/commands/upload.py"
+      ],
+      "url": "https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `data-artifact` surface to a single subnet manifest —
`registry/subnets/ridges.json`. Append-only; no other files touched.

## Summary

- Registers SN62 Ridges' public evaluation-set problem suite as a `data-artifact`:
  the no-auth `GET /evaluation-sets/all-latest-set-problems` endpoint on the Ridges
  backend API, which returns the full machine-readable SWE-bench problem suite
  (`set_id`, `problem_name`, `benchmark_family`, `problem_suite_name`, `execution_spec`)
  the subnet currently evaluates SWE agents against.
- Ownership is first-party: `agent-upload.ridges.ai` is the `DEFAULT_API_BASE_URL`
  used by the official `ridgesai/ridges` miner CLI; the route is defined without auth
  in `api/endpoints/evaluation_sets.py` and mounted at the `/evaluation-sets` prefix
  in `api/src/main.py` (both pinned to commit `06459e9`).
- Complements the existing Ridges `source-repo`, `subnet-api`, and `openapi` surfaces
  with reference data the registry did not yet capture.

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems
- Source URL (proves the claim): https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/endpoints/evaluation_sets.py
- Provider slug: ridges

## Checklist

- [x] Changes exactly one `registry/subnets/ridges.json` file, append-only.
- [x] `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct kind + URL from the existing `subnet-api`/`openapi`).
- [x] Links a tracked issue that is still OPEN.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`

Closes #4069