### PR TITLE
feat(rpc): wire first-party fullnode into the public RPC pool

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,8 +10,44 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 117,
+  "surface_count": 119,
   "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subtensor-rpc",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "metagraphed",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "metagraphed-fullnode-rpc",
+      "surface_key": "srf-78ffc33642323545",
+      "url": "https://fullnode-rpc.metagraph.sh"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subtensor-wss",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "WSS-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "metagraphed",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "metagraphed-fullnode-wss",
+      "surface_key": "srf-8e0ed44b4e9373b8",
+      "url": "wss://fullnode-rpc.metagraph.sh"
+    },
     {
       "auth_required": false,
       "authority": "provider-claimed",

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -268,6 +268,42 @@
     },
     {
       "auth_required": false,
+      "authority": "provider-claimed",
+      "id": "metagraphed-fullnode-rpc",
+      "kind": "subtensor-rpc",
+      "name": "Metagraphed self-hosted pruned RPC",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "metagraphed",
+      "public_safe": true,
+      "rate_limit_notes": "First-party pruned (non-archive) node behind a Cloudflare Tunnel, --rpc-methods=safe, node-level rate limiting underneath Cloudflare's own edge protection.",
+      "source_urls": ["https://metagraph.sh"],
+      "url": "https://fullnode-rpc.metagraph.sh"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "id": "metagraphed-fullnode-wss",
+      "kind": "subtensor-wss",
+      "name": "Metagraphed self-hosted pruned WSS",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "WSS-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "metagraphed",
+      "public_safe": true,
+      "rate_limit_notes": "First-party pruned (non-archive) node behind a Cloudflare Tunnel, --rpc-methods=safe, node-level rate limiting underneath Cloudflare's own edge protection.",
+      "source_urls": ["https://metagraph.sh"],
+      "url": "wss://fullnode-rpc.metagraph.sh"
+    },
+    {
+      "auth_required": false,
       "authority": "community",
       "id": "sn-0-tensorplex-docs",
       "kind": "docs",

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -430,4 +430,12 @@ export const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "wss://bittensor-finney.api.onfinality.io",
   "wss://entrypoint-finney.opentensor.ai",
   "wss://lite.chain.opentensor.ai",
+  // First-party pruned RPC node (#4965), behind a Cloudflare Tunnel --
+  // --rpc-methods=safe + node-level rate limiting at the origin, Cloudflare's
+  // own edge protection in front of that. Both HTTPS and WSS confirmed live
+  // 2026-07-14 (WSS via a real 101 Switching Protocols handshake, same bar as
+  // the testnet endpoints above), and an unsafe method (author_insertKey)
+  // confirmed rejected through the public URL, not just the private one.
+  "https://fullnode-rpc.metagraph.sh",
+  "wss://fullnode-rpc.metagraph.sh",
 ]);


### PR DESCRIPTION
## Summary
Closes #4965 (RPC proxy pool cutover, node 1 of 3).

Cuts over the last remaining piece of that issue's scope: the live indexer (`indexer-rs`) was already repointed at our self-hosted fullnode earlier — private-mesh, internal consumer only. The public-facing `/api/v1/rpc/*` pool (`TRUSTED_RPC_UPSTREAM_ORIGINS`) was still 100% third-party.

The node is now reachable at `https://fullnode-rpc.metagraph.sh` / `wss://fullnode-rpc.metagraph.sh` via a Cloudflare Tunnel (infra-side: `cloudflared` installed + hardened, tunnel created, DNS-routed — see the companion `metagraphed-infra` PRs). Protection layers: `--rpc-methods=safe` + node-level rate limiting at the origin (the indexer box's own consumer is whitelisted so it's never throttled), Cloudflare's own edge protection in front of that.

- `registry/subnets/root.json`: two new surfaces, `authority: provider-claimed` — same trust tier as OnFinality's self-operated public endpoint, not `official` (reserved for the chain's actual maintainer).
- `workers/config.mjs`: both URLs added to `TRUSTED_RPC_UPSTREAM_ORIGINS`.
- `public/metagraph/operational-surfaces.json` regenerated via `npm run build` (surface_count 117 → 119).
- No health-prober code changes needed — it matches purely on `surface.kind` (`subtensor-rpc`/`subtensor-wss`), so the new registry entries are picked up automatically once this deploys.

**Trusted-vs-public pool decision** (per #4965's own ask for a written note): additive, not a replacement for the existing third-party entries. A single new node shouldn't be the sole source of truth yet — #4962 frames this explicitly as "server 1 of an eventual 3-node pool." Revisit once nodes 2/3 exist and there's real signal on this node's reliability under public traffic.

## Test plan
- `npm run validate:surface -- registry/subnets/root.json` — clean
- `npm run build` — clean, confirmed the two new surfaces appear correctly in the built `rpc/pools.json` (layer `bittensor-base`, correct kind/provider)
- `npm run lint` / `npx prettier --check` — clean
- `npm run scan:public-safety` — clean
- `npm run test:coverage` — running, will confirm before merge
- Verified live end-to-end **before** opening this PR:
  - `https://fullnode-rpc.metagraph.sh`: `system_health` returns real, current peer/sync data
  - `wss://fullnode-rpc.metagraph.sh`: real `101 Switching Protocols` handshake
  - `author_insertKey` (unsafe method) rejected through the **public** URL with `-32601 RPC call is unsafe to be called externally` — confirms `--rpc-methods=safe` is enforced end-to-end, not just on the private tailnet path
  - `indexer-rs`'s live-follow reconnected with zero gap across the subtensor restart that applied these flags