### PR TITLE
fix(ui): stack Operational-status header controls on mobile so title/subtitle keep usable width

### DIFF
--- a/apps/ui/src/components/metagraphed/panel-shell.tsx
+++ b/apps/ui/src/components/metagraphed/panel-shell.tsx
@@ -69,7 +69,7 @@ export function PanelShell({
   };
 
   const headerRight = (
-    <div className="flex items-center gap-2 min-w-0">
+    <div className="flex flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-2 min-w-0">
       {isUsableTimestamp(meta?.generatedAt) ? (
         <span
           className={


### PR DESCRIPTION
## Summary
Fixes the mobile layout break on the **Operational status** section (`/subnets/{netuid}`, overview tab).

At <640px, `PanelShell`'s `headerRight` (freshness pill + refresh + `TimeRangeScrub`) rendered as one ~286px-wide row inside `SectionAnchor`'s `shrink-0` column, squeezing the `min-w-0 flex-1` title/subtitle column to **~33px** — so the subtitle wrapped one word per line and the title collided with the controls.

## Fix
One file — `apps/ui/src/components/metagraphed/panel-shell.tsx`:
- `headerRight` now **stacks vertically on mobile** (`flex flex-col items-end gap-1`) and restores the row at `sm+` (`sm:flex-row sm:items-center sm:gap-2`).
- This narrows the right column to its widest control (~144px), returning usable width to the title/subtitle. `SectionAnchor` is untouched.

## Acceptance criteria — verified live at 375px
- ✅ Subtitle wraps normally (full-width, not one word per line)
- ✅ Title and right-side controls no longer collide
- ✅ Desktop/tablet rendering unchanged (`sm:flex-row`)
- ✅ Controls (window toggle, refresh, freshness) remain fully functional

Closes #5112

## Screenshots
`/subnets/1` Operational-status header, 3 viewports × both themes. **Before** = `upstream/main`; **After** = this branch.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-5112-assets/5112/after-mobile-dark.png) |

## Validation
- Verified live (built + served, Playwright at 375px): title column ~33px → usable; subtitle wraps normally; no collision. `tsc`/`prettier` clean.