### PR TITLE
feat(registry): add SN124 Swarm public benchmark dashboard surface

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -70,6 +70,25 @@
       ],
       "url": "https://api.swarm124.com/leaderboard",
       "notes": "Public no-auth GET /leaderboard — ranked miner model leaderboard (rank, model id, uid, benchmark score) for SN124 Swarm. Served on the same api.swarm124.com host as the subnet's registered health API; the endpoint is defined in the subnet's backend API module."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-124-swarm-dashboard",
+      "kind": "dashboard",
+      "name": "Swarm public benchmark leaderboard",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/README.md",
+        "https://swarm124.com/benchmark"
+      ],
+      "url": "https://swarm124.com/benchmark",
+      "notes": "Public no-auth web leaderboard/benchmark view for SN124 Swarm — the drone-flight model rankings the subnet publishes at swarm124.com/benchmark (linked from the official swarm-subnet/swarm README). Renders the same data as the registered api.swarm124.com/leaderboard endpoint; distinct host from the api.swarm124.com API surfaces."
     }
   ],
   "website_url": "https://www.swarm124.com/"


### PR DESCRIPTION
Adds a **dashboard** surface for **SN124 Swarm** — the subnet's public web benchmark leaderboard, a surface kind the file did not yet have.

- **url:** https://swarm124.com/benchmark (public, no-auth drone-flight model leaderboard)
- **source_urls (proof):** https://github.com/swarm-subnet/swarm/blob/main/README.md (official SN124 repo — identifies the project as Bittensor **Subnet 124** and links the leaderboard at `swarm124.com/benchmark`) + https://swarm124.com/benchmark
- **kind:** dashboard (existing surfaces are subnet-api / data-artifact)
- **host:** swarm124.com — distinct from the `api.swarm124.com` API surfaces, and the domain itself encodes netuid **124**

The page renders the same rankings served by the already-registered `api.swarm124.com/leaderboard` endpoint (champion model, uid/coldkey, per-map benchmark scores for Swarm's drone map types).

**Verified live:** `https://swarm124.com/benchmark` → HTTP 200, no login redirect.

## Validation
- `npm run surface:add` live verification → `OK reachable + public-safe`
- `node scripts/validate-surface.mjs registry/subnets/swarm.json` → passed (4 surfaces)
- `npm run scan:public-safety` → passed
- `npx prettier --check registry/subnets/swarm.json` → clean

Append-only: one new surface on `registry/subnets/swarm.json` only; no existing surfaces or top-level metadata changed.

Part of #427.