### PR TITLE
fix(ui): map #activity to the Activity tab in SECTION_TO_TAB

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -200,6 +200,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   yield: "metagraph",
   turnover: "metagraph",
   validators: "validators",
+  activity: "activity",
   identity: "identity",
   hyperparameters: "hyperparameters",
   services: "services",


### PR DESCRIPTION
Closes #3978

## What

`subnets.$netuid.tsx` defines an `activity` tab (`TABS`, line 175) and an `ActivityPanel` wrapped in `<SectionAnchor id="activity">` (line 688), but `SECTION_TO_TAB` — the map `useHashScroll` uses to resolve an incoming `#<section>` hash to its owning tab — had no `activity` entry. So `/subnets/{netuid}#activity`, including the link `SectionAnchor`'s own "copy link" button generates for that exact section, silently failed to switch to the Activity tab. Verified this reproduces on current `main` before making any change: navigating to `/subnets/1#activity` landed on the Overview tab with no Activity content rendered.

## Fix

One entry added to `SECTION_TO_TAB`:

```diff
   validators: "validators",
+  activity: "activity",
   identity: "identity",
```

Matches the exact pattern every other tab already uses. No other change — `ActivityPanel`, `SectionAnchor`, and the six filter inputs on other tabs are untouched.

## Verification

- Before: `/subnets/1#activity` → lands on Overview, Activity tab never activates, `ActivityPanel` content never renders.
- After: `/subnets/1#activity` → Activity tab activates and its content (on-chain activity scorecards + table) renders and scrolls into view, identical to how `#validators`, `#endpoints`, etc. already behave.
- Spot-checked two other hash links (`#validators`, `#endpoints`) still resolve correctly — no regression to any existing `SECTION_TO_TAB` entry, since this is a pure addition.

## Evidence

This is a navigation/interaction behavior — not meaningfully different at rest in a single before/after screenshot pair, since the visual end-state (Activity tab showing its content) is identical to just clicking the tab manually. Per the repo's evidence guidance, a screen recording is more informative here than a static matrix:

- **Before**: https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-activity-hash-3978/before-activity-hash.webm — following `#activity` leaves the page on Overview.
- **After**: https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-subnet-activity-hash-3978/after-activity-hash.webm — following `#activity` switches to the Activity tab and its content renders.

Both recorded against the same live subnet (SN1) and the same navigation sequence, isolating just this one-line change.

## Acceptance criteria

- [x] `subnets.$netuid.tsx` appears in the diff
- [x] Navigating directly to `/subnets/{netuid}#activity` switches to the Activity tab and scrolls to the section
- [x] The "copy link" button on the Activity section now produces a link that works when followed (it writes `url.hash = "activity"`, the exact key this PR adds)
- [x] No regression to any other tab's existing hash-link behavior (pure addition, spot-checked two others)
- [x] Before/after screen recording, since a single static screenshot can't capture the navigation behavior

## Testing

```
npx tsc --noEmit           # 2 pre-existing unrelated errors reproduce identically on a clean checkout
npx eslint src/routes/subnets.$netuid.tsx     # clean aside from pre-existing CRLF line-ending noise (core.autocrlf) and pre-existing fast-refresh warnings, confirmed via `git diff --check`
npx prettier --check src/routes/subnets.$netuid.tsx   # same CRLF-only noise, diff itself is clean
```

Diff is 1 insertion, 0 deletions, in the exact file and map the issue names.
