### PR TITLE
feat(ui): add a "how to evaluate a validator" guide on /validators (#5168)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { ChevronDown, Info } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+/**
+ * Neutral explainer near the top of /validators so a first-time visitor can
+ * understand what the directory's columns mean before choosing a validator to
+ * delegate to (#5168).
+ *
+ * Strictly factual — it explains the on-chain signals, it does not rank or
+ * recommend any specific validator. Desktop is a collapsible callout (mirrors
+ * MethodologyCallout); mobile is an FAQ-style accordion where each metric
+ * expands on tap.
+ */
+const METRICS: Array<{ term: string; def: string }> = [
+  {
+    term: "Active subnets",
+    def: "How many subnets this hotkey is registered and validating on. A validator may operate broadly across many subnets or concentrate on a few.",
+  },
+  {
+    term: "UIDs",
+    def: "The total neuron slots the hotkey holds across those subnets — one registration is one UID.",
+  },
+  {
+    term: "Dominance",
+    def: "The validator's share of total network stake, as a percentage. Higher dominance means more influence over consensus and emission — and more of that influence concentrated in one operator.",
+  },
+  {
+    term: "Total stake",
+    def: "The TAO backing the validator: its own stake plus TAO delegated to it by nominators. Stake sets how much weight the validator's votes carry.",
+  },
+  {
+    term: "Total emission",
+    def: "The TAO the validator earned over the window. Emission is split between the validator and its nominators via commission — it reflects reward flow, not profit.",
+  },
+  {
+    term: "Validator trust (Sort)",
+    def: "Available from the Sort control: how consistently a subnet's consensus scores the validator as trustworthy. Steadier trust points to reliable participation.",
+  },
+];
+
+const GUIDANCE =
+  "Read these signals together, not in isolation — a large validator concentrates stake and influence, while a smaller one spreads it. Commission and nominator counts (coming in #2548/#2549) will add to this picture. This directory describes the on-chain data; it does not rank or recommend any validator.";
+
+const HEADING = "How to evaluate a validator";
+const SUBHEADING = "What each column means and how to read them together";
+
+export function ValidatorGuide() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <aside aria-label={HEADING} className="mb-6 rounded-lg border border-border bg-card/60">
+      {/* Desktop / tablet: collapsible callout with the full grid. */}
+      <div className="hidden sm:block">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+          <span className="min-w-0 flex-1">
+            <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              {HEADING}
+            </span>
+            <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
+              {SUBHEADING}
+            </span>
+          </span>
+          <ChevronDown
+            className={classNames(
+              "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        </button>
+        {open ? (
+          <div className="border-t border-border px-3 py-3">
+            <dl className="grid gap-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2">
+              {METRICS.map((m) => (
+                <div key={m.term}>
+                  <dt className="font-medium text-ink-strong">{m.term}</dt>
+                  <dd className="mt-0.5">{m.def}</dd>
+                </div>
+              ))}
+            </dl>
+            <p className="mt-3 border-t border-border pt-3 text-[11.5px] leading-relaxed text-ink-muted">
+              {GUIDANCE}
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Mobile: FAQ-style accordion — tap a metric to reveal its definition. */}
+      <div className="sm:hidden">
+        <div className="flex items-start gap-2 px-3 py-2">
+          <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+          <span className="min-w-0 flex-1">
+            <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              {HEADING}
+            </span>
+            <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
+              {SUBHEADING}
+            </span>
+          </span>
+        </div>
+        <div className="divide-y divide-border border-t border-border">
+          {METRICS.map((m) => (
+            <details key={m.term} className="group px-3">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2.5 text-[12px] font-medium text-ink-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+                <span>{m.term}</span>
+                <ChevronDown className="size-3.5 shrink-0 text-ink-muted transition-transform group-open:rotate-180" />
+              </summary>
+              <p className="pb-2.5 text-[11.5px] leading-relaxed text-ink-muted">{m.def}</p>
+            </details>
+          ))}
+        </div>
+        <p className="border-t border-border px-3 py-3 text-[11.5px] leading-relaxed text-ink-muted">
+          {GUIDANCE}
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -13,6 +13,7 @@ import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -76,6 +77,7 @@ function ValidatorsPage() {
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={<ShareButton />}
       />
+      <ValidatorGuide />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable


### PR DESCRIPTION
## Summary
`/validators` was a raw sortable directory with no in-product guidance — a first-time visitor had no explanation of what the columns mean or how to weigh them. This adds a neutral **"How to evaluate a validator"** guide near the top of the page.

## Change
New `ValidatorGuide` component (`apps/ui/src/components/metagraphed/validator-guide.tsx`), placed right after the page hero on `/validators`. It defines each visible signal — Active subnets, UIDs, Dominance, Total stake, Total emission — plus validator trust (via the Sort control), and closes with a neutral note on reading them together.

The layout is **responsive**:
- **Desktop / tablet** — a collapsible callout (mirrors `MethodologyCallout`) that opens to a two-column definition grid.
- **Mobile** — an **FAQ-style accordion**: each metric is a tappable `<details>` row that expands its definition on tap (multiple can be open), keeping the guide compact on small screens.

Strictly **factual and neutral** — it explains the on-chain data and explicitly **does not rank or recommend any validator**. Presentational only: no new query, endpoint, or state beyond the local open/closed toggle.

## Verification
- `npm run typecheck --workspace=apps/ui` — pass
- `npm run test --workspace=apps/ui` — pass (685 tests)
- `eslint` on the changed files (LF-normalized, CI-equivalent) — 0 errors
- CI green on this branch (ui / checks / test / changes).

## Screenshots
3 viewports x 2 themes x before/after = 12 images. Before = `/validators` with no guide; After = the guide in place (desktop/tablet grid open; mobile FAQ accordion with items expanded). _The dev environment has no indexed validators, so the directory shows its empty state below the guide — the guide is presentational and renders regardless._

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5168/v4/after-mobile-dark.png)<br><sub>after</sub> |

---

_Fresh PR replacing #5197, which was auto-closed for base-branch conflicts (CI was green). Rebased clean onto current `main`. This revision incorporates the review request on #5197 — the mobile layout is now an FAQ-style tap-to-expand accordion; desktop is unchanged._

Closes #5168
