### PR TITLE
fix(scripts): guard scan-public-safety.mjs against ENOENT races mid-walk

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -377,7 +377,17 @@ async function* walk(target) {
     return;
   }
 
-  const entries = await fs.readdir(fullPath, { withFileTypes: true });
+  let entries;
+  try {
+    entries = await fs.readdir(fullPath, { withFileTypes: true });
+  } catch (err) {
+    // Same TOCTOU race as the readFile guard below: the stat above can see a
+    // directory that a concurrent rebuild removes before readdir gets to it.
+    if (err.code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
   for (const entry of entries) {
     if (entry.name === ".DS_Store") {
       continue;
@@ -400,7 +410,20 @@ for (const root of targetRoots) {
     if (isBinaryOrIgnored(relative)) {
       continue;
     }
-    const content = await fs.readFile(filePath, "utf8");
+    let content;
+    try {
+      content = await fs.readFile(filePath, "utf8");
+    } catch (err) {
+      // A file that existed when walk() listed its directory can vanish
+      // before this read (e.g. a concurrent rebuild replacing the tree it's
+      // walking) -- that's nothing to scan, not a scan failure, so skip it
+      // rather than crashing the whole run on an ENOENT race. Any other
+      // error (permissions, etc.) is a real problem and still propagates.
+      if (err.code === "ENOENT") {
+        continue;
+      }
+      throw err;
+    }
     const lines = content.split(/\r?\n/);
     const skipSoft =
       isMirroredExternalSpec(relative) ||


### PR DESCRIPTION
## Summary
- `scan-public-safety.mjs`'s directory walk (`fs.readdir`) and file read (`fs.readFile`) were unguarded: an entry that exists when listed but vanishes before it's read (a concurrent rebuild replacing the tree being scanned) threw an uncaught ENOENT and crashed the whole scan, instead of just skipping the now-gone entry.
- Both call sites now catch ENOENT specifically and skip the vanished entry; any other error (permissions, etc.) still propagates unchanged.

## Context
Investigating #5048 (closed independently while this was in flight — PR #5196 already grouped `public-safety.test.mjs` into the same serial FS-writer set as `artifacts.test.mjs`/`discovery-artifacts.test.mjs`, so that specific race can no longer occur via any real `npm` script). While reproducing it I found this separate, genuine robustness gap: forcing vitest's file parallelism against `artifacts.test.mjs` (which `rm`s + repopulates `dist/metagraph-r2/metagraph` via `build-artifacts.mjs`) alongside `public-safety.test.mjs` (which walks that same tree) reliably crashed the scanner with a bare, unhandled `ENOENT` — not a false-positive finding, an actual process crash. That's a real weakness in a security-critical script independent of test scheduling: any concurrent mutation of a directory it's scanning (in tests, or a human running `npm run scan:public-safety` alongside a local build) could crash it outright instead of degrading gracefully.

## Test plan
- `npm run lint` / `npx prettier --check scripts/scan-public-safety.mjs` — clean
- `npx vitest run tests/artifacts.test.mjs tests/public-safety.test.mjs --fileParallelism`, repeated: crashed with a bare `ENOENT` before this fix on every run; no crashes across 5+ repeated runs after
- `npm run test:coverage` (full suite, default config) — green
- `scan-public-safety.mjs` isn't in `vitest.config.mjs`'s coverage `include` list (matches the existing convention for `execFileSync`-invoked scripts), so no dedicated unit test was added — the fix was verified by direct reproduction instead, since deterministically unit-testing a sub-millisecond TOCTOU race would itself be flaky.