### PR TITLE
feat(registry): add SN124 Swarm public benchmark dashboard surface

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -70,6 +70,25 @@
       ],
       "url": "https://api.swarm124.com/leaderboard",
       "notes": "Public no-auth GET /leaderboard — ranked miner model leaderboard (rank, model id, uid, benchmark score) for SN124 Swarm. Served on the same api.swarm124.com host as the subnet's registered health API; the endpoint is defined in the subnet's backend API module."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-124-swarm-benchmark-dashboard",
+      "kind": "dashboard",
+      "name": "Swarm benchmark dashboard",
+      "notes": "Public no-auth web dashboard for SN124 Swarm at swarm124.com/benchmark — the subnet's human-viewable king-of-the-hill benchmark board showing ranked miner models, benchmark scores, and current standings. Linked directly from the official swarm-subnet/swarm miner guide (docs/miner.md). Distinct host and surface kind from the api.swarm124.com backend API surfaces already registered (health, kings/active, leaderboard): this is the rendered dashboard page, not a JSON endpoint.",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/docs/miner.md",
+        "https://swarm124.com/benchmark"
+      ],
+      "url": "https://swarm124.com/benchmark"
     }
   ],
   "website_url": "https://www.swarm124.com/"


### PR DESCRIPTION
## Summary
Enriches **SN124 Swarm** with its public, no-auth **dashboard** — the human-viewable benchmark board the registry was missing.

## Surface
- **kind:** `dashboard`
- **url:** `https://swarm124.com/benchmark` — the SN124 king-of-the-hill benchmark board (ranked miner models, benchmark scores, current standings)
- **provider:** `swarm`  ·  **authority:** community  ·  **review.state:** community-submitted
- Distinct host and kind from the already-registered `api.swarm124.com` backend API surfaces (health, kings/active, leaderboard) — this is the rendered page, not a JSON endpoint.

## Proof (host ↔ subnet)
- The official **swarm-subnet/swarm** miner guide links this page directly: `https://github.com/swarm-subnet/swarm/blob/main/docs/miner.md` → `https://swarm124.com/benchmark`.
- The domain `swarm124.com` encodes netuid 124, and `source_repo` in the manifest is `swarm-subnet/swarm`.

## Change
- One file: `registry/subnets/swarm.json` — appends exactly one surface object. **Append-only** (pure `+19 / -0`); no edits to existing surfaces or metadata.

## Validation
- `node scripts/validate-surface.mjs registry/subnets/swarm.json` → *Surface validation passed: 4 surface(s)*
- `node scripts/scan-public-safety.mjs` → *Public-safety scan passed*
- `prettier --check registry/subnets/swarm.json` → *All matched files use Prettier code style*
- Live probe: `GET https://swarm124.com/benchmark` → **HTTP 200**, `text/html`, no login redirect, no auth.

Closes #5192