### PR TITLE
fix(data-api): isolate featured_validators read in a savepoint

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -218,13 +218,37 @@ vi.mock("postgres", () => ({
       return Promise.resolve(mockRows.current);
     };
     // sql.begin(["read only",] cb) reserves a connection for cb in real
-    // postgres.js; the mock just invokes cb with this same sql function so
-    // every existing tagged-template assertion (sqlCalls, mockQueue) still
-    // sees the identical call stream, and resolves to whatever cb returns.
+    // postgres.js; the mock invokes cb with a wrapped sql so every existing
+    // tagged-template assertion (sqlCalls, mockQueue) still sees the
+    // identical call stream, and resolves to whatever cb returns.
+    //
+    // #5220: this wrapper also mirrors a real postgres.js behavior that an
+    // earlier, naive `cb(sql)` pass-through did NOT reproduce and that let a
+    // production bug ship past this suite -- every query issued directly
+    // against a `begin()` transaction's `sql` poisons the whole transaction
+    // if it rejects, even when the *caller* catches that rejection locally
+    // (postgres.js tracks it via each query's own internal `.catch()`; see
+    // node_modules/postgres/src/index.js's `scope()`/`uncaughtError`).
+    // `sql.savepoint(fn)` is the only way to isolate a query's failure from
+    // the enclosing transaction, so it runs `fn` against the unwrapped sql
+    // (no poisoning) instead.
     sql.begin = (optionsOrCb, maybeCb) => {
       const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
       sqlBeginOptions.push(typeof optionsOrCb === "string" ? optionsOrCb : "");
-      return cb(sql);
+      let uncaughtError;
+      function scopedSql(...args) {
+        const result = sql(...args);
+        Promise.resolve(result).catch((e) => {
+          if (!uncaughtError) uncaughtError = e;
+        });
+        return result;
+      }
+      Object.assign(scopedSql, sql);
+      scopedSql.savepoint = (fn) => fn(sql);
+      return Promise.resolve(cb(scopedSql)).then((result) => {
+        if (uncaughtError) throw uncaughtError;
+        return result;
+      });
     };
     return sql;
   },
@@ -1339,6 +1363,43 @@ test("GET /api/v1/subnets/:netuid/validators still serves the primary rows when 
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.validator_count).toBe(1);
+  expect(body.validators[0].featured).toBe(false);
+});
+
+test("GET /api/v1/validators still serves the primary rows when the featured_validators read fails (#5220)", async () => {
+  // Regression test for #5220: this network-wide route (unlike the single
+  // /validators/:hotkey detail route, which never reads featured_validators)
+  // returned validator_count: 0 in production because a bare sql`...` inside
+  // loadFeaturedHotkeys poisoned the whole shared sql.begin() transaction --
+  // even though this function's own try/catch handled the rejection -- so
+  // the outer sql.begin() itself rejected after the route handler had
+  // already built its response. See loadFeaturedHotkeys's header comment and
+  // the sql.begin mock above for how postgres.js's real transaction-scoped
+  // error tracking works.
+  featuredValidatorsQueryFailure.error = new Error(
+    'relation "featured_validators" does not exist',
+  );
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        netuid: 7,
+        uid: 3,
+        hotkey: "5Hot",
+        coldkey: "5Cold",
+        validator_trust: "0.8",
+        emission_tao: "1.23",
+        stake_tao: "456.7",
+        block_number: "5000000",
+        captured_at: "1780000000000",
+      },
+    ],
+  ];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validator_count).toBe(1);
+  expect(body.validators[0].hotkey).toBe("5Hot");
   expect(body.validators[0].featured).toBe(false);
 });
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2292,9 +2292,28 @@ function json(data, status = 200) {
 // missing table (e.g. before the migration has landed) or any other read
 // failure here just yields "nothing is featured" instead of a 502 for the
 // whole /validators route.
+//
+// #5220: every caller runs inside the route dispatcher's shared
+// `sql.begin(...)` transaction (see the top of the fetch handler). A local
+// try/catch around a bare `sql\`...\`` call is NOT enough to contain a
+// failure there -- postgres.js's `begin()` independently tracks every query
+// issued against the transaction's `sql` via its own internal `.catch()`
+// (see node_modules/postgres/src/index.js's `scope()`/`uncaughtError`), so
+// even a query whose rejection THIS function already handles still poisons
+// the whole transaction and makes `sql.begin(...)` itself reject once the
+// route handler returns -- which is exactly what made the entire
+// /api/v1/validators (and /api/v1/subnets/:netuid/validators) response
+// degrade to the empty D1-era fallback in production despite this catch:
+// the primary `neurons` query's own results were discarded by the outer
+// `sql.begin()` rejecting *after* the route handler had already built its
+// response. `sql.savepoint()` runs the read in its own nested scope so a
+// failure there rolls back to a savepoint instead of the whole transaction,
+// leaving the enclosing transaction (and its other queries) unaffected.
 async function loadFeaturedHotkeys(sql) {
   try {
-    const rows = await sql`SELECT hotkey FROM featured_validators`;
+    const rows = await sql.savepoint(
+      (sql) => sql`SELECT hotkey FROM featured_validators`,
+    );
     return new Set(rows.map((row) => row.hotkey));
   } catch (err) {
     console.error("featured_validators query failed:", err);


### PR DESCRIPTION
## What

GET /api/v1/validators (network-wide validator leaderboard) and GET
/api/v1/subnets/:netuid/validators returned `validator_count: 0` in
production despite real `neurons` data in Postgres.

## Root cause (confirmed via `wrangler tail metagraphed-data-api`)

Live logs during a real failed request showed two errors for the same
request:

```
(error) featured_validators query failed: PostgresError: relation "featured_validators" does not exist
(error) data-api query failed: PostgresError: relation "featured_validators" does not exist
```

`loadFeaturedHotkeys` already wraps its `SELECT hotkey FROM featured_validators`
in a try/catch specifically so a missing table degrades to "nothing is
featured" instead of breaking the route. That works for the *individual*
query's promise. But every route in this Worker runs inside one shared
`sql.begin(...)` transaction, and postgres.js tracks query failures at the
transaction-scope level independently of what the calling code does with the
rejection (see `node_modules/postgres/src/index.js`'s `scope()`/`uncaughtError`
— every query gets its own internal `.catch()` that marks the transaction as
failed, regardless of whether the caller also catches it). So even though
`loadFeaturedHotkeys` handled its own rejection and returned an empty `Set`,
the surrounding `sql.begin()` transaction was still poisoned, and it rejected
*after* the route handler had already built the correct response — the
primary `neurons` query's real rows were discarded, the outer catch-all
returned a 502, and the main Worker's `tryPostgresTier` treated that as a
failure and fell back to the empty D1-era shape.

Confirmed this is a shared bug class, not specific to one route: the sibling
`/api/v1/subnets/:netuid/validators` (same `Promise.all` + `loadFeaturedHotkeys`
pattern) reproduces identically, while routes that never touch
`featured_validators` (`/api/v1/validators/:hotkey`, `/api/v1/subnets/:netuid/metagraph`)
are unaffected — matching the issue's own diagnosis exactly.

## Fix

Route the `featured_validators` read through `sql.savepoint()` instead of a
bare `sql\`...\`` call. A failure inside a savepoint rolls back to the
savepoint only, leaving the enclosing transaction (and the primary query's
already-computed results) untouched — this is exactly the isolation the
existing comment already promised but the bare try/catch didn't deliver.

## Tests

The existing `sql.begin` mock in `tests/data-api.test.mjs` was a naive
`(optionsOrCb, maybeCb) => cb(sql)` pass-through that didn't reproduce
postgres.js's real transaction-poisoning behavior, which is how this shipped
past the suite in the first place. Updated the mock to track query failures
at the transaction-scope level (mirroring the real `uncaughtError` behavior)
and to give `sql.savepoint()` proper isolation, then verified:

- Reverting only the `workers/data-api.mjs` fix now makes both
  "still serves the primary rows when the featured_validators read fails"
  tests fail with the exact production symptom (502 instead of 200) —
  confirming the mock actually catches this regression class now.
- Added a new regression test for the network-wide `/api/v1/validators`
  route specifically (the literal route from the issue), mirroring the
  existing subnet-scoped test.

`npm run lint`, `npx prettier --check`, and `npm run test:coverage` are all
green (7706 tests passed; `workers/data-api.mjs` at 99.86%/99.92% branch).

Closes #5220