### PR TITLE
feat(registry): add SN118 Ditto Admin API OpenAPI schema surface

### DIFF
--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -287,6 +287,27 @@
         "https://github.com/ditto-assistant/dittobench-starter-kit"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/118"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-118-ditto-admin-openapi",
+      "kind": "openapi",
+      "name": "Ditto Admin API OpenAPI schema",
+      "notes": "Public no-auth Swagger 2.0 schema (info.title \"Ditto Admin API\", 13 paths, basePath /api/admin/v1) served by the SN118 Ditto backend at api.heyditto.ai. The official Ditto developer docs (heyditto.ai/docs/building-apps-on-ditto) instruct developers to open the Swagger UI at /api/admin/v1/swagger/, which this doc.json backs. The schema document itself is public and unauthenticated (the API it describes uses an AdminKey). Fills the manifest gap: no machine-readable schema was recorded before.",
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "reyanthony062001-ops"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.heyditto.ai/api/admin/v1/swagger/doc.json",
+      "source_urls": [
+        "https://heyditto.ai/docs/building-apps-on-ditto/",
+        "https://api.heyditto.ai/api/admin/v1/swagger/doc.json"
+      ],
+      "url": "https://api.heyditto.ai/api/admin/v1/swagger/doc.json"
     }
   ],
   "website_url": "https://heyditto.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one `openapi` surface to `registry/subnets/ditto.json` (SN118 Ditto). Append-only — the manifest already existed on the base branch. One file, `+21 −0`.

Closes #4164

## Surface

- Netuid: 118
- Kind: openapi
- Public URL: https://api.heyditto.ai/api/admin/v1/swagger/doc.json
- Source URL (proves the claim): https://heyditto.ai/docs/building-apps-on-ditto/
- Provider slug: ditto-assistant

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Lands `authority: community` and `review.state: community-submitted` (same shape `surface:add` produces; hand-appended to keep the diff key-order-stable and additive).
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: the surface is a machine-readable schema document only — no secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (the manifest had no `openapi` surface).
- [x] Links a tracked issue that is still OPEN (`Closes #4164`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/ditto.json` — passed (13 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `prettier --check` — clean

## Notes

- `https://api.heyditto.ai/api/admin/v1/swagger/doc.json` returns HTTP 200 `application/json; charset=utf-8`, a valid **Swagger 2.0** document (`info.title` = "Ditto Admin API", 13 paths, `basePath /api/admin/v1`), fetched from a clean no-auth context — the schema document itself is public and unauthenticated.
- First-party + intended-public: the official Ditto developer docs at `heyditto.ai/docs/building-apps-on-ditto/` explicitly instruct developers to open the Swagger UI at `/api/admin/v1/swagger/`, which this `doc.json` backs; `api.heyditto.ai` is a subdomain of the official `heyditto.ai`.
- The API it documents uses an `AdminKey`, but the schema document is public — consistent with existing merged validator/admin-API openapi surfaces (e.g. SN70 NexisGen #4367, SN99 Leoma #4222).
- `provider: ditto-assistant` is the registered slug already used by every official Ditto surface on this manifest.
- Fills a real gap: the manifest previously had website/docs/dashboard/SDK/subnet-api surfaces but no machine-readable schema.
