### PR TITLE
feat(ui): add windowed event-summary rollup tile to the subnet masthead (#3486)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -31,6 +31,7 @@ import {
 import {
   subnetEndpointsQuery,
   subnetDeregistrationsQuery,
+  subnetEventSummaryQuery,
   subnetHealthPercentilesQuery,
   subnetRegistrationsQuery,
   subnetTrajectoryQuery,
@@ -97,6 +98,16 @@ function classifyKind(k: unknown): string {
   for (const b of KIND_BUCKETS) if (b.id !== "other" && b.match(key)) return b.id;
   return "other";
 }
+
+// On-token palette for the event-summary category stack — cycled across the
+// top event categories (registration, stake, serving, …) in count order.
+const CATEGORY_COLORS = [
+  "var(--accent)",
+  "var(--ink-strong)",
+  "var(--health-ok)",
+  "var(--health-warn)",
+  "var(--border)",
+] as const;
 
 // Collapse the per-surface daily uptime history into a single subnet-wide
 // time-series: for each day, the mean uptime % and mean p50 latency across all
@@ -175,8 +186,31 @@ export function SubnetMasthead({
   const { data: pctRes } = useQuery(subnetHealthPercentilesQuery(netuid));
   const { data: regRes } = useQuery(subnetRegistrationsQuery(netuid));
   const { data: deregRes } = useQuery(subnetDeregistrationsQuery(netuid));
+  const { data: eventsRes } = useQuery(subnetEventSummaryQuery(netuid));
   const reg = regRes?.data;
   const dereg = deregRes?.data;
+
+  // Windowed on-chain event rollup for the aggregate "Activity" tile — one
+  // consolidated call in place of several per-kind queries. Top categories by
+  // event volume drive the mini-stack; days with no events degrade to a dash.
+  const eventSummary = eventsRes?.data;
+  const topCategories = [...(eventSummary?.categories ?? [])]
+    .sort((a, b) => b.event_count - a.event_count)
+    .slice(0, CATEGORY_COLORS.length);
+  const categorySegments = topCategories
+    .map((c, i) => ({
+      label: c.category,
+      value: c.event_count,
+      color: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+    }))
+    .filter((s) => s.value > 0);
+  const activityHint = categorySegments.length
+    ? categorySegments
+        .slice(0, 3)
+        .map((s) => `${formatNumber(s.value)} ${s.label}`)
+        .join(" · ")
+    : "on-chain events";
+  const activityAt = eventSummary?.observed_at ?? eventsRes?.meta?.generated_at ?? generatedAt;
 
   // Subnet-wide daily uptime % + median latency, meaned across tracked surfaces.
   const trendWindowKey = uptimeRes?.data?.window ?? "90d";
@@ -436,6 +470,15 @@ export function SubnetMasthead({
           full={`Neuron-deregistration (eviction) events on this subnet over the trailing ${dereg?.window ?? "30d"} window.`}
           updatedAt={dereg?.observed_at ?? null}
           windowLabel={dereg?.window ?? "30d"}
+        />
+        <StatWithSpark
+          label="Activity"
+          value={formatNumber(eventSummary?.total_events)}
+          hint={activityHint}
+          full="Windowed on-chain event rollup for this subnet (registrations, stake, serving, transfers, etc.)"
+          updatedAt={activityAt}
+          windowLabel={eventSummary?.window ?? "7d"}
+          viz={<MiniStack segments={categorySegments} />}
         />
         <StatWithSpark
           label="Participants"

--- a/apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetEventSummary, subnetEventSummaryQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7",
+  });
+}
+
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+describe("normalizeSubnetEventSummary", () => {
+  it("passes a well-formed rollup through, keeping its categories", () => {
+    const card = normalizeSubnetEventSummary(7, {
+      schema_version: 1,
+      netuid: 7,
+      window: "7d",
+      observed_at: "2026-07-01T00:00:00Z",
+      total_events: 12,
+      kind_count: 4,
+      category_count: 2,
+      limit: 5,
+      categories: [
+        { category: "stake", event_count: 8, kind_count: 2, amount_tao: 1.5, alpha_amount: 0.5 },
+        { category: "registration", event_count: 4, kind_count: 2 },
+      ],
+    });
+    expect(card.total_events).toBe(12);
+    expect(card.category_count).toBe(2);
+    expect(card.categories).toHaveLength(2);
+    expect(card.categories[0]).toMatchObject({
+      category: "stake",
+      event_count: 8,
+      amount_tao: 1.5,
+    });
+  });
+
+  it("degrades cold / junk to a zeroed rollup with no categories (never NaN)", () => {
+    for (const raw of [{}, null, { total_events: "nope", categories: "nope" }]) {
+      const card = normalizeSubnetEventSummary(7, raw);
+      expect(card.netuid).toBe(7);
+      expect(card.total_events).toBe(0);
+      expect(card.category_count).toBe(0);
+      expect(card.categories).toEqual([]);
+    }
+  });
+
+  it("drops non-object category entries defensively", () => {
+    const card = normalizeSubnetEventSummary(7, {
+      categories: [null, "bad", { category: "serving", event_count: 3 }],
+    });
+    expect(card.categories).toHaveLength(1);
+    expect(card.categories[0].category).toBe("serving");
+  });
+});
+
+describe("subnetEventSummaryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits its route with an explicit window param", async () => {
+    resolveWith({ netuid: 7, total_events: 9 });
+    const res = await runQuery(subnetEventSummaryQuery(7, "30d"));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/event-summary",
+      expect.objectContaining({ params: { window: "30d" } }),
+    );
+    expect(res.data.total_events).toBe(9);
+  });
+
+  it("defaults to the 7d window", async () => {
+    resolveWith({});
+    await runQuery(subnetEventSummaryQuery(7));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/event-summary",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -168,6 +168,8 @@ import type {
   Subnet,
   SubnetAxonRemovals,
   SubnetDeregistrations,
+  SubnetEventCategorySummary,
+  SubnetEventSummary,
   SubnetStakeMoves,
   SubnetServing,
   SubnetPrometheus,
@@ -5097,6 +5099,63 @@ export const subnetDeregistrationsQuery = (netuid: number, window = "30d") =>
       };
     },
     staleTime: STALE_MED,
+  });
+
+// #3486: windowed on-chain event-summary rollup for one subnet — total event
+// count plus per-category/per-kind aggregates over a 7d/30d/90d window. The
+// dashboard-friendly companion to the raw per-event feed the Activity tab
+// renders; consolidates what would otherwise be several per-kind calls.
+function normalizeSubnetEventCategory(raw: unknown): SubnetEventCategorySummary | null {
+  if (!isRecord(raw)) return null;
+  return {
+    category: firstString(raw.category) ?? "other",
+    event_count: firstFiniteNumber(raw.event_count) ?? 0,
+    kind_count: firstFiniteNumber(raw.kind_count) ?? 0,
+    amount_tao: firstFiniteNumber(raw.amount_tao) ?? 0,
+    alpha_amount: firstFiniteNumber(raw.alpha_amount) ?? 0,
+    first_block: firstFiniteNumber(raw.first_block) ?? null,
+    last_block: firstFiniteNumber(raw.last_block) ?? null,
+    first_observed_at: firstString(raw.first_observed_at) ?? null,
+    last_observed_at: firstString(raw.last_observed_at) ?? null,
+  };
+}
+
+export function normalizeSubnetEventSummary(netuid: number, raw: unknown): SubnetEventSummary {
+  const rec = isRecord(raw) ? raw : {};
+  const categories = Array.isArray(rec.categories)
+    ? rec.categories.flatMap((c) => {
+        const normalized = normalizeSubnetEventCategory(c);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    window: firstString(rec.window) ?? null,
+    observed_at: firstString(rec.observed_at) ?? null,
+    total_events: firstFiniteNumber(rec.total_events) ?? 0,
+    kind_count: firstFiniteNumber(rec.kind_count) ?? 0,
+    category_count: firstFiniteNumber(rec.category_count) ?? 0,
+    limit: firstFiniteNumber(rec.limit) ?? 0,
+    categories,
+  };
+}
+
+export const subnetEventSummaryQuery = (netuid: number, window = "7d") =>
+  queryOptions({
+    queryKey: k("subnet-event-summary", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetEventSummary>>(
+        `/api/v1/subnets/${netuid}/event-summary`,
+        { params: { window }, signal },
+      );
+      return {
+        data: normalizeSubnetEventSummary(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
   });
 
 // Per-subnet aggregate weight-setting activity over a 7d/30d window.

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1823,6 +1823,37 @@ export interface SubnetDeregistrations {
   deregistrations_per_hotkey: number | null;
 }
 
+/** One event-category aggregate in a subnet's windowed event-summary rollup. */
+export interface SubnetEventCategorySummary {
+  category: string;
+  event_count: number;
+  kind_count: number;
+  amount_tao: number;
+  alpha_amount: number;
+  first_block: number | null;
+  last_block: number | null;
+  first_observed_at: string | null;
+  last_observed_at: string | null;
+}
+
+/**
+ * Windowed on-chain event-summary rollup for one subnet, from
+ * /api/v1/subnets/{netuid}/event-summary (#3486) — the dashboard-friendly
+ * companion to the raw per-event feed the Activity tab renders. Zeroed/empty
+ * when the account_events tier is cold, never an error.
+ */
+export interface SubnetEventSummary {
+  schema_version: number;
+  netuid: number;
+  window: string | null;
+  observed_at: string | null;
+  total_events: number;
+  kind_count: number;
+  category_count: number;
+  limit: number;
+  categories: SubnetEventCategorySummary[];
+}
+
 /**
  * Validator-set & registration turnover scorecard for one subnet, from
  * /api/v1/subnets/{netuid}/turnover — diffs the window's start/end


### PR DESCRIPTION
## Summary

The subnet masthead's stat spine covered identity, participants, endpoints,
surfaces, health, and registration/deregistration counts — but nothing
summarizing recent on-chain activity as a whole. This adds one **Activity** tile
that renders the windowed event-summary rollup (`total_events` + a compact
per-category breakdown) from the single `GET /api/v1/subnets/{netuid}/event-summary`
endpoint, consolidating what would otherwise require several per-kind/per-category calls.

## Changes

- `apps/ui/src/lib/metagraphed/types.ts`: add `SubnetEventSummary` + `SubnetEventCategorySummary` interfaces.
- `apps/ui/src/lib/metagraphed/queries.ts`: add `subnetEventSummaryQuery(netuid, window)` + `normalizeSubnetEventSummary`.
- `apps/ui/src/components/metagraphed/subnet-masthead.tsx`: wire the query via `useQuery` and add one `StatWithSpark` tile (headline `total_events`, `MiniStack` viz from top categories, graceful cold/empty degradation).
- `apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts`: tests for the normalizer (happy path, cold/junk degradation, defensive filtering) and the query (route + window param).

## Validation

- `npm run lint --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — passes
- `npm test --workspace=apps/ui -- run queries.subnet-event-summary` — 5/5 passing

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="360" src="https://github.com/user-attachments/assets/2a69d788-67b7-4e1a-9237-3f38d97923f2" /> | <img width="360" src="https://github.com/user-attachments/assets/75ee81e0-0552-4a88-8f3d-47263d78041f" /> |
| Desktop · Dark | <img width="360" src="https://github.com/user-attachments/assets/3774735f-db14-4347-a2a3-fe27dfafe3a3" /> | <img width="360" src="https://github.com/user-attachments/assets/0613544a-28d1-49b7-b16e-03274c6c9a80" /> |
| Tablet · Light | <img width="360" src="https://github.com/user-attachments/assets/380f5009-0b1a-4583-bbfd-19fbf7252d24" /> | <img width="360" src="https://github.com/user-attachments/assets/da3597d5-1e7e-4c9e-8624-354095a39697" /> |
| Tablet · Dark | <img width="360" src="https://github.com/user-attachments/assets/9fd399bc-b083-43dd-9f93-009e1baae6e4" /> | <img width="360" src="https://github.com/user-attachments/assets/7c45d1a8-1e4f-4ff5-921c-555bdf21ca28" /> |
| Mobile · Light | <img width="360" src="https://github.com/user-attachments/assets/1c962075-3f0b-44d9-a9e9-11d7c674ad22" /> | <img width="360" src="https://github.com/user-attachments/assets/db1c20de-809a-4a9e-a65b-a8803b50d872" /> |
| Mobile · Dark | <img width="360" src="https://github.com/user-attachments/assets/1a5d3fa8-8255-4919-88a3-114742e0cf0f" /> | <img width="360" src="https://github.com/user-attachments/assets/a8c5f062-2416-44bc-a96b-db004a27f316" /> |

Closes #3486