### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap candle-chart data-artifact

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,25 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-data-artifact",
+      "kind": "data-artifact",
+      "name": "SN31 TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/31/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN31 Recall's alpha token: each record carries period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 31. SN31 exposes no verified first-party website or API; this indexed feed is the concrete public JSON data endpoint for netuid 31, documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation",
+        "https://taomarketcap.com/subnets/31"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31/candle-chart"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #4034

## Summary

Registers **SN31 Recall**'s public **OHLCV candle-chart dataset** as a `data-artifact` surface — a no-auth JSON time-series of SN31's alpha-token price/volume, and the concrete public API data endpoint the registry did not yet capture for SN31. Append-only: one new surface on the existing subnet file, nothing else changed.

## Surface

- **kind:** `data-artifact`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/31/candle-chart`
- **provider:** `taomarketcap`
- **auth_required:** `false` · **public_safe:** `true`

A standalone historical price/volume dataset. SN31 exposes no verified first-party API/website; this indexed feed is the concrete public JSON data endpoint for netuid 31, documented in the TaoMarketCap developer API. Each record is scoped to `subnet_id: 31` and carries `period_name, timestamp, block_number, open/high/low/close, volume, start_volume, tao_price_usd/eur`.

Mirrors the merged shape for SN104 (#5059) and SN86 (#5006).

## Verification

- `surface:add` live-verified the URL: reachable + public-safe (715 hourly OHLCV records, `subnet_id: 31`)
- `npm run validate:surface -- --file registry/subnets/recall.json` → passed
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean
- Diff is a single file (`registry/subnets/recall.json`)

Made with [Cursor](https://cursor.com)