### PR TITLE
feat(registry): add SN82 Compelle system status dashboard surface

### DIFF
--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -102,6 +102,22 @@
         "https://github.com/compelle/compelle-validator/blob/main/compelle/config.json"
       ],
       "url": "https://raw.githubusercontent.com/compelle/compelle-validator/main/compelle/config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-82-compelle-status-dashboard",
+      "kind": "dashboard",
+      "name": "Compelle system status dashboard",
+      "notes": "Public no-auth web dashboard at compelle.com/status - a live system-status readout of the SN82 Compelle validator network (validator state, last epoch block and time, distinct validators reporting, eligible miners scored in the last epoch, total epochs and games indexed), refreshing every 30 seconds. Server-rendered human-viewable page (page title: System Status | Compelle) on the subnet's official compelle.com app host, distinct in kind from the JSON /api/health endpoint and the validator-config data-artifact.",
+      "provider": "compelle",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jaytbarimbao-collab"
+      },
+      "source_urls": ["https://compelle.com/status", "https://compelle.com/"],
+      "url": "https://compelle.com/status"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN82 Compelle** with its public, no-auth **system status dashboard** — a human-viewable surface the registry was missing (the file carried website, source-repo, `/api/health`, and a validator-config data-artifact, but no `dashboard`-kind surface).

## Surface

- **kind:** `dashboard`  ·  **url:** `https://compelle.com/status`  ·  **auth_required:** `false`
- A live system-status readout of the SN82 validator network — validator state, last epoch block/time, distinct validators reporting, eligible miners scored in the last epoch, and total epochs/games indexed — refreshing every 30 seconds (page title: *System Status · Compelle*).
- Server-rendered, no login, on the subnet's official `compelle.com` app host (same host as the already-registered website and `/api/health` surfaces). Distinct in kind and path from the JSON health endpoint and the config data-artifact.

## Verification

- `GET https://compelle.com/status` → `200`, `text/html` (~15 KB), no auth wall; renders the live validator/miner/epoch readout described above.

Closes #4102
