### PR TITLE
feat(validators): expose root-vs-alpha stake split

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5662,6 +5662,8 @@ export const validatorDetailQuery = (hotkey: string) =>
           coldkey_count: firstFiniteNumber(d.coldkey_count) ?? 0,
           subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
           total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? 0,
+          root_stake_tao: firstFiniteNumber(d.root_stake_tao) ?? 0,
+          alpha_stake_tao: firstFiniteNumber(d.alpha_stake_tao) ?? 0,
           total_emission_tao: firstFiniteNumber(d.total_emission_tao) ?? 0,
           avg_validator_trust: firstFiniteNumber(d.avg_validator_trust) ?? null,
           max_validator_trust: firstFiniteNumber(d.max_validator_trust) ?? null,

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2040,6 +2040,10 @@ export interface ValidatorDetail {
   coldkey_count: number;
   subnet_count: number;
   total_stake_tao: number;
+  /** Stake on netuid 0 (root), TAO-denominated 1:1, no AMM/price exposure (#2550). */
+  root_stake_tao: number;
+  /** total_stake_tao minus root_stake_tao — the alpha-token-denominated legs. */
+  alpha_stake_tao: number;
   total_emission_tao: number;
   avg_validator_trust: number | null;
   max_validator_trust: number | null;

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -234,7 +234,10 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           icon={Coins}
           eyebrow="Total stake"
           value={taoCompact(detail.total_stake_tao)}
-          hint="across all subnets"
+          // Root (netuid 0) is TAO-denominated with no price exposure; alpha
+          // is the sum across every other subnet's own alpha token (#2550).
+          hint={`Root ${taoCompact(detail.root_stake_tao)} · Alpha ${taoCompact(detail.alpha_stake_tao)}`}
+          truncate={false}
           tone="accent"
           className="rounded-2xl border-accent/25 bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11839,7 +11839,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.5",
+      "version": "0.15.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4928,6 +4928,8 @@ export interface components {
         };
         /** @description One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true. */
         GlobalValidatorEntry: {
+            /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
+            alpha_stake_tao: number;
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
@@ -4937,6 +4939,8 @@ export interface components {
             /** Format: date-time */
             latest_captured_at: string | null;
             max_validator_trust: number | null;
+            /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
+            root_stake_tao: number;
             stake_dominance: number | null;
             subnet_count: number;
             subnets: components["schemas"]["GlobalValidatorSubnet"][];
@@ -7594,6 +7598,8 @@ export interface components {
         };
         /** @description Cross-subnet detail for one validator identity: its validator_permit=1 rows aggregated across every subnet it operates in, served live from the neurons D1 tier at /api/v1/validators/{hotkey} (no static file). Cold/absent hotkey (no validator-permit rows) returns a zeroed aggregate with an empty subnets array, never a 404 — the single-entity drill-in of /api/v1/validators. */
         ValidatorDetailArtifact: {
+            /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
+            alpha_stake_tao: number;
             avg_validator_trust: number | null;
             block_number: number | null;
             /** Format: date-time */
@@ -7602,6 +7608,8 @@ export interface components {
             coldkey_count: number;
             hotkey: string;
             max_validator_trust: number | null;
+            /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
+            root_stake_tao: number;
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["ValidatorDetailSubnet"][];
@@ -28332,6 +28340,7 @@ export interface operations {
                      *         "validator_count": 1,
                      *         "validators": [
                      *           {
+                     *             "alpha_stake_tao": 0.5,
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
@@ -28340,6 +28349,7 @@ export interface operations {
                      *             "latest_block_number": 5000000,
                      *             "latest_captured_at": "2026-06-01T00:00:00.000Z",
                      *             "max_validator_trust": 0.5,
+                     *             "root_stake_tao": 0.5,
                      *             "stake_dominance": 0.5,
                      *             "subnet_count": 1,
                      *             "subnets": [
@@ -28462,6 +28472,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "alpha_stake_tao": 0.5,
                      *         "avg_validator_trust": 0.5,
                      *         "block_number": 5000000,
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
@@ -28469,6 +28480,7 @@ export interface operations {
                      *         "coldkey_count": 1,
                      *         "hotkey": "example",
                      *         "max_validator_trust": 0.5,
+                     *         "root_stake_tao": 0.5,
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
                      *         "subnets": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9659,6 +9659,11 @@
         "additionalProperties": false,
         "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true.",
         "properties": {
+          "alpha_stake_tao": {
+            "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao.",
+            "minimum": 0,
+            "type": "number"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -9699,6 +9704,11 @@
               "number",
               "null"
             ]
+          },
+          "root_stake_tao": {
+            "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
+            "minimum": 0,
+            "type": "number"
           },
           "stake_dominance": {
             "maximum": 1,
@@ -9748,6 +9758,8 @@
           "uid_count",
           "take",
           "total_stake_tao",
+          "root_stake_tao",
+          "alpha_stake_tao",
           "total_emission_tao",
           "stake_dominance",
           "avg_validator_trust",
@@ -20742,6 +20754,11 @@
         "additionalProperties": true,
         "description": "Cross-subnet detail for one validator identity: its validator_permit=1 rows aggregated across every subnet it operates in, served live from the neurons D1 tier at /api/v1/validators/{hotkey} (no static file). Cold/absent hotkey (no validator-permit rows) returns a zeroed aggregate with an empty subnets array, never a 404 — the single-entity drill-in of /api/v1/validators.",
         "properties": {
+          "alpha_stake_tao": {
+            "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao.",
+            "minimum": 0,
+            "type": "number"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -20780,6 +20797,11 @@
               "null"
             ]
           },
+          "root_stake_tao": {
+            "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
+            "minimum": 0,
+            "type": "number"
+          },
           "schema_version": {
             "type": "integer"
           },
@@ -20817,6 +20839,8 @@
           "subnet_count",
           "take",
           "total_stake_tao",
+          "root_stake_tao",
+          "alpha_stake_tao",
           "total_emission_tao",
           "avg_validator_trust",
           "max_validator_trust",
@@ -51404,6 +51428,7 @@
                     "validator_count": 1,
                     "validators": [
                       {
+                        "alpha_stake_tao": 0.5,
                         "avg_validator_trust": 0.5,
                         "coldkey": "example",
                         "coldkey_count": 1,
@@ -51412,6 +51437,7 @@
                         "latest_block_number": 5000000,
                         "latest_captured_at": "2026-06-01T00:00:00.000Z",
                         "max_validator_trust": 0.5,
+                        "root_stake_tao": 0.5,
                         "stake_dominance": 0.5,
                         "subnet_count": 1,
                         "subnets": [
@@ -51561,6 +51587,7 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "alpha_stake_tao": 0.5,
                     "avg_validator_trust": 0.5,
                     "block_number": 5000000,
                     "captured_at": "2026-06-01T00:00:00.000Z",
@@ -51568,6 +51595,7 @@
                     "coldkey_count": 1,
                     "hotkey": "example",
                     "max_validator_trust": 0.5,
+                    "root_stake_tao": 0.5,
                     "schema_version": 1,
                     "subnet_count": 1,
                     "subnets": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4928,6 +4928,8 @@ export interface components {
         };
         /** @description One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true. */
         GlobalValidatorEntry: {
+            /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
+            alpha_stake_tao: number;
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
@@ -4937,6 +4939,8 @@ export interface components {
             /** Format: date-time */
             latest_captured_at: string | null;
             max_validator_trust: number | null;
+            /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
+            root_stake_tao: number;
             stake_dominance: number | null;
             subnet_count: number;
             subnets: components["schemas"]["GlobalValidatorSubnet"][];
@@ -7594,6 +7598,8 @@ export interface components {
         };
         /** @description Cross-subnet detail for one validator identity: its validator_permit=1 rows aggregated across every subnet it operates in, served live from the neurons D1 tier at /api/v1/validators/{hotkey} (no static file). Cold/absent hotkey (no validator-permit rows) returns a zeroed aggregate with an empty subnets array, never a 404 — the single-entity drill-in of /api/v1/validators. */
         ValidatorDetailArtifact: {
+            /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
+            alpha_stake_tao: number;
             avg_validator_trust: number | null;
             block_number: number | null;
             /** Format: date-time */
@@ -7602,6 +7608,8 @@ export interface components {
             coldkey_count: number;
             hotkey: string;
             max_validator_trust: number | null;
+            /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
+            root_stake_tao: number;
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["ValidatorDetailSubnet"][];
@@ -28332,6 +28340,7 @@ export interface operations {
                      *         "validator_count": 1,
                      *         "validators": [
                      *           {
+                     *             "alpha_stake_tao": 0.5,
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
@@ -28340,6 +28349,7 @@ export interface operations {
                      *             "latest_block_number": 5000000,
                      *             "latest_captured_at": "2026-06-01T00:00:00.000Z",
                      *             "max_validator_trust": 0.5,
+                     *             "root_stake_tao": 0.5,
                      *             "stake_dominance": 0.5,
                      *             "subnet_count": 1,
                      *             "subnets": [
@@ -28462,6 +28472,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "alpha_stake_tao": 0.5,
                      *         "avg_validator_trust": 0.5,
                      *         "block_number": 5000000,
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
@@ -28469,6 +28480,7 @@ export interface operations {
                      *         "coldkey_count": 1,
                      *         "hotkey": "example",
                      *         "max_validator_trust": 0.5,
+                     *         "root_stake_tao": 0.5,
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
                      *         "subnets": [

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9637,6 +9637,11 @@
         "additionalProperties": false,
         "description": "One validator/operator row grouped by public identity across every current validator-permit UID in the neurons snapshot. `featured` (#5166) reflects a maintainer-toggled DB pin (featured_validators, keyed by hotkey) -- true moves the row to the front of the default (unsorted) view; an explicit non-default ?sort= keeps its normal rank while `featured` stays true.",
         "properties": {
+          "alpha_stake_tao": {
+            "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao.",
+            "minimum": 0,
+            "type": "number"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -9677,6 +9682,11 @@
               "number",
               "null"
             ]
+          },
+          "root_stake_tao": {
+            "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
+            "minimum": 0,
+            "type": "number"
           },
           "stake_dominance": {
             "maximum": 1,
@@ -9726,6 +9736,8 @@
           "uid_count",
           "take",
           "total_stake_tao",
+          "root_stake_tao",
+          "alpha_stake_tao",
           "total_emission_tao",
           "stake_dominance",
           "avg_validator_trust",
@@ -20720,6 +20732,11 @@
         "additionalProperties": true,
         "description": "Cross-subnet detail for one validator identity: its validator_permit=1 rows aggregated across every subnet it operates in, served live from the neurons D1 tier at /api/v1/validators/{hotkey} (no static file). Cold/absent hotkey (no validator-permit rows) returns a zeroed aggregate with an empty subnets array, never a 404 — the single-entity drill-in of /api/v1/validators.",
         "properties": {
+          "alpha_stake_tao": {
+            "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao.",
+            "minimum": 0,
+            "type": "number"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -20758,6 +20775,11 @@
               "null"
             ]
           },
+          "root_stake_tao": {
+            "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
+            "minimum": 0,
+            "type": "number"
+          },
           "schema_version": {
             "type": "integer"
           },
@@ -20795,6 +20817,8 @@
           "subnet_count",
           "take",
           "total_stake_tao",
+          "root_stake_tao",
+          "alpha_stake_tao",
           "total_emission_tao",
           "avg_validator_trust",
           "max_validator_trust",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -2005,6 +2005,8 @@
           "uid_count",
           "take",
           "total_stake_tao",
+          "root_stake_tao",
+          "alpha_stake_tao",
           "total_emission_tao",
           "stake_dominance",
           "avg_validator_trust",
@@ -2025,6 +2027,16 @@
             "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Global per-hotkey. Null if no SubtensorModule::Delegates entry existed at capture time."
           },
           "total_stake_tao": { "type": "number", "minimum": 0 },
+          "root_stake_tao": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao."
+          },
+          "alpha_stake_tao": {
+            "type": "number",
+            "minimum": 0,
+            "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao."
+          },
           "total_emission_tao": { "type": "number", "minimum": 0 },
           "stake_dominance": {
             "type": ["number", "null"],
@@ -2221,6 +2233,8 @@
           "subnet_count",
           "take",
           "total_stake_tao",
+          "root_stake_tao",
+          "alpha_stake_tao",
           "total_emission_tao",
           "avg_validator_trust",
           "max_validator_trust",
@@ -2239,6 +2253,16 @@
             "description": "Validator take/commission (#2548), 0..1 fraction of delegator rewards kept. Null if no SubtensorModule::Delegates entry existed at capture time."
           },
           "total_stake_tao": { "type": "number", "minimum": 0 },
+          "root_stake_tao": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao."
+          },
+          "alpha_stake_tao": {
+            "type": "number",
+            "minimum": 0,
+            "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao."
+          },
           "total_emission_tao": { "type": "number", "minimum": 0 },
           "avg_validator_trust": { "type": ["number", "null"] },
           "max_validator_trust": { "type": ["number", "null"] },

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -255,6 +255,16 @@ function buildGlobalValidatorEntry(entry) {
     entry.validatorTrustCount > 0
       ? entry.validatorTrustTotal / entry.validatorTrustCount
       : null;
+  // Root (netuid 0) stake is TAO-denominated with no AMM/price exposure;
+  // every other netuid's stake is that subnet's alpha token (#2550). Both
+  // legs are already present in entry.subnets -- one membership row per
+  // netuid, including netuid 0 when the hotkey holds root stake -- so the
+  // split needs no new ingestion, just separating the existing rao-precision
+  // total by whether a root membership row exists. Rao-BigInt subtraction
+  // (not float) keeps it exact, mirroring stakeTotalRao's own accumulation.
+  const rootSubnet = entry.subnets.find((s) => s.netuid === 0) ?? null;
+  const rootStakeRao = rootSubnet ? toRaoBig(rootSubnet.stake_tao) : 0n;
+  const alphaStakeRao = entry.stakeTotalRao - rootStakeRao;
   const subnets = entry.subnets
     .sort(
       (a, b) =>
@@ -273,6 +283,8 @@ function buildGlobalValidatorEntry(entry) {
     uid_count: entry.uidCount,
     take: round(entry.take),
     total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
+    root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
+    alpha_stake_tao: roundTao(raoBigToTao(alphaStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(entry.maxValidatorTrust),
@@ -549,6 +561,11 @@ export async function loadNeuron(d1, netuid, uid) {
 export function buildValidatorDetail(rows, hotkey) {
   const coldkeys = new Map();
   let stakeTotalRao = 0n;
+  // Root (netuid 0) stake is TAO-denominated with no AMM/price exposure;
+  // every other netuid's stake is that subnet's alpha token (#2550) --
+  // tracked separately here since the root membership row (when present) is
+  // already one of `rows`, no new ingestion needed.
+  let rootStakeRao = 0n;
   let emissionTotalRao = 0n;
   let validatorTrustTotal = 0;
   let validatorTrustCount = 0;
@@ -576,7 +593,9 @@ export function buildValidatorDetail(rows, hotkey) {
       const rowTake = nullableNumber(row?.take);
       if (rowTake != null) take = rowTake;
     }
-    stakeTotalRao += toRaoBig(numberOrZero(row?.stake_tao));
+    const rowStakeRao = toRaoBig(numberOrZero(row?.stake_tao));
+    stakeTotalRao += rowStakeRao;
+    if (netuid === 0) rootStakeRao += rowStakeRao;
     emissionTotalRao += toRaoBig(numberOrZero(row?.emission_tao));
     const trust = nullableNumber(row?.validator_trust);
     if (trust != null) {
@@ -613,6 +632,8 @@ export function buildValidatorDetail(rows, hotkey) {
     subnet_count: subnets.length,
     take: round(take),
     total_stake_tao: roundTao(raoBigToTao(stakeTotalRao)),
+    root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
+    alpha_stake_tao: roundTao(raoBigToTao(stakeTotalRao - rootStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(maxValidatorTrust),

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -42,7 +42,7 @@ const NEURON_CSV_HEADER =
 const MOVERS_CSV_HEADER =
   "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta";
 const GLOBAL_VALIDATOR_CSV_HEADER =
-  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
+  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,root_stake_tao,alpha_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
 
 describe("metagraph-neurons builders", () => {
   test("formatNeuron coerces 0/1 INTEGER flags to real booleans", () => {
@@ -459,6 +459,8 @@ describe("metagraph-neurons builders", () => {
     assert.equal(top.subnet_count, 3);
     assert.equal(top.uid_count, 3);
     assert.equal(top.total_stake_tao, 151.123456789);
+    assert.equal(top.root_stake_tao, 0); // no netuid-0 row for hk-a
+    assert.equal(top.alpha_stake_tao, 151.123456789);
     assert.equal(top.total_emission_tao, 16);
     assert.equal(top.stake_dominance, 0.232096);
     assert.equal(top.avg_validator_trust, 0.6);
@@ -473,6 +475,42 @@ describe("metagraph-neurons builders", () => {
         [5, 3],
       ],
     );
+  });
+
+  test("buildGlobalValidators splits root (netuid 0) stake from alpha stake in exact rao space (#2550)", () => {
+    const data = buildGlobalValidators([
+      {
+        ...ROW,
+        netuid: 0,
+        uid: 1,
+        hotkey: "hk-root",
+        coldkey: "ck-root",
+        stake_tao: 200.5,
+        emission_tao: 1,
+      },
+      {
+        ...ROW,
+        netuid: 7,
+        uid: 2,
+        hotkey: "hk-root",
+        coldkey: "ck-root",
+        stake_tao: 50.25,
+        emission_tao: 3,
+      },
+      {
+        ...ROW,
+        netuid: 9,
+        uid: 4,
+        hotkey: "hk-root",
+        coldkey: "ck-root",
+        stake_tao: 49.25,
+        emission_tao: 2,
+      },
+    ]);
+    const entry = data.validators.find((v) => v.hotkey === "hk-root");
+    assert.equal(entry.total_stake_tao, 300);
+    assert.equal(entry.root_stake_tao, 200.5);
+    assert.equal(entry.alpha_stake_tao, 99.5); // 50.25 + 49.25, exact
   });
 
   test("buildGlobalValidators takes the first non-null take per hotkey and ignores later rows (#2548)", () => {
@@ -742,6 +780,8 @@ describe("metagraph-neurons builders", () => {
     assert.equal(data.coldkey_count, 2);
     assert.equal(data.subnet_count, 5);
     assert.equal(data.total_stake_tao, 653.123456789);
+    assert.equal(data.root_stake_tao, 0); // no netuid-0 row for hk-a
+    assert.equal(data.alpha_stake_tao, 653.123456789);
     assert.equal(data.total_emission_tao, 19);
     assert.equal(data.avg_validator_trust, 0.6); // (0.4 + 0.8 + 0.6) / 3
     assert.equal(data.max_validator_trust, 0.8);
@@ -757,6 +797,41 @@ describe("metagraph-neurons builders", () => {
         [6, 0],
       ],
     );
+  });
+
+  test("buildValidatorDetail splits root (netuid 0) stake from alpha stake in exact rao space (#2550)", () => {
+    const data = buildValidatorDetail(
+      [
+        {
+          netuid: 0,
+          uid: 1,
+          hotkey: "hk-a",
+          coldkey: "ck-a",
+          stake_tao: 200.5,
+          emission_tao: 1,
+        },
+        {
+          netuid: 7,
+          uid: 2,
+          hotkey: "hk-a",
+          coldkey: "ck-a",
+          stake_tao: 50.25,
+          emission_tao: 3,
+        },
+        {
+          netuid: 9,
+          uid: 4,
+          hotkey: "hk-a",
+          coldkey: "ck-a",
+          stake_tao: 49.25,
+          emission_tao: 2,
+        },
+      ],
+      "hk-a",
+    );
+    assert.equal(data.total_stake_tao, 300);
+    assert.equal(data.root_stake_tao, 200.5);
+    assert.equal(data.alpha_stake_tao, 99.5); // 50.25 + 49.25, exact
   });
 
   test("buildValidatorDetail: a null latest block_number is beaten by a real one on a captured_at tie, and a null incoming block_number never wins one", () => {
@@ -797,6 +872,8 @@ describe("metagraph-neurons builders", () => {
     assert.equal(empty.coldkey_count, 0);
     assert.equal(empty.subnet_count, 0);
     assert.equal(empty.total_stake_tao, 0);
+    assert.equal(empty.root_stake_tao, 0);
+    assert.equal(empty.alpha_stake_tao, 0);
     assert.equal(empty.total_emission_tao, 0);
     assert.equal(empty.avg_validator_trust, null);
     assert.equal(empty.max_validator_trust, null);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -910,6 +910,8 @@ describe("handleGlobalValidators", () => {
       uid_count: 1,
       take: null,
       total_stake_tao: 0,
+      root_stake_tao: 0,
+      alpha_stake_tao: 0,
       total_emission_tao: 0,
       stake_dominance: null,
       avg_validator_trust: null,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -298,6 +298,8 @@ const GLOBAL_VALIDATOR_CSV_COLUMNS = [
   "subnet_count",
   "uid_count",
   "total_stake_tao",
+  "root_stake_tao",
+  "alpha_stake_tao",
   "total_emission_tao",
   "stake_dominance",
   "avg_validator_trust",


### PR DESCRIPTION
## Summary
- Closes #2550
- Root (netuid 0) stake is TAO-denominated with no AMM/price exposure; every other netuid's stake is that subnet's own alpha token. Both legs were **already present** in the neurons snapshot — a root membership row is ingested exactly like any other subnet's (verified live: 113 subnets for `tao.bot`'s hotkey include a real netuid-0 row with 1.22M TAO staked). So this needed **no new ingestion**, just splitting the existing rao-precision stake total by whether a netuid-0 membership row exists.
- Adds `root_stake_tao`/`alpha_stake_tao` to `buildGlobalValidatorEntry` and `buildValidatorDetail` (rao-BigInt subtraction, not float, to stay exact — mirrors `stakeTotalRao`'s own accumulation pattern).
- Schema: adds both fields to `GlobalValidatorEntry` and `ValidatorDetailArtifact` (`schemas/components/05-subnets.schema.json`), regenerates `openapi.json`/`types.d.ts`/`packages/contract`.
- Adds both to `GLOBAL_VALIDATOR_CSV_COLUMNS` so the `?format=csv` export carries them too.
- UI: the validator detail page's "Total stake" tile now shows a `Root X · Alpha Y` breakdown underneath the total.

## Screenshots

| Before | After (real data, mocked locally — backend not deployed yet) |
| --- | --- |
| `Total stake` tile showed only the total, no split | `56.26M` — `Root 1.22M · Alpha 55.03M`, verified end-to-end via a network-intercepted response injecting real production values (`root_stake_tao: 1224931.24`, `alpha_stake_tao: 55032093.74`) for hotkey `5E2LP6...TKeZ5u`, confirmed against that hotkey's real SN0 membership row in the per-subnet table |

## Test plan
- `npx vitest run` — 267 files, 7708 tests passing, including 4 new tests covering the split math (a hotkey with no root row, a hotkey with a real root row, both `buildGlobalValidatorEntry` and `buildValidatorDetail`)
- `npm run lint` / `npm run format:check` — clean
- `npm run validate` / `npm run validate:contract-drift` / `npm run validate:schemas` / `npm run validate:openapi` / `npm run validate:openapi-examples` — all clean
- `cd apps/ui && npx tsc --noEmit` — clean (also rebuilt `packages/client`'s gitignored type declarations locally to pick up the schema change, and fixed the resulting pre-existing `PartnershipMetadata` type-drift error the same way)
- Verified visually in the browser against the local dev server with a mocked API response carrying real production values — see screenshot table above