### PR TITLE
feat(ui): add a neutral "how to evaluate a validator" guide on /validators (#5168)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { ChevronDown, Info } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+/**
+ * Neutral, collapsible explainer that sits near the top of /validators so a
+ * first-time visitor can understand what the directory's columns mean and how
+ * to read them together before choosing a validator to delegate to (#5168).
+ *
+ * Strictly factual — it explains the on-chain signals, it does not rank or
+ * recommend any specific validator. Mirrors the collapsible-callout visual
+ * language of MethodologyCallout.
+ */
+const METRICS: Array<{ term: string; def: string }> = [
+  {
+    term: "Active subnets",
+    def: "How many subnets this hotkey is registered and validating on. A validator may operate broadly across many subnets or concentrate on a few.",
+  },
+  {
+    term: "UIDs",
+    def: "The total neuron slots the hotkey holds across those subnets — one registration is one UID.",
+  },
+  {
+    term: "Dominance",
+    def: "The validator's share of total network stake, as a percentage. Higher dominance means more influence over consensus and emission — and more of that influence concentrated in one operator.",
+  },
+  {
+    term: "Total stake",
+    def: "The TAO backing the validator: its own stake plus TAO delegated to it by nominators. Stake sets how much weight the validator's votes carry.",
+  },
+  {
+    term: "Total emission",
+    def: "The TAO the validator earned over the window. Emission is split between the validator and its nominators via commission — it reflects reward flow, not profit.",
+  },
+  {
+    term: "Validator trust (Sort)",
+    def: "Available from the Sort control: how consistently a subnet's consensus scores the validator as trustworthy. Steadier trust points to reliable participation.",
+  },
+];
+
+export function ValidatorGuide() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <aside
+      aria-label="How to evaluate a validator"
+      className="mb-6 rounded-lg border border-border bg-card/60"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+        <span className="min-w-0 flex-1">
+          <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            How to evaluate a validator
+          </span>
+          <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
+            What each column means and how to read them together
+          </span>
+        </span>
+        <ChevronDown
+          className={classNames(
+            "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="border-t border-border px-3 py-3">
+          <dl className="grid gap-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2">
+            {METRICS.map((m) => (
+              <div key={m.term}>
+                <dt className="font-medium text-ink-strong">{m.term}</dt>
+                <dd className="mt-0.5">{m.def}</dd>
+              </div>
+            ))}
+          </dl>
+          <p className="mt-3 border-t border-border pt-3 text-[11.5px] leading-relaxed text-ink-muted">
+            Read these signals together, not in isolation — a large validator
+            concentrates stake and influence, while a smaller one spreads it.
+            Commission and nominator counts (coming in #2548/#2549) will add to
+            this picture. This directory describes the on-chain data; it does not
+            rank or recommend any validator.
+          </p>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -12,6 +12,7 @@ import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
+import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
@@ -76,6 +77,7 @@ function ValidatorsPage() {
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={<ShareButton />}
       />
+      <ValidatorGuide />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable


### PR DESCRIPTION
## Summary
`/validators` was a raw sortable table with no in-product guidance — a first-time visitor had no explanation of what the columns mean or how to weigh them (confirmed: no validator explainer or comparison UI existed anywhere in `apps/ui`). Add a neutral, collapsible **"How to evaluate a validator"** guide near the top of the page.

## Change
New `ValidatorGuide` component (`apps/ui/src/components/metagraphed/validator-guide.tsx`), placed after the page hero on `/validators`. It mirrors the existing `MethodologyCallout` collapsible-callout pattern (same bordered `<aside>`, Info icon, chevron) and defines each **visible** signal — Active subnets, UIDs, Dominance, Total stake, Total emission — plus validator trust (available via the Sort control), and closes with a neutral note on reading them together.

Strictly **factual and neutral**: it explains the on-chain data and explicitly **does not rank or recommend any validator** (per the issue's non-goal). Presentational only — no new query, endpoint, or state beyond the local open/closed toggle. The optional validator-vs-validator comparison view is left as a follow-up; the acceptance ("a first-time visitor can understand what the columns mean") is satisfied by the explainer alone.

## Verification
- `npm run typecheck --workspace=apps/ui` — pass
- `npm run test --workspace=apps/ui` — pass (679 tests)
- `eslint` on both changed files — no new errors
- Rendered live on `/validators` at all three viewports, both themes; content matches the table's actual columns.

## Screenshots
The guide defaults **collapsed** (matching `MethodologyCallout`); the **after** column shows it **expanded** so the copy is reviewable. Before = the page with no guide.

| Viewport · Theme | Before (no guide) | After (guide, expanded) |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/after-mobile-dark.png)<br><sub>after</sub> |

Closes #5168
