### PR TITLE
fix(ui): stop the account address copy icon clipping at the mobile edge (#3944)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -201,8 +201,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
               Cross-subnet registrations, first-party chain events, and daily activity rollups for
               one Bittensor account.
             </p>
-            <div className="max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
-              <CopyableCode value={ss58} truncate={false} />
+            <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+              <CopyableCode value={ss58} truncate={false} className="max-w-full" />
             </div>
           </div>
         }


### PR DESCRIPTION
## Summary
On `/accounts/$ss58` the full ss58 address renders inside a `max-w-fit` wrapper around the shared `CopyableCode` button (`apps/ui/src/routes/accounts.$ss58.tsx`). Because the button is `inline-flex` and the wrapper is sized to `fit-content`, the button's width is never bounded on mobile — so the code's `truncate` never engages. Measured at 375px: the button's right edge lands at **382px (7px past the viewport)** and the trailing copy icon sits flush at **373px (~2px gutter)**, i.e. clipped against the screen edge.

## Change
Bound the box to the viewport **on mobile only**: `max-w-full sm:max-w-fit` on the wrapper plus `max-w-full` on this call site's `CopyableCode`. The mobile `truncate` now engages, and the copy icon keeps a full **~38px** gutter inside the edge. Scoped to this usage — the shared `CopyableCode` component and its other call sites are untouched (per the issue's non-goal). One file, +2/-2.

## Verification
- `npm run typecheck --workspace=apps/ui` — pass
- `npm run test --workspace=apps/ui` — pass (679 tests)
- `eslint` on the changed file — no new errors
- Measured geometry, 375px: before button-right `382` / icon-gap `2px` → after button-right `346` / icon-gap `38px`, button fully inside the viewport, mobile truncation engaged.
- sm+ (tablet 768 / desktop 1280) geometry **identical before/after** — the compact `fit-content` box is preserved (shown below for no-regression).

## Screenshots
Subnet-agnostic account `5FLoW…Rv8m`. **Mobile** rows show the fix (before = icon clipped at the edge; after = address truncates, icon fully visible with a gutter). **Desktop / Tablet** rows are unchanged (the box is `≥sm:max-w-fit` there and the address already fits).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/3944/after-mobile-dark.png)<br><sub>after</sub> |

Closes #3944
