### PR TITLE
feat(registry): add SN38 ChronoLLM (ChronoGPT) backend OpenAPI schema surface

### DIFF
--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -79,6 +79,27 @@
         "https://taomarketcap.com/subnets/38"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/38"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-38-chronogpt-backend-openapi",
+      "kind": "openapi",
+      "name": "SN38 ChronoGPT Backend OpenAPI schema",
+      "notes": "Public no-auth OpenAPI 3.1.0 schema (info.title \"SN38 ChronoGPT Backend\", 12 paths) auto-served by the ChronoLLM (SN38) backend at api.chronollm.com (FastAPI /openapi.json; Swagger UI at /docs). The official chronollm/sn38 miner docs reference this same host and endpoints (api.chronollm.com/docs, /rounds/current, /submissions/{round}/{uid}), tying it to the subnet. The spec declares no securitySchemes and documents the public round/submission/eval read endpoints. Distinct from the existing miner-docs and data-artifact surfaces on this manifest.",
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.chronollm.com/openapi.json",
+      "source_urls": [
+        "https://github.com/chronollm/sn38/blob/main/docs/miner.md",
+        "https://api.chronollm.com/openapi.json"
+      ],
+      "url": "https://api.chronollm.com/openapi.json"
     }
   ],
   "source_repo": "https://github.com/chronollm/sn38",


### PR DESCRIPTION
## Add or update a subnet surface

Appends one `openapi` surface to `registry/subnets/chronollm.json` (SN38 ChronoLLM). Append-only — the manifest already existed on the base branch. One file, `+21 −0`.

Closes #4040

## Surface

- Netuid: 38
- Kind: openapi
- Public URL: https://api.chronollm.com/openapi.json
- Source URL (proves the claim): https://github.com/chronollm/sn38/blob/main/docs/miner.md
- Provider slug: tao-colosseum

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Lands `authority: community` and `review.state: community-submitted` (same shape `surface:add` produces; hand-appended to keep the diff key-order-stable and additive).
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #4040`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/chronollm.json` — passed (5 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --check` — clean

## Notes

- `https://api.chronollm.com/openapi.json` returns HTTP 200 `application/json`, a valid **OpenAPI 3.1.0** document (`info.title` = "SN38 ChronoGPT Backend", 12 paths, no `securitySchemes`), fetched from a clean no-auth context — the spec is public and unauthenticated.
- First-party: the subnet's own `chronollm/sn38` miner docs reference this exact host and endpoints (`api.chronollm.com/docs`, `/rounds/current`, `/submissions/{round}/{uid}`); `source_repo` on the manifest is already `github.com/chronollm/sn38`.
- `provider: tao-colosseum` is the registered slug already used by every existing SN38 surface (SN38 ChronoLLM is a CrunchDAO / TAO Colosseum subnet).
- Fills a real gap: the manifest previously had only docs + data-artifact + on-chain-snapshot surfaces and no machine-readable schema.
