### PR TITLE
registry(sn62): add TaoMarketCap OHLCV candle-chart data artifact for Ridges

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-taomarketcap-candle-chart",
+      "kind": "data-artifact",
+      "name": "SN62 TaoMarketCap OHLCV candle-chart dataset",
+      "notes": "Public no-auth GET /public/v1/subnets/62/candle-chart on api.taomarketcap.com returning a machine-readable JSON time-series of hourly OHLCV candles for SN62 Ridges's alpha token: each record carries subnet_id, period_name, timestamp, block_number, open/high/low/close, volume, start_volume, and tao_price_usd/eur, every record scoped to subnet_id 62 (714 hourly records at time of submission). A standalone historical price/volume dataset for netuid 62 — distinct from the live agent-leaderboard subnet-api already registered — providing the machine-readable data artifact this subnet otherwise lacks. Documented in the TaoMarketCap developer API documentation; taomarketcap.com/subnets/62 is already this overlay's dashboard_url, confirming the provider indexes netuid 62.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://api.taomarketcap.com/developer/documentation/",
+        "https://taomarketcap.com/subnets/62"
+      ],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/62/candle-chart/"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary
Adds the missing **standalone machine-readable data artifact** for SN62 Ridges (Closes #4069). The overlay already registers the source repo, the live agent-leaderboard subnet-api, and an OpenAPI spec, but no static data artifact — the file's own `gap_notes` note *"No verified standalone static data artifact yet."*

## Surface added (one file, `registry/subnets/ridges.json`)
- **`sn-62-ridges-taomarketcap-candle-chart`** · kind `data-artifact` · authority `community` / `community-submitted`
- **URL:** `https://api.taomarketcap.com/public/v1/subnets/62/candle-chart/` — public, no-auth GET
- Returns a JSON time-series of hourly OHLCV candles for SN62's alpha token: each record carries `subnet_id`, `period_name`, `timestamp`, `block_number`, `open`/`high`/`low`/`close`, `volume`, `start_volume`, `tao_price_usd`/`eur` — every record scoped to `subnet_id: 62` (714 hourly records live at submission).

## Proof
- The endpoint is **subnet-scoped and self-proving** — `GET .../subnets/62/candle-chart` returns only `subnet_id: 62` records (verified 200, ~217 KB).
- `taomarketcap.com/subnets/62` is already this overlay's `dashboard_url`, confirming the provider indexes netuid 62.
- `source_urls`: the TaoMarketCap developer API documentation + the SN62 provider page.

`validate:schemas` passes. One file, one subnet, additive — no other changes.

Closes #4069
