### PR TITLE
feat(neurons): ingest validator take/commission into the neurons tier

### DIFF
--- a/migrations/0042_neurons_take.sql
+++ b/migrations/0042_neurons_take.sql
@@ -1,0 +1,15 @@
+-- Validator take/commission (#2548): the percentage of delegator rewards a
+-- validator keeps, exposed on-chain per hotkey via SubtensorModule::Delegates
+-- (a u16 out of 65535, same ratio convention as rank/validator_trust --
+-- verified live against the fullnode 2026-07-14: a raw value of 11796
+-- decodes to exactly 0.18, the documented Bittensor default/floor take).
+-- Global per-hotkey, not per (netuid, uid) -- stored denormalized on every
+-- row for that hotkey, same convention this table already uses for coldkey.
+-- NULL means the hotkey had no Delegates entry at capture time (never
+-- registered as a delegate, or a snapshot that predates this column).
+ALTER TABLE neurons ADD COLUMN IF NOT EXISTS take REAL;
+
+-- neuron_daily's shape mirrors neurons exactly (0011's own comment) so both
+-- share NEURON_INSERT_COLUMNS on the write path -- must gain the same column
+-- or that shared insert breaks.
+ALTER TABLE neuron_daily ADD COLUMN IF NOT EXISTS take REAL;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4940,6 +4940,8 @@ export interface components {
             stake_dominance: number | null;
             subnet_count: number;
             subnets: components["schemas"]["GlobalValidatorSubnet"][];
+            /** @description Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Global per-hotkey. Null if no SubtensorModule::Delegates entry existed at capture time. */
+            take: number | null;
             total_emission_tao: number;
             total_stake_tao: number;
             uid_count: number;
@@ -5267,6 +5269,8 @@ export interface components {
             rank?: number | null;
             registered_at_block?: number | null;
             stake_tao?: number | null;
+            /** @description Validator take/commission (#2548): the 0..1 fraction of delegator rewards this hotkey keeps, from SubtensorModule::Delegates. Global per-hotkey, not per-subnet -- identical across every Neuron row for the same hotkey. Null if the hotkey had no Delegates entry at capture time. */
+            take?: number | null;
             trust?: number | null;
             uid: number;
             validator_permit: boolean;
@@ -7601,6 +7605,8 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["ValidatorDetailSubnet"][];
+            /** @description Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Null if no SubtensorModule::Delegates entry existed at capture time. */
+            take: number | null;
             total_emission_tao: number;
             total_stake_tao: number;
         } & {
@@ -7621,6 +7627,8 @@ export interface components {
             rank?: number | null;
             registered_at_block?: number | null;
             stake_tao?: number | null;
+            /** @description Validator take/commission (#2548), 0..1 fraction. Global per-hotkey, identical across every subnet membership row here. */
+            take?: number | null;
             trust?: number | null;
             uid: number;
             validator_permit: boolean;
@@ -24617,6 +24625,7 @@ export interface operations {
                      *           "rank": 0.5,
                      *           "registered_at_block": 5000000,
                      *           "stake_tao": 0.5,
+                     *           "take": 0.5,
                      *           "trust": 0.5,
                      *           "uid": 1,
                      *           "validator_permit": false,
@@ -28342,6 +28351,7 @@ export interface operations {
                      *                 "validator_trust": 0.5
                      *               }
                      *             ],
+                     *             "take": 0.5,
                      *             "total_emission_tao": 0.5,
                      *             "total_stake_tao": 0.5,
                      *             "uid_count": 1
@@ -28471,6 +28481,7 @@ export interface operations {
                      *             "validator_permit": false
                      *           }
                      *         ],
+                     *         "take": 0.5,
                      *         "total_emission_tao": 0.5,
                      *         "total_stake_tao": 0.5
                      *       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9719,6 +9719,13 @@
             "maxItems": 10,
             "type": "array"
           },
+          "take": {
+            "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Global per-hotkey. Null if no SubtensorModule::Delegates entry existed at capture time.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "total_emission_tao": {
             "minimum": 0,
             "type": "number"
@@ -9739,6 +9746,7 @@
           "coldkey_count",
           "subnet_count",
           "uid_count",
+          "take",
           "total_stake_tao",
           "total_emission_tao",
           "stake_dominance",
@@ -11005,6 +11013,13 @@
             ]
           },
           "stake_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "take": {
+            "description": "Validator take/commission (#2548): the 0..1 fraction of delegator rewards this hotkey keeps, from SubtensorModule::Delegates. Global per-hotkey, not per-subnet -- identical across every Neuron row for the same hotkey. Null if the hotkey had no Delegates entry at capture time.",
             "type": [
               "number",
               "null"
@@ -20778,6 +20793,13 @@
             },
             "type": "array"
           },
+          "take": {
+            "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Null if no SubtensorModule::Delegates entry existed at capture time.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "total_emission_tao": {
             "minimum": 0,
             "type": "number"
@@ -20793,6 +20815,7 @@
           "coldkey",
           "coldkey_count",
           "subnet_count",
+          "take",
           "total_stake_tao",
           "total_emission_tao",
           "avg_validator_trust",
@@ -20872,6 +20895,13 @@
             ]
           },
           "stake_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "take": {
+            "description": "Validator take/commission (#2548), 0..1 fraction. Global per-hotkey, identical across every subnet membership row here.",
             "type": [
               "number",
               "null"
@@ -46391,6 +46421,7 @@
                       "rank": 0.5,
                       "registered_at_block": 5000000,
                       "stake_tao": 0.5,
+                      "take": 0.5,
                       "trust": 0.5,
                       "uid": 1,
                       "validator_permit": false,
@@ -51392,6 +51423,7 @@
                             "validator_trust": 0.5
                           }
                         ],
+                        "take": 0.5,
                         "total_emission_tao": 0.5,
                         "total_stake_tao": 0.5,
                         "uid_count": 1
@@ -51548,6 +51580,7 @@
                         "validator_permit": false
                       }
                     ],
+                    "take": 0.5,
                     "total_emission_tao": 0.5,
                     "total_stake_tao": 0.5
                   },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4940,6 +4940,8 @@ export interface components {
             stake_dominance: number | null;
             subnet_count: number;
             subnets: components["schemas"]["GlobalValidatorSubnet"][];
+            /** @description Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Global per-hotkey. Null if no SubtensorModule::Delegates entry existed at capture time. */
+            take: number | null;
             total_emission_tao: number;
             total_stake_tao: number;
             uid_count: number;
@@ -5267,6 +5269,8 @@ export interface components {
             rank?: number | null;
             registered_at_block?: number | null;
             stake_tao?: number | null;
+            /** @description Validator take/commission (#2548): the 0..1 fraction of delegator rewards this hotkey keeps, from SubtensorModule::Delegates. Global per-hotkey, not per-subnet -- identical across every Neuron row for the same hotkey. Null if the hotkey had no Delegates entry at capture time. */
+            take?: number | null;
             trust?: number | null;
             uid: number;
             validator_permit: boolean;
@@ -7601,6 +7605,8 @@ export interface components {
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["ValidatorDetailSubnet"][];
+            /** @description Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Null if no SubtensorModule::Delegates entry existed at capture time. */
+            take: number | null;
             total_emission_tao: number;
             total_stake_tao: number;
         } & {
@@ -7621,6 +7627,8 @@ export interface components {
             rank?: number | null;
             registered_at_block?: number | null;
             stake_tao?: number | null;
+            /** @description Validator take/commission (#2548), 0..1 fraction. Global per-hotkey, identical across every subnet membership row here. */
+            take?: number | null;
             trust?: number | null;
             uid: number;
             validator_permit: boolean;
@@ -24617,6 +24625,7 @@ export interface operations {
                      *           "rank": 0.5,
                      *           "registered_at_block": 5000000,
                      *           "stake_tao": 0.5,
+                     *           "take": 0.5,
                      *           "trust": 0.5,
                      *           "uid": 1,
                      *           "validator_permit": false,
@@ -28342,6 +28351,7 @@ export interface operations {
                      *                 "validator_trust": 0.5
                      *               }
                      *             ],
+                     *             "take": 0.5,
                      *             "total_emission_tao": 0.5,
                      *             "total_stake_tao": 0.5,
                      *             "uid_count": 1
@@ -28471,6 +28481,7 @@ export interface operations {
                      *             "validator_permit": false
                      *           }
                      *         ],
+                     *         "take": 0.5,
                      *         "total_emission_tao": 0.5,
                      *         "total_stake_tao": 0.5
                      *       },

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9697,6 +9697,13 @@
             "maxItems": 10,
             "type": "array"
           },
+          "take": {
+            "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Global per-hotkey. Null if no SubtensorModule::Delegates entry existed at capture time.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "total_emission_tao": {
             "minimum": 0,
             "type": "number"
@@ -9717,6 +9724,7 @@
           "coldkey_count",
           "subnet_count",
           "uid_count",
+          "take",
           "total_stake_tao",
           "total_emission_tao",
           "stake_dominance",
@@ -10983,6 +10991,13 @@
             ]
           },
           "stake_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "take": {
+            "description": "Validator take/commission (#2548): the 0..1 fraction of delegator rewards this hotkey keeps, from SubtensorModule::Delegates. Global per-hotkey, not per-subnet -- identical across every Neuron row for the same hotkey. Null if the hotkey had no Delegates entry at capture time.",
             "type": [
               "number",
               "null"
@@ -20756,6 +20771,13 @@
             },
             "type": "array"
           },
+          "take": {
+            "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Null if no SubtensorModule::Delegates entry existed at capture time.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "total_emission_tao": {
             "minimum": 0,
             "type": "number"
@@ -20771,6 +20793,7 @@
           "coldkey",
           "coldkey_count",
           "subnet_count",
+          "take",
           "total_stake_tao",
           "total_emission_tao",
           "avg_validator_trust",
@@ -20850,6 +20873,13 @@
             ]
           },
           "stake_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "take": {
+            "description": "Validator take/commission (#2548), 0..1 fraction. Global per-hotkey, identical across every subnet membership row here.",
             "type": [
               "number",
               "null"

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1416,7 +1416,11 @@
           "registered_at_block": { "type": ["integer", "null"] },
           "is_immunity_period": { "type": "boolean" },
           "axon": { "type": ["string", "null"] },
-          "featured": { "type": "boolean" }
+          "featured": { "type": "boolean" },
+          "take": {
+            "type": ["number", "null"],
+            "description": "Validator take/commission (#2548): the 0..1 fraction of delegator rewards this hotkey keeps, from SubtensorModule::Delegates. Global per-hotkey, not per-subnet -- identical across every Neuron row for the same hotkey. Null if the hotkey had no Delegates entry at capture time."
+          }
         }
       },
       "SubnetMetagraphArtifact": {
@@ -1999,6 +2003,7 @@
           "coldkey_count",
           "subnet_count",
           "uid_count",
+          "take",
           "total_stake_tao",
           "total_emission_tao",
           "stake_dominance",
@@ -2015,6 +2020,10 @@
           "coldkey_count": { "type": "integer", "minimum": 0 },
           "subnet_count": { "type": "integer", "minimum": 0 },
           "uid_count": { "type": "integer", "minimum": 0 },
+          "take": {
+            "type": ["number", "null"],
+            "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Global per-hotkey. Null if no SubtensorModule::Delegates entry existed at capture time."
+          },
           "total_stake_tao": { "type": "number", "minimum": 0 },
           "total_emission_tao": { "type": "number", "minimum": 0 },
           "stake_dominance": {
@@ -2193,7 +2202,11 @@
           "stake_tao": { "type": ["number", "null"] },
           "registered_at_block": { "type": ["integer", "null"] },
           "is_immunity_period": { "type": "boolean" },
-          "axon": { "type": ["string", "null"] }
+          "axon": { "type": ["string", "null"] },
+          "take": {
+            "type": ["number", "null"],
+            "description": "Validator take/commission (#2548), 0..1 fraction. Global per-hotkey, identical across every subnet membership row here."
+          }
         }
       },
       "ValidatorDetailArtifact": {
@@ -2206,6 +2219,7 @@
           "coldkey",
           "coldkey_count",
           "subnet_count",
+          "take",
           "total_stake_tao",
           "total_emission_tao",
           "avg_validator_trust",
@@ -2220,6 +2234,10 @@
           "coldkey": { "type": ["string", "null"] },
           "coldkey_count": { "type": "integer", "minimum": 0 },
           "subnet_count": { "type": "integer", "minimum": 0 },
+          "take": {
+            "type": ["number", "null"],
+            "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Null if no SubtensorModule::Delegates entry existed at capture time."
+          },
           "total_stake_tao": { "type": "number", "minimum": 0 },
           "total_emission_tao": { "type": "number", "minimum": 0 },
           "avg_validator_trust": { "type": ["number", "null"] },

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -12,6 +12,12 @@ Units (verified by the parity check vs the prior Taostats data, #1348):
   consensus/incentive/dividends = on-chain 0..1 floats
   rank/validator_trust = SubtensorModule u16 (0..65535) ÷ 65535
   trust = 0.0 (dead in dTAO — 0 across all neurons, Taostats included)
+  take = SubtensorModule::Delegates u16 (0..65535) ÷ 65535 (#2548) — global
+    per-hotkey (a StorageMap keyed only by hotkey, not netuid), fetched once
+    and joined onto every row for that hotkey. Verified live 2026-07-14: a raw
+    value of 11796 decodes to exactly 0.18, Bittensor's documented default/
+    floor take. Hotkeys with no Delegates entry get take=None (never
+    registered as a delegate, not "0% take").
 
 Run: uv run --with bittensor python scripts/fetch-metagraph-native.py
 """
@@ -110,6 +116,19 @@ def main():
         except Exception:
             return []
 
+    def delegate_takes():
+        """SubtensorModule::Delegates: hotkey (SS58) -> take (u16 raw), a flat
+        StorageMap with no netuid key — fetched once for the whole network."""
+        try:
+            takes = {}
+            for key, value in s.substrate.query_map("SubtensorModule", "Delegates"):
+                hotkey = getattr(key, "value", key)
+                takes[hotkey] = u16_ratio(getattr(value, "value", value))
+            return takes
+        except Exception:
+            return {}
+
+    takes = delegate_takes()
     captured_at = int(time.time() * 1000)
     rows = []
     for netuid in sorted(by_netuid):
@@ -134,11 +153,12 @@ def main():
         subnet_rows = []
         for uid in range(n):
             reg = _at(reg_at, uid)
+            hotkey = _at(hotkeys, uid)
             subnet_rows.append(
                 {
                     "netuid": netuid,
                     "uid": uid,
-                    "hotkey": _at(hotkeys, uid),
+                    "hotkey": hotkey,
                     "coldkey": _at(coldkeys, uid),
                     "active": 1 if _at(active, uid) else 0,
                     "validator_permit": 1 if _at(permits, uid) else 0,
@@ -157,6 +177,7 @@ def main():
                     "axon": fmt_axon(_at(axons, uid)),
                     "block_number": block,
                     "captured_at": captured_at,
+                    "take": takes.get(hotkey),
                 }
             )
         # SubtensorModule has no rank-position storage in dTAO; derive the

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -9,7 +9,7 @@
 export const NEURON_COLUMNS =
   "uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, " +
   "consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, " +
-  "is_immunity_period, axon, block_number, captured_at";
+  "is_immunity_period, axon, block_number, captured_at, take";
 
 // The full column set written to the neurons table (matches migration 0007 and
 // the normalizeNeuron row shape). Used by the cron's parameterized bulk load
@@ -34,6 +34,7 @@ export const NEURON_INSERT_COLUMNS = [
   "axon",
   "block_number",
   "captured_at",
+  "take",
 ];
 
 export const GLOBAL_VALIDATOR_SORTS = [
@@ -166,6 +167,9 @@ export function formatNeuron(row, featuredHotkeys) {
         : nonNegativeInt(row.registered_at_block),
     is_immunity_period: toD1Flag(row.is_immunity_period),
     axon: row.axon ?? null,
+    // Global per-hotkey (SubtensorModule::Delegates), not per (netuid, uid) --
+    // null means no Delegates entry at capture time (#2548).
+    take: row.take == null ? null : round(nullableNumber(row.take)),
   };
   if (featuredHotkeys) {
     neuron.featured = Boolean(hotkey && featuredHotkeys.has(hotkey));
@@ -267,6 +271,7 @@ function buildGlobalValidatorEntry(entry) {
     coldkey_count: entry.coldkeys.size,
     subnet_count: entry.netuids.size,
     uid_count: entry.uidCount,
+    take: round(entry.take),
     total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
     avg_validator_trust: round(avgTrust),
@@ -350,9 +355,16 @@ export function buildGlobalValidators(
         maxValidatorTrust: null,
         latestCapturedAt: null,
         latestBlockNumber: null,
+        take: null,
         subnets: [],
       };
       validatorsByHotkey.set(hotkey, entry);
+    }
+    // Global per-hotkey, identical across every row for this hotkey -- take
+    // the first non-null value seen rather than re-deriving/overwriting.
+    if (entry.take == null) {
+      const take = nullableNumber(row?.take);
+      if (take != null) entry.take = take;
     }
     if (typeof row?.coldkey === "string" && row.coldkey.length > 0) {
       entry.coldkeys.set(
@@ -543,6 +555,7 @@ export function buildValidatorDetail(rows, hotkey) {
   let maxValidatorTrust = null;
   let latestCapturedAt = null;
   let latestBlockNumber = null;
+  let take = null;
   const subnets = [];
 
   for (const row of Array.isArray(rows) ? rows : []) {
@@ -557,6 +570,11 @@ export function buildValidatorDetail(rows, hotkey) {
 
     if (typeof row?.coldkey === "string" && row.coldkey.length > 0) {
       coldkeys.set(row.coldkey, (coldkeys.get(row.coldkey) ?? 0) + 1);
+    }
+    // Global per-hotkey, identical across every row here -- first non-null wins.
+    if (take == null) {
+      const rowTake = nullableNumber(row?.take);
+      if (rowTake != null) take = rowTake;
     }
     stakeTotalRao += toRaoBig(numberOrZero(row?.stake_tao));
     emissionTotalRao += toRaoBig(numberOrZero(row?.emission_tao));
@@ -593,6 +611,7 @@ export function buildValidatorDetail(rows, hotkey) {
     coldkey: primaryColdkey(coldkeys),
     coldkey_count: coldkeys.size,
     subnet_count: subnets.length,
+    take: round(take),
     total_stake_tao: roundTao(raoBigToTao(stakeTotalRao)),
     total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
     avg_validator_trust: round(avgTrust),

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -475,6 +475,22 @@ describe("metagraph-neurons builders", () => {
     );
   });
 
+  test("buildGlobalValidators takes the first non-null take per hotkey and ignores later rows (#2548)", () => {
+    const data = buildGlobalValidators([
+      { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", take: 0.18 },
+      // A later row for the same hotkey with a different (or missing) take
+      // must not override the first value seen -- take is a single
+      // per-hotkey chain fact, not something to re-derive per subnet row.
+      { ...ROW, netuid: 2, uid: 0, hotkey: "hk-a", take: 0.25 },
+      { ...ROW, netuid: 3, uid: 0, hotkey: "hk-b" },
+    ]);
+    const byHotkey = Object.fromEntries(
+      data.validators.map((v) => [v.hotkey, v.take]),
+    );
+    assert.equal(byHotkey["hk-a"], 0.18);
+    assert.equal(byHotkey["hk-b"], null);
+  });
+
   test("buildGlobalValidators sets `featured` per hotkey entry, defaulting false", () => {
     const data = buildGlobalValidators(
       [
@@ -787,6 +803,19 @@ describe("metagraph-neurons builders", () => {
     assert.equal(empty.captured_at, null);
     assert.equal(empty.block_number, null);
     assert.deepEqual(empty.subnets, []);
+    assert.equal(empty.take, null);
+  });
+
+  test("buildValidatorDetail takes the first non-null take across subnet rows (#2548)", () => {
+    const data = buildValidatorDetail(
+      [
+        { ...ROW, netuid: 1, uid: 0, take: 0.18 },
+        // Same hotkey, later row -- must not override the first value seen.
+        { ...ROW, netuid: 2, uid: 0, take: 0.3 },
+      ],
+      "hk-a",
+    );
+    assert.equal(data.take, 0.18);
   });
 
   test("buildGlobalValidators reports a null block_number as null, not a fabricated 0", () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -908,6 +908,7 @@ describe("handleGlobalValidators", () => {
       coldkey_count: 0,
       subnet_count: 1,
       uid_count: 1,
+      take: null,
       total_stake_tao: 0,
       total_emission_tao: 0,
       stake_dominance: null,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -663,7 +663,8 @@ async function handleNeuronsSync(request, env) {
             is_immunity_period = EXCLUDED.is_immunity_period,
             axon = EXCLUDED.axon,
             block_number = EXCLUDED.block_number,
-            captured_at = EXCLUDED.captured_at
+            captured_at = EXCLUDED.captured_at,
+            take = EXCLUDED.take
           WHERE neurons.captured_at <= EXCLUDED.captured_at`;
       }
 
@@ -693,7 +694,8 @@ async function handleNeuronsSync(request, env) {
             axon = EXCLUDED.axon,
             block_number = EXCLUDED.block_number,
             captured_at = EXCLUDED.captured_at,
-            updated_at = EXCLUDED.updated_at
+            updated_at = EXCLUDED.updated_at,
+            take = EXCLUDED.take
           WHERE neuron_daily.captured_at <= EXCLUDED.captured_at`;
       }
 
@@ -949,7 +951,8 @@ async function handleNeuronDailyBackfill(request, env) {
             axon = EXCLUDED.axon,
             block_number = EXCLUDED.block_number,
             captured_at = EXCLUDED.captured_at,
-            updated_at = EXCLUDED.updated_at
+            updated_at = EXCLUDED.updated_at,
+            take = EXCLUDED.take
           WHERE neuron_daily.captured_at <= EXCLUDED.captured_at`;
       }
 


### PR DESCRIPTION
## Summary
Closes #2548.

Validator take/commission was previously unavailable in the directory: the neurons tier had no `take` field and the metagraph refresh cron never fetched it. Sourced directly from the chain (`SubtensorModule::Delegates`, a hotkey→take `u16` StorageMap, same ratio convention as `rank`/`validator_trust`) — no Taostats, no API key, consistent with #1348's first-party fetch pipeline. Verified live against our own fullnode 2026-07-14: a raw value of `11796` decodes to exactly `0.18`, Bittensor's documented default/floor take.

- `migrations/0042_neurons_take.sql`: `take REAL` on both `neurons` and `neuron_daily` (they share `NEURON_INSERT_COLUMNS` on the write path, so both need the column or the shared insert breaks). **Applied live** against the indexer box's Postgres.
- `scripts/fetch-metagraph-native.py`: fetches `Delegates` once per run (a flat map, not per-netuid) and joins `take` onto every row by hotkey.
- `src/metagraph-neurons.mjs`: `take` added to `NEURON_COLUMNS`/`NEURON_INSERT_COLUMNS`, `formatNeuron`, and the `buildGlobalValidators`/`buildValidatorDetail` accumulators — `take` is global per-hotkey (not per-subnet), so the first non-null value seen for a hotkey wins rather than being re-derived or overwritten by a later row.
- `workers/data-api.mjs`: `take = EXCLUDED.take` added to both the `neurons` and `neuron_daily` UPSERT clauses in `handleNeuronsSync` and `handleNeuronDailyBackfill`.
- `schemas/components/05-subnets.schema.json`: `take` added to `Neuron`, `GlobalValidatorEntry`, and `ValidatorDetailSubnet`/`Artifact` — nullable but required (never omitted, explicit `null` when no `Delegates` entry exists). `npm run build` regenerated `openapi.json`/`types.d.ts`/`packages/contract` accordingly. Not bumping `packages/client/package.json` — the `sync-client-version` post-merge automation owns that.
- Backfill scripts intentionally untouched: `take` reflects **current** chain state only (no historical Delegates-at-a-past-block query exists), so backfilled rows correctly get `take=null` via the existing nullish-coalescing coerce path rather than a fabricated value.

**Frontend intentionally left for a follow-up PR** — `apps/ui/validators.index.tsx` visual changes need a before/after screenshot table and are always held for manual review per house rule, a different review lane than this backend change.

## Test plan
- `npm run build` — clean, `openapi.json`/`types.d.ts` regenerated
- `npm run lint` / `npx prettier --check` — clean
- `npm run test:coverage` — 267/267 files, 7764/7764 tests, including 2 new tests closing the patch-coverage gap on the new per-hotkey take-accumulation branches (`buildGlobalValidators`/`buildValidatorDetail`)
- Migration applied and verified live: both `neurons.take` and `neuron_daily.take` confirmed present via `information_schema.columns`