### PR TITLE
fix(ui): stack PanelShell header controls on mobile to stop title/subtitle squeeze

### DIFF
--- a/apps/ui/src/components/metagraphed/panel-shell.tsx
+++ b/apps/ui/src/components/metagraphed/panel-shell.tsx
@@ -69,32 +69,34 @@ export function PanelShell({
   };
 
   const headerRight = (
-    <div className="flex items-center gap-2 min-w-0">
-      {isUsableTimestamp(meta?.generatedAt) ? (
-        <span
-          className={
-            "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] " +
-            (stale
-              ? "border-health-warn/40 bg-health-warn/10 text-health-warn"
-              : "border-border bg-paper/60 text-ink-muted")
-          }
-          title={meta?.generatedAt}
-        >
-          {stale ? "stale · " : "updated "}
-          <TimeAgo at={meta!.generatedAt} />
-        </span>
-      ) : null}
-      {refreshQueryKeys?.length ? (
-        <button
-          type="button"
-          onClick={onRefresh}
-          disabled={refreshing}
-          aria-label="Refresh panel"
-          className="inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:cursor-progress disabled:opacity-60"
-        >
-          <RefreshCw className={classNames("size-3", refreshing && "animate-spin")} />
-        </button>
-      ) : null}
+    <div className="flex flex-col items-end gap-1.5 sm:flex-row sm:items-center sm:gap-2 min-w-0">
+      <div className="flex items-center gap-2">
+        {isUsableTimestamp(meta?.generatedAt) ? (
+          <span
+            className={
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] " +
+              (stale
+                ? "border-health-warn/40 bg-health-warn/10 text-health-warn"
+                : "border-border bg-paper/60 text-ink-muted")
+            }
+            title={meta?.generatedAt}
+          >
+            {stale ? "stale · " : "updated "}
+            <TimeAgo at={meta!.generatedAt} />
+          </span>
+        ) : null}
+        {refreshQueryKeys?.length ? (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            aria-label="Refresh panel"
+            className="inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:cursor-progress disabled:opacity-60"
+          >
+            <RefreshCw className={classNames("size-3", refreshing && "animate-spin")} />
+          </button>
+        ) : null}
+      </div>
       {right}
     </div>
   );

--- a/apps/ui/tests/e2e/capture-operational-status-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-operational-status-screenshots.mjs
@@ -1,0 +1,92 @@
+/**
+ * Capture Operational status header screenshots for #5112 PR table.
+ *
+ * Captures the fixed viewport (not fullPage, not element crops) after scrolling
+ * the "Operational status" section into view so reviewers see what visitors see.
+ *
+ * Usage (dev server must already be running on BASE_URL):
+ *   VARIANT=before node tests/e2e/capture-operational-status-screenshots.mjs
+ *   VARIANT=after node tests/e2e/capture-operational-status-screenshots.mjs
+ *
+ * Writes to tmp/operational-status-screenshots/{VARIANT}-{viewport}-{theme}.png
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/operational-status-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "after" ? "after" : "before";
+const SUBNET_PATH = "/subnets/1";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openOperationalStatus(page) {
+  await page.goto(`${BASE_URL}${SUBNET_PATH}`, {
+    waitUntil: "networkidle",
+    timeout: 90_000,
+  });
+  await page.locator("#health-trends").waitFor({ state: "visible", timeout: 90_000 });
+
+  // Clear whatever the sticky masthead's *actual* rendered height is at this
+  // breakpoint (measured live, not guessed) plus a small margin.
+  const scrollToSection = () =>
+    page.evaluate(() => {
+      const section = document.getElementById("health-trends");
+      if (!section) return;
+      const header = document.querySelector("header");
+      const clearance = (header?.getBoundingClientRect().bottom ?? 0) + 12;
+      const top = section.getBoundingClientRect().top + window.scrollY - clearance;
+      window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+    });
+
+  // Scroll, then re-scroll after data-driven layout shifts (KPI tiles/queries
+  // resolving) settle, so the section header stays put in frame.
+  await scrollToSection();
+  await page.waitForTimeout(500);
+  await scrollToSection();
+  await page.waitForTimeout(300);
+}
+
+/** Fixed-viewport capture — never fullPage or element crop. */
+async function captureViewport(page, filePath) {
+  await page.screenshot({ path: filePath, fullPage: false });
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  for (const viewport of VIEWPORTS) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    for (const theme of THEMES) {
+      await setTheme(page, theme);
+      await openOperationalStatus(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await captureViewport(page, file);
+      console.log(`wrote ${file}`);
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

At 375px, `PanelShell`'s header packed the freshness badge, refresh button,
and whatever a consumer passed as `right` (e.g. `TimeRangeScrub` on the
Operational status panel) into one non-wrapping flex row shared with
`SectionAnchor`'s `shrink-0` right column. That forced the title/subtitle's
`flex-1 min-w-0` column down to near-zero width, so the subtitle wrapped
character-by-character and the title crowded the controls.

Fix: stack the header controls (badge+refresh, then the `right` slot) into a
column below the `sm` (640px) breakpoint, so they claim only their own
content width instead of squeezing the title/subtitle column. Unchanged
single-row layout from `sm` up — confirmed pixel-identical before/after at
tablet and desktop.

`ResourceExplorer`'s "Public resources" panel (same `PanelShell`) was already
unaffected — it has no freshness badge and its own `right` controls
(`SegmentBar` + `FiltersTrigger`) already have a compact mobile variant.

- `apps/ui/src/components/metagraphed/panel-shell.tsx` — the fix.
- `apps/ui/tests/e2e/capture-operational-status-screenshots.mjs` — the
  Playwright script used to generate the before/after table below (fixed
  viewport, never fullPage, scrolled to `#health-trends`).

## Screenshots

| Viewport · Theme | Before | After |
| ----------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5112-after-mobile-dark.png)<br><sub>after</sub> |

All shots scrolled to the Operational status section on `/subnets/1`. Mobile
before clearly shows the subtitle wrapping one word per line and the header
controls crowding the title; mobile after shows the subtitle wrapping
normally with the controls stacked cleanly to the right, no overlap.
Tablet/desktop are pixel-identical before vs. after.

## Validation

```
npm run lint --workspace=apps/ui
npm run format:check --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui
npm run test:e2e --workspace=apps/ui
npm run build --workspace=apps/ui
```

All green. Also manually verified in a live dev server: the time-range chips
and refresh button remain fully interactive at 375px after the layout change.

Closes #5112
