### PR TITLE
fix(ui): show distinct ErrorState on GapsPanel fetch failure

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1398,39 +1398,6 @@ function CandidatesPanel({ netuid }: { netuid: number }) {
 }
 
 function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
-  const { data: gapsResult, isLoading, error } = useQuery(subnetGapsQuery(netuid));
-  const gaps = gapsResult?.data;
-  const missing = gaps?.missing_kinds ?? [];
-  const notes = gaps?.gap_notes ?? [];
-  if (isLoading) {
-    return (
-      <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
-        <Skeleton className="h-24 w-full" />
-      </SectionAnchor>
-    );
-  }
-  if (error) {
-    return (
-      <SectionAnchor id="gaps" title={compact ? "Known gaps" : "Gaps"}>
-        <EmptyState
-          title="Gaps unavailable"
-          description="The subnet gaps endpoint did not respond."
-          action={RECOVERY.gaps}
-        />
-      </SectionAnchor>
-    );
-  }
-  if (missing.length === 0 && notes.length === 0) {
-    return (
-      <SectionAnchor id="gaps" title="Gaps">
-        <EmptyState
-          title="No outstanding gaps"
-          description="Profile looks complete."
-          action={RECOVERY.gaps}
-        />
-      </SectionAnchor>
-    );
-  }
   return (
     <SectionAnchor
       id="gaps"
@@ -1438,34 +1405,56 @@ function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
       subtitle="Missing resources, profile incompleteness, and curation notes."
       info="GET /api/v1/subnets/{netuid}/gaps"
     >
-      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-        {missing.length > 0 ? (
-          <div>
-            <div className="mg-label mb-1">Missing kinds</div>
-            <div className="flex flex-wrap gap-1">
-              {missing.map((k) => (
-                <span
-                  key={k}
-                  className="rounded border border-dashed border-ink-subtle bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
-                >
-                  {k}
-                </span>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {notes.length > 0 ? (
-          <ul className="space-y-1 text-[12px] text-ink leading-relaxed">
-            {notes.map((n, i) => (
-              <li key={i}>· {n}</li>
-            ))}
-          </ul>
-        ) : null}
-        <div className="border-t border-border pt-2 text-[11px] text-ink-muted">
-          Help close these gaps by opening a PR against the public registry repo.
-        </div>
-      </div>
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+          <GapsLoader netuid={netuid} />
+        </Suspense>
+      </QueryErrorBoundary>
     </SectionAnchor>
+  );
+}
+
+function GapsLoader({ netuid }: { netuid: number }) {
+  const { data: gapsResult } = useSuspenseQuery(subnetGapsQuery(netuid));
+  const missing = gapsResult.data.missing_kinds ?? [];
+  const notes = gapsResult.data.gap_notes ?? [];
+  if (missing.length === 0 && notes.length === 0) {
+    return (
+      <EmptyState
+        title="No outstanding gaps"
+        description="Profile looks complete."
+        action={RECOVERY.gaps}
+      />
+    );
+  }
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      {missing.length > 0 ? (
+        <div>
+          <div className="mg-label mb-1">Missing kinds</div>
+          <div className="flex flex-wrap gap-1">
+            {missing.map((k) => (
+              <span
+                key={k}
+                className="rounded border border-dashed border-ink-subtle bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+              >
+                {k}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {notes.length > 0 ? (
+        <ul className="space-y-1 text-[12px] text-ink leading-relaxed">
+          {notes.map((n, i) => (
+            <li key={i}>· {n}</li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="border-t border-border pt-2 text-[11px] text-ink-muted">
+        Help close these gaps by opening a PR against the public registry repo.
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

`GapsPanel` (`apps/ui/src/routes/subnets.$netuid.tsx`) was the only tab-panel on the subnet detail page managing its loading/error states manually via plain `useQuery`, instead of the `QueryErrorBoundary` + `Suspense` pattern its seven sibling tabs (Surfaces, Endpoints, Callable services, Schemas, Metagraph, Validators, Activity) already use. On a genuine fetch error it rendered the same `EmptyState` component/style used for the legitimate "no outstanding gaps" success case — same dashed-border box, just different copy — with no red border and no retry button.

- Split `GapsPanel` into an outer component that renders `SectionAnchor` (now with its static `subtitle`/`info` shown consistently, matching every sibling) wrapping `QueryErrorBoundary` + `Suspense`, and a new `GapsLoader` that uses `useSuspenseQuery(subnetGapsQuery(netuid))` — identical shape to `EndpointsPanel`/`EndpointsTableLoader` in the same file.
- A fetch failure now surfaces the shared `ErrorState` (red-bordered alert, the failing URL, a Retry button wired to `QueryErrorBoundary.reset()`) automatically — no manual error branching in `GapsPanel` itself.
- The legitimate "no outstanding gaps" success case is unchanged (`EmptyState` with the same title/description/action).
- No changes to `subnetGapsQuery` or what counts as "no outstanding gaps" vs. a genuine error.

## Verifying the error path

`subnetGapsQuery`'s `queryFn` already throws on a bad/empty response, and `apiFetch` already throws `ApiError` on non-2xx — both pre-existing, unchanged. To actually witness the corrected UI rather than assume it from code reading alone, I ran a local reverse-proxy in front of `api.metagraph.sh` that returns a 500 for only the `/subnets/1/gaps` route (everything else passes through untouched), pointed a dev server at it, and let the client's normal retry backoff (3 attempts, ~7s cumulative — `router.tsx`'s `retry: failureCount < 3`) exhaust before capturing. The `http://localhost:5299/...` URL visible in the "after" screenshots is that local proxy, not a real endpoint — it only appears because `ErrorState` displays the failing request URL.

## Screenshots

| Viewport · Theme | Before                                                                | After                                                              |
| ----------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/3961-mobile-dark-after.png)<br><sub>after</sub> |

All rows show the "Known gaps" section with a genuine forced fetch failure (see above) — the "before" state is visually indistinguishable from the "No incidents recorded"/"No evidence recorded" success states above it; the "after" state clearly differs with a red border, alert icon, the failing URL, and a Retry button.

## Validation

```
npm run lint --workspace=apps/ui
npm run format:check --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui
npm run test:e2e --workspace=apps/ui
npm run build --workspace=apps/ui
```

All green.

Closes #3961
