### PR TITLE
fix(data-api): ignore client-provided snapshot_date in neuron backfill validation

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -2834,6 +2834,26 @@ test("backfill-neuron-daily accepts a null stake_tao (backfill-neuron-history.py
   expect(body.neuron_daily_written).toBe(1);
 });
 
+test("backfill-neuron-daily ignores client snapshot_date and derives it from captured_at", async () => {
+  const capturedAt = Date.parse("2026-05-29T12:34:56.000Z");
+  const res = await postNeuronDailyBackfill(
+    [
+      neuronSyncRow({
+        captured_at: capturedAt,
+        snapshot_date: "1999-01-01",
+      }),
+    ],
+    { secret: NEURON_DAILY_BACKFILL_SECRET },
+  );
+  expect(res.status).toBe(200);
+  expect((await res.json()).neuron_daily_written).toBe(1);
+  const neuronDailyInsert = sqlCalls.find((call) =>
+    /INSERT INTO neuron_daily\b/.test(call.text),
+  );
+  expect(neuronDailyInsert.values).toContain("2026-05-29");
+  expect(neuronDailyInsert.values).not.toContain("1999-01-01");
+});
+
 test("backfill-neuron-daily writes neuron_daily + account_position_daily but NEVER the latest-only neurons table", async () => {
   const res = await postNeuronDailyBackfill([neuronSyncRow()], {
     secret: NEURON_DAILY_BACKFILL_SECRET,

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -2555,6 +2555,41 @@ test("neurons-sync rejects a row carrying an unknown column (400)", async () => 
   expect(res.status).toBe(400);
 });
 
+// #5163 follow-up: handleNeuronDailyBackfill was fixed to strip a
+// client-provided snapshot_date before validation, but handleNeuronsSync had
+// the exact same bug (snapshot_date isn't in NEURON_INSERT_COLUMNS, so
+// validNeuronSyncRow's key allowlist rejected the whole row) and was never
+// patched alongside it -- caught by review, fixed here too.
+test("neurons-sync ignores a client-provided snapshot_date instead of rejecting the row (400 bug, now fixed)", async () => {
+  const capturedAt = Date.parse("2026-05-29T12:34:56.000Z");
+  const res = await postNeurons(
+    [neuronSyncRow({ captured_at: capturedAt, snapshot_date: "1999-01-01" })],
+    { secret: NEURONS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.neurons_written).toBe(1);
+  const neuronDailyInsert = sqlCalls.find((call) =>
+    /INSERT INTO neuron_daily\b/.test(call.text),
+  );
+  expect(neuronDailyInsert.values).toContain("2026-05-29");
+  expect(neuronDailyInsert.values).not.toContain("1999-01-01");
+});
+
+test.each([
+  ["null", null],
+  ["a non-object primitive", "not-a-row"],
+  ["a nested array", [1, 2, 3]],
+])(
+  "neurons-sync rejects a row that is %s (400, not a throw)",
+  async (_label, malformedRow) => {
+    const res = await postNeurons([neuronSyncRow(), malformedRow], {
+      secret: NEURONS_SYNC_SECRET,
+    });
+    expect(res.status).toBe(400);
+  },
+);
+
 test("neurons-sync rejects a row with a string field over the byte cap (400)", async () => {
   const res = await postNeurons([neuronSyncRow({ hotkey: "5".repeat(600) })], {
     secret: NEURONS_SYNC_SECRET,
@@ -2853,6 +2888,23 @@ test("backfill-neuron-daily ignores client snapshot_date and derives it from cap
   expect(neuronDailyInsert.values).toContain("2026-05-29");
   expect(neuronDailyInsert.values).not.toContain("1999-01-01");
 });
+
+// stripClientSnapshotDate's own null/non-object/array guard (mirrors
+// validNeuronSyncRow's identical guard, workers/data-api.mjs) -- each malformed
+// row still fails validation with the same 400, never a crash on destructuring.
+test.each([
+  ["null", null],
+  ["a non-object primitive", "not-a-row"],
+  ["a nested array", [1, 2, 3]],
+])(
+  "backfill-neuron-daily rejects a row that is %s (400, not a throw)",
+  async (_label, malformedRow) => {
+    const res = await postNeuronDailyBackfill([neuronSyncRow(), malformedRow], {
+      secret: NEURON_DAILY_BACKFILL_SECRET,
+    });
+    expect(res.status).toBe(400);
+  },
+);
 
 test("backfill-neuron-daily writes neuron_daily + account_position_daily but NEVER the latest-only neurons table", async () => {
   const res = await postNeuronDailyBackfill([neuronSyncRow()], {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -628,11 +628,20 @@ async function handleNeuronsSync(request, env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validNeuronSyncRow)) {
+  // Mirrors handleNeuronDailyBackfill's identical strip-before-validate: a
+  // client-provided snapshot_date isn't in NEURON_INSERT_COLUMNS, so
+  // validNeuronSyncRow's key allowlist would otherwise reject the whole row
+  // -- this handler had the exact same bug, just never patched alongside
+  // the backfill one.
+  const validatedIncoming = incoming.map(stripClientSnapshotDate);
+  if (
+    !validatedIncoming.length ||
+    !validatedIncoming.every(validNeuronSyncRow)
+  ) {
     return writeJson({ error: "rows must match the neuron row shape" }, 400);
   }
 
-  const rows = incoming.map(coerceNeuronSyncRow);
+  const rows = validatedIncoming.map(coerceNeuronSyncRow);
   // Per-netuid max captured_at, NOT one batch-wide value -- a global max would
   // let one netuid's later capture prune rows this SAME request just upserted
   // for a different, earlier-captured netuid in the same batch (the max would
@@ -911,7 +920,10 @@ async function handleNeuronDailyBackfill(request, env) {
     );
   }
   const validatedIncoming = incoming.map(stripClientSnapshotDate);
-  if (!validatedIncoming.length || !validatedIncoming.every(validNeuronSyncRow)) {
+  if (
+    !validatedIncoming.length ||
+    !validatedIncoming.every(validNeuronSyncRow)
+  ) {
     return writeJson({ error: "rows must match the neuron row shape" }, 400);
   }
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -574,6 +574,12 @@ function coerceNeuronSyncRow(row) {
   return out;
 }
 
+function stripClientSnapshotDate(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return row;
+  const { snapshot_date: _snapshotDate, ...rest } = row;
+  return rest;
+}
+
 async function handleNeuronsSync(request, env) {
   if (!env.NEURONS_SYNC_SECRET) {
     return writeJson(
@@ -904,11 +910,12 @@ async function handleNeuronDailyBackfill(request, env) {
       413,
     );
   }
-  if (!incoming.length || !incoming.every(validNeuronSyncRow)) {
+  const validatedIncoming = incoming.map(stripClientSnapshotDate);
+  if (!validatedIncoming.length || !validatedIncoming.every(validNeuronSyncRow)) {
     return writeJson({ error: "rows must match the neuron row shape" }, 400);
   }
 
-  const rows = incoming.map(coerceNeuronSyncRow);
+  const rows = validatedIncoming.map(coerceNeuronSyncRow);
   const dailyRows = rows.map((row) => ({
     ...row,
     snapshot_date: neuronSyncSnapshotDate(row.captured_at),


### PR DESCRIPTION
### Motivation
- Backfill clients (scripts/backfill-*.py) include a `snapshot_date` field in each neuron row but the server-side validator only allows keys in `NEURON_INSERT_COLUMNS`, causing valid backfill requests to be rejected before the endpoint derives its own `snapshot_date` from `captured_at`.

### Description
- Add `stripClientSnapshotDate` to `workers/data-api.mjs` and strip any client-provided `snapshot_date` from incoming rows before validation in **both** `handleNeuronsSync` and `handleNeuronDailyBackfill` (the original diff only covered the backfill handler; a review caught that the neurons-sync handler had the identical bug and was unpatched -- fixed in a follow-up commit).
- Continue to derive and store `snapshot_date` on the server via `neuronSyncSnapshotDate(row.captured_at)` so stored dates remain authoritative.
- Regression tests in `tests/data-api.test.mjs`: one per handler asserting a stale client `snapshot_date` is ignored and the derived one is stored, plus malformed-row (null / non-object primitive / nested array) coverage for `stripClientSnapshotDate`'s own guard.

### Testing
- `npm run build && npm run validate`
- `npm run test:coverage` (full unsharded run, clean)
- `node scripts/scan-public-safety.mjs` (clean)
- `npx prettier --check` / `npx eslint` on both changed files

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552e9e93b8832cb767d111b41ac744)