### PR TITLE
fix(deploy): pin fetch image python base digest

### DIFF
--- a/deploy/metagraph-fetch.Dockerfile
+++ b/deploy/metagraph-fetch.Dockerfile
@@ -39,11 +39,11 @@
 # NOT curl|sh, which a security scan correctly flagged as an unverified
 # remote-installer execution (2026-07-13).
 FROM ghcr.io/astral-sh/uv:0.11.28@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa AS uv
-# python:3.12-slim is a mutable tag, not digest-pinned -- matches this repo's
-# existing convention (deploy/chain-firehose-relay.Dockerfile's node:22.23.1-
-# alpine is the same shape); not switching just this one Dockerfile to a
-# digest would be inconsistent, not more secure.
-FROM python:3.12-slim
+# Pin both the semantic Python/Debian version and the OCI index digest so the
+# fetch image has no mutable base-image input. When bumping Python, update the
+# tag and digest together (Docker Hub lists this index digest for
+# python:3.12.11-slim-bookworm).
+FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f1499a57e22e6c285135ae657bf7
 COPY --from=uv /uv /uvx /usr/local/bin/
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Motivation
- A security scan flagged that the fetch container performed runtime PyPI resolution (via `uvx --from bittensor==...`) and used a mutable `python:3.12-slim` base, exposing a supply-chain risk.  
- The intent is to eliminate runtime package-index resolution and remove mutable base-image inputs so the scheduled box-side fetch runs with build-time, hash-locked dependencies and a digest-pinned base image.

### Description
- Replace the mutable base `FROM python:3.12-slim` with a digest-pinned base `FROM python:3.12.11-slim-bookworm@sha256:519591d687...` in `deploy/metagraph-fetch.Dockerfile`.  
- Preserve and document the build-time, hash-locked dependency install using `scripts/pyproject.toml`, `scripts/uv.lock` and `uv sync --locked` so the venv is baked into the image at build time.  
- Ensure the runtime entrypoint executes the baked-in Python (`python scripts/<SCRIPT>`) and no longer invokes `uvx --from ...` at container runtime.  
- Update Dockerfile comments to reflect the pinned base and the rationale for build-time verification.

### Testing
- Ran `git diff --check` to validate whitespace/hunks and it passed.  
- Ran `bash -n scripts/metagraph-fetch-entrypoint.sh` to verify the entrypoint syntax and it passed.  
- Verified there are no remaining runtime `uvx` invocations or the mutable base tag with `rg` checks against `deploy/metagraph-fetch.Dockerfile` and `scripts/metagraph-fetch-entrypoint.sh`, which returned no matches.  
- Ran `npm run scan:public-safety` and the public-safety scan passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a554747fa28832c8ee4c6c941138944)