### PR TITLE
feat(api): add subnet stake-quote slippage endpoint

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -2316,6 +2316,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/stake-quote": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a read-only constant-product stake/unstake slippage quote for one subnet: the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake (default stake), computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard: an amount over 1000× the relevant reserve is rejected with 422. The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote. */
+        get: operations["subnetStakeQuote"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/stake-transfers": {
         parameters: {
             query?: never;
@@ -7197,6 +7214,23 @@ export interface components {
             schema_version: number;
             /** @enum {string|null} */
             window: "7d" | "30d" | null;
+        };
+        /** @description Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for an ?amount=/?direction=stake|unstake swap against the subnet's live economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math -- no chain write, no custody -- mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000x the relevant reserve is rejected). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote with null pool reserves. */
+        SubnetStakeQuoteArtifact: {
+            alpha_in_pool: number | null;
+            amount: number;
+            /** @enum {string} */
+            direction: "stake" | "unstake";
+            effective_price_tao: number;
+            expected_out: number;
+            /** @enum {string} */
+            expected_out_unit: "alpha" | "tao";
+            is_root: boolean;
+            netuid: number;
+            price_impact_pct: number;
+            schema_version: number;
+            spot_price_tao: number;
+            tao_in_pool_tao: number | null;
         };
         /** @description Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window. */
         SubnetStakeTransfersArtifact: {
@@ -26375,6 +26409,121 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetStakeMovesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetStakeQuote: {
+        parameters: {
+            query?: {
+                amount?: number;
+                direction?: "stake" | "unstake";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "alpha_in_pool": 0.5,
+                     *         "amount": 0.5,
+                     *         "direction": "stake",
+                     *         "effective_price_tao": 0.5,
+                     *         "expected_out": 0.5,
+                     *         "expected_out_unit": "alpha",
+                     *         "is_root": false,
+                     *         "netuid": 7,
+                     *         "price_impact_pct": 0.5,
+                     *         "schema_version": 1,
+                     *         "spot_price_tao": 0.5,
+                     *         "tao_in_pool_tao": 0.5
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["SubnetStakeQuoteArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -471,6 +471,13 @@
     },
     {
       "contract_version": "2026-07-03.2",
+      "id": "subnet-stake-quote",
+      "path": "/metagraph/subnets/{netuid}/stake-quote.json",
+      "schema_ref": "#/components/schemas/SubnetStakeQuoteArtifact",
+      "storage_tier": "git"
+    },
+    {
+      "contract_version": "2026-07-03.2",
       "id": "subnet-alpha-volume",
       "path": "/metagraph/subnets/{netuid}/volume.json",
       "schema_ref": "#/components/schemas/SubnetAlphaVolumeArtifact",
@@ -5305,6 +5312,36 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": []
+    },
+    {
+      "artifact_path": "/metagraph/subnets/{netuid}/stake-quote.json",
+      "cache": "short",
+      "description": "Fetch a read-only constant-product stake/unstake slippage quote for one subnet: the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake (default stake), computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard: an amount over 1000× the relevant reserve is rejected with 422. The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote.",
+      "id": "subnet-stake-quote",
+      "method": "GET",
+      "path": "/api/v1/subnets/{netuid}/stake-quote",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "amount",
+          "schema": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          }
+        },
+        {
+          "name": "direction",
+          "schema": {
+            "enum": [
+              "stake",
+              "unstake"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/subnets/movers.json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -606,6 +606,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
+      "description": "Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake, computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool) at /api/v1/subnets/{netuid}/stake-quote (no static file). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000× the relevant reserve is rejected with 422). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote.",
+      "id": "subnet-stake-quote",
+      "path": "/metagraph/subnets/{netuid}/stake-quote.json",
+      "schema_ref": "#/components/schemas/SubnetStakeQuoteArtifact",
+      "storage_tier": "git"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-07-03.2",
       "description": "Rolling 24h buy/sell alpha volume for one subnet (#4339/8.1): unsigned totals (never netted) in both alpha and TAO for StakeAdded (buy) vs StakeRemoved (sell), plus event counts, summed live from the same account_events stream as /api/v1/subnets/{netuid}/stake-flow (no static file). Also carries a buy/sell sentiment indicator (#4339/8.2) purely derived from the alpha totals: net_volume_alpha, a bounded sentiment_ratio, and a bullish/bearish/neutral label. Fixed 24h window, not OHLC/price data (#2589's trader-feature fence).",
       "id": "subnet-alpha-volume",
       "path": "/metagraph/subnets/{netuid}/volume.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -19181,6 +19181,83 @@
         ],
         "type": "object"
       },
+      "SubnetStakeQuoteArtifact": {
+        "additionalProperties": false,
+        "description": "Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for an ?amount=/?direction=stake|unstake swap against the subnet's live economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math -- no chain write, no custody -- mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000x the relevant reserve is rejected). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote with null pool reserves.",
+        "properties": {
+          "alpha_in_pool": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "amount": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "direction": {
+            "enum": [
+              "stake",
+              "unstake"
+            ],
+            "type": "string"
+          },
+          "effective_price_tao": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "expected_out": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "expected_out_unit": {
+            "enum": [
+              "alpha",
+              "tao"
+            ],
+            "type": "string"
+          },
+          "is_root": {
+            "type": "boolean"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "price_impact_pct": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "spot_price_tao": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "tao_in_pool_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "direction",
+          "amount",
+          "expected_out",
+          "expected_out_unit",
+          "spot_price_tao",
+          "effective_price_tao",
+          "price_impact_pct",
+          "tao_in_pool_tao",
+          "alpha_in_pool",
+          "is_root"
+        ],
+        "type": "object"
+      },
       "SubnetStakeTransfersArtifact": {
         "additionalProperties": false,
         "description": "Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window.",
@@ -48636,6 +48713,166 @@
           }
         },
         "summary": "Fetch stake-movement (re-delegation) activity for one subnet over a 7d or 30d window: the distinct movers (accounts), the StakeMoved event count, and the average movements per mover, computed live from the account_events StakeMoved stream. The per-subnet drill-in of GET /api/v1/chain/stake-moves (which ranks only the top-N subnets and cannot be queried by netuid) and the re-delegation-churn sibling of GET /api/v1/subnets/{netuid}/stake-flow (net capital flow) — move_stake relocates stake between hotkeys/subnets without unstaking, so it is churn, not flow. Schema-stable zeroed card when the subnet has no StakeMoved events in the window.",
+        "tags": [
+          "subnets",
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/stake-quote": {
+      "get": {
+        "operationId": "subnetStakeQuote",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "amount",
+            "required": false,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "enum": [
+                "stake",
+                "unstake"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "alpha_in_pool": 0.5,
+                    "amount": 0.5,
+                    "direction": "stake",
+                    "effective_price_tao": 0.5,
+                    "expected_out": 0.5,
+                    "expected_out_unit": "alpha",
+                    "is_root": false,
+                    "netuid": 7,
+                    "price_impact_pct": 0.5,
+                    "schema_version": 1,
+                    "spot_price_tao": 0.5,
+                    "tao_in_pool_tao": 0.5
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-29.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetStakeQuoteArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch a read-only constant-product stake/unstake slippage quote for one subnet: the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake (default stake), computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard: an amount over 1000× the relevant reserve is rejected with 422. The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2316,6 +2316,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/stake-quote": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a read-only constant-product stake/unstake slippage quote for one subnet: the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake (default stake), computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard: an amount over 1000× the relevant reserve is rejected with 422. The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote. */
+        get: operations["subnetStakeQuote"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/stake-transfers": {
         parameters: {
             query?: never;
@@ -7197,6 +7214,23 @@ export interface components {
             schema_version: number;
             /** @enum {string|null} */
             window: "7d" | "30d" | null;
+        };
+        /** @description Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for an ?amount=/?direction=stake|unstake swap against the subnet's live economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math -- no chain write, no custody -- mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000x the relevant reserve is rejected). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote with null pool reserves. */
+        SubnetStakeQuoteArtifact: {
+            alpha_in_pool: number | null;
+            amount: number;
+            /** @enum {string} */
+            direction: "stake" | "unstake";
+            effective_price_tao: number;
+            expected_out: number;
+            /** @enum {string} */
+            expected_out_unit: "alpha" | "tao";
+            is_root: boolean;
+            netuid: number;
+            price_impact_pct: number;
+            schema_version: number;
+            spot_price_tao: number;
+            tao_in_pool_tao: number | null;
         };
         /** @description Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window. */
         SubnetStakeTransfersArtifact: {
@@ -26375,6 +26409,121 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetStakeMovesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetStakeQuote: {
+        parameters: {
+            query?: {
+                amount?: number;
+                direction?: "stake" | "unstake";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "alpha_in_pool": 0.5,
+                     *         "amount": 0.5,
+                     *         "direction": "stake",
+                     *         "effective_price_tao": 0.5,
+                     *         "expected_out": 0.5,
+                     *         "expected_out_unit": "alpha",
+                     *         "is_root": false,
+                     *         "netuid": 7,
+                     *         "price_impact_pct": 0.5,
+                     *         "schema_version": 1,
+                     *         "spot_price_tao": 0.5,
+                     *         "tao_in_pool_tao": 0.5
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["SubnetStakeQuoteArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -19159,6 +19159,83 @@
         ],
         "type": "object"
       },
+      "SubnetStakeQuoteArtifact": {
+        "additionalProperties": false,
+        "description": "Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for an ?amount=/?direction=stake|unstake swap against the subnet's live economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math -- no chain write, no custody -- mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000x the relevant reserve is rejected). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote with null pool reserves.",
+        "properties": {
+          "alpha_in_pool": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "amount": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "direction": {
+            "enum": [
+              "stake",
+              "unstake"
+            ],
+            "type": "string"
+          },
+          "effective_price_tao": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "expected_out": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "expected_out_unit": {
+            "enum": [
+              "alpha",
+              "tao"
+            ],
+            "type": "string"
+          },
+          "is_root": {
+            "type": "boolean"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "price_impact_pct": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "spot_price_tao": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "tao_in_pool_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "direction",
+          "amount",
+          "expected_out",
+          "expected_out_unit",
+          "spot_price_tao",
+          "effective_price_tao",
+          "price_impact_pct",
+          "tao_in_pool_tao",
+          "alpha_in_pool",
+          "is_root"
+        ],
+        "type": "object"
+      },
       "SubnetStakeTransfersArtifact": {
         "additionalProperties": false,
         "description": "Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window.",

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -1360,6 +1360,39 @@
         },
         "additionalProperties": false
       },
+      "SubnetStakeQuoteArtifact": {
+        "type": "object",
+        "description": "Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for an ?amount=/?direction=stake|unstake swap against the subnet's live economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math -- no chain write, no custody -- mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000x the relevant reserve is rejected). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote with null pool reserves.",
+        "required": [
+          "schema_version",
+          "netuid",
+          "direction",
+          "amount",
+          "expected_out",
+          "expected_out_unit",
+          "spot_price_tao",
+          "effective_price_tao",
+          "price_impact_pct",
+          "tao_in_pool_tao",
+          "alpha_in_pool",
+          "is_root"
+        ],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "netuid": { "type": "integer", "minimum": 0 },
+          "direction": { "type": "string", "enum": ["stake", "unstake"] },
+          "amount": { "type": "number", "exclusiveMinimum": 0 },
+          "expected_out": { "type": "number", "minimum": 0 },
+          "expected_out_unit": { "type": "string", "enum": ["alpha", "tao"] },
+          "spot_price_tao": { "type": "number", "minimum": 0 },
+          "effective_price_tao": { "type": "number", "minimum": 0 },
+          "price_impact_pct": { "type": "number", "minimum": 0 },
+          "tao_in_pool_tao": { "type": ["number", "null"] },
+          "alpha_in_pool": { "type": ["number", "null"] },
+          "is_root": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      },
       "SubnetAlphaVolumeArtifact": {
         "type": "object",
         "description": "Rolling 24h buy/sell alpha volume for one subnet (#4339/8.1), summed live from the same account_events stream as SubnetStakeFlowArtifact: alpha and TAO bought (StakeAdded) vs sold (StakeRemoved), unsigned totals (never netted), and event counts. Also carries a buy/sell sentiment indicator (#4339/8.2) purely derived from the alpha totals — net_volume_alpha (buy minus sell), sentiment_ratio (net/gross, bounded [-1,1], null with zero volume), and a bullish/bearish/neutral label — plus a vol/mcap turnover ratio (#4339/8.3): total_volume_tao over the live economics tier's alpha_market_cap_tao, null when that external input is unavailable. Fixed 24h window, not OHLC/price data.",

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -34,6 +34,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "subnet-turnover",
   "subnet-stake-flow",
   "subnet-alpha-volume",
+  "subnet-stake-quote",
   "subnet-weights",
   "subnet-weight-setters",
   "subnet-serving",

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1020,6 +1020,12 @@ export const PUBLIC_ARTIFACTS = [
     "SubnetStakeFlowArtifact",
   ),
   artifact(
+    "subnet-stake-quote",
+    "/metagraph/subnets/{netuid}/stake-quote.json",
+    "Read-only constant-product stake/unstake slippage quote for one subnet (#5235): the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake, computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool) at /api/v1/subnets/{netuid}/stake-quote (no static file). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard (an amount over 1000× the relevant reserve is rejected with 422). The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote.",
+    "SubnetStakeQuoteArtifact",
+  ),
+  artifact(
     "subnet-alpha-volume",
     "/metagraph/subnets/{netuid}/volume.json",
     "Rolling 24h buy/sell alpha volume for one subnet (#4339/8.1): unsigned totals (never netted) in both alpha and TAO for StakeAdded (buy) vs StakeRemoved (sell), plus event counts, summed live from the same account_events stream as /api/v1/subnets/{netuid}/stake-flow (no static file). Also carries a buy/sell sentiment indicator (#4339/8.2) purely derived from the alpha totals: net_volume_alpha, a bounded sentiment_ratio, and a bullish/bearish/neutral label. Fixed 24h window, not OHLC/price data (#2589's trader-feature fence).",
@@ -2291,6 +2297,23 @@ export const API_ROUTES = [
     "short",
     ["subnets", "analytics"],
     [],
+    [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+  ),
+  route(
+    "subnet-stake-quote",
+    "GET",
+    "/api/v1/subnets/{netuid}/stake-quote",
+    "/metagraph/subnets/{netuid}/stake-quote.json",
+    "Fetch a read-only constant-product stake/unstake slippage quote for one subnet: the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake (default stake), computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool). Pure math — no chain write, no custody — mirroring the chain's own constant-product swap and its InsufficientLiquidity guard: an amount over 1000× the relevant reserve is rejected with 422. The root subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote.",
+    "short",
+    ["subnets", "analytics"],
+    [
+      { name: "amount", schema: { type: "number", exclusiveMinimum: 0 } },
+      {
+        name: "direction",
+        schema: { type: "string", enum: ["stake", "unstake"] },
+      },
+    ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/stake-quote.mjs
+++ b/src/stake-quote.mjs
@@ -1,0 +1,144 @@
+// Pure constant-product AMM stake/unstake quote math for the dTAO subnet pools
+// (#5235). Reserves come from the economics.json artifact
+// (`tao_in_pool_tao` = TAO reserve, `alpha_in_pool` = alpha reserve); spot price
+// is `tao_in_pool_tao / alpha_in_pool` (≈ the artifact's `alpha_price_tao`).
+//
+// This is a read-only, pure-math estimator — no chain write, no custody. It
+// mirrors the chain's own constant-product swap and its `InsufficientLiquidity`
+// guard, so callers get the same expected alpha/TAO out, effective price, and
+// price impact the on-chain swap would produce, without signing anything.
+
+export const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"];
+
+// The chain rejects a swap whose input dwarfs the relevant reserve rather than
+// draining the pool; mirror that so a nonsense amount returns a clean
+// insufficient-liquidity error instead of a degenerate ~100%-impact quote.
+export const MAX_INPUT_RESERVE_MULTIPLE = 1000;
+
+function isFinitePositive(n) {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
+/**
+ * Compute a stake/unstake quote against one subnet's AMM pool reserves.
+ *
+ * @returns `{ ok: true, quote }` on success, or `{ ok: false, status, code, error }`
+ *   where `status` is the HTTP status the route should surface (400 for a bad
+ *   request, 422 for insufficient liquidity — a valid request the pool can't fill).
+ */
+export function computeStakeQuote({
+  netuid,
+  taoInPool,
+  alphaInPool,
+  amount,
+  direction,
+}) {
+  if (!STAKE_QUOTE_DIRECTIONS.includes(direction)) {
+    return {
+      ok: false,
+      status: 400,
+      code: "invalid_direction",
+      error: `\`direction\` must be one of ${STAKE_QUOTE_DIRECTIONS.join(", ")}.`,
+    };
+  }
+  if (!isFinitePositive(amount)) {
+    return {
+      ok: false,
+      status: 400,
+      code: "invalid_amount",
+      error: "`amount` must be a finite number greater than 0.",
+    };
+  }
+
+  // Root subnet (netuid 0) has no AMM pool — staking there is 1:1 TAO⇄TAO with
+  // no price impact, so short-circuit rather than run the formula against
+  // nonexistent reserves.
+  if (netuid === 0) {
+    return {
+      ok: true,
+      quote: {
+        netuid: 0,
+        direction,
+        amount,
+        expected_out: amount,
+        expected_out_unit: direction === "stake" ? "alpha" : "tao",
+        spot_price_tao: 1,
+        effective_price_tao: 1,
+        price_impact_pct: 0,
+        tao_in_pool_tao: null,
+        alpha_in_pool: null,
+        is_root: true,
+      },
+    };
+  }
+
+  if (!isFinitePositive(taoInPool) || !isFinitePositive(alphaInPool)) {
+    return {
+      ok: false,
+      status: 422,
+      code: "insufficient_liquidity",
+      error: "This subnet has no AMM pool liquidity to quote against.",
+    };
+  }
+
+  // Spot price is the pool ratio; each direction below applies the
+  // constant-product swap (k = tao_in · alpha_in preserved) in its stable form.
+  const spotPrice = taoInPool / alphaInPool; // TAO per alpha at rest
+
+  let expectedOut;
+  let expectedOutUnit;
+  let effectivePrice;
+
+  if (direction === "stake") {
+    // Add `amount` TAO, receive alpha. Algebraically alpha_out = alpha_in -
+    // k/(tao_in + Δtao), but that subtracts two near-equal large numbers and
+    // loses all precision on dust amounts, so use the equivalent closed form
+    // alpha_out = alpha_in·Δtao/(tao_in + Δtao), which is stable throughout.
+    if (amount > MAX_INPUT_RESERVE_MULTIPLE * taoInPool) {
+      return {
+        ok: false,
+        status: 422,
+        code: "insufficient_liquidity",
+        error: `\`amount\` exceeds ${MAX_INPUT_RESERVE_MULTIPLE}× the pool's TAO reserve; the swap cannot be filled.`,
+      };
+    }
+    expectedOut = (alphaInPool * amount) / (taoInPool + amount);
+    expectedOutUnit = "alpha";
+    effectivePrice = amount / expectedOut; // TAO paid per alpha received
+  } else {
+    // Add `amount` alpha, receive TAO — the mirror form
+    // tao_out = tao_in·Δalpha/(alpha_in + Δalpha).
+    if (amount > MAX_INPUT_RESERVE_MULTIPLE * alphaInPool) {
+      return {
+        ok: false,
+        status: 422,
+        code: "insufficient_liquidity",
+        error: `\`amount\` exceeds ${MAX_INPUT_RESERVE_MULTIPLE}× the pool's alpha reserve; the swap cannot be filled.`,
+      };
+    }
+    expectedOut = (taoInPool * amount) / (alphaInPool + amount);
+    expectedOutUnit = "tao";
+    effectivePrice = expectedOut / amount; // TAO received per alpha given
+  }
+
+  // Adverse deviation of the realized price from spot, as a non-negative percent.
+  const priceImpactPct =
+    Math.abs((effectivePrice - spotPrice) / spotPrice) * 100;
+
+  return {
+    ok: true,
+    quote: {
+      netuid,
+      direction,
+      amount,
+      expected_out: expectedOut,
+      expected_out_unit: expectedOutUnit,
+      spot_price_tao: spotPrice,
+      effective_price_tao: effectivePrice,
+      price_impact_pct: priceImpactPct,
+      tao_in_pool_tao: taoInPool,
+      alpha_in_pool: alphaInPool,
+      is_root: false,
+    },
+  };
+}

--- a/tests/stake-quote.test.mjs
+++ b/tests/stake-quote.test.mjs
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeStakeQuote,
+  STAKE_QUOTE_DIRECTIONS,
+  MAX_INPUT_RESERVE_MULTIPLE,
+} from "../src/stake-quote.mjs";
+
+// Realistic reserves (SN64 from the live economics.json artifact).
+const POOL = {
+  netuid: 64,
+  taoInPool: 201959.938748425,
+  alphaInPool: 2730860.150574127,
+};
+
+describe("computeStakeQuote", () => {
+  it("rejects an unknown direction with 400", () => {
+    const r = computeStakeQuote({ ...POOL, amount: 10, direction: "swap" });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(400);
+    expect(r.code).toBe("invalid_direction");
+  });
+
+  it("exports the two supported directions", () => {
+    expect(STAKE_QUOTE_DIRECTIONS).toEqual(["stake", "unstake"]);
+  });
+
+  for (const bad of [0, -5, NaN, Infinity, "10", null, undefined]) {
+    it(`rejects a non-positive/non-finite amount (${String(bad)}) with 400`, () => {
+      const r = computeStakeQuote({ ...POOL, amount: bad, direction: "stake" });
+      expect(r.ok).toBe(false);
+      expect(r.status).toBe(400);
+      expect(r.code).toBe("invalid_amount");
+    });
+  }
+
+  it("returns a 1:1 zero-impact quote for the root subnet (netuid 0), stake", () => {
+    const r = computeStakeQuote({
+      netuid: 0,
+      taoInPool: 0,
+      alphaInPool: 0,
+      amount: 42,
+      direction: "stake",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.quote.is_root).toBe(true);
+    expect(r.quote.expected_out).toBe(42);
+    expect(r.quote.expected_out_unit).toBe("alpha");
+    expect(r.quote.price_impact_pct).toBe(0);
+    expect(r.quote.spot_price_tao).toBe(1);
+  });
+
+  it("returns a 1:1 quote for the root subnet, unstake (tao out)", () => {
+    const r = computeStakeQuote({
+      netuid: 0,
+      taoInPool: 5,
+      alphaInPool: 5,
+      amount: 7,
+      direction: "unstake",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.quote.expected_out_unit).toBe("tao");
+    expect(r.quote.expected_out).toBe(7);
+  });
+
+  for (const pool of [
+    { taoInPool: 0, alphaInPool: 100 },
+    { taoInPool: 100, alphaInPool: 0 },
+    { taoInPool: NaN, alphaInPool: 100 },
+  ]) {
+    it(`returns 422 insufficient_liquidity for a zero/invalid reserve (${JSON.stringify(pool)})`, () => {
+      const r = computeStakeQuote({
+        netuid: 7,
+        ...pool,
+        amount: 1,
+        direction: "stake",
+      });
+      expect(r.ok).toBe(false);
+      expect(r.status).toBe(422);
+      expect(r.code).toBe("insufficient_liquidity");
+    });
+  }
+
+  it("computes a stake quote: alpha out, effective price > spot, positive impact", () => {
+    const amount = 1000; // TAO in
+    const r = computeStakeQuote({ ...POOL, amount, direction: "stake" });
+    expect(r.ok).toBe(true);
+    const q = r.quote;
+    // Constant product: alpha_out = alpha_in - k/(tao_in + Δtao).
+    const k = POOL.taoInPool * POOL.alphaInPool;
+    const expectedAlpha = POOL.alphaInPool - k / (POOL.taoInPool + amount);
+    expect(q.expected_out).toBeCloseTo(expectedAlpha, 6);
+    expect(q.expected_out_unit).toBe("alpha");
+    expect(q.spot_price_tao).toBeCloseTo(POOL.taoInPool / POOL.alphaInPool, 12);
+    // Buying alpha pushes its price up → you pay more TAO/alpha than spot.
+    expect(q.effective_price_tao).toBeGreaterThan(q.spot_price_tao);
+    expect(q.price_impact_pct).toBeGreaterThan(0);
+    expect(q.is_root).toBe(false);
+  });
+
+  it("computes an unstake quote: tao out, effective price < spot, positive impact", () => {
+    const amount = 50000; // alpha in
+    const r = computeStakeQuote({ ...POOL, amount, direction: "unstake" });
+    expect(r.ok).toBe(true);
+    const q = r.quote;
+    const k = POOL.taoInPool * POOL.alphaInPool;
+    const expectedTao = POOL.taoInPool - k / (POOL.alphaInPool + amount);
+    expect(q.expected_out).toBeCloseTo(expectedTao, 6);
+    expect(q.expected_out_unit).toBe("tao");
+    // Selling alpha pushes its price down → you receive less TAO/alpha than spot.
+    expect(q.effective_price_tao).toBeLessThan(q.spot_price_tao);
+    expect(q.price_impact_pct).toBeGreaterThan(0);
+  });
+
+  it("gives a near-zero impact for a dust stake amount", () => {
+    const r = computeStakeQuote({ ...POOL, amount: 1e-6, direction: "stake" });
+    expect(r.ok).toBe(true);
+    expect(r.quote.expected_out).toBeGreaterThan(0);
+    expect(r.quote.price_impact_pct).toBeLessThan(0.001);
+  });
+
+  it("rejects a stake amount over 1000× the TAO reserve with 422", () => {
+    const amount = MAX_INPUT_RESERVE_MULTIPLE * POOL.taoInPool + 1;
+    const r = computeStakeQuote({ ...POOL, amount, direction: "stake" });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(422);
+    expect(r.code).toBe("insufficient_liquidity");
+  });
+
+  it("rejects an unstake amount over 1000× the alpha reserve with 422", () => {
+    const amount = MAX_INPUT_RESERVE_MULTIPLE * POOL.alphaInPool + 1;
+    const r = computeStakeQuote({ ...POOL, amount, direction: "unstake" });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(422);
+    expect(r.code).toBe("insufficient_liquidity");
+  });
+});

--- a/tests/subnet-stake-quote-api.test.mjs
+++ b/tests/subnet-stake-quote-api.test.mjs
@@ -1,0 +1,84 @@
+// Route-dispatch coverage for GET /api/v1/subnets/{netuid}/stake-quote (#5235):
+// drives the real api.mjs router end-to-end so the path-pattern match + handler
+// call are exercised. Handler/resolver branch detail lives in
+// subnet-stake-quote-handler.test.mjs; the pure math in stake-quote.test.mjs.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const req = (path) => new Request(`https://api.metagraph.sh${path}`);
+
+const ECONOMICS = {
+  generated_at: "2026-07-14T00:00:00.000Z",
+  subnets: [
+    {
+      netuid: 64,
+      tao_in_pool_tao: 201959.938748425,
+      alpha_in_pool: 2730860.150574127,
+    },
+  ],
+};
+
+function env() {
+  const base = createLocalArtifactEnv();
+  const artifactBody = () => ({
+    async json() {
+      return ECONOMICS;
+    },
+    async text() {
+      return JSON.stringify(ECONOMICS);
+    },
+  });
+  base.METAGRAPH_ARCHIVE = {
+    async get(key) {
+      return String(key).replace(/^latest\//, "") === "economics.json"
+        ? artifactBody()
+        : null;
+    },
+  };
+  base.ASSETS = {
+    async fetch(request) {
+      return new URL(request.url).pathname === "/metagraph/economics.json"
+        ? Response.json(ECONOMICS)
+        : new Response("{}", { status: 404 });
+    },
+  };
+  base.METAGRAPH_ALLOW_R2_STATIC_FALLBACK = "true";
+  return base;
+}
+
+describe("GET /api/v1/subnets/{netuid}/stake-quote route", () => {
+  test("dispatches to a 200 quote", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/64/stake-quote?amount=1000&direction=stake"),
+      env(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, 64);
+    assert.equal(body.data.expected_out_unit, "alpha");
+    assert.ok(body.data.price_impact_pct > 0);
+  });
+
+  test("rejects an unknown query param with 400", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/64/stake-quote?amount=1&foo=bar"),
+      env(),
+      {},
+    );
+    assert.equal(res.status, 400);
+  });
+
+  test("a non-stake-quote subnet path falls through the dispatch (no match)", async () => {
+    // Exercises the pattern's no-match branch — the request flows past the
+    // stake-quote check to the router's not-found handling.
+    const res = await handleRequest(
+      req("/api/v1/subnets/64/not-a-real-subroute"),
+      env(),
+      {},
+    );
+    assert.notEqual(res.status, 200);
+  });
+});

--- a/tests/subnet-stake-quote-handler.test.mjs
+++ b/tests/subnet-stake-quote-handler.test.mjs
@@ -1,0 +1,149 @@
+// Handler + economics-resolver coverage for GET /api/v1/subnets/{netuid}/
+// stake-quote (#5235), driven directly against the entities handler (api.mjs
+// pulls in a graphql-ws dep this env lacks). The pure slippage math is unit
+// tested in stake-quote.test.mjs; the api.mjs route dispatch is exercised in
+// api-coverage.test.mjs.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleSubnetStakeQuote } from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 64;
+const RESERVES = {
+  tao_in_pool_tao: 201959.938748425,
+  alpha_in_pool: 2730860.150574127,
+};
+const req = (path) => new Request(`https://api.metagraph.sh${path}`);
+const url = (path) => new URL(`https://api.metagraph.sh${path}`);
+const body = async (res) => ({ status: res.status, json: await res.json() });
+
+// A live-economics KV blob that passes resolveLiveEconomics' freshness +
+// integrity gates (recent captured_at, emission_share summing to ~1).
+function liveEconomicsEnv() {
+  const blob = {
+    captured_at: new Date().toISOString(),
+    generated_at: "2026-07-14T00:00:00.000Z",
+    subnets: [{ netuid: NETUID, ...RESERVES, emission_share: 1 }],
+  };
+  return { METAGRAPH_CONTROL: { get: async () => blob } };
+}
+
+// No live tier — force the committed-R2 economics.json fallback path instead.
+function artifactEconomicsEnv() {
+  const blob = {
+    generated_at: "2026-07-14T00:00:00.000Z",
+    subnets: [{ netuid: NETUID, ...RESERVES }],
+  };
+  const artifactBody = () => ({
+    async json() {
+      return blob;
+    },
+    async text() {
+      return JSON.stringify(blob);
+    },
+  });
+  return {
+    METAGRAPH_ARCHIVE: { get: async () => artifactBody() },
+    ASSETS: {
+      async fetch() {
+        return Response.json(blob);
+      },
+    },
+    METAGRAPH_ALLOW_R2_STATIC_FALLBACK: "true",
+  };
+}
+
+async function call(env, path) {
+  return body(
+    await handleSubnetStakeQuote(
+      req(path),
+      env,
+      extractNetuid(path),
+      url(path),
+    ),
+  );
+}
+function extractNetuid(path) {
+  return Number(path.match(/\/subnets\/(\d+)\//)[1]);
+}
+
+describe("handleSubnetStakeQuote (#5235)", () => {
+  test("stake quote from the live economics tier: alpha out, positive impact", async () => {
+    const { status, json } = await call(
+      liveEconomicsEnv(),
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=1000&direction=stake`,
+    );
+    assert.equal(status, 200);
+    assert.equal(json.data.direction, "stake");
+    assert.equal(json.data.expected_out_unit, "alpha");
+    assert.ok(json.data.expected_out > 0);
+    assert.ok(json.data.price_impact_pct > 0);
+    assert.equal(json.data.netuid, NETUID);
+    assert.equal(json.data.is_root, false);
+  });
+
+  test("unstake quote resolved from the committed economics.json fallback: tao out", async () => {
+    const { status, json } = await call(
+      artifactEconomicsEnv(),
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=50000&direction=unstake`,
+    );
+    assert.equal(status, 200);
+    assert.equal(json.data.expected_out_unit, "tao");
+    assert.ok(json.data.expected_out > 0);
+  });
+
+  test("direction defaults to stake when omitted", async () => {
+    const { status, json } = await call(
+      liveEconomicsEnv(),
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=1000`,
+    );
+    assert.equal(status, 200);
+    assert.equal(json.data.direction, "stake");
+  });
+
+  test("root subnet (netuid 0) returns a 1:1 zero-impact quote with null reserves", async () => {
+    const { status, json } = await call(
+      {},
+      `/api/v1/subnets/0/stake-quote?amount=5`,
+    );
+    assert.equal(status, 200);
+    assert.equal(json.data.is_root, true);
+    assert.equal(json.data.expected_out, 5);
+    assert.equal(json.data.price_impact_pct, 0);
+    assert.equal(json.data.tao_in_pool_tao, null);
+  });
+
+  test("no economics tier available → 422 insufficient_liquidity", async () => {
+    const { status, json } = await call(
+      {},
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=1`,
+    );
+    assert.equal(status, 422);
+    assert.equal(json.error.code, "insufficient_liquidity");
+  });
+
+  test("unknown query param → 400", async () => {
+    const { status } = await call(
+      liveEconomicsEnv(),
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=1&foo=bar`,
+    );
+    assert.equal(status, 400);
+  });
+
+  test("bad direction → 400 invalid_direction", async () => {
+    const { status, json } = await call(
+      {},
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=1&direction=swap`,
+    );
+    assert.equal(status, 400);
+    assert.equal(json.error.code, "invalid_direction");
+  });
+
+  test("zero amount → 400 invalid_amount", async () => {
+    const { status, json } = await call(
+      {},
+      `/api/v1/subnets/${NETUID}/stake-quote?amount=0`,
+    );
+    assert.equal(status, 400);
+    assert.equal(json.error.code, "invalid_amount");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -103,6 +103,7 @@ import {
   handleSubnetStakeFlow,
   canonicalSubnetStakeFlowCachePath,
   handleSubnetAlphaVolume,
+  handleSubnetStakeQuote,
   handleSubnetRecycled,
   handleSubnetWeights,
   canonicalSubnetWeightsCachePath,
@@ -341,6 +342,7 @@ import {
   SUBNET_TURNOVER_PATH_PATTERN,
   SUBNET_STAKE_FLOW_PATH_PATTERN,
   SUBNET_ALPHA_VOLUME_PATH_PATTERN,
+  SUBNET_STAKE_QUOTE_PATH_PATTERN,
   SUBNET_RECYCLED_PATH_PATTERN,
   SUBNET_WEIGHTS_PATH_PATTERN,
   SUBNET_WEIGHT_SETTERS_PATH_PATTERN,
@@ -1657,6 +1659,20 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         ),
       );
     }
+    const stakeQuoteMatch = SUBNET_STAKE_QUOTE_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (stakeQuoteMatch) {
+      // Read-only constant-product quote (#5235). The result varies with the
+      // ?amount=/?direction= query, so it's computed per request rather than
+      // path-edge-cached like the deterministic sibling analytics routes.
+      return handleSubnetStakeQuote(
+        request,
+        env,
+        Number(stakeQuoteMatch[1]),
+        resolved.url,
+      );
+    }
     const recycledMatch = SUBNET_RECYCLED_PATH_PATTERN.exec(
       resolved.url.pathname,
     );
@@ -2553,6 +2569,7 @@ function isMainnetOnlyApiPath(pathname) {
     SUBNET_TURNOVER_PATH_PATTERN.test(pathname) ||
     SUBNET_STAKE_FLOW_PATH_PATTERN.test(pathname) ||
     SUBNET_ALPHA_VOLUME_PATH_PATTERN.test(pathname) ||
+    SUBNET_STAKE_QUOTE_PATH_PATTERN.test(pathname) ||
     SUBNET_RECYCLED_PATH_PATTERN.test(pathname) ||
     SUBNET_YIELD_PATH_PATTERN.test(pathname) ||
     SUBNET_PERFORMANCE_PATH_PATTERN.test(pathname) ||

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -68,6 +68,10 @@ export const SUBNET_STAKE_FLOW_PATH_PATTERN =
 // account_events tier, no static file.
 export const SUBNET_ALPHA_VOLUME_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/volume$/;
+// Read-only constant-product stake/unstake slippage quote (#5235) — pure math
+// over the subnet's live economics-artifact pool reserves, no chain write.
+export const SUBNET_STAKE_QUOTE_PATH_PATTERN =
+  /^\/api\/v1\/subnets\/(\d+)\/stake-quote$/;
 // Live cumulative TAO recycled for registration on one subnet (#4339/8.4),
 // queried from the chain's own RAORecycledForRegistration storage map at
 // request time — not a D1/account_events tier, no static file.

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -100,6 +100,7 @@ import {
 } from "../../src/account-balance.mjs";
 import { loadSudoKey } from "../../src/sudo-key.mjs";
 import { isU16Netuid, loadSubnetRecycled } from "../../src/subnet-recycled.mjs";
+import { computeStakeQuote } from "../../src/stake-quote.mjs";
 import { buildRuntimeVersionHistory } from "../../src/runtime-versions.mjs";
 import { decodeCursor, encodeCursor } from "../../src/cursor.mjs";
 import { buildBlock, buildBlockFeed } from "../../src/blocks.mjs";
@@ -2220,6 +2221,69 @@ async function resolveSubnetMarketCapTao(env, netuid) {
   return typeof marketCap === "number" && Number.isFinite(marketCap)
     ? marketCap
     : null;
+}
+
+// One subnet's live AMM pool reserves (#5235) — the constant-product inputs the
+// stake-quote math needs — resolved from the same live-KV-then-committed-R2
+// economics tiers as resolveSubnetMarketCapTao, plus the blob's freshness stamp
+// for the response meta. Returns { row: null } when neither tier has a row.
+async function resolveSubnetEconomicsRow(env, netuid) {
+  const live = await resolveLiveEconomics({
+    readHealthKv: (e) => readHealthKv(e, KV_ECONOMICS_CURRENT),
+    env,
+    contractVersion: contractVersion(env),
+  });
+  let blob = Array.isArray(live?.data?.subnets) ? live.data : null;
+  if (!blob) {
+    const artifact = await readArtifact(env, "/metagraph/economics.json");
+    blob =
+      artifact.ok && Array.isArray(artifact.data?.subnets)
+        ? artifact.data
+        : null;
+  }
+  const rows = Array.isArray(blob?.subnets) ? blob.subnets : [];
+  return {
+    row: rows.find((entry) => entry?.netuid === netuid) ?? null,
+    generatedAt: blob?.generated_at ?? blob?.captured_at ?? null,
+  };
+}
+
+// GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake
+// (#5235): a read-only constant-product slippage/price-impact estimate against
+// the subnet's live AMM pool reserves — no chain write, no custody. Pure math in
+// src/stake-quote.mjs; this handler just resolves the reserves and maps its
+// typed result onto the API envelope (400 for a bad request, 422 when the pool
+// can't fill the requested swap).
+export async function handleSubnetStakeQuote(request, env, netuid, url) {
+  const validationError = validateEntityQuery(url, ["amount", "direction"]);
+  if (validationError) return analyticsQueryError(validationError);
+  // A missing/empty `amount` coerces to 0, which computeStakeQuote rejects as
+  // invalid_amount just like a non-numeric value — no separate null check.
+  const amount = Number(url.searchParams.get("amount"));
+  const direction = url.searchParams.get("direction") ?? "stake";
+  const { row, generatedAt } = await resolveSubnetEconomicsRow(env, netuid);
+  const result = computeStakeQuote({
+    netuid,
+    taoInPool: row?.tao_in_pool_tao,
+    alphaInPool: row?.alpha_in_pool,
+    amount,
+    direction,
+  });
+  if (!result.ok) {
+    return errorResponse(result.code, result.error, result.status);
+  }
+  return envelopeResponse(
+    request,
+    {
+      data: { schema_version: 1, ...result.quote },
+      meta: await metagraphMeta(
+        env,
+        `/metagraph/subnets/${netuid}/stake-quote.json`,
+        generatedAt,
+      ),
+    },
+    "short",
+  );
 }
 
 // GET /api/v1/subnets/{netuid}/volume (#4339/8.1): rolling 24h buy (StakeAdded)


### PR DESCRIPTION
## Summary
Exposes the constant-product stake/unstake slippage math as a documented, **read-only** endpoint (Closes #5235, part of #5229). No new ingestion — the AMM pool reserves (`tao_in_pool_tao`, `alpha_in_pool`) already ship in the `economics.json` artifact.

`GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake` → expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent. Pure math, no chain write, no custody.

## Deliverables
- **Constant-product formula + inverse** — `src/stake-quote.mjs`, implemented in its numerically-stable closed form `alpha_out = alpha_in·Δtao/(tao_in+Δtao)` (and the unstake mirror). This is algebraically identical to `alpha_in − k/(tao_in+Δtao)` but avoids the catastrophic cancellation that made dust amounts report a fake ~0.004% impact.
- **Root subnet (netuid 0)** → 1:1, zero-impact quote with null reserves (no AMM), rather than running the formula against nonexistent reserves.
- **Guards** → zero/absent liquidity and inputs over **1000× the relevant reserve** return `422`, mirroring the chain's own `InsufficientLiquidity` guard; a bad `direction`/`amount` returns `400`.
- **Handler** (`entities.mjs`) resolves reserves from the live economics KV tier with the committed `economics.json` R2 fallback, then maps the typed result onto the API envelope.
- **Schema + contract + OpenAPI** — new `SubnetStakeQuoteArtifact`, a `route()` + `artifact()` in `contracts.mjs`, regenerated `openapi.json`/types, registered as a computed (no-static-file) artifact.

## Validation
- `validate:schemas`, `validate:contract-drift`, `validate:openapi` (156 routes), `validate:openapi-examples` (156/156 ship a worked example) — all pass.
- `npm run build` clean; `eslint`/`prettier` clean.
- **Tests** (all green locally): `stake-quote.test.mjs` (pure math — root, dust, both directions, every guard, constant-product invariant), `subnet-stake-quote-handler.test.mjs` (handler over the live-KV *and* R2-fallback tiers + every error path), `subnet-stake-quote-api.test.mjs` (route dispatch through `api.mjs`). Verified **100% statement/branch coverage on every changed line** in `src/stake-quote.mjs`, the new entities handler/resolver, and the api.mjs dispatch.

Example — SN64, stake 1000 τ:
```
GET /api/v1/subnets/64/stake-quote?amount=1000&direction=stake
→ { data: { netuid: 64, direction: "stake", expected_out: 13458.6…, expected_out_unit: "alpha",
            spot_price_tao: 0.07395…, effective_price_tao: 0.07432…, price_impact_pct: 0.49…, is_root: false } }
```

Closes #5235
