### PR TITLE
feat(ui): surface the existing alert-triggers API as a "watch this validator" feature

### DIFF
--- a/apps/ui/src/components/metagraphed/watch-validator-alert.tsx
+++ b/apps/ui/src/components/metagraphed/watch-validator-alert.tsx
@@ -1,0 +1,228 @@
+import { useState, type FormEvent, type ReactNode } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { apiFetch, ApiError } from "@/lib/metagraphed/client";
+import { CopyableCode } from "@jsonbored/ui-kit";
+import { Skeleton } from "@/components/metagraphed/states";
+import type { AlertTriggerCreated } from "@/lib/metagraphed/types";
+
+// Must match src/alert-triggers.mjs — ALERT_TRIGGER_CREATE_TOKEN_HEADER.
+const CREATE_TOKEN_HEADER = "x-alert-trigger-create-token";
+
+// #4984's event_kind is a single value per trigger (not a filter list), so
+// this is a single-select rather than the webhook manager's checkbox-set
+// "kinds" pattern. Leaving it unset still matches every event for this
+// hotkey (validateAlertTriggerInput requires only one of
+// netuid/event_kind/account/min_amount_tao — `account` below always
+// satisfies that on its own).
+const EVENT_KINDS = [
+  { value: "", label: "Any delegation or stake event" },
+  { value: "DelegateAdded", label: "New delegation" },
+  { value: "StakeAdded", label: "Stake added" },
+] as const;
+
+const CHANNELS = ["webhook", "discord"] as const;
+
+const inputCls =
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+
+/** Distinguishes the create-token gate, validation, and rate-limit rejections. */
+function describeApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Unauthorized — check your creation token.";
+    if (error.status === 429) return "Too many requests — slow down and try again shortly.";
+    if (error.status === 503) return "Alert triggers aren't enabled on this deployment yet.";
+    if (error.status === 400) {
+      return "Invalid alert configuration — check the destination format for the selected channel.";
+    }
+    return error.message || "Request failed.";
+  }
+  return "Request failed.";
+}
+
+interface CreateVariables {
+  token: string;
+  eventKind: string;
+  channel: (typeof CHANNELS)[number];
+  destination: string;
+}
+
+/** "Watch this validator": a scoped alert trigger (account=hotkey) over the existing #4984 alerts API. */
+export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
+  const [token, setToken] = useState("");
+  const [eventKind, setEventKind] = useState("");
+  const [channel, setChannel] = useState<(typeof CHANNELS)[number]>("webhook");
+  const [destination, setDestination] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async (vars: CreateVariables): Promise<AlertTriggerCreated> => {
+      const res = await apiFetch<AlertTriggerCreated>("/api/v1/alerts/triggers", {
+        init: {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            [CREATE_TOKEN_HEADER]: vars.token,
+          },
+          body: JSON.stringify({
+            account: hotkey,
+            ...(vars.eventKind ? { event_kind: vars.eventKind } : {}),
+            channel: vars.channel,
+            destination: vars.destination,
+          }),
+        },
+      });
+      return res.data;
+    },
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    mutation.mutate({
+      token: token.trim(),
+      eventKind,
+      channel,
+      destination: destination.trim(),
+    });
+  }
+
+  const result = mutation.data;
+
+  return (
+    <div className="space-y-3">
+      <p className="max-w-2xl text-[13px] text-ink-muted">
+        Get a webhook or Discord notification when this validator receives new delegations or stake.
+        Creation requires a trigger token issued by a metagraphed operator — this app never bundles
+        one.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-3 rounded border border-border bg-card p-4">
+        <Field
+          label="Event"
+          hint="Leave as 'any' to watch every delegation/stake event for this hotkey."
+        >
+          <select
+            value={eventKind}
+            onChange={(e) => setEventKind(e.target.value)}
+            className={inputCls}
+          >
+            {EVENT_KINDS.map((k) => (
+              <option key={k.value} value={k.value}>
+                {k.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Delivery channel">
+          <div className="flex gap-4">
+            {CHANNELS.map((c) => (
+              <label key={c} className="inline-flex items-center gap-1.5 text-[12px] text-ink">
+                <input
+                  type="radio"
+                  name="channel"
+                  checked={channel === c}
+                  onChange={() => setChannel(c)}
+                />
+                <span className="capitalize">{c}</span>
+              </label>
+            ))}
+          </div>
+        </Field>
+        <Field
+          label={channel === "discord" ? "Discord webhook URL" : "Webhook URL"}
+          required
+          hint={
+            channel === "discord"
+              ? "A Discord incoming-webhook URL (Server Settings → Integrations → Webhooks)."
+              : "A public HTTPS endpoint that will receive the alert POST."
+          }
+        >
+          <input
+            type="url"
+            required
+            placeholder={
+              channel === "discord"
+                ? "https://discord.com/api/webhooks/…"
+                : "https://hooks.example.com/alert"
+            }
+            value={destination}
+            onChange={(e) => setDestination(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <Field
+          label="Creation token"
+          required
+          hint="Provided out-of-band by a metagraphed operator."
+        >
+          <input
+            type="password"
+            required
+            autoComplete="off"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <button
+          type="submit"
+          disabled={mutation.isPending}
+          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+        >
+          {mutation.isPending ? "Creating…" : "Watch this validator"}
+        </button>
+      </form>
+
+      {mutation.isPending ? <Skeleton className="h-20 w-full" /> : null}
+
+      {mutation.isError ? <ErrorPanel message={describeApiError(mutation.error)} /> : null}
+
+      {result ? (
+        <div className="space-y-2 rounded border border-accent/40 bg-primary-soft/40 p-4">
+          <p className="text-[12px] font-medium text-health-warn">
+            The owner token below is shown once and is never echoed back by GET — store it now to
+            manage or delete this alert later via the API.
+          </p>
+          <CopyableCode label="id" value={result.id} truncate={false} className="w-full" />
+          <CopyableCode
+            label="owner token"
+            value={result.owner_token}
+            truncate={false}
+            className="w-full"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+    >
+      {message}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  required,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        {label}
+        {required ? <span className="text-health-down"> *</span> : null}
+      </span>
+      {children}
+      {hint ? <span className="mt-1 block text-[11px] text-ink-muted">{hint}</span> : null}
+    </label>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -3242,3 +3242,26 @@ export interface WebhookSubscriptionView {
   active: boolean;
   delivery: WebhookDeliveryStatus;
 }
+
+/**
+ * POST /api/v1/alerts/triggers response (#4984 Part 1). `owner_token` is
+ * returned exactly once here — GET/PATCH never echo it back, matching the
+ * webhook subscription secret's own once-only convention.
+ */
+export interface AlertTriggerCreated {
+  id: string;
+  name: string | null;
+  table_filter: string[] | null;
+  netuid: number | null;
+  event_kind: string | null;
+  account: string | null;
+  min_amount_tao: number | null;
+  channel: "webhook" | "email" | "telegram" | "discord";
+  destination: string;
+  active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+  last_matched_at: string | null;
+  match_count: number;
+  owner_token: string;
+}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -11,6 +11,7 @@ import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@jsonbored/ui-kit";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
+import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import {
   ValidatorNominatorsTable,
   type ValidatorNominatorsSearch,
@@ -284,6 +285,15 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             <NominatorsSection hotkey={hotkey} />
           </Suspense>
         </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="watch"
+        title="Watch this validator"
+        subtitle="Alert on new delegations or stake, via the existing chain alert-triggers API."
+        tone="accent"
+      >
+        <WatchValidatorAlert hotkey={hotkey} />
       </SectionAnchor>
 
       <SectionAnchor


### PR DESCRIPTION
## Summary

A generic alert-trigger backend already exists and is fully built (`src/alert-triggers.mjs`, `src/alert-delivery.mjs`, `/api/v1/alerts/triggers`) with webhook/email/Telegram/Discord delivery and `netuid`/`event_kind`/`account`/`min_amount_tao` match conditions — but it was API-only, with no UI anywhere in `apps/ui` surfacing it.

This adds a **"Watch this validator"** section to `/validators/$hotkey` that creates an alert trigger scoped to that hotkey (`account=<hotkey>`), letting a visitor pick:

- **Event**: any delegation/stake event, a new delegation (`DelegateAdded`), or new stake (`StakeAdded`)
- **Delivery channel**: webhook or Discord (the two first targets suggested in the issue)
- **Destination**: the webhook URL or Discord incoming-webhook URL

On submit it `POST`s to the existing `/api/v1/alerts/triggers`, with no new client-side validation rules — malformed input is rejected server-side by the existing `validateAlertTriggerInput`, and the UI just maps status codes to readable messages (mirroring `webhook-subscription-manager.tsx`'s own `describeApiError`).

### Creation token

Trigger creation is gated by a shared anti-abuse token (`ALERT_TRIGGER_CREATE_TOKEN`), the same pattern `webhook-subscription-manager.tsx` already established for webhook subscriptions: a plain input field for a token "issued out-of-band by a metagraphed operator — this app never bundles one." No new auth model invented.

### Files

- `apps/ui/src/components/metagraphed/watch-validator-alert.tsx` (new) — the form
- `apps/ui/src/lib/metagraphed/types.ts` — `AlertTriggerCreated` (the `POST` response shape; didn't exist yet)
- `apps/ui/src/routes/validators.$hotkey.tsx` — wires the new section in between "Nominators" and "Call this endpoint"

## Verification

- [x] `npm run lint --workspace=apps/ui` / `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run test --workspace=apps/ui -- --run` (685 tests passed)
- [x] `npm run build --workspace=apps/ui`
- [x] Manually exercised the full flow against the **real** `api.metagraph.sh` backend (mocked only the validator-detail/nominators reads so the page renders regardless of live data state) — the form correctly submits to `/api/v1/alerts/triggers` and surfaces the real (503, "not enabled on this deployment") response; also verified the Webhook ⇄ Discord toggle correctly swaps the field label/placeholder/hint.

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/watch-validator-5167-mobile-dark-after.png)<br><sub>after</sub> |

Closes #5167
