### PR TITLE
feat(registry): add SN117 BrainPlay public leaderboard dashboard surface

### DIFF
--- a/registry/subnets/brainplay.json
+++ b/registry/subnets/brainplay.json
@@ -110,6 +110,25 @@
         "https://github.com/shiftlayer-llc/brainplay-subnet/blob/main/deploy/miner.py"
       ],
       "url": "https://raw.githubusercontent.com/shiftlayer-llc/brainplay-subnet/main/deploy/profiles/codenames.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-117-brainplay-leaderboard-dashboard",
+      "kind": "dashboard",
+      "name": "BrainPlay leaderboard dashboard",
+      "notes": "Public no-auth web dashboard at play.shiftlayer.ai/leaderboard — the SN117 BrainPlay competition leaderboard (server-rendered ranked table of players with ELO ratings; page title \"BrainPlay Leaderboard\"). Served on the same play.shiftlayer.ai host as the subnet's registered public app (website) and /api/health API surfaces. Human-viewable dashboard page, distinct in kind and path from the JSON health endpoint.",
+      "provider": "shiftlayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": [
+        "https://github.com/shiftlayer-llc/brainplay-subnet",
+        "https://play.shiftlayer.ai/leaderboard"
+      ],
+      "url": "https://play.shiftlayer.ai/leaderboard"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Enriches **SN117 BrainPlay** with its public, no-auth **dashboard** — the human-viewable leaderboard the registry was missing.

## Surface
- **kind:** `dashboard`  ·  **url:** `https://play.shiftlayer.ai/leaderboard`
- The SN117 BrainPlay competition leaderboard: a server-rendered ranked table of players with ELO ratings (page title *"BrainPlay Leaderboard"*).
- **provider:** `shiftlayer` · authority community · review.state community-submitted.
- Same host as the already-registered BrainPlay website and `/api/health` surfaces, but a distinct **kind** (dashboard vs subnet-api) and path — the rendered leaderboard page, not a JSON endpoint.

## Proof (host ↔ subnet)
- `play.shiftlayer.ai` is the subnet's **registered `website_url`** in `brainplay.json`, taken from the official `shiftlayer-llc/brainplay-subnet` repository homepage metadata; `/leaderboard` is a page on that same app.

## Change
- One file: `registry/subnets/brainplay.json` — appends exactly one surface. **Append-only** (`+19 / -0`); no edits to existing surfaces.

## Validation
- `node scripts/validate-surface.mjs registry/subnets/brainplay.json` → *Surface validation passed: 5 surface(s)*
- `node scripts/scan-public-safety.mjs` → *Public-safety scan passed*
- `prettier --check` → *All matched files use Prettier code style*
- Live probe: `GET https://play.shiftlayer.ai/leaderboard` → **HTTP 200**, `text/html`, no login redirect, server-rendered leaderboard table present.

Closes #4160