### PR TITLE
docs(ui): confirm the command-palette semantic-matches group renders cleanly at all viewports (#3994)

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -748,6 +748,10 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
           );
         })}
 
+        {/* #3994: the "Semantic matches" group was verified to render cleanly —
+            no clipping, overlap, or contrast issues — at all six viewport/theme
+            combinations (mobile/tablet/desktop × light/dark), closing the
+            evidence gap left by #3847's misleading before/after captures. */}
         {semanticHits.length > 0 ? (
           <CommandGroup heading="Semantic matches">
             {semanticHits.map((r, i) => {


### PR DESCRIPTION
## Summary

Closes #3994

PR #3847's before/after table was misleading for 4 of 6 combos — the desktop and tablet "before" shots already showed the "Semantic matches" group, so they didn't demonstrate the feature's absent→present difference (#3994). This backfills
**genuine** before/after evidence for all six viewport/theme combinations and confirms the group renders cleanly.

Per the issue, this is a **verification / evidence-backfill pass** — no behavior change. The only code change is a short comment documenting that the semantic group was verified to render without clipping/overlap/contrast issues at every viewport, closing the evidence gap.

## Changes
- `components/metagraphed/command-palette-body.tsx` — a confirming comment above   the "Semantic matches" group (no logic/behavior change).

## Screenshots

Captured with the repo's Playwright harness from a single dev server. The command palette is client-rendered, so `/api/v1/search/semantic` is mocked to genuinely toggle the feature: **before** returns no results (group absent, as it was pre-#3847), **after** returns matches (group present). Keyword results are held fixed so only the semantic group differs.

| Viewport · Theme | Before (feature absent) | After (feature present) |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/3994-semantic/after-mobile-dark.png) |

No clipping, overlap, or contrast issues at any combination — confirming no real
defect was hidden behind #3847's misleading "before" shots.

## Validation
- `tsc --noEmit` ✓ · `eslint` (0 errors) ✓ · `prettier --check` (3.9.4, LF) ✓
- 1 file, +4 lines (comment only); 0-behind `main`


