### PR TITLE
fix(ui-kit): keep TreemapMini tail-tile text legible in skewed distributions

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3641,8 +3641,10 @@ function NoDataSpark({
   ] });
 }
 var sum = (ns) => ns.reduce((a, b) => a + b, 0);
-var MIN_TILE_W_FOR_VALUE = 12;
-var MIN_TILE_H_FOR_VALUE = 14;
+var MIN_TILE_W_FOR_LABEL = 16;
+var MIN_TILE_H_FOR_LABEL = 12;
+var MIN_TILE_W_FOR_VALUE = 16;
+var MIN_TILE_H_FOR_VALUE = 22;
 function worstRatio(areas, side) {
   if (areas.length === 0 || side <= 0) return Infinity;
   const s = sum(areas);
@@ -3730,15 +3732,15 @@ function TreemapMini({
             width: `${t.w}%`,
             height: `${t.h}%`
           },
-          children: /* @__PURE__ */ jsxRuntime.jsxs(
+          children: /* @__PURE__ */ jsxRuntime.jsx(
             "div",
             {
               className: "flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5",
               style: { background: t.color ?? "var(--accent)" },
-              children: [
+              children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
                 /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate font-mono text-[10px] font-medium leading-none text-accent-foreground", children: t.label }),
                 t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate font-mono text-[9px] leading-none text-accent-foreground/80", children: formatValue(t.value) }) : null
-              ]
+              ] }) : null
             }
           )
         },

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3612,8 +3612,10 @@ function NoDataSpark({
   ] });
 }
 var sum = (ns) => ns.reduce((a, b) => a + b, 0);
-var MIN_TILE_W_FOR_VALUE = 12;
-var MIN_TILE_H_FOR_VALUE = 14;
+var MIN_TILE_W_FOR_LABEL = 16;
+var MIN_TILE_H_FOR_LABEL = 12;
+var MIN_TILE_W_FOR_VALUE = 16;
+var MIN_TILE_H_FOR_VALUE = 22;
 function worstRatio(areas, side) {
   if (areas.length === 0 || side <= 0) return Infinity;
   const s = sum(areas);
@@ -3701,15 +3703,15 @@ function TreemapMini({
             width: `${t.w}%`,
             height: `${t.h}%`
           },
-          children: /* @__PURE__ */ jsxs(
+          children: /* @__PURE__ */ jsx(
             "div",
             {
               className: "flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5",
               style: { background: t.color ?? "var(--accent)" },
-              children: [
+              children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxs(Fragment, { children: [
                 /* @__PURE__ */ jsx("span", { className: "truncate font-mono text-[10px] font-medium leading-none text-accent-foreground", children: t.label }),
                 t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsx("span", { className: "truncate font-mono text-[9px] leading-none text-accent-foreground/80", children: formatValue(t.value) }) : null
-              ]
+              ] }) : null
             }
           )
         },

--- a/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
@@ -25,10 +25,19 @@ interface Rect {
 
 const sum = (ns: number[]) => ns.reduce((a, b) => a + b, 0);
 
-// A tile only shows its value readout when it is large enough to fit one without
-// clipping — width/height are percentages of the map box.
-const MIN_TILE_W_FOR_VALUE = 12;
-const MIN_TILE_H_FOR_VALUE = 14;
+// Inline text is only drawn on tiles big enough to hold it without overlapping
+// or truncating — width/height are percentages of the map box. In a skewed
+// distribution (one dominant validator, several tiny tail tiles) the tail tiles
+// squash to near-zero, so an always-drawn label stacked its value on top of
+// itself into illegible text (#3937). Instead: below the label threshold a tile
+// draws no inline text at all (its full label/value/share stay available via the
+// native `title` tooltip); the value only appears once the tile is tall enough
+// to fit a second line under the label. Thresholds are tuned for the smallest
+// (mobile) map size, so a tile legible there is legible at every larger width.
+const MIN_TILE_W_FOR_LABEL = 16;
+const MIN_TILE_H_FOR_LABEL = 12;
+const MIN_TILE_W_FOR_VALUE = 16;
+const MIN_TILE_H_FOR_VALUE = 22;
 
 /** Worst (largest) aspect ratio in a row laid along `side`. */
 function worstRatio(areas: number[], side: number): number {
@@ -162,13 +171,17 @@ export function TreemapMini({
             className="flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5"
             style={{ background: t.color ?? "var(--accent)" }}
           >
-            <span className="truncate font-mono text-[10px] font-medium leading-none text-accent-foreground">
-              {t.label}
-            </span>
-            {t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? (
-              <span className="truncate font-mono text-[9px] leading-none text-accent-foreground/80">
-                {formatValue(t.value)}
-              </span>
+            {t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? (
+              <>
+                <span className="truncate font-mono text-[10px] font-medium leading-none text-accent-foreground">
+                  {t.label}
+                </span>
+                {t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? (
+                  <span className="truncate font-mono text-[9px] leading-none text-accent-foreground/80">
+                    {formatValue(t.value)}
+                  </span>
+                ) : null}
+              </>
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
## Summary
`TreemapMini` (the stake-dominance treemap) drew each tile's **label unconditionally**. When one validator dominates a subnet's stake — the common case, not an edge case — the tail tiles squash to near-zero height, so the label stacked directly on top of the value into overlapping, illegible text, and the smallest tiles showed a bare truncated `#` with no value (**#3937**).

## Change
Gate the inline **label** the same way the **value** already was, in `packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx`:

- A tile draws its **label** only above a minimum tile size (`MIN_TILE_W_FOR_LABEL` / `MIN_TILE_H_FOR_LABEL`).
- It draws its **value** only once it's tall enough to fit a second line under the label (`MIN_TILE_H_FOR_VALUE` raised so the two never collide).
- Below the label threshold a tile draws **no inline text at all** — its full label / value / share stay available through the existing per-tile `title` tooltip.

Thresholds are percentages of the map box tuned for the smallest (mobile) render, so a tile that's legible there is legible at every larger width — no viewport ever shows overlapping or truncated text. Pure/dependency-free component unchanged otherwise; no change to the stake data or its computation. ui-kit rebuilt (`dist/` regenerated + committed). `tsc` / `prettier` clean.

Closes #3937

## Screenshots
Same skewed distribution (one dominant validator `#42` at 1.52M τ + a long tail, incl. the issue's `#226` ≈ 119.4k tile). **Before**: `#226`'s label and `119.4k τ` value overlap, and the next tile shows a bare truncated `#…` with no value. **After**: legible tiles show label + value; tiles too small draw no inline text (detail still on hover via the native `title`) — no overlap, no truncated bare `#`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/before-desktop-1280-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/after-desktop-1280-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/before-desktop-1280-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/after-desktop-1280-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/before-tablet-768-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/after-tablet-768-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/before-tablet-768-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/after-tablet-768-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/before-mobile-375-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/after-mobile-375-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/before-mobile-375-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-3937-assets/3937/after-mobile-375-dark.png) |
