### PR TITLE
feat(api): stake-quote endpoint (slippage / price-impact estimate)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -2316,6 +2316,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/stake-quote": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool, computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves — a read-only quote, never a signed extrinsic. ?amount= (required, positive number) is TAO for direction=stake or alpha for direction=unstake (default stake); returns the quoted amount_out, the pre-trade spot_price_tao, this trade's effective_price_tao, and price_impact_pct. Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote. An amount exceeding 1000x the pool's own reserve is rejected (mirrors the chain's own InsufficientLiquidity guard). */
+        get: operations["subnetStakeQuote"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/stake-transfers": {
         parameters: {
             query?: never;
@@ -7197,6 +7214,23 @@ export interface components {
             schema_version: number;
             /** @enum {string|null} */
             window: "7d" | "30d" | null;
+        };
+        /** @description Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves -- a read-only quote, never a signed extrinsic. direction=stake takes amount_in in TAO and returns amount_out in alpha; direction=unstake takes amount_in in alpha and returns amount_out in TAO. Root (netuid 0) has no AMM -- stake there is TAO-denominated 1:1 with no swap fee and no price impact -- so it always returns a fixed 1:1, zero-impact quote rather than running the formula against nonexistent root pool reserves. */
+        SubnetStakeQuoteArtifact: {
+            /** @description The requested trade size: TAO for direction=stake, alpha for direction=unstake. */
+            amount_in: number;
+            /** @description The quoted output: alpha for direction=stake, TAO for direction=unstake. */
+            amount_out: number;
+            /** @enum {string} */
+            direction: "stake" | "unstake";
+            /** @description This trade's realized TAO-per-alpha rate (amount_in/amount_out for stake, amount_out/amount_in for unstake), inclusive of the price impact below. 1 on root. */
+            effective_price_tao: number;
+            netuid: number;
+            /** @description abs(effective_price_tao - spot_price_tao) / spot_price_tao * 100. 0 on root (no AMM, no impact). */
+            price_impact_pct: number;
+            schema_version: number;
+            /** @description Pre-trade marginal price, TAO per alpha (tao_in_pool_tao / alpha_in_pool). 1 on root. */
+            spot_price_tao: number;
         };
         /** @description Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window. */
         SubnetStakeTransfersArtifact: {
@@ -26375,6 +26409,117 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetStakeMovesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetStakeQuote: {
+        parameters: {
+            query?: {
+                amount?: number;
+                direction?: "stake" | "unstake";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "amount_in": 0.5,
+                     *         "amount_out": 0.5,
+                     *         "direction": "stake",
+                     *         "effective_price_tao": 0.5,
+                     *         "netuid": 7,
+                     *         "price_impact_pct": 0.5,
+                     *         "schema_version": 1,
+                     *         "spot_price_tao": 0.5
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["SubnetStakeQuoteArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -478,6 +478,13 @@
     },
     {
       "contract_version": "2026-07-03.2",
+      "id": "subnet-stake-quote",
+      "path": "/metagraph/subnets/{netuid}/stake-quote.json",
+      "schema_ref": "#/components/schemas/SubnetStakeQuoteArtifact",
+      "storage_tier": "git"
+    },
+    {
+      "contract_version": "2026-07-03.2",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
       "schema_ref": "#/components/schemas/SubnetMoversArtifact",
@@ -5305,6 +5312,36 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": []
+    },
+    {
+      "artifact_path": "/metagraph/subnets/{netuid}/stake-quote.json",
+      "cache": "short",
+      "description": "Fetch a constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool, computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves — a read-only quote, never a signed extrinsic. ?amount= (required, positive number) is TAO for direction=stake or alpha for direction=unstake (default stake); returns the quoted amount_out, the pre-trade spot_price_tao, this trade's effective_price_tao, and price_impact_pct. Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote. An amount exceeding 1000x the pool's own reserve is rejected (mirrors the chain's own InsufficientLiquidity guard).",
+      "id": "subnet-stake-quote",
+      "method": "GET",
+      "path": "/api/v1/subnets/{netuid}/stake-quote",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "amount",
+          "schema": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          }
+        },
+        {
+          "name": "direction",
+          "schema": {
+            "enum": [
+              "stake",
+              "unstake"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/subnets/movers.json",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -481,7 +481,7 @@
       "id": "subnet-stake-quote",
       "path": "/metagraph/subnets/{netuid}/stake-quote.json",
       "schema_ref": "#/components/schemas/SubnetStakeQuoteArtifact",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-07-03.2",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -619,7 +619,7 @@
       "id": "subnet-stake-quote",
       "path": "/metagraph/subnets/{netuid}/stake-quote.json",
       "schema_ref": "#/components/schemas/SubnetStakeQuoteArtifact",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -615,6 +615,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
+      "description": "Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live pool reserves at /api/v1/subnets/{netuid}/stake-quote (no static file). Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote.",
+      "id": "subnet-stake-quote",
+      "path": "/metagraph/subnets/{netuid}/stake-quote.json",
+      "schema_ref": "#/components/schemas/SubnetStakeQuoteArtifact",
+      "storage_tier": "git"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-07-03.2",
       "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between a window's start and end snapshots, with each subnet's share of network stake/emission and a network aggregate summary, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -19181,6 +19181,62 @@
         ],
         "type": "object"
       },
+      "SubnetStakeQuoteArtifact": {
+        "additionalProperties": false,
+        "description": "Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves -- a read-only quote, never a signed extrinsic. direction=stake takes amount_in in TAO and returns amount_out in alpha; direction=unstake takes amount_in in alpha and returns amount_out in TAO. Root (netuid 0) has no AMM -- stake there is TAO-denominated 1:1 with no swap fee and no price impact -- so it always returns a fixed 1:1, zero-impact quote rather than running the formula against nonexistent root pool reserves.",
+        "properties": {
+          "amount_in": {
+            "description": "The requested trade size: TAO for direction=stake, alpha for direction=unstake.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "amount_out": {
+            "description": "The quoted output: alpha for direction=stake, TAO for direction=unstake.",
+            "minimum": 0,
+            "type": "number"
+          },
+          "direction": {
+            "enum": [
+              "stake",
+              "unstake"
+            ],
+            "type": "string"
+          },
+          "effective_price_tao": {
+            "description": "This trade's realized TAO-per-alpha rate (amount_in/amount_out for stake, amount_out/amount_in for unstake), inclusive of the price impact below. 1 on root.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "price_impact_pct": {
+            "description": "abs(effective_price_tao - spot_price_tao) / spot_price_tao * 100. 0 on root (no AMM, no impact).",
+            "minimum": 0,
+            "type": "number"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "spot_price_tao": {
+            "description": "Pre-trade marginal price, TAO per alpha (tao_in_pool_tao / alpha_in_pool). 1 on root.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "direction",
+          "amount_in",
+          "amount_out",
+          "spot_price_tao",
+          "effective_price_tao",
+          "price_impact_pct"
+        ],
+        "type": "object"
+      },
       "SubnetStakeTransfersArtifact": {
         "additionalProperties": false,
         "description": "Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window.",
@@ -48636,6 +48692,162 @@
           }
         },
         "summary": "Fetch stake-movement (re-delegation) activity for one subnet over a 7d or 30d window: the distinct movers (accounts), the StakeMoved event count, and the average movements per mover, computed live from the account_events StakeMoved stream. The per-subnet drill-in of GET /api/v1/chain/stake-moves (which ranks only the top-N subnets and cannot be queried by netuid) and the re-delegation-churn sibling of GET /api/v1/subnets/{netuid}/stake-flow (net capital flow) — move_stake relocates stake between hotkeys/subnets without unstaking, so it is churn, not flow. Schema-stable zeroed card when the subnet has no StakeMoved events in the window.",
+        "tags": [
+          "subnets",
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/stake-quote": {
+      "get": {
+        "operationId": "subnetStakeQuote",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "amount",
+            "required": false,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "enum": [
+                "stake",
+                "unstake"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "amount_in": 0.5,
+                    "amount_out": 0.5,
+                    "direction": "stake",
+                    "effective_price_tao": 0.5,
+                    "netuid": 7,
+                    "price_impact_pct": 0.5,
+                    "schema_version": 1,
+                    "spot_price_tao": 0.5
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-29.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetStakeQuoteArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch a constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool, computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves — a read-only quote, never a signed extrinsic. ?amount= (required, positive number) is TAO for direction=stake or alpha for direction=unstake (default stake); returns the quoted amount_out, the pre-trade spot_price_tao, this trade's effective_price_tao, and price_impact_pct. Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote. An amount exceeding 1000x the pool's own reserve is rejected (mirrors the chain's own InsufficientLiquidity guard).",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2316,6 +2316,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/stake-quote": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool, computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves — a read-only quote, never a signed extrinsic. ?amount= (required, positive number) is TAO for direction=stake or alpha for direction=unstake (default stake); returns the quoted amount_out, the pre-trade spot_price_tao, this trade's effective_price_tao, and price_impact_pct. Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote. An amount exceeding 1000x the pool's own reserve is rejected (mirrors the chain's own InsufficientLiquidity guard). */
+        get: operations["subnetStakeQuote"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/stake-transfers": {
         parameters: {
             query?: never;
@@ -7197,6 +7214,23 @@ export interface components {
             schema_version: number;
             /** @enum {string|null} */
             window: "7d" | "30d" | null;
+        };
+        /** @description Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves -- a read-only quote, never a signed extrinsic. direction=stake takes amount_in in TAO and returns amount_out in alpha; direction=unstake takes amount_in in alpha and returns amount_out in TAO. Root (netuid 0) has no AMM -- stake there is TAO-denominated 1:1 with no swap fee and no price impact -- so it always returns a fixed 1:1, zero-impact quote rather than running the formula against nonexistent root pool reserves. */
+        SubnetStakeQuoteArtifact: {
+            /** @description The requested trade size: TAO for direction=stake, alpha for direction=unstake. */
+            amount_in: number;
+            /** @description The quoted output: alpha for direction=stake, TAO for direction=unstake. */
+            amount_out: number;
+            /** @enum {string} */
+            direction: "stake" | "unstake";
+            /** @description This trade's realized TAO-per-alpha rate (amount_in/amount_out for stake, amount_out/amount_in for unstake), inclusive of the price impact below. 1 on root. */
+            effective_price_tao: number;
+            netuid: number;
+            /** @description abs(effective_price_tao - spot_price_tao) / spot_price_tao * 100. 0 on root (no AMM, no impact). */
+            price_impact_pct: number;
+            schema_version: number;
+            /** @description Pre-trade marginal price, TAO per alpha (tao_in_pool_tao / alpha_in_pool). 1 on root. */
+            spot_price_tao: number;
         };
         /** @description Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window. */
         SubnetStakeTransfersArtifact: {
@@ -26375,6 +26409,117 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetStakeMovesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetStakeQuote: {
+        parameters: {
+            query?: {
+                amount?: number;
+                direction?: "stake" | "unstake";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "amount_in": 0.5,
+                     *         "amount_out": 0.5,
+                     *         "direction": "stake",
+                     *         "effective_price_tao": 0.5,
+                     *         "netuid": 7,
+                     *         "price_impact_pct": 0.5,
+                     *         "schema_version": 1,
+                     *         "spot_price_tao": 0.5
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["SubnetStakeQuoteArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -19159,6 +19159,62 @@
         ],
         "type": "object"
       },
+      "SubnetStakeQuoteArtifact": {
+        "additionalProperties": false,
+        "description": "Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves -- a read-only quote, never a signed extrinsic. direction=stake takes amount_in in TAO and returns amount_out in alpha; direction=unstake takes amount_in in alpha and returns amount_out in TAO. Root (netuid 0) has no AMM -- stake there is TAO-denominated 1:1 with no swap fee and no price impact -- so it always returns a fixed 1:1, zero-impact quote rather than running the formula against nonexistent root pool reserves.",
+        "properties": {
+          "amount_in": {
+            "description": "The requested trade size: TAO for direction=stake, alpha for direction=unstake.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "amount_out": {
+            "description": "The quoted output: alpha for direction=stake, TAO for direction=unstake.",
+            "minimum": 0,
+            "type": "number"
+          },
+          "direction": {
+            "enum": [
+              "stake",
+              "unstake"
+            ],
+            "type": "string"
+          },
+          "effective_price_tao": {
+            "description": "This trade's realized TAO-per-alpha rate (amount_in/amount_out for stake, amount_out/amount_in for unstake), inclusive of the price impact below. 1 on root.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "price_impact_pct": {
+            "description": "abs(effective_price_tao - spot_price_tao) / spot_price_tao * 100. 0 on root (no AMM, no impact).",
+            "minimum": 0,
+            "type": "number"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "spot_price_tao": {
+            "description": "Pre-trade marginal price, TAO per alpha (tao_in_pool_tao / alpha_in_pool). 1 on root.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "direction",
+          "amount_in",
+          "amount_out",
+          "spot_price_tao",
+          "effective_price_tao",
+          "price_impact_pct"
+        ],
+        "type": "object"
+      },
       "SubnetStakeTransfersArtifact": {
         "additionalProperties": false,
         "description": "Per-subnet stake-transfer activity over a 7d/30d window: distinct senders (accounts), StakeTransferred event count, and transfers per sender for ONE subnet. The per-subnet drill-in of /api/v1/chain/stake-transfers and the between-coldkeys sibling of /api/v1/subnets/{netuid}/stake-moves — transfer_stake relocates staked alpha between accounts on the same hotkey (origin leg only). Served live from the account_events StakeTransferred stream at /api/v1/subnets/{netuid}/stake-transfers (no static file); zeroed when the subnet has no events in the window.",

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -1405,6 +1405,51 @@
         },
         "additionalProperties": false
       },
+      "SubnetStakeQuoteArtifact": {
+        "type": "object",
+        "description": "Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves -- a read-only quote, never a signed extrinsic. direction=stake takes amount_in in TAO and returns amount_out in alpha; direction=unstake takes amount_in in alpha and returns amount_out in TAO. Root (netuid 0) has no AMM -- stake there is TAO-denominated 1:1 with no swap fee and no price impact -- so it always returns a fixed 1:1, zero-impact quote rather than running the formula against nonexistent root pool reserves.",
+        "required": [
+          "schema_version",
+          "netuid",
+          "direction",
+          "amount_in",
+          "amount_out",
+          "spot_price_tao",
+          "effective_price_tao",
+          "price_impact_pct"
+        ],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "netuid": { "type": "integer", "minimum": 0 },
+          "direction": { "type": "string", "enum": ["stake", "unstake"] },
+          "amount_in": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "The requested trade size: TAO for direction=stake, alpha for direction=unstake."
+          },
+          "amount_out": {
+            "type": "number",
+            "minimum": 0,
+            "description": "The quoted output: alpha for direction=stake, TAO for direction=unstake."
+          },
+          "spot_price_tao": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Pre-trade marginal price, TAO per alpha (tao_in_pool_tao / alpha_in_pool). 1 on root."
+          },
+          "effective_price_tao": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "This trade's realized TAO-per-alpha rate (amount_in/amount_out for stake, amount_out/amount_in for unstake), inclusive of the price impact below. 1 on root."
+          },
+          "price_impact_pct": {
+            "type": "number",
+            "minimum": 0,
+            "description": "abs(effective_price_tao - spot_price_tao) / spot_price_tao * 100. 0 on root (no AMM, no impact)."
+          }
+        },
+        "additionalProperties": false
+      },
       "SubnetMoversArtifact": {
         "type": "object",
         "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end neuron_daily snapshots.",

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -272,6 +272,18 @@ const checks = [
     },
   ],
   [
+    "/api/v1/subnets/7/stake-quote?amount=10",
+    (body) => {
+      assert.equal(body.data.netuid, 7);
+      assert.equal(body.data.direction, "stake");
+      assert.equal(body.data.amount_in, 10);
+      assert.equal(typeof body.data.amount_out, "number");
+      assert.equal(typeof body.data.spot_price_tao, "number");
+      assert.equal(typeof body.data.effective_price_tao, "number");
+      assert.equal(typeof body.data.price_impact_pct, "number");
+    },
+  ],
+  [
     "/api/v1/subnets/7/weights?window=30d",
     (body) => {
       assert.equal(body.data.netuid, 7);

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -34,6 +34,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "subnet-turnover",
   "subnet-stake-flow",
   "subnet-alpha-volume",
+  "subnet-stake-quote",
   "subnet-weights",
   "subnet-weight-setters",
   "subnet-serving",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -61,6 +61,9 @@ export const R2_ONLY_PATTERNS = [
   // Rolling 24h buy/sell alpha volume (#4339/8.1): computed live from the same
   // account_events stream as stake-flow.
   /^subnets\/(?:\d+|\{netuid\})\/volume\.json$/,
+  // Constant-product AMM slippage/price-impact quote (#5235): pure math over
+  // economics.json's live pool reserves, never written as a file.
+  /^subnets\/(?:\d+|\{netuid\})\/stake-quote\.json$/,
   // Validator weight-setting activity: computed live from the account_events WeightsSet stream.
   /^subnets\/(?:\d+|\{netuid\})\/weights\.json$/,
   // Per-subnet weight-setter leaderboard: computed live from the account_events WeightsSet stream.

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1026,6 +1026,12 @@ export const PUBLIC_ARTIFACTS = [
     "SubnetAlphaVolumeArtifact",
   ),
   artifact(
+    "subnet-stake-quote",
+    "/metagraph/subnets/{netuid}/stake-quote.json",
+    "Constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool (#5235, epic #5229), computed purely from economics.json's live pool reserves at /api/v1/subnets/{netuid}/stake-quote (no static file). Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote.",
+    "SubnetStakeQuoteArtifact",
+  ),
+  artifact(
     "subnet-movers",
     "/metagraph/subnets/movers.json",
     "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between a window's start and end snapshots, with each subnet's share of network stake/emission and a network aggregate summary, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
@@ -2291,6 +2297,23 @@ export const API_ROUTES = [
     "short",
     ["subnets", "analytics"],
     [],
+    [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+  ),
+  route(
+    "subnet-stake-quote",
+    "GET",
+    "/api/v1/subnets/{netuid}/stake-quote",
+    "/metagraph/subnets/{netuid}/stake-quote.json",
+    "Fetch a constant-product AMM slippage/price-impact estimate for staking into or unstaking out of one subnet's pool, computed purely from economics.json's live tao_in_pool_tao/alpha_in_pool reserves — a read-only quote, never a signed extrinsic. ?amount= (required, positive number) is TAO for direction=stake or alpha for direction=unstake (default stake); returns the quoted amount_out, the pre-trade spot_price_tao, this trade's effective_price_tao, and price_impact_pct. Root (netuid 0) has no AMM and always returns a fixed 1:1, zero-impact quote. An amount exceeding 1000x the pool's own reserve is rejected (mirrors the chain's own InsufficientLiquidity guard).",
+    "short",
+    ["subnets", "analytics"],
+    [
+      { name: "amount", schema: { type: "number", exclusiveMinimum: 0 } },
+      {
+        name: "direction",
+        schema: { type: "string", enum: ["stake", "unstake"] },
+      },
+    ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/stake-quote.mjs
+++ b/src/stake-quote.mjs
@@ -1,0 +1,101 @@
+// Constant-product AMM slippage/price-impact quote for one subnet's stake
+// pool (#5235, epic #5229's read-only "developer-grade API" gap -- a
+// scriptable quote endpoint alongside the wallet-connected signing flow).
+// Pure + exported for tests; the Worker handler resolves the economics row
+// (tao_in_pool_tao/alpha_in_pool, already TAO/alpha-float, no rao conversion)
+// and calls this. Deliberately does NOT use alpha_out_pool -- that field is
+// the subnet's total *emitted* alpha (a market-cap input), not an AMM swap
+// reserve; the formula only ever touches the two actual pool reserves.
+
+export const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"];
+export const DEFAULT_STAKE_QUOTE_DIRECTION = "stake";
+
+// The chain's own InsufficientLiquidity guard rejects an extrinsic whose
+// input would swing a pool by more than this multiple of its own reserve --
+// mirrored here as a static, documented client-side bound (the deliverable's
+// own ">1000x pool-reserve rejection" case) so this endpoint never quotes an
+// amount that could never actually confirm on-chain.
+const MAX_POOL_MULTIPLE = 1000;
+
+function isPositiveFinite(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+// Every call site here already has a finite value in hand (amountOut/
+// spotPriceTao/effectivePriceTao/priceImpactPct are all derived from the
+// isPositiveFinite-checked pool reserves above) -- no null/non-finite guard,
+// unlike src/metagraph-neurons.mjs's own round() which serves nullable D1
+// cells.
+function round(value, dp = 6) {
+  const factor = 10 ** dp;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * amount is the input leg: TAO being staked (direction "stake") or alpha
+ * being unstaked (direction "unstake"). Returns either the quote object or
+ * `{ error: { parameter, message } }` (mirrors parseGlobalValidatorsQuery's
+ * own { error } shape) for the handler to translate into a 400.
+ */
+export function buildStakeQuote(row, netuid, { amount, direction }) {
+  // Root (netuid 0) has no AMM -- stake there is TAO-denominated 1:1 with no
+  // swap fee and no price impact (ADR 0018 §3) -- exempt from the
+  // constant-product formula entirely rather than running it against
+  // economics.json's non-AMM root reserves.
+  if (netuid === 0) {
+    return {
+      schema_version: 1,
+      netuid,
+      direction,
+      amount_in: amount,
+      amount_out: amount,
+      spot_price_tao: 1,
+      effective_price_tao: 1,
+      price_impact_pct: 0,
+    };
+  }
+
+  const taoIn = row?.tao_in_pool_tao;
+  const alphaIn = row?.alpha_in_pool;
+  if (!isPositiveFinite(taoIn) || !isPositiveFinite(alphaIn)) {
+    return {
+      error: {
+        parameter: "netuid",
+        message: `subnet ${netuid} has no pool liquidity to quote against.`,
+      },
+    };
+  }
+
+  const spotPriceTao = taoIn / alphaIn; // TAO per alpha, pre-trade marginal price
+  const poolReserve = direction === "stake" ? taoIn : alphaIn;
+  if (amount > poolReserve * MAX_POOL_MULTIPLE) {
+    return {
+      error: {
+        parameter: "amount",
+        message: `amount exceeds ${MAX_POOL_MULTIPLE}x this subnet's pool reserve -- this trade would never confirm on-chain (mirrors the chain's own InsufficientLiquidity guard).`,
+      },
+    };
+  }
+
+  // alpha_out = alpha_in - (alpha_in * tao_in) / (tao_in + delta_tao), and its
+  // inverse (tao_out from delta_alpha) for the unstake direction.
+  const amountOut =
+    direction === "stake"
+      ? alphaIn - (alphaIn * taoIn) / (taoIn + amount)
+      : taoIn - (taoIn * alphaIn) / (alphaIn + amount);
+  const effectivePriceTao =
+    direction === "stake" ? amount / amountOut : amountOut / amount;
+  const priceImpactPct =
+    (Math.abs(effectivePriceTao - spotPriceTao) / spotPriceTao) * 100;
+
+  return {
+    schema_version: 1,
+    netuid,
+    direction,
+    amount_in: amount,
+    amount_out: round(amountOut),
+    spot_price_tao: round(spotPriceTao),
+    effective_price_tao: round(effectivePriceTao),
+    price_impact_pct: round(priceImpactPct),
+  };
+}

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -12,6 +12,7 @@ import { buildOpenApiArtifact } from "../src/contracts.mjs";
 import { MOVERS_WINDOWS } from "../src/movers.mjs";
 import { unsupportedWindowMessage } from "../src/neuron-history.mjs";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import {
   handleSubnetMetagraph,
   handleSubnetYield,
@@ -48,6 +49,7 @@ import {
   handleSubnetStakeFlow,
   handleSubnetWeights,
   handleSubnetAlphaVolume,
+  handleStakeQuote,
   handleSubnetServing,
   handleSubnetPrometheus,
   handleSubnetStakeMoves,
@@ -5141,6 +5143,115 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     );
     assert.equal(body.data.marker, "pg");
     assert.deepEqual(captures.sql, []);
+  });
+
+  test("handleStakeQuote computes a quote for a real subnet from the built economics.json artifact (#5235)", async () => {
+    const env = createLocalArtifactEnv();
+    const body = await json(
+      await handleStakeQuote(
+        req(`/api/v1/subnets/${NETUID}/stake-quote?amount=10`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-quote?amount=10`),
+      ),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.direction, "stake");
+    assert.equal(body.data.amount_in, 10);
+    assert.equal(typeof body.data.amount_out, "number");
+    assert.equal(typeof body.data.spot_price_tao, "number");
+    assert.equal(typeof body.data.price_impact_pct, "number");
+  });
+
+  test("handleStakeQuote defaults direction to stake and accepts an explicit unstake", async () => {
+    const env = createLocalArtifactEnv();
+    const unstakeBody = await json(
+      await handleStakeQuote(
+        req(
+          `/api/v1/subnets/${NETUID}/stake-quote?amount=10&direction=unstake`,
+        ),
+        env,
+        NETUID,
+        url(
+          `/api/v1/subnets/${NETUID}/stake-quote?amount=10&direction=unstake`,
+        ),
+      ),
+    );
+    assert.equal(unstakeBody.data.direction, "unstake");
+  });
+
+  test("handleStakeQuote: root subnet (netuid 0) always returns a 1:1 zero-impact quote", async () => {
+    const env = createLocalArtifactEnv();
+    const body = await json(
+      await handleStakeQuote(
+        req("/api/v1/subnets/0/stake-quote?amount=5"),
+        env,
+        0,
+        url("/api/v1/subnets/0/stake-quote?amount=5"),
+      ),
+    );
+    assert.equal(body.data.amount_out, 5);
+    assert.equal(body.data.price_impact_pct, 0);
+  });
+
+  test("handleStakeQuote rejects a missing amount", async () => {
+    const env = createLocalArtifactEnv();
+    await errorJson(
+      await handleStakeQuote(
+        req(`/api/v1/subnets/${NETUID}/stake-quote`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-quote`),
+      ),
+    );
+  });
+
+  test("handleStakeQuote rejects a non-positive amount", async () => {
+    const env = createLocalArtifactEnv();
+    await errorJson(
+      await handleStakeQuote(
+        req(`/api/v1/subnets/${NETUID}/stake-quote?amount=0`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-quote?amount=0`),
+      ),
+    );
+  });
+
+  test("handleStakeQuote rejects an unsupported direction", async () => {
+    const env = createLocalArtifactEnv();
+    await errorJson(
+      await handleStakeQuote(
+        req(`/api/v1/subnets/${NETUID}/stake-quote?amount=10&direction=bogus`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-quote?amount=10&direction=bogus`),
+      ),
+    );
+  });
+
+  test("handleStakeQuote rejects an unsupported query param", async () => {
+    const env = createLocalArtifactEnv();
+    await errorJson(
+      await handleStakeQuote(
+        req(`/api/v1/subnets/${NETUID}/stake-quote?amount=10&bogus=1`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-quote?amount=10&bogus=1`),
+      ),
+    );
+  });
+
+  test("handleStakeQuote: cold/unbound artifact store has no pool data to quote against", async () => {
+    const env = emptyEnv();
+    await errorJson(
+      await handleStakeQuote(
+        req(`/api/v1/subnets/${NETUID}/stake-quote?amount=10`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-quote?amount=10`),
+      ),
+    );
   });
 
   test("handleSubnetEvents: flag=postgres uses Postgres data, D1 never queried", async () => {

--- a/tests/stake-quote.test.mjs
+++ b/tests/stake-quote.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildStakeQuote } from "../src/stake-quote.mjs";
+
+const POOL = { tao_in_pool_tao: 1000, alpha_in_pool: 2000 };
+
+describe("buildStakeQuote (#5235)", () => {
+  test("stake direction applies the constant-product formula", () => {
+    const quote = buildStakeQuote(POOL, 7, { amount: 100, direction: "stake" });
+    // alpha_out = 2000 - (2000*1000)/(1000+100) = 2000 - 1818.181818... = 181.818181...
+    assert.equal(quote.schema_version, 1);
+    assert.equal(quote.netuid, 7);
+    assert.equal(quote.direction, "stake");
+    assert.equal(quote.amount_in, 100);
+    assert.equal(quote.amount_out, 181.818182);
+    assert.equal(quote.spot_price_tao, 0.5);
+    // effective price = 100 / 181.818182 = 0.55, worse than spot (buying pushes price up)
+    assert.equal(quote.effective_price_tao, 0.55);
+    assert.ok(quote.price_impact_pct > 0);
+  });
+
+  test("unstake direction applies the inverse formula", () => {
+    const quote = buildStakeQuote(POOL, 7, {
+      amount: 200,
+      direction: "unstake",
+    });
+    // tao_out = 1000 - (1000*2000)/(2000+200) = 1000 - 909.0909... = 90.9090...
+    assert.equal(quote.direction, "unstake");
+    assert.equal(quote.amount_in, 200);
+    assert.equal(quote.amount_out, 90.909091);
+    assert.equal(quote.spot_price_tao, 0.5);
+    assert.ok(quote.price_impact_pct > 0);
+  });
+
+  test("a larger trade produces a larger price impact than a smaller one (monotonic slippage)", () => {
+    const small = buildStakeQuote(POOL, 7, {
+      amount: 10,
+      direction: "stake",
+    });
+    const large = buildStakeQuote(POOL, 7, {
+      amount: 500,
+      direction: "stake",
+    });
+    assert.ok(large.price_impact_pct > small.price_impact_pct);
+  });
+
+  test("root subnet (netuid 0) returns a fixed 1:1, zero-impact quote regardless of pool reserves", () => {
+    const quote = buildStakeQuote(null, 0, { amount: 42, direction: "stake" });
+    assert.equal(quote.amount_in, 42);
+    assert.equal(quote.amount_out, 42);
+    assert.equal(quote.spot_price_tao, 1);
+    assert.equal(quote.effective_price_tao, 1);
+    assert.equal(quote.price_impact_pct, 0);
+
+    const unstakeQuote = buildStakeQuote(POOL, 0, {
+      amount: 42,
+      direction: "unstake",
+    });
+    assert.equal(unstakeQuote.amount_out, 42);
+    assert.equal(unstakeQuote.price_impact_pct, 0);
+  });
+
+  test("zero-liquidity pool is rejected with a descriptive error, not a NaN/Infinity quote", () => {
+    for (const row of [
+      null,
+      { tao_in_pool_tao: null, alpha_in_pool: 2000 },
+      { tao_in_pool_tao: 1000, alpha_in_pool: null },
+      { tao_in_pool_tao: 0, alpha_in_pool: 2000 },
+      { tao_in_pool_tao: 1000, alpha_in_pool: 0 },
+    ]) {
+      const quote = buildStakeQuote(row, 7, {
+        amount: 10,
+        direction: "stake",
+      });
+      assert.equal(quote.error.parameter, "netuid");
+      assert.ok(/no pool liquidity/.test(quote.error.message));
+    }
+  });
+
+  test("a dust amount produces a sane, near-zero-impact quote (no NaN/Infinity)", () => {
+    const quote = buildStakeQuote(POOL, 7, {
+      amount: 0.000001,
+      direction: "stake",
+    });
+    assert.equal(quote.error, undefined);
+    assert.ok(Number.isFinite(quote.amount_out));
+    assert.ok(Number.isFinite(quote.price_impact_pct));
+    assert.ok(quote.price_impact_pct < 0.001);
+  });
+
+  test("an amount over 1000x the relevant pool reserve is rejected (mirrors InsufficientLiquidity)", () => {
+    const tooBigStake = buildStakeQuote(POOL, 7, {
+      amount: POOL.tao_in_pool_tao * 1000 + 1,
+      direction: "stake",
+    });
+    assert.equal(tooBigStake.error.parameter, "amount");
+    assert.ok(/1000x/.test(tooBigStake.error.message));
+
+    const tooBigUnstake = buildStakeQuote(POOL, 7, {
+      amount: POOL.alpha_in_pool * 1000 + 1,
+      direction: "unstake",
+    });
+    assert.equal(tooBigUnstake.error.parameter, "amount");
+
+    // Exactly at the boundary is still accepted.
+    const atBoundary = buildStakeQuote(POOL, 7, {
+      amount: POOL.tao_in_pool_tao * 1000,
+      direction: "stake",
+    });
+    assert.equal(atBoundary.error, undefined);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -103,6 +103,7 @@ import {
   handleSubnetStakeFlow,
   canonicalSubnetStakeFlowCachePath,
   handleSubnetAlphaVolume,
+  handleStakeQuote,
   handleSubnetRecycled,
   handleSubnetWeights,
   canonicalSubnetWeightsCachePath,
@@ -341,6 +342,7 @@ import {
   SUBNET_TURNOVER_PATH_PATTERN,
   SUBNET_STAKE_FLOW_PATH_PATTERN,
   SUBNET_ALPHA_VOLUME_PATH_PATTERN,
+  SUBNET_STAKE_QUOTE_PATH_PATTERN,
   SUBNET_RECYCLED_PATH_PATTERN,
   SUBNET_WEIGHTS_PATH_PATTERN,
   SUBNET_WEIGHT_SETTERS_PATH_PATTERN,
@@ -1665,6 +1667,20 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       // /sudo/key) — not D1-backed, so no withEdgeCache here.
       return handleSubnetRecycled(request, env, Number(recycledMatch[1]));
     }
+    const stakeQuoteMatch = SUBNET_STAKE_QUOTE_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (stakeQuoteMatch) {
+      // Pure math over economics.json's pool reserves, keyed by an
+      // effectively-unbounded ?amount= — not worth an edge-cache entry per
+      // distinct amount, same reasoning as the RPC/KV-live routes above.
+      return handleStakeQuote(
+        request,
+        env,
+        Number(stakeQuoteMatch[1]),
+        resolved.url,
+      );
+    }
     const weightSettersMatch = SUBNET_WEIGHT_SETTERS_PATH_PATTERN.exec(
       resolved.url.pathname,
     );
@@ -2553,6 +2569,7 @@ function isMainnetOnlyApiPath(pathname) {
     SUBNET_TURNOVER_PATH_PATTERN.test(pathname) ||
     SUBNET_STAKE_FLOW_PATH_PATTERN.test(pathname) ||
     SUBNET_ALPHA_VOLUME_PATH_PATTERN.test(pathname) ||
+    SUBNET_STAKE_QUOTE_PATH_PATTERN.test(pathname) ||
     SUBNET_RECYCLED_PATH_PATTERN.test(pathname) ||
     SUBNET_YIELD_PATH_PATTERN.test(pathname) ||
     SUBNET_PERFORMANCE_PATH_PATTERN.test(pathname) ||

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -73,6 +73,10 @@ export const SUBNET_ALPHA_VOLUME_PATH_PATTERN =
 // request time — not a D1/account_events tier, no static file.
 export const SUBNET_RECYCLED_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/recycled$/;
+// Constant-product AMM slippage/price-impact quote (#5235, epic #5229) —
+// pure math over economics.json's pool reserves, no chain-write/custody risk.
+export const SUBNET_STAKE_QUOTE_PATH_PATTERN =
+  /^\/api\/v1\/subnets\/(\d+)\/stake-quote$/;
 // Validator weight-setting activity over the window, live from account_events, no static file.
 export const SUBNET_WEIGHTS_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/weights$/;

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -191,6 +191,11 @@ import {
   STAKE_FLOW_DIRECTIONS,
 } from "../../src/stake-flow.mjs";
 import { buildAlphaVolume } from "../../src/alpha-volume.mjs";
+import {
+  buildStakeQuote,
+  STAKE_QUOTE_DIRECTIONS,
+  DEFAULT_STAKE_QUOTE_DIRECTION,
+} from "../../src/stake-quote.mjs";
 import { resolveLiveEconomics } from "../../src/health-serving.mjs";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.mjs";
 import { readArtifact, readHealthKv } from "../storage.mjs";
@@ -2249,6 +2254,72 @@ export async function handleSubnetAlphaVolume(request, env, netuid, url) {
         `/metagraph/subnets/${netuid}/volume.json`,
         generatedAt,
       ),
+    },
+    "short",
+  );
+}
+
+// Full per-subnet economics row (pool reserves + everything else), same live
+// KV -> R2 fallback shape as resolveSubnetMarketCapTao just above -- this one
+// is used by handleStakeQuote, which needs the raw pool reserves rather than
+// just the derived market cap. Returns { row, generatedAt }; row is null when
+// neither tier has this subnet.
+async function resolveSubnetEconomicsRow(env, netuid) {
+  const live = await resolveLiveEconomics({
+    readHealthKv: (e) => readHealthKv(e, KV_ECONOMICS_CURRENT),
+    env,
+    contractVersion: contractVersion(env),
+  });
+  let rows = Array.isArray(live?.data?.subnets) ? live.data.subnets : null;
+  let generatedAt = live?.data?.captured_at ?? null;
+  if (!rows) {
+    const artifact = await readArtifact(env, "/metagraph/economics.json");
+    rows =
+      artifact.ok && Array.isArray(artifact.data?.subnets)
+        ? artifact.data.subnets
+        : [];
+    generatedAt = artifact.ok ? (artifact.data?.captured_at ?? null) : null;
+  }
+  const row = rows.find((entry) => entry?.netuid === netuid) ?? null;
+  return { row, generatedAt };
+}
+
+// GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake
+// (#5235, epic #5229): constant-product AMM slippage/price-impact estimate
+// for one subnet's stake pool, computed purely from economics.json's pool
+// reserves -- a read-only, pure-math route with no chain-write/custody risk.
+// Root (netuid 0) is exempt from the formula -- see buildStakeQuote's own
+// header for why.
+export async function handleStakeQuote(request, env, netuid, url) {
+  const validationError = validateQueryParams(url, ["amount", "direction"]);
+  if (validationError) return analyticsQueryError(validationError);
+
+  const direction =
+    url.searchParams.get("direction") || DEFAULT_STAKE_QUOTE_DIRECTION;
+  if (!STAKE_QUOTE_DIRECTIONS.includes(direction)) {
+    return analyticsQueryError({
+      parameter: "direction",
+      message: `"${direction}" is not a valid direction. Supported: ${STAKE_QUOTE_DIRECTIONS.join(", ")}.`,
+    });
+  }
+  const amountRaw = url.searchParams.get("amount");
+  const amount = Number(amountRaw);
+  if (!amountRaw || !Number.isFinite(amount) || amount <= 0) {
+    return analyticsQueryError({
+      parameter: "amount",
+      message: "amount is required and must be a positive number.",
+    });
+  }
+
+  const { row, generatedAt } = await resolveSubnetEconomicsRow(env, netuid);
+  const quote = buildStakeQuote(row, netuid, { amount, direction });
+  if (quote.error) return analyticsQueryError(quote.error);
+
+  return envelopeResponse(
+    request,
+    {
+      data: quote,
+      meta: await metagraphMeta(env, "/metagraph/economics.json", generatedAt),
     },
     "short",
   );


### PR DESCRIPTION
## Summary
- New `GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake` — a read-only, pure-math route with no chain-write/custody risk, computed purely from `economics.json`'s live `tao_in_pool_tao`/`alpha_in_pool` reserves (`workers/request-handlers/entities.mjs`'s new `resolveSubnetEconomicsRow` + `handleStakeQuote`, wired in `workers/api.mjs` via a new `SUBNET_STAKE_QUOTE_PATH_PATTERN`).
- Constant-product formula implemented in a new pure module, `src/stake-quote.mjs`: `alpha_out = alpha_in − (alpha_in·tao_in)/(tao_in+Δtao)` for `direction=stake`, and its inverse for `direction=unstake`. Returns `amount_out`, `spot_price_tao` (pre-trade marginal price), `effective_price_tao` (this trade's realized rate), and `price_impact_pct`.
- Root subnet (netuid 0) is exempt from the formula entirely — always returns a fixed 1:1, zero-impact quote, since there's no AMM on root (per ADR 0018 §3).
- An amount exceeding 1000x the relevant pool reserve is rejected with a 400, mirroring the chain's own `InsufficientLiquidity` guard; a pool with no/zero liquidity is also rejected rather than producing a NaN/Infinity quote.
- New `SubnetStakeQuoteArtifact` schema in `schemas/components/06-health.schema.json`, registered as both an `artifact()` and `route()` in `src/contracts.mjs`, plus the `validate-schemas`/`validate-api` route-coverage lists updated for the new "no static file, live-computed" route. `openapi.json` and generated types regenerated via `npm run build`.

## Tests
- `tests/stake-quote.test.mjs`: pure-function coverage of the constant-product/inverse formulas, monotonic slippage (bigger trade → bigger impact), the root-subnet 1:1 special case, zero-liquidity rejection, a dust-amount sanity check (no NaN/Infinity), and the >1000x pool-reserve rejection (including the exact boundary).
- `tests/request-handlers-entities.test.mjs`: route-level coverage against the real built `economics.json` artifact (successful stake/unstake quotes, the root-subnet case), plus 400s for a missing amount, non-positive amount, unsupported direction, unsupported query param, and a cold/unbound artifact store.

## Validation run
- `npm run lint` / `npm run format:check`
- `npm run validate`
- `npm run validate:contract-drift` / `npm run validate:schemas` / `npm run validate:openapi` / `npm run validate:api` / `npm run validate:openapi-examples`
- `node scripts/scan-public-safety.mjs` (passed)
- Targeted vitest run of the new/touched test files (all passing)

Closes #5235