### PR TITLE
feat(registry): add SN62 Ridges public TaoMarketCap data artifact

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-taomarketcap-subnet-snapshot",
+      "kind": "data-artifact",
+      "name": "SN62 Ridges on-chain subnet snapshot",
+      "notes": "Public no-auth GET /public/v1/subnets/62 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN62 Ridges on-chain subnet state, SubnetIdentitiesV3 metadata, economics, registration/burn parameters, and dTAO market fields. This indexed public JSON feed for netuid 62 is documented in the TaoMarketCap developer API and is a standalone machine-readable data artifact, distinct from the Ridges agent API surfaces already registered for this subnet.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://github.com/ridgesai/ridges"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/62"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary
Enriches **SN62 Ridges** with the public, no-auth machine-readable **data artifact** issue #4069 requests.

- The registry already lists Ridges' source repo and agent API, but `gap_notes` records *"No verified standalone static data artifact yet."* This fills that gap.
- Artifact: `GET https://api.taomarketcap.com/public/v1/subnets/62` — a machine-readable JSON snapshot of SN62's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, registration/burn parameters, and dTAO market fields.
- Documented in the TaoMarketCap developer API (`https://api.taomarketcap.com/developer/documentation/`). Distinct from the existing `agent-upload.ridges.ai` API surfaces and from the TaoMarketCap **dashboard** (an HTML page).

## Change
- One file: `registry/subnets/ridges.json` — appends a single `authority: community`, `review.state: community-submitted` surface. Purely additive.

Closes #4069