### PR TITLE
feat(api): join on-chain identity into the validator directory

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4273,6 +4273,21 @@ export interface components {
         });
         /** @enum {unknown} */
         Classification: "live" | "redirected" | "auth-required" | "dead" | "unsafe" | "unsupported" | "rate-limited" | "transient" | "timeout" | "content-mismatch" | "wrong-chain" | "unknown";
+        /** @description Self-declared on-chain identity (SubtensorModule::set_identity) for a `coldkey`, joined server-side (#5234) -- see the hotkey/coldkey caveat: this is NOT hotkey-specific. A single `coldkey` can run multiple hotkeys across different validators and subnets, so the same identity can appear on more than one leaderboard row, and it says nothing about how any one hotkey brands itself. has_identity is false, and every other field null, for the common case of a `coldkey` that has never called set_identity. Operator-controlled untrusted data. */
+        ColdkeyIdentity: {
+            additional?: string | null;
+            /** Format: date-time */
+            captured_at?: string | null;
+            description?: string | null;
+            discord?: string | null;
+            github?: string | null;
+            has_identity: boolean;
+            /** Format: uri */
+            image?: string | null;
+            name?: string | null;
+            /** Format: uri */
+            url?: string | null;
+        };
         CompareArtifact: {
             dimensions?: string[];
             observed_at?: string | null;
@@ -4931,6 +4946,8 @@ export interface components {
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
+            /** @description The row's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat. */
+            coldkey_identity: components["schemas"]["ColdkeyIdentity"] | null;
             featured: boolean;
             hotkey: string;
             latest_block_number: number | null;
@@ -7600,6 +7617,8 @@ export interface components {
             captured_at: string | null;
             coldkey: string | null;
             coldkey_count: number;
+            /** @description The validator's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat. */
+            coldkey_identity: components["schemas"]["ColdkeyIdentity"] | null;
             hotkey: string;
             max_validator_trust: number | null;
             schema_version: number;
@@ -28335,6 +28354,9 @@ export interface operations {
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
+                     *             "coldkey_identity": {
+                     *               "has_identity": false
+                     *             },
                      *             "featured": false,
                      *             "hotkey": "example",
                      *             "latest_block_number": 5000000,
@@ -28467,6 +28489,17 @@ export interface operations {
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
                      *         "coldkey": "example",
                      *         "coldkey_count": 1,
+                     *         "coldkey_identity": {
+                     *           "additional": "example",
+                     *           "captured_at": "2026-06-01T00:00:00.000Z",
+                     *           "description": "Example description.",
+                     *           "discord": "example",
+                     *           "github": "example",
+                     *           "has_identity": false,
+                     *           "image": "https://api.metagraph.sh/example",
+                     *           "name": "Example Subnet",
+                     *           "url": "https://api.metagraph.sh/example"
+                     *         },
                      *         "hotkey": "example",
                      *         "max_validator_trust": 0.5,
                      *         "schema_version": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6904,6 +6904,71 @@
           "unknown"
         ]
       },
+      "ColdkeyIdentity": {
+        "additionalProperties": false,
+        "description": "Self-declared on-chain identity (SubtensorModule::set_identity) for a `coldkey`, joined server-side (#5234) -- see the hotkey/coldkey caveat: this is NOT hotkey-specific. A single `coldkey` can run multiple hotkeys across different validators and subnets, so the same identity can appear on more than one leaderboard row, and it says nothing about how any one hotkey brands itself. has_identity is false, and every other field null, for the common case of a `coldkey` that has never called set_identity. Operator-controlled untrusted data.",
+        "properties": {
+          "additional": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "captured_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "discord": {
+            "maxLength": 200,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "github": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_identity": {
+            "type": "boolean"
+          },
+          "image": {
+            "format": "uri",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "format": "uri",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "has_identity"
+        ],
+        "type": "object"
+      },
       "CompareArtifact": {
         "additionalProperties": true,
         "properties": {
@@ -9675,6 +9740,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "coldkey_identity": {
+            "description": "The row's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ColdkeyIdentity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "featured": {
             "type": "boolean"
           },
@@ -9743,6 +9819,7 @@
           "hotkey",
           "featured",
           "coldkey",
+          "coldkey_identity",
           "coldkey_count",
           "subnet_count",
           "uid_count",
@@ -20771,6 +20848,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "coldkey_identity": {
+            "description": "The validator's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ColdkeyIdentity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "hotkey": {
             "type": "string"
           },
@@ -20813,6 +20901,7 @@
           "schema_version",
           "hotkey",
           "coldkey",
+          "coldkey_identity",
           "coldkey_count",
           "subnet_count",
           "take",
@@ -51407,6 +51496,9 @@
                         "avg_validator_trust": 0.5,
                         "coldkey": "example",
                         "coldkey_count": 1,
+                        "coldkey_identity": {
+                          "has_identity": false
+                        },
                         "featured": false,
                         "hotkey": "example",
                         "latest_block_number": 5000000,
@@ -51566,6 +51658,17 @@
                     "captured_at": "2026-06-01T00:00:00.000Z",
                     "coldkey": "example",
                     "coldkey_count": 1,
+                    "coldkey_identity": {
+                      "additional": "example",
+                      "captured_at": "2026-06-01T00:00:00.000Z",
+                      "description": "Example description.",
+                      "discord": "example",
+                      "github": "example",
+                      "has_identity": false,
+                      "image": "https://api.metagraph.sh/example",
+                      "name": "Example Subnet",
+                      "url": "https://api.metagraph.sh/example"
+                    },
                     "hotkey": "example",
                     "max_validator_trust": 0.5,
                     "schema_version": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4273,6 +4273,21 @@ export interface components {
         });
         /** @enum {unknown} */
         Classification: "live" | "redirected" | "auth-required" | "dead" | "unsafe" | "unsupported" | "rate-limited" | "transient" | "timeout" | "content-mismatch" | "wrong-chain" | "unknown";
+        /** @description Self-declared on-chain identity (SubtensorModule::set_identity) for a `coldkey`, joined server-side (#5234) -- see the hotkey/coldkey caveat: this is NOT hotkey-specific. A single `coldkey` can run multiple hotkeys across different validators and subnets, so the same identity can appear on more than one leaderboard row, and it says nothing about how any one hotkey brands itself. has_identity is false, and every other field null, for the common case of a `coldkey` that has never called set_identity. Operator-controlled untrusted data. */
+        ColdkeyIdentity: {
+            additional?: string | null;
+            /** Format: date-time */
+            captured_at?: string | null;
+            description?: string | null;
+            discord?: string | null;
+            github?: string | null;
+            has_identity: boolean;
+            /** Format: uri */
+            image?: string | null;
+            name?: string | null;
+            /** Format: uri */
+            url?: string | null;
+        };
         CompareArtifact: {
             dimensions?: string[];
             observed_at?: string | null;
@@ -4931,6 +4946,8 @@ export interface components {
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
+            /** @description The row's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat. */
+            coldkey_identity: components["schemas"]["ColdkeyIdentity"] | null;
             featured: boolean;
             hotkey: string;
             latest_block_number: number | null;
@@ -7600,6 +7617,8 @@ export interface components {
             captured_at: string | null;
             coldkey: string | null;
             coldkey_count: number;
+            /** @description The validator's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat. */
+            coldkey_identity: components["schemas"]["ColdkeyIdentity"] | null;
             hotkey: string;
             max_validator_trust: number | null;
             schema_version: number;
@@ -28335,6 +28354,9 @@ export interface operations {
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
+                     *             "coldkey_identity": {
+                     *               "has_identity": false
+                     *             },
                      *             "featured": false,
                      *             "hotkey": "example",
                      *             "latest_block_number": 5000000,
@@ -28467,6 +28489,17 @@ export interface operations {
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
                      *         "coldkey": "example",
                      *         "coldkey_count": 1,
+                     *         "coldkey_identity": {
+                     *           "additional": "example",
+                     *           "captured_at": "2026-06-01T00:00:00.000Z",
+                     *           "description": "Example description.",
+                     *           "discord": "example",
+                     *           "github": "example",
+                     *           "has_identity": false,
+                     *           "image": "https://api.metagraph.sh/example",
+                     *           "name": "Example Subnet",
+                     *           "url": "https://api.metagraph.sh/example"
+                     *         },
                      *         "hotkey": "example",
                      *         "max_validator_trust": 0.5,
                      *         "schema_version": 1,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -6890,6 +6890,71 @@
           "unknown"
         ]
       },
+      "ColdkeyIdentity": {
+        "additionalProperties": false,
+        "description": "Self-declared on-chain identity (SubtensorModule::set_identity) for a `coldkey`, joined server-side (#5234) -- see the hotkey/coldkey caveat: this is NOT hotkey-specific. A single `coldkey` can run multiple hotkeys across different validators and subnets, so the same identity can appear on more than one leaderboard row, and it says nothing about how any one hotkey brands itself. has_identity is false, and every other field null, for the common case of a `coldkey` that has never called set_identity. Operator-controlled untrusted data.",
+        "properties": {
+          "additional": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "captured_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "discord": {
+            "maxLength": 200,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "github": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_identity": {
+            "type": "boolean"
+          },
+          "image": {
+            "format": "uri",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "format": "uri",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "has_identity"
+        ],
+        "type": "object"
+      },
       "CompareArtifact": {
         "additionalProperties": true,
         "properties": {
@@ -9653,6 +9718,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "coldkey_identity": {
+            "description": "The row's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ColdkeyIdentity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "featured": {
             "type": "boolean"
           },
@@ -9721,6 +9797,7 @@
           "hotkey",
           "featured",
           "coldkey",
+          "coldkey_identity",
           "coldkey_count",
           "subnet_count",
           "uid_count",
@@ -20749,6 +20826,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "coldkey_identity": {
+            "description": "The validator's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ColdkeyIdentity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "hotkey": {
             "type": "string"
           },
@@ -20791,6 +20879,7 @@
           "schema_version",
           "hotkey",
           "coldkey",
+          "coldkey_identity",
           "coldkey_count",
           "subnet_count",
           "take",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1992,6 +1992,23 @@
           "validator_trust": { "type": ["number", "null"] }
         }
       },
+      "ColdkeyIdentity": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Self-declared on-chain identity (SubtensorModule::set_identity) for a `coldkey`, joined server-side (#5234) -- see the hotkey/coldkey caveat: this is NOT hotkey-specific. A single `coldkey` can run multiple hotkeys across different validators and subnets, so the same identity can appear on more than one leaderboard row, and it says nothing about how any one hotkey brands itself. has_identity is false, and every other field null, for the common case of a `coldkey` that has never called set_identity. Operator-controlled untrusted data.",
+        "required": ["has_identity"],
+        "properties": {
+          "has_identity": { "type": "boolean" },
+          "name": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"], "format": "uri" },
+          "github": { "type": ["string", "null"] },
+          "image": { "type": ["string", "null"], "format": "uri" },
+          "discord": { "type": ["string", "null"], "maxLength": 200 },
+          "description": { "type": ["string", "null"] },
+          "additional": { "type": ["string", "null"] },
+          "captured_at": { "type": ["string", "null"], "format": "date-time" }
+        }
+      },
       "GlobalValidatorEntry": {
         "type": "object",
         "additionalProperties": false,
@@ -2000,6 +2017,7 @@
           "hotkey",
           "featured",
           "coldkey",
+          "coldkey_identity",
           "coldkey_count",
           "subnet_count",
           "uid_count",
@@ -2017,6 +2035,13 @@
           "hotkey": { "type": "string" },
           "featured": { "type": "boolean" },
           "coldkey": { "type": ["string", "null"] },
+          "coldkey_identity": {
+            "description": "The row's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/ColdkeyIdentity" },
+              { "type": "null" }
+            ]
+          },
           "coldkey_count": { "type": "integer", "minimum": 0 },
           "subnet_count": { "type": "integer", "minimum": 0 },
           "uid_count": { "type": "integer", "minimum": 0 },
@@ -2217,6 +2242,7 @@
           "schema_version",
           "hotkey",
           "coldkey",
+          "coldkey_identity",
           "coldkey_count",
           "subnet_count",
           "take",
@@ -2232,6 +2258,13 @@
           "schema_version": { "type": "integer" },
           "hotkey": { "type": "string" },
           "coldkey": { "type": ["string", "null"] },
+          "coldkey_identity": {
+            "description": "The validator's primary `coldkey`'s self-declared identity, joined server-side from account_identity; null only when `coldkey` is null. See ColdkeyIdentity for the hotkey/coldkey caveat.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/ColdkeyIdentity" },
+              { "type": "null" }
+            ]
+          },
           "coldkey_count": { "type": "integer", "minimum": 0 },
           "subnet_count": { "type": "integer", "minimum": 0 },
           "take": {

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -5,6 +5,8 @@
 // Pure + exported for tests; the Worker handlers run the D1 or Postgres query
 // and call these builders.
 
+import { buildAccountIdentity, IDENTITY_FIELDS } from "./account-identity.mjs";
+
 // The columns the handlers SELECT for a neuron row.
 export const NEURON_COLUMNS =
   "uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, " +
@@ -250,7 +252,28 @@ function primaryColdkey(coldkeys) {
   return ranked[0]?.[0] ?? null;
 }
 
-function buildGlobalValidatorEntry(entry) {
+// The coldkey's own self-declared identity (#5234), joined by `coldkey` --
+// NOT the hotkey's. `identityByColdkey` is a coldkey -> account_identity row
+// Map built by the caller (empty by default, so every existing D1 call site
+// below that never passes one gets a stable "no identity" shape rather than
+// an omitted field). Reuses buildAccountIdentity's own has_identity/sanitize
+// logic and IDENTITY_FIELDS's field list (single source of truth with the
+// /accounts/{ss58}/identity artifact) rather than re-deriving it, dropping
+// only that artifact's own schema_version/account (redundant here -- the
+// caller already knows which coldkey this is).
+function coldkeyIdentity(coldkey, identityByColdkey) {
+  if (!coldkey) return null;
+  const full = buildAccountIdentity(
+    identityByColdkey.get(coldkey) ?? null,
+    coldkey,
+  );
+  const identity = { has_identity: full.has_identity };
+  for (const field of IDENTITY_FIELDS) identity[field] = full[field];
+  identity.captured_at = full.captured_at;
+  return identity;
+}
+
+function buildGlobalValidatorEntry(entry, identityByColdkey) {
   const avgTrust =
     entry.validatorTrustCount > 0
       ? entry.validatorTrustTotal / entry.validatorTrustCount
@@ -264,10 +287,12 @@ function buildGlobalValidatorEntry(entry) {
         a.uid - b.uid,
     )
     .slice(0, GLOBAL_VALIDATOR_SUBNET_LIMIT);
+  const coldkey = primaryColdkey(entry.coldkeys);
   return {
     hotkey: entry.hotkey,
     featured: entry.featured === true,
-    coldkey: primaryColdkey(entry.coldkeys),
+    coldkey,
+    coldkey_identity: coldkeyIdentity(coldkey, identityByColdkey),
     coldkey_count: entry.coldkeys.size,
     subnet_count: entry.netuids.size,
     uid_count: entry.uidCount,
@@ -310,6 +335,7 @@ export function buildGlobalValidators(
     sort = DEFAULT_GLOBAL_VALIDATOR_SORT,
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
     featuredHotkeys = new Set(),
+    identityByColdkey = new Map(),
   } = {},
 ) {
   const normalizedSort = GLOBAL_VALIDATOR_SORTS.includes(sort)
@@ -417,7 +443,12 @@ export function buildGlobalValidators(
   }
 
   const validators = applyStakeDominance(
-    [...validatorsByHotkey.values()].map(buildGlobalValidatorEntry),
+    // Wrapped (not a bare `.map(buildGlobalValidatorEntry)`) so Array#map's
+    // index arg never lands in buildGlobalValidatorEntry's identityByColdkey
+    // parameter -- same landmine formatNeuron's own header comment documents.
+    [...validatorsByHotkey.values()].map((entry) =>
+      buildGlobalValidatorEntry(entry, identityByColdkey),
+    ),
   ).sort(
     (a, b) =>
       validatorSortValue(b, normalizedSort) -
@@ -513,6 +544,12 @@ export async function loadSubnetValidators(d1, netuid) {
   return buildSubnetValidators(rows, netuid);
 }
 
+// No identityByColdkey passed here (#5234): account_identity's D1 write path
+// is retired -- Postgres is the only actively-written copy -- so this D1
+// fallback deliberately serves a stable coldkey_identity:{has_identity:false,
+// ...} shape rather than joining a frozen/stale D1 copy. The live route
+// (workers/data-api.mjs's /api/v1/validators, Postgres-backed) is what
+// actually joins.
 export async function loadGlobalValidators(
   d1,
   {
@@ -546,7 +583,11 @@ export async function loadNeuron(d1, netuid, uid) {
 // full per-subnet Neuron detail (not the leaderboard's 5-field/top-10-capped
 // GlobalValidatorSubnet slice) since a detail page's whole point is the full
 // per-subnet performance table.
-export function buildValidatorDetail(rows, hotkey) {
+export function buildValidatorDetail(
+  rows,
+  hotkey,
+  { identityByColdkey = new Map() } = {},
+) {
   const coldkeys = new Map();
   let stakeTotalRao = 0n;
   let emissionTotalRao = 0n;
@@ -604,11 +645,13 @@ export function buildValidatorDetail(rows, hotkey) {
   const avgTrust =
     validatorTrustCount > 0 ? validatorTrustTotal / validatorTrustCount : null;
   subnets.sort((a, b) => a.netuid - b.netuid || a.uid - b.uid);
+  const coldkey = primaryColdkey(coldkeys);
 
   return {
     schema_version: 1,
     hotkey,
-    coldkey: primaryColdkey(coldkeys),
+    coldkey,
+    coldkey_identity: coldkeyIdentity(coldkey, identityByColdkey),
     coldkey_count: coldkeys.size,
     subnet_count: subnets.length,
     take: round(take),
@@ -622,6 +665,7 @@ export function buildValidatorDetail(rows, hotkey) {
   };
 }
 
+// No identityByColdkey passed here either -- see loadGlobalValidators' comment.
 export async function loadValidatorDetail(d1, hotkey) {
   const rows = await d1(
     `SELECT ${NEURON_COLUMNS}, netuid FROM neurons WHERE hotkey = ? AND validator_permit = 1 ORDER BY netuid ASC, uid ASC`,

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1546,6 +1546,15 @@ test("GET /api/v1/validators skips the identity join query when there are no val
   expect(queryText()).not.toMatch(/FROM account_identity WHERE account IN/);
 });
 
+test("GET /api/v1/validators skips a row with no coldkey when collecting join keys, without erroring (#5234)", async () => {
+  mockRows.current = [{ ...NEURON_ROW, netuid: 7, coldkey: null }];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validators[0].coldkey_identity).toBe(null);
+  expect(queryText()).not.toMatch(/FROM account_identity WHERE account IN/);
+});
+
 test("GET /api/v1/validators still serves validators (has_identity:false) when the identity join query fails (#5234)", async () => {
   mockRows.current = [{ ...NEURON_ROW, netuid: 7 }];
   accountIdentityJoinQueryFailure.error = new Error(

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -79,6 +79,13 @@ const rpcUsageSyncFailure = vi.hoisted(() => ({ error: null }));
 // simulate the table not existing yet (pre-migration) without touching any
 // other query's mock plumbing.
 const featuredValidatorsQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for the /api/v1/validators + /api/v1/validators/:hotkey
+// account_identity join (#5234) tests only. Dispatched by its own text match
+// (like the DELETE FROM neurons / DELETE FROM subnet_hyperparams sql.unsafe
+// branches below) rather than the shared mockQueue, so priming it never
+// shifts any existing validators test's mockQueue-ordering assumptions.
+const accountIdentityJoinRows = vi.hoisted(() => ({ current: [] }));
+const accountIdentityJoinQueryFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -215,6 +222,12 @@ vi.mock("postgres", () => ({
       if (/DELETE FROM subnet_hyperparams\b/.test(text)) {
         return Promise.resolve(subnetHyperparamsPruneRows.current);
       }
+      if (/FROM account_identity WHERE account IN/.test(text)) {
+        if (accountIdentityJoinQueryFailure.error) {
+          return Promise.reject(accountIdentityJoinQueryFailure.error);
+        }
+        return Promise.resolve(accountIdentityJoinRows.current);
+      }
       return Promise.resolve(mockRows.current);
     };
     // sql.begin(["read only",] cb) reserves a connection for cb in real
@@ -301,6 +314,8 @@ beforeEach(() => {
   healthUptimeRollupSyncFailure.error = null;
   rpcUsageSyncFailure.error = null;
   featuredValidatorsQueryFailure.error = null;
+  accountIdentityJoinRows.current = [];
+  accountIdentityJoinQueryFailure.error = null;
   mockRows.current = [
     {
       block_number: "123",
@@ -1485,6 +1500,64 @@ test("GET /api/v1/validators falls back to the default sort/limit on invalid val
   expect(body.limit).toBe(20);
 });
 
+const IDENTITY_ROW = {
+  account: "5Cold",
+  name: "Acme Validators",
+  url: "https://acme-validators.io",
+  github: "https://github.com/acme-validators",
+  image: "https://acme-validators.io/logo.png",
+  discord: "acme#1234",
+  description: "Professional validator operator",
+  additional: "Est. 2023",
+  captured_at: "1750000000000",
+};
+
+test("GET /api/v1/validators joins coldkey_identity from account_identity by coldkey (#5234)", async () => {
+  mockRows.current = [{ ...NEURON_ROW, netuid: 7 }];
+  accountIdentityJoinRows.current = [IDENTITY_ROW];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validators[0].coldkey).toBe("5Cold");
+  expect(body.validators[0].coldkey_identity.has_identity).toBe(true);
+  expect(body.validators[0].coldkey_identity.name).toBe("Acme Validators");
+  expect(queryText()).toMatch(
+    /FROM account_identity WHERE account IN \(\$1::text\)/,
+  );
+  const joinCall = sqlCalls.find((call) =>
+    /FROM account_identity WHERE account IN/.test(call.text),
+  );
+  expect(joinCall.values).toEqual(["5Cold"]);
+});
+
+test("GET /api/v1/validators reports has_identity:false when no account_identity row matches the coldkey (#5234)", async () => {
+  mockRows.current = [{ ...NEURON_ROW, netuid: 7 }];
+  accountIdentityJoinRows.current = [];
+  const res = await req("/api/v1/validators");
+  const body = await res.json();
+  expect(body.validators[0].coldkey_identity.has_identity).toBe(false);
+  expect(body.validators[0].coldkey_identity.name).toBe(null);
+});
+
+test("GET /api/v1/validators skips the identity join query when there are no validator rows (#5234)", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  expect(queryText()).not.toMatch(/FROM account_identity WHERE account IN/);
+});
+
+test("GET /api/v1/validators still serves validators (has_identity:false) when the identity join query fails (#5234)", async () => {
+  mockRows.current = [{ ...NEURON_ROW, netuid: 7 }];
+  accountIdentityJoinQueryFailure.error = new Error(
+    'relation "account_identity" does not exist',
+  );
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validators[0].hotkey).toBe("5Hot");
+  expect(body.validators[0].coldkey_identity.has_identity).toBe(false);
+});
+
 test("GET /api/v1/validators/:hotkey resolves cross-subnet validator detail", async () => {
   mockRows.current = [{ ...NEURON_ROW, netuid: 7 }];
   const res = await req("/api/v1/validators/5Hot");
@@ -1495,6 +1568,44 @@ test("GET /api/v1/validators/:hotkey resolves cross-subnet validator detail", as
   expect(body.subnets[0].netuid).toBe(7);
   expect(queryText()).toMatch(/WHERE hotkey = /);
   expect(queryText()).toMatch(/validator_permit = TRUE/);
+});
+
+test("GET /api/v1/validators/:hotkey joins coldkey_identity for its primary coldkey (#5234)", async () => {
+  mockRows.current = [{ ...NEURON_ROW, netuid: 7 }];
+  accountIdentityJoinRows.current = [IDENTITY_ROW];
+  const res = await req("/api/v1/validators/5Hot");
+  const body = await res.json();
+  expect(body.coldkey).toBe("5Cold");
+  expect(body.coldkey_identity.has_identity).toBe(true);
+  expect(body.coldkey_identity.description).toBe(
+    "Professional validator operator",
+  );
+});
+
+test("GET /api/v1/validators/:hotkey sends one deduped identity lookup when every subnet row shares the same coldkey (#5234)", async () => {
+  mockRows.current = [
+    { ...NEURON_ROW, netuid: 7 },
+    { ...NEURON_ROW, netuid: 12 },
+  ];
+  accountIdentityJoinRows.current = [IDENTITY_ROW];
+  const res = await req("/api/v1/validators/5Hot");
+  const body = await res.json();
+  expect(body.subnet_count).toBe(2);
+  expect(body.coldkey_identity.has_identity).toBe(true);
+  const joinCalls = sqlCalls.filter((call) =>
+    /FROM account_identity WHERE account IN/.test(call.text),
+  );
+  expect(joinCalls.length).toBe(1);
+  expect(joinCalls[0].values).toEqual(["5Cold"]);
+});
+
+test("GET /api/v1/validators/:hotkey for an absent hotkey has coldkey_identity:null (no coldkey to look up) and skips the join query (#5234)", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/validators/${SS58}`);
+  const body = await res.json();
+  expect(body.coldkey).toBe(null);
+  expect(body.coldkey_identity).toBe(null);
+  expect(queryText()).not.toMatch(/FROM account_identity WHERE account IN/);
 });
 
 // #4832 Tier 2: the live-`neurons` routes with no shared D1 loader (the

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -794,6 +794,7 @@ describe("metagraph-neurons builders", () => {
     const empty = buildValidatorDetail(null, "hk-cold");
     assert.equal(empty.hotkey, "hk-cold");
     assert.equal(empty.coldkey, null);
+    assert.equal(empty.coldkey_identity, null);
     assert.equal(empty.coldkey_count, 0);
     assert.equal(empty.subnet_count, 0);
     assert.equal(empty.total_stake_tao, 0);
@@ -976,6 +977,100 @@ describe("metagraph-neurons builders", () => {
   test("buildNeuronDetail returns neuron:null for a cold/absent row", () => {
     assert.equal(buildNeuronDetail(null, 7).neuron, null);
     assert.equal(buildNeuronDetail(ROW, 7).neuron.uid, 0);
+  });
+
+  // #5234: server-side coldkey -> account_identity join, exposed as
+  // coldkey_identity on both GlobalValidatorEntry and ValidatorDetailArtifact.
+  const IDENTITY_ROW = {
+    name: "Acme Validators",
+    url: "https://acme-validators.io",
+    github: "https://github.com/acme-validators",
+    image: "https://acme-validators.io/logo.png",
+    discord: "acme#1234",
+    description: "Professional validator operator",
+    additional: "Est. 2023",
+    captured_at: 1750000000000,
+  };
+
+  test("buildGlobalValidators joins coldkey_identity by coldkey, not hotkey -- shared across two hotkeys (#5234)", () => {
+    const identityByColdkey = new Map([["ck-shared", IDENTITY_ROW]]);
+    const data = buildGlobalValidators(
+      [
+        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", coldkey: "ck-shared" },
+        { ...ROW, netuid: 2, uid: 0, hotkey: "hk-b", coldkey: "ck-shared" },
+      ],
+      { identityByColdkey },
+    );
+    const byHotkey = Object.fromEntries(
+      data.validators.map((v) => [v.hotkey, v.coldkey_identity]),
+    );
+    for (const hotkey of ["hk-a", "hk-b"]) {
+      assert.equal(byHotkey[hotkey].has_identity, true);
+      assert.equal(byHotkey[hotkey].name, "Acme Validators");
+      assert.equal(byHotkey[hotkey].url, "https://acme-validators.io/");
+      assert.equal(byHotkey[hotkey].discord, "acme#1234");
+      assert.equal(
+        byHotkey[hotkey].captured_at,
+        new Date(1750000000000).toISOString(),
+      );
+      // schema_version/account are AccountIdentityArtifact-only -- redundant
+      // once nested under a row that already states its own coldkey.
+      assert.equal(byHotkey[hotkey].schema_version, undefined);
+      assert.equal(byHotkey[hotkey].account, undefined);
+    }
+  });
+
+  test("buildGlobalValidators reports a has_identity:false shape (never omitted) when the coldkey has no identity row (#5234)", () => {
+    const data = buildGlobalValidators([
+      { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", coldkey: "ck-no-identity" },
+    ]);
+    const identity = data.validators[0].coldkey_identity;
+    assert.equal(identity.has_identity, false);
+    assert.equal(identity.name, null);
+    assert.equal(identity.url, null);
+    assert.equal(identity.github, null);
+    assert.equal(identity.image, null);
+    assert.equal(identity.discord, null);
+    assert.equal(identity.description, null);
+    assert.equal(identity.additional, null);
+    assert.equal(identity.captured_at, null);
+  });
+
+  test("buildGlobalValidators sets coldkey_identity null only when coldkey itself is null (#5234)", () => {
+    const identityByColdkey = new Map([["ck-shared", IDENTITY_ROW]]);
+    const data = buildGlobalValidators(
+      [{ ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", coldkey: "" }],
+      { identityByColdkey },
+    );
+    assert.equal(data.validators[0].coldkey, null);
+    assert.equal(data.validators[0].coldkey_identity, null);
+  });
+
+  test("buildValidatorDetail joins coldkey_identity for its primary coldkey (#5234)", () => {
+    const identityByColdkey = new Map([["ck-a", IDENTITY_ROW]]);
+    const data = buildValidatorDetail(
+      [{ ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", coldkey: "ck-a" }],
+      "hk-a",
+      { identityByColdkey },
+    );
+    assert.equal(data.coldkey, "ck-a");
+    assert.equal(data.coldkey_identity.has_identity, true);
+    assert.equal(data.coldkey_identity.name, "Acme Validators");
+    assert.equal(
+      data.coldkey_identity.description,
+      "Professional validator operator",
+    );
+  });
+
+  test("buildValidatorDetail reports has_identity:false when identityByColdkey has no row for the coldkey (#5234)", () => {
+    const data = buildValidatorDetail(
+      [{ ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", coldkey: "ck-a" }],
+      "hk-a",
+      { identityByColdkey: new Map([["ck-other", IDENTITY_ROW]]) },
+    );
+    assert.equal(data.coldkey, "ck-a");
+    assert.equal(data.coldkey_identity.has_identity, false);
+    assert.equal(data.coldkey_identity.name, null);
   });
 });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -905,6 +905,7 @@ describe("handleGlobalValidators", () => {
       hotkey: "hk-a",
       featured: false,
       coldkey: null,
+      coldkey_identity: null,
       coldkey_count: 0,
       subnet_count: 1,
       uid_count: 1,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2321,6 +2321,43 @@ async function loadFeaturedHotkeys(sql) {
   }
 }
 
+// account_identity rows keyed by coldkey, for the /api/v1/validators and
+// /api/v1/validators/:hotkey identity join (#5234). Same sql.savepoint
+// resilience as loadFeaturedHotkeys just above (enrichment data; its own
+// failure must never sink the primary validator response) and the same
+// scalar-positional-bind sql.unsafe shape as the /api/v1/internal/
+// compare-health route's coldkeys IN (...) query above -- this Worker's
+// Hyperdrive fetch_types:false setting breaks postgres.js's automatic
+// ARRAY-literal serialization for a bound JS array (ANY($1)), so every IN
+// clause here builds its own scalar placeholder list instead.
+async function loadAccountIdentitiesByColdkey(sql, coldkeys) {
+  if (coldkeys.length === 0) return new Map();
+  try {
+    const placeholders = coldkeys.map((_, i) => `$${i + 1}::text`).join(", ");
+    const rows = await sql.savepoint((sql) =>
+      sql.unsafe(
+        `SELECT ${ACCOUNT_IDENTITY_INSERT_COLUMNS.join(", ")}
+         FROM account_identity WHERE account IN (${placeholders})`,
+        coldkeys,
+      ),
+    );
+    return new Map(rows.map((row) => [row.account, row]));
+  } catch (err) {
+    console.error("account_identity join query failed:", err);
+    return new Map();
+  }
+}
+
+// Distinct, order-stable, non-empty coldkeys from a validators/validator-detail
+// result set -- the input to loadAccountIdentitiesByColdkey above.
+function distinctColdkeys(rows) {
+  const seen = new Set();
+  for (const row of rows) {
+    if (row?.coldkey?.length > 0) seen.add(row.coldkey);
+  }
+  return [...seen];
+}
+
 function clampLimit(raw) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
@@ -5719,8 +5756,19 @@ export default {
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
             loadFeaturedHotkeys(sql),
           ]);
+          // Identity join (#5234): needs `rows` resolved first to know which
+          // coldkeys to look up, so it can't join the Promise.all above.
+          const identityByColdkey = await loadAccountIdentitiesByColdkey(
+            sql,
+            distinctColdkeys(rows),
+          );
           return json(
-            buildGlobalValidators(rows, { sort, limit, featuredHotkeys }),
+            buildGlobalValidators(rows, {
+              sort,
+              limit,
+              featuredHotkeys,
+              identityByColdkey,
+            }),
           );
         }
 
@@ -5735,7 +5783,14 @@ export default {
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take, netuid
           FROM neurons WHERE hotkey = ${hotkey} AND validator_permit = TRUE
           ORDER BY netuid ASC, uid ASC`;
-          return json(buildValidatorDetail(rows, hotkey));
+          // Identity join (#5234): see the /api/v1/validators comment above.
+          const identityByColdkey = await loadAccountIdentitiesByColdkey(
+            sql,
+            distinctColdkeys(rows),
+          );
+          return json(
+            buildValidatorDetail(rows, hotkey, { identityByColdkey }),
+          );
         }
 
         // GET /api/v1/subnets/:netuid/concentration (#4832 Tier 2): stake &


### PR DESCRIPTION
## Summary
- Server-side join of `validator.coldkey -> account_identity` in `buildGlobalValidators`/`buildValidatorDetail` (`src/metagraph-neurons.mjs`), exposed as a new `coldkey_identity` field.
- Wired into the live Postgres-backed routes in `workers/data-api.mjs`: `GET /api/v1/validators` and `GET /api/v1/validators/{hotkey}` now fetch `account_identity` rows for the distinct coldkeys in the result set (deduped, single `IN (...)` query, `sql.savepoint`-isolated so a join failure can never sink the primary validator response) and pass them through.
- New `ColdkeyIdentity` schema, referenced from `GlobalValidatorEntry` and `ValidatorDetailArtifact`. Its description explicitly documents the coldkey-not-hotkey caveat: this is the coldkey's self-declared identity, not hotkey-specific branding, and the same identity can appear on multiple leaderboard rows when one coldkey runs several hotkeys.
- `has_identity:false` (never an omitted field) when no identity row exists, matching the existing `/api/v1/accounts/{ss58}/identity` contract's own shape.
- D1 fallback loaders (`loadGlobalValidators`/`loadValidatorDetail`) intentionally do **not** join — `account_identity`'s D1 write path is retired, so joining a stale/frozen D1 copy would be worse than a clean "no identity" shape. Only the live Postgres route joins.
- Regenerated `openapi.json`, `schemas/api-components.schema.json`, and generated types/client via `npm run build`.

## Tests
- `tests/metagraph-neurons.test.mjs`: pure-builder coverage for a validator with identity set, without identity set, a coldkey shared across two hotkeys (proves the join is keyed by coldkey not hotkey), and the null-coldkey case.
- `tests/data-api.test.mjs`: route-level coverage for the join query shape/params, has_identity:false on no match, skipping the join query when there are no coldkeys, resilience when the join query itself fails, and dedup (one identity lookup even when multiple subnet rows share the same coldkey).
- `tests/request-handlers-entities.test.mjs`: updated the existing `GlobalValidatorEntry` test fixture to the new required shape.

## Validation run
- `npm run lint` / `npm run format:check`
- `npm run validate`
- `npm run validate:contract-drift` / `npm run validate:schemas` / `npm run validate:openapi`
- `npm test` (267 files, 7718 tests, all passing)
- `node scripts/scan-public-safety.mjs` (passed)

Closes #5234