### PR TITLE
feat(ui): add a neutral how-to-evaluate-a-validator explainer to /validators (#5168)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { ChevronDown, Info } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+/**
+ * Neutral, collapsible "how to read a validator" explainer for #5168. Mirrors
+ * the MethodologyCallout pattern used on subnet profiles, but explains the
+ * signals a first-time visitor sees on /validators — stake, trust, dominance,
+ * breadth, and emission — strictly factually. It describes how to read each
+ * column; it does not rank, score, or recommend any specific validator.
+ */
+const SIGNALS: { term: string; body: string }[] = [
+  {
+    term: "Total stake",
+    body: "TAO backing the hotkey across every subnet it validates — its own stake plus delegations. Stake is what weights a validator in each subnet's consensus, so it is the headline size signal. Larger is not inherently better: it means more influence and more concentration, which delegators weigh differently.",
+  },
+  {
+    term: "Validator trust",
+    body: "An on-chain score (0–1) derived from how much other participants' weights agree with this validator, shown here as the average and the max across its subnets. It reflects consensus alignment on the subnets it serves, not honesty or returns — a validator active on one subnet can show a high max with a low average.",
+  },
+  {
+    term: "Dominance",
+    body: "The hotkey's share of total network stake — a concentration measure, not a quality score. High dominance means a larger slice of consensus weight sits with one operator; a more decentralized network spreads stake across many.",
+  },
+  {
+    term: "Active subnets & UIDs",
+    body: "Active subnets counts how many distinct subnets the hotkey validates on (breadth of participation); UIDs is its total neuron registrations across them. Breadth shows reach, not effectiveness — a specialist on one subnet is not worse than a generalist on many.",
+  },
+  {
+    term: "Total emission",
+    body: "TAO emitted to the hotkey over the current window across its subnets — the reward it is currently earning. It tracks present-day flow, which shifts with stake, weights, and subnet activity, so it is a snapshot rather than a guaranteed rate.",
+  },
+];
+
+export function ValidatorGuide() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <aside
+      aria-label="How to evaluate a validator"
+      className="mb-4 rounded-lg border border-border bg-card/60"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+        <span className="min-w-0 flex-1">
+          <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            How to evaluate a validator
+          </span>
+          <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
+            What each column means, and how to read it
+          </span>
+        </span>
+        <ChevronDown
+          className={classNames(
+            "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="border-t border-border px-3 py-3">
+          <dl className="grid gap-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2">
+            {SIGNALS.map((s) => (
+              <div key={s.term}>
+                <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+                  {s.term}
+                </dt>
+                <dd className="mt-1">{s.body}</dd>
+              </div>
+            ))}
+          </dl>
+          <p className="mt-3 border-t border-border pt-3 text-[11px] leading-relaxed text-ink-muted/90">
+            These are raw on-chain signals, not a ranking. Higher is not
+            inherently better — high dominance, for example, concentrates stake,
+            which some delegators weigh against. This explains how to read the
+            data; it does not recommend any specific validator.
+          </p>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -7,6 +7,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero, ShareButton } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
+import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
@@ -76,6 +77,7 @@ function ValidatorsPage() {
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={<ShareButton />}
       />
+      <ValidatorGuide />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable


### PR DESCRIPTION
## Summary

Closes #5168

`/validators` was a raw sortable table with no guidance — a first-time visitor had no way to know what "Dominance", "Validator trust", or the other columns mean or how to weigh them (#5168).

This adds a **neutral, collapsible "How to evaluate a validator" explainer** at the top of the page. It mirrors the existing `MethodologyCallout` pattern (Info icon, collapsed by default, chevron toggle) so it fits the design vocabulary without adding visual weight, and it explains the **actual columns the page shows** — Total stake, Validator trust, Dominance, Active subnets & UIDs, and Total emission — in plain language.

Per the issue's requirement, the copy is **strictly factual and neutral**: it describes how to *read* each signal, explicitly notes that higher is not inherently better (e.g. high dominance concentrates stake), and ends with a line stating it **does not recommend any specific validator**.

## Changes
- **New** `components/metagraphed/validator-guide.tsx` — self-contained collapsible  explainer (static content, no data/query changes).
- `routes/validators.index.tsx` — render `<ValidatorGuide />` between the hero and  the table.

## Scope note
The issue also *"consider[s]"* a validator-vs-validator comparison drawer. That's a larger, separate build (mirroring `SubnetsCompareDrawer`); this PR delivers the explainer, which is what the acceptance criterion turns on ("a first-time visitor
to `/validators` can understand what the columns mean and how to think about choosing a validator"). The comparison view is a natural follow-up.

## Screenshots

Default state is **collapsed** (compact 2-line callout); expanding reveals the signal guide. Captured with the repo's Playwright harness (fixed viewports, both themes) from a single dev server toggled between base and change.

| Viewport · Theme | Before (no guide) | After (collapsed, default) | After (expanded) |
| --- | --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-collapsed-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-expanded-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-collapsed-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-expanded-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-collapsed-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-expanded-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-collapsed-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-expanded-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-collapsed-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-expanded-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-collapsed-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5168-validator-guide/after-expanded-mobile-dark.png) |

## Validation
- `tsc --noEmit` ✓ · `eslint` (0 errors) ✓ · `prettier --check` (3.9.4) ✓ · `vitest` (684 passed) ✓ · `build` ✓
- 2 files, new component + one render line; 0-behind `main`

