### PR TITLE
fix(data-api): normalize HEAD through edge cache to prevent Postgres cache-bypass

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -75,6 +75,9 @@ function rowsForSql(sql) {
       { snapshot_date: "2026-06-27", stake_tao: 1, emission_tao: 1 },
     ];
   }
+  if (sql.includes("FROM neurons")) {
+    return [{ captured_at: 1_750_009_000_000 }];
+  }
   return [];
 }
 
@@ -882,6 +885,99 @@ describe("analytics edge cache", () => {
       "the per-response fallback marker must block cache.put",
     );
     assert.equal(cache.store.size, 0);
+  });
+
+  test("HEAD requests use the GET edge-cache key while returning HEAD semantics", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv([]);
+    const request = new Request("https://api.metagraph.sh/api/v1/test", {
+      method: "HEAD",
+    });
+    let buildCalls = 0;
+    let buildMethod = null;
+
+    const first = await withEdgeCache(
+      request,
+      ctx,
+      env,
+      "unit",
+      async (req) => {
+        buildCalls += 1;
+        buildMethod = req.method;
+        return envelopeResponse(
+          req,
+          {
+            data: { ok: true },
+            meta: { generated_at: LAST_RUN_AT },
+          },
+          "short",
+        );
+      },
+    );
+    await Promise.resolve();
+
+    assert.equal(first.status, 200);
+    assert.equal(await first.text(), "");
+    assert.equal(buildMethod, "GET");
+    assert.equal(buildCalls, 1);
+    assert.deepEqual(cache.putKeys, [expectedKey("unit", "/api/v1/test")]);
+
+    const second = await withEdgeCache(
+      request,
+      ctx,
+      env,
+      "unit",
+      async (_req) => {
+        buildCalls += 1;
+        throw new Error("cached HEAD should not rebuild");
+      },
+    );
+
+    assert.equal(second.status, 200);
+    assert.equal(await second.text(), "");
+    assert.equal(buildCalls, 1);
+    assert.equal(cache.matchCalls, 2);
+  });
+
+  test("HEAD /api/v1/validators reuses the GET edge cache before the Postgres tier", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const dataApiMethods = [];
+    const env = {
+      ...analyticsEnv([]),
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        async fetch(request) {
+          dataApiMethods.push(request.method);
+          return Response.json({
+            schema_version: 1,
+            sort: "subnet_count",
+            limit: 20,
+            captured_at: null,
+            block_number: null,
+            validator_count: 0,
+            validators: [],
+          });
+        },
+      },
+    };
+    const request = new Request("https://api.metagraph.sh/api/v1/validators", {
+      method: "HEAD",
+    });
+
+    const first = await handleRequest(request, env, ctx);
+    await Promise.resolve();
+    const second = await handleRequest(request, env, ctx);
+
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    assert.equal(await first.text(), "");
+    assert.equal(await second.text(), "");
+    assert.deepEqual(dataApiMethods, ["GET"]);
+    assert.equal(cache.matchCalls, 2);
   });
 
   test("NO-CACHE-ON-ERROR: a D1 failure with a snapshot stamp is served but not cached", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1343,7 +1343,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       ctx,
       env,
       "global-validators",
-      () => handleGlobalValidators(request, env, url),
+      (cacheRequest) => handleGlobalValidators(cacheRequest, env, url),
       validatorsCache.cachePathAndSearch,
       (edgeEnv) => readNeuronsCacheStamp(edgeEnv),
     );
@@ -1948,9 +1948,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         Number(metagraphMatch[1]),
         "subnet-metagraph",
-        () =>
+        (cacheRequest) =>
           handleSubnetMetagraph(
-            request,
+            cacheRequest,
             env,
             Number(metagraphMatch[1]),
             resolved.url,

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -349,7 +349,17 @@ export async function withEdgeCache(
   cachePathAndSearch = null,
   resolveCacheStamp = null,
 ) {
-  const cache = request.method === "GET" ? globalThis.caches?.default : null;
+  const isHead = request.method === "HEAD";
+  // Only opt HEAD into the GET cache path for handlers that accept the
+  // normalized request. Legacy zero-arg builders may close over the original
+  // HEAD request and return a bodyless response, which must not seed the GET
+  // cache for later clients.
+  const normalizesHead = isHead && buildResponse.length > 0;
+  const cacheRequest = normalizesHead
+    ? new Request(request, { method: "GET" })
+    : request;
+  const cache =
+    cacheRequest.method === "GET" ? globalThis.caches?.default : null;
   // Cheap freshness read. On a hit this + the cache match is the whole request
   // (no D1 aggregation at all for the handler body).
   let stamp = null;
@@ -362,7 +372,7 @@ export async function withEdgeCache(
   }
   let cacheKey = null;
   if (cache && stamp) {
-    const url = new URL(request.url);
+    const url = new URL(cacheRequest.url);
     const cacheRoute = cachePathAndSearch ?? `${url.pathname}${url.search}`;
     cacheKey = new Request(
       `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
@@ -376,12 +386,14 @@ export async function withEdgeCache(
       if (ifNoneMatchSatisfied(request, hit.headers.get("etag"))) {
         return new Response(null, { status: 304, headers: hit.headers });
       }
-      return hit;
+      return normalizesHead
+        ? new Response(null, { status: hit.status, headers: hit.headers })
+        : hit;
     }
   }
   const fallbackGeneration = d1FallbackGeneration;
   const pgFallbackGeneration = currentPostgresTierFallbackGeneration();
-  const response = await buildResponse();
+  const response = await buildResponse(cacheRequest);
   // Never cache errors / non-200s (cold-D1 still returns a 200 empty envelope;
   // a 400 bad-window or 5xx must not be persisted).
   if (
@@ -393,7 +405,9 @@ export async function withEdgeCache(
   ) {
     ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
   }
-  return response;
+  return normalizesHead
+    ? new Response(null, { status: response.status, headers: response.headers })
+    : response;
 }
 
 // D1 MAX(captured_at) is INTEGER but often surfaces as a numeric string; coerce


### PR DESCRIPTION
### Motivation
- Public read `HEAD` probes were being converted to `GET` only inside the Postgres tier, which allowed uncached `HEAD` requests to bypass the outer edge cache and force repeated `DATA_API`/Postgres work, amplifying origin cost and hurting availability.
- The intent is to ensure `HEAD` probes hit the same GET cache key as normal `GET` requests, while preserving final HEAD semantics for clients.

### Description
- Change `withEdgeCache` in `workers/request-handlers/analytics.mjs` to normalize eligible `HEAD` requests to a `GET` `cacheRequest` before cache lookup, compute the cache key from `cacheRequest.url`, call `buildResponse` with `cacheRequest`, and strip the body back to HEAD semantics on both cache hits and misses when appropriate.  It only opts-in HEAD normalization for builders that accept a parameter (`buildResponse.length > 0`) to avoid seeding the GET cache with legacy bodyless HEAD builders. 
- Update top-level routing in `workers/api.mjs` so cacheable handlers that may call the Postgres tier (examples: `/api/v1/validators` and per-subnet metagraph) receive the normalized `cacheRequest` from the cache wrapper so Postgres-backed HEAD probes reuse/populate the GET edge cache instead of bypassing it. 
- Add regression coverage in `tests/analytics-edge-cache.test.mjs` to assert that generic `HEAD` requests use the GET edge-cache key while still returning HEAD semantics and that `HEAD /api/v1/validators` reuses the GET edge cache (so the `DATA_API` sees `GET` only when necessary and only once). A small SQL fixture insertion ensures neuron `captured_at` is available to cache-stamp neuron-tier routes. 

### Testing
- Ran `npm test -- tests/analytics-edge-cache.test.mjs` and the analytics edge-cache test file passed (`44 tests` passed). 
- Ran formatting and linting checks with `npm run format:check` and `npm run lint` on the touched files and they succeeded. 
- Local test runs exercised both cache-hit and cache-miss paths and verified `DATA_API` was called with `GET` while repeated `HEAD` probes hit the edge cache rather than re-invoking the Postgres-backed path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54a3072048832c87df030bfcb89561)