### PR TITLE
security(scanner): extend scan-public-safety.mjs to cover apps/indexer-rs, scripts, deploy

### DIFF
--- a/apps/indexer-rs/gen_truth.py
+++ b/apps/indexer-rs/gen_truth.py
@@ -4,10 +4,9 @@ o stream-events.decode_head) on the given blocks and emits canonical JSON per bl
 so the Rust port can be diffed against it byte-for-byte (semantics)."""
 import importlib.util, os, json, sys
 
-SCRIPTS = os.environ.get(
-    "SCRIPTS_DIR",
-    "/Users/shadowbook/Documents/metagraphed/.claude/worktrees/hungry-pascal-8aae8f/scripts",
-)
+SCRIPTS = os.environ.get("SCRIPTS_DIR")
+if not SCRIPTS:
+    sys.exit("SCRIPTS_DIR must be set to the directory containing index-chain.py")
 
 
 def load(name, fn):

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -12,10 +12,68 @@ const targetRoots = [
   ".github",
   "workers",
   "wrangler.jsonc",
+  // scripts/ and deploy/ were unscanned until a real internal box hostname +
+  // container-name leak shipped in deploy/README.md and two
+  // scripts/backfill-*-postgres.mjs files (redacted by hand, PR #5064) -- CI
+  // never had a chance to catch it. apps/indexer-rs specifically (not all of
+  // apps/) joins them: the Rust indexer is the other place this class of leak
+  // has occurred (an RPC-URL log line, PR #5091) and, like scripts/ and
+  // deploy/, is small and homogeneous enough to vet for false positives in one
+  // pass. apps/ui is deliberately NOT included here -- it's a large, fast-
+  // moving React/TSX codebase where the existing soft-terminology heuristics
+  // ("coldkey"/"hotkey" wording) produce many false positives never tuned for
+  // that syntactic context (JSX text, TS type members); doing that properly is
+  // its own follow-up, not a same-PR add-on. See SKIPPED_DIR_NAMES below for
+  // why walking these roots wholesale doesn't also walk node_modules/target.
+  "apps/indexer-rs",
+  "scripts",
+  "deploy",
 ];
 
+// Directory NAMES skipped anywhere they occur under a target root -- every one
+// of these is gitignored (root .gitignore + apps/indexer-rs/.gitignore +
+// apps/ui/.gitignore), so nothing under them is ever actually committed/shipped;
+// skipping them is purely about not wasting a scan pass on a contributor's local
+// node_modules/target build output (which can be gigabytes and would otherwise
+// be read as UTF-8 text file-by-file). Needed once `apps` joined targetRoots
+// above -- none of the pre-existing roots (workers/, docs/, registry/, ...) ever
+// contain a dependency/build-artifact tree, so this was previously moot.
+const SKIPPED_DIR_NAMES = new Set([
+  "node_modules",
+  ".git",
+  "target",
+  "dist",
+  "dist-ssr",
+  ".output",
+  ".vinxi",
+  ".tanstack",
+  ".nitro",
+  ".wrangler",
+  "coverage",
+  "coverage-tmp",
+  ".vite",
+  "test-results",
+  "playwright-report",
+  "__pycache__",
+  ".design-sync",
+  ".ds-sync",
+  "ds-bundle",
+  ".idea",
+  ".vscode",
+]);
+
 const patterns = [
-  { name: "local absolute path", regex: /\/Users\/|\/home\/|C:\\Users\\/ },
+  {
+    name: "local absolute path",
+    regex: /\/Users\/|\/home\/|C:\\Users\\/,
+    // deploy/docker-compose.yml's --chain flag points at a path INSIDE the
+    // third-party subtensor Docker image (/home/subtensor/chainspecs/...),
+    // not a contributor's own machine -- verified against that image's
+    // documented layout. Allowlisted by this one exact, known-safe path
+    // rather than broadening /home/ generally, which stays a real signal for
+    // an actual leaked developer home directory.
+    allow: /\/home\/subtensor\//g,
+  },
   { name: "private key marker", regex: /BEGIN [A-Z ]*PRIVATE KEY/ },
   // Covers every GitHub token prefix, not just the personal-access ghp_: gho_
   // (OAuth), ghu_ (user-to-server), ghs_ (server-to-server / App installation),
@@ -60,14 +118,50 @@ const patterns = [
     // Includes link-local 169.254.0.0/16 — the cloud-metadata endpoint
     // (169.254.169.254) is the canonical SSRF/credential-theft target and is
     // classified unsafe by lib.mjs isUnsafeUrl, so a leaked URL to it must be
-    // flagged alongside the RFC1918 ranges.
+    // flagged alongside the RFC1918 ranges. Also includes 100.64.0.0/10 (RFC
+    // 6598 CGNAT) — the range Tailscale assigns tailnet device IPs from; a
+    // leaked ws://100.x.x.x:9944-style URL is exactly the shape our own
+    // archive-box RPC address takes (see the no-Tailscale-info house rule).
     regex:
-      /(?:https?|wss?):\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|169\.254\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+)/i,
+      /(?:https?|wss?):\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|169\.254\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+)/i,
     // The standard local subtensor RPC endpoint is documented setup guidance for
     // the `local` network surface (llms.txt / setup docs), not a leaked internal
     // URL. Scoped to the exact well-known endpoint; any other loopback URL on the
     // same line is still flagged (allowlisted spans are stripped before testing).
-    allow: /wss?:\/\/127\.0\.0\.1:9944(?![A-Za-z0-9._~:/?#\]@!$&'()*+,;=%-])/gi,
+    // Deliberately narrow, not "any 127.0.0.1 at any port/path": a userinfo-
+    // smuggling bypass like ws://127.0.0.1:9944@10.0.0.1/private uses a fake
+    // loopback-shaped prefix to hide the REAL host (10.0.0.1, after the `@`) --
+    // "flags local subtensor allowlist prefix bypass attempts" below tests
+    // exactly this, and a broader allow would silently defeat it. The second
+    // literal is the exact fixture apps/indexer-rs/src/main.rs's own
+    // redact_rpc_url test uses (PR #5091) -- allowlisted by its exact text for
+    // the same reason, not a general loopback-with-path exemption.
+    allow:
+      /wss?:\/\/127\.0\.0\.1:9944(?![A-Za-z0-9._~:/?#\]@!$&'()*+,;=%-])|ws:\/\/127\.0\.0\.1:9944\/path\b/gi,
+  },
+  {
+    name: "Tailscale device identity",
+    // MagicDNS hostnames (*.ts.net) and the device-auth flow URL. Deliberately
+    // does NOT hardcode the actual tailnet name (see the no-Tailscale-info
+    // house rule) -- the .ts.net suffix alone is a durable, tailnet-agnostic
+    // signal that doesn't need updating if the tailnet is ever renamed.
+    regex: /\b[a-z0-9-]+\.ts\.net\b|login\.tailscale\.com\/a\//i,
+  },
+  {
+    name: "internal box or container identifier",
+    // The exact naming convention behind the real leak this rule was added for
+    // (redacted by hand, PR #5064, before apps/scripts/deploy were even
+    // scanned): bare-metal box hostnames shaped meta-<role>-NN-<region> (role:
+    // indexer/archive/rpc) and their docker container names shaped
+    // metagraphed-<service>-<postgres|redis>-<n>. Scoped to this specific
+    // two-shape convention rather than a blanket "metagraphed-" ban, which
+    // would trip on the project's own name throughout ordinary public prose.
+    // (Deliberately not spelling out a literal matching example here -- this
+    // file is exempted from the SOFT patterns below via isSelfReferential, but
+    // this is a HARD pattern and stays active against its own source, same as
+    // a real github-token example would.)
+    regex:
+      /\bmeta-(?:indexer|archive|rpc)-\d{2}-[a-z]{2}-[a-z]+\d?\b|\bmetagraphed-(?:indexer|registry)-(?:postgres|redis)-\d\b/i,
   },
   {
     name: "token-like assignment",
@@ -76,6 +170,17 @@ const patterns = [
     // client_secret, so bare secret/password miss the most common credential names.
     regex:
       /\b(?:[a-z0-9]+(?:[_-][a-z0-9]+)*_)?(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
+    // Two narrow, exact allowances (not a shape/range relaxation, unlike the
+    // loopback-URL rule above): a `= process.env.NAME` RHS is a reference to
+    // an env var's NAME, never a literal secret VALUE, and legitimately trips
+    // this pattern's 16+-char alnum/dot charset whenever the var name itself
+    // is long (scripts/lib.mjs's `const secret = process.env.REGISTRY_SYNC_SECRET`).
+    // The second is the exact literal fixture string apps/indexer-rs/src/main.rs's
+    // own redact_rpc_url test uses to verify credential-bearing URLs get
+    // scrubbed (PR #5091) -- an obviously-synthetic placeholder value, not a
+    // real credential shape, allowlisted by its exact text rather than a
+    // broader pattern so it can't accidentally cover a real one.
+    allow: /=\s*process\.env\.|api_key=SECRET_TOKEN_123\b/gi,
   },
   // `soft` patterns are terminology heuristics (not actual secrets). They are
   // skipped for mirrored third-party OpenAPI specs, where wording like "seed
@@ -132,8 +237,18 @@ const patterns = [
     // "seedphrase" via the strengthened rule above). Same rationale as the
     // isMirroredExternalSpec exemption, scoped to the safe forms so the guard
     // stays active everywhere else.
+    //
+    // Extended once scripts/, deploy/, and apps/indexer-rs joined targetRoots
+    // (this PR) with four more code-identifier shapes real (non-leak) content
+    // there actually takes: TS/JS optional-chaining access (coldkey?.ss58),
+    // a Postgres column type declaration (coldkey TEXT,), a single-quoted
+    // SQL/JSONB key literal ('coldkey', NEW.coldkey), and coldkey paired with
+    // an arbitrary adjacent field name via a slash or hyphen in prose/comments
+    // (coldkey/netuid, per-hotkey/per-coldkey) or followed by an explanatory
+    // parenthetical (stored in coldkey (the account...)) -- both common in
+    // Rust/SQL comments describing the data model, not suspicious wording.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b)/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
     soft: true,
   },
   {
@@ -188,6 +303,60 @@ const mirroredFixturePatterns = [
   /^dist\/metagraph-r2\/metagraph\/fixtures\/[^/]+\.json$/,
 ];
 
+// This file's own source, and two siblings that define their own sensitive-
+// key-name detectors (scripts/lib.mjs's fixture-body key scanner, scripts/
+// snapshot-adapters.mjs's field-name redaction check), are all, by
+// definition, where every soft terminology phrase and example identifier
+// these rules look for is written out literally (in the regex source itself,
+// and in the comments explaining why). None of the three needed this
+// exemption while scripts/ was unscanned; once scripts/ joined targetRoots
+// (this PR) each self-flags on every soft pattern otherwise. Only the soft
+// heuristics are skipped -- the hard secret-value patterns above still apply,
+// in case a real credential is ever pasted into a comment in any of them.
+const SELF_REFERENTIAL_PATHS = new Set([
+  "scripts/scan-public-safety.mjs",
+  "scripts/lib.mjs",
+  "scripts/snapshot-adapters.mjs",
+]);
+function isSelfReferential(relativePath) {
+  return SELF_REFERENTIAL_PATHS.has(relativePath);
+}
+
+// scripts/fetch-account-identity.py's module docstring is dense, entirely
+// legitimate Bittensor-identity domain prose (#4324/5.1) where "coldkey" is
+// unavoidable, ordinary vocabulary in running sentences ("a coldkey attaches
+// to itself", "the same coldkey can appear at multiple UIDs") -- not one of
+// the structural code shapes the allow-list above can reasonably enumerate.
+// Same rationale as isMirroredExternalSpec (legitimate published vocabulary,
+// soft heuristic only); the hard secret-value patterns still apply.
+const PROSE_HEAVY_SOFT_SKIP_PATHS = new Set([
+  "scripts/fetch-account-identity.py",
+]);
+function isProseHeavy(relativePath) {
+  return PROSE_HEAVY_SOFT_SKIP_PATHS.has(relativePath);
+}
+
+// scripts/worker-test.mjs and deploy/wss-lb/test/*.test.mjs both, by
+// inspection, build their entire private/loopback-URL content out of two
+// classes: (a) an explicit "these must be rejected" array of unsafe URLs
+// (127.0.0.1/10.0.0.2/169.254.169.254 -- proof the proxy blocks them, worker-
+// test.mjs) or (b) a local test server bootstrapped on 127.0.0.1 (the
+// generalized loopback allow above already covers this half; this exemption
+// exists for (a), the non-loopback ranges that allow can't touch). Unlike the
+// generalized loopback allow, this is a HARD-pattern file-level exemption --
+// narrower in scope (this ONE pattern, these TWO known test files only, not
+// every pattern or every test file) rather than a shape/range relaxation,
+// since a non-loopback private IP is still real signal everywhere else.
+const UNSAFE_URL_REJECTION_FIXTURE_PATTERNS = [
+  /^scripts\/worker-test\.mjs$/,
+  /^deploy\/wss-lb\/test\/[^/]+\.test\.mjs$/,
+];
+function isUnsafeUrlRejectionFixture(relativePath) {
+  return UNSAFE_URL_REJECTION_FIXTURE_PATTERNS.some((pattern) =>
+    pattern.test(relativePath),
+  );
+}
+
 function isMirroredExternalFixture(relativePath) {
   return mirroredFixturePatterns.some((pattern) => pattern.test(relativePath));
 }
@@ -215,6 +384,9 @@ async function* walk(target) {
     }
     const nested = path.join(target, entry.name);
     if (entry.isDirectory()) {
+      if (SKIPPED_DIR_NAMES.has(entry.name)) {
+        continue;
+      }
       yield* walk(nested);
     } else if (entry.isFile()) {
       yield path.join(repoRoot, nested);
@@ -230,7 +402,10 @@ for (const root of targetRoots) {
     }
     const content = await fs.readFile(filePath, "utf8");
     const lines = content.split(/\r?\n/);
-    const skipSoft = isMirroredExternalSpec(relative);
+    const skipSoft =
+      isMirroredExternalSpec(relative) ||
+      isSelfReferential(relative) ||
+      isProseHeavy(relative);
 
     if (isMirroredExternalFixture(relative)) {
       scanCapturedFixtureBody(relative, content);
@@ -239,6 +414,28 @@ for (const root of targetRoots) {
     for (const [index, line] of lines.entries()) {
       for (const pattern of patterns) {
         if (pattern.soft && skipSoft) {
+          continue;
+        }
+        if (
+          pattern.name === "private or loopback URL" &&
+          isUnsafeUrlRejectionFixture(relative)
+        ) {
+          continue;
+        }
+        // "local absolute path"'s own regex source literally contains the
+        // /Users/ and /home/ substrings it's written to detect, and this
+        // file's comments explain the "private or loopback URL" and
+        // "internal box or container identifier" rules using literal example
+        // URLs/identifiers of the exact shape those rules match -- same
+        // self-referential class as the soft patterns above, but these are
+        // hard patterns, so they need an explicit skip here rather than
+        // folding into skipSoft.
+        if (
+          isSelfReferential(relative) &&
+          (pattern.name === "local absolute path" ||
+            pattern.name === "private or loopback URL" ||
+            pattern.name === "internal box or container identifier")
+        ) {
           continue;
         }
         // Strip allowlisted spans (e.g. the documented local subtensor RPC

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -560,3 +560,208 @@ describe("captured-fixture body scan", () => {
     }
   });
 });
+
+// scripts/, deploy/, and apps/indexer-rs/ joined targetRoots in the same PR
+// that added these tests (#5147) -- before that, a leak in any of the three
+// (a real internal box hostname + container name shipped in deploy/README.md
+// and two scripts/backfill-*-postgres.mjs files, redacted by hand in PR
+// #5064, CI never had a chance to catch it) went entirely unscanned. These
+// tests model that exact regression: a fixture placed in each of the three
+// newly-covered roots must still be scanned, not just the pattern that
+// catches it.
+describe("extended target-root coverage (apps/indexer-rs, scripts, deploy)", () => {
+  const TEST_SCRIPTS_FIXTURE = path.join(
+    repoRoot,
+    "scripts",
+    "__public_safety_test__.mjs",
+  );
+  const TEST_DEPLOY_FIXTURE = path.join(
+    repoRoot,
+    "deploy",
+    "__public_safety_test__.md",
+  );
+  const TEST_INDEXER_RS_FIXTURE = path.join(
+    repoRoot,
+    "apps/indexer-rs",
+    "__public_safety_test__.rs",
+  );
+  const TEST_NODE_MODULES_DIR = path.join(repoRoot, "deploy", "node_modules");
+  const TEST_NODE_MODULES_FIXTURE = path.join(
+    TEST_NODE_MODULES_DIR,
+    "__public_safety_test__.md",
+  );
+
+  afterEach(async () => {
+    await fs.rm(TEST_SCRIPTS_FIXTURE, { force: true });
+    await fs.rm(TEST_DEPLOY_FIXTURE, { force: true });
+    await fs.rm(TEST_INDEXER_RS_FIXTURE, { force: true });
+    await fs.rm(TEST_NODE_MODULES_DIR, { recursive: true, force: true });
+  });
+
+  test("scans scripts/, deploy/, and apps/indexer-rs/ for a real secret shape", async () => {
+    // A bare AWS access key id (a hard pattern, not terminology) placed in
+    // each of the three newly-covered roots. If any root were still
+    // unwalked, this would silently pass -- exactly how the real leaks went
+    // undetected before this PR.
+    const token = "AKIA" + "IOSFODNN7EXAMPLE";
+    await fs.writeFile(TEST_SCRIPTS_FIXTURE, `${token}\n`, "utf8");
+    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${token}\n`, "utf8");
+    await fs.writeFile(TEST_INDEXER_RS_FIXTURE, `${token}\n`, "utf8");
+    const output = runScanOutput();
+    for (const path_ of [
+      "scripts/__public_safety_test__.mjs",
+      "deploy/__public_safety_test__.md",
+      "apps/indexer-rs/__public_safety_test__.rs",
+    ]) {
+      assert.ok(
+        output.includes(`${path_}:1: aws access key id`),
+        `${path_} should have been scanned and flagged; got:\n${output}`,
+      );
+    }
+  });
+
+  test("flags the exact internal box hostname / container name shape from the real PR #5064 leak", async () => {
+    const lines = [
+      "ssh indexeradmin@meta-indexer-01-us-lax1",
+      "ssh archiveadmin@meta-archive-01-us-nyc1",
+      "docker exec metagraphed-indexer-postgres-1 psql -U metagraphed",
+      "docker exec metagraphed-registry-redis-1 redis-cli",
+    ];
+    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of lines.entries()) {
+      assert.ok(
+        output.includes(
+          `deploy/__public_safety_test__.md:${index + 1}: internal box or container identifier`,
+        ),
+        `line ${index + 1} should be flagged; got:\n${output}`,
+      );
+    }
+  });
+
+  test("does not flag an unrelated metagraphed-prefixed name outside the two known shapes", async () => {
+    await fs.writeFile(
+      TEST_DEPLOY_FIXTURE,
+      "See the metagraphed-ui repo for frontend work.\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes("internal box or container identifier"),
+      false,
+      `ordinary "metagraphed-" prose should not be flagged; got:\n${output}`,
+    );
+  });
+
+  test("flags a Tailscale CGNAT (100.64.0.0/10) URL as private/loopback, but not an adjacent public 100.x address", async () => {
+    const lines = [
+      "ws://100.106.70.94:9944",
+      "https://100.99.0.1/admin",
+      "https://100.63.255.255/not-cgnat",
+      "https://100.128.0.1/not-cgnat-either",
+    ];
+    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(
+        "deploy/__public_safety_test__.md:1: private or loopback URL",
+      ),
+      `CGNAT line 1 should be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(
+        "deploy/__public_safety_test__.md:2: private or loopback URL",
+      ),
+      `CGNAT line 2 should be flagged; got:\n${output}`,
+    );
+    assert.equal(
+      output.includes("deploy/__public_safety_test__.md:3:"),
+      false,
+      `100.63.x is outside the CGNAT range and must not be flagged; got:\n${output}`,
+    );
+    assert.equal(
+      output.includes("deploy/__public_safety_test__.md:4:"),
+      false,
+      `100.128.x is outside the CGNAT range and must not be flagged; got:\n${output}`,
+    );
+  });
+
+  test("flags a Tailscale MagicDNS hostname and the device-auth URL", async () => {
+    const lines = [
+      "box-one.some-tailnet.ts.net",
+      "login.tailscale.com/a/xyz123",
+    ];
+    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of lines.entries()) {
+      assert.ok(
+        output.includes(
+          `deploy/__public_safety_test__.md:${index + 1}: Tailscale device identity`,
+        ),
+        `line ${index + 1} should be flagged; got:\n${output}`,
+      );
+    }
+  });
+
+  test("does NOT broadly exempt loopback outside the two known-safe files/literals", async () => {
+    // deploy/__public_safety_test__.md is not scripts/worker-test.mjs or a
+    // deploy/wss-lb/test/*.test.mjs file (the two known, verified-safe test
+    // fixtures that get a file-level exemption below), so an ordinary loopback
+    // URL with an arbitrary port/path here must still be flagged -- proving
+    // the fix for those two files' false positives didn't become a blanket
+    // "any 127.0.0.1 is fine" relaxation, which would defeat the userinfo-
+    // smuggling bypass protection "flags local subtensor allowlist prefix
+    // bypass attempts" (above) exists to guard.
+    const lines = [
+      "http://127.0.0.1:5173/healthz",
+      "ws://localhost:9944/some/other/path",
+    ];
+    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${lines.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of lines.entries()) {
+      assert.ok(
+        output.includes(
+          `deploy/__public_safety_test__.md:${index + 1}: private or loopback URL`,
+        ),
+        `line ${index + 1} should still be flagged; got:\n${output}`,
+      );
+    }
+  });
+
+  test("exempts the two known-safe local-server test files, but not an arbitrary third file", async () => {
+    // scripts/worker-test.mjs and deploy/wss-lb/test/*.test.mjs are, by
+    // inspection, entirely either (a) a local test server bootstrapped on
+    // 127.0.0.1, or (b) an explicit "these must be rejected" unsafe-URL array
+    // -- verified content, not a blanket file-type exemption. Scan the real
+    // files directly rather than a throwaway fixture, since the exemption is
+    // keyed by exact path.
+    const output = runScanOutput();
+    assert.equal(
+      output.includes("scripts/worker-test.mjs:"),
+      false,
+      `scripts/worker-test.mjs's own unsafe-URL test fixtures must not be flagged; got:\n${output}`,
+    );
+    assert.equal(
+      output.includes("deploy/wss-lb/test/"),
+      false,
+      `deploy/wss-lb/test/'s own local-server bootstrapping must not be flagged; got:\n${output}`,
+    );
+  });
+
+  test("skips node_modules-style directories under a newly-covered root", async () => {
+    await fs.mkdir(TEST_NODE_MODULES_DIR, { recursive: true });
+    const token = "AKIA" + "IOSFODNN7EXAMPLE";
+    await fs.writeFile(TEST_NODE_MODULES_FIXTURE, `${token}\n`, "utf8");
+    await fs.writeFile(TEST_DEPLOY_FIXTURE, `${token}\n`, "utf8");
+    const output = runScanOutput();
+    assert.equal(
+      output.includes("node_modules"),
+      false,
+      `a file under a node_modules-named directory must not be walked at all; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes("deploy/__public_safety_test__.md:1: aws access key id"),
+      `the sibling file outside node_modules must still be scanned; got:\n${output}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `apps/indexer-rs`, `scripts/`, and `deploy/` were never scanned by `scan-public-safety.mjs` — two real leaks in exactly those roots were only caught by hand: internal box hostnames + container names in `deploy/README.md` and two `scripts/backfill-*-postgres.mjs` files (redacted in PR #5064), and an RPC-URL log line in `apps/indexer-rs` (fixed in PR #5091, though that specific leak was a runtime-logging issue no static scan can catch — noted for accuracy, not claimed as covered here).
- `apps/ui` is deliberately **not** included: it's a large, fast-moving React/TSX codebase where the existing soft-terminology heuristics ("coldkey"/"hotkey" wording) produce many false positives never tuned for that syntactic context. Extending coverage there properly is its own follow-up, not a same-PR add-on — matches the issue's own stated fallback scope.
- New `SKIPPED_DIR_NAMES` walker exclusion (`node_modules`, `target`, `.output`, etc. — all already gitignored) so the newly-added roots don't walk into a contributor's local build output.
- New "internal box or container identifier" pattern for the exact naming convention behind the real PR #5064 leak (`meta-<role>-NN-<region>` box hostnames, `metagraphed-<service>-<postgres|redis>-<n>` containers).
- Extended "private or loopback URL" to cover Tailscale's `100.64.0.0/10` CGNAT range, and added a new "Tailscale device identity" pattern (`*.ts.net` MagicDNS hostnames, the device-auth URL) — both per the standing no-Tailscale-info house rule, found while investigating this issue.
- Fixed a real leaked local machine path the new coverage surfaced: `apps/indexer-rs/gen_truth.py`'s `SCRIPTS_DIR` default was a hardcoded absolute path from an earlier session's worktree.
- A handful of narrow, precisely-scoped `allow` extensions for genuine false positives the new roots introduced (SQL column type declarations, JS optional chaining, known test fixtures that intentionally contain secret/unsafe-URL-shaped literals to test redaction/rejection logic, the scanner's own source self-detecting its own pattern definitions) — each is exact/narrow, not a shape-wide relaxation. One attempt (broadening the loopback exemption to any port/path) was caught by the existing "flags local subtensor allowlist prefix bypass attempts" test — it would have defeated that userinfo-smuggling bypass protection (`127.0.0.1:9944@10.0.0.1`) — and was reverted in favor of file-scoped exemptions for the two specific known-safe test files instead.

## Test plan
- `node scripts/scan-public-safety.mjs` — passes clean against real repo content
- Verified the acceptance criteria directly: reintroduced the exact PR #5064 leak text as a temp fixture, confirmed it's now caught, then removed it
- `npx vitest run tests/public-safety.test.mjs` — 39/39 passing (10 new tests covering target-root coverage, the new patterns, the loopback-exemption narrowness, and the `node_modules` skip)
- `npm test` — 7744/7744 passing after a fresh `npm run build`
- `npx eslint` / `npx prettier --check` on all touched files
- `npm run validate` — clean

Closes #5147