### PR TITLE
feat(registry): add SN114 SOMA platform OpenAPI schema

### DIFF
--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -178,6 +178,27 @@
         "https://thesoma.ai/"
       ],
       "url": "https://thesoma.ai/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-114-soma-openapi",
+      "kind": "openapi",
+      "name": "SOMA platform OpenAPI schema",
+      "notes": "Public no-auth OpenAPI 3.1 schema (title \"MCP-subnet\", 46 paths) for the SN114 SOMA platform API on platform.thesoma.ai. The official DendriteHQ/SOMA validator/.env.example sets NETUID=114 and PLATFORM_URL=https://platform.thesoma.ai, tying this host to the subnet; Swagger UI is served at /docs on the same host. Distinct from thesoma.ai website and /api/health surfaces.",
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://platform.thesoma.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/DendriteHQ/SOMA/blob/main/validator/.env.example",
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/openapi.json"
     }
   ],
   "website_url": "https://thesoma.ai/"


### PR DESCRIPTION
Closes #4153

## Summary

Registers **SN114 SOMA**'s public **OpenAPI 3.1 schema** — the exact machine-readable spec the issue asks for.

## Surface

- **kind:** `openapi`
- **url:** https://platform.thesoma.ai/openapi.json
- **provider:** `soma`
- **schema:** OpenAPI 3.1, title `MCP-subnet`, 46 paths (Swagger UI at `/docs`)

## Proof

Official `DendriteHQ/SOMA` `validator/.env.example` sets `NETUID=114` and `PLATFORM_URL=https://platform.thesoma.ai`, tying this host to SN114. Distinct from existing `thesoma.ai` website/health surfaces.

Append-only: one new surface on `registry/subnets/soma.json` only.

## Validation

- `npm run validate:surface` → passed
- `npm run scan:public-safety` → passed
- `npx prettier --check` → clean
- Live probe: OpenAPI schema verified (MCP-subnet, 46 paths)

Made with [Cursor](https://cursor.com)