### PR TITLE
security(codeowners): add path-specific rules for CI, deps, registry, release config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,19 @@
+# Default: everything.
 * @JSONbored
+
+# Explicit, path-specific rules below (#3080) for the highest-value targets a
+# compromised contributor or leaked token could hit: CI workflow definitions,
+# dependency manifests (a supply-chain injection point), the registry data
+# tree, and release/publish configuration. All still resolve to the sole
+# maintainer today (there's only one owner), but spelling them out
+# documents-as-code which paths are security-sensitive and is what
+# require_code_owner_reviews (branch protection) actually enforces against
+# once enabled — the blanket rule above alone doesn't give per-path signal.
+/.github/workflows/ @JSONbored
+/.github/CODEOWNERS @JSONbored
+/package.json @JSONbored
+/package-lock.json @JSONbored
+/registry/ @JSONbored
+/release-please-config.json @JSONbored
+/.release-please-manifest.json @JSONbored
+/renovate.json @JSONbored


### PR DESCRIPTION
## Summary
- CODEOWNERS had only a blanket `* @JSONbored` rule, with no path-specific coverage for the highest-value targets a compromised contributor or leaked token could hit — confirmed via the repo's own security scan (#3080, Severity: High).
- Adds explicit ownership entries for `.github/workflows/`, `package.json`/`package-lock.json`, `registry/`, and release/publish config (`release-please-config.json`, `.release-please-manifest.json`, `renovate.json`). All still resolve to the sole maintainer today — this is documentation-as-code for what path-specific review would gate once enabled, not a review-routing change today.

## Note — one part of #3080 needs a repo-settings change, not a code change
#3080 also asks to "enforce `require_code_owner_reviews` in branch protection." I confirmed via the API that main's branch protection currently has `require_code_owner_reviews: false`. That's a repository access-control setting (Settings → Branches → main → Require review from Code Owners), not a file in the repo, so it's outside what I can change via a PR — flagging it here so it isn't lost. Once this PR merges, enabling that one setting is what actually makes the path rules enforce anything.

## Test plan
- Reviewed CODEOWNERS syntax against GitHub's documented format (leading `/` anchors to repo root, trailing `/` for directories)
- `git diff --check` clean

Closes #3080