### PR TITLE
feat(validators): add a DB-backed featured-validator pin

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -26,6 +26,22 @@ export function scoreStr(v?: number | null): string {
   return v.toFixed(3);
 }
 
+/**
+ * Small pill marking a DB-toggled featured validator (#5166) — same visual
+ * language as the "Validator" permit pill below. Shared with the global
+ * validators leaderboard table (routes/validators.index.tsx).
+ */
+export function FeaturedBadge() {
+  return (
+    <span
+      className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-accent-text"
+      title="Featured validator"
+    >
+      Featured
+    </span>
+  );
+}
+
 type SortField =
   | "uid"
   | "stake_tao"
@@ -191,29 +207,32 @@ export function NeuronTable({
                     )}
                   </td>
                   <td className="px-3 py-2.5 font-mono text-[11px]">
-                    {n.hotkey ? (
-                      isValidator ? (
-                        <Link
-                          to="/validators/$hotkey"
-                          params={{ hotkey: n.hotkey }}
-                          className="text-ink-muted hover:text-ink hover:underline"
-                          title={n.hotkey}
-                        >
-                          {shortHash(n.hotkey) ?? n.hotkey}
-                        </Link>
+                    <div className="flex items-center gap-1.5">
+                      {n.featured ? <FeaturedBadge /> : null}
+                      {n.hotkey ? (
+                        isValidator ? (
+                          <Link
+                            to="/validators/$hotkey"
+                            params={{ hotkey: n.hotkey }}
+                            className="text-ink-muted hover:text-ink hover:underline"
+                            title={n.hotkey}
+                          >
+                            {shortHash(n.hotkey) ?? n.hotkey}
+                          </Link>
+                        ) : (
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: n.hotkey }}
+                            className="text-ink-muted hover:text-ink hover:underline"
+                            title={n.hotkey}
+                          >
+                            {shortHash(n.hotkey) ?? n.hotkey}
+                          </Link>
+                        )
                       ) : (
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: n.hotkey }}
-                          className="text-ink-muted hover:text-ink hover:underline"
-                          title={n.hotkey}
-                        >
-                          {shortHash(n.hotkey) ?? n.hotkey}
-                        </Link>
-                      )
-                    ) : (
-                      "—"
-                    )}
+                        "—"
+                      )}
+                    </div>
                   </td>
                   <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
                     {taoCompact(n.stake_tao)}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5277,6 +5277,10 @@ function normalizeMetagraphNeuron(raw: unknown): MetagraphNeuron | undefined {
     registered_at_block: coerceFiniteNumber(raw.registered_at_block),
     is_immunity_period: booleanValue(raw.is_immunity_period),
     axon: coerceString(raw.axon) ?? null,
+    // Only /validators rows carry this (#5166); booleanValue already maps an
+    // absent/non-boolean cell to undefined, so metagraph/neuron-detail rows
+    // (which never send it) keep the field genuinely absent, not a false.
+    featured: booleanValue(raw.featured),
   };
 }
 
@@ -5352,6 +5356,9 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
     value == null ? null : (coerceFiniteNumber(value) ?? null);
   return {
     hotkey,
+    // Always present on the wire (#5166); this builder has no `...raw`
+    // spread, so it must be listed explicitly or it silently vanishes.
+    featured: booleanValue(raw.featured) ?? false,
     coldkey: typeof raw.coldkey === "string" ? raw.coldkey : null,
     coldkey_count: coerceFiniteNumber(raw.coldkey_count) ?? 0,
     subnet_count: coerceFiniteNumber(raw.subnet_count) ?? 0,

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1931,6 +1931,8 @@ export interface MetagraphNeuron {
   registered_at_block?: number;
   is_immunity_period?: boolean;
   axon?: string | null;
+  /** DB-toggled maintainer pin (#5166) — only set on /validators rows, absent elsewhere. */
+  featured?: boolean;
   [key: string]: unknown;
 }
 
@@ -1974,6 +1976,8 @@ export interface GlobalValidatorSubnet {
 /** One validator/operator row grouped by hotkey across subnet memberships. */
 export interface GlobalValidator {
   hotkey: string;
+  /** DB-toggled maintainer pin (#5166) — always present, moves the row to the front of the default (unsorted) view. */
+  featured: boolean;
   coldkey: string | null;
   coldkey_count: number;
   subnet_count: number;

--- a/apps/ui/src/lib/metagraphed/validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators.test.ts
@@ -72,6 +72,20 @@ describe("normalizeGlobalValidators", () => {
     expect(out.sort).toBe("subnet_count");
   });
 
+  it("carries the `featured` flag through (#5166), defaulting false when absent", () => {
+    const out = normalizeGlobalValidators({
+      sort: "subnet_count",
+      limit: 20,
+      validators: [
+        { hotkey: "hk-featured", featured: true, subnet_count: 1, uid_count: 1, subnets: [] },
+        { hotkey: "hk-plain", subnet_count: 1, uid_count: 1, subnets: [] },
+      ],
+    });
+
+    expect(out.validators[0].featured).toBe(true);
+    expect(out.validators[1].featured).toBe(false);
+  });
+
   it("coerces string numerics from live API payloads", () => {
     const out = normalizeGlobalValidators({
       sort: "total_stake",

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -12,7 +12,7 @@ import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -174,14 +174,17 @@ function ValidatorsTable({
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
                   <td className="px-3 py-2 font-mono text-[11px]">
-                    <Link
-                      to="/validators/$hotkey"
-                      params={{ hotkey: v.hotkey }}
-                      className="text-ink-strong hover:text-accent hover:underline"
-                      title={v.hotkey}
-                    >
-                      {shortHash(v.hotkey) ?? v.hotkey}
-                    </Link>
+                    <div className="flex items-center gap-1.5">
+                      {v.featured ? <FeaturedBadge /> : null}
+                      <Link
+                        to="/validators/$hotkey"
+                        params={{ hotkey: v.hotkey }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                        title={v.hotkey}
+                      >
+                        {shortHash(v.hotkey) ?? v.hotkey}
+                      </Link>
+                    </div>
                   </td>
                   <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
                     {v.coldkey ? (

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -161,6 +161,23 @@ CREATE TABLE IF NOT EXISTS neurons (
 CREATE INDEX IF NOT EXISTS idx_neurons_netuid_permit ON neurons (netuid, validator_permit, stake_tao DESC);
 CREATE INDEX IF NOT EXISTS idx_neurons_hotkey        ON neurons (hotkey);
 
+-- Featured-validator pin (#5166): a maintainer toggle to elevate a validator to
+-- the top of /api/v1/validators and a subnet's validator list, keyed by
+-- hotkey rather than a column on `neurons`. `neurons`' primary key is
+-- (netuid, uid) -- a UID *slot*, not a stable identity -- and handleNeuronsSync
+-- (workers/data-api.mjs) hard-DELETEs a row once its UID falls out of the
+-- latest snapshot (deregistration), with that UID free to be reassigned to a
+-- different hotkey later. A `featured` column on `neurons` would either vanish
+-- silently on prune or, worse, incorrectly "follow" the slot to whatever
+-- hotkey registers into it next. hotkey identity survives deregistration/
+-- reassignment cycles, so this small side table sidesteps the hazard entirely.
+-- Toggled by a direct SQL UPDATE/INSERT -- no code deploy needed to change
+-- which validator is featured.
+CREATE TABLE IF NOT EXISTS featured_validators (
+  hotkey      TEXT PRIMARY KEY,
+  featured_at BIGINT NOT NULL
+);
+
 -- Daily per-UID history (mirror of D1 `neuron_daily`, ~10.8M rows / 370d).
 CREATE TABLE IF NOT EXISTS neuron_daily (
   netuid           INTEGER NOT NULL,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11839,7 +11839,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4926,11 +4926,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. */
+        /** @description One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true. */
         GlobalValidatorEntry: {
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
+            featured: boolean;
             hotkey: string;
             latest_block_number: number | null;
             /** Format: date-time */
@@ -5251,7 +5252,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. */
+        /** @description One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. `featured` (#5166) is only populated on the validators-list artifacts (SubnetValidatorsArtifact) -- a DB-toggled pin (featured_validators, keyed by hotkey) that surfaces a maintainer-highlighted validator; omitted (not false) on the metagraph/neuron-detail artifacts, which don't compute it. */
         Neuron: {
             active: boolean;
             axon?: string | null;
@@ -5259,6 +5260,7 @@ export interface components {
             consensus?: number | null;
             dividends?: number | null;
             emission_tao?: number | null;
+            featured?: boolean;
             hotkey: string | null;
             incentive?: number | null;
             is_immunity_period?: boolean;
@@ -24588,6 +24590,7 @@ export interface operations {
                      *           "consensus": 0.5,
                      *           "dividends": 0.5,
                      *           "emission_tao": 0.5,
+                     *           "featured": false,
                      *           "hotkey": "example",
                      *           "incentive": 0.5,
                      *           "is_immunity_period": false,
@@ -28299,6 +28302,7 @@ export interface operations {
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
+                     *             "featured": false,
                      *             "hotkey": "example",
                      *             "latest_block_number": 5000000,
                      *             "latest_captured_at": "2026-06-01T00:00:00.000Z",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9657,7 +9657,7 @@
       },
       "GlobalValidatorEntry": {
         "additionalProperties": false,
-        "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot.",
+        "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true.",
         "properties": {
           "avg_validator_trust": {
             "type": [
@@ -9674,6 +9674,9 @@
           "coldkey_count": {
             "minimum": 0,
             "type": "integer"
+          },
+          "featured": {
+            "type": "boolean"
           },
           "hotkey": {
             "type": "string"
@@ -9731,6 +9734,7 @@
         },
         "required": [
           "hotkey",
+          "featured",
           "coldkey",
           "coldkey_count",
           "subnet_count",
@@ -10935,7 +10939,7 @@
       },
       "Neuron": {
         "additionalProperties": false,
-        "description": "One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null.",
+        "description": "One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. `featured` (#5166) is only populated on the validators-list artifacts (SubnetValidatorsArtifact) -- a DB-toggled pin (featured_validators, keyed by hotkey) that surfaces a maintainer-highlighted validator; omitted (not false) on the metagraph/neuron-detail artifacts, which don't compute it.",
         "properties": {
           "active": {
             "type": "boolean"
@@ -10969,6 +10973,9 @@
               "number",
               "null"
             ]
+          },
+          "featured": {
+            "type": "boolean"
           },
           "hotkey": {
             "type": [
@@ -46324,6 +46331,7 @@
                       "consensus": 0.5,
                       "dividends": 0.5,
                       "emission_tao": 0.5,
+                      "featured": false,
                       "hotkey": "example",
                       "incentive": 0.5,
                       "is_immunity_period": false,
@@ -51311,6 +51319,7 @@
                         "avg_validator_trust": 0.5,
                         "coldkey": "example",
                         "coldkey_count": 1,
+                        "featured": false,
                         "hotkey": "example",
                         "latest_block_number": 5000000,
                         "latest_captured_at": "2026-06-01T00:00:00.000Z",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4926,11 +4926,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. */
+        /** @description One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true. */
         GlobalValidatorEntry: {
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
+            featured: boolean;
             hotkey: string;
             latest_block_number: number | null;
             /** Format: date-time */
@@ -5251,7 +5252,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. */
+        /** @description One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. `featured` (#5166) is only populated on the validators-list artifacts (SubnetValidatorsArtifact) -- a DB-toggled pin (featured_validators, keyed by hotkey) that surfaces a maintainer-highlighted validator; omitted (not false) on the metagraph/neuron-detail artifacts, which don't compute it. */
         Neuron: {
             active: boolean;
             axon?: string | null;
@@ -5259,6 +5260,7 @@ export interface components {
             consensus?: number | null;
             dividends?: number | null;
             emission_tao?: number | null;
+            featured?: boolean;
             hotkey: string | null;
             incentive?: number | null;
             is_immunity_period?: boolean;
@@ -24588,6 +24590,7 @@ export interface operations {
                      *           "consensus": 0.5,
                      *           "dividends": 0.5,
                      *           "emission_tao": 0.5,
+                     *           "featured": false,
                      *           "hotkey": "example",
                      *           "incentive": 0.5,
                      *           "is_immunity_period": false,
@@ -28299,6 +28302,7 @@ export interface operations {
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
+                     *             "featured": false,
                      *             "hotkey": "example",
                      *             "latest_block_number": 5000000,
                      *             "latest_captured_at": "2026-06-01T00:00:00.000Z",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9635,7 +9635,7 @@
       },
       "GlobalValidatorEntry": {
         "additionalProperties": false,
-        "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot.",
+        "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true.",
         "properties": {
           "avg_validator_trust": {
             "type": [
@@ -9652,6 +9652,9 @@
           "coldkey_count": {
             "minimum": 0,
             "type": "integer"
+          },
+          "featured": {
+            "type": "boolean"
           },
           "hotkey": {
             "type": "string"
@@ -9709,6 +9712,7 @@
         },
         "required": [
           "hotkey",
+          "featured",
           "coldkey",
           "coldkey_count",
           "subnet_count",
@@ -10913,7 +10917,7 @@
       },
       "Neuron": {
         "additionalProperties": false,
-        "description": "One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null.",
+        "description": "One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. `featured` (#5166) is only populated on the validators-list artifacts (SubnetValidatorsArtifact) -- a DB-toggled pin (featured_validators, keyed by hotkey) that surfaces a maintainer-highlighted validator; omitted (not false) on the metagraph/neuron-detail artifacts, which don't compute it.",
         "properties": {
           "active": {
             "type": "boolean"
@@ -10947,6 +10951,9 @@
               "number",
               "null"
             ]
+          },
+          "featured": {
+            "type": "boolean"
           },
           "hotkey": {
             "type": [

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1365,7 +1365,7 @@
       "Neuron": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null.",
+        "description": "One neuron (UID) in a subnet's metagraph (#1303). stake_tao/emission_tao are TAO floats; trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; axon is host:port or null. `featured` (#5166) is only populated on the validators-list artifacts (SubnetValidatorsArtifact) -- a DB-toggled pin (featured_validators, keyed by hotkey) that surfaces a maintainer-highlighted validator; omitted (not false) on the metagraph/neuron-detail artifacts, which don't compute it.",
         "required": ["uid", "hotkey", "coldkey", "active", "validator_permit"],
         "properties": {
           "uid": { "type": "integer", "minimum": 0 },
@@ -1383,7 +1383,8 @@
           "stake_tao": { "type": ["number", "null"] },
           "registered_at_block": { "type": ["integer", "null"] },
           "is_immunity_period": { "type": "boolean" },
-          "axon": { "type": ["string", "null"] }
+          "axon": { "type": ["string", "null"] },
+          "featured": { "type": "boolean" }
         }
       },
       "SubnetMetagraphArtifact": {
@@ -1958,9 +1959,10 @@
       "GlobalValidatorEntry": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot.",
+        "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true.",
         "required": [
           "hotkey",
+          "featured",
           "coldkey",
           "coldkey_count",
           "subnet_count",
@@ -1976,6 +1978,7 @@
         ],
         "properties": {
           "hotkey": { "type": "string" },
+          "featured": { "type": "boolean" },
           "coldkey": { "type": ["string", "null"] },
           "coldkey_count": { "type": "integer", "minimum": 0 },
           "subnet_count": { "type": "integer", "minimum": 0 },

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -131,11 +131,18 @@ function toD1Flag(value) {
 // are what keep "missing cell" cells flowing through as null. Mirrors the
 // proven toBlockNumber / toTaoOrNull null-guards in account-events.mjs
 // (#2487).
-export function formatNeuron(row) {
+// featuredHotkeys (optional) is a Set of hotkeys from the featured_validators
+// side table (#5166; see deploy/postgres/schema.sql for why that's a separate
+// hotkey-keyed table rather than a `neurons` column). Only passed by the
+// validator-list builders below -- buildSubnetMetagraph/buildNeuronDetail/
+// buildValidatorDetail never pass one, so `featured` is simply omitted from
+// their Neuron output, leaving those artifacts' shape unchanged.
+export function formatNeuron(row, featuredHotkeys) {
   if (!row || typeof row !== "object") return null;
-  return {
+  const hotkey = row.hotkey ?? null;
+  const neuron = {
     uid: row.uid == null ? null : nonNegativeInt(row.uid),
-    hotkey: row.hotkey ?? null,
+    hotkey,
     coldkey: row.coldkey ?? null,
     active: toD1Flag(row.active),
     validator_permit: toD1Flag(row.validator_permit),
@@ -160,6 +167,10 @@ export function formatNeuron(row) {
     is_immunity_period: toD1Flag(row.is_immunity_period),
     axon: row.axon ?? null,
   };
+  if (featuredHotkeys) {
+    neuron.featured = Boolean(hotkey && featuredHotkeys.has(hotkey));
+  }
+  return neuron;
 }
 
 // All rows of one subnet's snapshot share the same captured_at/block_number.
@@ -180,7 +191,9 @@ export function buildSubnetMetagraph(rows, netuid) {
   // Drop any malformed row (formatNeuron → null) so the array only holds real
   // Neuron objects, mirroring the blocks/extrinsics feed builders; the count
   // tracks the array, so callers can rely on neuron_count === neurons.length.
-  const neurons = rows.map(formatNeuron).filter(Boolean);
+  // Wrapped (not a bare `rows.map(formatNeuron)`) so Array#map's index arg
+  // never lands in formatNeuron's featuredHotkeys parameter.
+  const neurons = rows.map((row) => formatNeuron(row)).filter(Boolean);
   return {
     schema_version: 1,
     netuid,
@@ -191,9 +204,19 @@ export function buildSubnetMetagraph(rows, netuid) {
   };
 }
 
-export function buildSubnetValidators(rows, netuid) {
+export function buildSubnetValidators(
+  rows,
+  netuid,
+  { featuredHotkeys = new Set() } = {},
+) {
   const { captured_at, block_number } = snapshotStamp(rows);
-  const validators = rows.map(formatNeuron).filter(Boolean);
+  // A real (if possibly empty) Set is always passed to formatNeuron here, so
+  // `featured` is always present on a validator row -- unlike the metagraph/
+  // neuron-detail builders above, the frontend badge needs the field even
+  // when nothing is currently featured.
+  const validators = rows
+    .map((row) => formatNeuron(row, featuredHotkeys))
+    .filter(Boolean);
   return {
     schema_version: 1,
     netuid,
@@ -239,6 +262,7 @@ function buildGlobalValidatorEntry(entry) {
     .slice(0, GLOBAL_VALIDATOR_SUBNET_LIMIT);
   return {
     hotkey: entry.hotkey,
+    featured: entry.featured === true,
     coldkey: primaryColdkey(entry.coldkeys),
     coldkey_count: entry.coldkeys.size,
     subnet_count: entry.netuids.size,
@@ -280,6 +304,7 @@ export function buildGlobalValidators(
   {
     sort = DEFAULT_GLOBAL_VALIDATOR_SORT,
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+    featuredHotkeys = new Set(),
   } = {},
 ) {
   const normalizedSort = GLOBAL_VALIDATOR_SORTS.includes(sort)
@@ -314,6 +339,7 @@ export function buildGlobalValidators(
     if (!entry) {
       entry = {
         hotkey,
+        featured: featuredHotkeys.has(hotkey),
         coldkeys: new Map(),
         netuids: new Set(),
         uidCount: 0,
@@ -409,6 +435,42 @@ function validatorSortValue(row, key) {
   return typeof value === "number" && Number.isFinite(value)
     ? value
     : Number.NEGATIVE_INFINITY;
+}
+
+// Stable partition, not a re-sort: featured rows keep their relative order
+// among themselves, and everyone else keeps theirs, so the pin only ever
+// bubbles rows up -- it never re-ranks within either group.
+function moveFeaturedToFront(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return rows;
+  const featured = [];
+  const rest = [];
+  for (const row of rows) {
+    (row?.featured === true ? featured : rest).push(row);
+  }
+  return featured.length === 0 ? rows : [...featured, ...rest];
+}
+
+// Featured-validator pin overlay (#5166): moves any row with featured=true to
+// the front of GlobalValidatorsArtifact.validators / SubnetValidatorsArtifact.
+// validators, applied ONCE at the point where the D1/Postgres tiers already
+// converge (mirrors overlayPreviouslyKnownAs in src/subnet-identity-history.mjs
+// -- a small pure post-processing function, not duplicated per tier). Must
+// never run on an explicit, non-default sort: GlobalValidatorsArtifact carries
+// `sort`, so a caller who chose e.g. total_stake keeps that exact order; the
+// per-subnet artifact has no `sort` field at all (its ranking is always the
+// stake-DESC default), so it always gets the pin. The `featured` flag itself
+// is untouched either way -- this function only ever reorders.
+export function overlayFeaturedValidators(data) {
+  if (!data || typeof data !== "object" || !Array.isArray(data.validators)) {
+    return data;
+  }
+  if (
+    Object.hasOwn(data, "sort") &&
+    data.sort !== DEFAULT_GLOBAL_VALIDATOR_SORT
+  ) {
+    return data;
+  }
+  return { ...data, validators: moveFeaturedToFront(data.validators) };
 }
 
 // D1 read paths shared by the REST handlers and the MCP tools (one source of

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -75,6 +75,10 @@ const healthChecksSyncFailure = vi.hoisted(() => ({ error: null }));
 const healthUptimeRollupSyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetSnapshotSyncFailure = vi.hoisted(() => ({ error: null }));
 const rpcUsageSyncFailure = vi.hoisted(() => ({ error: null }));
+// State for the featured_validators read (#5166) tests only -- lets a test
+// simulate the table not existing yet (pre-migration) without touching any
+// other query's mock plumbing.
+const featuredValidatorsQueryFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -166,6 +170,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO surface_checks\b/.test(text)
       ) {
         return Promise.reject(healthChecksSyncFailure.error);
+      }
+      if (
+        featuredValidatorsQueryFailure.error &&
+        /FROM featured_validators\b/.test(text)
+      ) {
+        return Promise.reject(featuredValidatorsQueryFailure.error);
       }
       if (
         healthUptimeRollupSyncFailure.error &&
@@ -266,6 +276,7 @@ beforeEach(() => {
   subnetSnapshotSyncFailure.error = null;
   healthUptimeRollupSyncFailure.error = null;
   rpcUsageSyncFailure.error = null;
+  featuredValidatorsQueryFailure.error = null;
   mockRows.current = [
     {
       block_number: "123",
@@ -1295,6 +1306,42 @@ test("GET /api/v1/subnets/:netuid/validators ranks validator_permit rows by stak
   expect(queryText()).toMatch(/ORDER BY stake_tao DESC, uid ASC/);
 });
 
+test("GET /api/v1/subnets/:netuid/validators sets featured=true for a hotkey in featured_validators", async () => {
+  // mockQueue is consumed in call order: the transaction's leading `SET
+  // statement_timeout` (sql.begin, see workers/data-api.mjs) shifts first,
+  // then the neurons query, then loadFeaturedHotkeys's own query.
+  mockQueue.current = [[], [NEURON_ROW], [{ hotkey: "5Hot" }]];
+  const res = await req("/api/v1/subnets/7/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(queryText()).toMatch(/FROM featured_validators/);
+  // The reorder overlay (workers/request-handlers/entities.mjs) has already
+  // run by the time this route responds -- a single-row list just confirms
+  // the flag itself made it through the read path.
+  expect(body.validators[0].featured).toBe(true);
+});
+
+test("GET /api/v1/subnets/:netuid/validators sets featured=false when the hotkey isn't in featured_validators", async () => {
+  mockQueue.current = [[], [NEURON_ROW], []];
+  const res = await req("/api/v1/subnets/7/validators");
+  const body = await res.json();
+  expect(body.validators[0].featured).toBe(false);
+});
+
+test("GET /api/v1/subnets/:netuid/validators still serves the primary rows when the featured_validators read fails", async () => {
+  // A pre-migration deployment (table not created yet) or any other read
+  // failure must degrade to "nothing is featured", never break the route.
+  featuredValidatorsQueryFailure.error = new Error(
+    'relation "featured_validators" does not exist',
+  );
+  mockQueue.current = [[], [NEURON_ROW]];
+  const res = await req("/api/v1/subnets/7/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validator_count).toBe(1);
+  expect(body.validators[0].featured).toBe(false);
+});
+
 test("GET /api/v1/validators returns the network-wide validator leaderboard with defaults", async () => {
   mockRows.current = [
     {
@@ -1316,6 +1363,49 @@ test("GET /api/v1/validators returns the network-wide validator leaderboard with
   expect(body.limit).toBe(20);
   expect(body.validators[0].hotkey).toBe("5Hot");
   expect(body.validators[0].total_stake_tao).toBe(456.7);
+});
+
+test("GET /api/v1/validators sets featured per hotkey, matched against featured_validators", async () => {
+  // This route only sets the flag (via buildGlobalValidators) -- the "move to
+  // front" reorder is a separate overlay applied downstream in
+  // workers/request-handlers/entities.mjs (see request-handlers-entities.test.mjs),
+  // so this test asserts the flag only, not row order.
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        netuid: 1,
+        uid: 0,
+        hotkey: "hk-a",
+        coldkey: "ck-a",
+        validator_trust: "0.5",
+        emission_tao: "1",
+        stake_tao: "100",
+        block_number: "10",
+        captured_at: "1780000000000",
+      },
+      {
+        netuid: 2,
+        uid: 0,
+        hotkey: "hk-b",
+        coldkey: "ck-b",
+        validator_trust: "0.9",
+        emission_tao: "5",
+        stake_tao: "9000",
+        block_number: "10",
+        captured_at: "1780000000000",
+      },
+    ],
+    [{ hotkey: "hk-a" }],
+  ];
+  const res = await req("/api/v1/validators");
+  const body = await res.json();
+  expect(queryText()).toMatch(/FROM featured_validators/);
+  const byHotkey = Object.fromEntries(
+    body.validators.map((v) => [v.hotkey, v.featured]),
+  );
+  expect(byHotkey["hk-a"]).toBe(true);
+  expect(byHotkey["hk-b"]).toBe(false);
 });
 
 test("GET /api/v1/validators respects an explicit valid sort + limit", async () => {

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -7,6 +7,7 @@ import {
   buildGlobalValidators,
   buildNeuronDetail,
   buildValidatorDetail,
+  overlayFeaturedValidators,
   loadSubnetValidators,
   loadGlobalValidators,
   loadValidatorDetail,
@@ -302,6 +303,37 @@ describe("metagraph-neurons builders", () => {
     assert.equal(data.validators[0].validator_permit, true);
   });
 
+  test("formatNeuron omits `featured` when no featuredHotkeys set is passed", () => {
+    // buildSubnetMetagraph/buildNeuronDetail/buildValidatorDetail never pass a
+    // set, so metagraph/neuron-detail/validator-detail responses keep their
+    // existing Neuron shape unchanged (#5166).
+    const n = formatNeuron(ROW);
+    assert.equal("featured" in n, false);
+  });
+
+  test("formatNeuron sets `featured` true/false by hotkey when a set is passed", () => {
+    const featured = new Set(["5Hk1"]);
+    assert.equal(formatNeuron(ROW, featured).featured, true);
+    assert.equal(formatNeuron(MINER, featured).featured, false);
+    // An empty (but real) set still yields a real boolean, not an omission.
+    assert.equal(formatNeuron(ROW, new Set()).featured, false);
+  });
+
+  test("buildSubnetValidators always includes `featured`, matched by hotkey", () => {
+    const withNoFeatured = buildSubnetValidators([ROW], 7);
+    assert.equal(withNoFeatured.validators[0].featured, false);
+
+    const withFeatured = buildSubnetValidators([ROW], 7, {
+      featuredHotkeys: new Set(["5Hk1"]),
+    });
+    assert.equal(withFeatured.validators[0].featured, true);
+
+    const notFeatured = buildSubnetValidators([ROW], 7, {
+      featuredHotkeys: new Set(["someone-else"]),
+    });
+    assert.equal(notFeatured.validators[0].featured, false);
+  });
+
   test("coerces a string-typed D1 block_number to an integer in the snapshot stamp + neuron detail", () => {
     // block_number is a nullable D1 INTEGER that can come back as a numeric
     // string; the snapshot stamp (metagraph/validators) and neuron-detail top
@@ -441,6 +473,29 @@ describe("metagraph-neurons builders", () => {
         [5, 3],
       ],
     );
+  });
+
+  test("buildGlobalValidators sets `featured` per hotkey entry, defaulting false", () => {
+    const data = buildGlobalValidators(
+      [
+        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a" },
+        { ...ROW, netuid: 2, uid: 0, hotkey: "hk-a" },
+        { ...ROW, netuid: 3, uid: 0, hotkey: "hk-b" },
+      ],
+      { featuredHotkeys: new Set(["hk-a"]) },
+    );
+    const byHotkey = Object.fromEntries(
+      data.validators.map((v) => [v.hotkey, v.featured]),
+    );
+    assert.equal(byHotkey["hk-a"], true);
+    assert.equal(byHotkey["hk-b"], false);
+
+    // No featuredHotkeys option at all -> every entry still carries a real
+    // boolean (false), never an omitted/undefined field.
+    const noOption = buildGlobalValidators([
+      { ...ROW, netuid: 1, hotkey: "hk-c" },
+    ]);
+    assert.equal(noOption.validators[0].featured, false);
   });
 
   test("buildGlobalValidators is cold-safe and normalizes direct-call options", () => {
@@ -892,6 +947,105 @@ describe("metagraph-neurons builders", () => {
   test("buildNeuronDetail returns neuron:null for a cold/absent row", () => {
     assert.equal(buildNeuronDetail(null, 7).neuron, null);
     assert.equal(buildNeuronDetail(ROW, 7).neuron.uid, 0);
+  });
+});
+
+describe("overlayFeaturedValidators (#5166)", () => {
+  test("moves featured rows to the front on the default (unsorted) view", () => {
+    const data = {
+      schema_version: 1,
+      sort: "subnet_count",
+      limit: 20,
+      validator_count: 3,
+      validators: [
+        { hotkey: "hk-a", featured: false },
+        { hotkey: "hk-b", featured: true },
+        { hotkey: "hk-c", featured: false },
+      ],
+    };
+    const out = overlayFeaturedValidators(data);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["hk-b", "hk-a", "hk-c"],
+    );
+  });
+
+  test("preserves relative order within the featured and non-featured groups (stable partition, not a re-sort)", () => {
+    const data = {
+      sort: "subnet_count",
+      validators: [
+        { hotkey: "hk-a", featured: true },
+        { hotkey: "hk-b", featured: false },
+        { hotkey: "hk-c", featured: true },
+        { hotkey: "hk-d", featured: false },
+      ],
+    };
+    const out = overlayFeaturedValidators(data);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["hk-a", "hk-c", "hk-b", "hk-d"],
+    );
+  });
+
+  test("does NOT reorder when an explicit, non-default sort is requested -- featured stays present", () => {
+    const data = {
+      sort: "total_stake",
+      validators: [
+        { hotkey: "hk-a", featured: false },
+        { hotkey: "hk-b", featured: true },
+      ],
+    };
+    const out = overlayFeaturedValidators(data);
+    // Order is untouched (the caller's explicit ranking is honored)...
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["hk-a", "hk-b"],
+    );
+    // ...but the flag itself is still on every row, so the frontend can still
+    // render the badge.
+    assert.equal(out.validators[0].featured, false);
+    assert.equal(out.validators[1].featured, true);
+  });
+
+  test("always reorders a SubnetValidatorsArtifact (no `sort` field at all)", () => {
+    const data = {
+      schema_version: 1,
+      netuid: 7,
+      validator_count: 2,
+      validators: [
+        { hotkey: "hk-a", featured: false },
+        { hotkey: "hk-b", featured: true },
+      ],
+    };
+    const out = overlayFeaturedValidators(data);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["hk-b", "hk-a"],
+    );
+  });
+
+  test("is a no-op when nothing is featured", () => {
+    const data = {
+      sort: "subnet_count",
+      validators: [
+        { hotkey: "hk-a", featured: false },
+        { hotkey: "hk-b", featured: false },
+      ],
+    };
+    const out = overlayFeaturedValidators(data);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["hk-a", "hk-b"],
+    );
+  });
+
+  test("is null-safe / shape-safe (cold payloads, missing validators array)", () => {
+    assert.equal(overlayFeaturedValidators(null), null);
+    assert.equal(overlayFeaturedValidators(undefined), undefined);
+    const noValidators = { sort: "subnet_count" };
+    assert.equal(overlayFeaturedValidators(noValidators), noValidators);
+    const empty = { sort: "subnet_count", validators: [] };
+    assert.deepEqual(overlayFeaturedValidators(empty).validators, []);
   });
 });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -803,6 +803,76 @@ describe("handleSubnetValidators", () => {
     assert.equal(body.data.validator_count, 0);
     assert.deepEqual(body.data.validators, []);
   });
+
+  test("moves a featured validator to the front (#5166, Postgres tier)", async () => {
+    // This route has no `sort` param at all -- the overlay always applies to
+    // its default stake-ranked view (see overlayFeaturedValidators).
+    const env = {
+      ...emptyEnv(),
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            validator_count: 2,
+            captured_at: null,
+            block_number: null,
+            validators: [
+              {
+                uid: 0,
+                hotkey: "hk-a",
+                coldkey: null,
+                active: true,
+                validator_permit: true,
+                rank: null,
+                trust: null,
+                validator_trust: null,
+                consensus: null,
+                incentive: null,
+                dividends: null,
+                emission_tao: null,
+                stake_tao: 10,
+                registered_at_block: null,
+                is_immunity_period: false,
+                axon: null,
+                featured: false,
+              },
+              {
+                uid: 1,
+                hotkey: "hk-b",
+                coldkey: null,
+                active: true,
+                validator_permit: true,
+                rank: null,
+                trust: null,
+                validator_trust: null,
+                consensus: null,
+                incentive: null,
+                dividends: null,
+                emission_tao: null,
+                stake_tao: 5,
+                registered_at_block: null,
+                is_immunity_period: false,
+                axon: null,
+                featured: true,
+              },
+            ],
+          }),
+      },
+    };
+    const res = await handleSubnetValidators(
+      req(`/api/v1/subnets/${NETUID}/validators`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/validators`),
+    );
+    const body = await json(res);
+    assert.equal(body.data.validators[0].hotkey, "hk-b");
+    assert.equal(body.data.validators[0].featured, true);
+    assert.equal(body.data.validators[1].hotkey, "hk-a");
+    await assertValidComponent("SubnetValidatorsArtifact", body.data);
+  });
 });
 
 describe("handleGlobalValidators", () => {
@@ -828,6 +898,92 @@ describe("handleGlobalValidators", () => {
       url("/api/v1/validators"),
     );
     assert.deepEqual(body.data.validators, []);
+  });
+
+  function globalValidatorEntry(overrides = {}) {
+    return {
+      hotkey: "hk-a",
+      featured: false,
+      coldkey: null,
+      coldkey_count: 0,
+      subnet_count: 1,
+      uid_count: 1,
+      total_stake_tao: 0,
+      total_emission_tao: 0,
+      stake_dominance: null,
+      avg_validator_trust: null,
+      max_validator_trust: null,
+      latest_captured_at: null,
+      latest_block_number: null,
+      subnets: [],
+      ...overrides,
+    };
+  }
+
+  test("moves a featured validator to the front on the default (unsorted) view (#5166, Postgres tier)", async () => {
+    const env = {
+      ...emptyEnv(),
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            sort: "subnet_count",
+            limit: 20,
+            captured_at: null,
+            block_number: null,
+            validator_count: 2,
+            validators: [
+              globalValidatorEntry({ hotkey: "hk-a", featured: false }),
+              globalValidatorEntry({ hotkey: "hk-b", featured: true }),
+            ],
+          }),
+      },
+    };
+    const res = await handleGlobalValidators(
+      req("/api/v1/validators"),
+      env,
+      url("/api/v1/validators"),
+    );
+    const body = await json(res);
+    assert.equal(body.data.validators[0].hotkey, "hk-b");
+    assert.equal(body.data.validators[0].featured, true);
+    assert.equal(body.data.validators[1].hotkey, "hk-a");
+    await assertValidComponent("GlobalValidatorsArtifact", body.data);
+  });
+
+  test("does NOT reorder an explicit, non-default ?sort= -- `featured` stays present (#5166)", async () => {
+    const env = {
+      ...emptyEnv(),
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            sort: "total_stake",
+            limit: 20,
+            captured_at: null,
+            block_number: null,
+            validator_count: 2,
+            validators: [
+              globalValidatorEntry({ hotkey: "hk-a", featured: false }),
+              globalValidatorEntry({ hotkey: "hk-b", featured: true }),
+            ],
+          }),
+      },
+    };
+    const res = await handleGlobalValidators(
+      req("/api/v1/validators?sort=total_stake"),
+      env,
+      url("/api/v1/validators?sort=total_stake"),
+    );
+    const body = await json(res);
+    // The caller's explicit ranking is untouched...
+    assert.equal(body.data.validators[0].hotkey, "hk-a");
+    assert.equal(body.data.validators[1].hotkey, "hk-b");
+    // ...but the badge-driving flag is still on every row.
+    assert.equal(body.data.validators[0].featured, false);
+    assert.equal(body.data.validators[1].featured, true);
   });
 });
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2283,6 +2283,22 @@ function json(data, status = 200) {
   });
 }
 
+// featured_validators (#5166) is a small maintainer-toggled side table (see
+// deploy/postgres/schema.sql for why it's hotkey-keyed rather than a `neurons`
+// column) -- reading it must never break the primary validators query, so a
+// missing table (e.g. before the migration has landed) or any other read
+// failure here just yields "nothing is featured" instead of a 502 for the
+// whole /validators route.
+async function loadFeaturedHotkeys(sql) {
+  try {
+    const rows = await sql`SELECT hotkey FROM featured_validators`;
+    return new Set(rows.map((row) => row.hotkey));
+  } catch (err) {
+    console.error("featured_validators query failed:", err);
+    return new Set();
+  }
+}
+
 function clampLimit(raw) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
@@ -5648,11 +5664,14 @@ export default {
         );
         if (subnetValidators) {
           const netuid = Number(subnetValidators[1]);
-          const rows = await sql`
+          const [rows, featuredHotkeys] = await Promise.all([
+            sql`
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at
           FROM neurons WHERE netuid = ${netuid} AND validator_permit = TRUE
-          ORDER BY stake_tao DESC, uid ASC`;
-          return json(buildSubnetValidators(rows, netuid));
+          ORDER BY stake_tao DESC, uid ASC`,
+            loadFeaturedHotkeys(sql),
+          ]);
+          return json(buildSubnetValidators(rows, netuid, { featuredHotkeys }));
         }
 
         // GET /api/v1/validators?sort=&limit= (#4771): network-wide validator
@@ -5671,11 +5690,16 @@ export default {
             limitParam <= GLOBAL_VALIDATOR_LIMIT_MAX
               ? limitParam
               : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
-          const rows = await sql`
+          const [rows, featuredHotkeys] = await Promise.all([
+            sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at
           FROM neurons WHERE validator_permit = TRUE AND hotkey IS NOT NULL
-          ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`;
-          return json(buildGlobalValidators(rows, { sort, limit }));
+          ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
+            loadFeaturedHotkeys(sql),
+          ]);
+          return json(
+            buildGlobalValidators(rows, { sort, limit, featuredHotkeys }),
+          );
         }
 
         // GET /api/v1/validators/:hotkey (#4771): cross-subnet validator detail,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -49,6 +49,7 @@ import {
   buildSubnetValidators,
   buildNeuronDetail,
   buildValidatorDetail,
+  overlayFeaturedValidators,
   GLOBAL_VALIDATOR_SORTS,
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -655,9 +656,14 @@ export async function handleSubnetHyperparamsHistory(
 export async function handleSubnetValidators(request, env, netuid, url) {
   const validationError = validateEntityQuery(url, ["format"]);
   if (validationError) return analyticsQueryError(validationError);
-  const data =
+  // Featured-validator pin (#5166): applied once, right where the Postgres/D1
+  // tiers converge, so it never needs duplicating per tier. This route has no
+  // `sort` param at all -- its ranking is always the stake-DESC default -- so
+  // the overlay always applies here (see overlayFeaturedValidators).
+  const data = overlayFeaturedValidators(
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildSubnetValidators([], netuid);
+      buildSubnetValidators([], netuid),
+  );
   if (csvRequested(url, request)) {
     return csvResponse(
       data.validators,
@@ -731,12 +737,18 @@ export function canonicalGlobalValidatorsCachePath(url, request = null) {
 export async function handleGlobalValidators(request, env, url) {
   const parsed = parseGlobalValidatorsQuery(url);
   if (parsed.error) return analyticsQueryError(parsed.error);
-  const data =
+  // Featured-validator pin (#5166), applied once at tier convergence -- see
+  // handleSubnetValidators above. Unlike that route this one has a `sort`
+  // param, so overlayFeaturedValidators only reorders the default (unsorted)
+  // view; an explicit non-default ?sort= keeps the caller's exact order while
+  // `featured` stays present on every row either way.
+  const data = overlayFeaturedValidators(
     (await tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")) ??
-    buildGlobalValidators([], {
-      sort: parsed.sort,
-      limit: parsed.limit,
-    });
+      buildGlobalValidators([], {
+        sort: parsed.sort,
+        limit: parsed.limit,
+      }),
+  );
   if (csvRequested(url, request)) {
     return csvResponse(
       data.validators,


### PR DESCRIPTION
## Summary

- Adds a DB-toggled "featured validator" pin: mark a validator's hotkey in a
  new `featured_validators` Postgres table and it appears first on the
  default (unsorted) view of both `/api/v1/validators` and a subnet's
  `/api/v1/subnets/{netuid}/validators`, with a small "Featured" badge in the
  UI. No code deploy needed to change which validator is featured — it's a
  direct `INSERT`/`UPDATE` against that table.
- An explicit `?sort=` on the global leaderboard is never silently
  overridden by the pin (the acceptance-criteria subtlety called out in the
  issue).

## What Changed

- `deploy/postgres/schema.sql`: adds `featured_validators (hotkey TEXT
  PRIMARY KEY, featured_at BIGINT NOT NULL)`, keyed by hotkey rather than a
  column on `neurons`. `neurons`' PK is `(netuid, uid)` — a UID *slot*, not a
  stable identity — and `handleNeuronsSync` (`workers/data-api.mjs`) hard-
  `DELETE`s a row once its UID falls out of the latest snapshot
  (deregistration), with that UID free to be reassigned to a *different*
  hotkey later. A `featured` column on `neurons` would either vanish
  silently on prune or incorrectly "follow" the slot to whoever registers
  into it next — a hotkey-keyed side table sidesteps both failure modes.
- `workers/data-api.mjs`: a new `loadFeaturedHotkeys(sql)` helper
  (try/catch — a missing table or any read failure degrades to "nothing is
  featured" rather than a 502 for the whole `/validators` route) queried
  alongside the existing `neurons` query for both the subnet-validators and
  global-validators routes, feeding a `featuredHotkeys` Set into
  `buildSubnetValidators`/`buildGlobalValidators`.
- `src/metagraph-neurons.mjs`: `formatNeuron`/`buildSubnetValidators`/
  `buildGlobalValidators` thread the `featured` flag through by hotkey
  (only for the validator-list builders — metagraph/neuron-detail/
  validator-detail responses are unchanged). New
  `overlayFeaturedValidators` — a small pure post-processing function
  mirroring `overlayPreviouslyKnownAs` in `src/subnet-identity-history.mjs`
  — moves featured rows to the front (a stable partition, not a re-sort),
  applied exactly once at tier convergence.
- `workers/request-handlers/entities.mjs`: calls the overlay once in
  `handleSubnetValidators` (always applies — that route has no `sort`
  param) and once in `handleGlobalValidators` (skips the reorder when
  `sort` is an explicit non-default value; `featured` stays present on
  every row regardless).
- `schemas/components/05-subnets.schema.json` (+ regenerated
  `openapi.json`/`types.d.ts`/`packages/contract/index.d.ts`): adds
  `featured` to `Neuron` (optional — only populated on the validators-list
  artifacts) and `GlobalValidatorEntry` (required — always populated).
- Frontend (`apps/ui`): `MetagraphNeuron`/`GlobalValidator` types gain
  `featured`; `NeuronTable` and the global validators leaderboard
  (`routes/validators.index.tsx`) render a small "Featured" badge next to
  the hotkey, reusing the existing permit-pill visual convention (no new
  component library primitive invented).
- `packages/client/package.json`: patch-bumped to 0.15.5 — the local
  `validate:client-sdk-sync` pre-push guard blocked on the contract change
  otherwise. Per this repo's own convention the post-merge
  `sync-client-version` workflow normally owns this bump automatically; the
  validator script itself now notes the bump was technically unnecessary
  and can be dropped/reconciled once that workflow's own PR lands, at the
  maintainer's discretion.

## Design deviations from the linked issue's suggested shape

- **Overlay call site**: the issue text describes the tier-convergence
  overlay point as living in `workers/api.mjs`. In this codebase the actual
  Postgres/D1 convergence for both validator routes happens inside
  `workers/request-handlers/entities.mjs`'s `handleSubnetValidators`/
  `handleGlobalValidators` (each already does
  `tryPostgresTier(...) ?? buildXxx([])` before building its own envelope
  response) — `workers/api.mjs` only dispatches to those handlers and never
  sees the raw data object, so it can't host a pre-response data overlay
  the way it does for `overlayPreviouslyKnownAs` (a genuinely different
  route shape). `overlayFeaturedValidators` is called once per route at the
  literal point of tier convergence, which is the same *pattern* the issue
  asked for, just in the file where that convergence actually lives.

## Test Plan

- `npx vitest run tests/metagraph-neurons.test.mjs` — 53/53 (overlay
  reorder + sort-safety both directions, `formatNeuron`/
  `buildSubnetValidators`/`buildGlobalValidators` featured-flag matching)
- `npx vitest run tests/data-api.test.mjs` — 395/395 (featured_validators
  query wiring, hotkey matching, resilience when the table read fails)
- `npx vitest run tests/request-handlers-entities.test.mjs` — 339/339
  (handler-level overlay integration against a mocked Postgres tier,
  including the AJV component-schema check)
- `npm test` — 267 files / 7761 tests passed
- `npm run test:coverage` — 99.48% stmts / 97.9% branch overall; no gaps in
  changed lines (the sort-safety conditional is covered both ways)
- `apps/ui`: `npm test` — 98 files / 685 tests passed (incl. new
  `normalizeGlobalValidators` `featured` passthrough test);
  `npm run typecheck`, `npm run lint`, `npx prettier --check` on touched
  files — clean
- `npm run lint`, `npx prettier --check <touched files>`, `git diff --check`
  — clean
- `npm run validate`, `validate:contract-drift`, `validate:schemas`,
  `validate:api`, `validate:openapi`, `validate:types`,
  `validate:artifact-budgets`, `validate:docs`, `validate:intake`,
  `validate:workflows`, `validate:client-sdk-sync`, `worker:test`,
  `scan:public-safety` — all green
- `npm run pipeline:check`: every step green except `r2:manifest:dry-run`,
  which fails in this sandboxed dev environment because the local
  `dist/metagraph-r2` staging tree (built from this environment's own
  `sync:subnets`/`discover:candidates` runs) only reaches ~1765 artifacts
  vs. the ~2261 committed in `public/metagraph/r2-manifest.json` — almost
  certainly restricted external network/API access in this sandbox rather
  than anything in this diff. `public/metagraph/r2-manifest.json` itself is
  byte-identical to `origin/main` in this branch (confirmed via `git diff
  origin/main -- public/metagraph/r2-manifest.json`), and `pipeline:check`
  is a local-only convenience aggregator — `.github/workflows/validate.yml`
  never invokes it; real CI runs `npm run build` + `npm run r2:manifest`
  fresh on a clean checkout and the individual `validate:*` scripts above
  directly, all of which passed independently.

Closes #5166