### PR TITLE
feat(ui): add validator evaluation explainer and compare drawer

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-metrics-explainer.tsx
+++ b/apps/ui/src/components/metagraphed/validator-metrics-explainer.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { ChevronDown, Info } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+/**
+ * Collapsible, strictly-neutral explainer for the validator directory. It says
+ * what each visible column measures and how to read it — it does not rank,
+ * score, or recommend any validator. Sits near the top of /validators so a
+ * first-time visitor can orient before reading the table.
+ */
+
+type MetricNote = { title: string; body: string };
+
+const METRIC_NOTES: MetricNote[] = [
+  {
+    title: "Total stake (τ)",
+    body: "The TAO staked to this hotkey, summed across every subnet it validates on. More stake carries more weight in consensus and in dividend share — it measures size, not trustworthiness.",
+  },
+  {
+    title: "Dominance",
+    body: "This hotkey's total stake as a share of all validator stake network-wide. It is a concentration figure: a high value means a large slice of the network's validating stake sits behind one operator.",
+  },
+  {
+    title: "Validator trust (avg / max)",
+    body: "The on-chain validator_trust for the hotkey, averaged and at its peak across the subnets it validates. It reflects how much of the validator's weight is corroborated by consensus, on a 0–1 scale.",
+  },
+  {
+    title: "Total emission (τ)",
+    body: "The TAO emitted to the hotkey over the current window across its subnets — the reward flow it is currently earning. It tracks both stake and validating performance.",
+  },
+  {
+    title: "Active subnets / UIDs",
+    body: "How many distinct subnets the hotkey validates on, and how many UID registrations it holds across them. A wider footprint is broader participation, not necessarily stronger performance on any one subnet.",
+  },
+  {
+    title: "Commission & nominators",
+    body: "Not shown in this directory yet. Where you find them, commission is the cut a validator keeps before rewards reach its nominators (trading off against a delegator's net yield), and nominator count is how many delegators stake to it.",
+  },
+];
+
+export function ValidatorMetricsExplainer({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <aside
+      aria-label="How to read the validator directory"
+      className={classNames("rounded-lg border border-border bg-card/60", className)}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+        <span className="min-w-0 flex-1">
+          <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            How to read this table
+          </span>
+          <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
+            What each column means, and how to weigh it — neutral, no recommendation.
+          </span>
+        </span>
+        <ChevronDown
+          className={classNames(
+            "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="border-t border-border px-3 py-3">
+          <div className="grid gap-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2">
+            {METRIC_NOTES.map((note) => (
+              <div key={note.title}>
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+                  {note.title}
+                </div>
+                <p className="mt-1">{note.body}</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 border-t border-border pt-3 text-[11.5px] leading-relaxed text-ink-muted">
+            These signals describe a validator's scale and consensus standing — not its reliability,
+            custody practices, or future returns. Read them together, and weigh a validator's own
+            track record and the subnets it serves. Metagraphed does not rank or recommend
+            validators.
+          </p>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -1,0 +1,250 @@
+import { Link } from "@tanstack/react-router";
+import { X, BarChart3 } from "lucide-react";
+import { useState } from "react";
+import { useValidatorCompare } from "@/lib/metagraphed/validator-compare";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
+
+/**
+ * Floating bottom dock + expandable side-by-side compare drawer for selected
+ * validators. Selection state lives in localStorage via useValidatorCompare so
+ * it survives navigation. Unlike the subnet compare drawer this reads from the
+ * validator rows already loaded on the page (passed in) rather than a dedicated
+ * compare endpoint — the directory ships the full row set, so no extra fetch is
+ * needed. Strictly presentational; it lays values side by side and never ranks
+ * or recommends a validator.
+ */
+export function ValidatorsCompareDrawer({ validators }: { validators: GlobalValidator[] }) {
+  const { selected, max, remove, clear } = useValidatorCompare();
+  const [expanded, setExpanded] = useState(false);
+
+  if (selected.length === 0) return null;
+
+  const byHotkey = new Map<string, GlobalValidator>();
+  for (const v of validators) byHotkey.set(v.hotkey, v);
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
+        <div
+          className={classNames(
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_rgba(0,0,0,0.35)]",
+            "mg-fade-in",
+          )}
+        >
+          {/* Dock */}
+          <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+            <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <BarChart3 className="size-3 text-accent" />
+              Compare
+              <span className="text-ink-strong tabular-nums">
+                {selected.length}/{max}
+              </span>
+            </span>
+            <span aria-hidden className="h-4 w-px bg-border" />
+            <div className="flex flex-wrap gap-1.5 min-w-0">
+              {selected.map((hotkey) => (
+                <span
+                  key={hotkey}
+                  className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 font-mono text-[10px] text-ink-strong"
+                  title={hotkey}
+                >
+                  {shortHash(hotkey) ?? hotkey}
+                  <button
+                    type="button"
+                    onClick={() => remove(hotkey)}
+                    aria-label={`Remove ${shortHash(hotkey) ?? hotkey}`}
+                    className="ml-0.5 inline-flex size-4 items-center justify-center rounded-full text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <div className="ml-auto flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                disabled={selected.length < 2}
+                className={classNames(
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  selected.length < 2
+                    ? "opacity-50 cursor-not-allowed"
+                    : "hover:border-accent/60 hover:text-accent text-ink-strong",
+                )}
+              >
+                {expanded ? "Hide" : "Compare"}
+              </button>
+              <button
+                type="button"
+                onClick={clear}
+                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+
+          {/* Expanded side-by-side */}
+          {expanded && selected.length >= 2 ? (
+            <CompareGrid hotkeys={selected} byHotkey={byHotkey} />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function pct(v: number | null | undefined): string {
+  return v != null ? `${(v * 100).toFixed(2)}%` : "—";
+}
+
+function trust(v: number | null | undefined): string {
+  return v != null ? v.toFixed(4) : "—";
+}
+
+function CompareGrid({
+  hotkeys,
+  byHotkey,
+}: {
+  hotkeys: string[];
+  byHotkey: Map<string, GlobalValidator>;
+}) {
+  const rows: Array<{ label: string; render: (hotkey: string) => React.ReactNode }> = [
+    {
+      label: "Coldkey",
+      render: (hotkey) => {
+        const c = byHotkey.get(hotkey)?.coldkey;
+        return c ? (
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: c }}
+            className="font-mono text-ink-strong hover:text-accent"
+            title={c}
+          >
+            {shortHash(c) ?? c}
+          </Link>
+        ) : (
+          <span className="text-ink-muted">—</span>
+        );
+      },
+    },
+    {
+      label: "Active subnets",
+      render: (hotkey) => cell(formatNumber(byHotkey.get(hotkey)?.subnet_count)),
+    },
+    {
+      label: "UIDs",
+      render: (hotkey) => cell(formatNumber(byHotkey.get(hotkey)?.uid_count)),
+    },
+    {
+      label: "Dominance",
+      render: (hotkey) => cell(pct(byHotkey.get(hotkey)?.stake_dominance)),
+    },
+    {
+      label: "Total stake",
+      render: (hotkey) => cell(taoCompact(byHotkey.get(hotkey)?.total_stake_tao)),
+    },
+    {
+      label: "Total emission",
+      render: (hotkey) => cell(taoCompact(byHotkey.get(hotkey)?.total_emission_tao)),
+    },
+    {
+      label: "Avg trust",
+      render: (hotkey) => cell(trust(byHotkey.get(hotkey)?.avg_validator_trust)),
+    },
+    {
+      label: "Max trust",
+      render: (hotkey) => cell(trust(byHotkey.get(hotkey)?.max_validator_trust)),
+    },
+  ];
+
+  return (
+    <div className="border-t border-border max-h-[55vh] overflow-auto">
+      <table className="min-w-full text-[12px]">
+        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+          <tr>
+            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
+              Metric
+            </th>
+            {hotkeys.map((h) => (
+              <th
+                key={h}
+                className="min-w-[7rem] whitespace-nowrap px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+              >
+                <Link
+                  to="/validators/$hotkey"
+                  params={{ hotkey: h }}
+                  className="hover:text-accent"
+                  title={h}
+                >
+                  {shortHash(h) ?? h}
+                </Link>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td className="sticky left-0 z-[1] bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {row.label}
+              </td>
+              {hotkeys.map((h) => (
+                <td key={h} className="px-3 py-2">
+                  {row.render(h)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function cell(value: string) {
+  return <span className="font-mono tabular-nums text-ink-strong">{value}</span>;
+}
+
+/** Inline checkbox-style toggle for validator table rows. */
+export function ValidatorCompareToggle({ hotkey }: { hotkey: string }) {
+  const { has, toggle, selected, max } = useValidatorCompare();
+  const on = has(hotkey);
+  const disabled = !on && selected.length >= max;
+  const label = shortHash(hotkey) ?? hotkey;
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      aria-label={on ? `Remove ${label} from compare` : `Add ${label} to compare`}
+      disabled={disabled}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled) toggle(hotkey);
+      }}
+      title={disabled ? `Compare is full (${max})` : on ? "Remove from compare" : "Add to compare"}
+      className={classNames(
+        "inline-flex size-4 shrink-0 items-center justify-center rounded border transition-colors",
+        on ? "bg-accent border-accent text-paper" : "border-border bg-paper hover:border-accent/60",
+        disabled && "opacity-40 cursor-not-allowed",
+      )}
+    >
+      {on ? (
+        <svg viewBox="0 0 12 12" fill="none" className="size-2.5" aria-hidden>
+          <path
+            d="M2 6.5l2.5 2.5L10 3.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/validator-compare.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-compare.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const KEY = "metagraphed:validator-compare";
+
+// An EventTarget-based fake `window` (so subscribe's add/remove/dispatch of the "storage" event work)
+// plus a Map-backed localStorage. Node provides EventTarget globally.
+function makeWindow(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const win = new EventTarget() as EventTarget & {
+    localStorage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
+    store: Map<string, string>;
+    throwOnRead?: boolean;
+  };
+  win.store = store;
+  win.localStorage = {
+    getItem: (k: string) => {
+      if (win.throwOnRead) throw new Error("blocked");
+      return store.has(k) ? store.get(k)! : null;
+    },
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  return win;
+}
+
+// validator-compare caches raw/value + listeners at module scope, so a fresh module per case is the
+// only way to observe first-read/cache behaviour deterministically. Stub `window` before importing.
+async function freshStore(win?: ReturnType<typeof makeWindow>) {
+  vi.resetModules();
+  if (win) vi.stubGlobal("window", win);
+  return import("./validator-compare");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("parseRaw", () => {
+  it("returns [] for null/empty/non-array/malformed input", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(null)).toEqual([]);
+    expect(parseRaw("")).toEqual([]);
+    expect(parseRaw("{not json")).toEqual([]);
+    expect(parseRaw(JSON.stringify({ a: 1 }))).toEqual([]);
+  });
+
+  it("keeps only non-empty strings, drops duplicates, and caps at 4", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(JSON.stringify(["5A", 3, "", null, "5B", "5A"]))).toEqual(["5A", "5B"]);
+    expect(parseRaw(JSON.stringify(["a", "b", "c", "d", "e", "f"]))).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("readSnapshot", () => {
+  it("returns [] during SSR (no window)", async () => {
+    const { readSnapshot } = await freshStore(); // no window stubbed
+    expect(readSnapshot()).toEqual([]);
+  });
+
+  it("reads + parses the persisted selection", async () => {
+    const { readSnapshot } = await freshStore(makeWindow({ [KEY]: JSON.stringify(["5A", "5B"]) }));
+    expect(readSnapshot()).toEqual(["5A", "5B"]);
+  });
+
+  it("serves an unchanged snapshot from cache (same reference)", async () => {
+    const { readSnapshot } = await freshStore(makeWindow({ [KEY]: JSON.stringify(["5A", "5B"]) }));
+    const a = readSnapshot();
+    const b = readSnapshot();
+    expect(a).toBe(b); // second read short-circuits on the identical raw string
+  });
+
+  it("degrades to [] when localStorage access throws", async () => {
+    const win = makeWindow();
+    win.throwOnRead = true;
+    const { readSnapshot } = await freshStore(win);
+    expect(readSnapshot()).toEqual([]);
+  });
+});
+
+describe("writeRaw", () => {
+  it("is a no-op during SSR (no window)", async () => {
+    const { writeRaw, readSnapshot } = await freshStore(); // no window
+    expect(() => writeRaw(["5A", "5B"])).not.toThrow();
+    expect(readSnapshot()).toEqual([]);
+  });
+
+  it("cleans (string-only, dedup), caps at 4, and persists", async () => {
+    const win = makeWindow();
+    const { writeRaw, readSnapshot } = await freshStore(win);
+    writeRaw(["5A", "", "5A", "5B", "5C", "5D", "5E"]);
+    expect(win.store.get(KEY)).toBe(JSON.stringify(["5A", "5B", "5C", "5D"]));
+    expect(readSnapshot()).toEqual(["5A", "5B", "5C", "5D"]);
+  });
+
+  it("notifies registered subscribers", async () => {
+    const { writeRaw, subscribe } = await freshStore(makeWindow());
+    const calls: number[] = [];
+    subscribe(() => calls.push(1));
+    writeRaw(["5A"]);
+    expect(calls).toEqual([1]);
+  });
+});
+
+describe("subscribe", () => {
+  it("stops notifying after the returned unsubscribe runs", async () => {
+    const { writeRaw, subscribe } = await freshStore(makeWindow());
+    let count = 0;
+    const off = subscribe(() => (count += 1));
+    writeRaw(["5A"]);
+    off();
+    writeRaw(["5B"]);
+    expect(count).toBe(1);
+  });
+
+  it("re-notifies on a cross-tab 'storage' event for this key, and ignores other keys", async () => {
+    const win = makeWindow({ [KEY]: JSON.stringify(["5A"]) });
+    const { subscribe, readSnapshot } = await freshStore(win);
+    let count = 0;
+    subscribe(() => (count += 1));
+    readSnapshot(); // prime the cache
+
+    const other = new Event("storage") as Event & { key: string };
+    other.key = "some-other-key";
+    win.dispatchEvent(other);
+    expect(count).toBe(0); // unrelated key: ignored
+
+    win.store.set(KEY, JSON.stringify(["5A", "5B"]));
+    const ours = new Event("storage") as Event & { key: string };
+    ours.key = KEY;
+    win.dispatchEvent(ours);
+    expect(count).toBe(1); // our key: listener fired
+    expect(readSnapshot()).toEqual(["5A", "5B"]); // cache was invalidated + re-read
+  });
+
+  it("returns a no-op unsubscribe during SSR without throwing", async () => {
+    const { subscribe } = await freshStore(); // no window
+    const off = subscribe(() => {});
+    expect(typeof off).toBe("function");
+    expect(() => off()).not.toThrow();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-compare.ts
+++ b/apps/ui/src/lib/metagraphed/validator-compare.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+/**
+ * Tiny localStorage-backed selection store for validator comparison. Mirrors the
+ * subnet `compare-selection` store but keyed by hotkey (a string) instead of a
+ * numeric netuid. Holds up to MAX hotkeys and notifies subscribers across
+ * components so the compare dock survives navigation.
+ */
+const KEY = "metagraphed:validator-compare";
+const MAX = 4;
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+let cachedRaw: string | null = null;
+let cachedValue: string[] = [];
+
+// parseRaw / readSnapshot / writeRaw / subscribe are the store primitives the hook composes; they
+// are exported for unit testing. The public component API stays `useValidatorCompare`.
+export function parseRaw(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const out: string[] = [];
+    for (const v of parsed) {
+      if (typeof v === "string" && v.length > 0 && !out.includes(v)) out.push(v);
+      if (out.length >= MAX) break;
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export function readSnapshot(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (raw === cachedRaw) return cachedValue;
+    cachedRaw = raw;
+    cachedValue = parseRaw(raw);
+    return cachedValue;
+  } catch {
+    if (cachedRaw === null) return cachedValue;
+    cachedRaw = null;
+    cachedValue = [];
+    return cachedValue;
+  }
+}
+
+export function writeRaw(next: string[]) {
+  if (typeof window === "undefined") return;
+  const clean: string[] = [];
+  for (const v of next) {
+    if (typeof v === "string" && v.length > 0 && !clean.includes(v)) clean.push(v);
+    if (clean.length >= MAX) break;
+  }
+  const raw = JSON.stringify(clean);
+  try {
+    window.localStorage.setItem(KEY, raw);
+  } catch {
+    /* ignore quota errors */
+  }
+  cachedRaw = raw;
+  cachedValue = clean;
+  for (const l of listeners) l();
+}
+
+export function subscribe(l: Listener) {
+  listeners.add(l);
+  if (typeof window !== "undefined") {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === KEY) {
+        cachedRaw = null;
+        cachedValue = [];
+        l();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(l);
+      window.removeEventListener("storage", onStorage);
+    };
+  }
+  return () => listeners.delete(l);
+}
+
+const EMPTY: string[] = [];
+
+export function useValidatorCompare() {
+  // Avoid SSR/CSR snapshot mismatch — start empty on the server, hydrate on mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const value = useSyncExternalStore(
+    subscribe,
+    () => (hydrated ? readSnapshot() : EMPTY),
+    () => EMPTY,
+  );
+
+  return {
+    selected: value,
+    max: MAX,
+    has: (hotkey: string) => value.includes(hotkey),
+    toggle: (hotkey: string) => {
+      const cur = readSnapshot();
+      if (cur.includes(hotkey)) writeRaw(cur.filter((h) => h !== hotkey));
+      else if (cur.length < MAX) writeRaw([...cur, hotkey]);
+    },
+    remove: (hotkey: string) => writeRaw(readSnapshot().filter((h) => h !== hotkey)),
+    clear: () => writeRaw([]),
+  };
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -13,6 +13,11 @@ import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { ValidatorMetricsExplainer } from "@/components/metagraphed/validator-metrics-explainer";
+import {
+  ValidatorsCompareDrawer,
+  ValidatorCompareToggle,
+} from "@/components/metagraphed/validators-compare-drawer";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -76,6 +81,7 @@ function ValidatorsPage() {
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={<ShareButton />}
       />
+      <ValidatorMetricsExplainer className="mb-6" />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable
@@ -161,6 +167,9 @@ function ValidatorsTable({
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/50">
               <tr>
+                <th className={`${TH} w-8`}>
+                  <span className="sr-only">Compare</span>
+                </th>
                 <th className={TH}>Hotkey</th>
                 <th className={TH}>Coldkey</th>
                 <th className={`${TH} text-right`}>Active subnets</th>
@@ -173,6 +182,9 @@ function ValidatorsTable({
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
+                  <td className="px-3 py-2 align-middle">
+                    <ValidatorCompareToggle hotkey={v.hotkey} />
+                  </td>
                   <td className="px-3 py-2 font-mono text-[11px]">
                     <Link
                       to="/validators/$hotkey"
@@ -223,6 +235,8 @@ function ValidatorsTable({
           description="The global validator directory is empty for this window."
         />
       )}
+
+      <ValidatorsCompareDrawer validators={validators} />
     </div>
   );
 }


### PR DESCRIPTION
The /validators directory was a raw sortable table with no guidance on what
its columns mean. Add a collapsible, strictly-neutral explainer above the table
covering stake, dominance, validator trust, emission, active subnets/UIDs, plus
a note on commission/nominators, and a closing line that these signals describe
scale and consensus standing rather than trustworthiness or returns.

Add a validator-vs-validator compare drawer mirroring the subnet
SubnetsCompareDrawer pattern: a hotkey-keyed localStorage selection store
(useValidatorCompare), a per-row toggle, and a floating dock that lays selected
validators' metrics side by side. It reads from the rows already loaded on the
page, so no new endpoint is needed, and it never ranks or recommends.

Closes #5168
