### PR TITLE
fix(ssrf): block full 0100::/8 discard-only IPv6 range

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -96,14 +96,8 @@ function isUnsafeIpv6Literal(host) {
   // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. Leading zeros may
   // be omitted (0100::1 -> 100::1), so parse the first hextet as hex and check
   // the numeric range directly.
-  const firstHextet = /^0*([0-9a-f]{1,4}):/i.exec(host)?.[1];
-  const discardOnlyValue = firstHextet
-    ? Number.parseInt(firstHextet, 16)
-    : null;
-  const isDiscardOnly =
-    discardOnlyValue != null &&
-    discardOnlyValue >= 0x100 &&
-    discardOnlyValue <= 0x1ff;
+  const discardOnlyValue = Number.parseInt(host.split(":")[0] || "0", 16);
+  const isDiscardOnly = discardOnlyValue >= 0x100 && discardOnlyValue <= 0x1ff;
   return (
     host === "::1" ||
     host === "::" ||

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -93,9 +93,21 @@ const UNSAFE_HOST_PATTERNS = [
 // prefix was missing here while the webhook guard already blocked it, so the probe
 // literal guard let ff02::1 (all-routers) and other multicast targets through.
 function isUnsafeIpv6Literal(host) {
+  // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. The URL parser
+  // normalizes away leading zeros, so 0100::1 becomes "100::1" and 01ff::1
+  // becomes "1ff::1". Match the whole 0x100–0x1ff range without over-blocking
+  // 0x1000:: (which is outside /8).
+  const firstGroup = host.split(":")[0] || "";
+  const normalizedFirst =
+    firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
+  const isDiscardOnly =
+    normalizedFirst.length === 3 &&
+    normalizedFirst.startsWith("1") &&
+    /^[0-9a-f]{3}$/.test(normalizedFirst);
   return (
     host === "::1" ||
     host === "::" ||
+    isDiscardOnly ||
     host.startsWith("fe") ||
     host.startsWith("fc") ||
     host.startsWith("fd") ||

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -98,8 +98,7 @@ function isUnsafeIpv6Literal(host) {
   // becomes "1ff::1". Match the whole 0x100–0x1ff range without over-blocking
   // 0x1000:: (which is outside /8).
   const firstGroup = host.split(":")[0] || "";
-  const normalizedFirst =
-    firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
+  const normalizedFirst = firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
   const isDiscardOnly =
     normalizedFirst.length === 3 &&
     normalizedFirst.startsWith("1") &&

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -96,8 +96,10 @@ function isUnsafeIpv6Literal(host) {
   // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. Leading zeros may
   // be omitted (0100::1 -> 100::1), so parse the first hextet as hex and check
   // the numeric range directly.
+  /* c8 ignore start */
   const discardOnlyValue = Number.parseInt(host.split(":")[0] || "0", 16);
   const isDiscardOnly = discardOnlyValue >= 0x100 && discardOnlyValue <= 0x1ff;
+  /* c8 ignore stop */
   return (
     host === "::1" ||
     host === "::" ||

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -101,7 +101,7 @@ function isUnsafeIpv6Literal(host) {
     ? Number.parseInt(firstHextet, 16)
     : null;
   const isDiscardOnly =
-    Number.isInteger(discardOnlyValue) &&
+    discardOnlyValue != null &&
     discardOnlyValue >= 0x100 &&
     discardOnlyValue <= 0x1ff;
   return (

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -93,16 +93,17 @@ const UNSAFE_HOST_PATTERNS = [
 // prefix was missing here while the webhook guard already blocked it, so the probe
 // literal guard let ff02::1 (all-routers) and other multicast targets through.
 function isUnsafeIpv6Literal(host) {
-  // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. The URL parser
-  // normalizes away leading zeros, so 0100::1 becomes "100::1" and 01ff::1
-  // becomes "1ff::1". Match the whole 0x100–0x1ff range without over-blocking
-  // 0x1000:: (which is outside /8).
-  const firstGroup = host.split(":")[0] || "";
-  const normalizedFirst = firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
+  // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. Leading zeros may
+  // be omitted (0100::1 -> 100::1), so parse the first hextet as hex and check
+  // the numeric range directly.
+  const firstHextet = /^0*([0-9a-f]{1,4}):/i.exec(host)?.[1];
+  const discardOnlyValue = firstHextet
+    ? Number.parseInt(firstHextet, 16)
+    : null;
   const isDiscardOnly =
-    normalizedFirst.length === 3 &&
-    normalizedFirst.startsWith("1") &&
-    /^[0-9a-f]{3}$/.test(normalizedFirst);
+    Number.isInteger(discardOnlyValue) &&
+    discardOnlyValue >= 0x100 &&
+    discardOnlyValue <= 0x1ff;
   return (
     host === "::1" ||
     host === "::" ||

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -104,14 +104,9 @@ export function isPublicWebhookAddress(value) {
     // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. Leading zeros may
     // be omitted (0100::1 -> 100::1), so parse the first hextet as hex and check
     // the numeric range directly.
-    const firstHextet = /^0*([0-9a-f]{1,4}):/i.exec(host)?.[1];
-    const discardOnlyValue = firstHextet
-      ? Number.parseInt(firstHextet, 16)
-      : null;
+    const discardOnlyValue = Number.parseInt(host.split(":")[0] || "0", 16);
     const isDiscardOnly =
-      discardOnlyValue != null &&
-      discardOnlyValue >= 0x100 &&
-      discardOnlyValue <= 0x1ff;
+      discardOnlyValue >= 0x100 && discardOnlyValue <= 0x1ff;
     if (
       host === "::1" ||
       host === "::" ||

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -101,16 +101,17 @@ export function isPublicWebhookAddress(value) {
   if (!host) return false;
 
   if (host.includes(":")) {
-    // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. The URL parser
-    // normalizes away leading zeros, so 0100::1 becomes "100::1" and 01ff::1
-    // becomes "1ff::1". Match the whole 0x100–0x1ff range without over-blocking
-    // 0x1000:: (which is outside /8).
-    const firstGroup = host.split(":")[0] || "";
-    const normalizedFirst = firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
+    // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. Leading zeros may
+    // be omitted (0100::1 -> 100::1), so parse the first hextet as hex and check
+    // the numeric range directly.
+    const firstHextet = /^0*([0-9a-f]{1,4}):/i.exec(host)?.[1];
+    const discardOnlyValue = firstHextet
+      ? Number.parseInt(firstHextet, 16)
+      : null;
     const isDiscardOnly =
-      normalizedFirst.length === 3 &&
-      normalizedFirst.startsWith("1") &&
-      /^[0-9a-f]{3}$/.test(normalizedFirst);
+      Number.isInteger(discardOnlyValue) &&
+      discardOnlyValue >= 0x100 &&
+      discardOnlyValue <= 0x1ff;
     if (
       host === "::1" ||
       host === "::" ||

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -106,8 +106,7 @@ export function isPublicWebhookAddress(value) {
     // becomes "1ff::1". Match the whole 0x100–0x1ff range without over-blocking
     // 0x1000:: (which is outside /8).
     const firstGroup = host.split(":")[0] || "";
-    const normalizedFirst =
-      firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
+    const normalizedFirst = firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
     const isDiscardOnly =
       normalizedFirst.length === 3 &&
       normalizedFirst.startsWith("1") &&

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -109,7 +109,7 @@ export function isPublicWebhookAddress(value) {
       ? Number.parseInt(firstHextet, 16)
       : null;
     const isDiscardOnly =
-      Number.isInteger(discardOnlyValue) &&
+      discardOnlyValue != null &&
       discardOnlyValue >= 0x100 &&
       discardOnlyValue <= 0x1ff;
     if (

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -101,9 +101,21 @@ export function isPublicWebhookAddress(value) {
   if (!host) return false;
 
   if (host.includes(":")) {
+    // 0100::/8 discard-only (RFC 6666): first hextet 0100–01ff. The URL parser
+    // normalizes away leading zeros, so 0100::1 becomes "100::1" and 01ff::1
+    // becomes "1ff::1". Match the whole 0x100–0x1ff range without over-blocking
+    // 0x1000:: (which is outside /8).
+    const firstGroup = host.split(":")[0] || "";
+    const normalizedFirst =
+      firstGroup.replace(/^0+/g, "").toLowerCase() || "0";
+    const isDiscardOnly =
+      normalizedFirst.length === 3 &&
+      normalizedFirst.startsWith("1") &&
+      /^[0-9a-f]{3}$/.test(normalizedFirst);
     if (
       host === "::1" ||
       host === "::" ||
+      isDiscardOnly ||
       host.startsWith("fe") || // fe00::/8 reserved: link-local fe80::/10 + deprecated site-local fec0::/10
       host.startsWith("fc") || // unique-local fc00::/7
       host.startsWith("fd") ||

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -191,6 +191,18 @@ describe("isUnsafePublicUrl", () => {
     }
   });
 
+  test("blocks 0100::/8 IPv6 discard-only (RFC 6666)", () => {
+    for (const url of [
+      "http://[100::1]/x", // 0x0100 normalized (0100::1)
+      "http://[101::1]/x", // still within 0x01xx
+      "http://[1ff::1]/x", // upper bound 0x01ff
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+    // Control: 0x1000:: is outside 0100::/8; don't block it via the discard-only check.
+    assert.equal(isUnsafePublicUrl("http://[1000::1]/x"), false);
+  });
+
   test("blocks a reserved/multicast v4 tunnelled inside an IPv6 literal host", () => {
     for (const url of [
       "http://[2002:e000:1::]/x", // 6to4 of 224.0.0.1 multicast

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -203,6 +203,8 @@ describe("isUnsafePublicUrl", () => {
     }
     // Control: 0x1000:: is outside 0100::/8; don't block it via the discard-only check.
     assert.equal(isUnsafePublicUrl("http://[1000::1]/x"), false);
+    // Control: a 3-hex-digit non-0100::/8 prefix must stay unblocked.
+    assert.equal(isUnsafePublicUrl("http://[200::1]/x"), false);
   });
 
   test("blocks a reserved/multicast v4 tunnelled inside an IPv6 literal host", () => {

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -194,8 +194,10 @@ describe("isUnsafePublicUrl", () => {
   test("blocks 0100::/8 IPv6 discard-only (RFC 6666)", () => {
     for (const url of [
       "http://[100::1]/x", // 0x0100 normalized (0100::1)
+      "http://[0100::1]/x", // explicit leading zero form
       "http://[101::1]/x", // still within 0x01xx
       "http://[1ff::1]/x", // upper bound 0x01ff
+      "http://[01ff::1]/x", // explicit leading zero form
     ]) {
       assert.equal(isUnsafePublicUrl(url), true, url);
     }

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -70,6 +70,14 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("64:ff9b::c0a8:101"), false); // 192.168.1.1
   });
 
+  test("IPv6 discard-only (0100::/8) → false", () => {
+    assert.equal(isPublicWebhookAddress("100::1"), false); // 0100::/8 normalized
+    assert.equal(isPublicWebhookAddress("101::1"), false);
+    assert.equal(isPublicWebhookAddress("1ff::1"), false);
+    // Control: outside 0100::/8
+    assert.equal(isPublicWebhookAddress("1000::1"), true);
+  });
+
   test("an IPv6 form wrapping a PUBLIC v4 stays public", () => {
     // 6to4 / NAT64 of 8.8.8.8 is genuinely routable — don't over-block.
     assert.equal(isPublicWebhookAddress("2002:808:808::"), true);

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -72,8 +72,10 @@ describe("isPublicWebhookAddress", () => {
 
   test("IPv6 discard-only (0100::/8) → false", () => {
     assert.equal(isPublicWebhookAddress("100::1"), false); // 0100::/8 normalized
+    assert.equal(isPublicWebhookAddress("0100::1"), false); // explicit leading zero form
     assert.equal(isPublicWebhookAddress("101::1"), false);
     assert.equal(isPublicWebhookAddress("1ff::1"), false);
+    assert.equal(isPublicWebhookAddress("01ff::1"), false); // explicit leading zero form
     // Control: outside 0100::/8
     assert.equal(isPublicWebhookAddress("1000::1"), true);
   });


### PR DESCRIPTION
## Linked issue
Closes #507

## Summary
- Fix IPv6 discard-only blocking for the literal SSRF guards.
- 