### PR TITLE
feat(ui): one-step "Watch this validator" alert on the validator page (#5167)

### DIFF
--- a/apps/ui/src/components/metagraphed/watch-validator.tsx
+++ b/apps/ui/src/components/metagraphed/watch-validator.tsx
@@ -1,0 +1,127 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Check } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/metagraphed/client";
+import { CopyableCode } from "@jsonbored/ui-kit";
+
+// Must match src/alert-triggers.mjs (ALERT_TRIGGER_CREATE_TOKEN_HEADER).
+const CREATE_TOKEN_HEADER = "x-alert-trigger-create-token";
+// Discord incoming-webhook URLs — everything else is treated as a plain webhook.
+const DISCORD_WEBHOOK = /^https:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/api\/webhooks\//i;
+
+const inputCls =
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+
+interface AlertTriggerCreated {
+  id: string;
+  channel: string;
+  account: string | null;
+  owner_token: string;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Unauthorized — check your create token.";
+    if (error.status === 503) return error.message || "Alerts are disabled on this deployment.";
+    if (error.status === 400) return error.message || "That alert configuration was rejected.";
+    return error.message || "Request failed.";
+  }
+  return "Request failed.";
+}
+
+/**
+ * One-step "watch this validator": creates an alert trigger scoped to this
+ * hotkey's stake/delegation events via the existing /api/v1/alerts/triggers
+ * API (#5167). The channel is inferred from the URL (Discord webhook vs plain
+ * webhook); the create token is the API's own anti-abuse secret. Server-side
+ * validateAlertTriggerInput is the source of truth — its error is surfaced
+ * directly rather than re-implemented here.
+ */
+export function WatchValidator({ hotkey }: { hotkey: string }) {
+  const [destination, setDestination] = useState("");
+  const [token, setToken] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async (): Promise<AlertTriggerCreated> => {
+      const channel = DISCORD_WEBHOOK.test(destination.trim()) ? "discord" : "webhook";
+      const res = await apiFetch<AlertTriggerCreated>("/api/v1/alerts/triggers", {
+        init: {
+          method: "POST",
+          headers: { "content-type": "application/json", [CREATE_TOKEN_HEADER]: token.trim() },
+          body: JSON.stringify({ account: hotkey, channel, destination: destination.trim() }),
+        },
+      });
+      return res.data;
+    },
+  });
+
+  const created = mutation.data;
+  const canSubmit = destination.trim() !== "" && token.trim() !== "" && !mutation.isPending;
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (canSubmit) mutation.mutate();
+  }
+
+  if (created) {
+    return (
+      <div className="rounded-lg border border-accent/40 bg-primary-soft/40 p-4">
+        <div className="flex items-center gap-2 font-medium text-ink-strong">
+          <Check className="size-4 shrink-0 text-accent" />
+          You&rsquo;re watching this validator
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-ink-muted">
+          Stake &amp; delegation events for this hotkey will be delivered to your {created.channel}. Save
+          the owner token below — it&rsquo;s shown once and is needed to edit or remove this alert.
+        </p>
+        <div className="mt-2">
+          <CopyableCode label="owner token" value={created.owner_token} truncate={false} className="max-w-full" />
+        </div>
+        <button
+          type="button"
+          onClick={() => mutation.reset()}
+          className="mt-3 inline-flex items-center rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+        >
+          Set up another
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="rounded-lg border border-border bg-card p-4">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="url"
+          inputMode="url"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          placeholder="Webhook or Discord webhook URL"
+          aria-label="Delivery URL"
+          className={inputCls}
+        />
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="Create token"
+          aria-label="Alert create token"
+          className={`${inputCls} sm:w-44`}
+        />
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex shrink-0 items-center justify-center rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[13px] font-medium text-accent-text transition-colors hover:bg-accent/15 disabled:opacity-50"
+        >
+          {mutation.isPending ? "Watching…" : "Watch"}
+        </button>
+      </div>
+      {mutation.isError ? (
+        <p className="mt-2 text-xs text-health-down">{describeError(mutation.error)}</p>
+      ) : null}
+      <p className="mt-2 text-[11px] text-ink-muted">
+        The create token is an anti-abuse secret — ask a maintainer for one.
+      </p>
+    </form>
+  );
+}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -10,6 +10,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@jsonbored/ui-kit";
+import { WatchValidator } from "@/components/metagraphed/watch-validator";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
 import {
   ValidatorNominatorsTable,
@@ -259,6 +260,14 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
       </div>
+
+      <SectionAnchor
+        id="watch"
+        title="Watch this validator"
+        subtitle="One-step webhook or Discord alert on this validator's stake & delegation events."
+      >
+        <WatchValidator hotkey={hotkey} />
+      </SectionAnchor>
 
       <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
         <SubnetPerformanceTable subnets={detail.subnets} />


### PR DESCRIPTION
## Summary
The alert-triggers system (`/api/v1/alerts/triggers` — webhook/email/Telegram/Discord delivery, matching on `account`/`event_kind`/`netuid`/`min_amount_tao`) is fully built but had **no UI anywhere** in `apps/ui`. This surfaces it as a **one-step "Watch this validator"** control on `/validators/$hotkey`.

Deliberately minimal per the review on #5173 (which was closed as too complex/multi-step): a single form row — a **delivery URL** + the API's **create token** + a **Watch** button. Everything else is inferred:
- **Channel** is auto-detected from the URL (Discord incoming-webhook vs plain webhook).
- The trigger is **auto-scoped to this validator** (`account = hotkey`), so it fires on this hotkey's stake & delegation events.
- Server-side `validateAlertTriggerInput` stays the **source of truth** — its error is surfaced directly rather than re-implemented client-side (per the issue's non-goal).

New component is ~130 lines (vs the prior attempt's 318) and mirrors the existing `WebhookSubscriptionManager` (same `apiFetch` + token-header + `CopyableCode` result pattern). One row form on all three viewports; success returns the owner token once.

## Change
- New `apps/ui/src/components/metagraphed/watch-validator.tsx`.
- Wired as a `SectionAnchor` on `apps/ui/src/routes/validators.$hotkey.tsx` (+9 lines).

## Verification
- `npm run typecheck --workspace=apps/ui` — pass
- `npm run test --workspace=apps/ui` — pass (684 tests)
- `eslint` on the changed files — clean
- Create flow exercised end-to-end with the endpoint stubbed to a `201` (I don't hold a real create token) — the form posts `{ account, channel, destination }` and renders the returned owner token via the shared `CopyableCode`. Validation errors are surfaced from the server (401 token / 400 invalid / 503 disabled).

## Screenshots
Single-step form (before = no feature; after = the control), then the success state.

| Viewport · Theme | Before (no feature) | After (the control) |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-desktop-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-tablet-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-mobile-light.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/after-mobile-dark.png)<br><sub>after</sub> |

**Success state** (create endpoint stubbed to 201 for the shot):

| Viewport · Theme | Success state |
| --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-desktop-light.png" width="320">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-desktop-dark.png" width="320">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-tablet-light.png" width="320">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-tablet-dark.png" width="320">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-mobile-light.png" width="320">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-mobile-dark.png" width="320">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v2/success-mobile-dark.png) |

_Update: recolored the box to the site's accent/mint (was reading as stark white on the bone background in light theme) and added a gap below the section._

Closes #5167
