### PR TITLE
fix(ui): make activity-heatmap day cells keyboard-focusable (#3955)

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -125,7 +125,9 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
                 <Tooltip key={c.key} delayDuration={120}>
                   <TooltipTrigger asChild>
                     <div
-                      className="aspect-square rounded-[2px] border border-border/40"
+                      role="button"
+                      tabIndex={0}
+                      className="mg-focus-ring aspect-square rounded-[2px] border border-border/40"
                       style={{ background: tone(c.score, maxScore) }}
                       aria-label={`${c.key}: ${c.probes} probes, ${c.incidents} incidents`}
                     />


### PR DESCRIPTION
## Summary
The Registry activity heatmap (`apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx`) wraps each day cell in a Radix `Tooltip` around a bare `<div>` that has only an `aria-label` — no `tabIndex` or `role`. A bare `<div>` is never in the tab order, so keyboard users can never focus a cell, and Radix (which opens a tooltip on focus) never reveals that day's probes / incidents / uptime. The sibling `subnet-pulse-grid.tsx` already works because its cells are `<Link>`s, which are naturally focusable.

## Change
Make each day cell a focusable `role="button"` `tabIndex={0}` and apply the shared `mg-focus-ring` `:focus-visible` treatment (the ui-kit token the design system designates for focus rings). No content or data change; **at-rest rendering is unchanged** — the ring only appears on keyboard focus. One file, +3/-1, matching the sibling's focusable-cell pattern rather than adding a new mechanism.

## Verification
- `npm run typecheck --workspace=apps/ui` — pass
- `npm run test --workspace=apps/ui` — pass (679 tests)
- `eslint` on the changed file — clean
- Screenshots below captured with Playwright at 1280 / 768 / 375 × light/dark, per the Phase C2 contract.

## Screenshots
At-rest layout is identical (this is an a11y-only change). **Before** = focusing a day cell does nothing (it is not in the tab order), so no ring and no tooltip. **After** = the focused cell shows the `mg-focus-ring` and its Radix tooltip. Subnet 64.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/after-mobile-dark.png)<br><sub>after</sub> |

Closes #3955
