### PR TITLE
fix(ui): align weight-setters leaderboard card for mobile (#3942)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1252,11 +1252,14 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
   return (
     <div className="mt-6 min-w-0" data-weight-setters-leaderboard>
       <div className="overflow-hidden rounded-xl border border-border bg-card">
-        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-border px-4 py-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        <div className="flex flex-nowrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted sm:hidden">
+            Weight-setters
+          </span>
+          <span className="hidden shrink-0 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted sm:inline">
             Weight-setters · per-validator breakdown
           </span>
-          <span className="font-mono text-[10px] text-ink-muted">
+          <span className="shrink-0 font-mono text-[10px] text-ink-muted whitespace-nowrap">
             {formatNumber(d.setter_count)} validators · {windowLabel}
           </span>
         </div>

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1248,14 +1248,22 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
     );
   }
   const rows = d.setters.slice(0, 15);
+  const windowLabel = d.window ?? "30d";
   return (
-    <div className="mt-6">
-      <h3 className="mb-2 font-mono text-[11px] uppercase tracking-widest text-ink-muted">
-        Weight-setters (per-validator breakdown)
-      </h3>
+    <div className="mt-6 min-w-0" data-weight-setters-leaderboard>
       <div className="overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-border px-4 py-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Weight-setters · per-validator breakdown
+          </span>
+          <span className="font-mono text-[10px] text-ink-muted">
+            {formatNumber(d.setter_count)} validators · {windowLabel}
+          </span>
+        </div>
+        {/* overflow-x-auto keeps the 4-column table inside the card on narrow
+            viewports (#3942) — same inner scroll shell NeuronTable and ListShell use. */}
         <div className="overflow-x-auto">
-          <table className="w-full text-sm">
+          <table className="w-full min-w-[280px] text-sm">
             <thead className="bg-surface/50 text-ink-muted">
               <tr>
                 <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">


### PR DESCRIPTION
## Summary

- Verified the subnet Validators tab weight-setters leaderboard renders within the mobile viewport (375px) without page-level overflow — the 4-column table stays inside the card’s `overflow-x-auto` shell.
- Aligned the leaderboard’s card/border treatment with sibling sections (validator stake chart, KPI strip): title moved inside the card header, `data-weight-setters-leaderboard` hook added for screenshot/overflow checks.
- Added deterministic screenshot capture tooling (`capture-weight-setters-screenshots.mjs` + API fixtures) for full fixed-viewport before/after evidence.

Closes #3942

## Template Used

Frontend/UI change (`apps/ui/**` only)

## Test plan

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (684 passed)
- [x] `npm run build --workspace=apps/ui`
- [x] Manual overflow check at 375px on `/subnets/1?tab=validators` — table right edge stays inside viewport; no new page-level overflow from the leaderboard
- [x] Captured 12 fixed-viewport screenshots (375 / 768 / 1280 × light/dark × before/after) with page chrome and stake chart visible

## Screenshots

Fixed-viewport captures (not fullPage, not element crops) of `/subnets/1?tab=validators` scrolled to show the weight-setters leaderboard in page context alongside the validator stake chart and KPI strip above it.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/3942-mobile-dark-after.png)<br><sub>after</sub> |
