### PR TITLE
feat(mcp): wire the chain-*/subnet-* analytics family into the Postgres tier

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1097,6 +1097,21 @@ function mcpAccountIdentityRequest(ss58) {
   );
 }
 
+// Synthetic GET request for the neurons-tier chain-*/subnet-* analytics
+// family (concentration, performance, yield, turnover, movers + their
+// history variants) -- every one of these routes is gated on the SAME
+// METAGRAPH_NEURONS_SOURCE flag (entities.mjs's handleSubnetConcentration
+// et al. all call tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")),
+// so one shared pathname+params builder covers all of them.
+function mcpNeuronsTierRequest(pathname, params = {}) {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) qs.set(key, String(value));
+  }
+  const q = qs.toString();
+  return new Request(`https://d${pathname}${q ? `?${q}` : ""}`);
+}
+
 // Synthetic GET /api/v1/accounts/{ss58}/identity-history{...} request, same
 // limit/offset/cursor contract as mcpSubnetIdentityHistoryRequest above --
 // mirrors REST's handleAccountIdentityHistory, same
@@ -2600,9 +2615,15 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return buildConcentration([], netuid);
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/concentration`),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildConcentration([], netuid)
+      );
     },
   },
   {
@@ -2625,9 +2646,15 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return buildSubnetPerformance([], netuid);
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/performance`),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildSubnetPerformance([], netuid)
+      );
     },
   },
   {
@@ -2646,8 +2673,14 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, _ctx) {
-      return buildChainConcentration([]);
+    async handler(_args, ctx) {
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest("/api/v1/chain/concentration"),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildChainConcentration([])
+      );
     },
   },
   {
@@ -2667,8 +2700,14 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, _ctx) {
-      return buildChainPerformance([]);
+    async handler(_args, ctx) {
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest("/api/v1/chain/performance"),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildChainPerformance([])
+      );
     },
   },
   {
@@ -2730,8 +2769,14 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, _ctx) {
-      return buildChainYield([]);
+    async handler(_args, ctx) {
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest("/api/v1/chain/yield"),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildChainYield([])
+      );
     },
   },
   {
@@ -2764,7 +2809,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
       if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, window)) {
@@ -2778,12 +2823,19 @@ export const MCP_TOOLS = [
         CHAIN_TURNOVER_LIMIT_DEFAULT,
         CHAIN_TURNOVER_LIMIT_MAX,
       );
-      return buildChainTurnover([], {
-        window,
-        startDate: null,
-        endDate: null,
-        limit,
-      });
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest("/api/v1/chain/turnover", { window, limit }),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ??
+        buildChainTurnover([], {
+          window,
+          startDate: null,
+          endDate: null,
+          limit,
+        })
+      );
     },
   },
   {
@@ -3240,16 +3292,26 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
       const parsed = parseConcentrationHistoryWindow(args?.window);
       if (parsed.error) {
         throw toolError("invalid_params", parsed.error.message);
       }
-      return buildConcentrationHistory([], netuid, {
-        window: parsed.label,
-        capped: false,
-      });
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(
+            `/api/v1/subnets/${netuid}/concentration/history`,
+            { window: parsed.label },
+          ),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ??
+        buildConcentrationHistory([], netuid, {
+          window: parsed.label,
+          capped: false,
+        })
+      );
     },
   },
   {
@@ -3283,11 +3345,21 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
       const { label } = requireHistoryWindow(args);
+      const changes = optionalBoolean(args, "changes");
       const turnoverOptions = { window: label, startDate: null, endDate: null };
-      if (!optionalBoolean(args, "changes")) {
+      const postgres = await tryPostgresTier(
+        ctx.env,
+        mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/turnover`, {
+          window: label,
+          changes: changes ? "true" : undefined,
+        }),
+        "METAGRAPH_NEURONS_SOURCE",
+      );
+      if (postgres) return postgres;
+      if (!changes) {
         return buildTurnover([], netuid, turnoverOptions);
       }
       return {
@@ -3317,9 +3389,15 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return buildSubnetYield([], netuid);
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/yield`),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildSubnetYield([], netuid)
+      );
     },
   },
   {
@@ -3345,17 +3423,26 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
       const parsed = parseSubnetYieldHistoryWindow(args?.window);
       if (args?.window !== undefined && parsed.error) {
         throw toolError("invalid_params", parsed.error.message);
       }
       const { label } = parsed;
-      return buildSubnetYieldHistory([], netuid, {
-        window: label,
-        capped: false,
-      });
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/yield/history`, {
+            window: label,
+          }),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ??
+        buildSubnetYieldHistory([], netuid, {
+          window: label,
+          capped: false,
+        })
+      );
     },
   },
   {
@@ -3815,17 +3902,27 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const netuid = requireNetuid(args);
       const parsed = parseSubnetPerformanceHistoryWindow(args?.window);
       if (args?.window !== undefined && parsed.error) {
         throw toolError("invalid_params", parsed.error.message);
       }
       const { label } = parsed;
-      return buildSubnetPerformanceHistory([], netuid, {
-        window: label,
-        capped: false,
-      });
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(
+            `/api/v1/subnets/${netuid}/performance/history`,
+            { window: label },
+          ),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ??
+        buildSubnetPerformanceHistory([], netuid, {
+          window: label,
+          capped: false,
+        })
+      );
     },
   },
   {
@@ -3860,7 +3957,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const window = optionalString(args, "window") ?? DEFAULT_MOVERS_WINDOW;
       if (!Object.hasOwn(MOVERS_WINDOWS, window)) {
         throw toolError(
@@ -3880,13 +3977,24 @@ export const MCP_TOOLS = [
         MOVERS_LIMIT_DEFAULT,
         MOVERS_LIMIT_MAX,
       );
-      return buildMovers([], [], {
-        window,
-        startDate: null,
-        endDate: null,
-        sort,
-        limit,
-      });
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest("/api/v1/subnets/movers", {
+            window,
+            sort,
+            limit,
+          }),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ??
+        buildMovers([], [], {
+          window,
+          startDate: null,
+          endDate: null,
+          sort,
+          limit,
+        })
+      );
     },
   },
   {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14715,3 +14715,145 @@ describe("MCP endpoint tools — live overlay staleness fix (#5225)", () => {
     assert.equal(out.endpoints[0].status, "ok");
   });
 });
+
+// All twelve of these tools previously called their builder with []
+// unconditionally -- #4909's D1 retirement left no D1 path to route to
+// (neurons/neuron_daily are dropped), so they always served zeroed/empty
+// data in production while their REST siblings (entities.mjs's
+// handleSubnetConcentration et al.) served real Postgres data via
+// tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE"). This block
+// confirms the same wiring now reaches DATA_API at REST's exact path +
+// query params, and degrades safely to the schema-stable empty shape (never
+// isError) on any Postgres failure -- same contract as the pre-existing
+// get_subnet_identity_history/list_extrinsics Postgres-cutover blocks above.
+describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => {
+  const CASES = [
+    {
+      tool: "get_subnet_concentration",
+      args: { netuid: 7 },
+      path: "/api/v1/subnets/7/concentration",
+    },
+    {
+      tool: "get_subnet_performance",
+      args: { netuid: 7 },
+      path: "/api/v1/subnets/7/performance",
+    },
+    {
+      tool: "get_chain_concentration",
+      args: {},
+      path: "/api/v1/chain/concentration",
+    },
+    {
+      tool: "get_chain_performance",
+      args: {},
+      path: "/api/v1/chain/performance",
+    },
+    {
+      tool: "get_chain_yield",
+      args: {},
+      path: "/api/v1/chain/yield",
+    },
+    {
+      tool: "get_subnet_yield",
+      args: { netuid: 7 },
+      path: "/api/v1/subnets/7/yield",
+    },
+    {
+      tool: "get_subnet_concentration_history",
+      args: { netuid: 7, window: "30d" },
+      path: "/api/v1/subnets/7/concentration/history?window=30d",
+    },
+    {
+      tool: "get_subnet_performance_history",
+      args: { netuid: 7, window: "30d" },
+      path: "/api/v1/subnets/7/performance/history?window=30d",
+    },
+    {
+      tool: "get_subnet_yield_history",
+      args: { netuid: 7, window: "30d" },
+      path: "/api/v1/subnets/7/yield/history?window=30d",
+    },
+    {
+      tool: "get_subnet_turnover",
+      args: { netuid: 7, window: "30d" },
+      path: "/api/v1/subnets/7/turnover?window=30d",
+    },
+    {
+      tool: "get_subnet_turnover",
+      args: { netuid: 7, window: "30d", changes: true },
+      path: "/api/v1/subnets/7/turnover?window=30d&changes=true",
+    },
+    {
+      tool: "get_chain_turnover",
+      args: { window: "30d" },
+      path: "/api/v1/chain/turnover?window=30d&limit=20",
+    },
+    {
+      tool: "get_subnet_movers",
+      args: {},
+      path: "/api/v1/subnets/movers?window=30d&sort=stake&limit=20",
+    },
+  ];
+
+  for (const { tool, args, path } of CASES) {
+    const label = path.includes("changes=true")
+      ? `${tool} (changes=true)`
+      : tool;
+
+    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
+      let captured;
+      const env = {
+        METAGRAPH_NEURONS_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (req) => {
+            const reqUrl = new URL(req.url);
+            captured = reqUrl.pathname + reqUrl.search;
+            return Response.json({
+              schema_version: 1,
+              marker: "from-postgres",
+            });
+          },
+        },
+      };
+      const res = await callTool(tool, args, { env });
+      assert.equal(res.body.result.isError, false, label);
+      assert.equal(
+        res.body.result.structuredContent.marker,
+        "from-postgres",
+        label,
+      );
+      assert.equal(captured, path, label);
+    });
+
+    test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
+      const env = {
+        METAGRAPH_NEURONS_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async () => {
+            throw new Error("boom");
+          },
+        },
+      };
+      const res = await callTool(tool, args, { env });
+      assert.equal(res.body.result.isError, false, label);
+      assert.equal(res.body.result.structuredContent.marker, undefined, label);
+    });
+  }
+
+  test("flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () =>
+          Response.json({ schema_version: 1, marker: "should-not-be-used" }),
+      },
+    };
+    for (const { tool, args } of CASES) {
+      const res = await callTool(tool, args, { env });
+      assert.equal(
+        res.body.result.structuredContent.marker,
+        undefined,
+        `${tool} should not reach DATA_API without the flag`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- 12 MCP tools in the concentration/performance/yield/turnover/movers analytics family called their builder with an empty array unconditionally (`get_subnet_concentration`, `get_subnet_performance`, `get_chain_concentration`, `get_chain_performance`, `get_chain_yield`, `get_subnet_yield`, `get_subnet_concentration_history`, `get_subnet_performance_history`, `get_subnet_yield_history`, `get_subnet_turnover`, `get_chain_turnover`, `get_subnet_movers`) — meaning they always returned zeroed/empty data in production, while their REST siblings in `entities.mjs` served real live data via `tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")`.
- Wired each tool through the same flag with a synthetic request matching REST's exact path and query params, falling back to the same schema-stable empty shape on any Postgres failure — same contract as the existing `get_subnet_identity_history`/`list_extrinsics` Postgres-cutover tools.
- Added a shared `mcpNeuronsTierRequest(pathname, params)` helper since all 12 routes share one flag.

Closes #5258

## Test plan

- `npm run lint` — clean
- `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs` — clean
- `npm run build` — clean (only the expected `DEPLOY_OWNED_ARTIFACTS` auto-revert)
- `npx vitest run tests/mcp-server.test.mjs` — 772/772 passed (27 new: Postgres-success + Postgres-failure-fallback per tool, plus a flag-absent/unflipped regression check)
- `npm run test:coverage` (full unsharded suite) — 267/267 test files, 7782/7782 tests passed