### PR TITLE
feat(ui): one-step "watch this validator" alert control (#5167)

### DIFF
--- a/apps/ui/src/components/metagraphed/watch-validator.tsx
+++ b/apps/ui/src/components/metagraphed/watch-validator.tsx
@@ -1,0 +1,131 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Check } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/metagraphed/client";
+import { CopyableCode } from "@jsonbored/ui-kit";
+
+// Must match src/alert-triggers.mjs (ALERT_TRIGGER_CREATE_TOKEN_HEADER).
+const CREATE_TOKEN_HEADER = "x-alert-trigger-create-token";
+// Discord incoming-webhook URLs — everything else is treated as a plain webhook.
+const DISCORD_WEBHOOK = /^https:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/api\/webhooks\//i;
+
+const inputCls =
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+
+interface AlertTriggerCreated {
+  id: string;
+  channel: string;
+  account: string | null;
+  owner_token: string;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Unauthorized — check your create token.";
+    if (error.status === 503) return error.message || "Alerts are disabled on this deployment.";
+    if (error.status === 400) return error.message || "That alert configuration was rejected.";
+    return error.message || "Request failed.";
+  }
+  return "Request failed.";
+}
+
+/**
+ * One-step "watch this validator": creates an alert trigger scoped to this
+ * hotkey's stake/delegation events via the existing /api/v1/alerts/triggers
+ * API (#5167). The channel is inferred from the URL (Discord webhook vs plain
+ * webhook); the create token is the API's own anti-abuse secret. Server-side
+ * validateAlertTriggerInput is the source of truth — its error is surfaced
+ * directly rather than re-implemented here.
+ */
+export function WatchValidator({ hotkey }: { hotkey: string }) {
+  const [destination, setDestination] = useState("");
+  const [token, setToken] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async (): Promise<AlertTriggerCreated> => {
+      const channel = DISCORD_WEBHOOK.test(destination.trim()) ? "discord" : "webhook";
+      const res = await apiFetch<AlertTriggerCreated>("/api/v1/alerts/triggers", {
+        init: {
+          method: "POST",
+          headers: { "content-type": "application/json", [CREATE_TOKEN_HEADER]: token.trim() },
+          body: JSON.stringify({ account: hotkey, channel, destination: destination.trim() }),
+        },
+      });
+      return res.data;
+    },
+  });
+
+  const created = mutation.data;
+  const canSubmit = destination.trim() !== "" && token.trim() !== "" && !mutation.isPending;
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (canSubmit) mutation.mutate();
+  }
+
+  if (created) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <div className="flex items-center gap-2 font-medium text-ink-strong">
+          <Check className="size-4 shrink-0 text-accent" />
+          You&rsquo;re watching this validator
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-ink-muted">
+          {`Stake & delegation events for this hotkey will be delivered to your ${created.channel}. Save the owner token below — it’s shown once and is needed to edit or remove this alert.`}
+        </p>
+        <div className="mt-2">
+          <CopyableCode
+            label="owner token"
+            value={created.owner_token}
+            truncate={false}
+            className="max-w-full"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => mutation.reset()}
+          className="mt-3 inline-flex items-center rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+        >
+          Set up another
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="rounded-lg border border-border p-4">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="url"
+          inputMode="url"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          placeholder="Webhook or Discord webhook URL"
+          aria-label="Delivery URL"
+          className={inputCls}
+        />
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="Create token"
+          aria-label="Alert create token"
+          className={`${inputCls} sm:w-44`}
+        />
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex shrink-0 items-center justify-center rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[13px] font-medium text-accent-text transition-colors hover:bg-accent/15 disabled:opacity-50"
+        >
+          {mutation.isPending ? "Watching…" : "Watch"}
+        </button>
+      </div>
+      {mutation.isError ? (
+        <p className="mt-2 text-xs text-health-down">{describeError(mutation.error)}</p>
+      ) : null}
+      <p className="mt-2 text-[11px] text-ink-muted">
+        {`The create token is an anti-abuse secret — ask a maintainer for one.`}
+      </p>
+    </form>
+  );
+}

--- a/apps/ui/src/components/metagraphed/watch-validator.tsx
+++ b/apps/ui/src/components/metagraphed/watch-validator.tsx
@@ -115,7 +115,7 @@ export function WatchValidator({ hotkey }: { hotkey: string }) {
         <button
           type="submit"
           disabled={!canSubmit}
-          className="inline-flex shrink-0 items-center justify-center rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[13px] font-medium text-accent-text transition-colors hover:bg-accent/15 disabled:opacity-50"
+          className="inline-flex shrink-0 items-center justify-center rounded border border-border bg-card px-4 py-1.5 text-[13px] font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent disabled:opacity-50"
         >
           {mutation.isPending ? "Watching…" : "Watch"}
         </button>

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -11,6 +11,7 @@ import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@jsonbored/ui-kit";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
+import { WatchValidator } from "@/components/metagraphed/watch-validator";
 import {
   ValidatorNominatorsTable,
   type ValidatorNominatorsSearch,
@@ -258,6 +259,16 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           hint="mean across subnets"
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
+      </div>
+
+      <div className="mb-10">
+        <SectionAnchor
+          id="watch"
+          title="Watch this validator"
+          subtitle="One-step webhook or Discord alert on this validator's stake & delegation events."
+        >
+          <WatchValidator hotkey={hotkey} />
+        </SectionAnchor>
       </div>
 
       <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">


### PR DESCRIPTION
## Summary
The validator detail page (`/validators/$hotkey`) let you read a validator but gave you no way to **act** on it. This adds a one-step **"Watch this validator"** control that creates a stake/delegation alert scoped to the validator's hotkey.

## Change
New `WatchValidator` component (`apps/ui/src/components/metagraphed/watch-validator.tsx`), placed as a section right after the summary stat tiles on `/validators/$hotkey`. A single form takes a delivery URL + the alert create-token and POSTs to the **existing** `/api/v1/alerts/triggers` endpoint with `account = hotkey`; the channel is inferred from the URL (Discord incoming-webhook vs plain webhook). On success it surfaces the one-time `owner_token` via `CopyableCode`. Server-side `validateAlertTriggerInput` remains the source of truth — its error is shown directly.

Presentational + one existing API call — **no new endpoint, schema, or query**. The form and success cards use the neutral card style (`border-border`) so they match the surrounding sections rather than carrying an accent tint.

## Verification
- `npm run typecheck --workspace=apps/ui` — pass
- `npm run test --workspace=apps/ui` — pass (685 tests)
- `eslint` on the changed files (LF-normalized, CI-equivalent) — 0 errors
- Rendered live on `/validators/$hotkey` at desktop / tablet / mobile, both themes.

## Screenshots
3 viewports x 2 themes x before/after = 12 images. Before = the detail page with no watch control (stat tiles flow straight into per-subnet performance); After = the neutral "Watch this validator" form in place. _The dev environment has no indexed data for this hotkey, so the sections below show their empty states — the form is presentational and renders regardless._

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5167/v4/after-mobile-dark.png)<br><sub>after</sub> |

---

_Fresh PR replacing #5208, which was auto-closed on a `prettier/prettier` CI failure (the success-card copy and `CopyableCode` reflowed past printWidth 100). Fixed by moving the prose into template literals and breaking the component's attributes multi-line, re-verified with LF-normalized eslint. Rebased clean onto current `main`._

_Update: the Watch button now uses the app's neutral card button style (accent on hover only) instead of a filled mint button — screenshots refreshed._

Closes #5167
