### PR TITLE
feat(registry): schema-back the homepage Pilots featured-subnet section

### DIFF
--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -110,6 +110,11 @@ export interface ApiEnvelope<T> {
 // curation tier the assertion below stops compiling, forcing this to track it.
 export type CurationLevel = ApiSchema<"CurationLevel">;
 
+// Display/placement metadata (e.g. a featured-pilot homepage slot) — distinct
+// from CurationLevel above, which is a trust signal only and never drives
+// placement (docs/adr/0008-subnet-data-model.md, #5171).
+export type SubnetPartnership = ApiSchema<"PartnershipMetadata">;
+
 // CoverageLevel has no contract counterpart — it is a UI-only rollup label.
 export type CoverageLevel = "native-only" | "manifested" | "probed";
 
@@ -126,6 +131,7 @@ export type HealthState = "ok" | "warn" | "down" | "unknown";
 
 export interface Subnet {
   netuid: number;
+  slug?: string;
   name?: string;
   symbol?: string;
   type?: "root" | "application";
@@ -135,6 +141,7 @@ export interface Subnet {
   mechanism_count?: number;
   curation_level?: CurationLevel;
   coverage_level?: CoverageLevel;
+  partnership?: SubnetPartnership | null;
   surfaces_count?: number;
   candidates_count?: number;
   health?: HealthState;

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -193,29 +193,16 @@ function OverviewPage() {
 
       <QuickActionsRow />
 
-      <section className="mt-section-gap">
-        <SectionHeader
-          eyebrow="Pilots"
-          title="Adapter-backed subnets"
-          description="Subnets with live machine-verified data pulled directly through a maintained adapter."
-        />
-        <div className="grid gap-4 md:grid-cols-2">
-          <QueryErrorBoundary
-            fallback={() => <PilotCardFallback netuid={7} title="Allways" subtitle="SN7" />}
-          >
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <PilotCard slug="allways" netuid={7} title="Allways" subtitle="SN7" />
-            </Suspense>
-          </QueryErrorBoundary>
-          <QueryErrorBoundary
-            fallback={() => <PilotCardFallback netuid={74} title="Gittensor" subtitle="SN74" />}
-          >
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <PilotCard slug="gittensor" netuid={74} title="Gittensor" subtitle="SN74" />
-            </Suspense>
-          </QueryErrorBoundary>
-        </div>
-      </section>
+      {/* #5171: featured pilots are schema-backed (registry `partnership.tier ===
+          "pilot"`), not a hardcoded slug/netuid list — adding or removing one is
+          a registry data change. Renders null until the list resolves (and stays
+          null if it's empty), so an empty/failed fetch never leaves a dangling
+          "Pilots" heading. */}
+      <QueryErrorBoundary fallback={() => null}>
+        <Suspense fallback={null}>
+          <PilotsSection />
+        </Suspense>
+      </QueryErrorBoundary>
 
       <section className="mt-section-gap">
         <div className="flex items-end justify-between mb-6">
@@ -835,8 +822,61 @@ function PerfCard({
 /* ----------------------------- pilot ----------------------------- */
 
 /**
+ * Data-driven "Pilots" homepage section (#5171): the featured list comes from
+ * the registry (`partnership.tier === "pilot"`) instead of a hardcoded
+ * slug/netuid list, so adding or removing a pilot is a registry data change,
+ * not a source edit. `limit: 200` covers the full registry (well above the
+ * known subnet count) since a pilot can sit anywhere in netuid order; each
+ * card still owns its own QueryErrorBoundary/Suspense pair (unchanged from
+ * before) so one pilot's adapter failing never takes down the others. Renders
+ * null when the filtered list is empty so the section never leaves a dangling
+ * heading over an empty grid.
+ */
+function PilotsSection() {
+  const { data } = useSuspenseQuery(subnetsQuery({ limit: 200 }));
+  const subnets = (data.data ?? []) as Subnet[];
+  const pilots = subnets
+    .filter((subnet) => subnet.partnership?.tier === "pilot")
+    .sort((a, b) => {
+      const bySince = (a.partnership?.since ?? "").localeCompare(b.partnership?.since ?? "");
+      return bySince !== 0 ? bySince : a.netuid - b.netuid;
+    });
+
+  if (pilots.length === 0) return null;
+
+  return (
+    <section className="mt-section-gap">
+      <SectionHeader
+        eyebrow="Pilots"
+        title="Adapter-backed subnets"
+        description="Subnets with live machine-verified data pulled directly through a maintained adapter."
+      />
+      <div className="grid gap-4 md:grid-cols-2">
+        {pilots.map((subnet) => {
+          const title = subnet.name ?? `Subnet ${subnet.netuid}`;
+          const subtitle = `SN${subnet.netuid}`;
+          const slug = subnet.slug ?? `sn-${subnet.netuid}`;
+          return (
+            <QueryErrorBoundary
+              key={subnet.netuid}
+              fallback={() => (
+                <PilotCardFallback netuid={subnet.netuid} title={title} subtitle={subtitle} />
+              )}
+            >
+              <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+                <PilotCard slug={slug} netuid={subnet.netuid} title={title} subtitle={subtitle} />
+              </Suspense>
+            </QueryErrorBoundary>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+/**
  * Error fallback for PilotCard, rendered by the QueryErrorBoundary in
- * OverviewPage when the adapter snapshot fails to load. Kept separate so
+ * PilotsSection when the adapter snapshot fails to load. Kept separate so
  * PilotCard can call useSuspenseQuery unconditionally (a try/catch around the
  * hook breaks the Rules of Hooks).
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -11839,7 +11839,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -21923,7 +21923,7 @@ export interface operations {
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
                      *           "partnership": {
-                     *             "since": "example",
+                     *             "since": "2026-06-01",
                      *             "tier": "pilot"
                      *           },
                      *           "previously_known_as": [
@@ -25652,7 +25652,7 @@ export interface operations {
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
                      *           "partnership": {
-                     *             "since": "example",
+                     *             "since": "2026-06-01",
                      *             "tier": "pilot"
                      *           },
                      *           "previously_known_as": [

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5358,6 +5358,18 @@ export interface components {
             sort?: string | null;
             total: number;
         };
+        /** @description Display/placement metadata — e.g. a featured-pilot homepage slot. Distinct from `curation` and `authority`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md). */
+        PartnershipMetadata: {
+            /** Format: date */
+            since: string;
+            tier: components["schemas"]["PartnershipTier"];
+            validator_hotkey?: string;
+        };
+        /**
+         * @description Display/placement tier for a subnet — e.g. a featured-pilot homepage slot. Distinct from Authority and CurationLevel, which are trust signals only and never drive placement.
+         * @enum {unknown}
+         */
+        PartnershipTier: "pilot";
         /** @description One neuron position a wallet holds on a subnet: its economics and emission/stake yield. Score fields are null when the cell is absent; yield is null with zero stake. */
         PortfolioPosition: {
             active: boolean;
@@ -6440,6 +6452,8 @@ export interface components {
             netuid: number;
             notes?: string | null;
             participant_count?: number;
+            /** @description Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation, which is a trust signal only. */
+            partnership?: components["schemas"]["PartnershipMetadata"] | null;
             /** @description Distinct prior on-chain subnet_name values from identity history, excluding the current name, newest-seen first. Served live from the subnet_identity_history D1 tier (#1647). */
             previously_known_as?: string[];
             probed_surface_count?: number;
@@ -6753,6 +6767,8 @@ export interface components {
             /** @description Count of operator-official (first-party) curated surfaces for this subnet. */
             official_surface_count?: number;
             participant_count?: number;
+            /** @description Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation_level, which is a trust signal only. */
+            partnership?: components["schemas"]["PartnershipMetadata"] | null;
             probed_surface_count?: number;
             registered_at_block?: number;
             /** @description Count of low-trust registry-observed (harvested) surfaces for this subnet. */
@@ -21906,6 +21922,10 @@ export interface operations {
                      *           "netuid": 7,
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
+                     *           "partnership": {
+                     *             "since": "example",
+                     *             "tier": "pilot"
+                     *           },
                      *           "previously_known_as": [
                      *             "example"
                      *           ],
@@ -25631,6 +25651,10 @@ export interface operations {
                      *           "netuid": 7,
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
+                     *           "partnership": {
+                     *             "since": "example",
+                     *             "tier": "pilot"
+                     *           },
                      *           "previously_known_as": [
                      *             "example"
                      *           ],

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -42402,7 +42402,7 @@
                       "notes": "Example description.",
                       "participant_count": 1,
                       "partnership": {
-                        "since": "example",
+                        "since": "2026-06-01",
                         "tier": "pilot"
                       },
                       "previously_known_as": [
@@ -47589,7 +47589,7 @@
                       "notes": "Example description.",
                       "participant_count": 1,
                       "partnership": {
-                        "since": "example",
+                        "since": "2026-06-01",
                         "tier": "pilot"
                       },
                       "previously_known_as": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11325,6 +11325,33 @@
         ],
         "type": "object"
       },
+      "PartnershipMetadata": {
+        "additionalProperties": false,
+        "description": "Display/placement metadata — e.g. a featured-pilot homepage slot. Distinct from `curation` and `authority`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md).",
+        "properties": {
+          "since": {
+            "format": "date",
+            "type": "string"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/PartnershipTier"
+          },
+          "validator_hotkey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tier",
+          "since"
+        ],
+        "type": "object"
+      },
+      "PartnershipTier": {
+        "description": "Display/placement tier for a subnet — e.g. a featured-pilot homepage slot. Distinct from Authority and CurationLevel, which are trust signals only and never drive placement.",
+        "enum": [
+          "pilot"
+        ]
+      },
       "PortfolioPosition": {
         "additionalProperties": true,
         "description": "One neuron position a wallet holds on a subnet: its economics and emission/stake yield. Score fields are null when the cell is absent; yield is null with zero stake.",
@@ -15933,6 +15960,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "partnership": {
+            "description": "Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation, which is a trust signal only.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PartnershipMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "previously_known_as": {
             "description": "Distinct prior on-chain subnet_name values from identity history, excluding the current name, newest-seen first. Served live from the subnet_identity_history D1 tier (#1647).",
             "items": {
@@ -17290,6 +17328,17 @@
           "participant_count": {
             "minimum": 0,
             "type": "integer"
+          },
+          "partnership": {
+            "description": "Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation_level, which is a trust signal only.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PartnershipMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "probed_surface_count": {
             "minimum": 0,
@@ -42352,6 +42401,10 @@
                       "netuid": 7,
                       "notes": "Example description.",
                       "participant_count": 1,
+                      "partnership": {
+                        "since": "example",
+                        "tier": "pilot"
+                      },
                       "previously_known_as": [
                         "example"
                       ],
@@ -47535,6 +47588,10 @@
                       "netuid": 7,
                       "notes": "Example description.",
                       "participant_count": 1,
+                      "partnership": {
+                        "since": "example",
+                        "tier": "pilot"
+                      },
                       "previously_known_as": [
                         "example"
                       ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -21923,7 +21923,7 @@ export interface operations {
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
                      *           "partnership": {
-                     *             "since": "example",
+                     *             "since": "2026-06-01",
                      *             "tier": "pilot"
                      *           },
                      *           "previously_known_as": [
@@ -25652,7 +25652,7 @@ export interface operations {
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
                      *           "partnership": {
-                     *             "since": "example",
+                     *             "since": "2026-06-01",
                      *             "tier": "pilot"
                      *           },
                      *           "previously_known_as": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5358,6 +5358,18 @@ export interface components {
             sort?: string | null;
             total: number;
         };
+        /** @description Display/placement metadata — e.g. a featured-pilot homepage slot. Distinct from `curation` and `authority`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md). */
+        PartnershipMetadata: {
+            /** Format: date */
+            since: string;
+            tier: components["schemas"]["PartnershipTier"];
+            validator_hotkey?: string;
+        };
+        /**
+         * @description Display/placement tier for a subnet — e.g. a featured-pilot homepage slot. Distinct from Authority and CurationLevel, which are trust signals only and never drive placement.
+         * @enum {unknown}
+         */
+        PartnershipTier: "pilot";
         /** @description One neuron position a wallet holds on a subnet: its economics and emission/stake yield. Score fields are null when the cell is absent; yield is null with zero stake. */
         PortfolioPosition: {
             active: boolean;
@@ -6440,6 +6452,8 @@ export interface components {
             netuid: number;
             notes?: string | null;
             participant_count?: number;
+            /** @description Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation, which is a trust signal only. */
+            partnership?: components["schemas"]["PartnershipMetadata"] | null;
             /** @description Distinct prior on-chain subnet_name values from identity history, excluding the current name, newest-seen first. Served live from the subnet_identity_history D1 tier (#1647). */
             previously_known_as?: string[];
             probed_surface_count?: number;
@@ -6753,6 +6767,8 @@ export interface components {
             /** @description Count of operator-official (first-party) curated surfaces for this subnet. */
             official_surface_count?: number;
             participant_count?: number;
+            /** @description Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation_level, which is a trust signal only. */
+            partnership?: components["schemas"]["PartnershipMetadata"] | null;
             probed_surface_count?: number;
             registered_at_block?: number;
             /** @description Count of low-trust registry-observed (harvested) surfaces for this subnet. */
@@ -21906,6 +21922,10 @@ export interface operations {
                      *           "netuid": 7,
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
+                     *           "partnership": {
+                     *             "since": "example",
+                     *             "tier": "pilot"
+                     *           },
                      *           "previously_known_as": [
                      *             "example"
                      *           ],
@@ -25631,6 +25651,10 @@ export interface operations {
                      *           "netuid": 7,
                      *           "notes": "Example description.",
                      *           "participant_count": 1,
+                     *           "partnership": {
+                     *             "since": "example",
+                     *             "tier": "pilot"
+                     *           },
                      *           "previously_known_as": [
                      *             "example"
                      *           ],

--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -35,6 +35,10 @@
   "name": "Allways",
   "netuid": 7,
   "notes": "Pilot manifest. Registry observations are external status data, not Allways protocol authority.",
+  "partnership": {
+    "since": "2026-07-04",
+    "tier": "pilot"
+  },
   "schema_version": 1,
   "slug": "allways",
   "source_repo": "https://github.com/entrius/allways",

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -38,6 +38,10 @@
   "name": "Gittensor",
   "netuid": 74,
   "notes": "Pilot manifest. This tracks public-safe registry concepts only; validator credential flows and private scoring internals are out of scope.",
+  "partnership": {
+    "since": "2026-07-04",
+    "tier": "pilot"
+  },
   "schema_version": 1,
   "slug": "gittensor",
   "social": {

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -11303,6 +11303,33 @@
         ],
         "type": "object"
       },
+      "PartnershipMetadata": {
+        "additionalProperties": false,
+        "description": "Display/placement metadata — e.g. a featured-pilot homepage slot. Distinct from `curation` and `authority`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md).",
+        "properties": {
+          "since": {
+            "format": "date",
+            "type": "string"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/PartnershipTier"
+          },
+          "validator_hotkey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tier",
+          "since"
+        ],
+        "type": "object"
+      },
+      "PartnershipTier": {
+        "description": "Display/placement tier for a subnet — e.g. a featured-pilot homepage slot. Distinct from Authority and CurationLevel, which are trust signals only and never drive placement.",
+        "enum": [
+          "pilot"
+        ]
+      },
       "PortfolioPosition": {
         "additionalProperties": true,
         "description": "One neuron position a wallet holds on a subnet: its economics and emission/stake yield. Score fields are null when the cell is absent; yield is null with zero stake.",
@@ -15911,6 +15938,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "partnership": {
+            "description": "Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation, which is a trust signal only.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PartnershipMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "previously_known_as": {
             "description": "Distinct prior on-chain subnet_name values from identity history, excluding the current name, newest-seen first. Served live from the subnet_identity_history D1 tier (#1647).",
             "items": {
@@ -17268,6 +17306,17 @@
           "participant_count": {
             "minimum": 0,
             "type": "integer"
+          },
+          "partnership": {
+            "description": "Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation_level, which is a trust signal only.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PartnershipMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "probed_surface_count": {
             "minimum": 0,

--- a/schemas/components/01-enums.schema.json
+++ b/schemas/components/01-enums.schema.json
@@ -85,6 +85,10 @@
           "stale"
         ]
       },
+      "PartnershipTier": {
+        "description": "Display/placement tier for a subnet — e.g. a featured-pilot homepage slot. Distinct from Authority and CurationLevel, which are trust signals only and never drive placement.",
+        "enum": ["pilot"]
+      },
       "CandidateState": {
         "enum": [
           "schema-invalid",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -98,6 +98,24 @@
         },
         "additionalProperties": false
       },
+      "PartnershipMetadata": {
+        "type": "object",
+        "required": ["tier", "since"],
+        "description": "Display/placement metadata — e.g. a featured-pilot homepage slot. Distinct from `curation` and `authority`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md).",
+        "properties": {
+          "tier": {
+            "$ref": "#/components/schemas/PartnershipTier"
+          },
+          "since": {
+            "type": "string",
+            "format": "date"
+          },
+          "validator_hotkey": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "Gaps": {
         "type": "object",
         "required": ["missing_kinds", "supported_kinds", "gap_notes"],
@@ -319,6 +337,13 @@
             "type": ["string", "null"],
             "format": "uri",
             "description": "Normalized Discord URL when the on-chain contact is an explicit URL (scheme allowlist + SSRF/credential guards); null when the contact is a plain handle. Operator-controlled untrusted data."
+          },
+          "partnership": {
+            "description": "Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation_level, which is a trust signal only.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/PartnershipMetadata" },
+              { "type": "null" }
+            ]
           }
         },
         "additionalProperties": false
@@ -449,6 +474,13 @@
           },
           "curation": {
             "$ref": "#/components/schemas/CurationMetadata"
+          },
+          "partnership": {
+            "description": "Display/placement metadata (e.g. featured-pilot homepage slot) when curated for this subnet; null otherwise. Distinct from curation, which is a trust signal only.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/PartnershipMetadata" },
+              { "type": "null" }
+            ]
           },
           "gaps": {
             "$ref": "#/components/schemas/Gaps"

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -61,6 +61,9 @@
     "curation": {
       "$ref": "#/$defs/curation"
     },
+    "partnership": {
+      "$ref": "#/$defs/partnership"
+    },
     "links": {
       "type": "array",
       "items": {
@@ -376,6 +379,24 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "partnership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tier", "since"],
+      "description": "Display/placement metadata — e.g. a featured-pilot slot on the homepage. Distinct from `authority` and `curation.level`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md).",
+      "properties": {
+        "tier": {
+          "enum": ["pilot"]
+        },
+        "since": {
+          "type": "string",
+          "format": "date"
+        },
+        "validator_hotkey": {
+          "type": "string"
         }
       }
     },

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -493,6 +493,8 @@ const subnetIndex = mergedSubnets.map((subnet) => {
     native_name_quality: subnet.native_name_quality,
     native_slug: subnet.native_slug,
     netuid: subnet.netuid,
+    // Display/placement only (#5171) — never a trust signal like curation_level.
+    partnership: subnet.partnership,
     participant_count: subnet.participant_count,
     probed_surface_count: subnet.probed_surface_count,
     // #640: display-only freshness floor for the list's "last updated" column —
@@ -2774,6 +2776,10 @@ function mergeSubnet(nativeSubnet, overlay, candidateCount) {
       source_count: 0,
       gap_notes: [],
     },
+    // Display/placement only (#5171) — e.g. a featured-pilot homepage slot.
+    // Distinct from curation.level above, which is a trust signal and never
+    // drives placement (docs/adr/0008-subnet-data-model.md).
+    partnership: overlay?.partnership || null,
     links: overlay?.links || [],
     // Structured social handles (#745): curated overlay wins over on-chain
     // SubnetIdentitiesV3 `additional` extraction. Display/search-only — never

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -798,6 +798,9 @@ function buildExpectedGeneratedSubnet(nativeSnapshot, overlay, candidateCount) {
       source_count: 0,
       gap_notes: [],
     },
+    // Mirror mergeSubnet's partnership passthrough (#5171) so the per-subnet
+    // detail artifact reproducibility check matches the generator.
+    partnership: overlay?.partnership || null,
     links: overlay?.links || [],
     // Mirror mergeSubnet's #745 social backfill (overlay wins, else sanitized
     // on-chain `additional`) so the reproducibility check matches the generator.

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -13,6 +13,7 @@
 const OPTIONAL_DEPTH = 3;
 const MAX_DEPTH = 8;
 const ISO = "2026-06-01T00:00:00.000Z";
+const DATE_ONLY = "2026-06-01";
 const CURSOR2 = "123.4";
 const CURSOR3 = "100.123.4";
 const HEX64 = "a3f1".repeat(16); // 64 hex chars, matches ^[a-f0-9]{64}$
@@ -995,6 +996,7 @@ export function sampleFromSchema(
     if (schema.pattern) return valueForPattern(schema.pattern, name);
     if (schema.format === "uri") return "https://api.metagraph.sh/example";
     if (schema.format === "date-time") return ISO;
+    if (schema.format === "date") return DATE_ONLY;
     return seededString(name);
   }
   if (type === "integer" || type === "number")

--- a/tests/validate-error-messages.test.mjs
+++ b/tests/validate-error-messages.test.mjs
@@ -109,4 +109,36 @@ describe("validate-schemas.mjs enum error messages", () => {
     assert.match(output, /data-artifact/);
     assert.match(output, /got "totally-invalid-kind"/);
   });
+
+  // #5171: partnership.tier is a deliberately closed enum (just "pilot" today)
+  // — a subnet claiming any other tier must be rejected the same way an
+  // invalid surface kind is, with the allowed-values list surfaced.
+  test("lists the allowed partnership.tier values and the offending value on an invalid tier", async () => {
+    const subnetFiles = await listJsonFiles(
+      path.join(repoRoot, "registry/subnets"),
+    );
+    let targetFile;
+    let targetDocument;
+    for (const file of subnetFiles) {
+      const document = await readJson(file);
+      if (document.partnership) {
+        targetFile = file;
+        targetDocument = document;
+        break;
+      }
+    }
+    assert.ok(targetFile, "at least one subnet file must have a partnership");
+
+    mutatedFile = targetFile;
+    originalContents = readFileSync(mutatedFile, "utf8");
+    targetDocument.partnership.tier = "sponsor";
+    writeFileSync(mutatedFile, JSON.stringify(targetDocument, null, 2));
+
+    const { status, output } = runNode(["scripts/validate-schemas.mjs"]);
+
+    assert.equal(status, 1);
+    assert.match(output, /must be equal to one of the allowed values/);
+    assert.match(output, /pilot/);
+    assert.match(output, /got "sponsor"/);
+  });
 });


### PR DESCRIPTION
## Summary
- `apps/ui/src/routes/index.tsx`'s homepage "Pilots" section hardcoded exactly two `<PilotCard>` instances as literal JSX props (`slug="allways" netuid={7}`, `slug="gittensor" netuid={74}`) — adding a third partner subnet meant a source edit, not a data change.
- Added a `partnership` object to the subnet manifest schema (`tier` closed-enum `["pilot"]`, required `since` date, optional `validator_hotkey`) — deliberately distinct from `authority`/`curation.level`, which are documented trust signals only, never placement/visibility flags (per ADR 0008).
- Regenerated `openapi.json`/types/contracts, threaded `partnership` through `scripts/build-artifacts.mjs` and `scripts/validate.mjs`'s parallel expected-output builder (both must byte-match).
- Set `partnership: {tier: "pilot", since: "2026-07-04"}` on `registry/subnets/allways.json` and `registry/subnets/gittensor.json` (the `since` date corroborated via `git log -S` on the original PilotCard introduction commit).
- Replaced the hardcoded JSX with a `PilotsSection` component that queries the registry, filters `partnership?.tier === "pilot"`, and renders 0/1/many cards correctly (same `PilotCard`/`PilotCardFallback` pair and grid, no visual/behavior change for the two current pilots).
- Patch-bumped `packages/client/package.json` (0.15.4 → 0.15.5) for the contract change, matching this repo's local pre-push guard.

## Test plan
- `npm run validate:surface` on both registry files, `npm run scan:public-safety`
- `npm run validate`, `npm run validate:contract-drift`, `npm run validate:schemas`, `npm run validate:api`, `npm run validate:openapi`, `npm run validate:types`, `npm run validate:generated-client`, `npm run validate:client-sdk-sync`
- `npm run lint`, `npx prettier --check`, `git diff --check`
- Root `npm test`: 267 files / 7745 tests passing
- `apps/ui`: `npm run typecheck`, `npm run lint`, `npm test` (98 files / 684 tests), `npx prettier --check` — all clean
- `npm run pipeline:check` — clean

Closes #5171