### PR TITLE
fix(ui): resolve the #activity hash to the Activity tab (its own copy-link was dead)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -200,6 +200,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   yield: "metagraph",
   turnover: "metagraph",
   validators: "validators",
+  activity: "activity",
   identity: "identity",
   hyperparameters: "hyperparameters",
   services: "services",


### PR DESCRIPTION
## Summary
Fixes a broken self-referential deep link: the subnet page's **Activity** tab's own "copy link" button produces a `#activity` hash that silently fails to switch tabs when followed.

`subnets.$netuid.tsx` has an `activity` tab and an `ActivityPanel` wrapped in `<SectionAnchor id="activity">`, but the `SECTION_TO_TAB` map — which `useHashScroll` uses to resolve an incoming hash to its owning tab — had **no `activity` entry**. So `/subnets/N#activity` (including the link `SectionAnchor`'s copy-link button writes) never switched to the Activity tab.

## Fix
One line in `apps/ui/src/routes/subnets.$netuid.tsx`: add `activity: "activity"` to `SECTION_TO_TAB`, mirroring the existing entries (`endpoints`, `surfaces`, `validators`, …).

## Verified live
Built + served, Playwright: navigating to `/subnets/7#activity`
- **Before**: URL stays `#activity`, tab param `null` → page shows the **Overview** tab (bug).
- **After**: navigates to `?tab=activity#activity` → the **Activity** panel (On-chain activity) renders.

Closes #3978

## Screenshots
`/subnets/7#activity` followed directly. **Before** = `upstream/main`; **After** = this branch. The active tab / rendered panel is the difference (Overview → On-chain Activity).

| Viewport · Theme | Before (Overview shown) | After (Activity shown) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/sn-3978-assets/3978/after-mobile-dark.png) |

## Validation
- `tsc`/`prettier` clean. Behavior verified live at 3 viewports; no visual/layout change to any tab — only the `#activity` hash now resolves to the Activity tab.